### PR TITLE
Added the public attribute to the service_plans API response

### DIFF
--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
 
     default_order_by  :name
 
-    export_attributes :name, :free, :description, :service_guid, :extra, :unique_id
+    export_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public
 
     import_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public
 

--- a/spec/controllers/services/service_plans_controller_spec.rb
+++ b/spec/controllers/services/service_plans_controller_spec.rb
@@ -157,6 +157,16 @@ module VCAP::CloudController
         plan_guids.should include(private_plan.guid)
       end
     end
+
+    describe "public service plans" do
+      let!(:public_plan) { ServicePlan.make(public: true) }
+
+      it "should return correct visibility" do
+        get "/v2/service_plans/#{public_plan.guid}", {}, headers_for(developer)
+        last_response.status.should eq(200)
+        expect(parse(last_response.body)["entity"]).to include("public" => true)
+      end
+    end
   end
 
   describe "POST", "/v2/service_plans" do


### PR DESCRIPTION
We need the service plan API to return the visibility (whether it is public or not) in the response for a component we are writing.
This change adds the 'public' attribute to the response, and returns true or false accordingly
