### PR TITLE
Rename all "timestamp" columns.  Timestamp is a reserved word in Oracle.

### DIFF
--- a/app/controllers/core/app_events_controller.rb
+++ b/app/controllers/core/app_events_controller.rb
@@ -17,6 +17,6 @@ module VCAP::CloudController
       attribute :timestamp, String
     end
 
-    query_parameters :timestamp, :app_guid
+    query_parameters({:timestamp => :event_timestamp}, :app_guid)
   end
 end

--- a/app/controllers/core/billing_events_controller.rb
+++ b/app/controllers/core/billing_events_controller.rb
@@ -16,7 +16,7 @@ module VCAP::CloudController
         raise Errors::BillingEventQueryInvalid
       end
 
-      ds = model.user_visible.filter(:timestamp => start_time..end_time)
+      ds = model.user_visible.filter(:event_timestamp => start_time..end_time)
       RestController::Paginator.render_json(self.class, ds, self.class.path,
                                             @opts.merge(:serialization => serialization))
     end

--- a/app/models/core/app_event.rb
+++ b/app/models/core/app_event.rb
@@ -1,6 +1,8 @@
 module VCAP::CloudController::Models
   class AppEvent < Sequel::Model
     many_to_one :app
+    
+    def_column_alias :timestamp, :event_timestamp
 
     export_attributes :app_guid, :instance_guid, :instance_index, :exit_status, :exit_description, :timestamp
     import_attributes :app_guid, :instance_guid, :instance_index, :exit_status, :exit_description, :timestamp

--- a/app/models/core/billing_event.rb
+++ b/app/models/core/billing_event.rb
@@ -3,6 +3,8 @@
 module VCAP::CloudController::Models
   class BillingEvent < Sequel::Model
     plugin :single_table_inheritance, :kind
+    
+    def_column_alias :timestamp, :event_timestamp
 
     def validate
       validates_presence :timestamp

--- a/app/models/core/event.rb
+++ b/app/models/core/event.rb
@@ -1,6 +1,8 @@
 module VCAP::CloudController::Models
   class Event < Sequel::Model
     plugin :serialization
+    
+    def_column_alias :timestamp, :event_timestamp
 
     many_to_one :space
 

--- a/db/migrations/20130806175100_support_30char_identifiers_for_oracle.rb
+++ b/db/migrations/20130806175100_support_30char_identifiers_for_oracle.rb
@@ -144,6 +144,6 @@ Sequel.migration do
   end
 
   down do
-    raise Sequel::Error, "This migration cannot be reversed since we don't know if 'timestamp' and the fks were renamed originally."
+    raise Sequel::Error, "This migration cannot be reversed since we don't know if the common and permission table fk and indexes were renamed previously."
   end
 end

--- a/db/migrations/20130808164924_rename_timestamp_columns_for_oracle.rb
+++ b/db/migrations/20130808164924_rename_timestamp_columns_for_oracle.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  change do
+    rename_column(:billing_events, :timestamp, :event_timestamp)
+
+    rename_column(:app_events, :timestamp, :event_timestamp)
+
+    rename_column(:events, :timestamp, :event_timestamp)
+  end
+end

--- a/lib/cloud_controller/rest_controller/base.rb
+++ b/lib/cloud_controller/rest_controller/base.rb
@@ -213,7 +213,7 @@ module VCAP::CloudController::RestController
       # query parameter) for this rest/api endpoint.
       #
       # @param [Array] args One or more attributes that can be used
-      # as query parameters.
+      # as query parameters.  Supports a Hash for column aliases {:alias => :column}.
       #
       # @return [Set] If called with no arguments, returns the list
       # of query parameters.
@@ -222,7 +222,11 @@ module VCAP::CloudController::RestController
           @query_parameters ||= Set.new
         else
           @query_parameters ||= Set.new
-          @query_parameters |= Set.new(args.map { |a| a.to_s })
+          @query_parameters |= Set.new(args.map do |a|
+            param = a.to_s
+            param = {a.each_key.next.to_s => a.each_value.next} if a.is_a?(Hash)
+            param
+          end)
         end
       end
 

--- a/lib/vcap/rest_api/query.rb
+++ b/lib/vcap/rest_api/query.rb
@@ -81,13 +81,25 @@ module VCAP::RestAPI
         key, comparison, value = segment.split(/(:|>=|<=|<|>)/, 2)
 
         comparison = "=" if comparison == ":"
