### PR TITLE
Remove deprecated trial_db related code from CC.

### DIFF
--- a/app/controllers/runtime/quota_definitions_controller.rb
+++ b/app/controllers/runtime/quota_definitions_controller.rb
@@ -6,7 +6,6 @@ module VCAP::CloudController
       attribute  :total_services,             Integer
       attribute  :total_routes,               Integer
       attribute  :memory_limit,               Integer
-      attribute  :trial_db_allowed,           Message::Boolean, :default => false
     end
 
     query_parameters :name

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -27,8 +27,7 @@ module VCAP::CloudController
       if space_and_name_errors && space_and_name_errors.include?(:unique)
         Errors::ApiError.new_from_details("ServiceInstanceNameTaken", attributes["name"])
       elsif quota_errors
-        if quota_errors.include?(:free_quota_exceeded) ||
-          quota_errors.include?(:trial_quota_exceeded)
+        if quota_errors.include?(:free_quota_exceeded)
           Errors::ApiError.new_from_details("ServiceInstanceFreeQuotaExceeded")
         elsif quota_errors.include?(:paid_quota_exceeded)
           Errors::ApiError.new_from_details("ServiceInstancePaidQuotaExceeded")

--- a/app/models/runtime/quota_definition.rb
+++ b/app/models/runtime/quota_definition.rb
@@ -19,6 +19,13 @@ module VCAP::CloudController
       validates_presence :memory_limit
     end
 
+    def trial_db_allowed=(_)
+    end
+
+    def trial_db_allowed
+      false
+    end
+
     def self.configure(config)
       @default_quota_name = config[:default_quota_definition]
     end

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -18,14 +18,6 @@ module VCAP::CloudController
 
     alias_method :active?, :active
 
-    def self.configure(trial_db_config)
-      @trial_db_guid = trial_db_config ? trial_db_config[:guid] : nil
-    end
-
-    def self.trial_db_guid
-      @trial_db_guid
-    end
-
     def validate
       validates_presence :name,                message: 'is required'
       validates_presence :description,         message: 'is required'
@@ -47,10 +39,6 @@ module VCAP::CloudController
       Sequel.
         or(public: true, id: ServicePlanVisibility.visible_private_plan_ids_for_user(user)).
         &(active: true)
-    end
-
-    def trial_db?
-      unique_id == self.class.trial_db_guid
     end
 
     def bindable?

--- a/app/presenters/api/quota_definition_presenter.rb
+++ b/app/presenters/api/quota_definition_presenter.rb
@@ -7,7 +7,7 @@ class QuotaDefinitionPresenter < ApiPresenter
       non_basic_services_allowed: @object.non_basic_services_allowed,
       total_services: @object.total_services,
       memory_limit: @object.memory_limit,
-      trial_db_allowed: @object.trial_db_allowed
+      trial_db_allowed: false
     }
   end
 end

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -85,7 +85,6 @@ quota_definitions:
     total_services: 100
     non_basic_services_allowed: true
     total_routes: 1000
-    trial_db_allowed: true
 
 default_quota_definition: default
 
@@ -118,9 +117,6 @@ buildpacks:
     aws_secret_access_key: "fake_secret_access_key"
 
 db_encryption_key: "asdfasdfasdf"
-
-trial_db:
-  guid: "78ad16cf-3c22-4427-a982-b9d35d746914"
 
 tasks_disabled: false
 

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -127,10 +127,6 @@ module VCAP::CloudController
 
         :db_encryption_key => String,
 
-        optional(:trial_db) => {
-          :guid => String,
-        },
-
         optional(:tasks_disabled) => bool,
 
         optional(:hm9000_noop) => bool,
@@ -176,7 +172,6 @@ module VCAP::CloudController
 
         QuotaDefinition.configure(config)
         Stack.configure(config[:stacks_file])
-        ServicePlan.configure(config[:trial_db])
         App.configure(!config[:disable_custom_buildpacks])
 
         run_initializers(config)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -137,18 +137,6 @@ module VCAP::CloudController
         Config.configure_components(config)
       end
 
-      it "sets up the service plan" do
-        config = @test_config.merge(trial_db: "no quota")
-        ServicePlan.should_receive(:configure).with("no quota")
-        Config.configure_components(config)
-      end
-
-      it "sets up the service plan" do
-        config = @test_config.merge(trial_db: "no quota")
-        ServicePlan.should_receive(:configure).with("no quota")
-        Config.configure_components(config)
-      end
-
       it "sets up app with whether custom buildpacks are enabled" do
         config = @test_config.merge(disable_custom_buildpacks: true)
 

--- a/spec/fixtures/config/default_overriding_config.yml
+++ b/spec/fixtures/config/default_overriding_config.yml
@@ -58,7 +58,6 @@ quota_definitions:
     non_basic_services_allowed: true
     total_services: 100
     total_routes: 1000
-    trial_db_allowed: true
     memory_limit: 10240
 
   small:

--- a/spec/fixtures/config/minimal_config.yml
+++ b/spec/fixtures/config/minimal_config.yml
@@ -58,7 +58,6 @@ quota_definitions:
     non_basic_services_allowed: true
     total_services: 100
     total_routes: 1000
-    trial_db_allowed: true
     memory_limit: 10240
 
   small:

--- a/spec/fixtures/config/non_default_message_bus.yml
+++ b/spec/fixtures/config/non_default_message_bus.yml
@@ -68,7 +68,6 @@ quota_definitions:
     total_services: 100
     non_basic_services_allowed: true
     total_routes: 1000
