### PR TITLE
CC should reject apps that specify both a custom buildpack and a docker image

### DIFF
--- a/lib/cloud_controller/backends.rb
+++ b/lib/cloud_controller/backends.rb
@@ -24,6 +24,10 @@ module VCAP::CloudController
       if app.buildpack.custom? && !app.custom_buildpacks_enabled?
         raise Errors::ApiError.new_from_details("CustomBuildpacksDisabled")
       end
+
+      if app.docker_image.present? && app.buildpack.custom?
+        raise Errors::ApiError.new_from_details("DiegoDockerBuildpackConflict")
+      end
     end
 
     def find_one_to_stage(app)

--- a/spec/unit/lib/cloud_controller/backends_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends_spec.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
     end
 
     let(:custom_buildpacks_enabled?) do
-      false
+      true
     end
 
     let (:buildpack) do
@@ -84,12 +84,26 @@ module VCAP::CloudController
         end
 
         context "and custom buildpacks are disabled" do
+          let(:custom_buildpacks_enabled?) do
+            false
+          end
+
           it "raises" do
             expect {
               subject.validate_app_for_staging(app)
             }.to raise_error(Errors::ApiError, /Custom buildpacks are disabled/)
           end
 
+        end
+        context "and a docker image is specified" do
+          let(:docker_image) do
+            'fake-docker-image'
+          end
+          it "raises" do
+            expect {
+              subject.validate_app_for_staging(app)
+            }.to raise_error(Errors::ApiError, /You cannot specify a custom buildpack and a docker image at the same time/)
+          end
         end
       end
 


### PR DESCRIPTION
Must also take update to vendor/errors in pull request at https://github.com/cloudfoundry/errors/pull/16

Unit tests and CATs for apps and diego are both passing.

https://www.pivotaltracker.com/story/show/75859568
