### PR TITLE
Add HA enhancement with simple availability zone algorism

### DIFF
--- a/lib/cloud_controller/dea/dea_pool.rb
+++ b/lib/cloud_controller/dea/dea_pool.rb
@@ -42,10 +42,11 @@ module VCAP::CloudController
       mutex.synchronize do
         prune_stale_deas
 
-        best_dea_ad = EligibleDeaAdvertisementFilter.new(@dea_advertisements).
+        best_dea_ad = EligibleDeaAdvertisementFilter.new(@dea_advertisements, criteria[:app_id]).
                        only_with_disk(criteria[:disk] || 0).
                        only_meets_needs(criteria[:mem], criteria[:stack]).
-                       only_fewest_instances_of_app(criteria[:app_id]).
+                       only_in_zone_with_fewest_instances.
+                       only_fewest_instances_of_app.
                        upper_half_by_memory.
                        sample
 

--- a/lib/cloud_controller/dea/eligible_dea_advertisement_filter.rb
+++ b/lib/cloud_controller/dea/eligible_dea_advertisement_filter.rb
@@ -1,6 +1,8 @@
 class EligibleDeaAdvertisementFilter
-  def initialize(dea_advertisements)
+  def initialize(dea_advertisements, app_id)
+    @all_advertisements = dea_advertisements
     @dea_advertisements = dea_advertisements.dup
+    @app_id = app_id
   end
 
   def only_with_disk(minimum_disk)
@@ -13,9 +15,9 @@ class EligibleDeaAdvertisementFilter
     self
   end
 
-  def only_fewest_instances_of_app(app_id)
-    fewest_instances_of_app = @dea_advertisements.map { |ad| ad.num_instances_of(app_id) }.min
-    @dea_advertisements.select! { |ad| ad.num_instances_of(app_id) == fewest_instances_of_app }
+  def only_fewest_instances_of_app()
+    fewest_instances_of_app = @dea_advertisements.map { |ad| ad.num_instances_of(@app_id) }.min
+    @dea_advertisements.select! { |ad| ad.num_instances_of(@app_id) == fewest_instances_of_app }
     self
   end
 
@@ -31,5 +33,21 @@ class EligibleDeaAdvertisementFilter
 
   def sample
     @dea_advertisements.sample
+  end
+
+  def only_in_zone_with_fewest_instances()
+    min_in_zone = @dea_advertisements.map { |ad| number_in_zone(ad.zone) }.min
+    @dea_advertisements.select! { |ad| number_in_zone(ad.zone) == min_in_zone }
+    self
+  end
+
+  private
+
+  def number_in_zone(zone)
+    @_numinzone ||= {}
+    @_numinzone[zone] ||= @all_advertisements.inject(0) do |count, ad|
+      count += ad.num_instances_of(@app_id) if ad.zone == zone
+      count
+    end
   end
 end

--- a/lib/cloud_controller/nats_messages/dea_advertisment.rb
+++ b/lib/cloud_controller/nats_messages/dea_advertisment.rb
@@ -12,4 +12,8 @@ class DeaAdvertisement < Advertisement
   def num_instances_of(app_id)
     stats["app_id_to_count"].fetch(app_id, 0)
   end
+
+  def zone
+    stats.fetch("placement_properties", {}).fetch("zone", "default")
+  end
 end

--- a/spec/nats_messages/dea_advertisment_spec.rb
+++ b/spec/nats_messages/dea_advertisment_spec.rb
@@ -152,4 +152,29 @@ describe DeaAdvertisement do
       }.from(2).to(3)
     end
   end
+
+  describe "#zone" do
+    context "when the dea does not have the placement properties" do
+      it "returns default zone" do
+        expect(ad.zone).to eq "default"
+      end
+    end
+
+    context "when the dea has empty placement properties" do
+      before{ message["placement_properties"] = {} }
+
+      it "returns default zone" do
+        expect(ad.zone).to eq "default"
+      end
+    end
+
+    context "when the dea has the placement properties with zone info" do
+      before{ message["placement_properties"] = { "zone" => "zone_cf" } }
+
+      it "returns the zone with name zone_cf" do
+        expect(ad.zone).to eq "zone_cf"
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Cloud Controller currently does not consider high availability when deploying and scaling applications, which may lead to availability issues even the user has multiple  instances of the application. For example, when all of the application instances are located in one server rack, and this server rack crashed, the whole application system will be unavailable.<br>
The commit  improves the  algorism of DEA picking by taking account of "availability zones" defined in "placement_properties".  It simply tries to distribute application instances into different "availability zones" to achieve maximum availability. If there is no information of "availability zones" or all DEAs are located in the same "availability zone", it will make no difference from the old behavior. <br>
This commit relies on additional DEA properties named "placement_properties" having been added to the advertisement (see https://github.com/cloudfoundry/dea_ng/pull/78). However if the "placement_properties" is not there, it will revert to the old behavior, so there's no need to bump both modules at the same time.
