### PR TITLE
Add private docker image credentials to app

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -5,27 +5,24 @@ module VCAP::CloudController
     end
 
     define_attributes do
-      attribute :enable_ssh,             Message::Boolean, default: nil
-      attribute :buildpack,              String,           default: nil
-      attribute :command,                String,           default: nil
-      attribute :console,                Message::Boolean, default: false
-      attribute :diego,                  Message::Boolean, default: nil
-      attribute :docker_image,           String,           default: nil
-      attribute :docker_login_server,    String,           default: nil
-      attribute :docker_user,            String,           default: nil,      redact_in: [:create, :update]
-      attribute :docker_password,        String,           default: nil,      redact_in: [:create, :update]
-      attribute :docker_email,           String,           default: nil,      redact_in: [:create, :update]
-      attribute :debug,                  String,           default: nil
-      attribute :disk_quota,             Integer,          default: nil
-      attribute :environment_json,       Hash,             default: {}
-      attribute :health_check_type,      String,           default: 'port'
-      attribute :health_check_timeout,   Integer,          default: nil
-      attribute :instances,              Integer,          default: 1
-      attribute :memory,                 Integer,          default: nil
-      attribute :name,                   String
-      attribute :production,             Message::Boolean, default: false
-      attribute :state,                  String,           default: 'STOPPED'
-      attribute :detected_start_command, String,                              exclude_in: [:create, :update]
+      attribute :enable_ssh,              Message::Boolean, default: nil
+      attribute :buildpack,               String,           default: nil
+      attribute :command,                 String,           default: nil
+      attribute :console,                 Message::Boolean, default: false
+      attribute :diego,                   Message::Boolean, default: nil
+      attribute :docker_image,            String,           default: nil
+      attribute :docker_credentials_json, Hash,             default: {},       redact_in: [:create, :update]
+      attribute :debug,                   String,           default: nil
+      attribute :disk_quota,              Integer,          default: nil
+      attribute :environment_json,        Hash,             default: {}
+      attribute :health_check_type,       String,           default: 'port'
+      attribute :health_check_timeout,    Integer,          default: nil
+      attribute :instances,               Integer,          default: 1
+      attribute :memory,                  Integer,          default: nil
+      attribute :name,                    String
+      attribute :production,              Message::Boolean, default: false
+      attribute :state,                   String,           default: 'STOPPED'
+      attribute :detected_start_command,  String,                              exclude_in: [:create, :update]
 
       to_one :space
       to_one :stack,               optional_in: :create

--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -11,6 +11,10 @@ module VCAP::CloudController
       attribute :console,                Message::Boolean, default: false
       attribute :diego,                  Message::Boolean, default: nil
       attribute :docker_image,           String,           default: nil
+      attribute :docker_login_server,    String,           default: nil
+      attribute :docker_user,            String,           default: nil,      redact_in: [:create, :update]
+      attribute :docker_password,        String,           default: nil,      redact_in: [:create, :update]
+      attribute :docker_email,           String,           default: nil,      redact_in: [:create, :update]
       attribute :debug,                  String,           default: nil
       attribute :disk_quota,             Integer,          default: nil
       attribute :environment_json,       Hash,             default: {}
@@ -21,7 +25,7 @@ module VCAP::CloudController
       attribute :name,                   String
       attribute :production,             Message::Boolean, default: false
       attribute :state,                  String,           default: 'STOPPED'
-      attribute :detected_start_command, String,           exclude_in: [:create, :update]
+      attribute :detected_start_command, String,                              exclude_in: [:create, :update]
 
       to_one :space
       to_one :stack,               optional_in: :create

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -46,24 +46,21 @@ module VCAP::CloudController
                       :state, :version, :command, :console, :debug, :staging_task_id,
                       :package_state, :health_check_type, :health_check_timeout,
                       :staging_failed_reason, :diego, :docker_image, :package_updated_at,
-                      :detected_start_command, :enable_ssh, :docker_login_server, :docker_user,
-                      :docker_password, :docker_email
+                      :detected_start_command, :enable_ssh, :docker_credentials_json
 
     import_attributes :name, :production, :space_guid, :stack_guid, :buildpack,
                       :detected_buildpack, :environment_json, :memory, :instances, :disk_quota,
                       :state, :command, :console, :debug, :staging_task_id,
                       :service_binding_guids, :route_guids, :health_check_type,
                       :health_check_timeout, :diego, :docker_image, :app_guid, :enable_ssh,
