### PR TITLE
Call out rubocop for static code analysis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Follow these steps to make a contribution to any of our open source repositories
 1. Create a feature branch (`git checkout -b better_cloud_controller`)
 1. Make changes on your branch
 1. [Run tests](https://github.com/cloudfoundry/cloud_controller_ng#testing)
+1. [Run static analysis](https://github.com/cloudfoundry/cloud_controller_ng#static-analysis)
 1. Push to your fork (`git push origin better_cloud_controller`) and submit a pull request
 
 We favor pull requests with very small, single commits with a single purpose.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Due to the large number of tests, the rake spec task is configured to run in par
 
 Integration and acceptance tests, however, do not support concurrent testing (e.g. starting NATS on the same port at the same time), and are thus run serially.
 
+## Static Analysis
+
+To help maintain code consistency, rubocop is used to enforce code conventions and best practices.
+
+### Running static analysis
+
+    bundle exec rubucop
+
+Travis currently runs rubocop as part of the CI process.
+
 ## API documentation
 
 To genenerate the API documentation


### PR DESCRIPTION
Rubocop was introduced to Travis CI back in February but the README was not updated.  Given a rubocop offense will fail the build, it seems it should be highlighted along with tests and api specs.
