### PR TITLE
Unifiy service label in legacy service gateway

### DIFF
--- a/lib/cloud_controller/legacy_api/legacy_service_gateway.rb
+++ b/lib/cloud_controller/legacy_api/legacy_service_gateway.rb
@@ -77,8 +77,8 @@ module VCAP::CloudController
       empty_json
     end
 
-    def list_handles(label_and_version, provider = DEFAULT_PROVIDER)
-      (label, version) = label_and_version.split("-")
+    def list_handles(service_label, provider = DEFAULT_PROVIDER)
+      (label, version) = service_label.split("-")
 
       service = Models::Service[:label => label, :provider => provider]
       raise ServiceNotFound, "label=#{label} provider=#{provider}" unless service
@@ -109,7 +109,9 @@ module VCAP::CloudController
       Yajl::Encoder.encode({:handles => handles})
     end
 
-    def delete(label, provider = DEFAULT_PROVIDER)
+    def delete(service_label, provider = DEFAULT_PROVIDER)
+      (label, version) = service_label.split("-")
+
       validate_access(label, provider)
 
       VCAP::CloudController::SecurityContext.set(self.class.legacy_api_user)
@@ -133,7 +135,9 @@ module VCAP::CloudController
       end
     end
 
-    def get(label, provider = DEFAULT_PROVIDER)
+    def get(service_label, provider = DEFAULT_PROVIDER)
+      (label, version) = service_label.split("-")
+
       validate_access(label, provider)
 
       service = Models::Service[:label => label, :provider => provider]
@@ -171,7 +175,9 @@ module VCAP::CloudController
     #
     # P.S. While I applaud Ruby for allowing this default parameter in the
     # middle, I'm really not wild for _any_ function overloading in Ruby
-    def update_handle(label, provider=DEFAULT_PROVIDER, id)
+    def update_handle(service_label, provider=DEFAULT_PROVIDER, id)
+      (label, version) = service_label.split("-")
+
       validate_access(label, provider)
       VCAP::CloudController::SecurityContext.set(self.class.legacy_api_user)
 
@@ -222,14 +228,14 @@ module VCAP::CloudController
     end
 
     def self.setup_routes
-      get    "/services/v1/offerings/:label_and_version/handles",           :list_handles
-      get    "/services/v1/offerings/:label_and_version/:provider/handles", :list_handles
-      get    "/services/v1/offerings/:label/:provider",         :get
-      get    "/services/v1/offerings/:label",                   :get
-      delete "/services/v1/offerings/:label",                   :delete
-      delete "/services/v1/offerings/:label/:provider",         :delete
-      post   "/services/v1/offerings",                          :create_offering
-      post   "/services/v1/offerings/:label/handles/:id",       :update_handle
+      get    "/services/v1/offerings/:label/handles",               :list_handles
+      get    "/services/v1/offerings/:label/:provider/handles",     :list_handles
+      get    "/services/v1/offerings/:label/:provider",             :get
+      get    "/services/v1/offerings/:label",                       :get
+      delete "/services/v1/offerings/:label",                       :delete
+      delete "/services/v1/offerings/:label/:provider",             :delete
+      post   "/services/v1/offerings",                              :create_offering
+      post   "/services/v1/offerings/:label/handles/:id",           :update_handle
       post   "/services/v1/offerings/:label/:provider/handles/:id", :update_handle
     end
 


### PR DESCRIPTION
Split the service_label (e.g. postgresql-9.2) to get the label (e.g. postgresql) for we should use the latter one to look up the models.

ccng (v2) plan 100/200 yeti-test passed
ccng (v1) plan 100       yeti-test passed
cc           plan free       yeti-test passed

ad-hoc test:
    - service recovery test(to test update_handle api): passed.

original story:
    There is a bug in legacy_service_gateway
    From below two lines, we need a label w/o version to retrive service_auth_token in validate_access
    https://github.com/cloudfoundry/cloud_controller_ng/blob/master/lib/cloud_controller/legacy_api/legacy_service_gateway.rb#L175, 
    https://github.com/cloudfoundry/cloud_controller_ng/blob/master/lib/cloud_controller/legacy_api/legacy_service_gateway.rb#L127

```
But, from below these lines, service gateway will provide a service_label (label with version)
https://github.com/cloudfoundry/vcap-services-base/blob/master/lib/base/asynchronous_service_gateway.rb#L93
https://github.com/cloudfoundry/vcap-services-base/blob/master/lib/base/asynchronous_service_gateway.rb#L480
https://github.com/cloudfoundry/vcap-services-base/blob/master/lib/base/catalog_manager_v2.rb#L491
```

 So, use servie_label.split('-') will definitely get "postgresql" from service_label "postgresql-9.0"

Change-Id: I39e9a12aad934367a54d090e8027a88ffd4e12f0
