### PR TITLE
Add buildpack information to app usage event.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor
 .DS_Store
 log
 tmp
+tags

--- a/app/models/runtime/app_usage_event.rb
+++ b/app/models/runtime/app_usage_event.rb
@@ -1,6 +1,9 @@
 module VCAP::CloudController
   class AppUsageEvent < Sequel::Model
     plugin :serialization
-    export_attributes :state, :memory_in_mb_per_instance, :instance_count, :app_guid, :app_name, :space_guid, :space_name, :org_guid
+
+    export_attributes :state, :memory_in_mb_per_instance, :instance_count,
+      :app_guid, :app_name, :space_guid, :space_name, :org_guid,
+      :buildpack_guid, :buildpack_name
   end
 end

--- a/db/migrations/20140319191826_add_buildpack_info_to_app_usage_events.rb
+++ b/db/migrations/20140319191826_add_buildpack_info_to_app_usage_events.rb
@@ -1,0 +1,6 @@
+Sequel.migration do
+  change do
+    add_column :app_usage_events, :buildpack_guid, String
+    add_column :app_usage_events, :buildpack_name, String
+  end
+end

--- a/db/migrations/20140324172951_add_detected_buildpack_guid_to_app.rb
+++ b/db/migrations/20140324172951_add_detected_buildpack_guid_to_app.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :apps, :detected_buildpack_guid, String
+  end
+end

--- a/rubocop-todo.yml
+++ b/rubocop-todo.yml
@@ -99,7 +99,7 @@ CaseIndentation:
 # Offence count: 20
 # Configuration parameters: CountComments.
 ClassLength:
-  Max: 396
+  Max: 398
 
 # Offence count: 2
 ClassVars:

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "digest/sha1"
 
 describe "Stable API warning system", api_version_check: true do
-  API_FOLDER_CHECKSUM = "65a2269e8f71ee2c347cd02ecbdf8e8a9b09a1d7"
+  API_FOLDER_CHECKSUM = "b0f4ceeb12a5c59bb3413d57545a0932ad712f00"
 
   it "double-checks the version" do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq("2.2.0")

--- a/spec/api/documentation/app_usage_event_api_spec.rb
+++ b/spec/api/documentation/app_usage_event_api_spec.rb
@@ -19,6 +19,8 @@ resource "App Usage Events (experimental)", :type => :api do
     field :org_guid, "The GUID of the organization.", required: false, readonly: true
     field :space_guid, "The GUID of the space.", required: false, readonly: true
     field :space_name, "The name of the space.", required: false, readonly: true
+    field :buildpack_guid, "The GUID of the buildpack used to stage the app.", required: false, readonly: true
+    field :builpack_name, "The name of the buildpack or the URL of the custom buildpack used to stage the app.", required: false, readonly: true, example_values: %w[https://example.com/buildpack.git admin_buildpack]
     field :created_at, "The timestamp when the event is recorded. It is possible that later events may have earlier created_at values.", required: false, readonly: true
 
     standard_list_parameters VCAP::CloudController::AppUsageEventsController

--- a/spec/api/documentation/apps_api_spec.rb
+++ b/spec/api/documentation/apps_api_spec.rb
@@ -23,7 +23,8 @@ resource "Apps", :type => :api do
   field :health_check_timeout, "Timeout for health checking of an staged app when starting up", required: false
   field :environment_json, "Key/value pairs of all the environment variables to run in your app. Does not include any system or service variables.", required: false
 
-  field :detected_buildpack, "The autodetected buildpack that was run.", required: false, readonly: true
+  field :detected_buildpack, "The autodetected buildpack that staged the app.", required: false, readonly: true
+  field :detected_buildpack_guid, "The GUID of the autodetected admin buildpack that staged the app.", required: false, readonly: true
   field :space_url, "The url of the associated space.", required: false, readonly: true
   field :stack_url, "The url of the associated stack.", required: false, readonly: true
   field :service_bindings_url, "The url of all the associated service bindings.", required: false, readonly: true

--- a/spec/models/runtime/app_usage_event_spec.rb
+++ b/spec/models/runtime/app_usage_event_spec.rb
@@ -11,7 +11,9 @@ module VCAP::CloudController
         app_name: 'app-name',
         space_guid: 'space-guid',
         space_name: 'space-name',
-        org_guid: 'org-guid'
+        org_guid: 'org-guid',
+        buildpack_guid: 'buildpack',
+        buildpack_name: 'https://example.com/buildpack.git'
       }
     end
 
@@ -27,6 +29,16 @@ module VCAP::CloudController
       end
     end
 
+    describe "optional attributes" do
+      let(:optional_attributes) { [:buildpack_guid, :buildpack_name] }
+
+      it "does not raise exception when they are missing" do
+        expect {
+          AppUsageEvent.create(valid_attributes.except(optional_attributes))
+        }.to_not raise_error
+      end
+    end
+
     describe "serialization" do
       it "has the relevant fields" do
         event = AppUsageEvent.make
@@ -39,6 +51,8 @@ module VCAP::CloudController
         expect(json_hash.fetch('space_guid')).to eq(event.space_guid)
         expect(json_hash.fetch('space_name')).to eq(event.space_name)
         expect(json_hash.fetch('org_guid')).to eq(event.org_guid)
+        expect(json_hash.fetch('buildpack_guid')).to eq(event.buildpack_guid)
+        expect(json_hash.fetch('buildpack_name')).to eq(event.buildpack_name)
       end
     end
   end

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -269,5 +269,7 @@ module VCAP::CloudController
     org_guid { Sham.guid }
     space_guid { Sham.guid }
     space_name { Sham.name }
+    buildpack_guid { Sham.guid }
+    buildpack_name { Sham.name }
   end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -25,7 +25,9 @@ RSpec::Matchers.define :match_app do |app|
       state.app_name == app.name &&
       state.org_guid == app.space.organization_guid &&
       state.space_guid == app.space_guid &&
-      state.space_name == app.space.name
+      state.space_name == app.space.name &&
+      state.buildpack_name == (app.custom_buildpack_url || app.buildpack_name) &&
+      state.buildpack_guid == app.buildpack_guid
   end
 end
 


### PR DESCRIPTION
This adds information about the buildpack used to stage an application to the app usage events.  This intended to be part of the resolution to cloudfoundry/cloud_controller_ng#178.

I added a new column to the apps table to hold the detected buildpack guid but didn't expose it to the api
layer pending further discussions.  I also noticed some inconsistencies in the app usage event.  In some cases the name and guid are added to the record while in others it's only the guid.  I can't tell which is preferred.

There are some rough spots here so, as always, this is a proposal; I'm happy to work out the details.

/cc @markkropf @fraenkel
