### PR TITLE
Enable encryption configuration required for implementing FIPS-compliant encryption.

### DIFF
--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -243,6 +243,7 @@ module VCAP::CloudController
         @config = config
 
         Encryptor.db_encryption_key = config[:db_encryption_key]
+        Encryptor.configure(config)
         AccountCapacity.configure(config)
         ResourcePool.instance = ResourcePool.new(config)
 

--- a/lib/cloud_controller/encryptor.rb
+++ b/lib/cloud_controller/encryptor.rb
@@ -14,7 +14,7 @@ module VCAP::CloudController::Encryptor
     attr_accessor :db_encryption_key
 
     def encryption
-      @@encryption ||= {
+      @encryption ||= {
         fips_mode: FIPS_MODE,
         fips_algorithm: FIPS_ALGORITHM,
         fips_iv_length: FIPS_IV_LENGTH,

--- a/lib/cloud_controller/encryptor.rb
+++ b/lib/cloud_controller/encryptor.rb
@@ -6,6 +6,31 @@ module VCAP::CloudController::Encryptor
   class << self
     ALGORITHM = 'AES-128-CBC'.freeze
 
+    FIPS_MODE = false
+    FIPS_ALGORITHM = 'AES-128-CBC'
+    FIPS_IV_LENGTH = 16
+    FIPS_ITERATIONS = 20000
+
+    attr_accessor :db_encryption_key
+
+    def encryption
+      @@encryption ||= {
+        fips_mode: FIPS_MODE,
+        fips_algorithm: FIPS_ALGORITHM,
+        fips_iv_length: FIPS_IV_LENGTH,
+        fips_iterations: FIPS_ITERATIONS
+      }
+    end
+
+    def configure(config)
+      key = 'encryption'.to_sym
+      return unless config.key?(key)
+      options = send(key)
+      config[key].each do |param, value|
+        options[param.to_sym] = value
+      end
+    end
+
     def generate_salt
       SecureRandom.hex(4).to_s
     end
@@ -19,8 +44,6 @@ module VCAP::CloudController::Encryptor
       return nil unless encrypted_input
       run_cipher(make_cipher.decrypt, Base64.decode64(encrypted_input), salt)
     end
-
-    attr_accessor :db_encryption_key
 
     private
 

--- a/spec/unit/lib/cloud_controller/config_spec.rb
+++ b/spec/unit/lib/cloud_controller/config_spec.rb
@@ -281,6 +281,14 @@ module VCAP::CloudController
         expect(Encryptor.db_encryption_key).to eq('123-456')
       end
 
+      it 'sets up encryption' do
+        Config.configure_components(@test_config.merge(encryption: { fips_mode: true, fips_algorithm: 'BOGUS-ALGO', fips_iterations: 30000, fips_iv_length: 32 }))
+        expect(Encryptor.encryption[:fips_mode]).to be_truthy
+        expect(Encryptor.encryption[:fips_algorithm]).to eq('BOGUS-ALGO')
+        expect(Encryptor.encryption[:fips_iterations]).to eq(30000)
+        expect(Encryptor.encryption[:fips_iv_length]).to eq(32)
+      end
+
       it 'sets up the account capacity' do
         Config.configure_components(@test_config.merge(admin_account_capacity: { memory: 64 * 1024 }))
         expect(AccountCapacity.admin[:memory]).to eq(64 * 1024)


### PR DESCRIPTION
This information is loaded only at this time, not currently used by any other execution path.  The purpose is to make the use of FIPS-compliant encryption configurable when implemented.

From the integration tests in full bundle exec rake:

-- CUT HERE --

  GET /v3/processes/:guid
    * Get a Process
  PATCH /v3/processes/:guid
    * Updating a Process

Finished in 2 minutes 4.8 seconds (files took 39.16 seconds to load)
309 examples, 0 failures

-- CUT HERE --

No test failures reported in any of the suites in full bundle exec rake.  Static analysis with rubocop also reports no violations.
