### PR TITLE
Require 'yaml' and 'optparse' in the applicable places.

### DIFF
--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -1,5 +1,7 @@
 # Copyright (c) 2009-2012 VMware, Inc.
 
+require "optparse"
+
 require "steno"
 require File.expand_path("../message_bus.rb", __FILE__)
 

--- a/lib/vcap/errors.rb
+++ b/lib/vcap/errors.rb
@@ -1,4 +1,7 @@
 # Copyright (c) 2009-2012 VMware, Inc.
+
+require "yaml"
+
 require "vcap/rest_api/errors"
 
 module VCAP::Errors


### PR DESCRIPTION
We were still having issues with this, even after updating to the latest master. We can recreate for you if necessary, just let us know!

Chris & Alex & Sheel

```
/Users/pivotal/workspace/cloud_controller_ng/lib/vcap/errors.rb:9:in `<module:Errors>': uninitialized constant VCAP::Errors::YAML (NameError)
    from /Users/pivotal/workspace/cloud_controller_ng/lib/vcap/errors.rb:4:in `<top (required)>'
    from /Users/pivotal/workspace/cloud_controller_ng/lib/cloud_controller.rb:12:in `require'
    from /Users/pivotal/workspace/cloud_controller_ng/lib/cloud_controller.rb:12:in `<top (required)>'
    from bin/cloud_controller:11:in `require'
    from bin/cloud_controller:11:in `<main>'
```