-                      :docker_login_server, :docker_user, :docker_password, :docker_email
+                      :docker_credentials_json
 
     strip_attributes :name
 
     serialize_attributes :json, :metadata
 
     encrypt :environment_json, salt: :salt, column: :encrypted_environment_json
-    encrypt :docker_user, salt: :docker_salt, column: :encrypted_docker_user
-    encrypt :docker_password, salt: :docker_salt, column: :encrypted_docker_password
-    encrypt :docker_email, salt: :docker_salt, column: :encrypted_docker_email
+    encrypt :docker_credentials_json, salt: :docker_salt, column: :encrypted_docker_credentials_json
 
     APP_STATES = %w(STOPPED STARTED).map(&:freeze).freeze
     PACKAGE_STATES = %w(PENDING STAGED FAILED).map(&:freeze).freeze
@@ -77,9 +74,6 @@ module VCAP::CloudController
 
     # Last staging response which will contain streaming log url
     attr_accessor :last_stager_response
-
-    # docker login server used to authenticate against
-    attr_accessor :docker_login_server
 
     alias_method :diego?, :diego
 
@@ -328,6 +322,18 @@ module VCAP::CloudController
     end
     alias_method_chain :environment_json, 'serialization'
 
+    def docker_credentials_json_with_serialization=(env)
+      self.docker_credentials_json_without_serialization = MultiJson.dump(env)
+    end
+    alias_method_chain :docker_credentials_json=, 'serialization'
+
+    def docker_credentials_json_with_serialization
+      string = docker_credentials_json_without_serialization
+      return if string.blank?
+      MultiJson.load string
+    end
+    alias_method_chain :docker_credentials_json, 'serialization'
+
     def system_env_json
       vcap_services
     end
@@ -555,10 +561,10 @@ module VCAP::CloudController
     end
 
     def to_hash(opts={})
-      if !VCAP::CloudController::SecurityContext.admin? && !space.developers.include?(VCAP::CloudController::SecurityContext.current_user)
-        opts.merge!(redact: %w(environment_json system_env_json docker_user docker_password docker_email encrypted_docker_user encrypted_docker_password encrypted_docker_email))
+      if VCAP::CloudController::SecurityContext.admin? || space.developers.include?(VCAP::CloudController::SecurityContext.current_user)
+        opts.merge!(redact: %w(docker_credentials_json))
       else
-        opts.merge!(redact: %w(docker_user docker_password docker_email encrypted_docker_user encrypted_docker_password encrypted_docker_email))
+        opts.merge!(redact: %w(environment_json system_env_json docker_credentials_json))
       end
       super(opts)
     end

--- a/app/models/runtime/constraints/docker_policy.rb
+++ b/app/models/runtime/constraints/docker_policy.rb
@@ -1,5 +1,6 @@
 class DockerPolicy
   BUILDPACK_DETECTED_ERROR_MSG = 'incompatible with buildpack'
+  DOCKER_CREDENTIALS_ERROR_MSG = 'user, password and email required'
 
   def initialize(app)
     @errors = app.errors
@@ -9,6 +10,13 @@ class DockerPolicy
   def validate
     if @app.docker_image.present? && @app.buildpack_specified?
       @errors.add(:docker_image, BUILDPACK_DETECTED_ERROR_MSG)
+    end
+
+    docker_credentials = @app.docker_credentials_json
+    if docker_credentials.present?
+      unless docker_credentials['docker_user'].present? && docker_credentials['docker_password'].present? && docker_credentials['docker_email'].present?
+        @errors.add(:docker_credentials, DOCKER_CREDENTIALS_ERROR_MSG)
+      end
     end
   end
 end

--- a/app/repositories/runtime/app_event_repository.rb
+++ b/app/repositories/runtime/app_event_repository.rb
@@ -6,12 +6,8 @@ module VCAP::CloudController
                            :command,
                            :environment_json,
                            :environment_variables,
-                           :docker_user,
-                           :docker_password,
-                           :docker_email,
-                           :encrypted_docker_user,
-                           :encrypted_docker_password,
-                           :encrypted_docker_email]
+                           :docker_credentials_json,
+                           :encrypted_docker_credentials_json]
         CENSORED_MESSAGE = 'PRIVATE DATA HIDDEN'.freeze
         SYSTEM_ACTOR_HASH = { guid: 'system', type: 'system', name: 'system' }
 

--- a/app/repositories/runtime/app_event_repository.rb
+++ b/app/repositories/runtime/app_event_repository.rb
@@ -2,7 +2,16 @@ module VCAP::CloudController
   module Repositories
     module Runtime
       class AppEventRepository
