### PR TITLE
Disable docker apps when docker support is switched off

### DIFF
--- a/app/controllers/runtime/restages_controller.rb
+++ b/app/controllers/runtime/restages_controller.rb
@@ -35,5 +35,12 @@ module VCAP::CloudController
         object_renderer.render_json(self.class, app, @opts)
       ]
     end
+
+    def self.translate_validation_exception(e, attributes)
+      docker_errors = e.errors.on(:docker)
+      return Errors::ApiError.new_from_details('DockerDisabled') if docker_errors
+
+      Errors::ApiError.new_from_details('StagingError', e.errors.full_messages)
+    end
   end
 end

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -219,8 +219,8 @@ module VCAP::CloudController
       space.in_suspended_org?
     end
 
-    def state_changed?
-      column_changed?(:state)
+    def being_started?
+      column_changed?(:state) && started?
     end
 
     def being_stopped?

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -440,6 +440,13 @@ module VCAP::CloudController
       state == 'STARTED'
     end
 
+    def active?
+      if diego? && docker_image.present?
+        return false unless FeatureFlag.enabled?('diego_docker')
+      end
+      true
+    end
+
     def stopped?
       state == 'STOPPED'
     end

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -219,6 +219,10 @@ module VCAP::CloudController
       space.in_suspended_org?
     end
 
+    def state_changed?
+      column_changed?(:state)
+    end
+
     def being_stopped?
       column_changed?(:state) && stopped?
     end

--- a/app/models/runtime/constraints/docker_policy.rb
+++ b/app/models/runtime/constraints/docker_policy.rb
@@ -12,6 +12,10 @@ class DockerPolicy
       @errors.add(:docker_image, BUILDPACK_DETECTED_ERROR_MSG)
     end
 
+    if @app.docker_image.present? && !VCAP::CloudController::FeatureFlag.enabled?('diego_docker')
+      @errors.add(:docker, :docker_disabled) if @app.state_changed? unless @app.being_stopped?
+    end
+
     docker_credentials = @app.docker_credentials_json
     if docker_credentials.present?
       unless docker_credentials['docker_user'].present? && docker_credentials['docker_password'].present? && docker_credentials['docker_email'].present?

--- a/app/models/runtime/constraints/docker_policy.rb
+++ b/app/models/runtime/constraints/docker_policy.rb
@@ -13,7 +13,7 @@ class DockerPolicy
     end
 
     if @app.docker_image.present? && VCAP::CloudController::FeatureFlag.disabled?('diego_docker')
-      @errors.add(:docker, :docker_disabled) if @app.state_changed? unless @app.being_stopped?
+      @errors.add(:docker, :docker_disabled) if @app.being_started?
     end
 
     docker_credentials = @app.docker_credentials_json

--- a/app/models/runtime/constraints/docker_policy.rb
+++ b/app/models/runtime/constraints/docker_policy.rb
@@ -12,7 +12,7 @@ class DockerPolicy
       @errors.add(:docker_image, BUILDPACK_DETECTED_ERROR_MSG)
     end
 
-    if @app.docker_image.present? && !VCAP::CloudController::FeatureFlag.enabled?('diego_docker')
+    if @app.docker_image.present? && VCAP::CloudController::FeatureFlag.disabled?('diego_docker')
       @errors.add(:docker, :docker_disabled) if @app.state_changed? unless @app.being_stopped?
     end
 

--- a/app/models/runtime/feature_flag.rb
+++ b/app/models/runtime/feature_flag.rb
@@ -36,6 +36,10 @@ module VCAP::CloudController
       raise UndefinedFeatureFlagError.new "invalid key: #{feature_flag_name}"
     end
 
+    def self.disabled?(feature_flag_name)
+      !FeatureFlag.enabled?(feature_flag_name)
+    end
+
     def self.raise_unless_enabled!(feature_flag_name)
       feature_flag = FeatureFlag.find(name: feature_flag_name)
 

--- a/app/models/runtime/feature_flag.rb
+++ b/app/models/runtime/feature_flag.rb
@@ -12,6 +12,7 @@ module VCAP::CloudController
       app_scaling: true,
       route_creation: true,
       service_instance_creation: true,
+      diego_docker: false,
     }.freeze
 
     export_attributes :name, :enabled, :error_message

--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -7,6 +7,7 @@ module VCAP::CloudController
     class InvalidDomainRelation < VCAP::Errors::InvalidRelation; end
     class InvalidAppRelation < VCAP::Errors::InvalidRelation; end
     class InvalidOrganizationRelation < VCAP::Errors::InvalidRelation; end
+    class DockerDisabled < VCAP::Errors::InvalidRelation; end
 
     many_to_one :domain
     many_to_one :space, after_set: :validate_changed_space

