### PR TITLE
Stop double encoding recent_errors

### DIFF
--- a/lib/sinatra/vcap.rb
+++ b/lib/sinatra/vcap.rb
@@ -53,14 +53,13 @@ module Sinatra
           logger.error(presenter.log_message)
         end
 
-        payload = Yajl::Encoder.encode(presenter.error_hash)
-
         ::VCAP::Component.varz.synchronize do
-          varz[:recent_errors] << payload
+          varz[:recent_errors] << presenter.error_hash
         end
 
         request.env['vcap_exception_body_set'] = true
 
+        payload = Yajl::Encoder.encode(presenter.error_hash)
         body payload.concat("\n")
       end
     end

--- a/spec/sinatra/vcap_spec.rb
+++ b/spec/sinatra/vcap_spec.rb
@@ -148,7 +148,8 @@ describe 'Sinatra::VCAP' do
       VCAP::Component.varz.synchronize do
         recent_errors = VCAP::Component.varz[:vcap_sinatra][:recent_errors]
       end
-      recent_errors.size.should == 1
+      expect(recent_errors.size).to eq(1)
+      expect(recent_errors[0]).to be_an_instance_of(Hash)
     end
 
     include_examples 'vcap sinatra varz stats', 500


### PR DESCRIPTION
The recent_errors hash is double-encoded to json in /varz which makes it difficult to read for humans and requires double-decoding in code.  This commit stops encoding the error hash to json before adding it to the varz hash.
