### PR TITLE
Commands are not metadata

### DIFF
--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -262,8 +262,7 @@ module VCAP::CloudController
 
     def metadata_with_command
       result = metadata_without_command || self.metadata = {}
-      result.merge!('command' => command) if command
-      result
+      command ? result.merge('command' => command) : result
     end
     alias_method_chain :metadata, :command
 

--- a/spec/unit/models/runtime/app_spec.rb
+++ b/spec/unit/models/runtime/app_spec.rb
@@ -981,10 +981,13 @@ module VCAP::CloudController
       it 'stores the command in its own column, not metadata' do
         app = AppFactory.make(command: 'foobar')
         expect(app.metadata).to eq('command' => 'foobar')
+        expect(app.metadata_without_command).to_not eq('command' => 'foobar')
         app.save
         expect(app.metadata).to eq('command' => 'foobar')
+        expect(app.metadata_without_command).to_not eq('command' => 'foobar')
         app.refresh
         expect(app.metadata).to eq('command' => 'foobar')
+        expect(app.metadata_without_command).to_not eq('command' => 'foobar')
         expect(app.command).to eq('foobar')
       end
 


### PR DESCRIPTION
Allow commands to be reset to nothing
Merge command into metadata when necessary but don't save it as metadata

[#93386810]
