### PR TITLE
Rename indexes and fks to support Oracle's 30 char restriction

### DIFF
--- a/db/migrations/20130131184954_new_initial_schema.rb
+++ b/db/migrations/20130131184954_new_initial_schema.rb
@@ -30,7 +30,7 @@ Sequel.migration do
     # We don't use foreign keys here because the objects may get deleted after
     # the billing records are generated, and that should be allowed.
     create_table :billing_events do
-      VCAP::Migration.common(self)
+      VCAP::Migration.common(self, :be)
       DateTime :timestamp, :null => false
       String :kind, :null => false
       String :organization_guid, :null => false
@@ -56,7 +56,7 @@ Sequel.migration do
     end
 
     create_table :quota_definitions do
-      VCAP::Migration.common(self)
+      VCAP::Migration.common(self, :qd)
 
       String :name, :null => false, :unique => true, :case_insensitive => true
       Boolean :non_basic_services_allowed, :null => false
@@ -67,7 +67,7 @@ Sequel.migration do
     end
 
     create_table :service_auth_tokens do
-      VCAP::Migration.common(self)
+      VCAP::Migration.common(self, :sat)
 
       String :label,         :null => false, :case_insensitive => true
       String :provider,      :null => false, :case_insensitive => true
@@ -244,7 +244,7 @@ Sequel.migration do
     end
 
     create_table :service_instances do
-      VCAP::Migration.common(self)
+      VCAP::Migration.common(self, :si)
 
       String :name, :null => false, :case_insensitive => true
       String :credentials, :null => false, :size => 2048
@@ -283,11 +283,11 @@ Sequel.migration do
 
     # Organization permissions
     [:users, :managers, :billing_managers, :auditors].each do |perm|
-      VCAP::Migration.create_permission_table(self, :organization, perm)
+      VCAP::Migration.create_permission_table(self, :organization, :org, perm)
     end
 
     create_table(:service_bindings) do
-      VCAP::Migration.common(self)
+      VCAP::Migration.common(self, :sb)
 
       String :credentials, :null => false, :size => 2048
       String :binding_options
@@ -307,7 +307,7 @@ Sequel.migration do
 
     # App Space permissions
     [:developers, :managers, :auditors].each do |perm|
-      VCAP::Migration.create_permission_table(self, :space, perm)
+      VCAP::Migration.create_permission_table(self, :space, :space, perm)
     end
   end
 end

--- a/db/migrations/20130611175239_create_service_plan_visibilities_table.rb
+++ b/db/migrations/20130611175239_create_service_plan_visibilities_table.rb
@@ -1,7 +1,7 @@
 Sequel.migration do
   change do
     create_table :service_plan_visibilities do
-      VCAP::Migration.common(self)
+      VCAP::Migration.common(self, :spv)
       Integer :service_plan_id, null: false
       Integer :organization_id, null: false
       index [:organization_id, :service_plan_id], unique: true

--- a/db/migrations/20130730000217_create_service_brokers_table.rb
+++ b/db/migrations/20130730000217_create_service_brokers_table.rb
@@ -1,7 +1,7 @@
 Sequel.migration do
   change do
     create_table :service_brokers do
-      VCAP::Migration.common(self)
+      VCAP::Migration.common(self, :sbrokers)
       String :name,        :null => false
       String :broker_url, :null => false
       String :token,       :null => false

