### PR TITLE
Allow a buildpack to be locked to prevent changes

### DIFF
--- a/app/controllers/runtime/buildpack_bits_controller.rb
+++ b/app/controllers/runtime/buildpack_bits_controller.rb
@@ -11,6 +11,9 @@ module VCAP::CloudController
     put "#{path_guid}/bits", :upload
     def upload(guid)
       buildpack = find_guid_and_validate_access(:read_bits, guid)
+      
+      raise Errors::BuildpackLocked if buildpack.locked?
+      
       uploaded_file = upload_handler.uploaded_file(params, "buildpack")
       uploaded_filename = upload_handler.uploaded_filename(params, "buildpack")
       logger.info uploaded_file

--- a/app/controllers/runtime/buildpacks_controller.rb
+++ b/app/controllers/runtime/buildpacks_controller.rb
@@ -4,6 +4,7 @@ module VCAP::CloudController
       attribute :name, String
       attribute :position, Integer, default: 0
       attribute :enabled, Message::Boolean, default: true
+      attribute :locked, Message::Boolean, default: false
     end
 
     query_parameters :name

--- a/app/models/runtime/buildpack.rb
+++ b/app/models/runtime/buildpack.rb
@@ -1,9 +1,9 @@
 module VCAP::CloudController
   class Buildpack < Sequel::Model
 
-    export_attributes :name, :position, :enabled
+    export_attributes :name, :position, :enabled, :locked
 
-    import_attributes :name, :key, :position, :enabled
+    import_attributes :name, :key, :position, :enabled, :locked
 
     def self.list_admin_buildpacks
       results = exclude(:key => nil).exclude(:key => "").order(:position).all
@@ -112,6 +112,10 @@ module VCAP::CloudController
 
     def custom?
       false
+    end
+
+    def locked?
+      self.locked
     end
 
     private

--- a/db/migrations/20140114175047_add_locked_to_buildpack.rb
+++ b/db/migrations/20140114175047_add_locked_to_buildpack.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :buildpacks, :locked, 'Boolean', :default => false
+  end
+end

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "digest/sha1"
 
 describe "Stable API warning system", api_version_check: true do
-  API_FOLDER_CHECKSUM = "515f998afc25c9a2ef1e1b1fb7e8b977e7336545".freeze
+  API_FOLDER_CHECKSUM = "c8e36fd5199c7b6ac03740744214f7d2bce10831".freeze
 
   it "tells the developer if the API specs change" do
     api_folder = File.expand_path("..", __FILE__)

--- a/spec/api/buildpacks_api_spec.rb
+++ b/spec/api/buildpacks_api_spec.rb
@@ -12,6 +12,7 @@ resource "Buildpacks (experimental)", :type => :api do
   field :name, "The name of the buildpack. To be used by app buildpack field. (only alphanumeric characters)", required: true, example_values: ["Golang_buildpack"]
   field :position, "The order in which the buildpacks are checked during buildpack auto-detection.", required: false
   field :enabled, "Whether or not the buildpack will be used for staging", required: false, default: true
+  field :locked, "Whether or not the buildpack is locked to prevent updates", required: false, default: false
 
   standard_model_list(:buildpack, VCAP::CloudController::BuildpacksController)
   standard_model_get(:buildpack)
@@ -70,6 +71,25 @@ resource "Buildpacks (experimental)", :type => :api do
         VCAP::CloudController::Buildpack.find(guid: guid).enabled
       }.from(false).to(true)
     end
+    
+    example "Lock or unlock a buildpack" do
+      expect {
+        client.put "/v2/buildpacks/#{guid}", Yajl::Encoder.encode(locked: true), headers
+        expect(status).to eq 201
+        standard_entity_response parsed_response, :buildpack, locked: true
+      }.to change {
+        VCAP::CloudController::Buildpack.find(guid: guid).locked
+      }.from(false).to(true)
+
+      expect {
+        client.put "/v2/buildpacks/#{guid}", Yajl::Encoder.encode(locked: false), headers
+        expect(status).to eq 201
+        standard_entity_response parsed_response, :buildpack, locked: false
+      }.to change {
+        VCAP::CloudController::Buildpack.find(guid: guid).locked
+      }.from(true).to(false)
+    end
+    
   end
 
   put "/v2/buildpacks/:guid/bits" do

--- a/spec/controllers/runtime/buildpacks_controller_spec.rb
+++ b/spec/controllers/runtime/buildpacks_controller_spec.rb
@@ -90,7 +90,8 @@ module VCAP::CloudController
             expect(decoded_response["total_results"]).to eq(1)
             expect(decoded_response["resources"][0]["entity"]).to eq({'name' => 'get_buildpack',
                                                                       'position' => 1,
-                                                                      'enabled' => true})
+                                                                      'enabled' => true,
+                                                                      'locked' => false})
           end
         end
       end


### PR DESCRIPTION
As an administrator, in order to provide greater change control, it should be possible to lock (and unlock) buildpacks against further updates through the API.

This PR adds a `locked` attribute to the buildpack model and exposes it via the api.

Any attempt to upload new buildpack bits to a locked buildpack results in a 409 response. This error has been added to the errors repository in its own PR. Subsequently, travis will be unhappy with this PR until that one is accepted - https://github.com/cloudfoundry/errors/pull/12
