### PR TITLE
Improve CC composite error message to support i18n

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -57,9 +57,9 @@ module VCAP::CloudController
           Errors::ApiError.new_from_details("QuotaInstanceMemoryLimitExceeded")
         end
       elsif instance_number_errors
-        Errors::ApiError.new_from_details("AppInvalid", "Number of instances less than 1")
+        Errors::ApiError.new_from_details("AppInvalid.invalid_instance_number")
       elsif state_errors
-        Errors::ApiError.new_from_details("AppInvalid", "Invalid app state provided")
+        Errors::ApiError.new_from_details("AppInvalid.invalid_app_state")
       else
         Errors::ApiError.new_from_details("AppInvalid", e.errors.full_messages)
       end

--- a/lib/vcap/errors/api_error.rb
+++ b/lib/vcap/errors/api_error.rb
@@ -3,11 +3,22 @@ module VCAP
     class ApiError < StandardError
       attr_accessor :args
       attr_accessor :details
+      attr_accessor :full_error_name
 
-      def self.new_from_details(name, *args)
+      def self.new_from_details(full_error_name, *args)
+        # To support i18n, we use full error name in CC code. For example, in the code we change from:
+        # "VCAP::Errors::ApiError.new('AppInvalid', 'instance number less than 1')"
+        # to
+        # "VCAP::Errors::ApiError.new('AppInvalid.InvalidInstanceNumber')"
+        # 'AppInvalid.InvalidInstanceNumber' stands for the full error name, and in the i18n translation files under
+        # 'vendor/errors/i18n', we will put and translate the message of this message
+        name = full_error_name
+        name = full_error_name[0, full_error_name.index(/\./)] unless full_error_name.index(/\./).nil?
+
         details = Details.new(name)
         api_error = new
         api_error.details = details
+        api_error.full_error_name = full_error_name
         api_error.args = args
         api_error
       end
@@ -26,7 +37,11 @@ module VCAP
         end
 
         begin
-          sprintf(I18n.translate(details.name, raise: true, :locale => I18n.locale), *formatted_args)
+          translated_message = I18n.translate(full_error_name, raise: true, :locale => I18n.locale)
+          if translated_message.instance_of?(Hash) && translated_message.has_key?(:default)
+            translated_message = translated_message[:default]
+          end
+          sprintf(translated_message, *formatted_args)
         rescue I18n::MissingTranslationData => e
           sprintf(details.message_format, *formatted_args)
         end

--- a/spec/fixtures/i18n/en_US.yml
+++ b/spec/fixtures/i18n/en_US.yml
@@ -1,4 +1,8 @@
 ---
 en_US:
-  ServiceInvalid: "This is a translated message of %s %s."
+  MessageTranslated: "This is a translated message of %s %s."
   MessagePartialTranslated: "This is a translated message of %s %s only in default locale"
+  AppInvalid:
+    invalid_instance_number: "The app is invalid: Number of instances less than 1"
+    invalid_app_state: "Invalid app state provided"
+    default: "The app is invalid: %s"

--- a/spec/fixtures/i18n/zh_CN.yml
+++ b/spec/fixtures/i18n/zh_CN.yml
@@ -1,3 +1,3 @@
 ---
 zh_CN:
-  ServiceInvalid: "这是一条被翻译的信息：%s %s。"
+  MessageTranslated: "这是一条被翻译的信息：%s %s。"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,8 @@ RSpec.configure do |rspec_config|
 
     stub_v1_broker
     VCAP::CloudController::SecurityContext.clear
+
+    I18nHelper.set_i18n_env
   end
 
   rspec_config.around :each do |example|
@@ -80,6 +82,8 @@ RSpec.configure do |rspec_config|
       raise "Sequel Deprecation String found: #{Sequel::Deprecation.output.string}"
     end
     Sequel::Deprecation.output.close unless Sequel::Deprecation.output.closed?
+
+    I18nHelper.clear_i18n_env
   end
 
   rspec_config.after :all do

--- a/spec/support/i18n_helper.rb
+++ b/spec/support/i18n_helper.rb
@@ -1,0 +1,15 @@
+module I18nHelper
+  def self.set_i18n_env
+    I18n.enforce_available_locales = false
+    I18n.load_path = Dir[File.expand_path("../../fixtures/i18n/*.yml", __FILE__)]
+    I18n.default_locale = "en_US"
+    I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+    I18n.backend.reload!
+  end
+
+  def self.clear_i18n_env
+    I18n.locale = "en"
+    I18n.load_path = []
+    I18n.backend.reload!
+  end
+end

