### PR TITLE
Service bind should send service_instance_guid to gateway

### DIFF
--- a/lib/cloud_controller/models/service_binding.rb
+++ b/lib/cloud_controller/models/service_binding.rb
@@ -122,6 +122,7 @@ module VCAP::CloudController::Models
         :label      => "#{service.label}-#{service.version}",
         :email      => VCAP::CloudController::SecurityContext.
                              current_user_email,
+        :service_instance_guid => service_instance.guid,
         :binding_options => {}
       )
 


### PR DESCRIPTION
When binding a service, it would be really helpful if the CC sent the GUID of the service instance being bound to the service gateway. This would greatly simplify some of the services that we are building that rely on the CC for storage of credentials instead of the gateway storing that information.
