### PR TITLE
Sequel migration for trial_db removal

### DIFF
--- a/db/migrations/20140220184651_remove_trial_db_allowed.rb
+++ b/db/migrations/20140220184651_remove_trial_db_allowed.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :quota_definitions do
+      drop_column :trial_db_allowed
+    end
+  end
+
+  down do
+    alter_table :quota_definitions do
+      add_column :trial_db_allowed, TrueClass, :default => false
+    end
+  end
+end


### PR DESCRIPTION
Based on vcap-dev exchanges [[1]](https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/45DAQHwxww0/fWVP4kQXdaUJ) and an existing tracker story [[2]](https://www.pivotaltracker.com/s/projects/966314/stories/61846224), this PR is part 3/3 in support of removing `trial_db_allowed` and `trial_db_guid`.

Pull requests:
1. Updates to cf-release to remove references from the properties and templates (cloudfoundry/cf-release#299)
2. Removes code related to `trial_db_allowed` from the cloud controller (cloudfoundry/cloud_controller_ng#168)
3. Sequel migration to remove the database column (cloudfoundry/cloud_controller_ng#169)

1 and 2 can be done in one release (but 1 must happen with or before 2) while 3 should happen in a subsequent release.

While I believe the migration done here is safe when applied after 2, if it weren't applied, the `trial_db_allowed` field could be left in the schema without any adverse effects.

[1] https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/45DAQHwxww0/fWVP4kQXdaUJ
[2] https://www.pivotaltracker.com/s/projects/966314/stories/61846224
[3] https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/NY6VIIG-75U/0-2duMUsaa4J