--- a/spec/unit/lib/vcap/errors/api_error_spec.rb
+++ b/spec/unit/lib/vcap/errors/api_error_spec.rb
@@ -12,12 +12,12 @@ module VCAP::Errors
              message_format: "Before %s %s after.")
     end
 
-    let(:messageServiceInvalid) { "ServiceInvalid" }
+    let(:messageTranslated) { "MessageTranslated" }
     let(:messagePartialTranslated) { "MessagePartialTranslated"}
     let(:messageNotTranslated) { "MessageNotTranslated" }
     let(:args) { [ "foo", "bar" ] }
 
-    let(:messageServiceInvalidDetails) { create_details(messageServiceInvalid) }
+    let(:messageTranslatedDetails) { create_details(messageTranslated) }
     let(:messagePartialTranslatedDetails) { create_details(messagePartialTranslated) }
     let(:messageNotTranslatedDetails) { create_details(messageNotTranslated) }
 
@@ -30,7 +30,7 @@ module VCAP::Errors
       expect(I18n.load_path).to have(2).items
       expect(I18n.default_locale).to eq(:en_US)
 
-      allow(Details).to receive("new").with(messageServiceInvalid).and_return(messageServiceInvalidDetails)
+      allow(Details).to receive("new").with(messageTranslated).and_return(messageTranslatedDetails)
       allow(Details).to receive("new").with(messagePartialTranslated).and_return(messagePartialTranslatedDetails)
       allow(Details).to receive("new").with(messageNotTranslated).and_return(messageNotTranslatedDetails)
     end
@@ -42,7 +42,7 @@ module VCAP::Errors
     end
 
     context ".new_from_details" do
-      subject(:api_error) { ApiError.new_from_details(messageServiceInvalid, *args) }
+      subject(:api_error) { ApiError.new_from_details(messageTranslated, *args) }
 
       it "returns an ApiError" do
         expect(api_error).to be_a(ApiError)
@@ -53,7 +53,7 @@ module VCAP::Errors
       end
 
       context "if it doesn't recognise the error from v2.yml" do
-        let(:messageServiceInvalid) { "What is this?  I don't know?!!"}
+        let(:messageTranslated) { "What is this?  I don't know?!!"}
 
         before do
           allow(Details).to receive(:new).and_call_original
@@ -66,7 +66,7 @@ module VCAP::Errors
     end
 
     context "get error message" do
-      subject(:api_error) { ApiError.new_from_details(messageServiceInvalid, *args) }
+      subject(:api_error) { ApiError.new_from_details(messageTranslated, *args) }
       subject(:api_error_with_partial_translation) { ApiError.new_from_details(messagePartialTranslated, *args) }
       subject(:api_error_with_translation_missing)  { ApiError.new_from_details(messageNotTranslated, *args) }
 
@@ -97,7 +97,7 @@ module VCAP::Errors
       subject(:api_error) { ApiError.new }
 
       before do
-        api_error.details = messageServiceInvalidDetails
+        api_error.details = messageTranslatedDetails
       end
 
       it "exposes the code" do
@@ -109,7 +109,7 @@ module VCAP::Errors
       end
 
       it "exposes the name" do
-        expect(api_error.name).to eq("ServiceInvalid")
+        expect(api_error.name).to eq("MessageTranslated")
       end
     end
   end


### PR DESCRIPTION
At present, in CC, there are some of the error messages are composite message
which consist of two parts: general message part and error detail reason part.
For example, Application Invalid message has three kinds of details:
1. Errors::ApiError.new_from_details("AppInvalid", "Number of instances less than 1")
2. Errors::ApiError.new_from_details("AppInvalid", "Invalid app state provided")
3. Errors::ApiError.new_from_details("AppInvalid", e.errors.full_messages)

For this kind of composite message, both the general message part and the detail
reason part need to be translated. Considering the details part is hard coded
in CC code, suggest to enhance the CC code like the following format to support
full i18n:

Errors::ApiError.new_from_details("AppInvalid.invalid_instance_number")

and in the i18n translation file, we can put the full message of AppInvalid error message like:

AppInvalid:
  instances_less_than_1: "The app is invalid: Number of instances less than 1"
  invalid_app_state: "The app is invalid: Invalid app state provided"
  default: "The app is invalid: %s"

In this PR, I just use AppInvlid message as en example, if this solution is
ok for CC, we can use the same solution for other composite error messages
in CC code. Will submit following PRs after this one is accepted and merged.
