### PR TITLE
Correct how buildpack positions are managed.

### DIFF
--- a/lib/cloud_controller/rest_controller/model_controller.rb
+++ b/lib/cloud_controller/rest_controller/model_controller.rb
@@ -79,9 +79,7 @@ module VCAP::CloudController::RestController
 
     def do_delete(obj)
       raise_if_has_associations!(obj) if v2_api? && !recursive?
-
       model_deletion_job = Jobs::Runtime::ModelDeletion.new(obj.class, obj.guid)
-
       if async?
         job = Jobs::Enqueuer.new(model_deletion_job, queue: "cc-generic").enqueue()
         [HTTP::ACCEPTED, JobPresenter.new(job).to_json]

--- a/spec/controllers/runtime/buildpacks_controller_spec.rb
+++ b/spec/controllers/runtime/buildpacks_controller_spec.rb
@@ -25,8 +25,7 @@ module VCAP::CloudController
         end
 
         it "sets the position correctly even if an invalid position is provided" do
-          should_have_been_1 = 10
-          post "/v2/buildpacks", Yajl::Encoder.encode({name: "dynamic_test_buildpack", position: should_have_been_1}), admin_headers
+          post "/v2/buildpacks", Yajl::Encoder.encode({name: "dynamic_test_buildpack", position: 10}), admin_headers
           expect(decoded_response['entity']['position']).to eq(1)
         end
 
@@ -122,10 +121,10 @@ module VCAP::CloudController
             }.to change {
               Buildpack.order(:position).map { |bp| [bp.name, bp.position, bp.filename] }
             }.from(
-                   [["first_buildpack", 1, 'a'], ["second_buildpack", 2, 'b']]
-                 ).to(
-                   [["second_buildpack", 1, 'b'], ["first_buildpack", 2, 'a']]
-                 )
+              [["first_buildpack", 1, 'a'], ["second_buildpack", 2, 'b']]
+            ).to(
+              [["second_buildpack", 1, 'b'], ["first_buildpack", 2, 'a']]
+            )
           end
 
           it "updates current end to beyond end of list" do
@@ -144,18 +143,17 @@ module VCAP::CloudController
             }.to change {
               Buildpack.order(:position).map { |bp| [bp.name, bp.position] }
             }.from(
-                   [["first_buildpack", 1], ["second_buildpack", 2]]
-                 ).to(
-                   [["second_buildpack", 1], ["first_buildpack", 2]]
-                 )
+              [["first_buildpack", 1], ["second_buildpack", 2]]
+            ).to(
+              [["second_buildpack", 1], ["first_buildpack", 2]]
+            )
           end
         end
       end
 
       context "DELETE" do
         let!(:buildpack1) do
-          should_have_been_1 = 5
-          VCAP::CloudController::Buildpack.create({name: "first_buildpack", key: "xyz", position: should_have_been_1})
+          VCAP::CloudController::Buildpack.create({name: "first_buildpack", key: "xyz", position: 1})
         end
 
         before { Delayed::Worker.delay_jobs = false }
@@ -209,18 +207,32 @@ module VCAP::CloudController
             VCAP::CloudController::Buildpack.create({name: "third_buildpack", key: "xyz", position: should_have_been_3})
           end
 
-          it "shifts down" do
+          it "shifts all buildpacks down" do
             expect {
-            delete "/v2/buildpacks/#{buildpack1.guid}", {}, admin_headers
+              delete "/v2/buildpacks/#{buildpack1.guid}", {}, admin_headers
               expect(last_response.status).to eq(204)
             }.to change {
               Buildpack.order(:position).map { |bp| [bp.name, bp.position] }
             }.from(
-                   [["first_buildpack", 1], ["second_buildpack", 2], ["third_buildpack", 3]]
-                 ).to(
-                   [["second_buildpack", 1], ["third_buildpack", 2]]
-                 )
+              [["first_buildpack", 1], ["second_buildpack", 2], ["third_buildpack", 3]]
+            ).to(
+              [["second_buildpack", 1], ["third_buildpack", 2]]
+            )
           end
+
+          it "shifts only ones greater than itself" do
+            expect {
+              delete "/v2/buildpacks/#{buildpack2.guid}", {}, admin_headers
+              expect(last_response.status).to eq(204)
+            }.to change {
+              Buildpack.order(:position).map { |bp| [bp.name, bp.position] }
+            }.from(
+              [["first_buildpack", 1], ["second_buildpack", 2], ["third_buildpack", 3]]
+            ).to(
+              [["first_buildpack", 1], ["third_buildpack", 2]]
+            )
+          end
+
         end
       end
     end

--- a/spec/integration/app_staging_spec.rb
+++ b/spec/integration/app_staging_spec.rb
@@ -54,8 +54,9 @@ describe "Staging an app", type: :integration do
       )
 
       @expected_buildpack_shas = [
+        "#{@buildpack_response_2.json_body["metadata"]["guid"]}_#{valid_zip.hexdigest}",
         "#{@buildpack_response_1.json_body["metadata"]["guid"]}_#{valid_zip(4).hexdigest}",
-        "#{@buildpack_response_2.json_body["metadata"]["guid"]}_#{valid_zip.hexdigest}"]
+      ]
 
       org = make_post_request(
         "/v2/organizations",
@@ -177,10 +178,10 @@ describe "Staging an app", type: :integration do
             end
           end
         end
-        
+
         context "excludes disabled buildpacks" do
           before do
-            @enabled_buildpack_shas = @expected_buildpack_shas[0..0]
+            @enabled_buildpack_shas = @expected_buildpack_shas[1..1]
             @buildpack_response_2_disable = make_put_request(
               "/v2/buildpacks/#{@buildpack_response_2.json_body["metadata"]["guid"]}",
               { "enabled" => false }.to_json,


### PR DESCRIPTION
Insert/Update have different rules depending on where the new/update buildpack needs to slot into.
Added testcases to cover the more basic insert in the middle.
Overall test cleanup, removed tests that no longer made sense, fixed ones that had misleading intent.
