### PR TITLE
Allow Bootstrap CSS to load when API specs are run from disk

### DIFF
--- a/spec/api/templates/rspec_api_documentation/html_example.mustache
+++ b/spec/api/templates/rspec_api_documentation/html_example.mustache
@@ -3,7 +3,13 @@
   <head>
     <title>{{resource_name}} API</title>
     <meta charset="utf-8">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css"></link>
+    <link id="bootstrapcss" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css"></link>
+    <script>
+      if( "file:" == document.location.protocol ) {
+        var csslink = document.getElementById("bootstrapcss");
+        csslink.href = "http://" + csslink.href.replace(/.*\/\//, "");
+      }
+    </script>
     <style>
       p {
         padding: 15px;


### PR DESCRIPTION
Currently the Bootstrap CSS is loaded using a scheme-less URL, so
that it loads properly when the page is requested via HTTP and HTTPS.

This doesn't work when the page is accessed from a file URL (most commonly,
when you've just updated the API specs and want to preview them on
your local machine without spinning up a server).

This change adds a little javascript to change the link href so that
the CSS is loaded via http when the page is served from a file URL. 
(The CSS continues to load as normal via whatever scheme the rest of the page 
was loaded from when the page is served any other way).

Result: much prettier API specs when viewed locally. 
