### PR TITLE
Checks that app file size is within limits before adding to appbitscache

### DIFF
--- a/lib/cloud_controller/blobstore/client.rb
+++ b/lib/cloud_controller/blobstore/client.rb
@@ -7,11 +7,13 @@ require "cloud_controller/blobstore/idempotent_directory"
 module CloudController
   module Blobstore
     class Client
-      def initialize(connection_config, directory_key, cdn=nil, root_dir=nil)
+      def initialize(connection_config, directory_key, cdn=nil, root_dir=nil, min_size=nil, max_size=nil)
         @root_dir = root_dir
         @connection_config = connection_config
         @directory_key = directory_key
         @cdn = cdn
+        @min_size = min_size || 0
+        @max_size = max_size
       end
 
       def local?
@@ -46,18 +48,23 @@ module CloudController
         start = Time.now
         logger.info("blobstore.cp-start", destination_key: destination_key, source_path: source_path, bucket: @directory_key)
         size = -1
+        log_entry = "blobstore.cp-skip"
 
         File.open(source_path) do |file|
           size = file.size
+          next unless within_limits?(size)
+
           files.create(
             :key => partitioned_key(destination_key),
             :body => file,
             :public => local?,
           )
+
+          log_entry = "blobstore.cp-finish"
         end
 
         duration = Time.now - start
-        logger.info("blobstore.cp-finish",
+        logger.info(log_entry,
                     destination_key: destination_key,
                     duration_seconds: duration,
                     size: size,
@@ -121,6 +128,10 @@ module CloudController
 
       def logger
         @logger ||= Steno.logger("cc.blobstore")
+      end
+
+      def within_limits?(size)
+        size>=@min_size && (@max_size.nil? || size<=@max_size)
       end
     end
   end

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -61,12 +61,17 @@ module CloudController
     def global_app_bits_cache
       resource_pool = config.fetch(:resource_pool)
       cdn_uri = resource_pool.fetch(:cdn, nil) && resource_pool.fetch(:cdn).fetch(:uri, nil)
+      min_file_size = resource_pool[:minimum_size]
+      max_file_size = resource_pool[:maximum_size]
       app_bit_cdn = CloudController::Blobstore::Cdn.make(cdn_uri)
 
       Blobstore::Client.new(
         resource_pool.fetch(:fog_connection),
         resource_pool.fetch(:resource_directory_key),
-        app_bit_cdn
+        app_bit_cdn,
+        nil,
+        min_file_size,
+        max_file_size
       )
     end
 


### PR DESCRIPTION
Fixes the issue discussed in [1] where configured file size limits are being ignore when adding to the global app bits cache.

[1] https://github.com/cloudfoundry/cloud_controller_ng/issues/174