--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -260,7 +260,6 @@ cloud_controller_username_lookup_client_name: "cloud_controller_username_lookup"
 cloud_controller_username_lookup_client_secret: <%= p("uaa.clients.cloud_controller_username_lookup.secret") %>
 
 users_can_select_backend: <%= p("cc.users_can_select_backend") %>
-diego_docker: <%= p("cc.diego_docker") %>
 diego_nsync_url: http://nsync.service.consul:8787
 diego_stager_url: http://stager.service.consul:8888
 diego_tps_url: http://tps.service.consul:1518

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -241,7 +241,6 @@ uaa_client_scope: <%= p("uaa.clients.cc-service-dashboards.scope") %>
 <% end %>
 
 users_can_select_backend: <%= p("cc.users_can_select_backend") %>
-diego_docker: <%= p("cc.diego_docker") %>
 diego_nsync_url: http://nsync.service.consul:8787
 diego_stager_url: http://stager.service.consul:8888
 diego_tps_url: http://tps.service.consul:1518

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -239,7 +239,6 @@ uaa_client_scope: <%= p("uaa.clients.cc-service-dashboards.scope") %>
 <% end %>
 
 users_can_select_backend: <%= p("cc.users_can_select_backend") %>
-diego_docker: <%= p("cc.diego_docker") %>
 diego_nsync_url: http://nsync.service.consul:8787
 diego_stager_url: http://stager.service.consul:8888
 diego_tps_url: http://tps.service.consul:1518

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -152,7 +152,6 @@ cloud_controller_username_lookup_client_name: 'username_lookup_client_name'
 cloud_controller_username_lookup_client_secret: 'username_lookup_secret'
 
 users_can_select_backend: true
-diego_docker: false
 allow_app_ssh_access: true
 diego_nsync_url: http://nsync.service.consul:8787
 diego_stager_url: http://stager.service.consul:8888

--- a/lib/cloud_controller/app_observer.rb
+++ b/lib/cloud_controller/app_observer.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
       end
 
       def routes_changed(app)
-        @runners.runner_for_app(app).update_routes if app.started?
+        @runners.runner_for_app(app).update_routes if app.started? && app.active?
       end
 
       private
@@ -61,7 +61,7 @@ module VCAP::CloudController
       end
 
       def react_to_instances_change(app)
-        @runners.runner_for_app(app).scale if app.started?
+        @runners.runner_for_app(app).scale if app.started? && app.active?
       end
     end
   end

--- a/lib/cloud_controller/backends/runners.rb
+++ b/lib/cloud_controller/backends/runners.rb
@@ -50,13 +50,14 @@ module VCAP::CloudController
     end
 
     def diego_apps_cache_data(batch_size, last_id)
-      App.select(:id, :guid, :version, :updated_at).
+      diego_apps = App.select(:id, :guid, :version, :updated_at).
         where('id > ?', last_id).
         where(state: 'STARTED').
         where(package_state: 'STAGED').
         where('deleted_at IS NULL').
-        where(diego: true).
-        order(:id).
+        where(diego: true)
+      diego_apps = filter_docker_apps(diego_apps) unless FeatureFlag.enabled?('diego_docker')
+      diego_apps.order(:id).
         limit(batch_size).
         select_map([:id, :guid, :version, :updated_at])
     end
@@ -102,6 +103,10 @@ module VCAP::CloudController
 
     def staging_timeout
       @config[:staging][:timeout_in_seconds]
+    end
+
+    def filter_docker_apps(query)
+      query.where(docker_image: nil)
     end
   end
 end

--- a/lib/cloud_controller/backends/stagers.rb
+++ b/lib/cloud_controller/backends/stagers.rb
@@ -17,7 +17,7 @@ module VCAP::CloudController
     end
 
     def validate_app(app)
-      if app.docker_image.present? && docker_disabled?
+      if app.docker_image.present? && !FeatureFlag.enabled?('diego_docker')
         raise Errors::ApiError.new_from_details('DockerDisabled')
       end
 
@@ -43,10 +43,6 @@ module VCAP::CloudController
     end
 
     private
-
-    def docker_disabled?
-      !@config[:diego_docker]
-    end
 
     def dea_stager(app)
       Dea::Stager.new(app, @config, @message_bus, @dea_pool, @stager_pool, @runners)

--- a/lib/cloud_controller/backends/stagers.rb
+++ b/lib/cloud_controller/backends/stagers.rb
@@ -17,7 +17,7 @@ module VCAP::CloudController
     end
 
     def validate_app(app)
-      if app.docker_image.present? && !FeatureFlag.enabled?('diego_docker')
+      if app.docker_image.present? && FeatureFlag.disabled?('diego_docker')
         raise Errors::ApiError.new_from_details('DockerDisabled')
       end
 

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -223,7 +223,6 @@ module VCAP::CloudController
 
         optional(:dea_advertisement_timeout_in_seconds) => Integer,
 
