### PR TITLE
Return a SUCCESS, not an ERROR when uploading the same bits twice

### DIFF
--- a/app/controllers/runtime/buildpack_bits_controller.rb
+++ b/app/controllers/runtime/buildpack_bits_controller.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController
 
       sha1 = File.new(uploaded_file).hexdigest
 
-      return [HTTP::CONFLICT, nil] if sha1 == buildpack.key
+      return [HTTP::NO_CONTENT, nil] if sha1 == buildpack.key
 
       buildpack_blobstore.cp_to_blobstore(uploaded_file, sha1)
 

--- a/spec/controllers/runtime/buildpack_bits_controller_spec.rb
+++ b/spec/controllers/runtime/buildpack_bits_controller_spec.rb
@@ -101,11 +101,11 @@ module VCAP::CloudController
           expect(buildpack_blobstore.exists?(sha_valid_zip2)).to be_false
         end
 
-        it 'reports a conflict if the same buildpack is uploaded again' do
+        it 'reports a no content if the same buildpack is uploaded again' do
           put "/v2/buildpacks/#{@test_buildpack.guid}/bits", { :buildpack => valid_zip }, admin_headers
           put "/v2/buildpacks/#{@test_buildpack.guid}/bits", { :buildpack => valid_zip }, admin_headers
 
-          expect(last_response.status).to eq(409)
+          expect(last_response.status).to eq(204)
         end
 
         it "removes the uploaded buildpack file" do


### PR DESCRIPTION
Return 204 (NO CONTENT) instead of 409 (CONFLICT) when the same build pack bits are uploaded.  Its not an error but an optimization that is OK.
