### PR TITLE
Fix many typos in docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "rake"
 gem "bcrypt-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GIT
       yajl-ruby
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (3.2.8)
       i18n (~> 0.6)

--- a/docs/API_Overview.md
+++ b/docs/API_Overview.md
@@ -7,9 +7,11 @@ Overview
 The Cloud Foundry V2 family of APIs follow RESTful principles.
 The primary goal of the V2 API is to support the new entities in
 the Team Edition release, and to address the shortcomings of the V1 in terms
-features and consistency.  The specific high level goals are as follows:
+features and consistency.  
 
-* **Consistency** accross all resource URLs, parameters, request/response
+The specific high-level goals are as follows:
+
+* **Consistency** across all resource URLs, parameters, request/response
   bodies, and error responses.
 
 * **Partial updates** of a resource can be performed by providing a subset of
@@ -45,12 +47,12 @@ Basic Operations
 ----------------
 
 Operations on resources follow standard REST conventions.  Requests and
-responses for resources are JSON encoded.  Error responses are also JSON
+responses for resources are JSON-encoded.  Error responses are also JSON
 encoded.
 
 ### Common Attributes in Response Bodies
 
-Reponse bodies have 2 components, a `metadata` and `entity` sections.
+Response bodies have 2 components, a `metadata` and `entity` sections.
 
 The following attributes are contained in the `metadata` section:
 
@@ -66,24 +68,24 @@ The following attributes are contained in the `metadata` section:
 
 `POST /v2/foo_bars` creates a FooBar.
 
-The attributes for new FooBar are specified in a JSON encoded request body.
+The attributes for new FooBar are specified in a JSON-encoded request body.
 
-A successful `POST` results in an HTTP 201 with the `Location`
+A successful `POST` results in HTTP 201 with the `Location`
 header set to the URL of the newly created resource.  The API endpoint should
 return the Etag HTTP header for later use by the client
-in support of opportunistic concurency.
+in support of opportunistic concurrency.
 
-The attributes for the FooBar are returned in a JSON encoded response body.
+The attributes for the FooBar are returned in a JSON-encoded response body.
 
 ### Reading Resources
 
 `GET /v2/foo_bars/:guid` returns the attributes for a specific
 FooBar.
 
-A successful `GET` results in an HTTP 200.  The API endpoint should set the
-Etag HTTP header for later use in opportunistic concurency.
+A successful `GET` results in HTTP 200.  The API endpoint should set the
+Etag HTTP header for later use in opportunistic concurrency.
 
-The attributes for the FooBar are returned in a JSON encoded response body.
+The attributes for the FooBar are returned in a JSON-encoded response body.
 
 ### Listing Resources
 
@@ -91,7 +93,7 @@ The attributes for the FooBar are returned in a JSON encoded response body.
 
 Successful `GET` requests return HTTP 200.
 
-The attributes for the FooBar are returned in a JSON encoded response body.
+The attributes for the FooBar are returned in a JSON-encoded response body.
 
 #### Pagination
 
@@ -100,14 +102,14 @@ All `GET` requests to collections are implicitly paginated, i.e. `GET
 
 ##### Pagination Response Attributes
 
-A paginated reponse contains the following attributes:
+A paginated response contains the following attributes:
 
 | Attribute     | Description                                                                                       |
 | ---------     | -----------                                                                                       |
 | total_results | Total number of results in the entire data set.                                                   |
 | total_pages   | Total number of pages in the entire dataset.                                                      |
 | prev_url      | URL used to fetch the previous set of results in the paginated response.  null on the first call. |
-| next_url      | URL used to fetch the next set of ressults in the paginated response.  null on the last call.     |
+| next_url      | URL used to fetch the next set of results in the paginated response.  null on the last call.     |
 | resources     | Array of resources as returned by a GET on the resource id.                                       |
 
 The resources are expanded by default because in that is what is desired in the
@@ -122,7 +124,7 @@ included in the query string to `prev_url` or `next_url`.
 | ---------        | -----------                                                                      |
 | page             | Page from which to start iteration                                               |
 | results-per-page | Results to return per page                                                       |
-| urls-only        | If 1, only return a list of urls; do not expand metadata or resource attributues |
+| urls-only        | If 1, only return a list of urls; do not expand metadata or resource attributes |
 
 If the client is going to iterate through the entire dataset, they are
 encouraged to follow `next_url` rather than iterating by setting
@@ -170,7 +172,7 @@ Response:
 
 #### Search/Filtering
 
-Searching and Filtering are peformed via the `q` query parameter.  The value of
+Searching and Filtering are performed via the `q` query parameter.  The value of
 the `q` parameter is a key value pair containing the resource attribute name
 and the query value, e.g: `GET /v2/foo_bars?q=name:some*` would return
 both records shown in the pagination example above.
@@ -189,7 +191,7 @@ unindexed search.
 
 The caller may specify the `If-Match` HTTP header to enable opportunistic
 concurrency.  This is not required.  If there is an opportunistic concurrency
-failure, the API enpoint should return HTTP 412.
+failure, the API endpoint should return HTTP 412.
 
 A successful `DELETE` operation results in a 204.
 
@@ -197,7 +199,7 @@ A successful `DELETE` operation results in a 204.
 
 `PUT` differs from standard convention.  In order to avoid a read-modify-write
 cycle when updating a single attribute, `PUT` is handled as if the `PATCH` verb
-were used.  Specically, if a resource with URL `/v2/foo_bars/99` has attributes
+were used.  Specifically, if a resource with URL `/v2/foo_bars/99` has attributes
 
 ```json
 {
@@ -214,7 +216,7 @@ were used.  Specically, if a resource with URL `/v2/foo_bars/99` has attributes
 }
 ```
 
-then a `PUT /v2/foo_bars/99` with a requrest body of `{"instances":3}` results
+then a `PUT /v2/foo_bars/99` with a request body of `{"instances":3}` results
 in a resource with the following attributes
 
 ```json