-        optional(:diego_docker) => bool,
         optional(:diego_stager_url) => String,
         optional(:diego_tps_url) => String,
         optional(:users_can_select_backend) => bool,
@@ -324,7 +323,6 @@ module VCAP::CloudController
         config[:db][:database] ||= ENV['DB_CONNECTION_STRING']
         config[:default_locale] ||= 'en_US'
         config[:allowed_cors_domains] ||= []
-        config[:diego_docker] ||= false
         config[:default_to_diego_backend] ||= false
         config[:dea_advertisement_timeout_in_seconds] ||= 10
         config[:staging][:minimum_staging_memory_mb] ||= 1024

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = '118a92855c96e75e72acd0c8e010f9ffb102f149'
+  API_FOLDER_CHECKSUM = 'e45e0c44e8a14966a19b1708c7ec3fcd6159efb3'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.29.0')

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = 'e45e0c44e8a14966a19b1708c7ec3fcd6159efb3'
+  API_FOLDER_CHECKSUM = '3c338df8b218ac6faefa970f1bf62b5f103ec44d'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.29.0')

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = '3c338df8b218ac6faefa970f1bf62b5f103ec44d'
+  API_FOLDER_CHECKSUM = 'f623da91df095afe16e569dbd415b44e5bce97a1'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.29.0')

--- a/spec/api/documentation/apps_api_spec.rb
+++ b/spec/api/documentation/apps_api_spec.rb
@@ -69,7 +69,6 @@ resource 'Apps', type: [:api, :legacy_api] do
         staging: 'optional',
         running: 'optional',
       )
-      allow(VCAP::CloudController::Config.config).to receive(:[]).with(:diego_docker).and_return true
     end
 
     def after_standard_model_delete(guid)

--- a/spec/api/documentation/feature_flags_api_spec.rb
+++ b/spec/api/documentation/feature_flags_api_spec.rb
@@ -24,7 +24,7 @@ resource 'Feature Flags', type: [:api, :legacy_api] do
       client.get '/v2/config/feature_flags', {}, headers
 
       expect(status).to eq(200)
-      expect(parsed_response.length).to eq(6)
+      expect(parsed_response.length).to eq(7)
       expect(parsed_response).to include(
         {
           'name'          => 'user_org_creation',
@@ -163,6 +163,23 @@ resource 'Feature Flags', type: [:api, :legacy_api] do
           'error_message' => nil,
           'url'           => '/v2/config/feature_flags/service_instance_creation'
         })
+    end
+  end
+
+  get '/v2/config/feature_flags/diego_docker' do
+    example 'Get the Diego Docker feature flag' do
+      explanation '''When enabled, Docker applications are supported by Diego. When disabled, Docker applications will stop running.
+                     It will still be possible to stop them, delete them and manipulate their configuration such as routes, instances, services, resources, etc.'''
+      client.get '/v2/config/feature_flags/diego_docker', {}, headers
+
+      expect(status).to eq(200)
+      expect(parsed_response).to eq(
+                                   {
+                                     'name'          => 'diego_docker',
+                                     'enabled'       => false,
+                                     'error_message' => nil,
+                                     'url'           => '/v2/config/feature_flags/diego_docker'
+                                   })
     end
   end
 

