### PR TITLE
Add test cases to cover disabled build packs

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -54,7 +54,7 @@ http {
       root   /var/vcap/shared;
     }
 
-    location ~ (/apps/.*/application|/v2/apps/.*/bits|/services/v\d+/configurations/.*/serialized/data|/v2/custom_buildpacks/.*/bits) {
+    location ~ (/apps/.*/application|/v2/apps/.*/bits|/services/v\d+/configurations/.*/serialized/data) {
       # Pass altered request body to this location
       upload_pass   @cc_uploads;
       upload_pass_args on;


### PR DESCRIPTION
Add additional unit/integration tests to cover when buildpacks are disabled.
