### PR TITLE
use client_id when user_id is missing from token

### DIFF
--- a/lib/cloud_controller.rb
+++ b/lib/cloud_controller.rb
@@ -43,7 +43,11 @@ module VCAP::CloudController
       begin
         token_information = decode_token(auth_token)
         logger.info("Token received from the UAA #{token_information.inspect}")
-        uaa_id = token_information['user_id'] if token_information
+
+        if token_information
+          token_information['user_id'] ||= token_information['client_id']
+          uaa_id = token_information['user_id']
+        end
 
         if uaa_id
           user = Models::User.find(:guid => uaa_id)


### PR DESCRIPTION
UAA 1.4.1 will remove user_id from tokens that represent clients. This change allows cloud controller to still function the same.
- Eugenia & Sheel 