-    trial_db_allowed: true
 
 default_quota_definition: default
 

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -70,7 +70,6 @@ quota_definitions:
     total_services: 100
     non_basic_services_allowed: true
     total_routes: 1000
-    trial_db_allowed: true
 
 default_quota_definition: default
 

--- a/spec/fixtures/config/port_8182_config.yml
+++ b/spec/fixtures/config/port_8182_config.yml
@@ -66,7 +66,6 @@ quota_definitions:
     total_services: 100
     non_basic_services_allowed: true
     total_routes: 1000
-    trial_db_allowed: true
 
 default_quota_definition: default
 

--- a/spec/models/runtime/quota_definition_spec.rb
+++ b/spec/models/runtime/quota_definition_spec.rb
@@ -28,6 +28,7 @@ module VCAP::CloudController
           total_services: 3,
           total_routes: 1000,
           memory_limit: 20,
+          trial_db_allowed: false,
       }.each do |field, value|
         it "allows export of #{field}" do
           quota_definition.public_send(:"#{field}=", value)
@@ -44,6 +45,30 @@ module VCAP::CloudController
         }.to change {
           Organization.count(:id => org.id)
         }.by(-1)
+      end
+    end
+
+    describe "#trial_db_allowed=" do
+      it "can be called on the model object" do
+        quota_definition.trial_db_allowed = true
+      end
+
+      it "will not change the value returned (deprecated)" do
+        expect(quota_definition.trial_db_allowed)
+        expect {
+          quota_definition.trial_db_allowed = true
+        }.to_not change {
+          quota_definition
+        }
+      end
+    end
+
+    describe "#trial_db_allowed" do
+      it "always returns false (deprecated)" do
+        [false, true].each do |allowed|
+          quota_definition.trial_db_allowed = allowed
+          expect(quota_definition.trial_db_allowed).to be_false
+        end
       end
     end
   end

--- a/spec/models/services/managed_service_instance_spec.rb
+++ b/spec/models/services/managed_service_instance_spec.rb
@@ -143,24 +143,14 @@ module VCAP::CloudController
                                      :non_basic_services_allowed => true)
       end
 
-      context "with a trial quota" do
-        let(:trial_db_guid) { ServicePlan.trial_db_guid }
-        let(:trial_db_plan) { ServicePlan.make(:unique_id => trial_db_guid) }
-        let(:paid_db_plan) { ServicePlan.make(:unique_id => "aws_rds_mysql_cfinternal") }
-
-        let(:trial_quota) do
-          QuotaDefinition.make(:total_services => 0,
-                                       :non_basic_services_allowed => false,
-                                       :trial_db_allowed => true)
-        end
-
-        let(:org) { Organization.make(:quota_definition => trial_quota) }
+      context "with a free quota" do
+        let(:org) { Organization.make(:quota_definition => free_quota) }
         let(:space) { Space.make(:organization => org) }
 
-        context "when the service instance is not a trial db instance" do
+        context "when the service instance is not associated with a free plan" do
           it "raises an error" do
             expect {
-              ManagedServiceInstance.make(space: space, service_plan: paid_db_plan)
+              ManagedServiceInstance.make(space: space, service_plan: paid_plan)
             }.to raise_error(Sequel::ValidationFailed, /service_plan paid_services_not_allowed/)
           end
         end

--- a/spec/presenters/api/quota_definition_presenter_spec.rb
+++ b/spec/presenters/api/quota_definition_presenter_spec.rb
@@ -17,7 +17,7 @@ describe QuotaDefinitionPresenter do
           :non_basic_services_allowed => quota_definition.non_basic_services_allowed,
           :total_services => quota_definition.total_services,
           :memory_limit => quota_definition.memory_limit,
-          :trial_db_allowed => quota_definition.trial_db_allowed
+          :trial_db_allowed => false
         }
       })
     end

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -252,7 +252,6 @@ module VCAP::CloudController
     total_services { 60 }
     total_routes { 1_000 }
     memory_limit { 20_480 } # 20 GB
-    trial_db_allowed { false }
   end
 
   Buildpack.blueprint do


### PR DESCRIPTION
Based on vcap-dev exchanges [[1]](https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/45DAQHwxww0/fWVP4kQXdaUJ) and an existing tracker story [[2]](https://www.pivotaltracker.com/s/projects/966314/stories/61846224), this PR is part 2/3 in support of removing `trial_db_allowed` and `trial_db_guid`.

Pull requests:
1. Updates to cf-release to remove references from the properties and templates (cloudfoundry/cf-release#299)
2. Removes code related to `trial_db_allowed` from the cloud controller (cloudfoundry/cloud_controller_ng#168)
3. Sequel migration to remove the database column (cloudfoundry/cloud_controller_ng#169)

1 and 2 can be done in one release (but 1 must happen with or before 2) while 3 should happen in a subsequent release.

For this PR, I have some minor concerns over the change to the API spec but based on [[3]](https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/NY6VIIG-75U/0-2duMUsaa4J) it doesn't seem like it should be an issue.  When quotas are displayed from the cli, this field is not rendered.  Any guidance is welcome.

[1] https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/45DAQHwxww0/fWVP4kQXdaUJ
[2] https://www.pivotaltracker.com/s/projects/966314/stories/61846224
[3] https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/NY6VIIG-75U/0-2duMUsaa4J