-        CENSORED_FIELDS = [:encrypted_environment_json, :command, :environment_json, :environment_variables]
+        CENSORED_FIELDS = [:encrypted_environment_json,
+                           :command,
+                           :environment_json,
+                           :environment_variables,
+                           :docker_user,
+                           :docker_password,
+                           :docker_email,
+                           :encrypted_docker_user,
+                           :encrypted_docker_password,
+                           :encrypted_docker_email]
         CENSORED_MESSAGE = 'PRIVATE DATA HIDDEN'.freeze
         SYSTEM_ACTOR_HASH = { guid: 'system', type: 'system', name: 'system' }
 

--- a/db/migrations/20150511134747_add_docker_image_credentials.rb
+++ b/db/migrations/20150511134747_add_docker_image_credentials.rb
@@ -1,9 +1,7 @@
 Sequel.migration do
   change do
     alter_table :apps do
-      add_column :encrypted_docker_user, String
-      add_column :encrypted_docker_password, String
-      add_column :encrypted_docker_email, String
+      add_column :encrypted_docker_credentials_json, String
       add_column :docker_salt, String
     end
   end

--- a/db/migrations/20150511134747_add_docker_image_credentials.rb
+++ b/db/migrations/20150511134747_add_docker_image_credentials.rb
@@ -1,0 +1,10 @@
+Sequel.migration do
+  change do
+    alter_table :apps do
+      add_column :encrypted_docker_user, String
+      add_column :encrypted_docker_password, String
+      add_column :encrypted_docker_email, String
+      add_column :docker_salt, String
+    end
+  end
+end

--- a/lib/cloud_controller/diego/docker/lifecycle_data.rb
+++ b/lib/cloud_controller/diego/docker/lifecycle_data.rb
@@ -3,9 +3,20 @@ module VCAP::CloudController
     module Docker
       class LifecycleData
         attr_accessor :docker_image
+        attr_accessor :docker_login_server
+        attr_accessor :docker_user
+        attr_accessor :docker_password
+        attr_accessor :docker_email
 
         def message
-          message = { docker_image: docker_image }
+          message = {
+            docker_image: docker_image,
+            docker_login_server: docker_login_server,
+            docker_user: docker_user,
+            docker_password: docker_password,
+            docker_email: docker_email
+          }.delete_if { |k, v| v.blank? }
+
           schema.validate(message)
           message
         end
@@ -14,7 +25,13 @@ module VCAP::CloudController
 
         def schema
           @schema ||= Membrane::SchemaParser.parse do
-            { docker_image: String }
+            {
+              docker_image: String,
+              optional(:docker_login_server) => String,
+              optional(:docker_user) => String,
+              optional(:docker_password) => String,
+              optional(:docker_email) => String,
+            }
           end
         end
       end

--- a/lib/cloud_controller/diego/docker/protocol.rb
+++ b/lib/cloud_controller/diego/docker/protocol.rb
@@ -18,6 +18,10 @@ module VCAP::CloudController
         def stage_app_message(app, staging_config)
           lifecycle_data = LifecycleData.new
           lifecycle_data.docker_image = app.docker_image
+          lifecycle_data.docker_login_server = app.docker_login_server
+          lifecycle_data.docker_user = app.docker_user
+          lifecycle_data.docker_password = app.docker_password
+          lifecycle_data.docker_email = app.docker_email
 
           staging_request = StagingRequest.new
           staging_request.app_id = app.guid

--- a/lib/cloud_controller/diego/docker/protocol.rb
+++ b/lib/cloud_controller/diego/docker/protocol.rb
@@ -18,10 +18,13 @@ module VCAP::CloudController
         def stage_app_message(app, staging_config)
           lifecycle_data = LifecycleData.new
           lifecycle_data.docker_image = app.docker_image
-          lifecycle_data.docker_login_server = app.docker_login_server
-          lifecycle_data.docker_user = app.docker_user
-          lifecycle_data.docker_password = app.docker_password
-          lifecycle_data.docker_email = app.docker_email
+          docker_credentials = app.docker_credentials_json
+          if docker_credentials
+            lifecycle_data.docker_login_server = docker_credentials['docker_login_server']
+            lifecycle_data.docker_user = docker_credentials['docker_user']
+            lifecycle_data.docker_password = docker_credentials['docker_password']
+            lifecycle_data.docker_email = docker_credentials['docker_email']
+          end
 
           staging_request = StagingRequest.new
           staging_request.app_id = app.guid

--- a/lib/vcap/rest_api/attributes.rb
+++ b/lib/vcap/rest_api/attributes.rb
@@ -22,12 +22,15 @@ module VCAP::RestAPI
     #
     # @option opts [Object] :default default value for the attribute if it
     # isn't supplied.
