### PR TITLE
rename loggregator_endpoint to metron_endpoint

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -109,7 +109,7 @@ logging:
   level: <%= p("cc.logging_level") %>
   max_retries: <%= p("cc.logging_max_retries") %>
 
-<% if_p("loggregator_endpoint.host", "loggregator_endpoint.port", "loggregator_endpoint.shared_secret") do |host, port, shared_secret| %>
+<% if_p("metron_endpoint.host", "metron_endpoint.port", "metron_endpoint.shared_secret") do |host, port, shared_secret| %>
 loggregator:
   router: <%= host %>:<%= port %>
   shared_secret: <%= shared_secret %>

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -109,7 +109,7 @@ logging:
   level: <%= p("cc.logging_level") %>
   max_retries: <%= p("cc.logging_max_retries") %>
 
-<% if_p("loggregator_endpoint.host", "loggregator_endpoint.port", "loggregator_endpoint.shared_secret") do |host, port, shared_secret| %>
+<% if_p("metron_endpoint.host", "metron_endpoint.port", "metron_endpoint.shared_secret") do |host, port, shared_secret| %>
 loggregator:
   router: <%= host %>:<%= port %>
   shared_secret: <%= shared_secret %>

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -109,7 +109,7 @@ logging:
   level: <%= p("cc.logging_level") %>
   max_retries: <%= p("cc.logging_max_retries") %>
 
-<% if_p("loggregator_endpoint.host", "loggregator_endpoint.port", "loggregator_endpoint.shared_secret") do |host, port, shared_secret| %>
+<% if_p("metron_endpoint.host", "metron_endpoint.port", "metron_endpoint.shared_secret") do |host, port, shared_secret| %>
 loggregator:
   router: <%= host %>:<%= port %>
   shared_secret: <%= shared_secret %>


### PR DESCRIPTION
We're introducing an agent called "metron" on every VM that needs to send logs to loggregator. In preparation for this change, we're renaming the "loggregator_endpoint" spec/manifest setting to "metron_endpoint". The change has already been done in cf-release/develop, but since cloud controller templates live in their own repo, we also need to change it here.

Related story: https://www.pivotaltracker.com/story/show/74960322
