### PR TITLE
update response header content-type

### DIFF
--- a/lib/sinatra/vcap.rb
+++ b/lib/sinatra/vcap.rb
@@ -138,6 +138,7 @@ module Sinatra
           varz[:requests][:completed] += 1
           varz[:http_status][response.status] += 1
         end
+        headers["Content-Type"] = "application/json;charset=utf-8"
         headers["X-VCAP-Request-ID"] = @request_guid
         Thread.current[:vcap_request_id] = nil
         Steno.config.context.data.delete("request_guid")

--- a/spec/sinatra/vcap_spec.rb
+++ b/spec/sinatra/vcap_spec.rb
@@ -64,6 +64,12 @@ describe "Sinatra::VCAP" do
     end
   end
 
+  shared_examples "http header content type" do
+    it "should return json content type in the header" do
+      last_response.headers["Content-Type"].should eql("application/json;charset=utf-8")
+    end
+  end
+
   describe "access with no errors" do
     before do
       get "/"
@@ -76,6 +82,7 @@ describe "Sinatra::VCAP" do
 
     include_examples "vcap sinatra varz stats", 200
     include_examples "vcap request id"
+    include_examples "http header content type"
   end
 
   describe "accessing an invalid route" do
@@ -90,6 +97,7 @@ describe "Sinatra::VCAP" do
 
     include_examples "vcap sinatra varz stats", 404
     include_examples "vcap request id"
+    include_examples "http header content type"
     it_behaves_like "a vcap rest error response", /Unknown request/
   end
 
@@ -113,6 +121,7 @@ describe "Sinatra::VCAP" do
 
     include_examples "vcap sinatra varz stats", 500
     include_examples "vcap request id"
+    include_examples "http header content type"
     it_behaves_like "a vcap rest error response", /Server error/
   end
 


### PR DESCRIPTION
the previous type is default value, 'text/html'

cf-uaa-lib is attempting to talk to the CC, please see https://github.com/cloudfoundry/vcap-services/blob/master/oauth2/lib/service/provisioner.rb#L191 and https://github.com/cloudfoundry/cf-uaa-lib/blob/master/lib/uaa/http.rb#L79, the header content-type must be 'application/json'
