### PR TITLE
Configurable scope for Dashboard Clients

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -216,6 +216,7 @@ renderer:
 <% if_p("uaa.clients.cc_service_broker_client.secret") do %>
 uaa_client_name: "cc_service_broker_client"
 uaa_client_secret: <%= p("uaa.clients.cc_service_broker_client.secret") %>
+uaa_client_scope: <%= p("uaa.clients.cc_service_broker_client.scope") %>
 <% end %>
 
 diego: <%= p("ccng.diego") %>

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -216,6 +216,7 @@ renderer:
 <% if_p("uaa.clients.cc_service_broker_client.secret") do %>
 uaa_client_name: "cc_service_broker_client"
 uaa_client_secret: <%= p("uaa.clients.cc_service_broker_client.secret") %>
+uaa_client_scope: <%= p("uaa.clients.cc_service_broker_client.scope") %>
 <% end %>
 
 diego: <%= p("ccng.diego") %>

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -216,6 +216,7 @@ renderer:
 <% if_p("uaa.clients.cc_service_broker_client.secret") do %>
 uaa_client_name: "cc_service_broker_client"
 uaa_client_secret: <%= p("uaa.clients.cc_service_broker_client.secret") %>
+uaa_client_scope: <%= p("uaa.clients.cc_service_broker_client.scope") %>
 <% end %>
 
 diego: <%= p("ccng.diego") %>

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -132,6 +132,7 @@ broker_client_timeout_seconds: 60
 
 uaa_client_name: 'cc_service_broker_client'
 uaa_client_secret: 'some-sekret'
+uaa_client_scope: openid,cloud_controller_service_permissions.read
 
 diego: false
 

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -139,6 +139,7 @@ module VCAP::CloudController
         optional(:broker_client_timeout_seconds) => Integer,
         optional(:uaa_client_name) => String,
         optional(:uaa_client_secret) => String,
+        optional(:uaa_client_scope) => String,
 
         :renderer => {
           :max_results_per_page => Integer,

--- a/lib/services/sso/uaa/uaa_client_manager.rb
+++ b/lib/services/sso/uaa/uaa_client_manager.rb
@@ -115,7 +115,7 @@ module VCAP::Services::SSO::UAA
         client_id:              client_attrs['id'],
         client_secret:          client_attrs['secret'],
         redirect_uri:           client_attrs['redirect_uri'],
-        scope:                  ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read'],
+        scope:                  filter_uaa_client_scope,
         authorized_grant_types: ['authorization_code']
       }
     end
@@ -129,6 +129,15 @@ module VCAP::Services::SSO::UAA
 
     def logger
       @logger ||= Steno.logger('cc.uaa_client_manager')
+    end
+
+    def filter_uaa_client_scope
+      configured_scope = VCAP::CloudController::Config.config[:uaa_client_scope].split(',')
+      filtered_scope = configured_scope.select do |val|
+        ['cloud_controller.write', 'openid', 'cloud_controller.read', 'cloud_controller_service_permissions.read'].include?(val)
+      end
+
+      filtered_scope
     end
   end
 end

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -371,7 +371,7 @@ describe 'Service Broker' do
             'client_id'              => 'client-1',
             'client_secret'          => nil,
             'redirect_uri'           => nil,
-            'scope'                  => ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read'],
+            'scope'                  => ['openid', 'cloud_controller_service_permissions.read'],
             'authorized_grant_types' => ['authorization_code'],
             'action'                 => 'delete'
           },
@@ -379,7 +379,7 @@ describe 'Service Broker' do
             'client_id'              => 'client-2',
             'client_secret'          => nil,
             'redirect_uri'           => nil,
-            'scope'                  => ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read'],
+            'scope'                  => ['openid', 'cloud_controller_service_permissions.read'],
             'authorized_grant_types' => ['authorization_code'],
             'action'                 => 'delete'
           },
@@ -387,7 +387,7 @@ describe 'Service Broker' do
             'client_id'              => 'different-client',
             'client_secret'          => service_2[:dashboard_client][:secret],
             'redirect_uri'           => service_2[:dashboard_client][:redirect_uri],
-            'scope'                  => ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read'],
+            'scope'                  => ['openid', 'cloud_controller_service_permissions.read'],
             'authorized_grant_types' => ['authorization_code'],
             'action'                 => 'add'
           },
@@ -395,7 +395,7 @@ describe 'Service Broker' do
             'client_id'              => service_3[:dashboard_client][:id],
             'client_secret'          => 'SUPERsecret',
             'redirect_uri'           => service_3[:dashboard_client][:redirect_uri],
-            'scope'                  => ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read'],
+            'scope'                  => ['openid', 'cloud_controller_service_permissions.read'],
             'authorized_grant_types' => ['authorization_code'],
             'action'                 => 'update,secret'
           },
@@ -403,7 +403,7 @@ describe 'Service Broker' do
             'client_id'              => service_4[:dashboard_client][:id],
             'client_secret'          => service_4[:dashboard_client][:secret],
             'redirect_uri'           => service_4[:dashboard_client][:redirect_uri],
-            'scope'                  => ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read'],
+            'scope'                  => ['openid', 'cloud_controller_service_permissions.read'],
             'authorized_grant_types' => ['authorization_code'],
             'action'                 => 'add'
           },
@@ -411,7 +411,7 @@ describe 'Service Broker' do
             'client_id'              => service_5[:dashboard_client][:id],
             'client_secret'          => service_5[:dashboard_client][:secret],
             'redirect_uri'           => 'http://nowhere.net',
-            'scope'                  => ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read'],
+            'scope'                  => ['openid', 'cloud_controller_service_permissions.read'],
             'authorized_grant_types' => ['authorization_code'],
             'action'                 => 'update,secret'
           },
@@ -419,7 +419,7 @@ describe 'Service Broker' do
             'client_id'              => service_6[:dashboard_client][:id],
             'client_secret'          => service_6[:dashboard_client][:secret],
             'redirect_uri'           => service_6[:dashboard_client][:redirect_uri],
-            'scope'                  => ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read'],
+            'scope'                  => ['openid', 'cloud_controller_service_permissions.read'],
             'authorized_grant_types' => ['authorization_code'],
             'action'                 => 'update,secret'
           }
@@ -629,7 +629,7 @@ HEREDOC
             client_id:              service_1[:dashboard_client][:id],
             client_secret:          nil,
             redirect_uri:           nil,
-            scope:                  ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read'],
+            scope:                  ['openid', 'cloud_controller_service_permissions.read'],
             authorized_grant_types: ['authorization_code'],
             action:                 'delete'
           },
@@ -637,7 +637,7 @@ HEREDOC
             client_id:              service_2[:dashboard_client][:id],
             client_secret:          nil,
             redirect_uri:           nil,
-            scope:                  ['openid', 'cloud_controller.read', 'cloud_controller.write', 'cloud_controller_service_permissions.read' ],
+            scope:                  ['openid', 'cloud_controller_service_permissions.read'],
             authorized_grant_types: ['authorization_code'],
             action:                 'delete'
           }


### PR DESCRIPTION
Unfortunately, we were 90% done with this before we knew Cloud Controller work should be limited / halted. This can be merged whenever we are ready to start adding features again.
- Dashboard clients are given scope of cc_service_broker_client but no
- more than openid, cloud_controller.read, cloud_controller.write, and
- cloud_controller_service_permissions.read.

[#71594888]
