### PR TITLE
Access all git dependencies using https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,10 @@ gem "sequel"
 gem "sinatra"
 gem "sinatra-contrib"
 gem "yajl-ruby"
-gem 'vcap-concurrency', :git => 'git://github.com/cloudfoundry/vcap-concurrency.git'
+gem 'vcap-concurrency', :git => 'https://github.com/cloudfoundry/vcap-concurrency.git'
 gem "membrane", "~> 0.0.2"
-gem "vcap_common",  "~> 2.0.8", :git => 'git://github.com/cloudfoundry/vcap-common.git', :ref => '68d86f57fb'
-gem "cf-uaa-lib", "~> 1.3.7", :git => 'git://github.com/cloudfoundry/cf-uaa-lib.git', :ref =>  '8d34eede58'
+gem "vcap_common",  "~> 2.0.8", :git => 'https://github.com/cloudfoundry/vcap-common.git', :ref => '68d86f57fb'
+gem "cf-uaa-lib", "~> 1.3.7", :git => 'https://github.com/cloudfoundry/cf-uaa-lib.git', :ref =>  '8d34eede58'
 gem "httpclient"
 gem "steno", "~> 1.0.0"
 gem 'stager-client', '~> 0.0.02', :git => 'https://github.com/cloudfoundry/stager-client.git', :ref => '04c2aee9'


### PR DESCRIPTION
`git://` URIs can be problematic as the port used by the git protocol
(9418) is often blocked for outbound connections by a firewall. The
Gemfile was using a mixture of `git://` and `https://` URIs for its
Git-based dependencies. This PR makes them all use https.
