### PR TITLE
Making VCAP_SERVICES available via cf env

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -8,6 +8,7 @@ module VCAP::CloudController
       to_one     :stack,               :optional_in => :create
 
       attribute  :environment_json,    Hash,       :default => {}
+      attribute  :system_env_json,     Hash,       :default => {}
       attribute  :memory,              Integer,    :default => nil
       attribute  :instances,           Integer,    :default => 1
       attribute  :disk_quota,          Integer,    :default => 1024

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "digest/sha1"
 
 describe "Stable API warning system", api_version_check: true do
-  API_FOLDER_CHECKSUM = "71265eb959aeb8f9aff00cc52cafad63ac084b7e".freeze
+  API_FOLDER_CHECKSUM = "515f998afc25c9a2ef1e1b1fb7e8b977e7336545".freeze
 
   it "tells the developer if the API specs change" do
     api_folder = File.expand_path("..", __FILE__)

--- a/spec/api/apps_api_spec.rb
+++ b/spec/api/apps_api_spec.rb
@@ -34,6 +34,7 @@ resource "Apps", :type => :api do
   field :console, "Open the console port for the app (at $CONSOLE_PORT).", required: false, deprecated: true, default: false, valid_values: [true, false]
   field :debug, "Open the debug port for the app (at $DEBUG_PORT).", required: false, deprecated: true, default: false, valid_values: [true, false]
   field :package_state, "The current desired state of the package. One of PENDING, STAGED or FAILED.", required: false, readonly: true, valid_values: %w[PENDING STAGED FAILED]
+  field :system_env_json, "environment_json for system variables, contains vcap_services by default, a hash containing key/value pairs of the names and information of the services associated with your app.", required: false, readonly: true
 
   standard_model_list :app, VCAP::CloudController::AppsController
   standard_model_get :app

--- a/spec/controllers/runtime/apps_controller_spec.rb
+++ b/spec/controllers/runtime/apps_controller_spec.rb
@@ -353,6 +353,12 @@ module VCAP::CloudController
         last_response.status.should == 200
         expect(parse(last_response.body)["entity"]).to have_key("package_state")
       end
+
+      it "should return system_env_json" do
+        get_app
+        last_response.status.should == 200
+        expect(parse(last_response.body)["entity"]).to have_key("system_env_json")
+      end
     end
 
     describe "delete an app" do


### PR DESCRIPTION
Exposes vcap_services via the existing /app endpoint for the cf environment command. It is contained in a hash system_env_json, a new system counterpart for the existing environment_json that contains user variables.
