### PR TITLE
Openstack + HP fog provider blobstore support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "activesupport", "~> 3.0" # It looks like this is required for DelayedJob, e
 gem "rake"
 gem "bcrypt-ruby"
 gem "eventmachine", "~> 1.0.0"
-gem "fog"
+gem "fog", "~> 1.16.0"
 gem "rfc822"
 gem "sequel", "~> 3.48"
 gem "sinatra", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,15 +95,15 @@ GEM
     em-socksify (0.3.0)
       eventmachine (>= 1.0.0.beta.4)
     eventmachine (1.0.3)
-    excon (0.25.3)
+    excon (0.27.6)
     fakefs (0.4.2)
     ffi (1.9.0)
     fluent-logger (0.4.6)
       msgpack (>= 0.4.4, < 0.6.0, != 0.5.3, != 0.5.2, != 0.5.1, != 0.5.0)
       yajl-ruby (~> 1.0)
-    fog (1.15.0)
+    fog (1.16.0)
       builder
-      excon (~> 0.25.0)
+      excon (~> 0.27.0)
       formatador (~> 0.2.0)
       mime-types
       multi_json (~> 1.0)
@@ -111,6 +111,7 @@ GEM
       net-ssh (>= 2.1.3)
       nokogiri (~> 1.5)
       ruby-hmac
+      unicode (~> 0.4.4)
     formatador (0.2.4)
     grape (0.6.0)
       activesupport
@@ -150,7 +151,7 @@ GEM
     mime-types (1.25)
     mini_portile (0.5.1)
     msgpack (0.5.6)
-    multi_json (1.8.0)
+    multi_json (1.8.2)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
     mustache (0.99.4)
@@ -162,7 +163,7 @@ GEM
       thin (>= 1.4.1)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (2.6.8)
+    net-ssh (2.7.0)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     parallel (0.7.1)
@@ -245,6 +246,7 @@ GEM
     tilt (1.4.1)
     timecop (0.6.3)
     tzinfo (1.0.1)
+    unicode (0.4.4)
     uuidtools (2.1.4)
     virtus (0.5.5)
       backports (~> 3.3)
@@ -268,7 +270,7 @@ DEPENDENCIES
   debugger
   eventmachine (~> 1.0.0)
   fakefs
-  fog
+  fog (~> 1.16.0)
   guard-rspec
   httpclient
   loggregator_emitter (~> 1.0)

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -95,34 +95,19 @@ module VCAP::CloudController
           optional(:maximum_size) => Integer,
           optional(:minimum_size) => Integer,
           optional(:resource_directory_key) => String,
-          :fog_connection => {
-            :provider => String,
-            optional(:aws_access_key_id) => String,
-            optional(:aws_secret_access_key) => String,
-            optional(:local_root) => String
-          }
+          :fog_connection => Hash
         },
 
         :packages => {
           optional(:max_droplet_size) => Integer,
           optional(:app_package_directory_key) => String,
-          :fog_connection => {
-            :provider => String,
-            optional(:aws_access_key_id) => String,
-            optional(:aws_secret_access_key) => String,
-            optional(:local_root) => String
-          }
+          :fog_connection => Hash
         },
 
         :droplets => {
           optional(:max_droplet_size) => Integer,
           optional(:droplet_directory_key) => String,
-          :fog_connection => {
-            :provider => String,
-            optional(:aws_access_key_id) => String,
-            optional(:aws_secret_access_key) => String,
-            optional(:local_root) => String
-          }
+          :fog_connection => Hash
         },
 
         :db_encryption_key => String,


### PR DESCRIPTION
This PR updates the fog gem to 1.16.0 to support the openstack and hp provider additions in the new version. 

In addition it simplifies the config scheme for fog connections to allow to pass in any fog connection. It should be in the responsibility of the fog gem to ensure that the passed in configuration is valid.

@drnic : This implements the changes we discussed via email.
