### PR TITLE
Remove buildpacks with null urls

### DIFF
--- a/lib/cloud_controller/app_stager_task.rb
+++ b/lib/cloud_controller/app_stager_task.rb
@@ -105,7 +105,8 @@ module VCAP::CloudController
     def admin_buildpacks
       Buildpack.list_admin_buildpacks.
         select(&:enabled).
-        collect { |buildpack| admin_buildpack_entry(buildpack) }
+        collect { |buildpack| admin_buildpack_entry(buildpack) }.
+        select { |entry| entry[:url] }
     end
 
     def admin_buildpack_entry(buildpack)

--- a/spec/app_stager_task_spec.rb
+++ b/spec/app_stager_task_spec.rb
@@ -575,6 +575,17 @@ module VCAP::CloudController
               end
             end
           end
+
+          context "when a buildpack has missing bits" do
+            it "does not include the buildpack" do
+              buildpack_d = Buildpack.make(key: "d key", position: 5)
+
+              request = staging_task.staging_request
+              admin_buildpacks = request[:admin_buildpacks]
+              expect(admin_buildpacks).to have(2).items
+              expect(admin_buildpacks).to_not include(key: "d key", url: nil)
+            end
+          end
         end
 
       end


### PR DESCRIPTION
A failure in the DEA was caused by a nil URL sent by the cloud_controller.  Below is part of the message sent.  The blobstore can return a nil URL if the file is not present.

{"timestamp":1391436356.996865,"message":"nats.message.received","log_level":"debug","source":"Dea::Nats","data":{"subject":"staging.0-22e87f41e72044898fab0b448f67e1bd.start","data":{"app_id":"39c1650d-b1fa-45bd-bf92-bb5cba62545c","task_id":"290b114cbc274bceaa67fc953f1d7b01",

"admin_buildpacks":[{"key":"9871f17b4f441930422b1bbe9262b7513457a22f","url":null},{"key":"94b098dab91e77d2ce048af6193ce5957d0193f6","url":"http://a:b@10.0.116.48:9022/v2/buildpacks/aaeac7a7-a199-47f5-88b6-fe21d898d46f/download"}]

}},"thread_id":20146300,"fiber_id":27311040,"process_id":1420,"file":"/var/vcap/packages/dea_next/lib/dea/nats.rb","lineno":148,"method":"handle_incoming_message"} 
