### PR TITLE
Consider available disk before deciding where to start app.

### DIFF
--- a/lib/cloud_controller/dea/dea_client.rb
+++ b/lib/cloud_controller/dea/dea_client.rb
@@ -142,7 +142,7 @@ module VCAP::CloudController
         message = start_app_message(app)
         message[:index] = index
 
-        dea_id = dea_pool.find_dea(app.memory, app.stack.name, app.guid)
+        dea_id = dea_pool.find_dea(mem: app.memory, disk: app.disk_quota, stack: app.stack.name, app_id: app.guid)
         if dea_id
           dea_publish_start(dea_id, message)
           dea_pool.mark_app_started(dea_id: dea_id, app_id: app.guid)

--- a/lib/cloud_controller/dea/dea_pool.rb
+++ b/lib/cloud_controller/dea/dea_pool.rb
@@ -38,13 +38,14 @@ module VCAP::CloudController
       end
     end
 
-    def find_dea(mem, stack, app_id)
+    def find_dea(criteria)
       mutex.synchronize do
         prune_stale_deas
 
         best_dea_ad = EligibleDeaAdvertisementFilter.new(@dea_advertisements).
-                       only_meets_needs(mem, stack).
-                       only_fewest_instances_of_app(app_id).
+                       only_with_disk(criteria[:disk] || 0).
+                       only_meets_needs(criteria[:mem], criteria[:stack]).
+                       only_fewest_instances_of_app(criteria[:app_id]).
                        upper_half_by_memory.
                        sample
 

--- a/lib/cloud_controller/dea/eligible_dea_advertisement_filter.rb
+++ b/lib/cloud_controller/dea/eligible_dea_advertisement_filter.rb
@@ -3,6 +3,11 @@ class EligibleDeaAdvertisementFilter
     @dea_advertisements = dea_advertisements.dup
   end
 
+  def only_with_disk(minimum_disk)
+    @dea_advertisements.select! { |ad| ad.has_sufficient_disk?(minimum_disk) }
+    self
+  end
+
   def only_meets_needs(mem, stack)
     @dea_advertisements.select! { |ad| ad.meets_needs?(mem, stack) }
     self

--- a/lib/cloud_controller/nats_messages/advertisment.rb
+++ b/lib/cloud_controller/nats_messages/advertisment.rb
@@ -12,6 +12,10 @@ class Advertisement
     stats["available_memory"]
   end
 
+  def available_disk
+    stats["available_disk"]
+  end
+
   def expired?
     (Time.now.to_i - @updated_at.to_i) > ADVERTISEMENT_EXPIRATION
   end
@@ -26,5 +30,10 @@ class Advertisement
 
   def has_sufficient_memory?(mem)
     available_memory >= mem
+  end
+
+  def has_sufficient_disk?(disk)
+    return true unless available_disk
+    available_disk >= disk
   end
 end

--- a/spec/dea/dea_client_spec.rb
+++ b/spec/dea/dea_client_spec.rb
@@ -172,6 +172,20 @@ module VCAP::CloudController
 
         DeaClient.start(app)
       end
+
+      it "includes memory in find_dea request" do
+        app.instances = 1
+        app.memory = 512
+        dea_pool.should_receive(:find_dea).with(include(mem: 512))
+        DeaClient.start(app)
+      end
+
+      it "includes disk in find_dea request" do
+        app.instances = 1
+        app.disk_quota = 13
+        dea_pool.should_receive(:find_dea).with(include(disk: 13))
+        DeaClient.start(app)
+      end
     end
 
     describe "stop_indices" do

--- a/spec/dea/dea_pool_spec.rb
+++ b/spec/dea/dea_pool_spec.rb
@@ -27,7 +27,7 @@ module VCAP::CloudController
       it "finds advertised dea" do
         subject.register_subscriptions
         message_bus.publish("dea.advertise", dea_advertise_msg)
-        subject.find_dea(1, "stack", "app-id").should == "dea-id"
+        subject.find_dea(mem: 1, stack: "stack", app_id: "app-id").should == "dea-id"
       end
 
       it "clears advertisements of DEAs being shut down" do
