### PR TITLE
Do not allow private domains that overlap with shared domains

### DIFF
--- a/app/models/runtime/domain.rb
+++ b/app/models/runtime/domain.rb
@@ -64,6 +64,7 @@ module VCAP::CloudController
       validates_length_range 3..255, :name
 
       errors.add(:name, :overlapping_domain) if overlaps_domain_in_other_org?
+      errors.add(:name, :overlapping_domain) if overlaps_with_shared_domains?
     end
 
     def overlaps_domain_in_other_org?
@@ -81,6 +82,15 @@ module VCAP::CloudController
       end
 
       overlapping_domains.count != 0
+    end
+    
+    def overlaps_with_shared_domains?
+      if owning_organization
+        return true if Domain.dataset.filter(
+          Sequel.like(:name,"%.#{name}"),
+          owning_organization_id: nil
+        ).count > 0
+      end
     end
 
     def self.intermediate_domains(name)

--- a/spec/models/runtime/private_domain_spec.rb
+++ b/spec/models/runtime/private_domain_spec.rb
@@ -78,6 +78,23 @@ module VCAP::CloudController
 
         it { should be_valid }
       end
+      
+      context "when the name is foo.com and shared domains has bar.foo.com" do
+        before do
+          SharedDomain.make name: "bar.foo.com"
+        end
+
+        it { expect { PrivateDomain.make name: "foo.com" }.to raise_error Sequel::ValidationFailed }
+      end  
+
+      context "when the name is pans.com and shared domains has my.potsandpans.com" do
+        before do
+          SharedDomain.make name: "my.potsandpans.com"
+          subject.name = "pans.com"
+        end
+
+        it { should be_valid } 
+      end  
     end
 
     describe "#destroy" do

--- a/spec/models/runtime/shared_domain_spec.rb
+++ b/spec/models/runtime/shared_domain_spec.rb
@@ -14,6 +14,15 @@ module VCAP::CloudController
 
     describe "#validate" do
       include_examples "domain validation"
+
+      context "when the name is foo.com and bar.foo.com is a shared domain" do
+        before do
+          SharedDomain.make name: "bar.foo.com"
+          subject.name = "foo.com"
+        end
+
+        it { should be_valid }
+      end          
     end
 
     describe "#destroy" do

--- a/spec/support/model_helpers/domain_validation.rb
+++ b/spec/support/model_helpers/domain_validation.rb
@@ -136,17 +136,6 @@ module VCAP::CloudController
         it { should_not be_valid }
       end
 
-      context "when the name is foo.com and bar.foo.com is a shared domain" do
-        before do
-          SharedDomain.make name: "bar.foo.com"
-          subject.name = "foo.com"
-        end
-
-        # this is kind of wonky behavior but it's pending further
-        # simplification (i.e. only allowing top-level domains)
-        it { should be_valid }
-      end
-
       context "when the name is bar.foo.com and foo.com is a shared domain" do
         before do
           SharedDomain.make name: "foo.com"


### PR DESCRIPTION
This PR addresses issue stated in https://github.com/cloudfoundry/cloud_controller_ng/issues/218 and I have added code as per @MarkKropf comments to stop users from adding private domains that are subsets of shared domains and avoid failures in the domain validation logic when an API server is rebooted.
I have also refactored one example from the shared examples to make the separation for the shared domain vs private domain tests to make sure they are run correctly.
Please merge this request as this is important in production environments where there is no check that stops users from adding a private domain like "b.com" when a shared domain like "a.b.com" exists, causing eventual issues in validating that shared domain during reboot.
