### PR TITLE
New app domains from the deployment manifest are now added to the existi...

### DIFF
--- a/lib/cloud_controller/seeds.rb
+++ b/lib/cloud_controller/seeds.rb
@@ -38,6 +38,7 @@ module VCAP::CloudController
 
       def create_seed_domains(config, system_org)
         Domain.populate_from_config(config, system_org)
+        Organization.all.each { |org| org.add_inheritable_domains }
       end
     end
   end

--- a/spec/seeds_spec.rb
+++ b/spec/seeds_spec.rb
@@ -71,5 +71,23 @@ module VCAP::CloudController
         Seeds.create_seed_domains(config, @system_org)
       end
     end
+ 
+    describe "create_seed_domains" do
+      let(:existing_org) { Organization.make }
+
+      it "should add app domains to existing organizations" do
+        @system_org = Seeds.create_seed_organizations(config)
+        Seeds.create_seed_domains(config, @system_org) 
+
+        existing_org.reload
+        existing_org.domains.size.should eq(2)
+
+        config[:app_domains] << "foo.com"
+        Seeds.create_seed_domains(config,@system_org)
+
+        existing_org.reload
+        existing_org.domains.size.should eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
...ng organizations during deployment

Fixes : 57345390. Previously If you add more app_domains to your deployment manifest and redeploy, existing organizations would not be able to see them. The population of an org's domains is only done during the org creation time and it gets the app domains present at that time.
The fix will add the new app domains to the organizations so that the existing organization will be updated to contain all app domains listed in the deployment.
Please note that this fix will not address the case where new domains are added programmatically, these new app domains will not be available to the existing organizations.
