### PR TITLE
Allow updating services when quota is almost reached

### DIFF
--- a/app/models/runtime/quota_constraints/max_service_instances_policy.rb
+++ b/app/models/runtime/quota_constraints/max_service_instances_policy.rb
@@ -20,7 +20,19 @@ class MaxServiceInstancePolicy
 
   def service_instance_quota_remaining?
     @quota_definition.total_services == -1 || # unlimited
-      @organization.service_instances.count < @quota_definition.total_services
+      desired_service_instance_count <= @quota_definition.total_services
+  end
+
+  def desired_service_instance_count
+    existing_service_instances + requested_service_instances
+  end
+
+  def existing_service_instances
+    @organization.service_instances.count
+  end
+
+  def requested_service_instances
+    @service_instance.new? ? 1 : 0
   end
 
   def paid_services_allowed?


### PR DESCRIPTION
The MaxServiceInstancesPolicy assumes that all requests are to create a
service instance, and therefore checks whether the current quota is less than
the allowed quota, rather than <=. That's fine, but the same validation is used for update.
This is a problem when you're exactly at the quota limit (e.g. used services=20,
allowed services=20) and try to, for example, rename a service instance. You 
get a message saying you've exceeded your quota, which you haven't.
