### PR TITLE
Support for specifying an https url for staging upload

### DIFF
--- a/app/controllers/runtime/stagings_controller.rb
+++ b/app/controllers/runtime/stagings_controller.rb
@@ -59,7 +59,7 @@ module VCAP::CloudController
       if async?
         job = Jobs::Enqueuer.new(droplet_upload_job, queue: LocalQueue.new(config)).enqueue()
         external_domain = Array(config[:external_domain]).first
-        [HTTP::OK, JobPresenter.new(job, "http://#{external_domain}").to_json]
+        [HTTP::OK, JobPresenter.new(job, "#{config[:external_protocol]}://#{external_domain}").to_json]
       else
         droplet_upload_job.perform
         HTTP::OK

--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -11,6 +11,7 @@ message_bus_servers:
   - nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= ip %>:<%= p("nats.port") %>
 <% end %>
 
+external_protocol: <%= p("ccng.external_protocol") %>
 external_domain:
   - <%= p("ccng.external_host") %>.<%= p("domain") %>
 

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -11,6 +11,7 @@ message_bus_servers:
   - nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= ip %>:<%= p("nats.port") %>
 <% end %>
 
+external_protocol: <%= p("ccng.external_protocol") %>
 external_domain:
   - <%= p("ccng.external_host") %>.<%= p("domain") %>
 

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -11,6 +11,7 @@ message_bus_servers:
   - nats://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= ip %>:<%= p("nats.port") %>
 <% end %>
 
+external_protocol: <%= p("ccng.external_protocol") %>
 external_domain:
   - <%= p("ccng.external_host") %>.<%= p("domain") %>
 

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -5,6 +5,7 @@ pid_filename: /tmp/cloud_controller.pid
 message_bus_servers:
   - nats://127.0.0.1:4222
 
+external_protocol: http
 external_domain: api2.vcap.me
 
 bootstrap_admin_email: sre@vmware.com

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -8,6 +8,7 @@ module VCAP::CloudController
     define_schema do
       {
         :external_port => Integer,
+        :external_protocol => String,
         :info => {
           :name            => String,
           :build           => String,

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -51,6 +51,10 @@ module VCAP::CloudController
           expect(config[:maximum_app_disk_in_mb]).to eq(3)
         end
 
+        it "preserves the external_protocol value from the file" do
+          expect(config[:external_protocol]).to eq("http")
+        end
+
         it "preserves the directories value from the file" do
           expect(config[:directories]).to eq({ some: "value" })
         end

--- a/spec/controllers/runtime/stagings_controller_spec.rb
+++ b/spec/controllers/runtime/stagings_controller_spec.rb
@@ -222,6 +222,13 @@ module VCAP::CloudController
           config = VCAP::CloudController::Config.config
           expect(decoded_response.fetch('metadata').fetch('url')).to eql("http://#{config.fetch(:external_domain)}/v2/jobs/#{job.guid}")
         end
+        
+        it "returns a JSON body with full url containing the correct external_protocol" do
+          config[:external_protocol] = "https"
+          post "/staging/droplets/#{app_obj.guid}/upload?async=true", upload_req
+          job = Delayed::Job.last
+          expect(decoded_response.fetch('metadata').fetch('url')).to start_with("https://")
+        end
 
         it "returns a JSON body with full url to query for job's status even Cloud Controller has multiple external domains" do
           config[:external_domain] = ["www.example.com", config[:external_domain]]

--- a/spec/fixtures/config/default_overriding_config.yml
+++ b/spec/fixtures/config/default_overriding_config.yml
@@ -8,6 +8,8 @@ info:
   support_address: "http://support.cloudfoundry.com"
   description: "Cloud Foundry sponsored by Pivotal"
 
+external_protocol: http
+
 system_domain_organization: the-system-domain-org-name
 system_domain: the-system-domain.com
 app_domains:

--- a/spec/fixtures/config/minimal_config.yml
+++ b/spec/fixtures/config/minimal_config.yml
@@ -8,6 +8,8 @@ info:
   support_address: "http://support.cloudfoundry.com"
   description: "Cloud Foundry sponsored by Pivotal"
 
+external_protocol: http
+
 system_domain_organization: the-system-domain-org-name
 system_domain: the-system-domain.com
 app_domains:

--- a/spec/fixtures/config/non_default_message_bus.yml
+++ b/spec/fixtures/config/non_default_message_bus.yml
@@ -9,6 +9,7 @@ info:
   support_address: "http://support.cloudfoundry.com"
   description: "Cloud Foundry sponsored by Pivotal"
 
+external_protocol: http
 external_domain: api2.vcap.me
 
 system_domain_organization: the-system-domain-org-name

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -10,6 +10,8 @@ info:
   support_address: "http://support.cloudfoundry.com"
   description: "Cloud Foundry sponsored by Pivotal"
 
+external_protocol: http
+
 system_domain_organization: the-system-domain-org-name
 system_domain: the-system-domain.com
 app_domains:

--- a/spec/fixtures/config/port_8182_config.yml
+++ b/spec/fixtures/config/port_8182_config.yml
@@ -10,6 +10,8 @@ info:
   support_address: "http://support.cloudfoundry.com"
   description: "Cloud Foundry sponsored by Pivotal"
 
+external_protocol: http
+
 system_domain_organization: the-system-domain-org-name
 system_domain: the-system-domain.com
 app_domains:


### PR DESCRIPTION
This PR fixes issues https://github.com/cloudfoundry/cloud_controller_ng/issues/140 and https://github.com/cloudfoundry/cloud_controller_ng/issues/183 by adding an `external_protocol` configuration entry to match the `external_domain` value currently used to create the poll url.
