### PR TITLE
Fix name validation

### DIFF
--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
   class App < Sequel::Model
     plugin :serialization
 
-    APP_NAME_REGEX = /\A[[:alnum:][:punct:][:print:]]+\Z/.freeze
+    APP_NAME_REGEX = /\A[[[:alnum:][:punct:][:print:]]&&[^;]]+\Z/.freeze
 
     one_to_many :droplets
     one_to_many :service_bindings

--- a/app/models/runtime/app_security_group.rb
+++ b/app/models/runtime/app_security_group.rb
@@ -2,7 +2,7 @@ require 'netaddr'
 
 module VCAP::CloudController
   class AppSecurityGroup < Sequel::Model
-    APP_SECURITY_GROUP_NAME_REGEX = /\A[[:alnum:][:punct:][:print:]]+\Z/.freeze
+    APP_SECURITY_GROUP_NAME_REGEX = /\A[[[:alnum:][:punct:][:print:]]&&[^;]]+\Z/.freeze
     TRANSPORT_RULE_FIELDS = ["protocol", "port", "destination"].map(&:freeze).freeze
     ICMP_RULE_FIELDS = ["protocol", "code", "type", "destination"].map(&:freeze).freeze
 

--- a/app/models/runtime/organization.rb
+++ b/app/models/runtime/organization.rb
@@ -1,6 +1,6 @@
 module VCAP::CloudController
   class Organization < Sequel::Model
-    ORG_NAME_REGEX = /\A[[:alnum:][:punct:][:print:]]+\Z/.freeze
+    ORG_NAME_REGEX = /\A[[[:alnum:][:punct:][:print:]]&&[^;]]+\Z/.freeze
 
     one_to_many :spaces
 

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
     class InvalidManagerRelation < VCAP::Errors::InvalidRelation; end
     class UnauthorizedAccessToPrivateDomain < RuntimeError; end
 
-    SPACE_NAME_REGEX = /\A[[:alnum:][:punct:][:print:]]+\Z/.freeze
+    SPACE_NAME_REGEX = /\A[[[:alnum:][:punct:][:print:]]&&[^;]]+\Z/.freeze
 
     define_user_group :developers, reciprocal: :spaces, before_add: :validate_developer
     define_user_group :managers, reciprocal: :managed_spaces, before_add: :validate_manager

--- a/spec/support/shared_examples/models/name_validation.rb
+++ b/spec/support/shared_examples/models/name_validation.rb
@@ -1,0 +1,11 @@
+module VCAP::CloudController
+  shared_examples_for "name with semicolon is not valid" do |clazz|
+    [";semicolon", "semi;colon", "semicolon;"].each do |name|
+      it "should detect name format error for #{clazz.to_s} name with semicolon '#{name}'" do
+        sbj = clazz.new(:name => name)
+        sbj.validate
+        expect(sbj.errors[:name]).to include(:format)
+      end
+    end
+  end
+end

--- a/spec/unit/models/runtime/app_security_group_spec.rb
+++ b/spec/unit/models/runtime/app_security_group_spec.rb
@@ -522,5 +522,9 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe "#validate" do
+      it_should_behave_like "name with semicolon is not valid", described_class
+    end
   end
 end

--- a/spec/unit/models/runtime/app_spec.rb
+++ b/spec/unit/models/runtime/app_spec.rb
@@ -1768,6 +1768,10 @@ module VCAP::CloudController
         expect { app.save }.to raise_error(Errors::ApplicationMissing)
       end
     end
+
+    describe "#validate" do
+      it_should_behave_like "name with semicolon is not valid", described_class
+    end
   end
 
   describe "default disk_quota" do

--- a/spec/unit/models/runtime/organization_spec.rb
+++ b/spec/unit/models/runtime/organization_spec.rb
@@ -452,5 +452,9 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe "#validate" do
+      it_should_behave_like "name with semicolon is not valid", described_class
+    end
   end
 end

--- a/spec/unit/models/runtime/space_spec.rb
+++ b/spec/unit/models/runtime/space_spec.rb
@@ -336,6 +336,10 @@ module VCAP::CloudController
         expect(eager_space.app_security_groups).to match_array [associated_asg, default_asg, another_default_asg]
       end
     end
+
+    describe "#validate" do
+      it_should_behave_like "name with semicolon is not valid", described_class
+    end
   end
 
   describe "#having_developer" do


### PR DESCRIPTION
Prohibit ';' in name of app / space / organization / app security group,
because the character is used as the separator in query.

We have happend to a problem with an app whose name ends with a semicolon <code>;</code>.
The app could be deployed with <code>cf push</code>, however it was not operatable. We could not <code>cf app</code>, <code>cf scale</code>, and <code>cf delete</code>.

The original cause is here:
https://github.com/tamac-io/cloud_controller_ng/blob/262c4fd7723cd04b28d2b6bafeca5b1800a39e73/lib/vcap/rest_api/query.rb#L76

```
  segments = query.split(";")
```

Query-enabled CC APIs use this method. Because CLI uses query heavily (especially to get guid for human readable name), many operations fail.

Actually, we can push an app with <code>;</code> in the middle or beginning of its name, by using <code>cf curl</code>. Such an app is also unoperatable.

I send this pull request to fix this issue.
