### PR TITLE
Ignore errors when the service broker isn't available

### DIFF
--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -86,7 +86,8 @@ module VCAP::CloudController
       # TODO: transactionally move this into a queue
       begin
         client.deprovision(self)
-      rescue => e
+      rescue HttpResponseError => e
+        raise e if 404 != e.status
         logger.error "Failed to deprovision #{as_summary_json}: #{e}"
       end
 

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -68,7 +68,8 @@ module VCAP::CloudController
       # TODO: transactionally move this into a queue
       begin
         client.unbind(self)
-      rescue => e
+      rescue HttpResponseError => e
+        raise e if 404 != e.status
         logger.error "Failed to unbind #{self.inspect}: #{e}"
       end
 

--- a/spec/models/services/managed_service_instance_spec.rb
+++ b/spec/models/services/managed_service_instance_spec.rb
@@ -75,9 +75,18 @@ module VCAP::CloudController
       end
 
       context "when deprovision fails" do
-        it "should ignore and continue" do
-          service_instance.client.stub(:deprovision).and_raise
+        it "should ignore and continue when 404" do
+          service_instance.client.stub(:deprovision).and_raise(HttpResponseError.new('message', 'http://example.com/', :get, double(code: 404, reason: '', body: '')))
           service_instance.destroy(savepoint: true)
+        end
+
+        it "should raise and rollback when not 404" do
+          service_instance.client.stub(:deprovision).and_raise
+          expect {
+            service_instance.destroy(savepoint: true)
+          }.to raise_error
+
+          VCAP::CloudController::ManagedServiceInstance.find(id: service_instance.id).should be
         end
       end
     end


### PR DESCRIPTION
When service brokers are down, it is impossible to delete an application.  The broker errors should be ignored and logged.  When the brokers are active, they will be notified that the binding and or instance is no longer needed.
