### PR TITLE
Added support for specifying custom fields in /v2/info endpoint.

### DIFF
--- a/app/controllers/runtime/info_controller.rb
+++ b/app/controllers/runtime/info_controller.rb
@@ -18,6 +18,10 @@ module VCAP::CloudController
         info[:logging_endpoint] = @config[:loggregator][:url]
       end
 
+      if @config[:info][:custom]
+        info[:custom] = @config[:info][:custom]
+      end
+
       if user
         info[:user] = user.guid
       end

--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -89,6 +89,12 @@ info:
   version: <%= p("version") %>
   support_address: <%= p("support_address") %>
   description: <%= p("description") %>
+<% if_p("ccng.info.custom") do |custom| %>
+  custom:
+  <% custom.each do |key, value| %>
+    <%= key %>: <%= value %>
+  <% end %>
+<% end %>
 
 <% if_p("ccng.directories.tmpdir") do |tmpdir| %>
 directories:

--- a/spec/controllers/runtime/info_controller_spec.rb
+++ b/spec/controllers/runtime/info_controller_spec.rb
@@ -132,6 +132,23 @@ module VCAP::CloudController
             end
           end
         end
+
+        describe "custom fields" do
+          context "without custom fields in config" do
+            it "should not have custom fields in the hash" do
+              get "/v2/info"
+              hash = Yajl::Parser.parse(last_response.body)
+              hash.should_not have_key("custom")
+            end
+          end
+          context "with custom fields in config" do
+            include_examples "info endpoint verification" do
+              before { config_override(:info => { :custom => {:foo => "bar", :baz => "foobar"}}) }
+              let(:endpoint) { "custom" }
+              let(:endpoint_value) { {"foo" => "bar", "baz" => "foobar"} }
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
We have a number of features that we've added to Cloud Foundry (remote debug, remote console/JMX). Our client for these features determines the host it needs to connect by extracting them domain from the API URL and prepending a host name to the domain. This is what `cf logs` used to do.

We would like to do what `cf logs` does now by querying /v2/info to determine the endpoint our client should use to fulfill our custom features.

This PR adds support for adding custom fields to /v2/info. I don't know if "custom" is the right name to use but I couldn't think of anything better.

This change will also require adding an entry to the cloud controller job spec in cf-release. Such an entry could look like:

ccng.info.custom:
  description: "Custom values for /v2/info endpoint"
