### PR TITLE
Adds a 'name' query parameter to new domains endpoints

### DIFF
--- a/app/controllers/runtime/private_domains_controller.rb
+++ b/app/controllers/runtime/private_domains_controller.rb
@@ -5,6 +5,8 @@ module VCAP::CloudController
       to_one :owning_organization
     end
 
+    query_parameters :name
+
     def delete(guid)
       do_delete(find_guid_and_validate_access(:delete, guid))
     end

--- a/app/controllers/runtime/shared_domains_controller.rb
+++ b/app/controllers/runtime/shared_domains_controller.rb
@@ -4,6 +4,8 @@ module VCAP::CloudController
       attribute :name, String
     end
 
+    query_parameters :name
+
     def delete(guid)
       do_delete(find_guid_and_validate_access(:delete, guid))
     end

--- a/spec/controllers/runtime/private_domains_controller_spec.rb
+++ b/spec/controllers/runtime/private_domains_controller_spec.rb
@@ -76,6 +76,17 @@ module VCAP::CloudController
         parsed_body["total_results"].should == 2
       end
 
+      describe "filtering by name" do
+        let(:domain) { PrivateDomain.make }
+
+        it "should return the domain with the matching name" do
+          get "/v2/private_domains?q=name:#{domain.name}", {}, admin_headers
+          last_response.status.should == 200
+          decoded_response["resources"].size.should == 1
+          decoded_response["resources"][0]["entity"]["name"].should == domain.name
+        end
+      end
+
       describe "GET /v2/private_domains/:guid" do
         context "when the guid is valid" do
           it "returns the correct private domain" do

--- a/spec/controllers/runtime/shared_domains_controller_spec.rb
+++ b/spec/controllers/runtime/shared_domains_controller_spec.rb
@@ -60,6 +60,18 @@ module VCAP::CloudController
         parsed_body["total_results"].should == 2
       end
 
+      describe "filtering by name" do
+        let(:domain) { SharedDomain.make }
+
+        it "should return the domain with the matching name" do
+          get "/v2/shared_domains?q=name:#{domain.name}", {}, admin_headers
+          last_response.status.should == 200
+          decoded_response["resources"].size.should == 1
+          decoded_response["resources"][0]["entity"]["name"].should == domain.name
+        end
+      end
+
+
       describe "GET /v2/shared_domains/:guid" do
         context "when the guid is valid" do
           it "returns the correct shared domain" do


### PR DESCRIPTION
This affects the /v2/shared_domains and /v2/private_domains endpoints. The change is
purely additive and makes these endpoints more backwards compatible with the /v2/domains
endpoint.
