### PR TITLE
Service instance deletions succeed even though service gateway failed

### DIFF
--- a/lib/cloud_controller/models/service_instance.rb
+++ b/lib/cloud_controller/models/service_instance.rb
@@ -196,8 +196,6 @@ module VCAP::CloudController::Models
       return unless client # TODO: see service_gateway_client
       @provisioned_on_gateway_for_plan = nil
       client.unprovision(:service_id => gateway_name)
-    rescue => e
-      logger.error "deprovision failed #{e}"
     end
 
     def create_snapshot


### PR DESCRIPTION
I've been working on a custom service for ccng. I can create the service just fine. When I delete the service, my gateway fails but the cc deletes the service instance anyway.

It appears this is because the exception is being swallowed. Removing the rescue clause causes the delete to fail as it should and the error is reported back to VMC correctly.
