### PR TITLE
Use S3 bucket instead of trying to create and use it?

### DIFF
--- a/lib/cloud_controller/blobstore/blobstore.rb
+++ b/lib/cloud_controller/blobstore/blobstore.rb
@@ -101,7 +101,7 @@ class Blobstore
   end
 
   def dir
-    @dir ||= connection.directories.create(:key => @directory_key, :public => false)
+    @dir ||= connection.directories.new(:key => @directory_key, :public => false)
   end
 
   def connection


### PR DESCRIPTION
Whilst setting up cc_ng to connect with our private (non-Amazon) corporate S3 service, I noticed that the blobstore code attempts to create the directory_key (which I read as meaning 'bucket name') before populating @dir with it.

With our private S3 service, it fails hard when attempting to create the bucket (as it already exists).

```
jobs_work.stdout.log:  response => #<Excon::Response:0x00000003d2d5e0 @data={:body=>"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Error><Code>BucketAlreadyExists</Code><Message>The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.</Message><Resource>/cf-resource-pools/</Resource><RequestId>47bcddb7-d65f-4ad4-86cf-ecb77f424764</RequestId><httpStatusCode>409</httpStatusCode></Error>", :headers=>{"Accept-Ranges"=>"bytes", "Date"=>"Tue, 28 Jan 2014 11:25:47 GMT", "X-Request-Id"=>"47bcddb7-d65f-4ad4-86cf-ecb77f424764", "x-amz-request-id"=>"47bcddb7-d65f-4ad4-86cf-ecb77f424764", "Content-Type"=>"application/xml", "Content-Length"=>"404"}, :status=>409, :remote_ip=>"xxx"}, @body="<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Error><Code>BucketAlreadyExists</Code><Message>The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.</Message><Resource>/cf-resource-pools/</Resource><RequestId>47bcddb7-d65f-4ad4-86cf-ecb77f424764</RequestId><httpStatusCode>409</httpStatusCode></Error>", @headers={ "Accept-Ranges"=>"bytes", "Date"=>"Tue, 28 Jan 2014 11:25:47 GMT", "X-Request-Id"=>"47bcddb7-d65f-4ad4-86cf-ecb77f424764", "x-amz-request-id"=>"47bcddb7-d65f-4ad4-86cf-ecb77f424764", "Content-Type"=>"application/xml", "Content-Length"=>"404"}, @status=409, @remote_ip="xxx">
```

I'm just wondering does it need to create the bucket if it doesnt exist? Can we not assume that it already exists (and fail if fogs attempts to write to it fail instead)? 
