### PR TITLE
Explicitly require 'optparse'.

### DIFF
--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -1,5 +1,7 @@
 # Copyright (c) 2009-2012 VMware, Inc.
 
+require "optparse"
+
 require "steno"
 require File.expand_path("../message_bus.rb", __FILE__)
 


### PR DESCRIPTION
When we tried to start cloud controller this morning we got an error about `OptionParser` not being defined. It looks like it was being required in a dependency of yours before that is no longer requiring it.
