### PR TITLE
Add package_state to App api.

### DIFF
--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -56,7 +56,7 @@ module VCAP::CloudController
       :space_guid, :stack_guid, :buildpack, :detected_buildpack,
       :environment_json, :memory, :instances, :disk_quota,
       :state, :version, :command, :console, :debug,
-      :staging_task_id
+      :staging_task_id, :package_state
 
     import_attributes :name, :production,
       :space_guid, :stack_guid, :buildpack, :detected_buildpack,

--- a/spec/api/apps_api_spec.rb
+++ b/spec/api/apps_api_spec.rb
@@ -35,6 +35,7 @@ resource "Apps", :type => :api do
   field :production, "Deprecated.", required: false, deprecated: true, default: true, valid_values: [true, false]
   field :console, "Open the console port for the app (at $CONSOLE_PORT).", required: false, deprecated: true, default: false, valid_values: [true, false]
   field :debug, "Open the debug port for the app (at $DEBUG_PORT).", required: false, deprecated: true, default: false, valid_values: [true, false]
+  field :package_state, "The current desired state of the package. One of PENDING, STAGED or FAILED.", required: false, readonly: true, valid_values: %w[PENDING STAGED FAILED]
 
   standard_model_list :app
   standard_model_get :app

--- a/spec/controllers/runtime/apps_controller_spec.rb
+++ b/spec/controllers/runtime/apps_controller_spec.rb
@@ -261,6 +261,20 @@ module VCAP::CloudController
         end
       end
 
+      context "when package_state is provided" do
+        before { update_hash[:package_state] = 'FAILED' }
+
+        it "ignores the attribute" do
+          update_app
+
+          last_response.status.should == 201
+
+          app_obj.reload
+          expect(app_obj.package_state).to_not be == 'FAILED'
+          expect(parse(last_response.body)["entity"]).not_to include("package_state" => "FAILED")
+        end
+      end
+
       context "when the app is already deleted" do
         before { app_obj.soft_delete }
 
@@ -344,6 +358,12 @@ module VCAP::CloudController
         get_app
         last_response.status.should == 200
         decoded_response["entity"]["detected_buildpack"].should eq("buildpack-name")
+      end
+
+      it "should return the package state" do
+        get_app
+        last_response.status.should == 200
+        expect(parse(last_response.body)["entity"]).to have_key("package_state")
       end
 
       context "when the app is already deleted" do


### PR DESCRIPTION
We need to be able to display the package_state for apps for use in an admin UI. This change exposes this additional field through the Cloud Controller api.

'package_state' will be returned by the API amongst the rest of the App details.
The package_state is read-only.

Travis build show as failing.....it actually passes for mysql but fails for postgres. I am trying to work out why, but i am not sure this is to do with my code, and actually might be to do with parallel processing of tests. Will update if I find anything but any guidance/comments would be much appreciated.
