### PR TITLE
Support for setting a default disk_quota for newly pushed apps.

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -11,7 +11,7 @@ module VCAP::CloudController
       attribute  :system_env_json,     Hash,       :default => {}
       attribute  :memory,              Integer,    :default => nil
       attribute  :instances,           Integer,    :default => 1
-      attribute  :disk_quota,          Integer,    :default => 1024
+      attribute  :disk_quota,          Integer,    :default => nil
 
       attribute  :state,               String,     :default => "STOPPED"
       attribute  :command,             String,     :default => nil

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -126,6 +126,7 @@ module VCAP::CloudController
 
       self.stack ||= Stack.default
       self.memory ||= Config.config[:default_app_memory]
+      self.disk_quota ||= Config.config[:default_app_disk_in_mb]
 
       set_new_version if version_needs_to_be_updated?
 

--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -66,6 +66,7 @@ audit_events:
 billing_event_writing_enabled: <%= p("ccng.billing_event_writing_enabled") %>
 
 default_app_memory: <%= p("ccng.default_app_memory") %>
+default_app_disk_in_mb: <%= p("ccng.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("ccng.maximum_app_disk_in_mb") %>
 
 request_timeout_in_seconds: <%= p("request_timeout_in_seconds") %>

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -66,6 +66,7 @@ audit_events:
 billing_event_writing_enabled: <%= p("ccng.billing_event_writing_enabled") %>
 
 default_app_memory: <%= p("ccng.default_app_memory") %>
+default_app_disk_in_mb: <%= p("ccng.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("ccng.maximum_app_disk_in_mb") %>
 
 request_timeout_in_seconds: <%= p("request_timeout_in_seconds") %>

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -66,6 +66,7 @@ audit_events:
 billing_event_writing_enabled: <%= p("ccng.billing_event_writing_enabled") %>
 
 default_app_memory: <%= p("ccng.default_app_memory") %>
+default_app_disk_in_mb: <%= p("ccng.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("ccng.maximum_app_disk_in_mb") %>
 
 request_timeout_in_seconds: <%= p("request_timeout_in_seconds") %>

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -31,6 +31,7 @@ audit_events:
 billing_event_writing_enabled: true
 
 default_app_memory: 1024 #mb
+default_app_disk_in_mb: 1024
 maximum_app_disk_in_mb: 2048
 
 info:

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -27,6 +27,7 @@ module VCAP::CloudController
         },
         optional(:billing_event_writing_enabled) => bool,
         :default_app_memory => Fixnum,
+        :default_app_disk_in_mb => Fixnum,
         optional(:maximum_app_disk_in_mb) => Fixnum,
         :maximum_health_check_timeout => Fixnum,
 

--- a/rubocop-todo.yml
+++ b/rubocop-todo.yml
@@ -99,7 +99,7 @@ CaseIndentation:
 # Offence count: 20
 # Configuration parameters: CountComments.
 ClassLength:
-  Max: 398
+  Max: 399
 
 # Offence count: 2
 ClassVars:

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -47,6 +47,10 @@ module VCAP::CloudController
           expect(config[:stacks_file]).to eq("/tmp/foo")
         end
 
+        it "preserves the default_app_disk_in_mb value from the file" do
+          expect(config[:default_app_disk_in_mb]).to eq(512)
+        end
+        
         it "preserves the maximum_app_disk_in_mb value from the file" do
           expect(config[:maximum_app_disk_in_mb]).to eq(3)
         end

--- a/spec/controllers/runtime/apps_controller_spec.rb
+++ b/spec/controllers/runtime/apps_controller_spec.rb
@@ -96,6 +96,31 @@ module VCAP::CloudController
         end
       end
 
+      context "disk quota" do
+         let (:default_disk) { 512 }
+
+        before do
+          config_override({ :default_app_disk_in_mb => default_disk })
+        end
+
+        it "uses the configured default when no quota is specified" do
+          create_app
+          decoded_response["entity"]["disk_quota"].should == default_disk
+        end
+        context "when disk quota provided" do
+           let(:provided_disk) { 256 }
+             
+           before do
+             initial_hash[:disk_quota] = provided_disk
+           end
+ 
+           it "uses the provided disk quota" do
+             create_app
+             decoded_response["entity"]["disk_quota"].should == provided_disk
+           end
+         end
+      end
+
       context "when instances is less than 0" do
         before do
           initial_hash[:instances] = -1

--- a/spec/fixtures/config/default_overriding_config.yml
+++ b/spec/fixtures/config/default_overriding_config.yml
@@ -91,6 +91,7 @@ renderer:
   default_results_per_page: 50
 
 stacks_file: "/tmp/foo"
+default_app_disk_in_mb: 512
 maximum_app_disk_in_mb: 3
 directories:
   some: "value"

--- a/spec/fixtures/config/minimal_config.yml
+++ b/spec/fixtures/config/minimal_config.yml
@@ -21,6 +21,7 @@ app_usage_events:
   cutoff_age_in_days: 31
 
 default_app_memory: 1024 #mb
+default_app_disk_in_mb: 1024
 maximum_health_check_timeout: 180
 
 uaa:

--- a/spec/fixtures/config/non_default_message_bus.yml
+++ b/spec/fixtures/config/non_default_message_bus.yml
@@ -31,6 +31,7 @@ audit_events:
   cutoff_age_in_days: 31
 
 default_app_memory: 1024 #mb
+default_app_disk_in_mb: 1024
 maximum_app_disk_in_mb: 2048
 
 uaa:

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -30,6 +30,7 @@ audit_events:
   cutoff_age_in_days: 31
 
 default_app_memory: 1024 #mb
+default_app_disk_in_mb: 1024
 maximum_app_disk_in_mb: 2048
 
 uaa:

--- a/spec/fixtures/config/port_8182_config.yml
+++ b/spec/fixtures/config/port_8182_config.yml
@@ -30,6 +30,7 @@ audit_events:
   cutoff_age_in_days: 31
 
 default_app_memory: 1024 #mb
+default_app_disk_in_mb: 1024
 maximum_app_disk_in_mb: 2048
 
 uaa:

--- a/spec/models/runtime/app_spec.rb
+++ b/spec/models/runtime/app_spec.rb
@@ -1612,4 +1612,30 @@ module VCAP::CloudController
       end
     end
   end
+
+  describe "default disk_quota" do
+    before do
+      config_override({ :default_app_disk_in_mb => 512 })
+    end
+  
+    it "should use the provided quota" do
+      app = AppFactory.make(disk_quota: 256)
+      expect(app.disk_quota).to eq(256)
+    end
+
+    it "should use the default quota" do
+      app = AppFactory.make
+      expect(app.disk_quota).to eq(512)
+    end
+
+    context "default is greater than maximum" do
+      before do
+        config_override({ :default_app_disk_in_mb => 4096 })
+      end
+
+      it "should fail" do
+        expect{AppFactory.make}.to raise_error(Sequel::ValidationFailed)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is the PR for issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/186

I even added a few bonus tests to the existing disk_quota support. :)
