### PR TITLE
Remove token_endpoint from /info

### DIFF
--- a/lib/cloud_controller/api/info.rb
+++ b/lib/cloud_controller/api/info.rb
@@ -12,7 +12,6 @@ module VCAP::CloudController
         :version     => @config[:info][:version],
         :description => @config[:info][:description],
         :authorization_endpoint => @config[:login] ? @config[:login][:url] : @config[:uaa][:url],
-        :token_endpoint => @config[:uaa][:url],
         :api_version => @config[:info][:api_version]
       }
 


### PR DESCRIPTION
It was dumb to add it (sorry) - the logic for discovering a UAA
if login server is available has been moved to uaa-lib.