@@ -35,7 +35,7 @@ module VCAP::CloudController
         message_bus.publish("dea.advertise", dea_advertise_msg)
         message_bus.publish("dea.shutdown", dea_shutdown_msg)
 
-        subject.find_dea(1, "stack", "app-id").should be_nil
+        subject.find_dea(mem: 1, stack: "stack", app_id: "app-id").should be_nil
       end
     end
 
@@ -45,16 +45,20 @@ module VCAP::CloudController
           "id" => "dea-id",
           "stacks" => ["stack"],
           "available_memory" => 1024,
+          "available_disk" => available_disk,
           "app_id_to_count" => {
             "other-app-id" => 1
           }
         }
       end
+
+      let(:available_disk) { 100 }
+
       describe "dea availability" do
         it "only finds registered deas" do
           expect {
             subject.process_advertise_message(dea_advertise_msg)
-          }.to change { subject.find_dea(1, "stack", "app-id") }.from(nil).to("dea-id")
+          }.to change { subject.find_dea(mem: 1, stack: "stack", app_id: "app-id") }.from(nil).to("dea-id")
         end
       end
 
@@ -64,10 +68,10 @@ module VCAP::CloudController
             subject.process_advertise_message(dea_advertise_msg)
 
             Timecop.travel(9)
-            subject.find_dea(1024, "stack", "app-id").should == "dea-id"
+            subject.find_dea(mem: 1024, stack: "stack", app_id: "app-id").should == "dea-id"
 
             Timecop.travel(2)
-            subject.find_dea(1024, "stack", "app-id").should be_nil
+            subject.find_dea(mem: 1024, stack: "stack", app_id: "app-id").should be_nil
           end
         end
       end
@@ -75,16 +79,34 @@ module VCAP::CloudController
       describe "memory capacity" do
         it "only finds deas that can satisfy memory request" do
           subject.process_advertise_message(dea_advertise_msg)
-          subject.find_dea(1025, "stack", "app-id").should be_nil
-          subject.find_dea(1024, "stack", "app-id").should == "dea-id"
+          subject.find_dea(mem: 1025, stack: "stack", app_id: "app-id").should be_nil
+          subject.find_dea(mem: 1024, stack: "stack", app_id: "app-id").should == "dea-id"
+        end
+      end
+
+      describe "disk capacity" do
+        context "when the disk capacity is not available" do
+          let(:available_disk) { 0 }
+          it "it doesn't find any deas" do
+            subject.process_advertise_message(dea_advertise_msg)
+            subject.find_dea(mem: 1024, disk: 10, stack: "stack", app_id: "app-id").should be_nil
+          end
+        end
+
+        context "when the disk capacity is available" do
+          let(:available_disk) { 50 }
+          it "finds the DEA" do
+            subject.process_advertise_message(dea_advertise_msg)
+            subject.find_dea(mem: 1024, disk: 10, stack: "stack", app_id: "app-id").should == "dea-id"
+          end
         end
       end
 
       describe "stacks availability" do
         it "only finds deas that can satisfy stack request" do
           subject.process_advertise_message(dea_advertise_msg)
-          subject.find_dea(0, "unknown-stack", "app-id").should be_nil
-          subject.find_dea(0, "stack", "app-id").should == "dea-id"
+          subject.find_dea(mem: 0, stack: "unknown-stack", app_id: "app-id").should be_nil
+          subject.find_dea(mem: 0, stack: "stack", app_id: "app-id").should == "dea-id"
         end
       end
 
@@ -100,8 +122,8 @@ module VCAP::CloudController
         end
 
         it "picks DEAs that have no existing instances of the app" do
-          subject.find_dea(1, "stack", "app-id").should == "dea-id"
-          subject.find_dea(1, "stack", "other-app-id").should == "other-dea-id"
+          subject.find_dea(mem: 1, stack: "stack", app_id: "app-id").should == "dea-id"
+          subject.find_dea(mem: 1, stack: "stack", app_id: "other-app-id").should == "other-dea-id"
         end
       end
 
@@ -124,7 +146,7 @@ module VCAP::CloudController
           it "randomly picks one of the eligible DEAs" do
             found_dea_ids = []
             20.times do
