### PR TITLE
import several fields for the handle update of service gateway

### DIFF
--- a/lib/cloud_controller/api/service_instance.rb
+++ b/lib/cloud_controller/api/service_instance.rb
@@ -11,6 +11,9 @@ module VCAP::CloudController
 
     define_attributes do
       attribute :name,             String
+      attribute :credentials,      Hash
+      attribute :gateway_data,     Hash
+      attribute :gateway_name,     String
       to_one    :space
       to_one    :service_plan
       to_many   :service_bindings

--- a/lib/cloud_controller/models/service_instance.rb
+++ b/lib/cloud_controller/models/service_instance.rb
@@ -28,7 +28,7 @@ module VCAP::CloudController::Models
                       :space_guid, :gateway_data
 
     import_attributes :name, :service_plan_guid,
-                      :space_guid, :gateway_data
+                      :space_guid, :gateway_data, :credentials, :gateway_name
 
     strip_attributes  :name
 


### PR DESCRIPTION
import fields for the update handle operation on service gateway

currently service gateway will cache some information from cc and need to be able to update these fields on ccng when they found that those fields are obsolete. the commit added gateway_data, gateway_name and credential for the 

put /v2/service_instance/:guid

api for the functionality.

tests done with the commit:
manually did the update operation on service gateway using v2 api and they can update the record in ccdb_ng.
