### PR TITLE
send binding_options to service_gateway

### DIFF
--- a/lib/cloud_controller/api/service_binding.rb
+++ b/lib/cloud_controller/api/service_binding.rb
@@ -15,6 +15,7 @@ module VCAP::CloudController
     define_attributes do
       to_one    :app
       to_one    :service_instance
+      attribute :binding_options, String, :default => nil
     end
 
     query_parameters :app_guid, :service_instance_guid

--- a/lib/cloud_controller/models/service_binding.rb
+++ b/lib/cloud_controller/models/service_binding.rb
@@ -123,7 +123,7 @@ module VCAP::CloudController::Models
         :label      => "#{service.label}-#{service.version}",
         :email      => VCAP::CloudController::SecurityContext.
                              current_user_email,
-        :binding_options => {}
+        :binding_options => binding_options,
       )
 
       logger.debug "binding response for #{guid} #{gw_attrs.inspect}"
@@ -141,7 +141,7 @@ module VCAP::CloudController::Models
       client.unbind(
         :service_id      => service_instance.gateway_name,
         :handle_id       => gateway_name,
-        :binding_options => {}
+        :binding_options => binding_options,
       )
     rescue => e
       logger.error "unbind failed #{e}"
@@ -154,5 +154,16 @@ module VCAP::CloudController::Models
     def generate_salt
       self.salt ||= VCAP::CloudController::Encryptor.generate_salt
     end
+
+    DEFAULT_BINDING_OPTIONS = '{}'
+
+    def binding_options
+      Yajl::Parser.parse(super || DEFAULT_BINDING_OPTIONS)
+    end
+
+    def binding_options=(bo)
+      super(Yajl::Encoder.encode(bo))
+    end
+
   end
 end

--- a/spec/api/service_binding_spec.rb
+++ b/spec/api/service_binding_spec.rb
@@ -1,13 +1,36 @@
 require File.expand_path("../spec_helper", __FILE__)
 
 module VCAP::CloudController
+
   describe VCAP::CloudController::ServiceBinding do
-    include_examples "uaa authenticated api", path: "/v2/service_bindings"
-    include_examples "enumerating objects", path: "/v2/service_bindings", model: Models::ServiceBinding
-    include_examples "reading a valid object", path: "/v2/service_bindings", model: Models::ServiceBinding, basic_attributes: %w(app_guid service_instance_guid)
-    include_examples "operations on an invalid object", path: "/v2/service_bindings"
-    include_examples "deleting a valid object", path: "/v2/service_bindings", model: Models::ServiceBinding, one_to_many_collection_ids: {}, one_to_many_collection_ids_without_url: {}
-    include_examples "creating and updating", path: "/v2/service_bindings", model: Models::ServiceBinding, required_attributes: %w(app_guid service_instance_guid), unique_attributes: %w(app_guid service_instance_guid), extra_attributes: [],
+
+    include_examples "uaa authenticated api",
+      path: "/v2/service_bindings"
+
+    include_examples "enumerating objects",
+      path: "/v2/service_bindings",
+      model: Models::ServiceBinding
+
+    include_examples "reading a valid object",
+      path: "/v2/service_bindings",
+      model: Models::ServiceBinding,
+      basic_attributes: %w(app_guid service_instance_guid)
+
+    include_examples "operations on an invalid object",
+      path: "/v2/service_bindings"
+
+    include_examples "deleting a valid object",
+      path: "/v2/service_bindings",
+      model: Models::ServiceBinding,
+      one_to_many_collection_ids: {},
+      one_to_many_collection_ids_without_url: {}
+    
+    include_examples "creating and updating",
+      path: "/v2/service_bindings",
+      model: Models::ServiceBinding,
+      required_attributes: %w(app_guid service_instance_guid),
+      unique_attributes: %w(app_guid service_instance_guid),
+      extra_attributes: %w(binding_options),
       create_attribute: lambda { |name|
         @space ||= Models::Space.make
         case name.to_sym

--- a/spec/models/service_binding_spec.rb
+++ b/spec/models/service_binding_spec.rb
@@ -203,5 +203,43 @@ module VCAP::CloudController
         app.needs_staging?.should be_true
       end
     end
+
+    describe "binding options" do
+
+      let(:gw_client) { double(:client) }
+      let(:response) do
+        VCAP::Services::Api::GatewayHandleResponse.new(
+          :service_id => "gwname_instance",
+          :configuration => "abc",
+          :credentials => {:password => "foo"}
+        )
+      end
+
+      before do
+        Models::ManagedServiceInstance.any_instance.stub(:service_gateway_client).and_return(gw_client)
+        gw_client.stub(:provision).and_return(response)
+        gw_client.stub(:bind).and_return(response)
+      end
+
+      context "service gateway" do
+
+        it "send binding_options to gateway" do
+          binding_options = Sham.binding_options
+          gw_client.
+            should_receive(:bind).
+            with(hash_including(:binding_options => binding_options))
+          Models::ServiceBinding.make(:binding_options => binding_options)
+        end
+
+        it "send default binding_options to gateway" do
+          gw_client.
+            should_receive(:bind).
+            with(hash_including(:binding_options => {}))
+          Models::ServiceBinding.make
+        end
+
+      end
+    end
+
   end
 end

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -16,6 +16,7 @@ Sham.define do
   service_credentials { |index|
     { "creds-key-#{index}" => "creds-val-#{index}" }
   }
+  binding_options     { |index| "binding-options-#{index}" }
   uaa_id              { |index| "uaa-id-#{index}" }
   domain              { |index| "domain-#{index}.com" }
   host                { |index| "host-#{index}" }


### PR DESCRIPTION
Required for vCHS Services -- binding_options allows sharing a service_instance with reduced privileges (for example, a 'read-only' binding-option for a relational DB would allow SELECT queries but not INSERT, UPDATE or DELETE).

Binding options are already in CCDB and supported by service gateways.  So this is a pretty simple change: just send them, instead of sending nil.

(FYI -- a similar PR for plan_options in a provision request is on the way...)
