### PR TITLE
Make sure we are going to delete the same blob

### DIFF
--- a/app/models/runtime/buildpack_bits_delete.rb
+++ b/app/models/runtime/buildpack_bits_delete.rb
@@ -2,8 +2,20 @@ module VCAP::CloudController
   class BuildpackBitsDelete
     def self.delete_when_safe(blobstore_key, blobstore_name, staging_timeout)
       return unless blobstore_key
-      blobstore_delete = Jobs::Runtime::BlobstoreDelete.new(blobstore_key, blobstore_name)
+
+      b = blob(blobstore_key, blobstore_name)
+      return unless b
+
+      attrs = b.attributes(*CloudController::Blobstore::Blob::CACHE_ATTRIBUTES)
+      blobstore_delete = Jobs::Runtime::BlobstoreDelete.new(blobstore_key, blobstore_name, attrs)
       Delayed::Job.enqueue(blobstore_delete, queue: "cc-generic", run_at: Delayed::Job.db_time_now + staging_timeout)
+    end
+
+    private
+
+    def self.blob(blobstore_key, blobstore_name)
+      blobstore = CloudController::DependencyLocator.instance.public_send(blobstore_name)
+      blobstore.blob(blobstore_key)
     end
   end
 end

--- a/lib/cloud_controller/blobstore/blob.rb
+++ b/lib/cloud_controller/blobstore/blob.rb
@@ -2,6 +2,9 @@ module CloudController
   module Blobstore
     # Central place to get download urls for a blob object stored in a blobstore
     class Blob
+
+      CACHE_ATTRIBUTES = [:etag, :last_modified, :created_at]
+
       def initialize(file, cdn)
         @file = file
         @cdn = cdn
@@ -17,6 +20,15 @@ module CloudController
 
       def public_url
         @file.public_url
+      end
+
+      def attributes(*keys)
+        return @file.attributes if keys.empty?
+        @file.attributes.select {|key,_| keys.include? key}
+      end
+
+      def delete
+        @file.destroy
       end
 
       private

--- a/spec/cloud_controller/blobstore/blob_spec.rb
+++ b/spec/cloud_controller/blobstore/blob_spec.rb
@@ -6,7 +6,8 @@ module CloudController
       subject(:blob) do
         Blob.new(file, cdn)
       end
-      let(:file) { double("file", key: "abcdef") }
+      let(:attrs) {{'a' => 'b', 'c' => 'd'}}
+      let(:file) { double("file", key: "abcdef", attributes: attrs, destroy: nil) }
       let(:cdn) { double(:cdn) }
 
       context "it is backed by a CDN" do
@@ -64,6 +65,23 @@ module CloudController
         it "comes path of the file" do
           expect(file).to receive(:path).and_return("path")
           expect(blob.local_path).to eql("path")
+        end
+      end
+
+      describe "attributes" do
+        it "returns the blob's attributes" do
+          expect(blob.attributes).to eq(attrs)
+        end
+
+        it "returns attributes for a set of keys" do
+          expect(blob.attributes("c")).to eq({'c'=>'d'})
+        end
+      end
+
+      describe "delete" do
+        it "destroys the file" do
+          file.should_receive(:destroy)
+          blob.delete
         end
       end
     end

--- a/spec/controllers/runtime/buildpack_bits_delete_spec.rb
+++ b/spec/controllers/runtime/buildpack_bits_delete_spec.rb
@@ -3,20 +3,55 @@ require "spec_helper"
 module VCAP::CloudController
   describe BuildpackBitsDelete do
     let(:staging_timeout) { 144 }
