### PR TITLE
fix undefined method `num_waiting'  exception when resultqueue=[]

### DIFF
--- a/lib/cloud_controller/varz.rb
+++ b/lib/cloud_controller/varz.rb
@@ -57,7 +57,7 @@ module VCAP::CloudController
           },
           resultqueue: {
             size: resultqueue ? resultqueue.size : 0,
-            num_waiting: resultqueue ? resultqueue.num_waiting : 0,
+            num_waiting: (resultqueue and !resultqueue.empty?) ? resultqueue.num_waiting : 0,
           },
         },
       }


### PR DESCRIPTION
I try to deploy cloud foundry on my local computer by manual, first deploy gnastd, then gorouter, when I try deploy cloud controller, it throw a exception.
underline is  msg:
 /home/hushan/work/cf-release/src/cloud_controller_ng/lib/cloud_controller/varz.rb:60:in `get_thread_info': undefined method`num_waiting' for []:Array (NoMethodError)
    from /home/hushan/work/cf-release/src/cloud_controller_ng/lib/cloud_controller/varz.rb:25:in `update_thread_info'
    from /home/hushan/work/cf-release/src/cloud_controller_ng/lib/cloud_controller/varz.rb:9:in`block in setup_updates'
    from /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/lib/em/timers.rb:56:in `call'
    from /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/lib/em/timers.rb:56:in`fire'
    from /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `call'
    from /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in`run_machine'
    from /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run'
    from /home/hushan/work/cf-release/src/cloud_controller_ng/lib/cloud_controller/runner.rb:84:in`run!'
