### PR TITLE
Deleting a space recursively should soft delete apps instead of destroying  them.

### DIFF
--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -152,6 +152,7 @@ module VCAP::CloudController
     def before_create
       super
       set_new_version
+      raise Sequel::DatabaseError, "space is required" if self.space_id.nil?
     end
 
     def before_save
@@ -216,7 +217,11 @@ module VCAP::CloudController
       (column_changed?(:production) || column_changed?(:memory) ||
         column_changed?(:instances))
     end
-
+    
+    def destroy(savepoint=:true)
+      self.soft_delete unless self.not_deleted.nil?
+    end
+   
     def after_destroy
       AppStopEvent.create_from_app(self) unless stopped? || has_stop_event_for_latest_run?
     end

--- a/db/migrations/20131117253318_remove_foreign_key_from_space_id_and_stack_id_in_apps.rb
+++ b/db/migrations/20131117253318_remove_foreign_key_from_space_id_and_stack_id_in_apps.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+    change do
+       alter_table :apps do
+        drop_foreign_key ([:space_id])
+        set_column_allow_null(:space_id)
+        add_foreign_key [:space_id], :spaces, :name => :fk_apps_space_id,:on_delete => :set_null
+   
+        drop_foreign_key ([:stack_id])
+        set_column_allow_null(:stack_id)
+        add_foreign_key [:stack_id], :stacks, :name => :fk_apps_stack_id, :on_delete => :set_null
+      end
+    end
+  end

--- a/spec/models/runtime/space_spec.rb
+++ b/spec/models/runtime/space_spec.rb
@@ -138,17 +138,11 @@ module VCAP::CloudController
     describe "#destroy" do
       subject(:space) { Space.make }
 
-      it "destroys all apps" do
-        app = AppFactory.make(:space => space)
-        soft_deleted_app = AppFactory.make(:space => space)
-        soft_deleted_app.soft_delete
-
-        expect {
-          subject.destroy(savepoint: true)
-        }.to change {
-          App.with_deleted.where(:id => [app.id, soft_deleted_app.id]).count
-        }.from(2).to(0)
-      end
+     it "soft deletes all apps" do
+       app = App.make(:space => space)
+       subject.destroy(savepoint: true)
+       App.deleted[:id => app.id].should_not be_nil
+     end
 
       it "destroys all service instances" do
         service_instance = ManagedServiceInstance.make(:space => space)

--- a/spec/models/runtime/stack_spec.rb
+++ b/spec/models/runtime/stack_spec.rb
@@ -114,9 +114,10 @@ module VCAP::CloudController
     describe "#destroy" do
       let(:stack) { Stack.make }
 
-      it "destroys the apps" do
+      it "soft deletes all apps" do
         app = AppFactory.make(:stack => stack)
-        expect { stack.destroy(savepoint: true) }.to change { App.where(:id => app.id).count }.by(-1)
+        stack.destroy(savepoint: true)
+        App.deleted[:id => app.id].should_not be_nil
       end
     end
 


### PR DESCRIPTION
Deleting a space recursively should soft delete apps instead of destroying  them.
Fixes 57414538.
We thought about various approaches, and decided to use the approach where we override the default destroy method of app.rb to do soft delete. Now since we are retaining the apps after Space is deleted, we are making the space_id column to be nullable, and ading checks in model to ensure that it is nullified when space is deleted. Stack is also nullified for apps as we want to only soft delete apps rather than destroying them when Stack is deleted. I have also added tests in space, apps and stacks specs to ensure  everything is tested.
