### PR TITLE
Add "create-service-key" to cloud controller, based on story #87057732

### DIFF
--- a/app/access/service_key_access.rb
+++ b/app/access/service_key_access.rb
@@ -1,0 +1,13 @@
+module VCAP::CloudController
+  class ServiceKeyAccess < BaseAccess
+    def create?(service_key, params=nil)
+      return true if admin_user?
+      return false if service_key.in_suspended_org?
+      service_key.service_instance.space.developers.include?(context.user)
+    end
+
+    def delete?(service_key)
+      create?(service_key)
+    end
+  end
+end

--- a/app/controllers/services/lifecycle/service_key_manager.rb
+++ b/app/controllers/services/lifecycle/service_key_manager.rb
@@ -1,0 +1,62 @@
+module VCAP::CloudController
+  class ServiceKeyManager
+    class ServiceInstanceNotFound < StandardError; end
+    class ServiceInstanceNotBindable < StandardError; end
+
+    def initialize(services_event_repository, access_validator, logger)
+      @services_event_repository = services_event_repository
+      @access_validator = access_validator
+      @logger = logger
+    end
+
+    def create_service_key(request_attrs)
+      service_instance = ServiceInstance.first(guid: request_attrs['service_instance_guid'])
+      raise ServiceInstanceNotFound unless service_instance
+      raise ServiceInstanceNotBindable unless service_instance.bindable?
+
+      service_key = ServiceKey.new(request_attrs)
+      @access_validator.validate_access(:create, service_key)
+      raise Sequel::ValidationFailed.new(service_key) unless service_key.valid?
+
+      lock_service_instance_by_blocking(service_instance) do
+        attributes_to_update = service_key.client.bind(service_key)
+        begin
+          service_key.set_all(attributes_to_update)
+          service_key.save
+        rescue
+          safe_unbind_instance(service_key)
+          raise
+        end
+      end
+
+      service_key
+    end
+
+    private
+
+    def safe_unbind_instance(service_key)
+      service_key.client.unbind(service_key)
+    rescue => e
+      @logger.error "Unable to unbind #{service_key}: #{e}"
+    end
+
+    def lock_service_instance_by_blocking(service_instance, &block)
+      return block.call unless service_instance.managed_instance?
+
+      original_attributes = service_instance.last_operation.try(:to_hash)
+      begin
+        service_instance.lock_by_failing_other_operations('update') do
+          block.call
+        end
+      ensure
+        if original_attributes
+          service_instance.last_operation.set_all(original_attributes)
+          service_instance.last_operation.save
+        else
+          service_instance.service_instance_operation.destroy
+          service_instance.save
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/services/service_keys_controller.rb
+++ b/app/controllers/services/service_keys_controller.rb
@@ -1,0 +1,42 @@
+require 'services/api'
+
+module VCAP::CloudController
+  class ServiceKeysController < RestController::ModelController
+    define_attributes do
+      to_one :service_instance
+      attribute :name, String
+    end
+
+    post path, :create
+    def create
+      @request_attrs = self.class::CreateMessage.decode(body).extract(stringify_keys: true)
+      logger.debug 'cc.create', model: self.class.model_class_name, attributes: request_attrs
+      raise InvalidRequest unless request_attrs
+      service_key_manager = ServiceKeyManager.new(@services_event_repository, self, logger)
+      service_key = service_key_manager.create_service_key(@request_attrs)
+      [HTTP::CREATED,
+       { 'Location' => "#{self.class.path}/#{service_key.guid}" },
+       object_renderer.render_json(self.class, service_key, @opts)
+      ]
+    rescue ServiceKeyManager::ServiceInstanceNotFound
+      raise VCAP::Errors::ApiError.new_from_details('ServiceInstanceNotFound', @request_attrs['service_instance_guid'])
+    rescue ServiceKeyManager::ServiceInstanceNotBindable
+      raise VCAP::Errors::ApiError.new_from_details('UnbindableService')
+    end
+
+    private
+
+    def self.translate_validation_exception(e, attributes)
+      unique_errors = e.errors.on([:name, :service_instance_id])
+      if unique_errors && unique_errors.include?(:unique)
+        Errors::ApiError.new_from_details('ServiceKeyTaken', "#{attributes['name']} #{attributes['service_instance_guid']}")
+      elsif e.errors.on(:service_instance) && e.errors.on(:service_instance).include?(:presence)
+        Errors::ApiError.new_from_details('ServiceInstanceNotFound', attributes['service_instance_guid'])
+      else
+        Errors::ApiError.new_from_details('ServiceKeyInvalid', e.errors.full_messages)
+      end
+    end
+
+    define_messages
+  end
+end

