### PR TITLE
new field in api endpoint to allow configurable health check timeout

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -16,7 +16,7 @@ module VCAP::CloudController
       attribute  :command,             String,     :default => nil
       attribute  :console,             Message::Boolean, :default => false
       attribute  :debug,               String,     :default => nil
-      attribute  :health_check_timeout, Integer,   :default => nil
+      attribute  :health_check_timeout_seconds, Integer,   :default => nil
 
       attribute  :buildpack,           String, :default => nil
       attribute  :detected_buildpack,  String, :exclude_in => [:create, :update]

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -56,13 +56,13 @@ module VCAP::CloudController
       :space_guid, :stack_guid, :buildpack, :detected_buildpack,
       :environment_json, :memory, :instances, :disk_quota,
       :state, :version, :command, :console, :debug,
-      :staging_task_id, :package_state, :health_check_timeout
+      :staging_task_id, :package_state, :health_check_timeout_seconds
 
     import_attributes :name, :production,
       :space_guid, :stack_guid, :buildpack, :detected_buildpack,
       :environment_json, :memory, :instances, :disk_quota,
       :state, :command, :console, :debug,
-      :staging_task_id, :service_binding_guids, :route_guids, :health_check_timeout
+      :staging_task_id, :service_binding_guids, :route_guids, :health_check_timeout_seconds
 
     strip_attributes :name
 
@@ -123,7 +123,7 @@ module VCAP::CloudController
       validate_environment
       validate_metadata
       check_memory_quota
-      validate_health_check_timeout
+      validate_health_check_timeout_seconds
     end
 
     def before_create
@@ -304,9 +304,9 @@ module VCAP::CloudController
       end
     end
 
-    def validate_health_check_timeout
-      return unless health_check_timeout
-      errors.add(:health_check_timeout, :less_than_zero) unless health_check_timeout >= 0
+    def validate_health_check_timeout_seconds
+      return unless health_check_timeout_seconds
+      errors.add(:health_check_timeout_seconds, :less_than_zero) unless health_check_timeout_seconds >= 0
     end
 
     # We need to overide this ourselves because we are really doing a

--- a/db/migrations/20131111155640_add_health_check_timeout_seconds_to_apps.rb
+++ b/db/migrations/20131111155640_add_health_check_timeout_seconds_to_apps.rb
@@ -1,7 +1,7 @@
 Sequel.migration do
   change do
     alter_table(:apps) do
-      add_column :health_check_timeout, Integer
+      add_column :health_check_timeout_seconds, Integer
     end
   end
 end

--- a/lib/cloud_controller/dea/dea_client.rb
+++ b/lib/cloud_controller/dea/dea_client.rb
@@ -285,7 +285,7 @@ module VCAP::CloudController
           :console => app.console,
           :debug => app.debug,
           :start_command => app.command,
-          :health_check_timeout => app.health_check_timeout,
+          :health_check_timeout_seconds => app.health_check_timeout_seconds,
         }
       end
 

--- a/spec/api/apps_api_spec.rb
+++ b/spec/api/apps_api_spec.rb
@@ -36,7 +36,7 @@ resource "Apps", :type => :api do
   field :console, "Open the console port for the app (at $CONSOLE_PORT).", required: false, deprecated: true, default: false, valid_values: [true, false]
   field :debug, "Open the debug port for the app (at $DEBUG_PORT).", required: false, deprecated: true, default: false, valid_values: [true, false]
   field :package_state, "The current desired state of the package. One of PENDING, STAGED or FAILED.", required: false, readonly: true, valid_values: %w[PENDING STAGED FAILED]
-  field :health_check_timeout, "Timeout for health checking of an staged app when starting up", required: false
+  field :health_check_timeout_seconds, "Timeout for health checking of an staged app when starting up", required: false
 
   standard_model_list :app
   standard_model_get :app

--- a/spec/controllers/runtime/apps_controller_spec.rb
+++ b/spec/controllers/runtime/apps_controller_spec.rb
@@ -175,21 +175,21 @@ module VCAP::CloudController
         end
       end
 
-      describe "update app health_check_timeout" do
-        context "when health_check_timeout value is provided" do
+      describe "update app health_check_timeout_seconds" do
+        context "when health_check_timeout_seconds value is provided" do
           let(:update_hash) do
-            {"health_check_timeout" => 80}
+            {"health_check_timeout_seconds" => 80}
           end
  
           it "should set to provided value" do
             update_app
             app_obj.refresh