+    #
+    # @option opts :redact redact the value if supplied
     def initialize(name, opts={})
       @name        = name
       @exclude_in  = Set.new(Array(opts[:exclude_in]))
       @optional_in = Set.new(Array(opts[:optional_in]))
       @default     = opts[:default]
       @has_default = opts.key?(:default)
+      @redact_in   = Set.new(Array(opts[:redact_in]))
     end
 
     # Predicate to check if the attribute is excluded for a certain type of
@@ -48,6 +51,16 @@ module VCAP::RestAPI
     # @return [Boolean] True if the attribute is optional.
     def optional_in?(operation_type)
       @optional_in.include?(operation_type)
+    end
+
+    # Predicate to check if the attribute needs redacting for a certain type of
+    # operation.
+    #
+    # @param [Symbol] operation_type The type of operation.
+    #
+    # @return [Boolean] True if the attribute should be redacted.
+    def redact_in?(operation_type)
+      @redact_in.include?(operation_type)
     end
   end
 

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = '4d8e9aaef87183fab81e28078d24a8842f9845c9'
+  API_FOLDER_CHECKSUM = 'e081c3ca7e411309c4f543eb5f478de1f464e302'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.27.0')

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = 'e081c3ca7e411309c4f543eb5f478de1f464e302'
+  API_FOLDER_CHECKSUM = '4b7deae6fc04fdb44eb09a3c8d8289515e87f544'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.27.0')

--- a/spec/api/documentation/apps_api_spec.rb
+++ b/spec/api/documentation/apps_api_spec.rb
@@ -43,14 +43,13 @@ resource 'Apps', type: [:api, :legacy_api] do
       default: nil,
       experimental: true,
       example_values: ['cloudfoundry/helloworld', 'registry.example.com:5000/user/repository/tag']
-    field :docker_login_server,
-      'Server to authenticate to when pulling Docker image',
-      default: nil,
+    field :docker_credentials_json, 'Docker credentials for pulling docker image.',
+      default: {},
       experimental: true,
-      example_values: ['https://index.docker.io/v1/']
-    field :docker_user, 'User to use for Docker image pull', default: nil, experimental: true
-    field :docker_password, 'Password to use for Docker image pull', default: nil, experimental: true
-    field :docker_email, 'Email to use for Docker image pull', default: nil, experimental: true
+      example_values: [{ 'docker_user' => 'user name',
+                         'docker_password' => 's3cr3t',
+                         'docker_email' => 'email@example.com',
+                         'docker_login_server' => 'https://index.docker.io/v1/' }]
 
     field :environment_json, 'Key/value pairs of all the environment variables to run in your app. Does not include any system or service variables.'
     field :production, 'Deprecated.', deprecated: true, default: true, valid_values: [true, false]

--- a/spec/api/documentation/apps_api_spec.rb
+++ b/spec/api/documentation/apps_api_spec.rb
@@ -43,6 +43,14 @@ resource 'Apps', type: [:api, :legacy_api] do
       default: nil,
       experimental: true,
       example_values: ['cloudfoundry/helloworld', 'registry.example.com:5000/user/repository/tag']
+    field :docker_login_server,
+      'Server to authenticate to when pulling Docker image',
+      default: nil,
+      experimental: true,
+      example_values: ['https://index.docker.io/v1/']
+    field :docker_user, 'User to use for Docker image pull', default: nil, experimental: true
+    field :docker_password, 'Password to use for Docker image pull', default: nil, experimental: true
+    field :docker_email, 'Email to use for Docker image pull', default: nil, experimental: true
 
     field :environment_json, 'Key/value pairs of all the environment variables to run in your app. Does not include any system or service variables.'
     field :production, 'Deprecated.', deprecated: true, default: true, valid_values: [true, false]

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -88,7 +88,10 @@ resource 'Events', type: [:api, :legacy_api] do
         'instances' => 1,
         'memory' => 84,
         'state' => 'STOPPED',
-        'environment_json' => { 'super' => 'secret' }
+        'environment_json' => { 'super' => 'secret' },
+        'docker_user' => 'user',
+        'docker_password' => 'password',
+        'docker_email' => 'email',
       }
     end
     let(:space_request) do
@@ -108,6 +111,9 @@ resource 'Events', type: [:api, :legacy_api] do
     let(:expected_app_request) do
       expected_request = app_request
       expected_request['environment_json'] = 'PRIVATE DATA HIDDEN'
