### PR TITLE
Allowing routes to be queried by organization guid

### DIFF
--- a/app/controllers/runtime/routes_controller.rb
+++ b/app/controllers/runtime/routes_controller.rb
@@ -7,7 +7,7 @@ module VCAP::CloudController
       to_many :apps
     end
 
-    query_parameters :host, :domain_guid
+    query_parameters :host, :domain_guid, :organization_guid
 
     def self.translate_validation_exception(e, attributes)
       name_errors = e.errors.on([:host, :domain_id])
@@ -30,6 +30,22 @@ module VCAP::CloudController
 
     def delete(guid)
       do_delete(find_guid_and_validate_access(:delete, guid))
+    end
+
+    def get_filtered_dataset_for_enumeration(model, ds, qp, opts)
+      org_index = opts[:q].index { |query| query.start_with?('organization_guid:') } if opts[:q]
+      if !org_index.nil?
+        org_guid = opts[:q][org_index].split(':')[1]
+        opts[:q].delete(opts[:q][org_index])
+
+        super(model, ds, qp, opts).
+          select_all(:routes).
+          left_join(:spaces, id: :routes__space_id).
+          left_join(:organizations, id: :spaces__organization_id).
+          where(organizations__guid: org_guid)
+      else
+        super(model, ds, qp, opts)
+      end
     end
 
     get "#{path}/reserved/domain/:domain_guid/host/:host", :route_reserved

--- a/spec/unit/controllers/runtime/routes_controller_spec.rb
+++ b/spec/unit/controllers/runtime/routes_controller_spec.rb
@@ -5,6 +5,7 @@ module VCAP::CloudController
     describe 'Query Parameters' do
       it { expect(described_class).to be_queryable_by(:host) }
       it { expect(described_class).to be_queryable_by(:domain_guid) }
+      it { expect(described_class).to be_queryable_by(:organization_guid) }
     end
 
     describe 'Attributes' do
@@ -188,6 +189,80 @@ module VCAP::CloudController
           expect(last_response.status).to eq(403)
           expect(decoded_response['error_code']).to match(/FeatureDisabled/)
           expect(decoded_response['description']).to match(/route_creation/)
+        end
+      end
+    end
+
+    describe 'GET /v2/routes' do
+      let(:organization) { Organization.make }
+      let(:domain) { PrivateDomain.make(owning_organization: organization) }
+      let(:space) { Space.make(organization: organization) }
+      let(:route) { Route.make(domain: domain, space: space) }
+
+      describe 'Filtering with Organization Guid' do
+        context 'When Organization Guid Not Present' do
+          it 'Return Resource length zero' do
+            get 'v2/routes?q=organization_guid:notpresent', {}, admin_headers
+            expect(last_response.status).to eq(200)
+            expect(decoded_response['resources'].length).to eq(0)
+          end
+        end
+
+        context 'When Organization Guid Present' do
+          let(:first_route_info) { decoded_response.fetch('resources').first }
+          let(:second_route_info) { decoded_response.fetch('resources').last }
+          let(:space1) { Space.make(organization: organization) }
+          let(:route1) { Route.make(domain: domain, space: space1) }
+
+          it 'Allows filtering by organization_guid' do
+            org_guid = organization.guid
+            route_guid = route.guid
+
+            get "v2/routes?q=organization_guid:#{org_guid}", {}, admin_headers
+
+            expect(last_response.status).to eq(200)
+            expect(decoded_response['resources'].length).to eq(1)
+            expect(first_route_info.fetch('metadata').fetch('guid')).to eq(route_guid)
+          end
+
+          it 'Allows organization_guid query at any place in query ' do
+            org_guid = organization.guid
+            route_guid = route.guid
+            domain_guid = domain.guid
+
+            get "v2/routes?q=domain_guid:#{domain_guid}&q=organization_guid:#{org_guid}", {}, admin_headers
+
+            expect(last_response.status).to eq(200)
+            expect(decoded_response['resources'].length).to eq(1)
+            expect(first_route_info.fetch('metadata').fetch('guid')).to eq(route_guid)
+          end
+
+          it 'Allows organization_guid query at any place in query with all querables' do
+            org_guid = organization.guid
+            taken_host = 'someroute'
+            route_temp = Route.make(host: taken_host, domain: domain, space: space)
+            route_guid = route_temp.guid
+            domain_guid = domain.guid
+
+            get "v2/routes?q=host:#{taken_host}&q=organization_guid:#{org_guid}&q=domain_guid:#{domain_guid}", {}, admin_headers
+
+            expect(last_response.status).to eq(200)
+            expect(decoded_response['resources'].length).to eq(1)
+            expect(first_route_info.fetch('metadata').fetch('guid')).to eq(route_guid)
+          end
+
+          it 'Allows filtering at organization level' do
+            org_guid = organization.guid
+            route_guid = route.guid
+            route1_guid = route1.guid
+
+            get "v2/routes?q=organization_guid:#{org_guid}", {}, admin_headers
+
+            expect(last_response.status).to eq(200)
+            expect(decoded_response['resources'].length).to eq(2)
+            expect(first_route_info.fetch('metadata').fetch('guid')).to eq(route_guid)
+            expect(second_route_info.fetch('metadata').fetch('guid')).to eq(route1_guid)
+          end
         end
       end
     end


### PR DESCRIPTION
Solution to the story :- 'cf routes' output should be scoped to the org and output grouped by space
[#79407556]

Using q=organization_guid:guid-id-123, the routes enumeration endpoint(/v2/routes?) will
return all routes that belong to the organization, even if they are in
different spaces