### PR TITLE
346 - have DropletsController inherit from a richer parent class

### DIFF
--- a/app/controllers/v3/droplets_controller.rb
+++ b/app/controllers/v3/droplets_controller.rb
@@ -4,7 +4,7 @@ require 'queries/droplet_delete_fetcher'
 require 'actions/droplet_delete'
 
 module VCAP::CloudController
-  class DropletsController < RestController::BaseController
+  class DropletsController < RestController::ModelController
     def self.dependencies
       [:droplets_handler, :droplet_presenter]
     end


### PR DESCRIPTION
Update the class.  Running the tests in spec/unit/controllers/v3/droplets_controller_spec.rb
is sufficient to test this change, so no new test is necessary to test breakage. (Testing third-party
code that monkeypatches DropletsController is another matter.)