### PR TITLE
Upload buildpack bits if they are missing in the blobstore

### DIFF
--- a/lib/cloud_controller/upload_buildpack.rb
+++ b/lib/cloud_controller/upload_buildpack.rb
@@ -11,11 +11,12 @@ module VCAP::CloudController
 
       sha1 = File.new(bits_file).hexdigest
       new_key = "#{buildpack.guid}_#{sha1}"
+      missing_bits = buildpack.key && !buildpack_blobstore.exists?(buildpack.key)
 
-      return false if !new_bits?(buildpack, new_key) && !new_filename?(buildpack, new_filename)
+      return false if !new_bits?(buildpack, new_key) && !new_filename?(buildpack, new_filename) && !missing_bits
 
       # replace blob if new
-      if new_bits?(buildpack, new_key)
+      if missing_bits || new_bits?(buildpack, new_key)
         buildpack_blobstore.cp_to_blobstore(bits_file, new_key)
         old_buildpack_key = buildpack.key
       end
@@ -25,8 +26,10 @@ module VCAP::CloudController
         buildpack.update_from_hash(key: new_key, filename: new_filename)
       end
 
-      staging_timeout = VCAP::CloudController::Config.config[:staging][:timeout_in_seconds]
-      BuildpackBitsDelete.delete_when_safe(old_buildpack_key, :buildpack_blobstore, staging_timeout)
+      if !missing_bits
+        staging_timeout = VCAP::CloudController::Config.config[:staging][:timeout_in_seconds]
+        BuildpackBitsDelete.delete_when_safe(old_buildpack_key, :buildpack_blobstore, staging_timeout)
+      end
       return true
     end
 


### PR DESCRIPTION
See https://groups.google.com/a/cloudfoundry.org/forum/#!topic/vcap-dev/FEwDy37NL6A

If you change blobstores or somehow wipe your current blobstore, 
and you attempt to update the existing buildpacks
the buildpacks should be uploaded.
