### PR TITLE
Fix erroneous fk columns created by bad foreign_key syntax

### DIFF
--- a/db/migrations/20130530173342_fix_permission_fk_problems.rb
+++ b/db/migrations/20130530173342_fix_permission_fk_problems.rb
@@ -1,0 +1,56 @@
+# Copyright (c) 2009-2012 VMware, Inc.
+
+# Helper method to cleanup erroneous fk columns in permission tables
+def cleanup_permission_table(name, permission)
+  name = name.to_s
+  join_table = "#{name.pluralize}_#{permission}".to_sym
+  id_attr = "#{name}_id".to_sym
+  fk_name = "#{name}_fk".to_sym
+  new_fk_name = "#{join_table}_#{name}_fk".to_sym
+  new_fk_user = "#{join_table}_user_fk".to_sym
+  table = name.pluralize.to_sym
+  fk_current_name = nil
+  fk_user_name = nil
+  #rename based on finding an fk that references one of the bad columns
+  fks = foreign_key_list(join_table).each do | fk |
+    if(fk[:columns] == [fk_name])
+      alter_table join_table do
+        drop_constraint fk[:name], :type => :foreign_key
+        drop_column fk_name
+        add_foreign_key [id_attr], table, :name => new_fk_name
+      end
+    elsif(fk[:columns] == [:user_fk])
+      alter_table join_table do
+        drop_constraint fk[:name], :type => :foreign_key
+        drop_column :user_fk
+        add_foreign_key [:user_id], :users, :name => new_fk_user
+      end
+    end
+  end
+end
+
+Sequel.migration do
+  up do
+    [:users, :managers, :billing_managers, :auditors].each do |perm|
+      cleanup_permission_table(:organization, perm)
+    end
+
+    [:developers, :managers, :auditors].each do |perm|
+      cleanup_permission_table(:space, perm)
+    end
+
+    foreign_key_list(:app_events).each do | fk |
+      if(fk[:columns] == [:fk_app_events_app_id])
+        alter_table :app_events do
+          drop_constraint fk[:name], :type => :foreign_key
+          drop_column :fk_app_events_app_id
+          add_foreign_key [:app_id], :apps, :name => :fk_app_events_app_id
+        end
+      end
+    end
+  end
+
+  down do
+    raise Sequel::Error, "This migration cannot be reversed."
+  end
+end

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -143,15 +143,16 @@ module VCAP
       name = name.to_s
       join_table = "#{name.pluralize}_#{permission}".to_sym
       id_attr = "#{name}_id".to_sym
-      fk_name = "#{name}_fk".to_sym
+      fk_name = "#{join_table}_#{name}_fk".to_sym
+      fk_user = "#{join_table}_user_fk".to_sym
       table = name.pluralize.to_sym
 
       migration.create_table(join_table) do
         Integer id_attr, :null => false
-        foreign_key id_attr, table, :name => fk_name
+        foreign_key [id_attr], table, :name => fk_name
 
         Integer :user_id, :null => false
-        foreign_key :user_id, :users, :name => :user_fk
+        foreign_key [:user_id], :users, :name => fk_user
 
         index [id_attr, :user_id], :unique => true
       end


### PR DESCRIPTION
This PR is a fix for Issue https://github.com/cloudfoundry/cloud_controller_ng/issues/48

This fix breaks my Oracle pull request.  So, once this is merged I will immediately update my Oracle support PR which I'm still hoping can be merged soon.

It should safely fix Schemas that have the problem and ignore Schemas that are new and created with the fixed create_permission_table syntax.
