### PR TITLE
Only seed app usage events with STARTED apps.

### DIFF
--- a/app/controllers/runtime/app_usage_events_controller.rb
+++ b/app/controllers/runtime/app_usage_events_controller.rb
@@ -12,7 +12,9 @@ module VCAP::CloudController
       AppUsageEvent.db[:app_usage_events].truncate
       usage_query = App.join(:spaces, id: :apps__space_id).
         join(:organizations, id: :spaces__organization_id).
-        select(:apps__guid, :apps__guid, :apps__name, :apps__state, :apps__instances, :apps__memory, :spaces__guid, :spaces__name, :organizations__guid, Sequel.datetime_class.now).order(:apps__id)
+        select(:apps__guid, :apps__guid, :apps__name, :apps__state, :apps__instances, :apps__memory, :spaces__guid, :spaces__name, :organizations__guid, Sequel.datetime_class.now).
+        where(:apps__state => 'STARTED').
+        order(:apps__id)
       AppUsageEvent.insert([:guid, :app_guid, :app_name, :state, :instance_count, :memory_in_mb_per_instance, :space_guid, :space_name, :org_guid, :created_at], usage_query)
 
       [HTTP::NO_CONTENT, nil]

--- a/spec/controllers/runtime/app_usage_events_controller_spec.rb
+++ b/spec/controllers/runtime/app_usage_events_controller_spec.rb
@@ -56,6 +56,7 @@ module VCAP::CloudController
 
       it "creates events for existing STARTED apps" do
         app = AppFactory.make(state: "STARTED", package_hash: Sham.guid)
+        AppFactory.make(state: "STOPPED")
         post "/v2/app_usage_events/destructively_purge_all_and_reseed_started_apps", {}, admin_headers
         expect(last_response).to be_successful
         expect(AppUsageEvent.count).to eq(1)


### PR DESCRIPTION
Currently STOPPED apps are also getting seeded into app usage events.
