### PR TITLE
Catch instances less than zero error

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -31,6 +31,7 @@ module VCAP::CloudController
     def self.translate_validation_exception(e, attributes)
       space_and_name_errors = e.errors.on([:space_id, :name])
       memory_quota_errors = e.errors.on(:memory)
+      instance_number_errors = e.errors.on(:instances)
 
       if space_and_name_errors && space_and_name_errors.include?(:unique)
         Errors::AppNameTaken.new(attributes["name"])
@@ -40,6 +41,8 @@ module VCAP::CloudController
         elsif memory_quota_errors.include?(:zero_or_less)
           Errors::AppMemoryInvalid.new
         end
+      elsif instance_number_errors
+        Errors::AppInvalid.new("Number of instances less than 0")
       else
         Errors::AppInvalid.new(e.errors.full_messages)
       end

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -123,6 +123,7 @@ module VCAP::CloudController
       validate_environment
       validate_metadata
       check_memory_quota
+      validate_instances
     end
 
     def before_create
@@ -280,10 +281,8 @@ module VCAP::CloudController
     end
 
     def additional_memory_requested
-      default_instances = db_schema[:instances][:default].to_i
 
-      num_instances = instances ? instances : default_instances
-      total_requested_memory = requested_memory * num_instances
+      total_requested_memory = requested_memory * requested_instances
 
       return total_requested_memory if new?
 
@@ -303,6 +302,17 @@ module VCAP::CloudController
 
       if space && (space.organization.memory_remaining < additional_memory_requested)
         errors.add(:memory, :quota_exceeded)
+      end
+    end
+
+    def requested_instances
+      default_instances = db_schema[:instances][:default].to_i
+      instances ? instances : default_instances
+    end
+
+    def validate_instances
+      if (requested_instances < 0)
+        errors.add(:instances, :less_than_zero)
       end
     end
 

--- a/spec/controllers/runtime/apps_controller_spec.rb
+++ b/spec/controllers/runtime/apps_controller_spec.rb
@@ -82,6 +82,18 @@ module VCAP::CloudController
         end
       end
 
+      context "when instances is less than 0" do
+        before do
+          initial_hash[:instances] = -1
+        end
+
+        it "responds invalid arguments" do
+          create_app
+          last_response.status.should == 400
+          last_response.body.should match /instances less than 0/
+        end
+      end
+
       context "when name is not provided" do
         let(:initial_hash) {{ :space_guid => space_guid }}
         it "responds with missing field name error" do

--- a/spec/models/runtime/app_spec.rb
+++ b/spec/models/runtime/app_spec.rb
@@ -1097,6 +1097,17 @@ module VCAP::CloudController
           expect { app.save }.to raise_error(Sequel::ValidationFailed, /quota_exceeded/)
           expect { app.delete }.not_to raise_error
         end
+
+        it "should raise an error if instances is less than zero" do
+          org = Organization.make(:quota_definition => quota)
+          space = Space.make(:organization => org)
+          app = AppFactory.make(:space => space,
+                                :memory => 64,
+                                :instances => 1)
+
+          app.instances = -1
+          expect { app.save }.to raise_error(Sequel::ValidationFailed, /instances less_than_zero/)
+        end
       end
     end
 


### PR DESCRIPTION
This change prevents the number of App instances being set to a negative number, which can currently happen when using 'cf scale' for example.

This defect was initially reported back in September, exposed by a defect in a gradle plugin.