--- a/app/models.rb
+++ b/app/models.rb
@@ -58,6 +58,7 @@ require 'models/services/service_base_event'
 require 'models/services/service_create_event'
 require 'models/services/service_delete_event'
 require 'models/services/service_usage_event'
+require 'models/services/service_key'
 
 require 'models/job'
 

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -1,0 +1,71 @@
+module VCAP::CloudController
+  class ServiceKey < Sequel::Model
+    class InvalidAppAndServiceRelation < StandardError; end
+
+    many_to_one :service_instance
+
+    export_attributes :name, :service_instance_guid, :credentials
+
+    import_attributes :name, :service_instance_guid, :credentials
+
+    delegate :client, :service, :service_plan, to: :service_instance
+
+    plugin :after_initialize
+
+    encrypt :credentials, salt: :salt
+
+    def to_hash(opts={})
+      if !VCAP::CloudController::SecurityContext.admin? && !service_instance.space.developers.include?(VCAP::CloudController::SecurityContext.current_user)
+        opts.merge!({ redact: ['credentials'] })
+      end
+      super(opts)
+    end
+
+    def in_suspended_org?
+      space.in_suspended_org?
+    end
+
+    def space
+      service_instance.space
+    end
+
+    def validate
+      validates_presence :name
+      validates_presence :service_instance
+      validates_unique [:name, :service_instance_id]
+    end
+
+    def credentials_with_serialization=(val)
+      self.credentials_without_serialization = MultiJson.dump(val)
+    end
+    alias_method_chain :credentials=, 'serialization'
+
+    def credentials_with_serialization
+      string = credentials_without_serialization
+      return if string.blank?
+      MultiJson.load string
+    end
+    alias_method_chain :credentials, 'serialization'
+
+    def self.user_visibility_filter(user)
+      { service_instance: ServiceInstance.user_visible(user) }
+    end
+
+    def after_initialize
+      super
+      self.guid ||= SecureRandom.uuid
+    end
+
+    def logger
+      @logger ||= Steno.logger('cc.models.service_key')
+    end
+
+    private
+
+    def safe_unbind
+      client.unbind(self)
+    rescue => unbind_e
+      logger.error "Unable to unbind #{self}: #{unbind_e}"
+    end
+  end
+end

--- a/db/migrations/20150316184259_create_service_key_table.rb
+++ b/db/migrations/20150316184259_create_service_key_table.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  change do
+    create_table(:service_keys) do
+      VCAP::Migration.common(self, :sk)
+      String :name, null: false
+      String :salt
+      String :credentials, null: false, size: 2048
+      Integer :service_instance_id, null: false
+      foreign_key [:service_instance_id], :service_instances, name: :fk_svc_key_svc_instance_id
+      index [:name, :service_instance_id], unique: true, name: :svc_key_name_instance_id_index
+    end
+  end
+end

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -92,11 +92,15 @@ module VCAP::Services::ServiceBrokers::V2
 
     def bind(binding)
       path = service_binding_resource_path(binding)
