### PR TITLE
add job_name to registration with collector

### DIFF
--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -227,6 +227,7 @@ module VCAP::CloudController
           user: @config[:varz_user],
           password: @config[:varz_password],
           index: @config[:index],
+          job_name: @config[:name],
           nats: message_bus,
           logger: logger,
           log_counter: @log_counter

--- a/spec/fixtures/config/minimal_config.yml
+++ b/spec/fixtures/config/minimal_config.yml
@@ -1,6 +1,9 @@
 ---
 external_port: 8181
 
+index: 0
+name: api_z1
+
 info:
   name: "vcap"
   build: "2222"

--- a/spec/unit/lib/cloud_controller/runner_spec.rb
+++ b/spec/unit/lib/cloud_controller/runner_spec.rb
@@ -43,7 +43,9 @@ module VCAP::CloudController
             expect(steno_config.sinks).to include log_counter
           end
 
-          expect(VCAP::Component).to receive(:register).with(hash_including(log_counter: log_counter))
+          expect(VCAP::Component).to receive(:register).with(
+            hash_including(log_counter: log_counter, job_name: 'api_z1')
+          )
           subject.run!
         end
 


### PR DESCRIPTION
will have an effect only if vcap-common gets a new release
that uses the job_name

Signed-off-by: Marco Voelz <marco.voelz@sap.com>