### PR TITLE
run bundle update. lockdown builder gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-gem "activesupport", "~> 3.0"
+gem "builder", "~> 3.0.0"
+gem "activesupport", "~> 3.2"
 gem "rake"
 gem "bcrypt-ruby"
 gem "eventmachine", "~> 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/cloudfoundry/vcap-common.git
-  revision: d42b6c8bb1d132e31335faad25f94c9286308d23
+  revision: 8afde2091ee1609a121285634e241bb46a6381e6
   specs:
     vcap_common (2.2.1)
       addressable (~> 2.2)
@@ -44,6 +44,7 @@ GIT
       squash_ruby
       steno
       thin
+      uuidtools
       vmstat (~> 2.0)
       yajl-ruby
 
@@ -73,8 +74,8 @@ GEM
       activesupport (>= 3.2)
       i18n
     arel (3.0.2)
-    backports (3.3.3)
-    bcrypt-ruby (3.1.1)
+    backports (3.3.4)
+    bcrypt-ruby (3.1.2)
     beefcake (0.3.7)
     builder (3.0.4)
     ci_reporter (1.9.0)
@@ -109,7 +110,7 @@ GEM
       eventmachine (>= 1.0.0.beta.4)
     eventmachine (1.0.3)
     excon (0.25.3)
-    fakefs (0.4.2)
+    fakefs (0.4.3)
     ffi (1.9.0)
     fluent-logger (0.4.6)
       msgpack (>= 0.4.4, < 0.6.0, != 0.5.3, != 0.5.2, != 0.5.1, != 0.5.0)
@@ -125,7 +126,7 @@ GEM
       nokogiri (~> 1.5)
       ruby-hmac
     formatador (0.2.4)
-    grape (0.5.0)
+    grape (0.6.0)
       activesupport
       builder
       hashie (>= 1.2.0)
@@ -135,13 +136,13 @@ GEM
       rack-accept
       rack-mount
       virtus
-    guard (1.8.2)
+    guard (1.8.3)
       formatador (>= 0.2.4)
-      listen (>= 1.0.0)
+      listen (~> 1.3)
       lumberjack (>= 1.0.2)
       pry (>= 0.9.10)
       thor (>= 0.14.6)
-    guard-rspec (3.0.2)
+    guard-rspec (3.0.3)
       guard (>= 1.8)
       rspec (~> 2.13)
     hashie (2.0.5)
@@ -150,11 +151,11 @@ GEM
     i18n (0.6.5)
     json (1.8.0)
     json_pure (1.8.0)
-    listen (1.3.0)
+    listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
-    loggregator_emitter (0.0.11.pre)
+    loggregator_emitter (0.0.12.pre)
       loggregator_messages (~> 0.0.1.pre)
     loggregator_messages (0.0.5.pre)
       beefcake (~> 0.3.7)
@@ -176,13 +177,13 @@ GEM
       thin (>= 1.4.1)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (2.6.8)
+    net-ssh (2.7.0)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
-    parallel (0.7.1)
-    parallel_tests (0.15.1)
+    parallel (0.8.3)
+    parallel_tests (0.15.4)
       parallel
-    pg (0.16.0)
+    pg (0.17.0)
     posix-spawn (0.3.6)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -199,7 +200,7 @@ GEM
       rack (>= 1.0)
     rake (10.1.0)
     rb-fsevent (0.9.3)
-    rb-inotify (0.9.1)
+    rb-inotify (0.9.2)
       ffi (>= 0.5.0)
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
@@ -213,7 +214,7 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.3)
     ruby-hmac (0.4.0)
-    safe_yaml (0.9.5)
+    safe_yaml (0.9.7)
     sequel (3.48.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
@@ -234,7 +235,7 @@ GEM
       tilt (~> 1.3)
     slop (3.4.6)
     sqlite3 (1.3.8)
-    squash_ruby (1.2.0)
+    squash_ruby (1.2.2)
       json
     steno (1.2.2)
       fluent-logger
@@ -248,6 +249,7 @@ GEM
     tilt (1.4.1)
     timecop (0.6.3)
     tzinfo (0.3.37)
+    uuidtools (2.1.4)
     virtus (0.5.5)
       backports (~> 3.3)
       descendants_tracker (~> 0.0.1)
@@ -261,9 +263,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 3.0)
+  activesupport (~> 3.2)
   allowy
   bcrypt-ruby
+  builder (~> 3.0.0)
   cf-message-bus!
   cf-uaa-lib (~> 1.3.7)!
   ci_reporter


### PR DESCRIPTION
also update activesupport to 3.2.x, otherwise
"bundle update" downgrades it.

locking down builder solves is of bundle update
failing to resolve dependencies.
