### PR TITLE
Pass the GET request of /staging/(buildpack_cache|droplets)/ to cloud_controller directly

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -80,7 +80,12 @@ http {
       upload_cleanup 400-505;
     }
 
+    # Droplet uploads from the stager should be authenticated
     location ~ /staging/(buildpack_cache|droplets)/.*/upload {
+      # Download the droplets and buildpacks
+      if ($request_method = GET){
+        proxy_pass                 http://cloud_controller;
+      }    
       # Pass along auth header
       set $auth_header $upstream_http_x_auth;
       proxy_set_header Authorization $auth_header;


### PR DESCRIPTION
The problem described here:
https://groups.google.com/a/cloudfoundry.org/forum/?fromgroups=#!topic/vcap-dev/PZLovYnQrS0

DEA can not download the staged application as it gets a 405 error from nginx and the GET request never goes to cloud_controller.

Download(GET) should not goes to the upload module. This pull request can solve it.
