### PR TITLE
Filter stopped and unstaged on hm9k bulk endpoint

### DIFF
--- a/lib/cloud_controller/backends/runners.rb
+++ b/lib/cloud_controller/backends/runners.rb
@@ -87,6 +87,8 @@ module VCAP::CloudController
         where('deleted_at IS NULL').
         order(:id).
         where(diego: false).
+        where(state: 'STARTED').
+        exclude(package_state: 'FAILED').
         limit(batch_size).
         select_map([:id, :guid, :instances, :state, :memory, :package_state, :version, :created_at, :updated_at])
 

--- a/spec/unit/controllers/runtime/legacy_bulk_spec.rb
+++ b/spec/unit/controllers/runtime/legacy_bulk_spec.rb
@@ -32,7 +32,7 @@ module VCAP::CloudController
     end
 
     describe 'GET', '/bulk/apps' do
-      before { 5.times { AppFactory.make } }
+      before { 5.times { AppFactory.make(state: 'STARTED', package_state: 'STAGED') } }
 
       it 'requires authentication' do
         get '/bulk/apps'
@@ -141,7 +141,7 @@ module VCAP::CloudController
         end
 
         it 'does not include diego apps' do
-          app = AppFactory.make(diego: true)
+          app = AppFactory.make(state: 'STARTED', package_state: 'STAGED', diego: true)
 
           get '/bulk/apps', {
                               'batch_size' => 20,

--- a/spec/unit/lib/cloud_controller/backends/runners_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends/runners_spec.rb
@@ -551,6 +551,33 @@ module VCAP::CloudController
 
         expect(batch).not_to include(deleted_app)
       end
+
+      it 'does not return stopped apps' do
+        stopped_app = make_dea_app(id: 6, state: 'STOPPED')
+
+        batch, _ = runners.dea_apps_hm9k(100, 0)
+
+        guids = batch.map { |entry| entry['id'] }
+        expect(guids).not_to include(stopped_app.guid)
+      end
+
+      it 'does not return apps that failed to stage' do
+        staging_failed_app = AppFactory.make(id: 6, state: 'STARTED', package_state: 'FAILED')
+
+        batch, _ = runners.dea_apps_hm9k(100, 0)
+
+        guids = batch.map { |entry| entry['id'] }
+        expect(guids).not_to include(staging_failed_app.guid)
+      end
+
+      it 'returns apps that have not yet been staged' do
+        staging_pending_app = AppFactory.make(id: 6, state: 'STARTED', package_state: 'PENDING')
+
+        batch, _ = runners.dea_apps_hm9k(100, 0)
+
+        guids = batch.map { |entry| entry['id'] }
+        expect(guids).to include(staging_pending_app.guid)
+      end
     end
   end
 end


### PR DESCRIPTION
The health manager only cares about apps that are started and with a package state of STAGED or PENDING so don't bother returning STOPPED apps or apps that have failed to stage them from CC. This reduces the amount of data coming back from the CC when the fetcher runs.

The hm9k filtering can be seen [here](https://github.com/cloudfoundry/hm9000/blob/2b8ae84685cd36c613ce8e5a80b66d97db97b8f3/desiredstatefetcher/desired_state_fetcher.go#L162).