### PR TITLE
Don't stage on stagers without enough disk

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -139,6 +139,7 @@ uaa:
 staging:
   timeout_in_seconds: <%= p("ccng.staging_timeout_in_seconds") %>
   minimum_staging_memory_mb: <%= p("dea_next.staging_memory_limit_mb") %>
+  minimum_staging_disk_mb: <%= p("dea_next.staging_disk_limit_mb") %>
   auth:
     user: <%= p("ccng.staging_upload_user") %>
     password: "<%= p("ccng.staging_upload_password") %>"

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -139,6 +139,7 @@ uaa:
 staging:
   timeout_in_seconds: <%= p("ccng.staging_timeout_in_seconds") %>
   minimum_staging_memory_mb: <%= p("dea_next.staging_memory_limit_mb") %>
+  minimum_staging_disk_mb: <%= p("dea_next.staging_disk_limit_mb") %>
   auth:
     user: <%= p("ccng.staging_upload_user") %>
     password: "<%= p("ccng.staging_upload_password") %>"

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -139,6 +139,7 @@ uaa:
 staging:
   timeout_in_seconds: <%= p("ccng.staging_timeout_in_seconds") %>
   minimum_staging_memory_mb: <%= p("dea_next.staging_memory_limit_mb") %>
+  minimum_staging_disk_mb: <%= p("dea_next.staging_disk_limit_mb") %>
   auth:
     user: <%= p("ccng.staging_upload_user") %>
     password: "<%= p("ccng.staging_upload_password") %>"

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -74,6 +74,7 @@ staging:
   # Max duration for staging process
   timeout_in_seconds: 120 # secs
   minimum_staging_memory_mb: 1024
+  minimum_staging_disk_mb: 1024
   auth:
     user: zxsfhgjg
     password: ZNVfdase9

--- a/lib/cloud_controller/app_stager_task.rb
+++ b/lib/cloud_controller/app_stager_task.rb
@@ -45,7 +45,7 @@ module VCAP::CloudController
     end
 
     def stage(&completion_callback)
-      @stager_id = @stager_pool.find_stager(@app.stack.name, staging_task_memory_mb)
+      @stager_id = @stager_pool.find_stager(@app.stack.name, staging_task_memory_mb, staging_task_disk_mb)
       raise Errors::ApiError.new_from_details("StagingError", "no available stagers") unless @stager_id
 
       subject = "staging.#{@stager_id}.start"
@@ -237,6 +237,10 @@ module VCAP::CloudController
 
     def staging_timeout
       @config[:staging][:timeout_in_seconds]