+      expected_request['docker_user'] = 'PRIVATE DATA HIDDEN'
+      expected_request['docker_password'] = 'PRIVATE DATA HIDDEN'
+      expected_request['docker_email'] = 'PRIVATE DATA HIDDEN'
       expected_request
     end
 

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -89,9 +89,11 @@ resource 'Events', type: [:api, :legacy_api] do
         'memory' => 84,
         'state' => 'STOPPED',
         'environment_json' => { 'super' => 'secret' },
-        'docker_user' => 'user',
-        'docker_password' => 'password',
-        'docker_email' => 'email',
+        'docker_credentials_json' => {
+          'docker_user' => 'user',
+          'docker_password' => 'password',
+          'docker_email' => 'email'
+        }
       }
     end
     let(:space_request) do
@@ -111,9 +113,7 @@ resource 'Events', type: [:api, :legacy_api] do
     let(:expected_app_request) do
       expected_request = app_request
       expected_request['environment_json'] = 'PRIVATE DATA HIDDEN'
-      expected_request['docker_user'] = 'PRIVATE DATA HIDDEN'
-      expected_request['docker_password'] = 'PRIVATE DATA HIDDEN'
-      expected_request['docker_email'] = 'PRIVATE DATA HIDDEN'
+      expected_request['docker_credentials_json'] = 'PRIVATE DATA HIDDEN'
       expected_request
     end
 

--- a/spec/support/bootstrap/fake_model_tables.rb
+++ b/spec/support/bootstrap/fake_model_tables.rb
@@ -63,6 +63,14 @@ class FakeModelTables
       foreign_key [:test_model_id], :test_models, name: :fk_tmmtmtm_tmi
       foreign_key [:test_model_many_to_many_id], :test_model_many_to_manies, name: :fk_tmmtmtm_tmmtmi
     end
+
+    db.create_table :test_model_redacts do
+      primary_key :id
+      String :guid
+      String :redacted
+      DateTime :created_at
+      DateTime :updated_at
+    end
   end
 
   def tables_for_vcap_relations_spec

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -409,4 +409,7 @@ module VCAP::CloudController
 
   TestModelSecondLevel.blueprint do
   end
+
+  TestModelRedact.blueprint do
+  end
 end

--- a/spec/support/test_models.rb
+++ b/spec/support/test_models.rb
@@ -83,4 +83,20 @@ module VCAP::CloudController
 
   class TestModelSecondLevelsController < RestController::ModelController
   end
+
+  class TestModelRedact < Sequel::Model
+    import_attributes :redacted
+    export_attributes :redacted
+  end
+
+  class TestModelRedactAccess < BaseAccess; end
+
+  class TestModelRedactController < RestController::ModelController
+    define_attributes do
+      attribute :redacted, String, redact_in: [:create, :update]
+    end
+
+    define_messages
+    define_routes
+  end
 end

--- a/spec/support/test_models.rb
+++ b/spec/support/test_models.rb
@@ -93,7 +93,7 @@ module VCAP::CloudController
 
   class TestModelRedactController < RestController::ModelController
     define_attributes do
-      attribute :redacted, String, redact_in: [:create, :update]
+      attribute :redacted, Hash, redact_in: [:create, :update]
     end
 
     define_messages

--- a/spec/unit/controllers/base/model_controller_spec.rb
+++ b/spec/unit/controllers/base/model_controller_spec.rb
@@ -163,6 +163,18 @@ module VCAP::CloudController
 
         expect(last_response.status).to eq(201)
       end
+
+      context 'with attributes for redacting' do
+        let(:request_attributes) { { redacted: 'super secret data' } }
+        let(:redact_request_attributes) { { 'redacted' =>  'super secret data' } }
+
+        it 'attempts to redact the attributes' do
+          expect_any_instance_of(TestModelRedactController).to receive(:redact_attributes).with(:create, redact_request_attributes)
+
+          post '/v2/test_model_redact', MultiJson.dump(request_attributes), admin_headers
+          expect(last_response.status).to eq(201)
+        end
+      end
     end
 
     describe '#read' do
@@ -258,6 +270,19 @@ module VCAP::CloudController
 
         put "/v2/test_models/#{model.guid}", MultiJson.dump(fields), admin_headers
         expect(calls).to eq([:before_update, :read_for_update, :update_from_hash, :update, :after_update])
