### PR TITLE
Filter docker applications if Docker is disabled

### DIFF
--- a/app/controllers/runtime/restages_controller.rb
+++ b/app/controllers/runtime/restages_controller.rb
@@ -35,5 +35,12 @@ module VCAP::CloudController
         object_renderer.render_json(self.class, app, @opts)
       ]
     end
+
+    def self.translate_validation_exception(e, attributes)
+      docker_errors = e.errors.on(:docker)
+      return Errors::ApiError.new_from_details('DockerDisabled') if docker_errors
+
+      Errors::ApiError.new_from_details('StagingError', e.errors.full_messages)
+    end
   end
 end

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -377,6 +377,10 @@ module VCAP::CloudController
       raise objection if space.nil?
       raise objection if route.space_id != space.id
 
+      if docker_image.present?
+        raise VCAP::Errors::ApiError.new_from_details('DockerDisabled') unless FeatureFlag.enabled?('diego_docker')
+      end
+
       raise objection unless route.domain.usable_by_organization?(space.organization)
     end
 

--- a/app/models/runtime/constraints/docker_policy.rb
+++ b/app/models/runtime/constraints/docker_policy.rb
@@ -12,6 +12,10 @@ class DockerPolicy
       @errors.add(:docker_image, BUILDPACK_DETECTED_ERROR_MSG)
     end
 
+    if @app.docker_image.present? && !VCAP::CloudController::FeatureFlag.enabled?('diego_docker')
+      @errors.add(:docker, :docker_disabled) unless @app.being_stopped?
+    end
+
     docker_credentials = @app.docker_credentials_json
     if docker_credentials.present?
       unless docker_credentials['docker_user'].present? && docker_credentials['docker_password'].present? && docker_credentials['docker_email'].present?

--- a/app/models/runtime/feature_flag.rb
+++ b/app/models/runtime/feature_flag.rb
@@ -12,6 +12,7 @@ module VCAP::CloudController
       app_scaling: true,
       route_creation: true,
       service_instance_creation: true,
+      diego_docker: false,
     }.freeze
 
     export_attributes :name, :enabled, :error_message

--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -260,7 +260,6 @@ cloud_controller_username_lookup_client_name: "cloud_controller_username_lookup"
 cloud_controller_username_lookup_client_secret: <%= p("uaa.clients.cloud_controller_username_lookup.secret") %>
 
 users_can_select_backend: <%= p("cc.users_can_select_backend") %>
-diego_docker: <%= p("cc.diego_docker") %>
 diego_nsync_url: http://nsync.service.consul:8787
 diego_stager_url: http://stager.service.consul:8888
 diego_tps_url: http://tps.service.consul:1518

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -241,7 +241,6 @@ uaa_client_scope: <%= p("uaa.clients.cc-service-dashboards.scope") %>
 <% end %>
 
 users_can_select_backend: <%= p("cc.users_can_select_backend") %>
-diego_docker: <%= p("cc.diego_docker") %>
 diego_nsync_url: http://nsync.service.consul:8787
 diego_stager_url: http://stager.service.consul:8888
 diego_tps_url: http://tps.service.consul:1518

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -239,7 +239,6 @@ uaa_client_scope: <%= p("uaa.clients.cc-service-dashboards.scope") %>
 <% end %>
 
 users_can_select_backend: <%= p("cc.users_can_select_backend") %>
-diego_docker: <%= p("cc.diego_docker") %>
 diego_nsync_url: http://nsync.service.consul:8787
 diego_stager_url: http://stager.service.consul:8888
 diego_tps_url: http://tps.service.consul:1518

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -152,7 +152,6 @@ cloud_controller_username_lookup_client_name: 'username_lookup_client_name'
 cloud_controller_username_lookup_client_secret: 'username_lookup_secret'
 
 users_can_select_backend: true
-diego_docker: false
 allow_app_ssh_access: true
 diego_nsync_url: http://nsync.service.consul:8787
 diego_stager_url: http://stager.service.consul:8888

--- a/lib/cloud_controller/backends/runners.rb
+++ b/lib/cloud_controller/backends/runners.rb
@@ -50,13 +50,14 @@ module VCAP::CloudController
     end
 
     def diego_apps_cache_data(batch_size, last_id)
-      App.select(:id, :guid, :version, :updated_at).
+      diego_apps = App.select(:id, :guid, :version, :updated_at).
         where('id > ?', last_id).
         where(state: 'STARTED').
         where(package_state: 'STAGED').
         where('deleted_at IS NULL').
