### PR TITLE
Carry app staging failure reason into ccdb

### DIFF
--- a/app/controllers/runtime/instances_controller.rb
+++ b/app/controllers/runtime/instances_controller.rb
@@ -8,7 +8,8 @@ module VCAP::CloudController
       app = find_guid_and_validate_access(:read, guid)
 
       if app.staging_failed?
-        raise VCAP::Errors::ApiError.new_from_details("StagingError", "cannot get instances since staging failed")
+        reason = app.staging_failed_reason || "StagingError"
+        raise VCAP::Errors::ApiError.new_from_details(reason, "cannot get instances since staging failed")
       elsif app.pending?
         raise VCAP::Errors::ApiError.new_from_details("NotStaged")
       end

--- a/db/migrations/20140515155207_add_staging_failed_reason_to_apps.rb
+++ b/db/migrations/20140515155207_add_staging_failed_reason_to_apps.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :apps, :staging_failed_reason, String
+  end
+end

--- a/spec/controllers/runtime/instances_controller_spec.rb
+++ b/spec/controllers/runtime/instances_controller_spec.rb
@@ -47,6 +47,36 @@ module VCAP::CloudController
           Yajl::Parser.parse(last_response.body)["code"].should == 170002
         end
 
+        it "returns '170003 NoAppDetectedError' when the app was not detected by a buildpack" do
+          @app.mark_as_failed_to_stage("NoAppDetectedError")
+          @app.save
+
+          subject
+
+          last_response.status.should == 400
+          Yajl::Parser.parse(last_response.body)["code"].should == 170003
+        end
+
+        it "returns '170004 BuildpackCompileFailed' when the app fails due in the buildpack compile phase" do
+          @app.mark_as_failed_to_stage("BuildpackCompileFailed")
+          @app.save
+
+          subject
+
+          last_response.status.should == 400
+          Yajl::Parser.parse(last_response.body)["code"].should == 170004
+        end
+
+        it "returns '170005 BuildpackReleaseFailed' when the app fails due in the buildpack compile phase" do
+          @app.mark_as_failed_to_stage("BuildpackReleaseFailed")
+          @app.save
+
+          subject
+
+          last_response.status.should == 400
+          Yajl::Parser.parse(last_response.body)["code"].should == 170005
+        end
+
         it "returns the instances" do
           @app.state = "STARTED"
           @app.instances = 1


### PR DESCRIPTION
Improve the end user experience by providing a detailed message when no buildpack detected an application.
- Add staging_failed_reason column to app to hold error key for well known staging errors.
- Populate staging failed reason with information from the staging response and use it when raising api errors from the instances endpoint.

[#68122384]
