### PR TITLE
Restore max_package_size in the config template

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -170,6 +170,7 @@ resource_pool:
 
 packages:
   app_package_directory_key: <%= p("ccng.packages.app_package_directory_key") %>
+  max_package_size: <%= p("ccng.packages.max_package_size") %>
   <% if_p("ccng.packages.cdn") do %>
   cdn:
     uri: <%= p("ccng.packages.cdn.uri") %>

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -170,6 +170,7 @@ resource_pool:
 
 packages:
   app_package_directory_key: <%= p("ccng.packages.app_package_directory_key") %>
+  max_package_size: <%= p("ccng.packages.max_package_size") %>
   <% if_p("ccng.packages.cdn") do %>
   cdn:
     uri: <%= p("ccng.packages.cdn.uri") %>

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -170,6 +170,7 @@ resource_pool:
 
 packages:
   app_package_directory_key: <%= p("ccng.packages.app_package_directory_key") %>
+  max_package_size: <%= p("ccng.packages.max_package_size") %>
   <% if_p("ccng.packages.cdn") do %>
   cdn:
     uri: <%= p("ccng.packages.cdn.uri") %>


### PR DESCRIPTION
The recent refactor to pull cc templates out of cf-release reverted a
change to support large application packages.
