### PR TITLE
Add the service broker id to the API attributes exposed on a service

### DIFF
--- a/app/controllers/services/services_controller.rb
+++ b/app/controllers/services/services_controller.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
       to_many   :service_plans
     end
 
-    query_parameters :active
+    query_parameters :active, :service_broker_guid
 
     def self.translate_validation_exception(e, attributes)
       label_provider_errors = e.errors.on([:label, :provider])

--- a/app/models/services/service.rb
+++ b/app/models/services/service.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
 
     export_attributes :label, :provider, :url, :description, :long_description,
                       :version, :info_url, :active, :bindable,
-                      :unique_id, :extra, :tags, :requires, :documentation_url
+                      :unique_id, :extra, :tags, :requires, :documentation_url, :service_broker_guid
 
     import_attributes :label, :provider, :url, :description, :long_description,
                       :version, :info_url, :active, :bindable,
@@ -82,6 +82,14 @@ module VCAP::CloudController
     # The "unique_id" should really be called broker_provided_id because it's the id assigned by the broker
     def broker_provided_id
       unique_id
+    end
+
+    def service_broker_guid
+      if (service_broker.nil?)
+        nil
+      else
+        service_broker.guid
+      end
     end
   end
 end


### PR DESCRIPTION
Exposes service_broker_guid for a service, and enables a query to be done to list all services associated with a service broker.