-        where(diego: true).
-        order(:id).
+        where(diego: true)
+      diego_apps = filter_docker_apps(diego_apps) unless FeatureFlag.enabled?('diego_docker')
+      diego_apps.order(:id).
         limit(batch_size).
         select_map([:id, :guid, :version, :updated_at])
     end
@@ -102,6 +103,10 @@ module VCAP::CloudController
 
     def staging_timeout
       @config[:staging][:timeout_in_seconds]
+    end
+
+    def filter_docker_apps(query)
+      query.where(docker_image: nil)
     end
   end
 end

--- a/lib/cloud_controller/backends/stagers.rb
+++ b/lib/cloud_controller/backends/stagers.rb
@@ -17,7 +17,7 @@ module VCAP::CloudController
     end
 
     def validate_app(app)
-      if app.docker_image.present? && docker_disabled?
+      if app.docker_image.present? && !FeatureFlag.enabled?('diego_docker')
         raise Errors::ApiError.new_from_details('DockerDisabled')
       end
 
@@ -43,10 +43,6 @@ module VCAP::CloudController
     end
 
     private
-
-    def docker_disabled?
-      !@config[:diego_docker]
-    end
 
     def dea_stager(app)
       Dea::Stager.new(app, @config, @message_bus, @dea_pool, @stager_pool, @runners)

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -223,7 +223,6 @@ module VCAP::CloudController
 
         optional(:dea_advertisement_timeout_in_seconds) => Integer,
 
-        optional(:diego_docker) => bool,
         optional(:diego_stager_url) => String,
         optional(:diego_tps_url) => String,
         optional(:users_can_select_backend) => bool,
@@ -324,7 +323,6 @@ module VCAP::CloudController
         config[:db][:database] ||= ENV['DB_CONNECTION_STRING']
         config[:default_locale] ||= 'en_US'
         config[:allowed_cors_domains] ||= []
-        config[:diego_docker] ||= false
         config[:default_to_diego_backend] ||= false
         config[:dea_advertisement_timeout_in_seconds] ||= 10
         config[:staging][:minimum_staging_memory_mb] ||= 1024

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = '338e23f6c1796aea155fe642c8dac04c2a5bcaf9'
+  API_FOLDER_CHECKSUM = 'b8d307998cee532b007c0f1f92ba341744208963'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.28.0')

--- a/spec/api/documentation/apps_api_spec.rb
+++ b/spec/api/documentation/apps_api_spec.rb
@@ -69,7 +69,7 @@ resource 'Apps', type: [:api, :legacy_api] do
         staging: 'optional',
         running: 'optional',
       )
-      allow(VCAP::CloudController::Config.config).to receive(:[]).with(:diego_docker).and_return true
+      allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return true
     end
 
     def after_standard_model_delete(guid)

--- a/spec/api/documentation/feature_flags_api_spec.rb
+++ b/spec/api/documentation/feature_flags_api_spec.rb
@@ -24,7 +24,7 @@ resource 'Feature Flags', type: [:api, :legacy_api] do
       client.get '/v2/config/feature_flags', {}, headers
 
       expect(status).to eq(200)
-      expect(parsed_response.length).to eq(6)
+      expect(parsed_response.length).to eq(7)
       expect(parsed_response).to include(
         {
           'name'          => 'user_org_creation',
@@ -163,6 +163,22 @@ resource 'Feature Flags', type: [:api, :legacy_api] do
           'error_message' => nil,
           'url'           => '/v2/config/feature_flags/service_instance_creation'
         })
+    end
+  end
+
+  get '/v2/config/feature_flags/diego_docker' do
+    example 'Get the Diego Docker feature flag' do
+      explanation 'When enabled, Docker applications are supported by Diego. When disabled, Docker applications can only be stopped or deleted.'
+      client.get '/v2/config/feature_flags/diego_docker', {}, headers
+
+      expect(status).to eq(200)
+      expect(parsed_response).to eq(
+                                   {
+                                     'name'          => 'diego_docker',
+                                     'enabled'       => false,
+                                     'error_message' => nil,
+                                     'url'           => '/v2/config/feature_flags/diego_docker'
+                                   })
     end
   end
 

