### PR TITLE
Record events on deletion for auditing purposes

### DIFF
--- a/app/controllers/runtime/private_domains_controller.rb
+++ b/app/controllers/runtime/private_domains_controller.rb
@@ -1,5 +1,9 @@
 module VCAP::CloudController
   class PrivateDomainsController < RestController::ModelController
+    def self.dependencies
+      [:domain_event_repository]
+    end
+
     define_attributes do
       attribute :name, String
       to_one :owning_organization
@@ -7,8 +11,15 @@ module VCAP::CloudController
 
     query_parameters :name
 
+    def inject_dependencies(dependencies)
+      super
+      @domain_event_repository = dependencies.fetch(:domain_event_repository)
+    end
+
     def delete(guid)
-      do_delete(find_guid_and_validate_access(:delete, guid))
+      domain = find_guid_and_validate_access(:delete, guid)
+      @domain_event_repository.record_domain_delete_request(domain, SecurityContext.current_user, SecurityContext.current_user_email)
+      do_delete(domain)
     end
 
     define_messages

--- a/app/controllers/runtime/shared_domains_controller.rb
+++ b/app/controllers/runtime/shared_domains_controller.rb
@@ -1,13 +1,24 @@
 module VCAP::CloudController
   class SharedDomainsController < RestController::ModelController
+    def self.dependencies
+      [:domain_event_repository]
+    end
+
     define_attributes do
       attribute :name, String
     end
 
     query_parameters :name
 
+    def inject_dependencies(dependencies)
+      super
+      @domain_event_repository = dependencies.fetch(:domain_event_repository)
+    end
+
     def delete(guid)
-      do_delete(find_guid_and_validate_access(:delete, guid))
+      domain = find_guid_and_validate_access(:delete, guid)
+      @domain_event_repository.record_domain_delete_request(domain, SecurityContext.current_user, SecurityContext.current_user_email)
+      do_delete(domain)
     end
 
     define_messages

--- a/app/controllers/services/service_auth_tokens_controller.rb
+++ b/app/controllers/services/service_auth_tokens_controller.rb
@@ -5,6 +5,10 @@ module VCAP::CloudController
       'Consider upgrading your broker to implement the v2 Service Broker API.'
     ].join(' ').freeze
 
+    def self.dependencies
+      [:service_auth_token_event_repository]
+    end
+
     define_attributes do
       attribute :label,    String
       attribute :provider, String
@@ -12,6 +16,11 @@ module VCAP::CloudController
     end
 
     query_parameters :label, :provider
+
+    def inject_dependencies(dependencies)
+      super
+      @service_auth_token_event_repository = dependencies.fetch(:service_auth_token_event_repository)
+    end
 
     def self.translate_validation_exception(e, attributes)
       label_provider_errors = e.errors.on([:label, :provider])
@@ -23,7 +32,9 @@ module VCAP::CloudController
     end
 
     def delete(guid)
-      do_delete(find_guid_and_validate_access(:delete, guid))
+      service_auth_token = find_guid_and_validate_access(:delete, guid)
+      @service_auth_token_event_repository.record_service_auth_token_delete_request(service_auth_token, SecurityContext.current_user, SecurityContext.current_user_email)
+      do_delete(service_auth_token)
     end
 
     define_messages

--- a/app/models/runtime/event.rb
+++ b/app/models/runtime/event.rb
@@ -31,6 +31,7 @@ module VCAP::CloudController
 
     def denormalize_space_and_org_guids
       return if space_guid && organization_guid
+      return if space.nil?
       self.space_guid = space.guid
       self.organization_guid = space.organization.guid
     end

