### PR TITLE
Limit the undo on failures to only stop or scale down

### DIFF
--- a/lib/cloud_controller/undo_app_changes.rb
+++ b/lib/cloud_controller/undo_app_changes.rb
@@ -1,0 +1,49 @@
+module VCAP::CloudController
+  class UndoAppChanges
+    attr_reader :app
+
+    def initialize(app)
+      @app = app
+    end
+
+    def undo(changes)
+      if !undo_start(changes)
+        undo_scale(changes)
+      end
+    end
+
+    private
+
+    def undo_start(changes)
+      state = changes[:state]
+      return false if state.nil? || state[1] != 'STARTED'
+      update(changes, :state)
+    end
+
+
+    def undo_scale(changes)
+      instances = changes[:instances]
+      return false if instances.nil? || instances[0] >= instances[1]
+
+      update(changes, :instances)
+    end
+
+    def update(changes, key)
+      where_columns = app.pk_hash
+      where_columns[key] = changes[key][1]
+      where_columns[:updated_at] = changes[:updated_at][1]
+
+      update_columns = { key => changes[key][0]}
+
+      count = App.dataset.where(where_columns).update(update_columns)      
+      app.refresh
+      logger.warn("app.rollback.failed", guid: app.guid, self: app.inspect, to: update_columns) if count == 0
+
+      return count == 1
+    end
+
+    def logger
+       @logger ||= Steno.logger("cc.undo_app_changes")
+    end
+  end
+end

--- a/spec/models/runtime/app_spec.rb
+++ b/spec/models/runtime/app_spec.rb
@@ -1105,24 +1105,23 @@ module VCAP::CloudController
       end
 
       context "when AppObserver.updated fails" do
-        it "should undo any change", non_transactional: true do
+        let(:undo_app) {double(:undo_app_changes, :undo => true)}
+
+        it "calls UndoAppChanges.undo", non_transactional: true do
           app = AppFactory.make
-          previous_state = app.state
+          UndoAppChanges.stub(:new).with(app).and_return(undo_app)
 
           AppObserver.should_receive(:updated).once.with(app).and_raise Errors::ApiError.new_from_details("AppPackageInvalid", "The app package hash is empty")
+          undo_app.should_receive(:undo)
           expect{app.update(state: "STARTED")}.to raise_error
-          expect(app.state).to eql(previous_state)
         end
 
-        it "should undo multiple changes made", non_transactional: true do
+        it "does not call UndoAppChanges when its not an ApiError", non_transactional: true do
           app = AppFactory.make
-          previous_instances = app.instances
-          previous_memory = app.memory
 
-          AppObserver.should_receive(:updated).once.with(app).and_raise Errors::ApiError.new_from_details("AppPackageInvalid", "The app package hash is empty")
-          expect{app.update(instances: app.instances + 1, memory: 4096)}.to raise_error
-          expect(app.instances).to eql(previous_instances)
-          expect(app.memory).to eql(previous_memory)
+          AppObserver.should_receive(:updated).once.with(app).and_raise("boom")
+          UndoAppChanges.should_not_receive(:new)
+          expect{app.update(state: "STARTED")}.to raise_error
         end
       end
 

--- a/spec/undo_app_changes_spec.rb
+++ b/spec/undo_app_changes_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+
+module VCAP::CloudController
+  describe UndoAppChanges do
+    let(:state) {"STARTED"}
+    let(:instances) {2}
+    let(:app) do
+      AppFactory.make(:package_hash  => "abc",
+                      :name => "app-name",
+                      :droplet_hash  => "I DO NOTHING",
+                      :state         => state,
+                      :instances     => instances,
+                      )
+    end
+    let(:changes) { {:updated_at => [1, app.updated_at]} }
+    let(:undo_changes) {UndoAppChanges.new(app)}
+
+    describe "#undo" do
+
+      context "state has changed" do
+        it "should stop an app that has started", non_transactional: true do
+          changes[:state] = ["STOPPED", "STARTED"]
+          undo_changes.undo(changes)
+          expect(app.state).to eq("STOPPED")
+        end
+
+        it "does not undo when the states do not match" do
+          changes[:state] = ["STARTED", "STOPPED"]
+          undo_changes.undo(changes)
+          expect(app.state).to eq("STARTED")
+        end
+
+        context("when the app is stopped") do
+          let(:state) {"STOPPED"}
+
+          it "should not undo any stop", non_transactional: true do
+            changes[:state] = ["STARTED", "STOPPED"]
+            undo_changes.undo(changes)
+            expect(app.state).to eq("STOPPED")
+          end
+        end
+      end
+
+      context "instances have changed" do
+        it "should undo any increase", non_transactional: true do
+          changes[:instances] = [1, 2]
+          undo_changes.undo(changes)
+          expect(app.instances).to eq(1)
+        end
+
+        it "should not undo any decrease", non_transactional: true do
+          changes[:instances] = [3, 2]
+          undo_changes.undo(changes)
+          expect(app.instances).to eq(2)
+        end
+
+        it "should not undo if the instances do not match" do
+          changes[:instances] = [2, 3]
+          undo_changes.undo(changes)
+          expect(app.instances).to eq(2)
+        end
+      end
+
+      context "no undo if already updated" do
+        it "should not stop an app that has started", non_transactional: true do
+          changes[:state] = ["STOPPED", "STARTED"]
+          changes[:updated_at][1] = changes[:updated_at][1] + 1
+          undo_changes.undo(changes)
+          expect(app.state).to eq("STARTED")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rather than undo all changes, this will only change the state to STOPPED or scale down instances.  It will also only do it if no other updates have occurred since.
