### PR TITLE
Uploading droplet better uses local ip and port 

### DIFF
--- a/app/presenters/api/staging_job_presenter.rb
+++ b/app/presenters/api/staging_job_presenter.rb
@@ -3,10 +3,11 @@ require_relative "job_presenter"
 class StagingJobPresenter < JobPresenter
   def status_url
     config = VCAP::CloudController::Config.config
-    external_domain = Array(config[:external_domain]).first
+    local_route = config[:local_route]
+    external_port = config[:external_port]
     user = config[:staging][:auth][:user]
     password = config[:staging][:auth][:password]
 
-    "#{config[:external_protocol]}://#{user}:#{password}@#{external_domain}/staging/jobs/#{@object.guid}"
+    "#{config[:external_protocol]}://#{user}:#{password}@#{local_route}:#{external_port}/staging/jobs/#{@object.guid}"
   end
 end

--- a/spec/unit/controllers/runtime/stagings_controller_spec.rb
+++ b/spec/unit/controllers/runtime/stagings_controller_spec.rb
@@ -232,7 +232,9 @@ module VCAP::CloudController
           config = VCAP::CloudController::Config.config
           user = config[:staging][:auth][:user]
           password = config[:staging][:auth][:password]
-          polling_url = "http://#{user}:#{password}@#{config[:external_domain].first}/staging/jobs/#{job.guid}"
+          local_route = config[:local_route]
+          external_port = config[:external_port]
+          polling_url = "http://#{user}:#{password}@#{local_route}:#{external_port}/staging/jobs/#{job.guid}"
 
           expect(decoded_response.fetch('metadata').fetch('url')).to eql(polling_url)
         end

--- a/spec/unit/presenters/api/staging_job_presenter_spec.rb
+++ b/spec/unit/presenters/api/staging_job_presenter_spec.rb
@@ -12,7 +12,9 @@ describe StagingJobPresenter do
     it "creates a valid JSON with the correct url" do
       user = TestConfig.config[:staging][:auth][:user]
       password = TestConfig.config[:staging][:auth][:password]
-      polling_url = "http://#{user}:#{password}@#{TestConfig.config[:external_domain]}/staging/jobs/#{job.guid}"
+      local_route = TestConfig.config[:local_route]
+      external_port = TestConfig.config[:external_port]
+      polling_url = "http://#{user}:#{password}@#{local_route}:#{external_port}/staging/jobs/#{job.guid}"
 
       expect(StagingJobPresenter.new(job).to_hash).to eq(
         metadata: {


### PR DESCRIPTION
instead of domain because it's internal communication between cf components.