+    let(:key) { "key" }
+    let(:blobstore_name) {"buildpack_blobstore"}
+    let!(:blobstore) do
+      CloudController::DependencyLocator.instance.buildpack_blobstore
+    end
+
+    let(:tmpfile) { Tempfile.new("")}
+
+    before do
+      blobstore.cp_to_blobstore(tmpfile.path, key)
+    end
+
+    after do
+      tmpfile.delete
+    end
 
     context "delays the blobstore delete until staging completes" do
       it "based on config" do
         Timecop.freeze do
           Delayed::Job.should_receive(:enqueue).with(an_instance_of(BlobstoreDelete),
-            hash_including(run_at: 144.seconds.from_now))
-          BuildpackBitsDelete.delete_when_safe("key", "blobstore", staging_timeout)
+                                                     hash_including(run_at: 144.seconds.from_now))
+          BuildpackBitsDelete.delete_when_safe(key, blobstore_name, staging_timeout)
         end
       end
     end
 
     it 'does nothing if the key is nil' do
       Delayed::Job.should_not_receive(:enqueue)
-      BuildpackBitsDelete.delete_when_safe(nil, "blobstore", staging_timeout)
+      BuildpackBitsDelete.delete_when_safe(nil, blobstore_name, staging_timeout)
+    end
+
+    context "when the blob exists" do
+      it "will create a job with attributes" do
+        attrs = blobstore.blob(key).attributes
+        job_attrs = {:last_modified => attrs[:last_modified],
+                     :etag => attrs[:etag]}
+
+        Jobs::Runtime::BlobstoreDelete.should_receive(:new).with(key, blobstore_name, job_attrs).and_call_original
+        BuildpackBitsDelete.delete_when_safe(key, blobstore_name, staging_timeout)
+      end
+    end
+
+    context "when the blob does not exist" do
+      it "will not create a job" do
+        blobstore.delete(key)
+
+        Jobs::Runtime::BlobstoreDelete.should_not_receive(:new)
+        BuildpackBitsDelete.delete_when_safe(key, blobstore_name, staging_timeout)
+      end
     end
   end
 end

--- a/spec/jobs/runtime/blobstore_delete_spec.rb
+++ b/spec/jobs/runtime/blobstore_delete_spec.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
   module Jobs::Runtime
     describe BlobstoreDelete do
       let(:key) { "key" }
-      subject(:job) do
+      let(:job) do
         BlobstoreDelete.new(key, :droplet_blobstore)
       end
 
@@ -19,12 +19,52 @@ module VCAP::CloudController
         blobstore.cp_to_blobstore(tmpfile.path, key)
       end
 
-      it "deletes the blob blobstore" do
-        expect {
+      after do
+        tmpfile.delete
+      end
+
+      context "when no attributes defined" do
+        it "deletes the blob" do
+          expect {
+            job.perform
+          }.to change {
+            blobstore.exists?(key)
+          }.from(true).to(false)
+        end
+      end
+
+      context "when attributes match" do
+        it "deletes the blob" do
+          blob = blobstore.blob(key)
+          job.attributes = blob.attributes
+
+          expect {
+            job.perform
+          }.to change {
+            blobstore.exists?(key)
+          }.from(true).to(false)
+        end
+      end
+
+      context "when attributes do not match" do
+        let(:job) do
+          BlobstoreDelete.new(key, :droplet_blobstore, { "mis" => "match"})
+        end
+
+        it "does not delete the blob" do
+          expect {
+            job.perform
+          }.to_not change {
+            blobstore.exists?(key)
+          }
+        end
+      end
+
+      context "when the blob does not exist" do
+        it "does not invoke delete" do
+          blobstore.should_receive(:blob).and_return(nil)
           job.perform
-        }.to change {
-          blobstore.exists?(key)
-        }.from(true).to(false)
+        end
       end
 
       it "knows its job name" do


### PR DESCRIPTION
Compare the cache headers when a delete was requested and when we are about to perform the delete.
We need to guarantee that the blob has not changed in any way.  The key may be reused.

There are 2 cases that caused this issue.  The easiest way that this can work is if you have a buildpack with 2 binary versions.

Install buildpack v1.
Update the buildpack with v2.
Update the buildpack with v1 a few seconds later.
The delete triggered by the update with v2 should not occur, i.e., the v1 binary should remain in the blobstore.
