### PR TITLE
Added prior state to app.update event

### DIFF
--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -545,6 +545,19 @@ module VCAP::CloudController
       app_event_repository.record_unmap_route(self, route, SecurityContext.current_user, SecurityContext.current_user_email)
     end
 
+    def prior_state
+      changes = previous_changes
+      return self.state unless changes
+
+      if changes.key?(:state)
+        return changes[:state][0]
+      elsif changes.key?(:staging_task_id)
+        return 'STOPPED'
+      end
+
+      self.state
+    end
+
     private
 
     def mark_routes_changed(_=nil)

--- a/app/models/v3/domain/app_process.rb
+++ b/app/models/v3/domain/app_process.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   class AppProcess
     attr_reader :guid, :app_guid, :space_guid, :stack_guid, :disk_quota,
       :memory, :instances, :state, :command, :buildpack, :health_check_timeout,
-      :docker_image, :environment_json, :name, :type
+      :docker_image, :environment_json, :name, :type, :prior_state
 
     def initialize(opts)
       opts.symbolize_keys!
@@ -21,6 +21,7 @@ module VCAP::CloudController
       @state                = opts[:state]
       @type                 = opts[:type] || 'web'
       @name                 = opts[:name] || "v3-proc-#{@type}-#{@guid}"
+      @prior_state          = opts[:prior_state]
     end
 
     def with_changes(changes)

--- a/app/models/v3/mappers/process_mapper.rb
+++ b/app/models/v3/mappers/process_mapper.rb
@@ -15,7 +15,8 @@ module VCAP::CloudController
         'health_check_timeout' => model.values[:health_check_timeout],
         'docker_image'         => model.values[:docker_image],
         'environment_json'     => model.environment_json,
-        'type'                 => model.type
+        'type'                 => model.type,
+        'prior_state'          => model.prior_state
       })
     end
 

--- a/app/repositories/runtime/app_event_repository.rb
+++ b/app/repositories/runtime/app_event_repository.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
           Loggregator.emit(app.guid, "Updated app with guid #{app.guid} (#{app_audit_hash(request_attrs)})")
 
           actor = { name: actor_name, guid: actor.guid, type: 'user' }
-          metadata = { request: app_audit_hash(request_attrs) }
+          metadata = { request: app_audit_hash(request_attrs), prior_state: app.prior_state }
           create_app_audit_event('audit.app.update', app, space, actor, metadata)
         end
 

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = 'e6bc0b047a062ff6a36147c47c8b3904da584490'
+  API_FOLDER_CHECKSUM = 'a4773bdf3fdba5bdb51fe0b1b19758fe5c7052eb'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.23.0')

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -165,6 +165,7 @@ resource 'Events', type: [:api, :legacy_api] do
                                space_guid: test_app.space.guid,
                                metadata: {
                                  'request' => expected_app_request,
+                                 'prior_state' => test_app.prior_state,
                                }
     end
 

--- a/spec/unit/controllers/runtime/apps_controller_spec.rb
+++ b/spec/unit/controllers/runtime/apps_controller_spec.rb
@@ -187,6 +187,41 @@ module VCAP::CloudController
 
             update_app
           end
+
+          it 'receive prior state' do
+            allow(app_event_repository).to receive(:record_app_update).and_call_original
+
+            update_app
+
+            expect(app_event_repository).to have_received(:record_app_update) do |recorded_app, recorded_space, user, user_name, attributes|
+              expect(recorded_app.guid).to eq(app_obj.guid)
+              expect(recorded_app.instances).to eq(2)
+              expect(user).to eq(admin_user)
+              expect(user_name).to eq(SecurityContext.current_user_email)
+              expect(attributes).to eq({ 'instances' => 2 })
+              expect(recorded_app.prior_state).to eq('STOPPED')
+            end
+          end
+        end
+
+        context 'when state update succeeds' do
+          let(:update_hash) { { 'state' => 'STARTED' } }
+          let(:app_tmp_obj) { AppFactory.make(instances: 1) }
+
+          it 'receive previous state' do
+            allow(app_event_repository).to receive(:record_app_update).and_call_original
+
+            update_app
+
+            expect(app_event_repository).to have_received(:record_app_update) do |recorded_app, recorded_space, user, user_name, attributes|
+              expect(recorded_app.guid).to eq(app_obj.guid)
+              expect(recorded_app.state).to eq('STARTED')
+              expect(user).to eq(admin_user)
+              expect(user_name).to eq(SecurityContext.current_user_email)
+              expect(attributes).to eq({ 'state' => 'STARTED' })
+              expect(recorded_app.prior_state).to eq('STOPPED')
+            end
+          end
         end
 
         context 'when the update fails' do


### PR DESCRIPTION
Solution to the story :- 'As a CF api consumer I expect that /v2/events returns prior state as a part of its metadata for all app.update events'
[#74624460]

After this commit, /v2/events will contain prior state as part of metadata for all app.update event.
For eg...
```
{
         "metadata": {
            "guid": "efcf3dab-4314-406c-b796-98973cff1abf",
            "url": "/v2/events/efcf3dab-4314-406c-b796-98973cff1abf",
            "created_at": "2015-01-28T12:13:17+00:00",
            "updated_at": null
         },
         "entity": {
            "type": "audit.app.update",
            "actor": "c85f70bb-0e7f-44f1-ae2b-63429309c89c",
            "actor_type": "user",
            "actor_name": "admin",
            "actee": "fbeb946e-c2fd-49c3-abf7-99918c1572a2",
            "actee_type": "app",
            "actee_name": "Dev6",
            "timestamp": "2015-01-28T12:13:17+00:00",
            "metadata": {
               "request": {
                  "state": "STARTED"
               },
               "previous_state": {
                  "state": "STOPPED"
               }
            },
            "space_guid": "57921333-7f00-4151-8dc3-fc654e8e332f",
            "organization_guid": "e28b54ce-acff-4dac-afe7-ad59fd446f53"
         }
      }
```