### PR TITLE
Current usage against space quota

### DIFF
--- a/app/models/runtime/space_quota_definition.rb
+++ b/app/models/runtime/space_quota_definition.rb
@@ -5,6 +5,7 @@ module VCAP::CloudController
     many_to_one :organization, before_set: :validate_change_organization
     one_to_many :spaces
 
+    attr_accessor :space_usage
     export_attributes :name, :organization_guid, :non_basic_services_allowed, :total_services,
       :total_routes, :memory_limit, :instance_memory_limit
     import_attributes :name, :organization_guid, :non_basic_services_allowed, :total_services,
@@ -27,6 +28,11 @@ module VCAP::CloudController
 
     def validate_change_organization(new_org)
       raise OrganizationAlreadySet unless organization.nil? || organization.guid == new_org.guid
+    end
+
+    def to_hash(opts={})
+      return super(opts) unless space_usage
+      super(opts).merge!('space_usage' => space_usage)
     end
 
     def self.user_visibility_filter(user)

--- a/app/transformers/quota_usage_populator.rb
+++ b/app/transformers/quota_usage_populator.rb
@@ -2,14 +2,54 @@ module VCAP::CloudController
   class QuotaUsagePopulator
     def transform(quota, opts={})
       org_id = opts[:organization_id]
+      space_id = opts[:space_id]
 
       unless org_id.nil?
         spaces = Space.where(organization: quota.organizations_dataset.filter(id: org_id))
         quota.org_usage = map_organization_usage(spaces) unless spaces.nil?
       end
+
+      unless space_id.nil?
+        space = Space.where(id: space_id)
+        quota.space_usage = map_space_usage(space) unless space.nil?
+      end
     end
 
     private
+
+    def map_space_usage(space)
+      quota = {}
+      quota['routes'] = space_routes_count(space)
+      quota['services'] = space_services_count(space)
+      quota['memory'] = space_memory_usage(space)
+      quota
+    end
+
+    def space_routes_count(space)
+      route_count = 0
+      space.collect(&:routes).each do |space_routes|
+        route_count += space_routes.count
+      end
+      route_count
+    end
+
+    def space_services_count(space)
+      service_count = 0
+      space.collect(&:service_instances).each do |space_service_instances|
+        service_count += space_service_instances.count
+      end
+      service_count
+    end
+
+    def space_memory_usage(space)
+      memory_usage = 0
+      space.collect(&:apps).each do |apps|
+        apps.each do |app|
+          memory_usage += app.memory * app.instances if app.started?
+        end
+      end
+      memory_usage
+    end
 
     def map_organization_usage(spaces)
       quota = {}

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = '691810a6326ed4f84e597f1bc520650d2914da40'
+  API_FOLDER_CHECKSUM = '58541134a4f9a22141fbf2a75eedb5d766237a4f'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.27.0')

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -194,6 +194,22 @@ module VCAP::CloudController
       end
     end
 
+    describe 'GET /v2/spaces/:guid/quota_usage' do
+      context 'for an space that does not exist' do
+        it 'returns a 404' do
+          get '/v2/spaces/foobar/quota_usage', {}, admin_headers
+          expect(last_response.status).to eq(404)
+        end
+      end
+      context 'when the user does not have permissions to read' do
+        let(:user) { User.make }
+        it 'returns a 403' do
+          get "/v2/spaces/#{space_one.guid}/quota_usage", {}, headers_for(user)
+          expect(last_response.status).to eq(403)
+        end
+      end
+    end
+
     describe 'GET /v2/spaces/:guid/service_instances' do
       let(:space) { Space.make }
       let(:developer) { make_developer_for_space(space) }

--- a/spec/unit/models/runtime/space_quota_definition_spec.rb
+++ b/spec/unit/models/runtime/space_quota_definition_spec.rb
@@ -60,5 +60,15 @@ module VCAP::CloudController
         expect { space_quota_definition.destroy }.to change { space.reload.space_quota_definition }.from(space_quota_definition).to(nil)
       end
     end
+
+    describe '#to_hash' do
+      it 'does not include space usage when space_usage has not been set' do
+        expect(space_quota_definition.to_hash).to_not include('space_usage')
+      end
+      it 'includes space usage when space_usage has been set' do
+        space_quota_definition.space_usage = 'someusage'
+        expect(space_quota_definition.to_hash).to include('space_usage')
+      end
+    end
   end
 end

--- a/spec/unit/transformers/quota_usage_populator_spec.rb
+++ b/spec/unit/transformers/quota_usage_populator_spec.rb
@@ -4,11 +4,13 @@ module VCAP::CloudController
   describe QuotaUsagePopulator do
     let(:quotaUsage_populator) { QuotaUsagePopulator.new }
     let(:quota_definition) { QuotaDefinition.make }
+    let(:space_quota_definition) { SpaceQuotaDefinition.make(organization: org) }
     let(:quota_definition_guid) { quota_definition.guid }
     let(:org) { Organization.make_unsaved(quota_definition: quota_definition, quota_definition_guid: quota_definition_guid) }
-    let(:space) { Space.make(organization: org) }
+    let(:space) { Space.make(organization: org, space_quota_definition: space_quota_definition) }
     let(:domain) { PrivateDomain.make(owning_organization: org) }
     let(:route) { Route.make(domain: domain, space: space) }
+    let(:route1) { Route.make(domain: domain, space: space) }
     let(:service_instance) { ManagedServiceInstance.make(space: space) }
     let(:app) { AppFactory.make(space: space, instances: 1, memory: 500, state: 'STARTED') }
 
@@ -16,14 +18,20 @@ module VCAP::CloudController
       org.save
       org.add_space(space)
       app.add_route(route)
+      app.add_route(route1)
       space.add_service_instance(service_instance)
       space.add_app(app)
     end
 
     describe 'transform' do
-      it 'populates users with usernames from UAA' do
+      it 'populates organization quota usage' do
         quotaUsage_populator.transform(quota_definition, organization_id: org.id)
-        expect(quota_definition.org_usage).to eq({ 'routes' => 1, 'services' => 1, 'memory' => 500 })
+        expect(quota_definition.org_usage).to eq({ 'routes' => 2, 'services' => 1, 'memory' => 500 })
+      end
+
+      it 'populates space quota usage' do
+        quotaUsage_populator.transform(space.space_quota_definition, space_id: space.id)
+        expect(space.space_quota_definition.space_usage).to eq({ 'routes' => 2, 'services' => 1, 'memory' => 500 })
       end
     end
   end


### PR DESCRIPTION
Provide current status of routes, service instances and memory usage for space against associated space quota.
[#91309436]

As of now we are returning error when space is not associated with any quota.
So one idea we can think of is to populate space_usage in 'QuotaDefinition' model when space is not associated with any space quota.
We need feedback from Runtime Team on this.