### PR TITLE
Don't ignore X-Vcap-Request-Id from the router

### DIFF
--- a/lib/sinatra/vcap.rb
+++ b/lib/sinatra/vcap.rb
@@ -101,8 +101,8 @@ module Sinatra
         logger_name = opts[:logger_name] || 'vcap.api'
         env['rack.logger'] = Steno.logger(logger_name)
 
-        @request_guid = env['X_VCAP_REQUEST_ID']
-        @request_guid ||= env['X_REQUEST_ID']
+        @request_guid = env['HTTP_X_VCAP_REQUEST_ID']
+        @request_guid ||= env['HTTP_X_REQUEST_ID']
 
         # we append a new guid to the request because we have no idea if the
         # caller is really going to be giving us a unique guid, i.e. they might

--- a/spec/sinatra/vcap_spec.rb
+++ b/spec/sinatra/vcap_spec.rb
@@ -217,7 +217,7 @@ describe 'Sinatra::VCAP' do
 
   describe 'caller provided x-vcap-request-id' do
     before do
-      get '/request_id', {}, {'X_VCAP_REQUEST_ID' => 'abcdef'}
+      get '/request_id', {}, {'HTTP_X_VCAP_REQUEST_ID' => 'abcdef'}
     end
 
     it 'should set the X-VCAP-Request-ID to the caller specified value' do
@@ -233,7 +233,7 @@ describe 'Sinatra::VCAP' do
 
   describe 'caller provided x-request-id' do
     before do
-      get '/request_id', {}, {'X_REQUEST_ID' => 'abcdef'}
+      get '/request_id', {}, {'HTTP_X_REQUEST_ID' => 'abcdef'}
     end
 
     it 'should set the X-VCAP-Request-ID to the caller specified value' do
@@ -249,10 +249,10 @@ describe 'Sinatra::VCAP' do
 
   describe 'caller provided x-request-id and x-vcap-request-id' do
     before do
-      get '/request_id', {}, {'X_REQUEST_ID' => 'abc', 'X_VCAP_REQUEST_ID' => 'def'}
+      get '/request_id', {}, {'HTTP_X_REQUEST_ID' => 'abc', 'HTTP_X_VCAP_REQUEST_ID' => 'def'}
     end
 
-    it 'should set the X-VCAP-Request-ID to the caller specified value of X_VCAP_REQUEST_ID' do
+    it 'should set the X-VCAP-Request-ID to the caller specified value of X-VCAP-Request-ID' do
       last_response.status.should == 200
       last_response.headers['X-VCAP-Request-ID'].should match /def::.*/
     end


### PR DESCRIPTION
The code in `vcap.rb` did not adhere to the sinatra request header normalization conventions so it wasn't picking up the request id propagated from the go router.
