### PR TITLE
Sort the buildpacks by priority via the Controller

### DIFF
--- a/app/controllers/runtime/buildpacks_controller.rb
+++ b/app/controllers/runtime/buildpacks_controller.rb
@@ -9,6 +9,11 @@ module VCAP::CloudController
 
     query_parameters :name
 
+    def initialize(*args)
+      super
+      @opts.merge!(order_by: :position)
+    end
+
     def self.translate_validation_exception(e, attributes)
       buildpack_errors = e.errors.on(:name)
       if buildpack_errors && buildpack_errors.include?(:unique)


### PR DESCRIPTION
Its been a common complaint that when you list the buildpacks they are in somewhat of a random order.  This makes the buildpack list sorted by priority as the default.