-      response = @http_client.put(path, {
-        service_id:  binding.service.broker_provided_id,
-        plan_id:     binding.service_plan.broker_provided_id,
-        app_guid:    binding.app_guid
-      })
+      attr = {
+          service_id:  binding.service.broker_provided_id,
+          plan_id:     binding.service_plan.broker_provided_id
+      }
+      if binding.respond_to? 'app_guid'
+        attr[:app_guid] = binding.app_guid
+      end
+
+      response = @http_client.put(path, attr)
       parsed_response = @response_parser.parse(:put, path, response)
 
       attributes = {

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -194,6 +194,12 @@ module VCAP::CloudController
     syslog_drain_url  { nil }
   end
 
+  ServiceKey.blueprint do
+    credentials       { Sham.service_credentials }
+    service_instance  { ManagedServiceInstance.make }
+    name               { Sham.name }
+  end
+
   ServiceBroker.blueprint do
     name              { Sham.name }
     broker_url        { Sham.url }

--- a/spec/unit/access/service_key_access_spec.rb
+++ b/spec/unit/access/service_key_access_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  describe ServiceKeyAccess, type: :access do
+    subject(:access) { ServiceKeyAccess.new(Security::AccessContext.new) }
+    let(:token) { { 'scope' => ['cloud_controller.read', 'cloud_controller.write'] } }
+
+    let(:user) { VCAP::CloudController::User.make }
+    let(:service) { VCAP::CloudController::Service.make }
+    let(:org) { VCAP::CloudController::Organization.make }
+    let(:space) { VCAP::CloudController::Space.make(organization: org) }
+    let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
+
+    let(:object) { VCAP::CloudController::ServiceKey.make(name: 'fake-key', service_instance: service_instance) }
+
+    before do
+      SecurityContext.set(user, token)
+    end
+
+    after do
+      SecurityContext.clear
+    end
+
+    it_should_behave_like :admin_full_access
+
+    context 'for a logged in user (defensive)' do
+      it_behaves_like :no_access
+    end
+
+    context 'a user that isnt logged in (defensive)' do
+      let(:user) { nil }
+      it_behaves_like :no_access
+    end
+
+    context 'organization manager (defensive)' do
+      before { org.add_manager(user) }
+      it_behaves_like :no_access
+    end
+
+    context 'organization billing manager (defensive)' do
+      before { org.add_billing_manager(user) }
+      it_behaves_like :no_access
+    end
+
+    context 'organization auditor (defensive)' do
+      before { org.add_auditor(user) }
+      it_behaves_like :no_access
+    end
+
+    context 'organization user (defensive)' do
+      before { org.add_user(user) }
+      it_behaves_like :no_access
+    end
+
+    context 'space auditor' do
+      before do
+        org.add_user(user)
+        space.add_auditor(user)
+      end
+
+      it_behaves_like :read_only
+    end
+
+    context 'space manager (defensive)' do
+      before do
+        org.add_user(user)
+        space.add_manager(user)
+      end
+
+      it_behaves_like :no_access
+    end
+
+    context 'space developer' do
+      before do
+        org.add_user(user)
+        space.add_developer(user)
+      end
+
+      it { is_expected.to allow_op_on_object :create, object }
+      it { is_expected.to allow_op_on_object :read, object }
+      it { is_expected.not_to allow_op_on_object :read_for_update, object }
+      it { is_expected.to allow_op_on_object :delete, object }
+
+      context 'when the organization is suspended' do
+        before { allow(object).to receive(:in_suspended_org?).and_return(true) }
+        it_behaves_like :read_only
+      end
+    end
+
+    context 'any user using client without cloud_controller.write' do
+      let(:token) { { 'scope' => ['cloud_controller.read'] } }
+      before do
+        org.add_user(user)
+        org.add_manager(user)
+        org.add_billing_manager(user)
+        org.add_auditor(user)
+        space.add_manager(user)
+        space.add_developer(user)
+        space.add_auditor(user)
+      end
+
+      it_behaves_like :read_only
+    end
+
+    context 'any user using client without cloud_controller.read' do
+      let(:token) { { 'scope' => [] } }
+      before do
+        org.add_user(user)
+        org.add_manager(user)
+        org.add_billing_manager(user)
+        org.add_auditor(user)
+        space.add_manager(user)
+        space.add_developer(user)
+        space.add_auditor(user)
+      end
+
+      it_behaves_like :no_access
+    end
+  end
+end

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -814,6 +814,12 @@ module VCAP::Services::ServiceBrokers::V2
           app: app
         )
       end
