### PR TITLE
Correcting the parameter name in create-space api docs

### DIFF
--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "digest/sha1"
 
 describe "Stable API warning system", api_version_check: true do
-  API_FOLDER_CHECKSUM = "98146abf52f917f4ce1eacaefcd5195eb2eb129b"
+  API_FOLDER_CHECKSUM = "70a774db4a5605211ac47615ad29d8e3850d4942"
 
   it "double-checks the version" do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq("2.18.0")

--- a/spec/api/documentation/spaces_api_spec.rb
+++ b/spec/api/documentation/spaces_api_spec.rb
@@ -21,7 +21,7 @@ resource "Spaces", :type => [:api, :legacy_api] do
       field :auditor_guids, "The list of the associated auditors"
       field :domain_guids, "The list of the associated domains"
       field :security_group_guids, "The list of the associated security groups"
-      field :space_quota_definition, "The guid of the associated space quota definition"
+      field :space_quota_definition_guid, "The guid of the associated space quota definition"
     end
 
     shared_context "updatable_fields" do |opts|


### PR DESCRIPTION
When we use the create-space command with optional space_quota_definition, and the request is sent with space_quota_definition the cc_ng is sending OK response but ignoring the space_quota. 

We found the issue in api docs: the field is "space_quota_definition_guid" not "space_quota_definition".
