### PR TITLE
Use stager_minimum_task_memory from config rather than hardcoding 1024

### DIFF
--- a/lib/cloud_controller/app_stager_task.rb
+++ b/lib/cloud_controller/app_stager_task.rb
@@ -45,7 +45,7 @@ module VCAP::CloudController
     end
 
     def stage(&completion_callback)
-      @stager_id = @stager_pool.find_stager(@app.stack.name, [1024, @app.memory].max)
+      @stager_id = @stager_pool.find_stager(@app.stack.name, staging_task_memory_mb)
       raise Errors::ApiError.new_from_details("StagingError", "no available stagers") unless @stager_id
 
       subject = "staging.#{@stager_id}.start"


### PR DESCRIPTION
The previous logic hard-coded 1024, which works when dea.yml/staging:memory_limit_mb isn't overridden, because that's the [default value](https://github.com/cloudfoundry/dea_ng/blob/dca6f83aab94d5b780b68e742f4eb5e98681a000/lib/dea/config.rb#L158) of the config, but is wrong if the property was [overridden](https://github.com/cloudfoundry/cf-release/blob/master/jobs/dea_next/templates/dea.yml.erb#L65).