+      let(:service_key) do
+        VCAP::CloudController::ServiceKey.new(
+            name: 'fake-service_key',
+            service_instance: instance
+        )
+      end
 
       let(:response_data) do
         {
@@ -850,6 +856,16 @@ module VCAP::Services::ServiceBrokers::V2
              plan_id:    binding.service_plan.broker_provided_id,
              service_id: binding.service.broker_provided_id,
              app_guid:   binding.app_guid
+        )
+      end
+
+      it 'makes a put request to create a service key with correct message' do
+        client.bind(service_key)
+
+        expect(http_client).to have_received(:put).
+          with(anything,
+              plan_id:    binding.service_plan.broker_provided_id,
+              service_id: binding.service.broker_provided_id
         )
       end
 

--- a/spec/unit/models/services/service_key_spec.rb
+++ b/spec/unit/models/services/service_key_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  describe VCAP::CloudController::ServiceKey, type: :model do
+    let(:client) { double('broker client', unbind: nil, deprovision: nil) }
+
+    before do
+      allow_any_instance_of(Service).to receive(:client).and_return(client)
+    end
+
+    it { is_expected.to have_timestamp_columns }
+
+    describe 'Associations' do
+      it { is_expected.to have_associated :service_instance, associated_instance: ->(service_key) { ServiceInstance.make(space: service_key.space) } }
+    end
+
+    describe 'Validations' do
+      it { is_expected.to validate_presence :service_instance }
+      it { is_expected.to validate_presence :name }
+      it { is_expected.to validate_db_presence :service_instance_id }
+      it { is_expected.to validate_db_presence :credentials }
+      it { is_expected.to validate_uniqueness [:name, :service_instance_id] }
+    end
+
+    describe 'Serialization' do
+      it { is_expected.to export_attributes :name, :service_instance_guid, :credentials }
+      it { is_expected.to import_attributes :name, :service_instance_guid, :credentials }
+    end
+
+    describe '#new' do
+      it 'has a guid when constructed' do
+        service_key = described_class.new
+        expect(service_key.guid).to be
+      end
+    end
+
+    it_behaves_like 'a model with an encrypted attribute' do
+      let(:service_instance) { ManagedServiceInstance.make }
+
+      def new_model
+        ServiceKey.make(
+            name: Sham.name,
+            service_instance: service_instance,
+            credentials: value_to_encrypt
+        )
+      end
+
+      let(:encrypted_attr) { :credentials }
+      let(:attr_salt) { :salt }
+    end
+
+    describe '#to_hash' do
+      let(:service_key) { ServiceKey.make }
+      let(:developer) { make_developer_for_space(service_key.service_instance.space) }
+      let(:auditor) { make_auditor_for_space(service_key.service_instance.space) }
+      let(:user) { make_user_for_space(service_key.service_instance.space) }
+
+      it 'does not redact creds for an admin' do
+        allow(VCAP::CloudController::SecurityContext).to receive(:admin?).and_return(true)
+        expect(service_key.to_hash['credentials']).not_to eq({ redacted_message: '[PRIVATE DATA HIDDEN]' })
+      end
+
+      it 'does not redact creds for a space developer' do
+        allow(VCAP::CloudController::SecurityContext).to receive(:current_user).and_return(developer)
+        expect(service_key.to_hash['credentials']).not_to eq({ redacted_message: '[PRIVATE DATA HIDDEN]' })
+      end
+
+      it 'redacts creds for a space auditor' do
+        allow(VCAP::CloudController::SecurityContext).to receive(:current_user).and_return(auditor)
+        expect(service_key.to_hash['credentials']).to eq({ redacted_message: '[PRIVATE DATA HIDDEN]' })
+      end
+
+      it 'redacts creds for a space user' do
+        allow(VCAP::CloudController::SecurityContext).to receive(:current_user).and_return(user)
+        expect(service_key.to_hash['credentials']).to eq({ redacted_message: '[PRIVATE DATA HIDDEN]' })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the rest API controller and DB model for "create service key", this patch includes the following part:

1. 1 new rest controller for "create-service-key"
2. DB migration script for adding a new table to record service keys
3. 1 new DB model for service key
4. Changes the v2 service broker client to support create service key

This patch is submitted to implement story #87057732 in Service Key API
More test cases will be added in other commits

Signed-off-by: Tom Xing <xingzhou@cn.ibm.com>