--- a/db/migrations/20130806175100_support_30char_identifiers_for_oracle.rb
+++ b/db/migrations/20130806175100_support_30char_identifiers_for_oracle.rb
@@ -1,0 +1,149 @@
+# Copyright (c) 2009-2012 VMware, Inc.
+
+def rename_foreign_key_internal(db, alter_table, table, current_name, new_name, &block)
+  processed = false
+  db.foreign_key_list(table).each do |fk|
+    if fk[:name] && fk[:name] == current_name
+      alter_table.drop_constraint current_name, :type => :foreign_key
+      block.call(db, alter_table) unless block.nil?
+      alter_table.add_foreign_key fk[:columns], fk[:table], :name => new_name
+      processed = true
+    end
+  end
+  #Since Sqlite doesn't return fk names let's just not rename them but still rename the nested index.
+  if !processed
+    block.call(db, alter_table) unless block.nil?
+  end
+end
+
+def rename_foreign_key(table, current_name, new_name, &block)
+  db = self
+  alter_table table do
+    rename_foreign_key_internal(db, self, table, current_name, new_name, &block)
+  end
+end
+
+def rename_index_internal(db, alter_table, table, columns, opts = {})
+  columns = [columns] unless columns.is_a?(Array)
+  db.indexes(table).each do | name, index |
+    if ((index[:columns] - columns).empty? &&
+        (columns - index[:columns]).empty? &&
+        name != opts[:name])
+      alter_table.drop_index columns
+      alter_table.add_index columns, opts
+      break
+    end
+  end
+end
+
+def rename_index(table, columns, opts = {})
+  db = self
+  alter_table table do
+    rename_index_internal(db, self, table, columns, opts)
+  end
+end
+
+def rename_common_indexes(table, table_key)
+  rename_index(table, :created_at, :name => "#{table_key}_created_at_index".to_sym)
+  rename_index(table, :updated_at, :name => "#{table_key}_updated_at_index".to_sym)
+  rename_index(table, :guid, :unique => true, :name => "#{table_key}_guid_index".to_sym)
+end
+
+def rename_permission_table(name, name_short, permission)
+  name = name.to_s
+  join_table = "#{name.pluralize}_#{permission}".to_sym
+  join_table_short = "#{name_short}_#{permission}".to_sym
+  id_attr = "#{name}_id".to_sym
+  idx_name = "#{name_short}_#{permission}_idx".to_sym
+  fk_name = "#{join_table}_#{name}_fk".to_sym
+  fk_user = "#{join_table}_user_fk".to_sym
+  fk_name_short = "#{join_table_short}_#{name_short}_fk".to_sym
+  fk_user_short = "#{join_table_short}_user_fk".to_sym
+
+  rename_foreign_key(join_table, fk_name, fk_name_short) do | db, alter_table |
+    rename_foreign_key_internal(db, alter_table, join_table, fk_user, fk_user_short) do | db, alter_table |
+      rename_index_internal(db, alter_table, join_table, [id_attr, :user_id], :unique => true, :name => idx_name)
+    end
+  end
+end
+
+Sequel.migration do
+  up do
+    rename_foreign_key(:organizations, :fk_organizations_quota_definition_id, :fk_org_quota_definition_id)
+    rename_foreign_key(:domains, :fk_domains_owning_organization_id, :fk_domains_owning_org_id)
+    rename_foreign_key(:domains_organizations, :fk_domains_organizations_organization_id, :fk_domains_orgs_org_id)
+    rename_foreign_key(:service_instances, :service_instances_service_plan_id, :svc_instances_service_plan_id)
+
+    #Where indexes and fk cross mysql requires that the fk be dropped before the index is dropped
+    rename_foreign_key(:service_plans, :fk_service_plans_service_id, :fk_service_plans_service_id) do | db, alter_table |
+      rename_index_internal(db, alter_table, :service_plans, [:service_id, :name], :unique => true, :name => :svc_plan_svc_id_name_index)
+    end
+    rename_foreign_key(:spaces, :fk_spaces_organization_id, :fk_spaces_organization_id) do | db, alter_table |
+      rename_index_internal(db, alter_table, :spaces, [:organization_id, :name], :unique => true, :name => :spaces_org_id_name_index)
+    end
+    rename_foreign_key(:domains_organizations, :fk_domains_organizations_domain_id, :fk_domains_orgs_domain_id) do | db, alter_table |
+      rename_index_internal(db, alter_table, :domains_organizations, [:domain_id, :organization_id], :unique => true, :name => :do_domain_id_org_id_index)
+    end
+    rename_foreign_key(:domains_spaces, :fk_domains_spaces_space_id, :fk_domains_spaces_space_id) do | db, alter_table |
+      rename_foreign_key_internal(db, alter_table, :domains_spaces, :fk_domains_spaces_domain_id, :fk_domains_spaces_domain_id) do | db, alter_table |
+        rename_index_internal(db, alter_table, :domains_spaces, [:space_id, :domain_id], :unique => true, :name => :ds_space_id_domain_id_index)
+      end
+    end
+    rename_foreign_key(:service_instances, :service_instances_space_id, :service_instances_space_id) do | db, alter_table |
+      rename_index_internal(db, alter_table, :service_instances, [:space_id, :name], :unique => true, :name => :si_space_id_name_index)
+    end
+
+    rename_foreign_key(:apps_routes, :fk_apps_routes_app_id, :fk_apps_routes_app_id) do | db, alter_table |
+      rename_foreign_key_internal(db, alter_table, :apps_routes, :fk_apps_routes_route_id, :fk_apps_routes_route_id) do | db, alter_table |
+        rename_index_internal(db, alter_table, :apps_routes, [:app_id, :route_id], :unique => true, :name => :ar_app_id_route_id_index)
+      end
+    end
+
+    rename_foreign_key(:service_bindings, :fk_service_bindings_service_instance_id, :fk_sb_service_instance_id) do | db, alter_table |
+      rename_foreign_key_internal(db, alter_table, :service_bindings, :fk_service_bindings_app_id, :fk_service_bindings_app_id) do | db, alter_table |
+        rename_index_internal(db, alter_table, :service_bindings, [:app_id, :service_instance_id], :unique => true, :name => :sb_app_id_srv_inst_id_index)
+      end
+    end
+          
+    rename_index(:billing_events, :timestamp, :name => :be_event_timestamp_index)
+    rename_common_indexes(:billing_events, :be)
+    rename_index(:quota_definitions, :name, :unique => true, :name => :qd_name_index)
+    rename_common_indexes(:quota_definitions, :qd)
+    rename_index(:service_auth_tokens, [:label, :provider], :unique => true, :name => :sat_label_provider_index)
+    rename_common_indexes(:service_auth_tokens, :sat)
+    rename_index(:services, [:label, :provider], :unique => true, :name => :services_label_provider_index)
+    rename_index(:organizations, :name, :unique => true, :name => :organizations_name_index)
+    rename_index(:routes, [:host, :domain_id], :unique => true, :name => :routes_host_domain_id_index)
+    rename_common_indexes(:service_instances, :si)
+    rename_index(:service_instances, :name, :name => :service_instances_name_index)
+    rename_common_indexes(:service_bindings, :sb)
+
+    rename_foreign_key(:apps, :fk_apps_space_id, :fk_apps_space_id) do | db, alter_table |    
+      rename_index_internal(db, alter_table, :apps, [:space_id, :name, :not_deleted], :unique => true, :name => :apps_space_id_name_nd_idx)
+    end
+
+    rename_index(:service_instances, :gateway_name, :name => :si_gateway_name_index)
+   
+    rename_foreign_key(:service_plan_visibilities, :fk_service_plan_visibilities_organization_id, :fk_spv_organization_id) do | db, alter_table |
+      rename_foreign_key_internal(db, alter_table, :service_plan_visibilities, :fk_service_plan_visibilities_service_plan_id, :fk_spv_service_plan_id) do | db, alter_table |
+        rename_index_internal(db, alter_table, :service_plan_visibilities, [:organization_id, :service_plan_id], unique: true, :name => :spv_org_id_sp_id_index)
+      end
+    end
+    
+    rename_common_indexes(:service_plan_visibilities, :spv)
+    rename_common_indexes(:service_brokers, :sbrokers)
+    rename_index(:service_brokers, :broker_url, :unique => true, :name => :sb_broker_url_index)
+          
+    [:users, :managers, :billing_managers, :auditors].each do |perm|
+      rename_permission_table(:organization, :org, perm)
+    end
+
+    [:developers, :managers, :auditors].each do |perm|
+      rename_permission_table(:space, :space, perm)
+    end
+  end
+
+  down do
+    raise Sequel::Error, "This migration cannot be reversed since we don't know if 'timestamp' and the fks were renamed originally."
+  end
+end

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -124,41 +124,45 @@ end
 # the migration methods.
 module VCAP
   module Migration
