### PR TITLE
Build the staging messsage on the request thread

### DIFF
--- a/lib/cloud_controller/dea/app_stager_task.rb
+++ b/lib/cloud_controller/dea/app_stager_task.rb
@@ -40,6 +40,8 @@ module VCAP::CloudController
         @stager_pool.reserve_app_memory(@stager_id, staging_task_memory_mb)
 
         logger.info('staging.begin', app_guid: @app.guid)
+        staging_msg = staging_request
+
         staging_result = EM.schedule_sync do |promise|
           # First response is blocking stage_app.
           @multi_message_bus_request.on_response(staging_timeout) do |response, error|
@@ -55,7 +57,7 @@ module VCAP::CloudController
             handle_second_response(response, error)
           end
 
-          @multi_message_bus_request.request(staging_request)
+          @multi_message_bus_request.request(staging_msg)
         end
 
         staging_result

--- a/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
@@ -200,6 +200,13 @@ module VCAP::CloudController
             stage { callback_called = true }
             expect(callback_called).to be false
           end
+
+          it 'builds the staging message before scheduling the promise' do
+            expect(staging_task).to receive(:staging_request).ordered
+            expect(EM).to receive(:schedule_sync).ordered
+
+            staging_task.stage
+          end
         end
 
         context 'when staging setup fails without a reason' do


### PR DESCRIPTION
- Avoid making network calls to the blobstore on the reactor thread when
  building the staging request

Do not block the reactor thread while making network calls to build blobstore URLs. If you have a slow blobstore, NATs and other background work is blocked.