### PR TITLE
Make symmetric_secret an optional config property.

### DIFF
--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -28,7 +28,7 @@ class VCAP::CloudController::Config < VCAP::Config
       :uaa => {
         :url                => String,
         :resource_id        => String,
-        :symmetric_secret   => String
+        optional(:symmetric_secret)   => String
       },
 
       :logging => {


### PR DESCRIPTION
The token validation logic in uaa_util.rb decides whether
to use symmetric or asymmetric key validation base on whether
this property is set. Without this change the CC won't start
unless it is set, hence it won't work with a UAA which is
configured to use an RSA key signature.
