### PR TITLE
Rename max_droplet_size to max_package_size

### DIFF
--- a/app/jobs/runtime/app_bits_packer.rb
+++ b/app/jobs/runtime/app_bits_packer.rb
@@ -10,8 +10,8 @@ module VCAP::CloudController
           app = VCAP::CloudController::App.find(guid: app_guid)
           package_blobstore = CloudController::DependencyLocator.instance.package_blobstore
           global_app_bits_cache = CloudController::DependencyLocator.instance.global_app_bits_cache
-          max_droplet_size = VCAP::CloudController::Config.config[:packages][:max_droplet_size] || 512 * 1024 * 1024
-          app_bits_packer = AppBitsPackage.new(package_blobstore, global_app_bits_cache, max_droplet_size, VCAP::CloudController::Config.config[:directories][:tmpdir])
+          max_package_size = VCAP::CloudController::Config.config[:packages][:max_package_size] || 512 * 1024 * 1024
+          app_bits_packer = AppBitsPackage.new(package_blobstore, global_app_bits_cache, max_package_size, VCAP::CloudController::Config.config[:directories][:tmpdir])
           app_bits_packer.create(app, uploaded_compressed_path, CloudController::Blobstore::FingerprintsCollection.new(fingerprints))
         end
 

--- a/app/models/runtime/app_bits_package.rb
+++ b/app/models/runtime/app_bits_package.rb
@@ -2,12 +2,12 @@ require "cloud_controller/blobstore/local_app_bits"
 require "cloud_controller/blobstore/fingerprints_collection"
 
 class AppBitsPackage
-  attr_reader :package_blobstore, :global_app_bits_cache, :max_droplet_size, :tmp_dir
+  attr_reader :package_blobstore, :global_app_bits_cache, :max_package_size, :tmp_dir
 
-  def initialize(package_blobstore, global_app_bits_cache, max_droplet_size, tmp_dir)
+  def initialize(package_blobstore, global_app_bits_cache, max_package_size, tmp_dir)
     @package_blobstore = package_blobstore
     @global_app_bits_cache = global_app_bits_cache
-    @max_droplet_size = max_droplet_size
+    @max_package_size = max_package_size
     @tmp_dir = tmp_dir
   end
 
@@ -33,11 +33,11 @@ class AppBitsPackage
   private
 
   def validate_size!(fingerprints_in_app_cache, local_app_bits)
-    return unless max_droplet_size
+    return unless max_package_size
 
     total_size = local_app_bits.storage_size + fingerprints_in_app_cache.storage_size
-    if total_size > max_droplet_size
-      raise VCAP::Errors::AppPackageInvalid, "Package may not be larger than #{max_droplet_size} bytes"
+    if total_size > max_package_size
+      raise VCAP::Errors::AppPackageInvalid, "Package may not be larger than #{max_package_size} bytes"
     end
   end
 end

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -113,13 +113,12 @@ module VCAP::CloudController
         },
 
         :packages => {
-          optional(:max_droplet_size) => Integer,
+          optional(:max_package_size) => Integer,
           optional(:app_package_directory_key) => String,
           :fog_connection => Hash
         },
 
         :droplets => {
-          optional(:max_droplet_size) => Integer,
           optional(:droplet_directory_key) => String,
           :fog_connection => Hash
         },

--- a/spec/jobs/runtime/app_bits_packer_spec.rb
+++ b/spec/jobs/runtime/app_bits_packer_spec.rb
@@ -15,10 +15,10 @@ module VCAP::CloudController
         let(:package_blobstore) { double(:package_blobstore) }
         let(:global_app_bits_cache) { double(:global_app_bits_cache) }
         let(:tmpdir) { "/tmp/special_temp" }
-        let(:max_droplet_size) { 256 }
+        let(:max_package_size) { 256 }
 
         before do
-          config_override({:directories => {:tmpdir => tmpdir}, :packages => config[:packages].merge(:max_droplet_size => max_droplet_size)})
+          config_override({:directories => {:tmpdir => tmpdir}, :packages => config[:packages].merge(:max_package_size => max_package_size)})
 
           CloudController::Blobstore::FingerprintsCollection.stub(:new) { fingerprints }
           App.stub(:find) { app }
@@ -41,7 +41,7 @@ module VCAP::CloudController
           CloudController::DependencyLocator.instance.should_receive(:global_app_bits_cache).and_return(global_app_bits_cache)
 
           packer = double
-          AppBitsPackage.should_receive(:new).with(package_blobstore, global_app_bits_cache, max_droplet_size, tmpdir).and_return(packer)
+          AppBitsPackage.should_receive(:new).with(package_blobstore, global_app_bits_cache, max_package_size, tmpdir).and_return(packer)
           packer.should_receive(:create).with(app, uploaded_path, fingerprints)
           job.perform
         end

--- a/spec/models/runtime/app_bits_package_spec.rb
+++ b/spec/models/runtime/app_bits_package_spec.rb
@@ -23,8 +23,8 @@ describe AppBitsPackage do
     CloudController::Blobstore::Client.new({provider: "Local", local_root: blobstore_dir}, "package")
   end
 
-  let(:packer) { AppBitsPackage.new(package_blobstore, global_app_bits_cache, max_droplet_size, local_tmp_dir) }
-  let(:max_droplet_size) { 1_073_741_824 }
+  let(:packer) { AppBitsPackage.new(package_blobstore, global_app_bits_cache, max_package_size, local_tmp_dir) }
+  let(:max_package_size) { 1_073_741_824 }
 
   around do |example|
     begin
@@ -90,7 +90,7 @@ describe AppBitsPackage do
     end
 
     context "when the app bits are too large" do
-      let(:max_droplet_size) { 10 }
+      let(:max_package_size) { 10 }
 
       it "raises an exception" do
         expect {
@@ -105,7 +105,7 @@ describe AppBitsPackage do
     end
 
     context "when the max droplet size is not configured" do
-      let(:max_droplet_size) { nil }
+      let(:max_package_size) { nil }
 
       it "always accepts any droplet size" do
         fingerprints_in_app_cache = CloudController::Blobstore::FingerprintsCollection.new(


### PR DESCRIPTION
In preparation for surfacing the max app bits package size as a configurable attribute in cf-release, rename
`ccng.packages.max_droplet_size` to `ccng.packages.max_package_size` to more accurately reflect its purpose.  Since there is currently no support in the cf-release templates for this config, the impact of the rename is minimal.

Also, since ccng.droplet.max_droplet_size is not used in the code, remove its declaration from config.
