### PR TITLE
Expose configuration for diagnostic output directory

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -91,9 +91,9 @@ info:
   support_address: <%= p("support_address") %>
   description: <%= p("description") %>
 
-<% if_p("ccng.directories.tmpdir") do |tmpdir| %>
-directories:
- tmpdir: <%= tmpdir %>
+<% if_p("ccng.directories") do %>
+directories:<% p("ccng.directories").each do |key, value| %>
+  <%= key %>: <%= value %><% end %>
 <% end %>
 
 logging:

--- a/bosh-templates/cloud_controller_api_ctl.erb
+++ b/bosh-templates/cloud_controller_api_ctl.erb
@@ -54,6 +54,11 @@ case $1 in
     chown vcap:vcap $LOG_DIR
     chown vcap:vcap $TMPDIR
 
+    <% if_p("ccng.directories.diagnostics") do |diag_dir| %>
+    mkdir -p <%= diag_dir %>
+    chown vcap:vcap <%= diag_dir %>
+    <% end %>
+
     source $CC_JOB_DIR/bin/handle_nfs_or_local_blobstore.sh
 
     # Configure the core file location

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -91,9 +91,9 @@ info:
   support_address: <%= p("support_address") %>
   description: <%= p("description") %>
 
-<% if_p("ccng.directories.tmpdir") do |tmpdir| %>
-directories:
- tmpdir: <%= tmpdir %>
+<% if_p("ccng.directories") do %>
+directories:<% p("ccng.directories").each do |key, value| %>
+  <%= key %>: <%= value %><% end %>
 <% end %>
 
 logging:

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -91,9 +91,9 @@ info:
   support_address: <%= p("support_address") %>
   description: <%= p("description") %>
 
-<% if_p("ccng.directories.tmpdir") do |tmpdir| %>
-directories:
- tmpdir: <%= tmpdir %>
+<% if_p("ccng.directories") do %>
+directories:<% p("ccng.directories").each do |key, value| %>
+  <%= key %>: <%= value %><% end %>
 <% end %>
 
 logging:


### PR DESCRIPTION
- Generate `directories` configuration in the cc config documents
- Update control scripts to create diagnostics directory with the appropriate owner

This is associated with story 69981718 and build on cloudfoundry/cloud_controller_ng#227
