### PR TITLE
update response header content-type

### DIFF
--- a/lib/sinatra/vcap.rb
+++ b/lib/sinatra/vcap.rb
@@ -138,6 +138,7 @@ module Sinatra
           varz[:requests][:completed] += 1
           varz[:http_status][response.status] += 1
         end
+        headers["Content-Type"] = "application/json;charset=utf-8"
         headers["X-VCAP-Request-ID"] = @request_guid
         Thread.current[:vcap_request_id] = nil
         Steno.config.context.data.delete("request_guid")


### PR DESCRIPTION
the previous type is default value, 'text/html'

cf-uaa-lib is attempting to talk to the CC, please see https://github.com/cloudfoundry/vcap-services/blob/master/oauth2/lib/service/provisioner.rb#L191 and https://github.com/cloudfoundry/cf-uaa-lib/blob/master/lib/uaa/http.rb#L79, the header content-type must be 'application/json'
