### PR TITLE
add space_guid to dea start message

### DIFF
--- a/lib/cloud_controller/dea/dea_client.rb
+++ b/lib/cloud_controller/dea/dea_client.rb
@@ -260,6 +260,7 @@ module VCAP::CloudController
         # TODO: add debug support
         {
           :droplet => app.guid,
+          :tags => {:space => app.space_guid},
           :name => app.name,
           :uris => app.uris,
           :prod => app.production,

--- a/spec/dea/dea_client_spec.rb
+++ b/spec/dea/dea_client_spec.rb
@@ -37,6 +37,7 @@ module VCAP::CloudController
         res = DeaClient.send(:start_app_message, @app)
         res.should be_kind_of(Hash)
         res[:droplet].should == @app.guid
+        res[:tags].should == {space: @app.space_guid}
         res[:services].should be_kind_of(Array)
         res[:services].count.should == NUM_SVC_INSTANCES
         res[:services].first.should be_kind_of(Hash)


### PR DESCRIPTION
Signed-off-by: Stephan Hagemann stephan@pivotallabs.com

We added the space_guid to the dea start message so that we can annotate the logs with the space and app id.   This is more efficient than looking up this data later in the pipeline.
