### PR TITLE
fix clobbering app updates during staging

### DIFF
--- a/lib/cloud_controller/app_stager_task.rb
+++ b/lib/cloud_controller/app_stager_task.rb
@@ -53,8 +53,7 @@ module VCAP::CloudController
       # this cloud controller completes the staging.
       @current_droplet_hash = @app.droplet_hash
 
-      @app.staging_task_id = task_id
-      @app.save
+      @app.update(staging_task_id: task_id)
 
       @message_bus.publish("staging.stop", :app_id => @app.guid)
 
@@ -173,8 +172,7 @@ module VCAP::CloudController
     def staging_completion(stager_response)
       instance_was_started_by_dea = !!stager_response.droplet_hash
 
-      @app.detected_buildpack = stager_response.detected_buildpack
-      @app.save
+      @app.update(detected_buildpack: stager_response.detected_buildpack)
 
       DeaClient.dea_pool.mark_app_started(:dea_id => @stager_id, :app_id => @app.guid) if instance_was_started_by_dea
 

--- a/spec/app_stager_task_spec.rb
+++ b/spec/app_stager_task_spec.rb
@@ -261,7 +261,20 @@ module VCAP::CloudController
               end
 
               it "saves the detected buildpack" do
-                expect { stage }.to change { app.detected_buildpack }.from(nil)
+                expect { stage }.to change { app.refresh.detected_buildpack }.from(nil)
+              end
+
+              it "does not clobber other attributes that changed between staging" do
+                # fake out the app refresh as the race happens after it
+                app.stub(:refresh)
+
+                other_app_ref = App.find(guid: app.guid)
+                other_app_ref.command = "some other command"
+                other_app_ref.save
+
+                expect { stage }.to_not change {
+                  other_app_ref.refresh.command
+                }
               end
 
               it "marks app started in dea pool" do


### PR DESCRIPTION
There was a race between calling app.refresh and checking if the task is
current, and updating the detected buildpack attribute. It called .save, which
meant any changes that happend between there would get blown away.

This replaces .save usage with .update, which only updates the given
attributes.

[finishes #58774740]
