### PR TITLE
Remove the tag hash with the org and space from the start app message

### DIFF
--- a/lib/cloud_controller/dea/dea_client.rb
+++ b/lib/cloud_controller/dea/dea_client.rb
@@ -270,7 +270,6 @@ module VCAP::CloudController
         # TODO: add debug support
         {
           :droplet => app.guid,
-          :tags => {:space => app.space_guid, :organization => app.space.organization_guid},
           :name => app.name,
           :uris => app.uris,
           :prod => app.production,

--- a/spec/dea/dea_client_spec.rb
+++ b/spec/dea/dea_client_spec.rb
@@ -37,7 +37,6 @@ module VCAP::CloudController
         res = DeaClient.start_app_message(@app)
         res.should be_kind_of(Hash)
         res[:droplet].should == @app.guid
-        res[:tags].should == {space: @app.space_guid, organization: @app.space.organization_guid }
         res[:services].should be_kind_of(Array)
         res[:services].count.should == NUM_SVC_INSTANCES
         res[:services].first.should be_kind_of(Hash)


### PR DESCRIPTION
Remove the tag hash that contains the org and space from the start app message, since loggregator does not need the space and org anymore

Signed-off-by: Johannes Tuchscherer jtuchscherer@pivotallabs.com