+      end
+
+      context 'with attributes for redacting' do
+        let!(:model) { TestModelRedact.make }
+        let(:request_attributes) { { redacted: 'super secret data' } }
+        let(:redact_request_attributes) { { 'redacted' =>  'super secret data' } }
+
+        it 'attempts to redact the attributes' do
+          expect_any_instance_of(TestModelRedactController).to receive(:redact_attributes).with(:update, redact_request_attributes)
+
+          put "/v2/test_model_redact/#{model.guid}", MultiJson.dump(request_attributes), admin_headers
+          expect(last_response.status).to eq(201)
+        end
       end
     end
 
@@ -772,6 +797,40 @@ module VCAP::CloudController
               end
             end
           end
+        end
+      end
+    end
+
+    describe 'attributes censoring' do
+      let(:dep) { { object_renderer: nil, collection_renderer: nil } }
+      let(:model_controller) { TestModelRedactController.new(nil, FakeLogger.new([]), nil, {}, nil, nil, dep) }
+
+      context 'when the request contains sensitive attributes' do
+        let(:request_attributes) { { 'one' => 1, 'two' => 2, 'redacted' => 'password' } }
+        let(:redacted_attributes) { { 'one' => 1, 'two' => 2, 'redacted' => 'PRIVATE DATA HIDDEN' } }
+
+        it 'redacts attributes for censoring' do
+          processed_attributes = model_controller.redact_attributes(:create, request_attributes)
+          expect(processed_attributes).to eq redacted_attributes
+        end
+
+        context 'and the operation does not require censoring' do
+          let(:redacted_attributes) { { 'one' => 1, 'two' => 2, 'redacted' => 'password' } }
+
+          it 'does not redact' do
+            processed_attributes = model_controller.redact_attributes(:read, request_attributes)
+            expect(processed_attributes).to eq redacted_attributes
+          end
+        end
+      end
+
+      context 'when the request has no sensitive attributes' do
+        let(:request_attributes) { { 'one' => 1, 'two' => 2 } }
+        let(:redacted_attributes) { { 'one' => 1, 'two' => 2 } }
+
+        it 'does not redact' do
+          processed_attributes = model_controller.redact_attributes(:create, request_attributes)
+          expect(processed_attributes).to eq redacted_attributes
         end
       end
     end

--- a/spec/unit/controllers/base/model_controller_spec.rb
+++ b/spec/unit/controllers/base/model_controller_spec.rb
@@ -165,10 +165,23 @@ module VCAP::CloudController
       end
 
       context 'with attributes for redacting' do
-        let(:request_attributes) { { redacted: 'super secret data' } }
-        let(:redact_request_attributes) { { 'redacted' =>  'super secret data' } }
+        let(:request_attributes) { { redacted: { a: 'b' } } }
+        let(:redact_request_attributes) { { 'redacted' =>  { 'a' => 'b' } } }
 
         it 'attempts to redact the attributes' do
+          expect_any_instance_of(TestModelRedactController).to receive(:redact_attributes).with(:create, redact_request_attributes)
+
+          post '/v2/test_model_redact', MultiJson.dump(request_attributes), admin_headers
+          expect(last_response.status).to eq(201)
+        end
+      end
+
+      context 'with empty attributes for redacting' do
+        let(:request_attributes) { { redacted: {} } }
+        let(:redact_request_attributes) { { 'redacted' =>  {} } }
+
+        it 'attempts to redact the attributes' do
+          expect(TestModelRedact).to receive(:create_from_hash) { TestModelRedact.make }
           expect_any_instance_of(TestModelRedactController).to receive(:redact_attributes).with(:create, redact_request_attributes)
 
           post '/v2/test_model_redact', MultiJson.dump(request_attributes), admin_headers
@@ -274,8 +287,8 @@ module VCAP::CloudController
 
       context 'with attributes for redacting' do
         let!(:model) { TestModelRedact.make }
-        let(:request_attributes) { { redacted: 'super secret data' } }
-        let(:redact_request_attributes) { { 'redacted' =>  'super secret data' } }
+        let(:request_attributes) { { redacted: { secret: 'super secret data' } } }
+        let(:redact_request_attributes) { { 'redacted' => { 'secret' => 'super secret data' } } }
 
         it 'attempts to redact the attributes' do
           expect_any_instance_of(TestModelRedactController).to receive(:redact_attributes).with(:update, redact_request_attributes)

--- a/spec/unit/lib/cloud_controller/diego/docker/lifecycle_data_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/lifecycle_data_spec.rb
@@ -5,23 +5,56 @@ module VCAP::CloudController
   module Diego
     module Docker
       describe LifecycleData do
+        let(:image) { 'docker:///image/something' }
+        let(:login_server) { 'http://loginServer.com' }
+        let(:user) { 'user' }
+        let(:password) { 'password' }
+        let(:email) { 'email@example.com' }
+
         let(:lifecycle_data) do
           data = LifecycleData.new