--- a/spec/api/documentation/feature_flags_api_spec.rb
+++ b/spec/api/documentation/feature_flags_api_spec.rb
@@ -169,7 +169,7 @@ resource 'Feature Flags', type: [:api, :legacy_api] do
   get '/v2/config/feature_flags/diego_docker' do
     example 'Get the Diego Docker feature flag' do
       explanation '''When enabled, Docker applications are supported by Diego. When disabled, Docker applications will stop running.
-                     It will still be possible to stop them, delete them and manipulate their configuration such as routes, instances, services, resources, etc.'''
+                     It will still be possible to stop and delete them and update their configurations.'''
       client.get '/v2/config/feature_flags/diego_docker', {}, headers
 
       expect(status).to eq(200)

--- a/spec/fixtures/config/default_overriding_config.yml
+++ b/spec/fixtures/config/default_overriding_config.yml
@@ -147,7 +147,6 @@ allowed_cors_domains:
 - http://sharon.corr
 
 users_can_select_backend: false
-diego_docker: true
 default_to_diego_backend: true
 allow_app_ssh_access: true
 

--- a/spec/unit/controllers/internal/bulk_apps_controller_spec.rb
+++ b/spec/unit/controllers/internal/bulk_apps_controller_spec.rb
@@ -200,7 +200,7 @@ module VCAP::CloudController
             get '/internal/bulk/apps', {
                                          'batch_size' => App.count,
                                          'token' => '{}',
-                                     }
+                                       }
 
             expect(last_response.status).to eq(200)
             expect(decoded_response['apps'].size).to eq(App.count - 1)
@@ -208,18 +208,21 @@ module VCAP::CloudController
         end
 
         context 'when docker is enabled' do
+          let(:space) { Space.make }
+          let!(:docker_app) do
+            FeatureFlag.create(name: 'diego_docker', enabled: true)
+            make_diego_app(docker_image: 'some-image', state: 'STARTED')
+          end
+
           before do
-            TestConfig.override(diego_docker: true, diego: { staging: 'optional', running: 'optional' })
+            TestConfig.override(diego: { staging: 'optional', running: 'optional' })
           end
 
           it 'does return docker apps' do
-            app = make_diego_app(state: 'STARTED', docker_image: 'fake-docker-image')
-            app.save
-
             get '/internal/bulk/apps', {
                                          'batch_size' => App.count,
                                          'token' => '{}',
-                                     }
+                                       }
 
             expect(last_response.status).to eq(200)
             expect(decoded_response['apps'].size).to eq(App.count)
@@ -232,7 +235,7 @@ module VCAP::CloudController
               get '/internal/bulk/apps', {
                                            'batch_size' => size,
                                            'token' => { id: 0 }.to_json,
-                                       }
+                                         }
 
               expect(last_response.status).to eq(200)
               expect(decoded_response['apps'].size).to eq(size)
@@ -243,7 +246,7 @@ module VCAP::CloudController
             get '/internal/bulk/apps', {
                                          'batch_size' => 2,
                                          'token' => { id: 0 }.to_json,
-                                     }
+                                       }
 
             expect(last_response.status).to eq(200)
 
@@ -253,7 +256,7 @@ module VCAP::CloudController
             get '/internal/bulk/apps', {
                                          'batch_size' => 2,
                                          'token' => MultiJson.dump(decoded_response['token']),
-                                     }
+                                       }
 
             expect(last_response.status).to eq(200)
 

--- a/spec/unit/controllers/internal/bulk_apps_controller_spec.rb
+++ b/spec/unit/controllers/internal/bulk_apps_controller_spec.rb
@@ -209,12 +209,12 @@ module VCAP::CloudController
 
         context 'when docker is enabled' do
           let(:space) { Space.make }
-          let!(:docker_app) do
-            FeatureFlag.create(name: 'diego_docker', enabled: true)
+          let(:docker_app) do
             make_diego_app(docker_image: 'some-image', state: 'STARTED')
           end
 
           before do
+            FeatureFlag.create(name: 'diego_docker', enabled: true)
             TestConfig.override(diego: { staging: 'optional', running: 'optional' })
           end
 

--- a/spec/unit/controllers/runtime/apps_controller_spec.rb
+++ b/spec/unit/controllers/runtime/apps_controller_spec.rb
@@ -791,6 +791,53 @@ module VCAP::CloudController
         expect(last_response.status).to eq(201)
       end
 
+      context 'with Docker app' do
+        let(:route) { domain.add_route(host: 'app', space: space) }
+        let(:pre_mapped_route) { domain.add_route(host: 'pre_mapped_route', space: space) }
+        let(:docker_app) do
+          FeatureFlag.create(name: 'diego_docker', enabled: true)
+          AppFactory.make(
+            space: space,
+            state: 'STARTED',
+            package_hash: 'abc',
+            droplet_hash: 'def',
+            package_state: 'STAGED',
+            diego: true,
+            docker_image: 'some-image',
+          )
+        end
+
+        before do
+          put "/v2/apps/#{docker_app.guid}/routes/#{pre_mapped_route.guid}", {}, json_headers(@headers_for_user)
+        end
+
+        context 'when Docker is disabled' do
+          before do
+            FeatureFlag.find(name: 'diego_docker').update(enabled: false)
+          end
+
+          context 'and a route is mapped' do
+            before do
+              put "/v2/apps/#{docker_app.guid}/routes/#{route.guid}", nil, json_headers(@headers_for_user)
+            end
+
+            it 'succeeds' do
+              expect(last_response.status).to eq(201)
+            end
+          end
+
+          context 'and a previously mapped route is unmapped' do
+            before do
+              delete "/v2/apps/#{docker_app.guid}/routes/#{pre_mapped_route.guid}", nil, json_headers(@headers_for_user)
+            end
+
+            it 'succeeds' do
+              expect(last_response.status).to eq(201)
+            end
+          end
+        end
+      end
+
       it 'tells the dea client to update when we remove a url through PUT /v2/apps/:guid' do
         bar_route = @app.add_route(
           host: 'bar',
@@ -814,6 +861,41 @@ module VCAP::CloudController
         put @app_url, MultiJson.dump({ route_guids: [route.guid] }), json_headers(@headers_for_user)
 
         expect(last_response.status).to eq(201)
+      end
+    end
+
+    describe 'on instance number change' do
+      context 'when docker is disabled' do
+        let(:space) { Space.make }
+        let(:stopped_app) { App.make(space: space, state: 'STOPPED', package_hash: 'made-up-package-hash', docker_image: 'docker-image') }
+        let!(:started_app) do
+          FeatureFlag.create(name: 'diego_docker', enabled: true)
+          App.make(space: space, state: 'STARTED', package_hash: 'made-up-package-hash', docker_image: 'docker-image')
+        end
+
+        before do
+          FeatureFlag.find(name: 'diego_docker').update(enabled: false)
+        end
+
+        it 'does not return docker disabled message on instance change' do
+          put "/v2/apps/#{started_app.guid}", MultiJson.dump(instances: 2), json_headers(admin_headers)
+
+          expect(last_response.status).to eq(201)
+        end
+
+        it 'returns docker disabled message on start' do
+          put "/v2/apps/#{stopped_app.guid}", MultiJson.dump(state: 'STARTED'), json_headers(admin_headers)
+
+          expect(last_response.status).to eq(400)
+          expect(last_response.body).to match /Docker support has not been enabled/
+          expect(decoded_response['code']).to eq(320003)
+        end
+
+        it 'does not return docker disabled message on stop' do
+          put "/v2/apps/#{started_app.guid}", MultiJson.dump(state: 'STOPPED'), json_headers(admin_headers)
+
+          expect(last_response.status).to eq(201)
+        end
       end
     end
 

--- a/spec/unit/controllers/runtime/restages_controller_spec.rb
+++ b/spec/unit/controllers/runtime/restages_controller_spec.rb
@@ -54,28 +54,35 @@ module VCAP::CloudController
           end
         end
 
-        context 'when there are validation error' do
-          let!(:application) do
+        context 'with a Docker app' do
+          before do
             FeatureFlag.create(name: 'diego_docker', enabled: true)
+          end
+
+          let!(:docker_app) do
             AppFactory.make(package_hash: 'abc', docker_image: 'some_image', state: 'STARTED')
           end
 
-          before do
-            allow_any_instance_of(VCAP::CloudController::RestagesController).to receive(:find_guid_and_validate_access).with(:read, application.guid).and_return(application)
-            allow(application).to receive(:package_state).and_return('STAGED')
-          end
+          subject(:restage_request) { post("/v2/apps/#{docker_app.guid}/restage", {}, headers_for(account)) }
 
-          context 'when Docker is disabled' do
+          context 'when there are validation errors' do
             before do
-              FeatureFlag.find(name: 'diego_docker').update(enabled: false)
+              allow_any_instance_of(VCAP::CloudController::RestagesController).to receive(:find_guid_and_validate_access).with(:read, docker_app.guid).and_return(docker_app)
+              allow(docker_app).to receive(:package_state).and_return('STAGED')
             end
 
-            it 'correctly propagates the error' do
-              restage_request
+            context 'when Docker is disabled' do
+              before do
+                FeatureFlag.find(name: 'diego_docker').update(enabled: false)
+              end
 
-              expect(last_response.status).to eq(400)
-              expect(decoded_response['code']).to eq(320003)
-              expect(decoded_response['description']).to match(/Docker support has not been enabled./)
+              it 'correctly propagates the error' do
+                restage_request
+
+                expect(last_response.status).to eq(400)
+                expect(decoded_response['code']).to eq(320003)
+                expect(decoded_response['description']).to match(/Docker support has not been enabled./)
+              end
             end
           end
         end

--- a/spec/unit/controllers/runtime/restages_controller_spec.rb
+++ b/spec/unit/controllers/runtime/restages_controller_spec.rb
@@ -54,6 +54,32 @@ module VCAP::CloudController
           end
         end
 
+        context 'when there are validation error' do
+          let!(:application) do
+            FeatureFlag.create(name: 'diego_docker', enabled: true)
+            AppFactory.make(package_hash: 'abc', docker_image: 'some_image', state: 'STARTED')
+          end
+
+          before do
+            allow_any_instance_of(VCAP::CloudController::RestagesController).to receive(:find_guid_and_validate_access).with(:read, application.guid).and_return(application)
+            allow(application).to receive(:package_state).and_return('STAGED')
+          end
+
+          context 'when Docker is disabled' do
+            before do
+              FeatureFlag.find(name: 'diego_docker').update(enabled: false)
+            end
+
+            it 'correctly propagates the error' do
+              restage_request
+
+              expect(last_response.status).to eq(400)
+              expect(decoded_response['code']).to eq(320003)
+              expect(decoded_response['description']).to match(/Docker support has not been enabled./)
+            end
+          end
+        end
+
         describe 'events' do
           before do
             allow(app_event_repository).to receive(:record_app_restage).and_call_original

--- a/spec/unit/controllers/runtime/routes_controller_spec.rb
+++ b/spec/unit/controllers/runtime/routes_controller_spec.rb
@@ -209,6 +209,29 @@ module VCAP::CloudController
       it do
         expect(described_class).to have_nested_routes({ apps: [:get, :put, :delete] })
       end
+
+      context 'with Docker app' do
+        let(:organization) { Organization.make }
+        let(:domain) { PrivateDomain.make(owning_organization: organization) }
+        let(:space) { Space.make(organization: organization) }
+        let(:route) { Route.make(domain: domain, space: space) }
+        let!(:docker_app) do
+          FeatureFlag.create(name: 'diego_docker', enabled: true)
+          AppFactory.make(space: space, docker_image: 'some-image', state: 'STARTED')
+        end
+
+        context 'and Docker disabled' do
+          before do
+            FeatureFlag.find(name: 'diego_docker').update(enabled: false)
+          end
+
+          it 'associates the route with the app' do
+            put "/v2/routes/#{route.guid}/apps/#{docker_app.guid}", MultiJson.dump(guid: route.guid), json_headers(admin_headers)
+
+            expect(last_response.status).to eq(201)
+          end
+        end
+      end
     end
 
     describe 'POST /v2/routes' do

--- a/spec/unit/controllers/runtime/routes_controller_spec.rb
+++ b/spec/unit/controllers/runtime/routes_controller_spec.rb
@@ -211,12 +211,15 @@ module VCAP::CloudController
       end
 
       context 'with Docker app' do
+        before do
+          FeatureFlag.create(name: 'diego_docker', enabled: true)
+        end
+
         let(:organization) { Organization.make }
         let(:domain) { PrivateDomain.make(owning_organization: organization) }
         let(:space) { Space.make(organization: organization) }
         let(:route) { Route.make(domain: domain, space: space) }
         let!(:docker_app) do
-          FeatureFlag.create(name: 'diego_docker', enabled: true)
           AppFactory.make(space: space, docker_image: 'some-image', state: 'STARTED')
         end
 

--- a/spec/unit/lib/cloud_controller/backends/runners_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends/runners_spec.rb
@@ -432,8 +432,11 @@ module VCAP::CloudController
       end
 
       context 'with Docker app' do
-        let!(:docker_app) do
+        before do
           FeatureFlag.create(name: 'diego_docker', enabled: true)
+        end
+
+        let!(:docker_app) do
           make_diego_app(docker_image: 'some-image', state: 'STARTED')
         end
 

--- a/spec/unit/lib/cloud_controller/backends/runners_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends/runners_spec.rb
@@ -5,7 +5,6 @@ module VCAP::CloudController
   describe Runners do
     let(:config) do
       {
-          diego_docker: true,
           staging: {
               timeout_in_seconds: 90
           }
@@ -429,7 +428,40 @@ module VCAP::CloudController
       it 'acquires the data in one select' do
         expect {
           runners.diego_apps_cache_data(100, 0)
-        }.to have_queried_db_times(/SELECT/, 1)
+        }.to have_queried_db_times(/SELECT.*FROM.*apps.*/, 1)
+      end
+
+      context 'with Docker app' do
+        let!(:docker_app) do
+          FeatureFlag.create(name: 'diego_docker', enabled: true)
+          make_diego_app(docker_image: 'some-image', state: 'STARTED')
+        end
+
+        context 'when docker is enabled' do
+          before do
+            FeatureFlag.find(name: 'diego_docker').update(enabled: true)
+          end
+
+          it 'returns docker apps' do
+            batch = runners.diego_apps_cache_data(100, 0)
+            app_ids = batch.map { |data| data[0] }
+
+            expect(app_ids).to include(docker_app.id)
+          end
+        end
+
+        context 'when docker is disabled' do
+          before do
+            FeatureFlag.find(name: 'diego_docker').update(enabled: false)
+          end
+
+          it 'does not return docker apps' do
+            batch = runners.diego_apps_cache_data(100, 0)
+            app_ids = batch.map { |data| data[0] }
+
+            expect(app_ids).not_to include(docker_app.id)
+          end
+        end
       end
     end
 

--- a/spec/unit/lib/cloud_controller/backends/stagers_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends/stagers_spec.rb
@@ -81,20 +81,31 @@ module VCAP::CloudController
         end
       end
 
-      context 'if diego docker support is not enabled' do
-        before do
-          config[:diego_docker] = false
+      context 'with a docker app' do
+        let(:buildpack)    { instance_double(AutoDetectionBuildpack, custom?: true) }
+        let(:docker_image) do
+          'fake-docker-image'
         end
 
-        context 'and the app has a docker_image' do
-          let(:docker_image) do
-            'fake-docker-image'
+        context 'and Docker disabled' do
+          before do
+            FeatureFlag.create(name: 'diego_docker', enabled: false)
           end
 
           it 'raises' do
             expect {
               subject.validate_app(app)
             }.to raise_error(Errors::ApiError, /Docker support has not been enabled/)
+          end
+        end
+
+        context 'and Docker enabled' do
+          before do
+            FeatureFlag.create(name: 'diego_docker', enabled: true)
+          end
+
+          it 'does not raise' do
+            expect { subject.validate_app(app) }.not_to raise_error
           end
         end
       end

--- a/spec/unit/lib/cloud_controller/config_spec.rb
+++ b/spec/unit/lib/cloud_controller/config_spec.rb
@@ -51,10 +51,6 @@ module VCAP::CloudController
           expect(config[:allowed_cors_domains]).to eq([])
         end
 
-        it 'disables docker images on diego' do
-          expect(config[:diego_docker]).to eq(false)
-        end
-
         it 'allows users to select the backend for their apps' do
           expect(config[:users_can_select_backend]).to eq(true)
         end
@@ -154,10 +150,6 @@ module VCAP::CloudController
 
           it 'preserves the backend selection configuration from the file' do
             expect(config[:users_can_select_backend]).to eq(false)
-          end
-
-          it 'preserves the diego configuration from the file' do
-            expect(config[:diego_docker]).to eq(true)
           end
 
           it 'runs apps on diego' do

--- a/spec/unit/lib/cloud_controller/diego/docker/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/protocol_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
     module Docker
       describe Protocol do
         before do
-          TestConfig.override(diego_docker: true)
+          FeatureFlag.create(name: 'diego_docker', enabled: true)
         end
 
         let(:default_health_check_timeout) { 9999 }

--- a/spec/unit/lib/cloud_controller/diego/docker/staging_completion_handler_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/staging_completion_handler_spec.rb
@@ -121,6 +121,10 @@ module VCAP::CloudController
             end
             let(:droplet) { app.reload.current_droplet }
 
+            before do
+              FeatureFlag.create(name: 'diego_docker', enabled: true)
+            end
+
             context 'when image was cached' do
               let(:app) { AppFactory.make(staging_task_id: 'fake-staging-task-id', docker_image: 'user_provided') }
 

--- a/spec/unit/models/runtime/app_spec.rb
+++ b/spec/unit/models/runtime/app_spec.rb
@@ -66,6 +66,39 @@ module VCAP::CloudController
       it { is_expected.to have_associated :space }
       it { is_expected.to have_associated :stack }
       it { is_expected.to have_associated :routes, associated_instance: ->(app) { Route.make(space: app.space) } }
+
+      context 'with Docker app' do
+        let!(:docker_app) do
+          FeatureFlag.create(name: 'diego_docker', enabled: true)
+          AppFactory.make(space: space, docker_image: 'some-image', state: 'STARTED')
+        end
+
+        context 'and Docker disabled' do
+          before do
+            FeatureFlag.find(name: 'diego_docker').update(enabled: false)
+          end
+
+          it 'should associate an app with a route' do
+            expect { docker_app.add_route(route) }.not_to raise_error
+          end
+        end
+      end
+
+      context 'with non-docker app' do
+        let(:non_docker_app) do
+          AppFactory.make(space: space)
+        end
+
+        context 'and Docker disabled' do
+          before do
+            FeatureFlag.create(name: 'diego_docker', enabled: false)
+          end
+
+          it 'should associate an app with a route' do
+            expect { non_docker_app.add_route(route) }.not_to raise_error
+          end
+        end
+      end
     end
 
     describe 'Validations' do

--- a/spec/unit/models/runtime/app_spec.rb
+++ b/spec/unit/models/runtime/app_spec.rb
@@ -68,8 +68,11 @@ module VCAP::CloudController
       it { is_expected.to have_associated :routes, associated_instance: ->(app) { Route.make(space: app.space) } }
 
       context 'with Docker app' do
-        let!(:docker_app) do
+        before do
           FeatureFlag.create(name: 'diego_docker', enabled: true)
+        end
+
+        let!(:docker_app) do
           AppFactory.make(space: space, docker_image: 'some-image', state: 'STARTED')
         end
 

--- a/spec/unit/models/runtime/constraints/docker_policy_spec.rb
+++ b/spec/unit/models/runtime/constraints/docker_policy_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe DockerPolicy do
+  let(:app) { VCAP::CloudController::AppFactory.make }
+
+  subject(:validator) { DockerPolicy.new(app) }
+
+  before do
+    allow(app).to receive(:docker_image).and_return('some-image:latest')
+  end
+
+  context 'when a buildpack is specified' do
+    before do
+      allow(app).to receive(:buildpack_specified?).and_return(true)
+    end
+
+    it 'registers an appropriate error' do
+      expect(validator).to validate_with_error(app, :docker_image, DockerPolicy::BUILDPACK_DETECTED_ERROR_MSG)
+    end
+  end
+
+  context 'when Docker is disabled' do
+    before do
+      VCAP::CloudController::FeatureFlag.create(name: 'diego_docker', enabled: false)
+    end
+
+    context 'when app is being started' do
+      before do
+        allow(app).to receive(:being_started?).and_return(true)
+      end
+
+      it 'registers an appropriate error' do
+        expect(validator).to validate_with_error(app, :docker, :docker_disabled)
+      end
+    end
+
+    context 'when app is being stopped' do
+      before do
+        allow(app).to receive(:being_started?).and_return(false)
+      end
+
+      it 'does not register an error' do
+        expect(validator).to validate_without_error(app)
+      end
+    end
+  end
+
+  context 'when Docker is enabled' do
+    before do
+      VCAP::CloudController::FeatureFlag.create(name: 'diego_docker', enabled: true)
+    end
+
+    it 'does not register an error' do
+      expect(validator).to validate_without_error(app)
+    end
+  end
+
+  context 'when complete set of Docker credentials is supplied' do
+    before do
+      allow(app).to receive(:docker_credentials_json).and_return({ 'docker_user' => 'user', 'docker_password' => 'pass', 'docker_email' => 'someone@somewhere.com' })
+    end
+
+    it 'does not register an error' do
+      expect(validator).to validate_without_error(app)
+    end
+  end
+
+  context 'when an incomplete set of Docker credentials is supplied' do
+    before do
+      allow(app).to receive(:docker_credentials_json).and_return({ 'docker_email' => 'someone@somewhere.com' })
+    end
+
+    it 'does not register an error' do
+      expect(validator).to validate_with_error(app, :docker_credentials, DockerPolicy::DOCKER_CREDENTIALS_ERROR_MSG)
+    end
+  end
+end

--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 module VCAP::CloudController
   describe FeatureFlag, type: :model do
-    let(:valid_flags) { [:user_org_creation, :private_domain_creation, :app_bits_upload, :app_scaling, :route_creation, :service_instance_creation] }
+    let(:valid_flags) { [:user_org_creation, :private_domain_creation, :app_bits_upload, :app_scaling, :route_creation, :service_instance_creation, :diego_docker] }
     let(:feature_flag) { FeatureFlag.make }
 
     it { is_expected.to have_timestamp_columns }

--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -100,12 +100,14 @@ module VCAP::CloudController
 
         it 'should return the override value' do
           expect(FeatureFlag.enabled?(key)).to eq(!default_value)
+          expect(FeatureFlag.disabled?(key)).to eq(default_value)
         end
       end
 
       context 'when the feature flag is not overridden' do
         it 'should return the default value' do
           expect(FeatureFlag.enabled?(key)).to eq(default_value)
+          expect(FeatureFlag.disabled?(key)).to_not eq(default_value)
         end
       end
 
@@ -113,6 +115,9 @@ module VCAP::CloudController
         it 'blows up somehow' do
           expect {
             FeatureFlag.enabled?('bogus_feature_flag')
+          }.to raise_error(FeatureFlag::UndefinedFeatureFlagError, /bogus_feature_flag/)
+          expect {
+            FeatureFlag.disabled?('bogus_feature_flag')
           }.to raise_error(FeatureFlag::UndefinedFeatureFlagError, /bogus_feature_flag/)
         end
       end

--- a/spec/unit/models/runtime/route_spec.rb
+++ b/spec/unit/models/runtime/route_spec.rb
@@ -448,6 +448,25 @@ module VCAP::CloudController
           )
         }.to raise_error Sequel::ValidationFailed
       end
+
+      context 'when docker is disabled' do
+        subject(:route) { Route.make(space: space_a, domain: domain_a) }
+
+        context 'when docker app is added to a route' do
+          let!(:docker_app) do
+            FeatureFlag.create(name: 'diego_docker', enabled: true)
+            AppFactory.make(space: space_a, docker_image: 'some-image', state: 'STARTED')
+          end
+
+          before do
+            FeatureFlag.find(name: 'diego_docker').update(enabled: false)
+          end
+
+          it 'should associate with the docker app' do
+            expect { route.add_app(docker_app) }.not_to raise_error
+          end
+        end
+      end
     end
 
     describe '#destroy' do

--- a/spec/unit/models/runtime/route_spec.rb
+++ b/spec/unit/models/runtime/route_spec.rb
@@ -453,8 +453,11 @@ module VCAP::CloudController
         subject(:route) { Route.make(space: space_a, domain: domain_a) }
 
         context 'when docker app is added to a route' do
-          let!(:docker_app) do
+          before do
             FeatureFlag.create(name: 'diego_docker', enabled: true)
+          end
+
+          let!(:docker_app) do
             AppFactory.make(space: space_a, docker_image: 'some-image', state: 'STARTED')
           end
 


### PR DESCRIPTION
* Add a feature flag for toggling Docker support
* Filter out docker apps from bulk response  when Docker is disabled
* Add validation logic to prevent app stage/start operations
* Do not issue desire app request on routes or instances update for Docker apps  when Docker disabled