### PR TITLE
Use https:// rather than git:// for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/errors"]
 	path = vendor/errors
-	url = git://github.com/cloudfoundry/errors.git
+	url = https://github.com/cloudfoundry/errors.git


### PR DESCRIPTION
To avoid problems with the git protocol's port being blocked by a
firewall, use https URIs for submodules
