### PR TITLE
Make buildpack bits (key) unique.

### DIFF
--- a/app/controllers/runtime/buildpack_bits_controller.rb
+++ b/app/controllers/runtime/buildpack_bits_controller.rb
@@ -25,9 +25,10 @@ module VCAP::CloudController
       raise Errors::ApiError.new_from_details("BuildpackBitsUploadInvalid", "a file must be provided") if uploaded_file.to_s == ""
 
       sha1 = File.new(uploaded_file).hexdigest
+      unique_buildpack_key = "#{buildpack.guid}_#{sha1}"
       uploaded_filename = File.basename(uploaded_filename)
 
-      if upload_bits(buildpack, sha1, uploaded_file, uploaded_filename)
+      if upload_bits(buildpack, unique_buildpack_key, uploaded_file, uploaded_filename)
         [HTTP::CREATED, object_renderer.render_json(self.class, buildpack, @opts)]
       else
          [HTTP::NO_CONTENT, nil]
@@ -36,7 +37,7 @@ module VCAP::CloudController
       FileUtils.rm_f(uploaded_file) if uploaded_file
     end
 
-    def upload_bits(buildpack, new_key, bits_file, new_filename)
+    def upload_bits(buildpack, new_key, bits_file, new_filename)      
       return false if !new_bits?(buildpack, new_key) && !new_filename?(buildpack, new_filename)
 
       # replace blob if new

--- a/spec/integration/app_staging_spec.rb
+++ b/spec/integration/app_staging_spec.rb
@@ -53,6 +53,10 @@ describe "Staging an app", type: :integration do
         authed_headers
       )
 
+      @expected_buildpack_shas = [
+        "#{@buildpack_response_1.json_body["metadata"]["guid"]}_#{valid_zip(4).hexdigest}",
+        "#{@buildpack_response_2.json_body["metadata"]["guid"]}_#{valid_zip.hexdigest}"]
+
       org = make_post_request(
         "/v2/organizations",
         { "name" => "foo_org-#{SecureRandom.uuid}" }.to_json,
@@ -129,7 +133,6 @@ describe "Staging an app", type: :integration do
 
     context "and the admin has uploaded the buildpacks" do
       before do
-        @expected_buildpack_shas = [valid_zip(4).hexdigest, valid_zip.hexdigest]
         @buildpack_bits_response_1 = make_put_request(
           "/v2/buildpacks/#{@buildpack_response_1.json_body["metadata"]["guid"]}/bits?buildpack[tempfile]=#{valid_zip(4).path}&buildpack_name=foo.zip",
           "{}",


### PR DESCRIPTION
If you upload the same bits to two different buildpacks, they both have the same key.  If you delete one of the buildpacks, the bits are removed from both.

I would have preferred to make the key based on the buildpack guid and buildpack zip file name rather than appending two guids.
