### PR TITLE
Inject the new buildpack installer task

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -222,3 +222,5 @@ diego: <%= p("ccng.diego") %>
 <% if_p("ssl.skip_cert_verify") do |skip_cert_verify|%>
 skip_cert_verify: <%= skip_cert_verify %>
 <% end %>
+
+install_buildpacks: <%= p("ccng.install_buildpacks", []).to_yaml.gsub("---", "") %>

--- a/bosh-templates/cloud_controller_api_worker_ctl.erb
+++ b/bosh-templates/cloud_controller_api_worker_ctl.erb
@@ -50,6 +50,22 @@ case $1 in
     <% end %>
 
     cd $CC_PACKAGE_DIR/cloud_controller_ng
+    
+    # Run the buildpack install only on the first CC Worker launch
+    <% if spec.index.to_i == 0 %>
+    chpst -u vcap:vcap bundle exec rake buildpacks:install \<% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
+      > >(tee -a >(logger -p user.info -t vcap.buildpacks.stdout) $LOG_DIR/buildpacks.stdout.log) \
+      2> >(tee -a >(logger -p user.error -t vcap.buildpacks.stderr) $LOG_DIR/buildpacks.stderr.log)<% else %>
+      >>$LOG_DIR/buildpacks.stdout.log \
+      2>>$LOG_DIR/buildpacks.stderr.log
+      <% end %>
+
+    if [ $? != 0 ]; then
+      echo "Buildpacks installation failed"
+      exit 1
+    fi
+    <% end %>
+
     <% task_name = "jobs:local"  %>
     exec chpst -u vcap:vcap bundle exec rake <%= task_name %> \<% if properties.syslog_aggregator && properties.syslog_aggregator.address %>
       > >(tee -a >(logger -p user.info -t vcap.jobs_work.stdout) $LOG_DIR/jobs_work.stdout.log) \

--- a/lib/tasks/buildpacks.rake
+++ b/lib/tasks/buildpacks.rake
@@ -4,6 +4,6 @@ namespace :buildpacks do
   task :install do
     buildpacks = config[:install_buildpacks]
     BackgroundJobEnvironment.new(config).setup_environment
-    VCAP::CloudController::InstallBuildpacks.install(buildpacks)
+    VCAP::CloudController::InstallBuildpacks.new(config).install(buildpacks)
   end
 end


### PR DESCRIPTION
Now that the job is in place, this is part 2 of 4.
See dea_ng and cf-release for the other pull requests.

Wire in the installer as part of starting the local queue.
Add configuration to CC to specify the buildpacks to install.
