### PR TITLE
User-provided service instances: url should start with /u_p_s_i/...

### DIFF
--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -88,6 +88,14 @@ module VCAP::CloudController
       ]
     end
 
+    def self.url_for_guid(guid)
+      if ServiceInstance.find(guid: guid).instance_of? UserProvidedServiceInstance
+        "#{ROUTE_PREFIX}/user_provided_service_instances/#{guid}"
+      else
+        super
+      end
+    end
+
     class BulkUpdateMessage < VCAP::RestAPI::Message
       required :service_plan_guid, String
     end

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -240,6 +240,16 @@ module VCAP::CloudController
             expect(managed_service_instance_response.fetch('entity').fetch('space_url')).to be
             expect(managed_service_instance_response.fetch('entity').fetch('service_bindings_url')).to be
           end
+
+          it 'returns the correct service_bindings_url for user-provided service instances' do
+            get "v2/spaces/#{space.guid}/service_instances", {return_user_provided_service_instances: true}, headers_for(developer)
+
+            user_provided_service_instance_response = decoded_response.fetch('resources').detect {|si|
+              si.fetch('metadata').fetch('guid') == user_provided_service_instance.guid
+            }
+            expect(user_provided_service_instance_response.fetch('entity')).to_not include('service_plan_url')
+            expect(user_provided_service_instance_response.fetch('entity').fetch('service_bindings_url')).to eq("/v2/user_provided_service_instances/#{user_provided_service_instance.guid}/service_bindings")
+          end
         end
 
         describe 'when return_user_provided_service_instances flag is not present' do

--- a/spec/unit/controllers/services/user_provided_service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/user_provided_service_instances_controller_spec.rb
@@ -54,6 +54,28 @@ module VCAP::CloudController
       end
     end
 
+    describe 'GET', '/v2/service_instances' do
+      let(:space) { Space.make }
+      let(:developer) { make_developer_for_space(space) }
+      let(:service_instance) { UserProvidedServiceInstance.make(gateway_name: Sham.name) }
+
+      it "provides the correct service bindings url" do
+        get "v2/service_instances/#{service_instance.guid}", {}, admin_headers
+        expect(decoded_response.fetch('entity').fetch('service_bindings_url')).to eq("/v2/user_provided_service_instances/#{service_instance.guid}/service_bindings")
+      end
+    end
+
+    describe 'GET', '/v2/user_provided_service_instances' do
+      let(:space) { Space.make }
+      let(:developer) { make_developer_for_space(space) }
+      let(:service_instance) { UserProvidedServiceInstance.make(gateway_name: Sham.name) }
+
+      it "provides the correct service bindings url" do
+        get "v2/user_provided_service_instances/#{service_instance.guid}", {}, admin_headers
+        expect(decoded_response.fetch('entity').fetch('service_bindings_url')).to eq("/v2/user_provided_service_instances/#{service_instance.guid}/service_bindings")
+      end
+    end
+
     it "allows creation of empty credentials with a syslog drain" do
       space = Space.make
       json_body = Yajl::Encoder.encode({


### PR DESCRIPTION
`/service_instances/:guid` doesn't work with user-provided service instances; this makes sure we generate `/user_provided_service_instances/:guid` urls for them instead.