-          data.docker_image = 'docker:///image/something'
+          data.docker_image = image
+          data.docker_login_server = login_server
+          data.docker_user = user
+          data.docker_password = password
+          data.docker_email = email
           data
         end
 
-        let(:lifecycle_payload) do
-          { docker_image: 'docker:///image/something' }
-        end
+        describe '#message' do
+          let(:lifecycle_payload) do
+            {
+              docker_image: image,
+              docker_login_server: login_server,
+              docker_user: user,
+              docker_password: password,
+              docker_email: email
+            }
+          end
 
-        it 'populates the message' do
-          expect(lifecycle_data.message).to eq(lifecycle_payload)
+          it 'populates the message' do
+            expect(lifecycle_data.message).to eq(lifecycle_payload)
+          end
+
+          context 'empty optional field' do
+            let(:lifecycle_payload) do
+              { docker_image: image }
+            end
+
+            before do
+              lifecycle_data.docker_login_server = nil
+              lifecycle_data.docker_user = ''
+              lifecycle_data.docker_password = nil
+              lifecycle_data.docker_email = '   '
+            end
+
+            it 'is not included in the message' do
+              expect(lifecycle_data.message).to eq(lifecycle_payload)
+            end
+          end
         end
 
         describe 'validation' do
-          let(:optional_keys) { [:build_artifacts_cache_download_uri] }
-
           context 'when the docker image is missing' do
             before do
               lifecycle_data.docker_image = nil
@@ -31,6 +64,21 @@ module VCAP::CloudController
               expect {
                 lifecycle_data.message
               }.to raise_error(Membrane::SchemaValidationError)
+            end
+          end
+
+          context 'when optional arguments are missing' do
+            before do
+              lifecycle_data.docker_login_server = nil
+              lifecycle_data.docker_user = ''
+              lifecycle_data.docker_password = nil
+              lifecycle_data.docker_email = '   '
+            end
+
+            it 'does not raise an error' do
+              expect {
+                lifecycle_data.message
+              }.not_to raise_error
             end
           end
         end

--- a/spec/unit/lib/cloud_controller/diego/docker/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/protocol_spec.rb
@@ -112,14 +112,15 @@ module VCAP::CloudController
             let(:user) { 'user' }
             let(:password) { 'password' }
             let(:email) { 'email' }
-            let(:app) { AppFactory.make(docker_image: 'fake/docker_image') }
-
-            before do
-              app.docker_login_server = server
-              app.docker_user = user
-              app.docker_password = password
-              app.docker_email = email
+            let(:docker_credentials) do
+              {
+                docker_login_server: server,
+                docker_user: user,
+                docker_password: password,
+                docker_email: email
+              }
             end
+            let(:app) { AppFactory.make(docker_image: 'fake/docker_image', docker_credentials_json: docker_credentials) }
 
             it 'uses the provided credentials to stage a Docker app' do
               expect(message[:lifecycle_data][:docker_login_server]).to eq(server)

--- a/spec/unit/lib/cloud_controller/diego/docker/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/protocol_spec.rb
@@ -106,6 +106,28 @@ module VCAP::CloudController
               expect(message[:file_descriptors]).to eq(staging_config[:minimum_staging_file_descriptor_limit])
             end
           end
+
+          context 'when there are image credentials' do
+            let(:server) { 'http://loginServer.com' }
+            let(:user) { 'user' }
+            let(:password) { 'password' }
+            let(:email) { 'email' }
+            let(:app) { AppFactory.make(docker_image: 'fake/docker_image') }
+
+            before do
+              app.docker_login_server = server
+              app.docker_user = user
+              app.docker_password = password
+              app.docker_email = email
+            end
+
+            it 'uses the provided credentials to stage a Docker app' do
+              expect(message[:lifecycle_data][:docker_login_server]).to eq(server)
+              expect(message[:lifecycle_data][:docker_user]).to eq(user)
+              expect(message[:lifecycle_data][:docker_password]).to eq(password)
+              expect(message[:lifecycle_data][:docker_email]).to eq(email)
+            end
+          end
         end
 
         describe '#desire_app_request' do

--- a/spec/unit/lib/vcap/rest_api/attribute_spec.rb
+++ b/spec/unit/lib/vcap/rest_api/attribute_spec.rb
@@ -51,5 +51,6 @@ module VCAP::CloudController
 
     include_examples 'operation list', :exclude_in, :exclude_in?, 'excluded'
     include_examples 'operation list', :optional_in, :optional_in?, 'optional'