-
-        unless queryable_attributes.include?(key)
+        
+        unless valid_query_param?(key)
           raise VCAP::Errors::BadQueryParameter.new(key)
         end
 
-        [key.to_sym, comparison, value]
+        [query_column_name(key).to_sym, comparison, value]
       end
+    end
+    
+    def valid_query_param?(key)
+      !query_column_name(key).nil?
+    end
+    
+    def query_column_name(key)
+      queryable_attributes.each do | attribute |
+        return attribute if key == attribute
+        return attribute[key] if attribute.is_a?(Hash) && attribute.has_key?(key)
+      end
+      nil
     end
 
     def query_filter(key, comparison, val)

--- a/spec/db/db_standards_spec.rb
+++ b/spec/db/db_standards_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
-describe "DB Schema" do
-  context "To support Oracle" do
+describe "For the DB schema" do
+  context "to support Oracle" do
     $spec_env.db.tables.each do |table|
       
       it "the table #{table}'s name should not be longer than 30 characters" do
@@ -9,9 +9,14 @@ describe "DB Schema" do
       end
       
       $spec_env.db.schema(table).each do |column|
-        it "the column #{table}.#{column}'s name should not be longer than 30 characters" do          
+        it "the column #{table}.#{column[0]}'s name should not be longer than 30 characters" do          
           column[0].length.should <= 30
         end
+        
+        it "the column #{table}.#{column[0]} cannot be named 'timestamp'" do
+          column[0].should_not eq(:timestamp)
+        end
+        
       end if $spec_env.db.supports_schema_parsing?
 
       $spec_env.db.foreign_key_list(table).each do |fk|

--- a/spec/models/core/app_start_event_spec.rb
+++ b/spec/models/core/app_start_event_spec.rb
@@ -17,7 +17,7 @@ module VCAP::CloudController
         :app_instance_count,
       ],
       :db_required_attributes => [
-        :timestamp,
+        :event_timestamp,
         :organization_guid,
         :organization_name,
       ],

--- a/spec/models/core/app_stop_event_spec.rb
+++ b/spec/models/core/app_stop_event_spec.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
         :app_name,
       ],
       :db_required_attributes => [
-        :timestamp,
+        :event_timestamp,
         :organization_guid,
         :organization_name,
       ],

--- a/spec/models/services/service_create_event_spec.rb
+++ b/spec/models/services/service_create_event_spec.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
         :service_plan_name,
       ],
       :db_required_attributes => [
-        :timestamp,
+        :event_timestamp,
         :organization_guid,
         :organization_name,
       ],

--- a/spec/models/services/service_delete_event_spec.rb
+++ b/spec/models/services/service_delete_event_spec.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
         :service_instance_name,
       ],
       :db_required_attributes => [
-        :timestamp,
+        :event_timestamp,
         :organization_guid,
         :organization_name,
       ],

--- a/spec/rest_controller/base_spec.rb
+++ b/spec/rest_controller/base_spec.rb
@@ -10,6 +10,31 @@ describe VCAP::CloudController::RestController::Base do
   subject {
     VCAP::CloudController::RestController::Base.new(double(:config), logger, double(:env), double(:params, :[] => nil), double(:body))
   }
+  
+  describe "query_parameters" do
+    it "should convert symbols to strings" do
+      module VCAP::CloudController
+        rest_controller :SymbolToStrings do
+          query_parameters(:param1,:param2)
+          query_parameters.each do | a |
+            a.is_a?(String).should == true
+          end
+        end
+      end
+    end
+    
+    it "should convert the param of a Hash to string but not touch column" do
+      module VCAP::CloudController
+        rest_controller :HashSymbolsToStrings do
+          query_parameters({:param1 => :column1},{:param2 => :column2})
+          query_parameters.each do | a |
+            a.each_key.next.is_a?(String).should == true
+            a.each_value.next.is_a?(Symbol).should == true
+          end
+        end
+      end
+    end
+  end
 
   describe "#dispatch" do
     context "when the dispatch is succesful" do


### PR DESCRIPTION
This is Part 2 of commits to add support for Oracle to the Cloud Controller.

In this PR I am amending the Cloud Controller to not use columns named "timestamp" since timestamp is a reserved word in Oracle.

To accomplish this I:
- renamed the columns and added tests to ensure no columns named "timestamp" are added in the future.
- created Sequel aliases for those columns to maintain API compatibility.
- Added support for aliases to the query_parameters portion of the CC API query framework with appropriate tests.

Lets see if you can merge this one as quick as the last one. :)
