### PR TITLE
Configurable file_descriptors limit for warden container

### DIFF
--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -138,6 +138,10 @@ module VCAP::CloudController
       self.memory ||= Config.config[:default_app_memory]
       self.disk_quota ||= Config.config[:default_app_disk_in_mb]
 
+      if Config.config[:container_file_descriptor_limit]
+        self.file_descriptors ||= Config.config[:container_file_descriptor_limit]
+      end
+
       set_new_version if version_needs_to_be_updated?
 
       AppStopEvent.create_from_app(self) if generate_stop_event?

--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -74,6 +74,8 @@ default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
 
+container_file_descriptor_limit: <%= p("cc.container_file_descriptor_limit") %>
+
 request_timeout_in_seconds: <%= p("request_timeout_in_seconds") %>
 
 cc_partition: <%= p("cc.cc_partition") %>

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -78,6 +78,8 @@ default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
 
+container_file_descriptor_limit: <%= p("cc.container_file_descriptor_limit") %>
+
 request_timeout_in_seconds: <%= p("request_timeout_in_seconds") %>
 
 cc_partition: <%= p("cc.cc_partition") %>

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -74,6 +74,8 @@ default_app_memory: <%= p("cc.default_app_memory") %>
 default_app_disk_in_mb: <%= p("cc.default_app_disk_in_mb") %>
 maximum_app_disk_in_mb: <%= p("cc.maximum_app_disk_in_mb") %>
 
+container_file_descriptor_limit: <%= p("cc.container_file_descriptor_limit") %>
+
 request_timeout_in_seconds: <%= p("request_timeout_in_seconds") %>
 
 cc_partition: <%= p("cc.cc_partition") %>

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -44,6 +44,8 @@ module VCAP::CloudController
         optional(:maximum_app_disk_in_mb) => Fixnum,
         :maximum_health_check_timeout => Fixnum,
 
+        optional(:container_file_descriptor_limit) => Fixnum,
+
         optional(:allow_debug) => bool,
 
         optional(:login) => {

--- a/spec/unit/models/runtime/app_spec.rb
+++ b/spec/unit/models/runtime/app_spec.rb
@@ -1643,6 +1643,17 @@ module VCAP::CloudController
           expect(app.disk_quota).to eq(512)
         end
       end
+
+      describe 'container_file_descriptor_limit' do
+        before do
+          TestConfig.override({ container_file_descriptor_limit: 200 })
+        end
+
+        it 'uses the container_file_descriptor_limit config variable' do
+          app = App.create_from_hash(name: 'awesome app', space_guid: space.guid)
+          expect(app.file_descriptors).to eq(200)
+        end
+      end
     end
 
     describe 'saving' do


### PR DESCRIPTION
file_descriptors for a warden container is made configurable through
deployment manifest.
Currently the default is 16384 which is read from the database table
and is not configurable. To configure, cf operator needs to add the
following config variable under cc
cc:
  default_app_file_descriptors: 4096

[#82011156]