### PR TITLE
More flexible nested domain creation rules.

### DIFF
--- a/app/models/runtime/private_domain.rb
+++ b/app/models/runtime/private_domain.rb
@@ -40,6 +40,8 @@ module VCAP::CloudController
     def validate
       super
       validates_presence :owning_organization
+      exclude_domains_from_same_org = Domain.dataset.exclude(:owning_organization_id => owning_organization_id).or(SHARED_DOMAIN_CONDITION)
+      errors.add(:name, :overlapping_domain) if exclude_domains_from_same_org.filter(Sequel.like(:name, "%.#{name}")).count > 0
     end
 
     def in_suspended_org?

--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -48,6 +48,12 @@ module VCAP::CloudController
 
       validate_domain
       validate_total_routes
+      errors.add(:host, :domain_conflict) if domains_match?
+    end
+
+    def domains_match?
+        return false if domain.nil? || host.nil? || host.empty?
+        return !Domain.find(name: fqdn).nil?
     end
 
     def validate_app(app)

--- a/spec/unit/models/runtime/route_spec.rb
+++ b/spec/unit/models/runtime/route_spec.rb
@@ -127,6 +127,17 @@ module VCAP::CloudController
             )
           }.to raise_error(Sequel::ValidationFailed)
         end
+
+        it "should not allow route to match existing domain" do
+          SharedDomain.make name: "bar.foo.com"
+          expect {
+            Route.make(
+              :space  => space,
+              :domain => SharedDomain.make(name: "foo.com"),
+              :host   => "bar"
+            )
+          }.to raise_error(Sequel::ValidationFailed, /domain_conflict/)
+        end
       end
 
       describe "total allowed routes" do

--- a/spec/unit/models/runtime/shared_domain_spec.rb
+++ b/spec/unit/models/runtime/shared_domain_spec.rb
@@ -29,7 +29,29 @@ module VCAP::CloudController
         end
 
         it { is_expected.to be_valid }
-      end          
+      end
+
+      it "allows shared foo.com when private bar.foo.com exists" do
+        private_domain = PrivateDomain.make name: "bar.foo.com"
+        expect { SharedDomain.make name: "foo.com" }.to_not raise_error
+      end
+      
+      it "allows shared foo.com when shared bar.foo.com exists" do
+        private_domain = SharedDomain.make name: "bar.foo.com"
+        expect { SharedDomain.make name: "foo.com" }.to_not raise_error
+      end
+
+      it "allows shared bar.foo.com a when shared baz.bar.foo.com and foo.com exist" do
+        SharedDomain.make name: "baz.bar.foo.com"
+        SharedDomain.make name: "foo.com"
+        expect { SharedDomain.make name: "bar.foo.com" }.to_not raise_error
+      end
+
+      it "allows shared bar.foo.com a when private baz.bar.foo.com and shared foo.com exist" do
+        PrivateDomain.make name: "baz.bar.foo.com"
+        SharedDomain.make name: "foo.com"
+        expect { SharedDomain.make name: "bar.foo.com" }.to_not raise_error
+      end
     end
 
     describe "#destroy" do


### PR DESCRIPTION
This is the PR for Issue https://github.com/cloudfoundry/cloud_controller_ng/issues/311.

This PR changes domain and route creation in the following ways:
- You can now create private and shared sub domains of a shared domain
- You can now create shared parent domains of private and shared domains
- You can now create private sub and parent domains of private domains if all are in the same org
- You cannot create a shared domain with a parent private domain
- When a domain is created a check for matching routes is done
- When a route is created a check for matching domains is done

This has some tricky logic but I believe I got all of the use cases covered in tests.
