### PR TITLE
Revert "Merge pull request #111 from cloudfoundry/fix_events_pagination"

### DIFF
--- a/lib/cloud_controller/rest_controller/paginator.rb
+++ b/lib/cloud_controller/rest_controller/paginator.rb
@@ -101,7 +101,7 @@ module VCAP::CloudController::RestController
       if @opts[:inline_relations_depth]
         res += "inline-relations-depth=#{@opts[:inline_relations_depth]}&"
       end
-      res += "q=#{URI.encode(@opts[:q])}&" if @opts[:q]
+      res += "q=#{@opts[:q]}&" if @opts[:q]
       res += "page=#{page}&results-per-page=#{@paginated.page_size}"
     end
   end

--- a/spec/controllers/runtime/events_controller_spec.rb
+++ b/spec/controllers/runtime/events_controller_spec.rb
@@ -182,7 +182,7 @@ module VCAP::CloudController
         get "/v2/events?q=timestamp%3E#{(base_timestamp + 50).utc.iso8601}", {}, admin_headers
         decoded_response["total_pages"].should == 2
         decoded_response["prev_url"].should be_nil
-        decoded_response["next_url"].should == "/v2/events?q=timestamp%3E#{(base_timestamp + 50).utc.iso8601}&page=2&results-per-page=50"
+        decoded_response["next_url"].should == "/v2/events?q=timestamp>#{(base_timestamp + 50).utc.iso8601}&page=2&results-per-page=50"
       end
     end
 


### PR DESCRIPTION
This reverts commit c8811691ca2ed64a46f3ef62438bfbbd2ea99167, reversing
changes made to 62e32be46aab3e95b3499a1ee67c9375889b030a.

Apologies for the double work. We have decided to do the URI escaping in the cfoundry gem.
