### PR TITLE
Correct api doc for positioning buidpacks

### DIFF
--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "digest/sha1"
 
 describe "Stable API warning system", api_version_check: true do
-  API_FOLDER_CHECKSUM = "d5fffb68de722ffe005d2a644448a706b2b5d54d"
+  API_FOLDER_CHECKSUM = "d6eeac6944a3ac3e22a98465f9797dc491eda768"
 
   it "double-checks the version" do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq("2.4.0")

--- a/spec/api/documentation/buildpacks_api_spec.rb
+++ b/spec/api/documentation/buildpacks_api_spec.rb
@@ -27,20 +27,13 @@ resource "Buildpacks (experimental)", :type => :api do
     end
   end
 
-  put "/v2/buildpacks" do
+  put "/v2/buildpacks/:guid" do
     example "Change the position of a buildpack" do
-      first = <<-DOC
+      explanation <<-DOC
         Buildpacks are maintained in an ordered list.  If the target position is already occupied,
         the entries will be shifted down the list to make room.  If the target position is beyond
         the end of the current list, the buildpack will be positioned at the end of the list.
       DOC
-
-      second = <<-DOC
-        Position 0 indicates an unpriorized buildpack.  Unprioritized buildpacks will be treated
-        as if the are at the end of the list.  No ordering is implied across unprioritized buildpacks.
-      DOC
-
-      explanation [{explanation: first}, {explanation: second}]
 
       expect {
         client.put "/v2/buildpacks/#{guid}", Yajl::Encoder.encode(position: 3), headers


### PR DESCRIPTION
Added the required buildpack guid to the resource name and removed stale comment about 'position 0` buildpacks.

[#71328862]