+    end
+
+    def staging_task_disk_mb
+      [ @config[:staging][:minimum_staging_disk_mb] || 2048, @app.disk_quota ].max
     end
 
     def staging_task_memory_mb

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -72,6 +72,7 @@ module VCAP::CloudController
         :staging => {
           :timeout_in_seconds => Fixnum,
           optional(:minimum_staging_memory_mb) => Fixnum,
+          optional(:minimum_staging_disk_mb) => Fixnum,
           :auth => {
             :user => String,
             :password => String,

--- a/lib/cloud_controller/stager/stager_pool.rb
+++ b/lib/cloud_controller/stager/stager_pool.rb
@@ -25,12 +25,12 @@ module VCAP::CloudController
       end
     end
 
-    def find_stager(stack, memory)
+    def find_stager(stack, memory, disk)
       mutex.synchronize do
         validate_stack_availability(stack)
 
         prune_stale_advertisements
-        best_ad = top_5_stagers_for(memory, stack).sample
+        best_ad = top_5_stagers_for(memory, disk, stack).sample
         best_ad && best_ad.stager_id
       end
     end
@@ -46,9 +46,9 @@ module VCAP::CloudController
     end
 
     private
-    def top_5_stagers_for(memory, stack)
+    def top_5_stagers_for(memory, disk, stack)
       @stager_advertisements.select do |advertisement|
-        advertisement.meets_needs?(memory, stack)
+        advertisement.meets_needs?(memory, stack) && advertisement.has_sufficient_disk?(disk)
       end.sort do |advertisement_a, advertisement_b|
         advertisement_a.available_memory <=> advertisement_b.available_memory
       end.last(5)

--- a/spec/app_stager_task_spec.rb
+++ b/spec/app_stager_task_spec.rb
@@ -12,7 +12,8 @@ module VCAP::CloudController
         :droplet_hash => nil,
         :package_state => "PENDING",
         :state => "STARTED",
-        :instances => 1
+        :instances => 1,
+        :disk_quota => 1024
       )
     end
     let(:stager_id) { "my_stager" }
@@ -56,7 +57,7 @@ module VCAP::CloudController
       app.staged?.should be_false
 
       VCAP.stub(:secure_uuid) { "some_task_id" }
-      stager_pool.stub(:find_stager).with(app.stack.name, 1024).and_return(stager_id)
+      stager_pool.stub(:find_stager).with(app.stack.name, 1024, anything).and_return(stager_id)
 
       EM.stub(:add_timer)
       EM.stub(:defer).and_yield
@@ -84,7 +85,7 @@ module VCAP::CloudController
       context 'when the app memory requirement exceeds the staging memory requirement (1024)' do
         it 'should request a stager with the app memory requirement' do
           app.memory = 1025
-          stager_pool.should_receive(:find_stager).with(app.stack.name, 1025).and_return(stager_id)
+          stager_pool.should_receive(:find_stager).with(app.stack.name, 1025, anything).and_return(stager_id)
           staging_task.stage
         end
       end
@@ -92,7 +93,36 @@ module VCAP::CloudController
       context 'when the app memory requirement is less than the staging memory requirement' do
         it "requests the staging memory requirement" do
           config_hash[:staging][:minimum_staging_memory_mb] = 2048
-          stager_pool.should_receive(:find_stager).with(app.stack.name, 2048).and_return(stager_id)
+          stager_pool.should_receive(:find_stager).with(app.stack.name, 2048, anything).and_return(stager_id)
+          staging_task.stage
+        end
+      end
+    end
+
+    describe "staging disk requirements" do
+      context 'when the app disk requirement is less than the staging disk requirement' do
+        it "should request a stager with enough disk" do
+          app.disk_quota = 12
+          config_hash[:staging][:minimum_staging_disk_mb] = 1025
+          stager_pool.should_receive(:find_stager).with(app.stack.name, anything, 1025).and_return(stager_id)
+          staging_task.stage
+        end
+      end
+
+      context 'when the app disk requirement is less than the default (2048) staging disk requirement, and it wasnt overridden' do
+        it "should request a stager with enough disk" do
+          app.disk_quota = 123
+          config_hash[:staging][:minimum_staging_disk_mb] = nil
+          stager_pool.should_receive(:find_stager).with(app.stack.name, anything, 2048).and_return(stager_id)
+          staging_task.stage
+        end
+      end
+
+      context 'when the app disk requirement exceeds the staging disk requirement' do
+        it "should request a stager with enough disk" do
+          app.disk_quota = 123
+          config_hash[:staging][:minimum_staging_disk_mb] = 122
+          stager_pool.should_receive(:find_stager).with(app.stack.name, anything, 123).and_return(stager_id)
           staging_task.stage
         end
       end
@@ -408,7 +438,7 @@ module VCAP::CloudController
 
       describe "reserve app memory" do
         before do
-          stager_pool.stub(:find_stager).with(app.stack.name, 1025).and_return(stager_id)
+          stager_pool.stub(:find_stager).with(app.stack.name, 1025, 2048).and_return(stager_id)
         end
 
         context "when app memory is less when configured minimum_staging_memory_mb" do


### PR DESCRIPTION
Consider available_disk reported by stager before making staging request. This avoids errors which occur when cloud controller attempts to stage on a DEA that's out of disk. The same logic already exists for find_dea, this PR adds the same checks to find_stager.

Relies on https://github.com/cloudfoundry/dea_ng/pull/117 and https://github.com/cloudfoundry/cf-release/pull/346
