### PR TITLE
Complete deletion of v1 service when 404 is returned from v1 service gateway

### DIFF
--- a/lib/services/service_brokers/v1/http_client.rb
+++ b/lib/services/service_brokers/v1/http_client.rb
@@ -77,6 +77,11 @@ module VCAP::Services
             return Yajl::Parser.parse(response.body)
           end
         else
+          if (req_class == "Delete") && ([404, 410].include?(response.code.to_i))
+            logger.warn("Already deleted: #{uri.to_s}")
+            return nil
+          end
+
           begin
             hash = Yajl::Parser.parse(response.body)
           rescue Yajl::ParseError

--- a/spec/unit/lib/services/service_brokers/v1/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v1/http_client_spec.rb
@@ -200,6 +200,21 @@ module VCAP::Services
           expect(request).to have_been_made
           expect(response).to be_nil
         end
+
+        [404, 410].each do |status_code|
+          context "when the API returns #{status_code}" do
+            it 'should swallow the error' do
+              request = stub_request(:delete, unbind_url).
+                with(body: expected_request_body, headers: expected_request_headers).
+                to_return(status: status_code, body: '{"code": 98765, "description": "not exist"}')
+
+              response = client.unbind(instance_id, binding_id, binding_options)
+
+              expect(request).to have_been_made
+              expect(response).to be_nil
+            end
+          end
+        end
       end
 
       describe '#deprovision' do
@@ -215,6 +230,21 @@ module VCAP::Services
 
           expect(request).to have_been_made
           expect(response).to be_nil
+        end
+
+        [404, 410].each do |status_code|
+          context "when the API returns #{status_code}" do
+            it 'should swallow the error' do
+              request = stub_request(:delete, deprovision_url).
+                with(headers: expected_request_headers).
+                to_return(status: status_code, body: '{"code": 87654, "description": "not exist"}')
+
+              response = client.deprovision(instance_id)
+
+              expect(request).to have_been_made
+              expect(response).to be_nil
+            end
+          end
         end
       end
 


### PR DESCRIPTION
To avoid failure on deletion of v1 service binding / instance
when v1 service gateway returns "404 Not Found".

This problem is not limited on deletion of service binding / instance.
The deletion of related app, space, and org also fails.

So this commit modifies http client of v1 service gateway to ignore
"404 Not Found" response for delete request, like client of v2 service
ignores "410 Gone" response for delete request.
