### PR TITLE
Bump loggregator_emitter gem to 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "cf-uaa-lib", "~> 1.3.7", git: "https://github.com/cloudfoundry/cf-uaa-lib.g
 gem "cf-message-bus", git: "https://github.com/cloudfoundry/cf-message-bus.git"
 gem "vcap_common", git: "https://github.com/cloudfoundry/vcap-common.git"
 gem "allowy"
-gem "loggregator_emitter", "~> 2.0"
+gem "loggregator_emitter", "~> 3.0"
 gem "talentbox-delayed_job_sequel", git: "https://github.com/TalentBox/delayed_job_sequel", ref: "8725e1ee"
 gem "thin", "~> 1.5.1"
 gem "newrelic_rpm"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lockfile (2.1.0)
-    loggregator_emitter (2.0.3)
+    loggregator_emitter (3.0.0)
       beefcake (~> 0.3.7)
     lumberjack (1.0.4)
     machinist (1.0.6)
@@ -291,7 +291,7 @@ DEPENDENCIES
   fog
   guard-rspec
   httpclient
-  loggregator_emitter (~> 2.0)
+  loggregator_emitter (~> 3.0)
   machinist (~> 1.0.6)
   membrane (~> 0.0.2)
   mysql2

--- a/spec/integration/loggregator_spec.rb
+++ b/spec/integration/loggregator_spec.rb
@@ -53,7 +53,6 @@ describe "Cloud controller Loggregator Integration", :type => :integration do
     message = messages[0]
     expect(message.message).to eq "Created app with guid #{@app_id}"
     expect(message.app_id).to eq @app_id
-    expect(message.source_type).to eq LogMessage::SourceType::UNKNOWN
     expect(message.source_name).to eq "API"
     expect(message.message_type).to eq LogMessage::MessageType::OUT
   end


### PR DESCRIPTION
This Removes the Source Type from the LogMessages. 

Signed-off-by: Matthew McNew mmcnew@pivotallabs.com