-            app_obj.health_check_timeout.should == 80
+            app_obj.health_check_timeout_seconds.should == 80
             last_response.status.should == 201
           end
         end
 
-        context "when health_check_timeout value is not provided" do
+        context "when health_check_timeout_seconds value is not provided" do
           let(:update_hash) do
             {}
           end
@@ -591,21 +591,21 @@ module VCAP::CloudController
       end
     end
 
-    describe "health_check_timeout" do
+    describe "health_check_timeout_seconds" do
       let(:app_obj)   { AppFactory.make }
       let(:decoded_response) { Yajl::Parser.parse(last_response.body) }
 
-      it "should have no health_check_timeout entry in the metadata if not provided" do
+      it "should have no health_check_timeout_seconds entry in the metadata if not provided" do
         get "/v2/apps/#{app_obj.guid}", {}, json_headers(admin_headers)
         last_response.status.should == 200
-        decoded_response["entity"]["health_check_timeout"].should be_nil
+        decoded_response["entity"]["health_check_timeout_seconds"].should be_nil
         decoded_response["entity"]["metadata"].should be_nil
       end
 
-      it "should set the health_check_timeout on the app metadata if provided" do
-        put "/v2/apps/#{app_obj.guid}", Yajl::Encoder.encode(:health_check_timeout => 100), json_headers(admin_headers)
+      it "should set the health_check_timeout_seconds on the app metadata if provided" do
+        put "/v2/apps/#{app_obj.guid}", Yajl::Encoder.encode(:health_check_timeout_seconds => 100), json_headers(admin_headers)
         last_response.status.should == 201
-        decoded_response["entity"]["health_check_timeout"].should == 100
+        decoded_response["entity"]["health_check_timeout_seconds"].should == 100
         decoded_response["entity"]["metadata"].should be_nil
       end
     end

--- a/spec/dea/dea_client_spec.rb
+++ b/spec/dea/dea_client_spec.rb
@@ -49,7 +49,7 @@ module VCAP::CloudController
         res[:env].should be_kind_of(Array)
         res[:console].should == false
         res[:start_command].should be_nil
-        res[:health_check_timeout].should be_nil
+        res[:health_check_timeout_seconds].should be_nil
       end
 
       context "with an app enabled for console support" do
@@ -75,12 +75,12 @@ module VCAP::CloudController
           res[:start_command].should == "custom start command"
         end
       end
-      
-      context "with an app enabled for custom health check timeout value" do
+
+      context "with an app enabled for custom health check timeout value in seconds" do
         it "should enable health check timeout in the start message" do
-          app.update(:health_check_timeout => 82)
+          app.update(:health_check_timeout_seconds => 82)
           res = DeaClient.start_app_message(app)
-          res[:health_check_timeout].should == 82
+          res[:health_check_timeout_seconds].should == 82
         end
       end
     end

--- a/spec/models/runtime/app_spec.rb
+++ b/spec/models/runtime/app_spec.rb
@@ -568,24 +568,24 @@ module VCAP::CloudController
       end
     end
 
-    describe "health_check_timeout" do
+    describe "health_check_timeout_seconds" do
       it "should raise error if value is less than zero" do
         expect {
-          AppFactory.make(health_check_timeout: -10)
-        }.to raise_error(Sequel::ValidationFailed, /health_check_timeout less_than_zero/)
+          AppFactory.make(health_check_timeout_seconds: -10)
+        }.to raise_error(Sequel::ValidationFailed, /health_check_timeout_seconds less_than_zero/)
       end
 
       it "should not raise error if value is greater than zero" do
         expect {
-          AppFactory.make(health_check_timeout: 10)
+          AppFactory.make(health_check_timeout_seconds: 10)
         }.to_not raise_error
       end
 
       it "should not raise error if value is nil" do
         expect {
-          AppFactory.make(health_check_timeout: nil)
+          AppFactory.make(health_check_timeout_seconds: nil)
         }.to_not raise_error
-      end 
+      end
     end
 
     describe "package_hash=" do


### PR DESCRIPTION
Currently Dea health check timeout is configurable through dea.yml.  The timeout config applies to all pushed apps, and there isn't a way to configure the timeout for each individual app.

With this change, individual app can configure it's timeout through a new field (healthcheck_timeout) in the api endpoint.  The value will be exposed to Dea through start_app_message.
