### PR TITLE
Enable retrieval of app usage event by guid

### DIFF
--- a/app/controllers/runtime/app_usage_events_controller.rb
+++ b/app/controllers/runtime/app_usage_events_controller.rb
@@ -4,6 +4,8 @@ module VCAP::CloudController
 
     get "/v2/app_usage_events", :enumerate
 
+    get "#{path_guid}", :read
+
     post "/v2/app_usage_events/destructively_purge_all_and_reseed_started_apps", :reset
 
     def reset
@@ -18,6 +20,10 @@ module VCAP::CloudController
       AppUsageEvent.insert([:guid, :app_guid, :app_name, :state, :instance_count, :memory_in_mb_per_instance, :space_guid, :space_name, :org_guid, :created_at], usage_query)
 
       [HTTP::NO_CONTENT, nil]
+    end
+
+    def self.not_found_exception_name
+      "EventNotFound"
     end
 
     private

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "digest/sha1"
 
 describe "Stable API warning system", api_version_check: true do
-  API_FOLDER_CHECKSUM = "e92ec59b4dcab7e5e4c1355f04d311d7bbb97717"
+  API_FOLDER_CHECKSUM = "06d8c6726711f17e4891ee13ba23cb8ee72ca303"
 
   it "double-checks the version" do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq("2.2.0")

--- a/spec/api/documentation/app_usage_event_api_spec.rb
+++ b/spec/api/documentation/app_usage_event_api_spec.rb
@@ -4,6 +4,7 @@ require 'rspec_api_documentation/dsl'
 resource "App Usage Events (experimental)", :type => :api do
   let(:admin_auth_header) { headers_for(admin_user, :admin_scope => true)["HTTP_AUTHORIZATION"] }
   authenticated_request
+  let(:guid) { VCAP::CloudController::AppUsageEvent.first.guid }
   let!(:event1) { VCAP::CloudController::AppUsageEvent.make }
   let!(:event2) { VCAP::CloudController::AppUsageEvent.make }
   let!(:event3) { VCAP::CloudController::AppUsageEvent.make }
@@ -21,6 +22,7 @@ resource "App Usage Events (experimental)", :type => :api do
     field :created_at, "The timestamp when the event is recorded. It is possible that later events may have earlier created_at values.", required: false, readonly: true
 
     standard_list_parameters VCAP::CloudController::AppUsageEventsController
+    standard_model_get :app_usage_event
     request_parameter :after_guid, "Restrict results to App Usage Events after the one with the given guid"
 
     example "List app usage events" do

--- a/spec/controllers/runtime/app_usage_events_controller_spec.rb
+++ b/spec/controllers/runtime/app_usage_events_controller_spec.rb
@@ -39,10 +39,25 @@ module VCAP::CloudController
           expect(decoded_response.fetch("prev_url")).to eql("/v2/app_usage_events?after_guid=#{@event1.guid}&page=1&results-per-page=1")
         end
 
-        it "returns 404 when guid does not exist" do
+        it "returns 400 when guid does not exist" do
           get "/v2/app_usage_events?after_guid=ABC", {}, admin_headers
           expect(last_response.status).to eql(400)
         end
+      end
+    end
+
+    describe "GET /v2/app_usage_events/:guid" do
+      it "retrieves an event by guid" do
+        url = "/v2/app_usage_events/#{@event1.guid}"
+        get url, {}, admin_headers
+        expect(last_response).to be_successful
+        expect(decoded_response["metadata"]["guid"]).to eq(@event1.guid)
+        expect(decoded_response["metadata"]["url"]).to eq(url)
+      end
+
+      it "returns 404 when he guid does nos exist" do
+        get "/v2/app_usage_events/bogus", {}, admin_headers
+        expect(last_response.status).to eql(404)
       end
     end
 


### PR DESCRIPTION
The `app_usage_events_controller` does not include the standard `define_routes` call to the base model controller since there's no need to provide all CRUD operations.  That's fine but the existing base controller will return enumerations with url's for individual events that were not handled by the `app_usage_events_controller`.

This simply adds the ability to get usage events by guid so the urls returned from the enumeration work and the behavior is consistent.