+    include_examples 'operation list', :redact_in, :redact_in?, 'redacted'
   end
 end

--- a/spec/unit/repositories/runtime/app_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/app_event_repository_spec.rb
@@ -15,9 +15,12 @@ module VCAP::CloudController
             'memory' => 84,
             'state' => 'STOPPED',
             'environment_json' => { 'foo' => 1 },
-            'docker_user' => user,
-            'docker_password' => 'password',
-            'docker_email' => 'email',
+            'docker_credentials_json' => {
+              'docker_login_server' => 'server',
+              'docker_user' => 'user',
+              'docker_password' => 'password',
+              'docker_email' => 'email'
+            }
           }
         end
 
@@ -33,9 +36,7 @@ module VCAP::CloudController
            'memory' => 84,
            'state' => 'STOPPED',
            'environment_json' => 'PRIVATE DATA HIDDEN',
-           'docker_user' => 'PRIVATE DATA HIDDEN',
-           'docker_password' => 'PRIVATE DATA HIDDEN',
-           'docker_email' => 'PRIVATE DATA HIDDEN',
+           'docker_credentials_json' => 'PRIVATE DATA HIDDEN',
           }
 
           expect(Loggregator).to receive(:emit).with(app.guid, "Updated app with guid #{app.guid} (#{expected_request_field})")
@@ -64,9 +65,12 @@ module VCAP::CloudController
             'memory' => 84,
             'state' => 'STOPPED',
             'environment_json' => { 'super' => 'secret ' },
-            'docker_user' => 'user',
-            'docker_password' => 'password',
-            'docker_email' => 'email,'
+            'docker_credentials_json' => {
+              'docker_login_server' => 'server',
+              'docker_user' => 'user',
+              'docker_password' => 'password',
+              'docker_email' => 'email'
+            }
           }
         end
 
@@ -91,9 +95,7 @@ module VCAP::CloudController
                                'memory' => 84,
                                'state' => 'STOPPED',
                                'environment_json' => 'PRIVATE DATA HIDDEN',
-                               'docker_user' => 'PRIVATE DATA HIDDEN',
-                               'docker_password' => 'PRIVATE DATA HIDDEN',
-                               'docker_email' => 'PRIVATE DATA HIDDEN',
+                               'docker_credentials_json' => 'PRIVATE DATA HIDDEN',
                              )
         end
 

--- a/spec/unit/repositories/runtime/app_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/app_event_repository_spec.rb
@@ -15,6 +15,9 @@ module VCAP::CloudController
             'memory' => 84,
             'state' => 'STOPPED',
             'environment_json' => { 'foo' => 1 },
+            'docker_user' => user,
+            'docker_password' => 'password',
+            'docker_email' => 'email',
           }
         end
 
@@ -30,6 +33,9 @@ module VCAP::CloudController
            'memory' => 84,
            'state' => 'STOPPED',
            'environment_json' => 'PRIVATE DATA HIDDEN',
+           'docker_user' => 'PRIVATE DATA HIDDEN',
+           'docker_password' => 'PRIVATE DATA HIDDEN',
+           'docker_email' => 'PRIVATE DATA HIDDEN',
           }
 
           expect(Loggregator).to receive(:emit).with(app.guid, "Updated app with guid #{app.guid} (#{expected_request_field})")
@@ -57,7 +63,10 @@ module VCAP::CloudController
             'instances' => 1,
             'memory' => 84,
             'state' => 'STOPPED',
-            'environment_json' => { 'super' => 'secret ' }
+            'environment_json' => { 'super' => 'secret ' },
+            'docker_user' => 'user',
+            'docker_password' => 'password',
+            'docker_email' => 'email,'
           }
         end
 
@@ -82,6 +91,9 @@ module VCAP::CloudController
                                'memory' => 84,
                                'state' => 'STOPPED',
                                'environment_json' => 'PRIVATE DATA HIDDEN',
+                               'docker_user' => 'PRIVATE DATA HIDDEN',
+                               'docker_password' => 'PRIVATE DATA HIDDEN',
+                               'docker_email' => 'PRIVATE DATA HIDDEN',
                              )
         end
 


### PR DESCRIPTION
[#86969554]

Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>

This pull request enables storing encrypted credentials for the Docker Hub in ccdb. Please have a look and tell us what you think?

We are concerned about encrypting several things with the same salt. We now have 5 columns (server, user, password, email and salt). We can either:
* combine all of these into single json
* add salt columns for all of the credentials
* any other ideas are welcome