-              found_dea_ids << subject.find_dea(1, "stack", "app-id")
+              found_dea_ids << subject.find_dea(mem: 1, stack: "stack", app_id: "app-id")
             end
 
             found_dea_ids.uniq.should =~ %w(dea-id1 dea-id2)
@@ -145,7 +167,7 @@ module VCAP::CloudController
             it "always picks the one with the greater memory" do
               found_dea_ids = []
               20.times do
-                found_dea_ids << subject.find_dea(1, "stack", "app-id")
+                found_dea_ids << subject.find_dea(mem: 1, stack: "stack", app_id: "app-id")
               end
 
               found_dea_ids.uniq.should =~ %w(dea-id1)
@@ -168,7 +190,7 @@ module VCAP::CloudController
             it "always picks from the half of the list (rounding up) with greater memory" do
               found_dea_ids = []
               40.times do
-                found_dea_ids << subject.find_dea(1, "stack", "app-id")
+                found_dea_ids << subject.find_dea(mem: 1, stack: "stack", app_id: "app-id")
               end
 
               found_dea_ids.uniq.should =~ %w(dea-id1 dea-id2 dea-id3)
@@ -197,7 +219,7 @@ module VCAP::CloudController
         it "will use different DEAs when starting an app with multiple instances" do
           dea_ids = []
           10.times do
-            dea_id = subject.find_dea(0, "stack", "app-id")
+            dea_id = subject.find_dea(mem: 0, stack: "stack", app_id: "app-id")
             dea_ids << dea_id
             subject.mark_app_started(dea_id: dea_id, app_id: "app-id")
           end
@@ -218,7 +240,7 @@ module VCAP::CloudController
             next_advertisement["available_memory"] = 0
             subject.process_advertise_message(next_advertisement)
 
-            subject.find_dea(64, "stack", "foo").should be_nil
+            subject.find_dea(mem: 64, stack: "stack", app_id: "foo").should be_nil
           end
         end
       end

--- a/spec/nats_messages/dea_advertisment_spec.rb
+++ b/spec/nats_messages/dea_advertisment_spec.rb
@@ -7,6 +7,7 @@ describe DeaAdvertisement do
       "id" => "staging-id",
       "stacks" => ["stack-name"],
       "available_memory" => 1024,
+      "available_disk" => 756,
       "app_id_to_count" => {
         "app_id" => 2,
         "app_id_2" => 1
@@ -26,6 +27,10 @@ describe DeaAdvertisement do
 
   describe "#available_memory" do
     its(:available_memory) { should eq 1024 }
+  end
+
+  describe "#available_disk" do
+    its(:available_disk) { should eq 756 }
   end
 
   describe "#expired?" do
@@ -93,6 +98,28 @@ describe DeaAdvertisement do
     context "when the dea has enough memory" do
       it "returns false" do
         expect(ad.has_sufficient_memory?(512)).to be_true
+      end
+    end
+  end
+
+  describe "#has_sufficient_disk?" do
+    context "when the dea does not have enough disk" do
+      it "returns false" do
+        expect(ad.has_sufficient_disk?(2048)).to be_false
+      end
+    end
+
+    context "when the dea does have enough disk" do
+      it "returns false" do
+        expect(ad.has_sufficient_disk?(512)).to be_true
+      end
+    end
+
+    context "when the dea does not report disk space" do
+      before { message.delete "available_disk" }
+
+      it "always returns true" do
+        expect(ad.has_sufficient_disk?(4096 * 10)).to be_true
       end
     end
   end


### PR DESCRIPTION
CC currently assumes that if a DEA has enough memory, it has enough disk
space. This doesn't work in all cases, especially with larger build packs
or apps with larger disk_quota settings. This change considers the
available disk space on a DEA before making the placement decision.

We had many problems starting apps when a DEA which had enough memory but
had run out of reservable disk space would often get chosen to start an app and
immediately fail when it attempted to reserve the resources.

This commit relies on an available_disk key having been added to the advertisement (see  https://github.com/cloudfoundry/dea_ng/pull/77 ). 
However if the key isn't there, it will revert to the old behaviour, so there's no need
to bump both modules at the same time.
