### PR TITLE
[314] Make boolean queries database-agnostic.

### DIFF
--- a/lib/vcap/rest_api/query.rb
+++ b/lib/vcap/rest_api/query.rb
@@ -161,7 +161,7 @@ module VCAP::RestAPI
       if column[:db_type] == TINYINT_TYPE
         TINYINT_FROM_TRUE_FALSE.fetch(q_val, q_val)
       else
-        q_val == "t"
+        q_val == "t" ? true : q_val
       end
     end
 


### PR DESCRIPTION
https://github.com/cloudfoundry/cloud_controller_ng/issues/314

Assume any values that aren't '"t"' can stand for themselves (although if the
code is assuming these values are either always "t" or "f" this is incorrect).

What about just running all the values through a hash:

return {"t":true, "true":true, "f":false, "false":false, 1:true, 0:false}.fetch(q_val, q_val)

And why is the code returning 1 and 0 instead of true and false?

It would be better if I knew the requirements of the providers and consumers that
rely on this method. Not documented, which is why this PR shouldn't be accepted.