--- a/spec/fixtures/config/default_overriding_config.yml
+++ b/spec/fixtures/config/default_overriding_config.yml
@@ -147,7 +147,6 @@ allowed_cors_domains:
 - http://sharon.corr
 
 users_can_select_backend: false
-diego_docker: true
 default_to_diego_backend: true
 allow_app_ssh_access: true
 

--- a/spec/unit/controllers/internal/bulk_apps_controller_spec.rb
+++ b/spec/unit/controllers/internal/bulk_apps_controller_spec.rb
@@ -200,7 +200,7 @@ module VCAP::CloudController
             get '/internal/bulk/apps', {
                                          'batch_size' => App.count,
                                          'token' => '{}',
-                                     }
+                                       }
 
             expect(last_response.status).to eq(200)
             expect(decoded_response['apps'].size).to eq(App.count - 1)
@@ -209,17 +209,18 @@ module VCAP::CloudController
 
         context 'when docker is enabled' do
           before do
-            TestConfig.override(diego_docker: true, diego: { staging: 'optional', running: 'optional' })
+            TestConfig.override(diego: { staging: 'optional', running: 'optional' })
+            allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return true
+
+            @docker_app = make_diego_app(state: 'STARTED', docker_image: 'fake-docker-image')
+            @docker_app.save
           end
 
           it 'does return docker apps' do
-            app = make_diego_app(state: 'STARTED', docker_image: 'fake-docker-image')
-            app.save
-
             get '/internal/bulk/apps', {
                                          'batch_size' => App.count,
                                          'token' => '{}',
-                                     }
+                                       }
 
             expect(last_response.status).to eq(200)
             expect(decoded_response['apps'].size).to eq(App.count)
@@ -232,7 +233,7 @@ module VCAP::CloudController
               get '/internal/bulk/apps', {
                                            'batch_size' => size,
                                            'token' => { id: 0 }.to_json,
-                                       }
+                                         }
 
               expect(last_response.status).to eq(200)
               expect(decoded_response['apps'].size).to eq(size)
@@ -243,7 +244,7 @@ module VCAP::CloudController
             get '/internal/bulk/apps', {
                                          'batch_size' => 2,
                                          'token' => { id: 0 }.to_json,
-                                     }
+                                       }
 
             expect(last_response.status).to eq(200)
 
@@ -253,7 +254,7 @@ module VCAP::CloudController
             get '/internal/bulk/apps', {
                                          'batch_size' => 2,
                                          'token' => MultiJson.dump(decoded_response['token']),
-                                     }
+                                       }
 
             expect(last_response.status).to eq(200)
 

--- a/spec/unit/controllers/runtime/restages_controller_spec.rb
+++ b/spec/unit/controllers/runtime/restages_controller_spec.rb
@@ -54,6 +54,32 @@ module VCAP::CloudController
           end
         end
 
+        context 'when there are validation error' do
+          let!(:application) do
+            allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return true
+            AppFactory.make(package_hash: 'abc', docker_image: 'some_image', state: 'STARTED')
+          end
+
+          before do
+            allow_any_instance_of(VCAP::CloudController::RestagesController).to receive(:find_guid_and_validate_access).with(:read, application.guid).and_return(application)
+            allow(application).to receive(:package_state).and_return('STAGED')
+          end
+
+          context 'when Docker is disabled' do
+            before do
+              allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return false
+            end
+
+            it 'correctly propagates the error' do
+              restage_request
+
+              expect(last_response.status).to eq(400)
+              expect(decoded_response['code']).to eq(320003)
+              expect(decoded_response['description']).to match(/Docker support has not been enabled./)
+            end
+          end
+        end
+
         describe 'events' do
           before do
             allow(app_event_repository).to receive(:record_app_restage).and_call_original

--- a/spec/unit/lib/cloud_controller/backends/runners_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends/runners_spec.rb
@@ -428,7 +428,7 @@ module VCAP::CloudController
       it 'acquires the data in one select' do
         expect {
           runners.diego_apps_cache_data(100, 0)
-        }.to have_queried_db_times(/SELECT.*FROM `apps`/, 1)
+        }.to have_queried_db_times(/SELECT.*FROM.*apps.*/, 1)
       end
 
       context 'when docker is enabled' do

