### PR TITLE
Convert route.host to support nil value.

### DIFF
--- a/spec/api/app_summary_spec.rb
+++ b/spec/api/app_summary_spec.rb
@@ -21,6 +21,7 @@ module VCAP::CloudController
       @space = Models::Space.make
       @route1 = Models::Route.make(:space => @space)
       @route2 = Models::Route.make(:space => @space)
+      @nil_host_route = Models::Route.make(:space => @space, :host => nil)
       @services = []
 
       @app = Models::App.make(
@@ -41,6 +42,7 @@ module VCAP::CloudController
 
       @app.add_route(@route1)
       @app.add_route(@route2)
+      @app.add_route(@nil_host_route)
     end
 
     after(:all) do
@@ -66,7 +68,7 @@ module VCAP::CloudController
         decoded_response["name"].should == @app.name
       end
 
-      it "should return the app routes" do
+      it "should return correct app routes" do
         decoded_response["routes"].should == [{
           "guid" => @route1.guid,
           "host" => @route1.host,
@@ -80,6 +82,12 @@ module VCAP::CloudController
           "domain" => {
             "guid" => @route2.domain.guid,
             "name" => @route2.domain.name}
+        }, {
+          "guid" => @nil_host_route.guid,
+          "host" => "",
+          "domain" => {
+            "guid" => @nil_host_route.domain.guid,
+            "name" => @nil_host_route.domain.name}
         }]
       end
 
@@ -94,10 +102,11 @@ module VCAP::CloudController
       end
 
       it "should contain list of available domains" do
-        _, domain1, domain2 = @app.space.domains
+        _, domain1, domain2, domain3 = @app.space.domains
         decoded_response["available_domains"].should =~ [
           {"guid" => domain1.guid, "name" => domain1.name, "owning_organization_guid" => domain1.owning_organization.guid},
           {"guid" => domain2.guid, "name" => domain2.name, "owning_organization_guid" => domain2.owning_organization.guid},
+          {"guid" => domain3.guid, "name" => domain3.name, "owning_organization_guid" => domain3.owning_organization.guid},
           {"guid" => @system_domain.guid, "name" => @system_domain.name, "owning_organization_guid" => nil}
         ]
       end

--- a/spec/api/route_spec.rb
+++ b/spec/api/route_spec.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
     }
 
     context "with a wildcard domain" do
-      it "should allow a nil host" do
+      it "should correctly handle a nil host" do
         cf_admin = Models::User.make(:admin => true)
         domain = Models::Domain.make(:wildcard => true)
         space = Models::Space.make(:organization => domain.owning_organization)
@@ -44,6 +44,9 @@ module VCAP::CloudController
                                :space_guid => space.guid),
           headers_for(cf_admin)
         last_response.status.should == 201
+        get decoded_response["metadata"]["url"], {}, headers_for(cf_admin)
+        last_response.status.should == 200
+        expect(decoded_response["entity"]["host"]).to be_empty
       end
     end
 


### PR DESCRIPTION
This patch is part of my work to support Oracle in the Cloud Controller.

While doing the conversion work I discovered another annoying Oracle feature where an empty varchar is equal to null.  If you insert an empty string into oracle it will insert null into the column and fail any not null constraints you may have associated with the column.

I scanned through all of the CC code and pretty much all not null var chars are also validated as "validates_presence", which should be compatible with this Oracle behavior, except for Route.host.

From what I could gather by looking at the code, Route.Host is not null but default "".  It seems that the purpose of this behavior is to assign "" the value of no host to ensure that a "validate_unique" against host and domain_id will always work.

In oracle this functionality is duplicated by using a null value since null == "".  But in other databases you need to be sure that only "" or null is put in the database.

So in this patch I've actually changed the behavior of the Route model to allow for nil as a host value.  Then I use a "before_save" hook to always switch nil with "".  And provide a function to only present host as an "" regardless of if it is nil or empty.

I then updated the subsequent tests to make host nilable and added a few more test to ensure that when a route is queried a nil value will be an empty string.
