### PR TITLE
Update the Loggregator Emitter gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "stager-client", "~> 0.0.02", :git => "https://github.com/cloudfoundry/stage
 gem "cf-message-bus", :git => "https://github.com/cloudfoundry/cf-message-bus.git"
 gem "vcap_common", :git => "https://github.com/cloudfoundry/vcap-common.git"
 gem "allowy"
-gem "loggregator_emitter", "~> 0.0.13.pre"
+gem "loggregator_emitter", "~> 0.0.15.pre"
 gem "talentbox-delayed_job_sequel", "~> 4.0.0.beta1.1"
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
-    loggregator_emitter (0.0.13.pre)
+    loggregator_emitter (0.0.15.pre)
       beefcake (~> 0.3.7)
     lumberjack (1.0.4)
     machinist (1.0.6)
@@ -271,7 +271,7 @@ DEPENDENCIES
   fog
   guard-rspec
   httpclient
-  loggregator_emitter (~> 0.0.13.pre)
+  loggregator_emitter (~> 0.0.15.pre)
   machinist (~> 1.0.6)
   membrane (~> 0.0.2)
   mysql2


### PR DESCRIPTION
This update uses the loggregator_emitter gem that has inlined loggregator_messages.

@matthewmcnew / @caseymct
