### PR TITLE
Enable nginx_status endpoint always

### DIFF
--- a/bosh-templates/nginx.conf.erb
+++ b/bosh-templates/nginx.conf.erb
@@ -154,7 +154,7 @@ http {
 
     location /nginx_status {
       stub_status on;
-      access_log  /var/vcap/sys/log/nginx_newrelic_plugin/nginx_newrelic_plugin.access.log main;
+      access_log  /var/vcap/sys/log/nginx_cc/nginx_status.access.log main;
       allow 127.0.0.1;
       deny all;
     }

--- a/bosh-templates/nginx.conf.erb
+++ b/bosh-templates/nginx.conf.erb
@@ -152,14 +152,12 @@ http {
       proxy_pass $download_url;
     }
 
-    <% if_p("cc.newrelic.license_key") do %>
     location /nginx_status {
       stub_status on;
       access_log  /var/vcap/sys/log/nginx_newrelic_plugin/nginx_newrelic_plugin.access.log main;
       allow 127.0.0.1;
       deny all;
     }
-    <% end %>
 
   }
 }


### PR DESCRIPTION
We have an nginx_status release that uses this endpoint, so we'd like to have it on even if `cc.newrelic.license_key` is not configured.

We could add a new property to handle this, but we didn't see a reason why *not* to enable it all the time.