-    def self.timestamps(migration)
+    def self.timestamps(migration, table_key)
+      created_at_idx = "#{table_key}_created_at_index".to_sym if table_key
+      updated_at_idx = "#{table_key}_updated_at_index".to_sym if table_key
       migration.Timestamp :created_at, :null => false
       migration.Timestamp :updated_at
-
-      migration.index :created_at
-      migration.index :updated_at
+      migration.index :created_at, :name => created_at_idx
+      migration.index :updated_at, :name => updated_at_idx
     end
 
-    def self.guid(migration)
+    def self.guid(migration, table_key)
+      guid_idx = "#{table_key}_guid_index".to_sym if table_key
       migration.String :guid, :null => false
-      migration.index :guid, :unique => true
+      migration.index :guid, :unique => true, :name => guid_idx
     end
 
-    def self.common(migration)
+    def self.common(migration, table_key = nil)
       migration.primary_key :id
-      guid(migration)
-      timestamps(migration)
+      guid(migration, table_key)
+      timestamps(migration, table_key)
     end
 
-    def self.create_permission_table(migration, name, permission)
+    def self.create_permission_table(migration, name, name_short, permission)
       name = name.to_s
       join_table = "#{name.pluralize}_#{permission}".to_sym
+      join_table_short = "#{name_short}_#{permission}".to_sym
       id_attr = "#{name}_id".to_sym