@@ -232,13 +234,13 @@ in a resource with the following attributes
 }
 ```
 
-A sucessful `PUT` results in an HTTP 200.
+A successful `PUT` results in HTTP 200.
 
 The caller may specify the `If-Match` HTTP header to enable opportunistic
 concurrency.  This is not required.  If there is an opportunistic concurrency
-failure, the API enpoint should return HTTP 412.
+failure, the API endpoint should return HTTP 412.
 
-The attributes for the updated FooBar are returned in a JSON encoded response body.
+The attributes for the updated FooBar are returned in a JSON-encoded response body.
 
 Note: version 3 of this API might require `PUT` to contain the full list of required
 attributes and such partial updates might only be supported via the HTTP
@@ -298,9 +300,9 @@ resource, during an update via `PUT`.
 To create the association during a `POST` or to edit it with a `PUT`, supply a
 an array of ids.  For example, in the FooBaz has multiple Bars example
 above, a caller could issue a `POST /v2/foo_baz` with a body of `{ "bar_guid": [1,
-5, 10]}` to make an initial assocation of the new FooBaz with Bars with ids 1,
+5, 10]}` to make an initial association of the new FooBaz with Bars with ids 1,
 5 and 10 (other attributes omitted).  Similarly, a `PUT` will update the
-assocations between the resources to only those provided in the list.
+associations between the resources to only those provided in the list.
 
 Adding and removing elements from a large collection would be onerous if the
 entire list had to be provided every time.
@@ -311,7 +313,7 @@ A `DELETE /v2/foo_baz/1/bars/2` will remove bar with id 2 to from foobaz with
 id 1.
 
 Batching incremental updates may be supported in the future.
-To controll how the list of ids are added to the collection, supply the
+To control how the list of ids are added to the collection, supply the
 following query parameter `collection-method=add`, `collection-method=replace`, or
 `collection-method=delete`.  If the collection-method is not supplied,
 it defaults to replace.  NOTE: this is a future design note.
@@ -320,7 +322,7 @@ collection-method is not currently supported.
 
 ### Inlining Relationships
 
-There are common Cloud Foundary use cases that would require a relatively high
+There are common Cloud Foundry use cases that would require a relatively high
 number of API calls if the relation URLs have to be fetched when traversing a
 set of resources, e.g. when performing the calls necessary to satisfy a `vmc
 apps` command line call.  In these cases, the caller intends to walk the entire
@@ -334,7 +336,7 @@ inline in the response, but URLs are provided for the next level of relations.
 
 For example, in the request below a FooBar has a to-many relationship to Bars
 and Bars has a to-one relationship with a Baz.  Setting the
-`inline-relations-depth=1` results in bars being exapanded but not baz.
+`inline-relations-depth=1` results in bars being expanded but not baz.
 
 Request: `GET /v2/FooBar/5?inline-relations-depth=1`
 
@@ -369,7 +371,7 @@ Response:
 }
 ```
 
-Specifiying `inline-releations-depth` > 1 should not result in an circular
+Specifying `inline-releations-depth` > 1 should not result in an circular
 expansion of resources.  For example, if there is a bidirectional relationship
 between two resources, e.g. an Organization has many Users and a User is a
 member of many Organizations, then the response to `GET
@@ -386,12 +388,12 @@ header, i.e. 400 if the request body can not be parsed, 404 if an operation
 is requested on a resource that doesn't exist, etc.
 
 In addition to the HTTP response code, an error response is returned in the
-reponse body.  The error response is json encoded with the following
+response body.  The error response is JSON-encoded with the following
 attributes:
 
 | Attribute    | Description                             |
 | ---------    | -----------                             |
-| code         | Unique numeric resposne code            |
+| code         | Unique numeric response code            |
 | descriptions | Human readable description of the error |
 
 Actions

--- a/docs/cc_api.md.erb
+++ b/docs/cc_api.md.erb
@@ -57,7 +57,7 @@
 
 ## CC Specific API
 
-NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hiearchy and relationships only.
+NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
 
 ### LIST <%= api.class_basename %>s
 
@@ -71,7 +71,7 @@ Returns a paginated response of <%= api.class_basename %>s.
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
 | offset                 | Offset from which to start iteration.                                            |
-| urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
+| urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributes |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 <% if api.query_parameters %>
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |


### PR DESCRIPTION
Docs had numerous small typos - due to repeating template these got reproduced many times. Now we are going to cf-docs this was very visible.
Updated Gemfile for deprecation of :rubygems magic symbol
TODO: split API doc generated markdown into separate pages per entity.
