### PR TITLE
Propagate actual error message upon staging failure

### DIFF
--- a/lib/cloud_controller/diego/stager.rb
+++ b/lib/cloud_controller/diego/stager.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController
         end
       rescue Errors::ApiError => e
         logger.error('stage.app', staging_guid: StagingGuid.from_app(@app), error: e)
-        staging_complete(StagingGuid.from_app(@app), { error: { id: 'StagingError', message: 'staging failed' } })
+        staging_complete(StagingGuid.from_app(@app), { error: { id: 'StagingError', message: e.message } })
         raise e
       end
 

--- a/lib/cloud_controller/diego/stager_client.rb
+++ b/lib/cloud_controller/diego/stager_client.rb
@@ -78,8 +78,8 @@ module VCAP::CloudController
       end
 
       def error_message(response)
-        JSON.parse(response.body)['error']['message'] || response.code
-      rescue JSON::ParserError, NoMethodError
+        JSON.parse(response.body).fetch('error', {})['message'] || response.code
+      rescue JSON::ParserError
         response.code
       end
     end

--- a/lib/cloud_controller/diego/stager_client.rb
+++ b/lib/cloud_controller/diego/stager_client.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController
         logger.info('stage.response', staging_guid: staging_guid, response_code: response.code)
 
         if response.code != '202'
-          raise Errors::ApiError.new_from_details('StagerError', "staging failed: #{response.code}")
+          raise Errors::ApiError.new_from_details('StagerError', "staging failed: #{error_message(response)}")
         end
 
         nil
@@ -75,6 +75,12 @@ module VCAP::CloudController
 
       def logger
         @logger ||= Steno.logger('cc.stager.client')
+      end
+
+      def error_message(response)
+        JSON.parse(response.body)['error']['message'] || response.code
+      rescue JSON::ParserError, NoMethodError
+        response.code
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/diego/stager_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/stager_spec.rb
@@ -55,11 +55,11 @@ module VCAP::CloudController
 
         context 'when the stage fails' do
           let(:error) do
-            { error: { id: 'StagingError', message: 'staging failed' } }
+            { error: { id: 'StagingError', message: 'Stager error: staging failed' } }
           end
 
           before do
-            allow(messenger).to receive(:send_stage_request).and_raise Errors::ApiError.new_from_details('StagerError')
+            allow(messenger).to receive(:send_stage_request).and_raise Errors::ApiError.new_from_details('StagerError', 'staging failed')
             allow(stager).to receive(:staging_complete)
           end
 


### PR DESCRIPTION
Give the user some more context upon staging failure