-      fk_name = "#{join_table}_#{name}_fk".to_sym
-      fk_user = "#{join_table}_user_fk".to_sym
+      idx_name = "#{name_short}_#{permission}_idx".to_sym
+      fk_name = "#{join_table_short}_#{name_short}_fk".to_sym
+      fk_user = "#{join_table_short}_user_fk".to_sym
       table = name.pluralize.to_sym
-
+    
       migration.create_table(join_table) do
         Integer id_attr, :null => false
         foreign_key [id_attr], table, :name => fk_name
-
+    
         Integer :user_id, :null => false
         foreign_key [:user_id], :users, :name => fk_user
-
-        index [id_attr, :user_id], :unique => true
+    
+        index [id_attr, :user_id], :unique => true, :name => idx_name
       end
     end
   end

--- a/spec/db/db_standards_spec.rb
+++ b/spec/db/db_standards_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+describe "DB Schema" do
+  context "To support Oracle" do
+    $spec_env.db.tables.each do |table|
+      
+      it "the table #{table}'s name should not be longer than 30 characters" do
+        table.length.should <= 30
+      end
+      
+      $spec_env.db.schema(table).each do |column|
+        it "the column #{table}.#{column}'s name should not be longer than 30 characters" do          
+          column[0].length.should <= 30
+        end
+      end if $spec_env.db.supports_schema_parsing?
+
+      $spec_env.db.foreign_key_list(table).each do |fk|
+        it "the foreign key #{table}.#{fk[:name]}'s name should not be longer than 30 characters" do
+          fk[:name].length.should <= 30
+        end unless fk[:name].nil?
+      end if $spec_env.db.supports_foreign_key_parsing?
+
+      $spec_env.db.indexes(table).each do |name,index|
+        it "the index #{table}.#{name}'s name should not be longer than 30 characters" do
+          name.length.should <= 30
+        end
+      end if $spec_env.db.supports_index_parsing?
+    end if $spec_env.db.supports_table_listing? 
+  end 
+end


### PR DESCRIPTION
This is the beginning of try 2 at oracle support in the cloud controller.  For more information see the old oracle PRs:
- https://github.com/cloudfoundry/cloud_controller_ng/pull/44
- https://github.com/cloudfoundry/cloud_controller_ng/pull/47
- https://github.com/cloudfoundry/cloud_controller_ng/pull/46
- https://github.com/cloudfoundry/cloud_controller_ng/pull/42
- https://github.com/cloudfoundry/cloud_controller_ng/pull/41
- https://github.com/cloudfoundry/cloud_controller_ng/pull/38

This time my team has loose timelines requirements so I plan to do this one step/PR at a time.

This PR only renames the indexes and fks to a length of < 30 chars.  I've also provided tests that ensure nothing is adding in the future longer than 30 chars so I don't have to continually chase other migration changes.

Once this PR is accepted then I'll move onto another aspect of the integration.
