### PR TITLE
Add :latest to docker image strings without a tag

### DIFF
--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -476,6 +476,7 @@ module VCAP::CloudController
     end
 
     def docker_image=(value)
+      value = fill_docker_string(value)
       super
       self.package_hash = value
     end
@@ -552,6 +553,18 @@ module VCAP::CloudController
     end
 
     private
+
+    # there's no concrete schema for what constitutes a valid docker 
+    # repo/image reference online at the moment, so make a best effort to turn
+    # the passed value into a complete, plausible docker image reference:
+    # registry-name:registry-port/[scope-name/]repo-name:tag-name
+    def fill_docker_string(value)    
+      segs = value.split('/')
+      if not segs.last.include?(':')
+        segs[-1] = segs.last + ':latest'
+      end
+      segs.join('/')
+    end
 
     def metadata_deserialized
       deserialized_values[:metadata]

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "digest/sha1"
 
 describe "Stable API warning system", api_version_check: true do
-  API_FOLDER_CHECKSUM = "b55dce5d0d70f7599fd8f4da34217d8ec09f211c"
+  API_FOLDER_CHECKSUM = "864ee9c0bb634ee7d8d0758006a986b31a3c7e76"
 
   it "double-checks the version" do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq("2.11.0")

--- a/spec/api/documentation/apps_api_spec.rb
+++ b/spec/api/documentation/apps_api_spec.rb
@@ -65,7 +65,7 @@ resource "Apps", :type => :api do
         expect(status).to eq(201)
 
         standard_entity_response parsed_response, :app
-        expect(parsed_response['entity']['docker_image']).to eq("cloudfoundry/hello")
+        expect(parsed_response['entity']['docker_image']).to eq("cloudfoundry/hello:latest")
         expect(parsed_response['entity']['environment_json']).to match(diego_environment)
 
         app_guid = parsed_response['metadata']['guid']

--- a/spec/unit/models/runtime/app_spec.rb
+++ b/spec/unit/models/runtime/app_spec.rb
@@ -1883,14 +1883,52 @@ module VCAP::CloudController
 
       it "sets the package hash to the image name any time the image is set" do
         expect {
-          app.docker_image = "foo/bar"
-        }.to change { app.package_hash }.to("foo/bar")
+          app.docker_image = "foo/bar:latest"
+        }.to change { app.package_hash }.to("foo/bar:latest")
       end
 
       it "preserves its existing behavior as a setter" do
         expect {
-          app.docker_image = "foo/bar"
-        }.to change { app.docker_image }.to("foo/bar")
+          app.docker_image = "foo/bar:latest"
+        }.to change { app.docker_image }.to("foo/bar:latest")
+      end
+
+      user_docker_images = [
+        "bar", 
+        "foo/bar",
+        "foo/bar/baz",
+        "fake.registry.com/bar", 
+        "fake.registry.com/foo/bar",
+        "fake.registry.com/foo/bar/baz",
+        "fake.registry.com:5000/bar",
+        "fake.registry.com:5000/foo/bar",
+        "fake.registry.com:5000/foo/bar/baz",
+      ]
+
+      user_docker_images.each do |partial_ref|
+        complete_ref = partial_ref + ":0.1"
+        it "keeps the user specified tag :0.1 on #{complete_ref}" do
+          expect {
+            app.docker_image = complete_ref
+          }.to change { app.docker_image }.to end_with(":0.1")
+        end
+      end
+
+      user_docker_images.each do |partial_ref|
+        complete_ref = partial_ref + ":latest"
+        it "keeps the user specified tag :latest on #{complete_ref}" do
+          expect {
+            app.docker_image = complete_ref
+          }.to change { app.docker_image }.to end_with(":latest")
+        end
+      end
+
+      user_docker_images.each do |partial_ref|
+        it "inserts the tag :latest on #{partial_ref}" do
+          expect {
+            app.docker_image = partial_ref
+          }.to change { app.docker_image }.to end_with(":latest")
+        end
       end
     end
 


### PR DESCRIPTION
Passes spec and CATs with latest cf-release and diego-release.

Has an API change because of the docker example so probably requires a cf-release bump. No submodules touched in this one that need to be bumped.

[#75755060]

Signed-off-by: Stewart Nickolas nickolas@us.ibm.com

/cc @onsi @hiremaga
