### PR TITLE
Add tests to solidify and verify debug api

### DIFF
--- a/spec/api/app_spec.rb
+++ b/spec/api/app_spec.rb
@@ -126,6 +126,68 @@ module VCAP::CloudController
 
       subject { put "/v2/apps/#{app_obj.guid}", Yajl::Encoder.encode(update_hash), json_headers(admin_headers) }
 
+      describe "update app debug" do
+        context "set debug" do
+          let(:update_hash) do
+            {"debug" => "run"}
+          end
+
+          it "should work" do
+            subject
+            app_obj.refresh
+            app_obj.debug.should == "run"
+            last_response.status.should == 201
+          end
+                    
+        end
+        
+        context "change debug" do
+          let(:app_obj) { Models::App.make(:debug => "run") }
+
+          let(:update_hash) do
+            {"debug" => "suspend"}
+          end
+
+          it "should work" do
+            subject
+            app_obj.refresh
+            app_obj.debug.should == "suspend"
+            last_response.status.should == 201
+          end
+        end
+
+        context "reset debug" do
+          let(:app_obj) { Models::App.make(:debug => "run") }
+
+          let(:update_hash) do
+            {"debug" => "none"}
+          end
+
+          it "should work" do
+            subject
+            app_obj.refresh
+            app_obj.debug.should be_nil
+            last_response.status.should == 201
+          end
+        end
+
+        context "passing in nil" do
+          let(:app_obj) { Models::App.make(:debug => "run") }
+
+          let(:update_hash) do
+            {"debug" => nil}
+          end
+
+          it "should do nothing" do
+            subject
+            app_obj.refresh
+            app_obj.debug.should == "run"
+            last_response.status.should == 201
+          end
+        end
+      end
+
+        
       context "when detected buildpack is not provided" do
         let(:update_hash) do
           {}


### PR DESCRIPTION
Currently it is not possible with CF and cloud controller to turn off debug mode.  I think this is a caused by a misunderstanding in the debug change api between cf and the cloud controller.

Since I cannot find any specification I'm going to assume that the cloud controller is correct.  So I've created some tests to help solidify what the api is.