--- a/spec/unit/lib/cloud_controller/backends/runners_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends/runners_spec.rb
@@ -5,7 +5,6 @@ module VCAP::CloudController
   describe Runners do
     let(:config) do
       {
-          diego_docker: true,
           staging: {
               timeout_in_seconds: 90
           }
@@ -429,7 +428,37 @@ module VCAP::CloudController
       it 'acquires the data in one select' do
         expect {
           runners.diego_apps_cache_data(100, 0)
-        }.to have_queried_db_times(/SELECT/, 1)
+        }.to have_queried_db_times(/SELECT.*FROM `apps`/, 1)
+      end
+
+      context 'when docker is enabled' do
+        before do
+          allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return true
+          @docker_app = make_diego_app(state: 'STARTED', docker_image: 'some-image')
+        end
+
+        it 'returns docker apps' do
+          batch = runners.diego_apps_cache_data(100, 0)
+          app_ids = batch.map { |data| data[0] }
+
+          expect(app_ids).to include(@docker_app.id)
+        end
+      end
+
+      context 'when docker is disabled' do
+        before do
+          allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return true
+          @docker_app = make_diego_app(state: 'STARTED', docker_image: 'some-image')
+
+          allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return false
+        end
+
+        it 'does not return docker apps' do
+          batch = runners.diego_apps_cache_data(100, 0)
+          app_ids = batch.map { |data| data[0] }
+
+          expect(app_ids).not_to include(@docker_app.id)
+        end
       end
     end
 

--- a/spec/unit/lib/cloud_controller/backends/stagers_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends/stagers_spec.rb
@@ -83,11 +83,18 @@ module VCAP::CloudController
 
       context 'if diego docker support is not enabled' do
         before do
-          config[:diego_docker] = false
+          allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return true
+          @docker_app = instance_double(App,
+                                        docker_image: docker_image,
+                                        package_hash: package_hash,
+                                        buildpack: buildpack,
+                                        custom_buildpacks_enabled?: custom_buildpacks_enabled?,
+                                        buildpack_specified?: false)
+          allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return false
         end
 
         context 'and the app has a docker_image' do
-          let(:docker_image) do
+          let!(:docker_image) do
             'fake-docker-image'
           end
 

--- a/spec/unit/lib/cloud_controller/config_spec.rb
+++ b/spec/unit/lib/cloud_controller/config_spec.rb
@@ -51,10 +51,6 @@ module VCAP::CloudController
           expect(config[:allowed_cors_domains]).to eq([])
         end
 
-        it 'disables docker images on diego' do
-          expect(config[:diego_docker]).to eq(false)
-        end
-
         it 'allows users to select the backend for their apps' do
           expect(config[:users_can_select_backend]).to eq(true)
         end
@@ -154,10 +150,6 @@ module VCAP::CloudController
 
           it 'preserves the backend selection configuration from the file' do
             expect(config[:users_can_select_backend]).to eq(false)
-          end
-
-          it 'preserves the diego configuration from the file' do
-            expect(config[:diego_docker]).to eq(true)
           end
 
           it 'runs apps on diego' do

--- a/spec/unit/lib/cloud_controller/diego/docker/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/protocol_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
     module Docker
       describe Protocol do
         before do
-          TestConfig.override(diego_docker: true)
+          allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return true
         end
 
         let(:default_health_check_timeout) { 9999 }

--- a/spec/unit/lib/cloud_controller/diego/docker/staging_completion_handler_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/staging_completion_handler_spec.rb
@@ -121,6 +121,10 @@ module VCAP::CloudController
             end
             let(:droplet) { app.reload.current_droplet }
 
+            before do
+              allow(VCAP::CloudController::FeatureFlag).to receive(:enabled?).with('diego_docker').and_return true
+            end
+
             context 'when image was cached' do
               let(:app) { AppFactory.make(staging_task_id: 'fake-staging-task-id', docker_image: 'user_provided') }
 

--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 module VCAP::CloudController
   describe FeatureFlag, type: :model do
-    let(:valid_flags) { [:user_org_creation, :private_domain_creation, :app_bits_upload, :app_scaling, :route_creation, :service_instance_creation] }
+    let(:valid_flags) { [:user_org_creation, :private_domain_creation, :app_bits_upload, :app_scaling, :route_creation, :service_instance_creation, :diego_docker] }
     let(:feature_flag) { FeatureFlag.make }
 
     it { is_expected.to have_timestamp_columns }


### PR DESCRIPTION
* Added `diego_docker` feature flag
* When flag is disabled, Docker apps cannot scale, start, map/unmap routes
* Docker apps can always be stopped & deleted

[#95275686]

Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>