### PR TITLE
Encryptor fips

### DIFF
--- a/lib/cloud_controller/encryptor.rb
+++ b/lib/cloud_controller/encryptor.rb
@@ -1,5 +1,5 @@
 require 'securerandom'
-require 'openssl/cipher'
+require 'openssl'
 require 'base64'
 
 module VCAP::CloudController::Encryptor
@@ -10,17 +10,29 @@ module VCAP::CloudController::Encryptor
       SecureRandom.hex(4).to_s
     end
 
+    attr_accessor :db_encryption_key
+
+    def generate_key(salt)
+      iter = 200000
+      key_len = 16
+      OpenSSL::PKCS5.pbkdf2_hmac_sha1(db_encryption_key, salt, iter, key_len)
+    end
+
     def encrypt(input, salt)
       return nil unless input
-      Base64.strict_encode64(run_cipher(make_cipher.encrypt, input, salt))
+
+      unless salt
+        salt = salt.to_s
+      end
+
+      iv = SecureRandom.hex
+      return(iv + Base64.strict_encode64(run_cipher(make_cipher.encrypt, input, salt, iv)))
     end
 
     def decrypt(encrypted_input, salt)
       return nil unless encrypted_input
-      run_cipher(make_cipher.decrypt, Base64.decode64(encrypted_input), salt)
+      run_cipher(make_cipher.decrypt, Base64.decode64(encrypted_input[32, (encrypted_input.length - 32)]), salt, encrypted_input[0,32])
     end
-
-    attr_accessor :db_encryption_key
 
     private
 
@@ -28,8 +40,9 @@ module VCAP::CloudController::Encryptor
       OpenSSL::Cipher::Cipher.new(ALGORITHM)
     end
 
-    def run_cipher(cipher, input, salt)
-      cipher.pkcs5_keyivgen(db_encryption_key, salt)
+    def run_cipher(cipher, input, salt, iv)
+      cipher.key=(generate_key(salt))
+      cipher.iv=(iv)
       cipher.update(input).tap { |result| result << cipher.final }
     end
   end

--- a/lib/cloud_controller/encryptor.rb
+++ b/lib/cloud_controller/encryptor.rb
@@ -26,12 +26,12 @@ module VCAP::CloudController::Encryptor
       end
 
       iv = SecureRandom.hex
-      return(iv + Base64.strict_encode64(run_cipher(make_cipher.encrypt, input, salt, iv)))
+      (iv + Base64.strict_encode64(run_cipher(make_cipher.encrypt, input, salt, iv)))
     end
 
     def decrypt(encrypted_input, salt)
       return nil unless encrypted_input
-      run_cipher(make_cipher.decrypt, Base64.decode64(encrypted_input[32, (encrypted_input.length - 32)]), salt, encrypted_input[0,32])
+      run_cipher(make_cipher.decrypt, Base64.decode64(encrypted_input[32, (encrypted_input.length - 32)]), salt, encrypted_input[0, 32])
     end
 
     private
@@ -41,8 +41,8 @@ module VCAP::CloudController::Encryptor
     end
 
     def run_cipher(cipher, input, salt, iv)
-      cipher.key=(generate_key(salt))
-      cipher.iv=(iv)
+      cipher.key = (generate_key(salt))
+      cipher.iv = (iv)
       cipher.update(input).tap { |result| result << cipher.final }
     end
   end

--- a/spec/unit/lib/cloud_controller/encryptor_spec.rb
+++ b/spec/unit/lib/cloud_controller/encryptor_spec.rb
@@ -2,12 +2,25 @@ require 'spec_helper'
 
 module VCAP::CloudController
   describe Encryptor do
+
+    # Use rspec -t ~fips if your Ruby is not built against a FIPS-enabled OpenSSL library
+    it 'supports FIPS mode', :fips => true do
+        OpenSSL::fips_mode = true
+    end
+
     let(:salt) { Encryptor.generate_salt }
+    let(:key) { Encryptor.generate_key(salt) }
 
     describe 'generating some salt' do
       it 'returns a short, random string' do
         expect(salt.length).to eql(8)
         expect(salt).not_to eql(Encryptor.generate_salt)
+      end
+    end
+
+    describe 'generating a key' do
+      it 'returns a generated key of the specified length' do
+        expect(key.length).to eq(16)
       end
     end
 
@@ -20,8 +33,8 @@ module VCAP::CloudController
         expect(encrypted_string).not_to include(input)
       end
 
-      it 'is deterministic' do
-        expect(Encryptor.encrypt(input, salt)).to eql(encrypted_string)
+      it 'does not produce a predictable output' do
+        expect(Encryptor.encrypt(input, salt)).not_to eql(encrypted_string)
       end
 
       it 'depends on the salt' do

--- a/spec/unit/lib/cloud_controller/encryptor_spec.rb
+++ b/spec/unit/lib/cloud_controller/encryptor_spec.rb
@@ -2,10 +2,9 @@ require 'spec_helper'
 
 module VCAP::CloudController
   describe Encryptor do
-
     # Use rspec -t ~fips if your Ruby is not built against a FIPS-enabled OpenSSL library
-    it 'supports FIPS mode', :fips => true do
-        OpenSSL::fips_mode = true
+    it 'supports FIPS mode', fips: true do
+      OpenSSL.fips_mode = true
     end
 
     let(:salt) { Encryptor.generate_salt }

--- a/spec/unit/lib/cloud_controller/encryptor_spec.rb
+++ b/spec/unit/lib/cloud_controller/encryptor_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 module VCAP::CloudController
   describe Encryptor do
     # Use rspec -t ~fips if your Ruby is not built against a FIPS-enabled OpenSSL library
+    RSpec.configure do |c|
+      c.filter_run_excluding fips: true
+    end
+
     it 'supports FIPS mode', fips: true do
       OpenSSL.fips_mode = true
     end


### PR DESCRIPTION
I updated lib/cloud_controller/encryptor.rb so that it can be used when OpenSSL::fips_mode = true is set.  This required moving off of the (deprecated) keyivgen method and following the better practice of using a random IV for every message, which IV is then returned as part of the encrypted string for use in decryption.  I updated the spec file so that it enables fips_mode, but I tagged this so that you can avoid enabling fips mode with rspec -t ~fips. 

RSPEC: 

[sandy@oc1718273258 cloud_controller_ng]$ bundle exec rspec spec/unit/lib/cloud_controller/encryptor_spec.rb 
.......................

Finished in 3.38 seconds (files took 42.58 seconds to load)
23 examples, 0 failures

RSPEC (fips disabled): 

[sandy@oc1718273258 cloud_controller_ng]$ bundle exec rspec -t ~fips spec/unit/lib/cloud_controller/encryptor_spec.rb 
Run options: exclude {:fips=>true}
......................

Finished in 3.01 seconds (files took 1 minute 6.34 seconds to load)
22 examples, 0 failures

RUBOCOP:

[sandy@oc1718273258 cloud_controller_ng]$ bundle exec rubocop
warning: parser/current is loading parser/ruby21, which recognizes
warning: 2.1.5-compliant syntax, but you are running 2.1.6.
Inspecting 1228 files
[...]
1228 files inspected, no offenses detected
