### PR TITLE
Correct typo in logging that may cause DEA crash

### DIFF
--- a/lib/cloud_controller/legacy_api/legacy_staging.rb
+++ b/lib/cloud_controller/legacy_api/legacy_staging.rb
@@ -202,7 +202,7 @@ module VCAP::CloudController
         logger.debug "nginx redirect #{url}"
         return [200, { "X-Accel-Redirect" => url }, ""]
       else
-        logger.debug "send_file #{patchage_path}"
+        logger.debug "send_file #{package_path}"
         return send_file package_path
       end
     end


### PR DESCRIPTION
If debug logging is enabled the DEA will crash due to a typo in
a logging call. Correct the typo: patchage -> package
