### PR TITLE
fix API behavior for SpaceManager and SpaceAuditor to receive 403

### DIFF
--- a/app/access/service_key_access.rb
+++ b/app/access/service_key_access.rb
@@ -14,5 +14,11 @@ module VCAP::CloudController
       return true if admin_user?
       service_key.service_instance.space.developers.include?(context.user)
     end
+
+    def index?(_, params=nil)
+      return true if admin_user?
+      return true unless params && params.key?(:related_obj)
+      params[:related_obj].space.developers.include?(context.user)
+    end
   end
 end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2319,14 +2319,14 @@ module VCAP::CloudController
         context 'when the user is not of developer role' do
           it 'return an empty service key list if the user is of space manager role' do
             get "/v2/service_instances/#{instance_a.guid}/service_keys", {}, headers_for(manager)
-            expect(last_response.status).to eql(200)
-            expect(decoded_response.fetch('total_results')).to eq(0)
+            expect(last_response.status).to eql(403)
+            expect(MultiJson.load(last_response.body)['description']).to eq('You are not authorized to perform the requested action')
           end
 
           it 'return an empty service key list if the user is of space auditor role' do
             get "/v2/service_instances/#{instance_a.guid}/service_keys", {}, headers_for(auditor)
-            expect(last_response.status).to eql(200)
-            expect(decoded_response.fetch('total_results')).to eq(0)
+            expect(last_response.status).to eql(403)
+            expect(MultiJson.load(last_response.body)['description']).to eq('You are not authorized to perform the requested action')
           end
         end
 


### PR DESCRIPTION
this PR is to fix the bug of both SpaceManager and SpaceAuditor should
receive 403 when list keys for a service instance, not 0 results.

[#87481016]

Signed-off-by: Hua Zhang <zhuadl@cn.ibm.com>