### PR TITLE
Reduce default disk per app to 100Mb

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
       attribute  :environment_json,    Hash,       :default => {}
       attribute  :memory,              Integer,    :default => 256
       attribute  :instances,           Integer,    :default => 1
-      attribute  :disk_quota,          Integer,    :default => 1024
+      attribute  :disk_quota,          Integer,    :default => 100
 
       attribute  :state,               String,     :default => "STOPPED"
       attribute  :command,             String,     :default => nil

--- a/spec/integration/app_staging_spec.rb
+++ b/spec/integration/app_staging_spec.rb
@@ -80,7 +80,7 @@ describe "Staging an app", type: :integration do
           "name" => "foobar",
           "memory" => 64,
           "instances" => 2,
-          "disk_quota" => 1024,
+          "disk_quota" => 100,
           "space_guid" => space.json_body["metadata"]["guid"],
         }.to_json,
         authed_headers


### PR DESCRIPTION
Developers can scale the disk upwards for an app using the cf CLI.

Discussion at https://groups.google.com/a/cloudfoundry.org/forum/#!topic/vcap-dev/bQLp7_k8q7w