--- a/app/repositories/runtime/buildpack_event_repository.rb
+++ b/app/repositories/runtime/buildpack_event_repository.rb
@@ -1,0 +1,20 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class BuildpackEventRepository
+        def record_buildpack_delete_request(buildpack, actor, actor_name)
+          Event.create(
+            type: 'audit.buildpack.delete-request',
+            actee: buildpack.guid,
+            actee_type: 'buildpack',
+            actee_name: buildpack.name,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/runtime/domain_event_repository.rb
+++ b/app/repositories/runtime/domain_event_repository.rb
@@ -1,0 +1,31 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class DomainEventRepository
+        def record_domain_delete_request(domain, actor, actor_name)
+          Event.create(
+            type: 'audit.domain.delete-request',
+            actee: domain.guid,
+            actee_type: 'domain',
+            actee_name: domain.name,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+            organization_guid: organization_guid(domain)
+          )
+        end
+
+        private
+
+        def organization_guid(domain)
+          if domain.owning_organization.nil?
+            ''
+          else
+            domain.owning_organization.guid
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/runtime/organization_event_repository.rb
+++ b/app/repositories/runtime/organization_event_repository.rb
@@ -1,0 +1,21 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class OrganizationEventRepository
+        def record_organization_delete_request(organization, actor, actor_name)
+          Event.create(
+            type: 'audit.organization.delete-request',
+            actee: organization.guid,
+            actee_type: 'organization',
+            actee_name: organization.name,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+            organization_guid: organization.guid
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/runtime/quota_definition_event_repository.rb
+++ b/app/repositories/runtime/quota_definition_event_repository.rb
@@ -1,0 +1,20 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class QuotaDefinitionEventRepository
+        def record_quota_definition_delete_request(quota_definition, actor, actor_name)
+          Event.create(
+            type: 'audit.quota_definition.delete-request',
+            actee: quota_definition.guid,
+            actee_type: 'quota_definition',
+            actee_name: quota_definition.name,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/runtime/route_event_repository.rb
+++ b/app/repositories/runtime/route_event_repository.rb
@@ -1,0 +1,22 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class RouteEventRepository
+        def record_route_delete_request(route, actor, actor_name)
+          Event.create(
+            type: 'audit.route.delete-request',
+            actee: route.guid,
+            actee_type: 'route',
+            actee_name: route.fqdn,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+            organization_guid: route.space.organization.guid,
+            space_guid: route.space.guid
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/runtime/security_group_event_repository.rb
+++ b/app/repositories/runtime/security_group_event_repository.rb
@@ -1,0 +1,22 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class SecurityGroupEventRepository
+        def record_security_group_delete_request(security_group, actor, actor_name)
+          Event.create(
+            type: 'audit.security_group.delete-request',
+            actee: security_group.guid,
+            actee_type: 'security_group',
+            actee_name: security_group.name,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+            organization_guid: '',
+            space_guid: ''
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/runtime/service_auth_token_event_repository.rb
+++ b/app/repositories/runtime/service_auth_token_event_repository.rb
@@ -1,0 +1,21 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class ServiceAuthTokenEventRepository
+        def record_service_auth_token_delete_request(service_auth_token, actor, actor_name)
+          Event.create(
+            type: 'audit.service_auth_token.delete-request',
+            actee: service_auth_token.guid,
+            actee_type: 'service_auth_token',
+            actee_name: service_auth_token.label,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+            organization_guid: ''
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/runtime/space_quota_definition_event_repository.rb
+++ b/app/repositories/runtime/space_quota_definition_event_repository.rb
@@ -1,0 +1,22 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class SpaceQuotaDefinitionEventRepository
+        def record_space_quota_definition_delete_request(space_quota_definition, actor, actor_name)
+          Event.create(
+            type: 'audit.space_quota_definition.delete-request',
+            actee: space_quota_definition.guid,
+            actee_type: 'space_quota_definition',
+            actee_name: space_quota_definition.name,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+            space_guid: '',
+            organization_guid: space_quota_definition.organization.guid
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/runtime/user_event_repository.rb
+++ b/app/repositories/runtime/user_event_repository.rb
@@ -1,0 +1,20 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class UserEventRepository
+        def record_user_delete_request(user, actor, actor_name)
+          Event.create(
+            type: 'audit.user.delete-request',
+            actee: user.guid,
+            actee_type: 'user',
+            actee_name: user.guid,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/constants.rb
+++ b/lib/cloud_controller/constants.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
   class Constants
-    API_VERSION = '2.22.0'.freeze
+    API_VERSION = '2.22.1'.freeze
   end
 end

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -1,5 +1,14 @@
 require 'repositories/runtime/app_event_repository'
+require 'repositories/runtime/buildpack_event_repository'
+require 'repositories/runtime/domain_event_repository'
+require 'repositories/runtime/organization_event_repository'
+require 'repositories/runtime/quota_definition_event_repository'
+require 'repositories/runtime/route_event_repository'
+require 'repositories/runtime/security_group_event_repository'
+require 'repositories/runtime/service_auth_token_event_repository'
 require 'repositories/runtime/space_event_repository'
+require 'repositories/runtime/space_quota_definition_event_repository'
+require 'repositories/runtime/user_event_repository'
 require 'cloud_controller/rest_controller/object_renderer'
 require 'cloud_controller/rest_controller/paginated_collection_renderer'
 require 'cloud_controller/upload_handler'
@@ -141,8 +150,52 @@ module CloudController
       )
     end
 
+    def app_event_repository
+      @dependencies[:app_event_repository] || raise('app_event_repository not set')
+    end
+
+    def buildpack_event_repository
+      @dependencies[:buildpack_event_repository] || Repositories::Runtime::BuildpackEventRepository.new
+    end
+
+    def domain_event_repository
+      @dependencies[:domain_event_repository] || Repositories::Runtime::DomainEventRepository.new
+    end
+
+    def organization_event_repository
+      @dependencies[:organization_event_repository] || Repositories::Runtime::OrganizationEventRepository.new
+    end
+
+    def quota_definition_event_repository
+      @dependencies[:quota_definition_event_repository] || Repositories::Runtime::QuotaDefinitionEventRepository.new
+    end
+
+    def route_event_repository
+      @dependencies[:route_event_repository] || Repositories::Runtime::RouteEventRepository.new
+    end
+
+    def security_group_event_repository
+      @dependencies[:security_group_event_repository] || Repositories::Runtime::SecurityGroupEventRepository.new
+    end
+
+    def services_event_repository
+      @dependencies[:services_event_repository] || Repositories::Services::EventRepository.new(SecurityContext)
+    end
+
+    def service_auth_token_event_repository
+      @dependencies[:service_auth_token_event_repository] || Repositories::Runtime::ServiceAuthTokenEventRepository.new
+    end
+
     def space_event_repository
       Repositories::Runtime::SpaceEventRepository.new
+    end
+
+    def space_quota_definition_event_repository
+      @dependencies[:space_quota_event_repository] || Repositories::Runtime::SpaceQuotaDefinitionEventRepository.new
+    end
+
+    def user_event_repository
+      @dependencies[:user_event_repository] || Repositories::Runtime::UserEventRepository.new
     end
 
     def services_event_repository

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = 'b6c466b423ef8caaa3510cadeeaa560737b42912'
+  API_FOLDER_CHECKSUM = 'db099b0cdf6ff945c0b79347de4d5fd1cf4d0649'
 
   it 'double-checks the version' do
-    expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.22.0')
+    expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.22.1')
   end
 
   it 'tells the developer if the API specs change' do

--- a/spec/unit/controllers/runtime/buildpacks_controller_spec.rb
+++ b/spec/unit/controllers/runtime/buildpacks_controller_spec.rb
@@ -103,5 +103,21 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe 'audit events' do
+      it 'logs audit.buildpack.delete-request when deleting a buildpack' do
+        buildpack = Buildpack.make(name: 'my-buildpack')
+        buildpack_guid = buildpack.guid
+        delete "/v2/buildpacks/#{buildpack_guid}", '', json_headers(admin_headers)
+
+        expect(last_response.status).to eq(204)
+
+        event = Event.find(type: 'audit.buildpack.delete-request', actee: buildpack_guid)
+        expect(event).not_to be_nil
+        expect(event.actee).to eq(buildpack_guid)
+        expect(event.actee_name).to eq(buildpack.name)
+        expect(event.actor_name).to eq(SecurityContext.current_user_email)
+      end
+    end
   end
 end

--- a/spec/unit/controllers/runtime/domains_controller_spec.rb
+++ b/spec/unit/controllers/runtime/domains_controller_spec.rb
@@ -223,4 +223,21 @@ module VCAP::CloudController
       expect(last_response).to be_a_deprecated_response
     end
   end
+
+  describe 'audit events' do
+    it 'logs audit.domain.delete-request when deleting a domain' do
+      domain = PrivateDomain.make
+      domain_guid = domain.guid
+      delete "/v2/domains/#{domain_guid}", '', json_headers(admin_headers)
+
+      expect(last_response.status).to eq(204)
+
+      event = Event.find(type: 'audit.domain.delete-request', actee: domain_guid)
+      expect(event).not_to be_nil
+      expect(event.actee).to eq(domain_guid)
+      expect(event.actee_name).to eq(domain.name)
+      expect(event.organization_guid).to eq(domain.owning_organization.guid)
+      expect(event.actor_name).to eq(SecurityContext.current_user_email)
+    end
+  end
 end

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -327,6 +327,21 @@ module VCAP::CloudController
       end
     end
 
+    describe 'audit events' do
+      it 'logs audit.organization.delete-request when deleting an organization' do
+        organization = Organization.make
+        organization_guid = organization.guid
+        delete "/v2/organizations/#{organization_guid}", '', json_headers(admin_headers)
+
+        expect(last_response.status).to eq(204)
+
+        event = Event.find(type: 'audit.organization.delete-request', actee: organization_guid)
+        expect(event).not_to be_nil
+        expect(event.organization_guid).to eq(organization_guid)
+        expect(event.actor_name).to eq(SecurityContext.current_user_email)
+      end
+    end
+
     describe 'Deprecated endpoints' do
       describe 'GET /v2/organizations/:guid/domains' do
         it 'should be deprecated' do

--- a/spec/unit/controllers/runtime/private_domains_controller_spec.rb
+++ b/spec/unit/controllers/runtime/private_domains_controller_spec.rb
@@ -51,5 +51,20 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe 'audit events' do
+      it 'logs audit.domain.delete-request when deleting a domain' do
+        domain = PrivateDomain.make
+        domain_guid = domain.guid
+        delete "/v2/private_domains/#{domain_guid}", '', json_headers(admin_headers)
+
+        expect(last_response.status).to eq(204)
+
+        event = Event.find(type: 'audit.domain.delete-request', actee: domain_guid)
+        expect(event).not_to be_nil
+        expect(event.organization_guid).to eq(domain.owning_organization_guid)
+        expect(event.actor_name).to eq(SecurityContext.current_user_email)
+      end
+    end
   end
 end

--- a/spec/unit/controllers/runtime/quota_definitions_controller_spec.rb
+++ b/spec/unit/controllers/runtime/quota_definitions_controller_spec.rb
@@ -104,5 +104,22 @@ module VCAP::CloudController
         expect(decoded_response['code']).to eq(240004)
       end
     end
+
+    describe 'audit events' do
+      it 'logs audit.quota_definition.delete-request when deleting a quota definition' do
+        quota_definition = QuotaDefinition.make
+        quota_definition_guid = quota_definition.guid
+        delete "/v2/quota_definitions/#{quota_definition_guid}", '', json_headers(admin_headers)
+
+        expect(last_response.status).to eq(204)
+
+        event = Event.find(type: 'audit.quota_definition.delete-request', actee: quota_definition_guid)
+        expect(event).not_to be_nil
+        expect(event.actee).to eq(quota_definition_guid)
+        expect(event.actee_name).to eq(quota_definition.name)
+        expect(event.organization_guid).to eq('')
+        expect(event.actor_name).to eq(SecurityContext.current_user_email)
+      end
+    end
   end
 end

--- a/spec/unit/controllers/runtime/shared_domains_controller_spec.rb
+++ b/spec/unit/controllers/runtime/shared_domains_controller_spec.rb
@@ -19,5 +19,22 @@ module VCAP::CloudController
         })
       end
     end
+
+    describe 'audit events' do
+      it 'logs audit.domain.delete-request when deleting a domain' do
+        domain = SharedDomain.make
+        domain_guid = domain.guid
+        delete "/v2/shared_domains/#{domain_guid}", '', json_headers(admin_headers)
+
+        expect(last_response.status).to eq(204)
+
+        event = Event.find(type: 'audit.domain.delete-request', actee: domain_guid)
+        expect(event).not_to be_nil
+        expect(event.actee).to eq(domain_guid)
+        expect(event.actee_name).to eq(domain.name)
+        expect(event.organization_guid).to eq('')
+        expect(event.actor_name).to eq(SecurityContext.current_user_email)
+      end
+    end
   end
 end

--- a/spec/unit/controllers/runtime/space_quota_definitions_controller_spec.rb
+++ b/spec/unit/controllers/runtime/space_quota_definitions_controller_spec.rb
@@ -168,5 +168,22 @@ module VCAP::CloudController
         expect(last_response.status).to eq(204)
       end
     end
+
+    describe 'audit events' do
+      it 'logs audit.space_quota_definition.delete-request when deleting a space quota definition' do
+        space_quota_definition = SpaceQuotaDefinition.make
+        space_quota_definition_guid = space_quota_definition.guid
+        delete "/v2/space_quota_definitions/#{space_quota_definition_guid}", '', json_headers(admin_headers)
+
+        expect(last_response.status).to eq(204)
+
+        event = Event.find(type: 'audit.space_quota_definition.delete-request', actee: space_quota_definition_guid)
+        expect(event).not_to be_nil
+        expect(event.actee).to eq(space_quota_definition_guid)
+        expect(event.actee_name).to eq(space_quota_definition.name)
+        expect(event.organization_guid).to eq(space_quota_definition.organization.guid)
+        expect(event.actor_name).to eq(SecurityContext.current_user_email)
+      end
+    end
   end
 end

--- a/spec/unit/controllers/runtime/users_controller_spec.rb
+++ b/spec/unit/controllers/runtime/users_controller_spec.rb
@@ -118,5 +118,21 @@ module VCAP::CloudController
         expect(last_response.status).to eq(403)
       end
     end
+
+    describe 'audit events' do
+      it 'logs audit.user.delete-request when deleting a user' do
+        user = User.make
+        user_guid = user.guid
+        delete "/v2/users/#{user_guid}", '', json_headers(admin_headers)
+
+        expect(last_response.status).to eq(204)
+
+        event = Event.find(type: 'audit.user.delete-request', actee: user_guid)
+        expect(event).not_to be_nil
+        expect(event.actee).to eq(user_guid)
+        expect(event.actee_name).to eq(user_guid)
+        expect(event.actor_name).to eq(SecurityContext.current_user_email)
+      end
+    end
   end
 end

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -220,6 +220,48 @@ describe CloudController::DependencyLocator do
     end
   end
 
+  describe '#buildpack_event_repository' do
+    subject { locator.buildpack_event_repository }
+
+    it { is_expected.to be_a(VCAP::CloudController::Repositories::Runtime::BuildpackEventRepository) }
+  end
+
+  describe '#domain_event_repository' do
+    subject { locator.domain_event_repository }
+
+    it { is_expected.to be_a(VCAP::CloudController::Repositories::Runtime::DomainEventRepository) }
+  end
+
+  describe '#organization_event_repository' do
+    subject { locator.organization_event_repository }
+
+    it { is_expected.to be_a(VCAP::CloudController::Repositories::Runtime::OrganizationEventRepository) }
+  end
+
+  describe '#quota_definition_event_repository' do
+    subject { locator.quota_definition_event_repository }
+
+    it { is_expected.to be_a(VCAP::CloudController::Repositories::Runtime::QuotaDefinitionEventRepository) }
+  end
+
+  describe '#route_event_repository' do
+    subject { locator.route_event_repository }
+
+    it { is_expected.to be_a(VCAP::CloudController::Repositories::Runtime::RouteEventRepository) }
+  end
+
+  describe '#security_group_event_repository' do
+    subject { locator.security_group_event_repository }
+
+    it { is_expected.to be_a(VCAP::CloudController::Repositories::Runtime::SecurityGroupEventRepository) }
+  end
+
+  describe '#service_auth_token_event_repository' do
+    subject { locator.service_auth_token_event_repository }
+
+    it { is_expected.to be_a(VCAP::CloudController::Repositories::Runtime::ServiceAuthTokenEventRepository) }
+  end
+
   describe '#space_event_repository' do
     subject { locator.space_event_repository }
 
@@ -230,6 +272,18 @@ describe CloudController::DependencyLocator do
     subject { locator.process_repository }
 
     it { is_expected.to be_a(VCAP::CloudController::ProcessRepository) }
+  end
+
+  describe '#space_quota_definition_event_repository' do
+    subject { locator.space_quota_definition_event_repository }
+
+    it { is_expected.to be_a(VCAP::CloudController::Repositories::Runtime::SpaceQuotaDefinitionEventRepository) }
+  end
+
+  describe '#user_event_repository' do
+    subject { locator.user_event_repository }
+
+    it { is_expected.to be_a(VCAP::CloudController::Repositories::Runtime::UserEventRepository) }
   end
 
   describe '#object_renderer' do

--- a/spec/unit/models/runtime/event_spec.rb
+++ b/spec/unit/models/runtime/event_spec.rb
@@ -86,5 +86,21 @@ module VCAP::CloudController
         end
       end
     end
+
+    context 'when there is no space on the event' do
+      let!(:new_event) { Event.make(space: nil) }
+
+      it 'returns nil' do
+        expect(new_event.space).to be_nil
+      end
+
+      it 'does not have a denormalized space guid' do
+        expect(new_event.space_guid).to eq('')
+      end
+
+      it 'does not have a denormalized organization guid' do
+        expect(new_event.organization_guid).to eq('')
+      end
+    end
   end
 end

--- a/spec/unit/repositories/runtime/buildpack_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/buildpack_event_repository_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe BuildpackEventRepository do
+      let(:user) { User.make }
+      let(:buildpack) { Buildpack.make }
+      let(:user_email) { 'email address' }
+
+      subject(:buildpack_event_repository) { BuildpackEventRepository.new }
+
+      describe '#record_buildpack_delete' do
+        it 'records event correctly' do
+          event = buildpack_event_repository.record_buildpack_delete_request(buildpack, user, user_email)
+          event.reload
+          expect(event.type).to eq('audit.buildpack.delete-request')
+          expect(event.actee).to eq(buildpack.guid)
+          expect(event.actee_type).to eq('buildpack')
+          expect(event.actee_name).to eq(buildpack.name)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/runtime/domain_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/domain_event_repository_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe DomainEventRepository do
+      let(:user) { User.make }
+      let(:organization) { Organization.make }
+      let(:domain) { Domain.make(owning_organization: organization) }
+      let(:user_email) { 'email address' }
+
+      subject(:domain_event_repository) { DomainEventRepository.new }
+
+      describe '#record_domain_delete' do
+        it 'records event correctly' do
+          event = domain_event_repository.record_domain_delete_request(domain, user, user_email)
+          event.reload
+          expect(event.type).to eq('audit.domain.delete-request')
+          expect(event.actee).to eq(domain.guid)
+          expect(event.actee_type).to eq('domain')
+          expect(event.actee_name).to eq(domain.name)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.organization_guid).to eq(domain.owning_organization.guid)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/runtime/organization_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/organization_event_repository_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe OrganizationEventRepository do
+      let(:user) { User.make }
+      let(:organization) { Organization.make }
+      let(:user_email) { 'email address' }
+
+      subject(:organization_event_repository) { OrganizationEventRepository.new }
+
+      describe '#record_organization_delete' do
+        it 'records event correctly' do
+          event = organization_event_repository.record_organization_delete_request(organization, user, user_email)
+          event.reload
+          expect(event.type).to eq('audit.organization.delete-request')
+          expect(event.actee).to eq(organization.guid)
+          expect(event.actee_type).to eq('organization')
+          expect(event.actee_name).to eq(organization.name)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.space_guid).to eq('')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/runtime/quota_definition_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/quota_definition_event_repository_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe QuotaDefinitionEventRepository do
+      let(:user) { User.make }
+      let(:quota_definition) { QuotaDefinition.make }
+      let(:user_email) { 'email address' }
+
+      subject(:quota_definition_event_repository) { QuotaDefinitionEventRepository.new }
+
+      describe '#record_quota_definition_delete' do
+        it 'records event correctly' do
+          event = quota_definition_event_repository.record_quota_definition_delete_request(quota_definition, user, user_email)
+          event.reload
+          expect(event.type).to eq('audit.quota_definition.delete-request')
+          expect(event.actee).to eq(quota_definition.guid)
+          expect(event.actee_type).to eq('quota_definition')
+          expect(event.actee_name).to eq(quota_definition.name)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.space_guid).to eq('')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/runtime/route_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/route_event_repository_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe RouteEventRepository do
+      let(:user) { User.make }
+      let(:route) { Route.make }
+      let(:user_email) { 'email address' }
+
+      subject(:route_event_repository) { RouteEventRepository.new }
+
+      describe '#record_route_delete' do
+        it 'records event correctly' do
+          event = route_event_repository.record_route_delete_request(route, user, user_email)
+          event.reload
+          expect(event.type).to eq('audit.route.delete-request')
+          expect(event.actee).to eq(route.guid)
+          expect(event.actee_type).to eq('route')
+          expect(event.actee_name).to eq(route.fqdn)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.organization_guid).to eq(route.space.organization.guid)
+          expect(event.space_guid).to eq(route.space.guid)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/runtime/security_group_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/security_group_event_repository_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe SecurityGroupEventRepository do
+      let(:user) { User.make }
+      let(:security_group) { SecurityGroup.make }
+      let(:user_email) { 'email address' }
+
+      subject(:security_group_event_repository) { SecurityGroupEventRepository.new }
+
+      describe '#record_security_group_delete' do
+        it 'records event correctly' do
+          event = security_group_event_repository.record_security_group_delete_request(security_group, user, user_email)
+          event.reload
+          expect(event.type).to eq('audit.security_group.delete-request')
+          expect(event.actee).to eq(security_group.guid)
+          expect(event.actee_type).to eq('security_group')
+          expect(event.actee_name).to eq(security_group.name)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.organization_guid).to eq('')
+          expect(event.space_guid).to eq('')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/runtime/service_auth_token_spec.rb
+++ b/spec/unit/repositories/runtime/service_auth_token_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe ServiceAuthTokenEventRepository do
+      let(:user) { User.make }
+      let(:service_auth_token) { ServiceAuthToken.make }
+      let(:user_email) { 'email address' }
+
+      subject(:service_auth_token_event_repository) { ServiceAuthTokenEventRepository.new }
+
+      describe '#record_service_auth_token_delete' do
+        it 'records event correctly' do
+          event = service_auth_token_event_repository.record_service_auth_token_delete_request(service_auth_token, user, user_email)
+          event.reload
+          expect(event.type).to eq('audit.service_auth_token.delete-request')
+          expect(event.actee).to eq(service_auth_token.guid)
+          expect(event.actee_type).to eq('service_auth_token')
+          expect(event.actee_name).to eq(service_auth_token.label)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.organization_guid).to eq('')
+          expect(event.space_guid).to eq('')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/runtime/space_quota_definition_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/space_quota_definition_event_repository_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe SpaceQuotaDefinitionEventRepository do
+      let(:user) { User.make }
+      let(:space_quota_definition) { SpaceQuotaDefinition.make }
+      let(:user_email) { 'email address' }
+
+      subject(:space_quota_definition_event_repository) { SpaceQuotaDefinitionEventRepository.new }
+
+      describe '#record_space_delete' do
+        it 'records event correctly' do
+          event = space_quota_definition_event_repository.record_space_quota_definition_delete_request(space_quota_definition, user, user_email)
+          event.reload
+          expect(event.space).to be_nil
+          expect(event.type).to eq('audit.space_quota_definition.delete-request')
+          expect(event.actee).to eq(space_quota_definition.guid)
+          expect(event.actee_type).to eq('space_quota_definition')
+          expect(event.actee_name).to eq(space_quota_definition.name)
+          expect(event.space_guid).to eq('')
+          expect(event.organization_guid).to eq(space_quota_definition.organization.guid)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/runtime/user_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/user_event_repository_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe UserEventRepository do
+      let(:actor) { User.make }
+      let(:user) { User.make }
+      let(:actor_email) { 'email address' }
+
+      subject(:user_event_repository) { UserEventRepository.new }
+
+      describe '#record_user_delete' do
+        it 'records event correctly' do
+          event = user_event_repository.record_user_delete_request(user, actor, actor_email)
+          event.reload
+          expect(event.space).to be_nil
+          expect(event.type).to eq('audit.user.delete-request')
+          expect(event.actee).to eq(user.guid)
+          expect(event.actee_type).to eq('user')
+          expect(event.actee_name).to eq(user.guid)
+          expect(event.actor).to eq(actor.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(actor_email)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This purpose of this pull request is to add further delete events. This was requested for auditing purposes within our organization. Delete events have been added for the following object types:

  * buildpack
  * domain
  * organization
  * quota
  * route
  * service auth token
  * security group
  * shared domain
  * space quota
  * user

Note that this would not capture deletes of users directly through the UAA API.
An alternative approach would be to use the forthcoming [Route Services feature](https://docs.google.com/document/d/1bGOQxiKkmaw6uaRWGd-sXpxL0Y28d3QihcluI15FiIA/edit?usp=sharing) to capture the DELETE events there.

Thanks,
Jim and Bala