### PR TITLE
Service binding validation should assert syslog_drain_url is empty

### DIFF
--- a/lib/services/service_brokers/v2/response_parser.rb
+++ b/lib/services/service_brokers/v2/response_parser.rb
@@ -213,7 +213,7 @@ module VCAP::Services
           def validate(method:, uri:, code:, response:)
             service = VCAP::CloudController::Service.first(guid: @service_guid)
             parsed_response = MultiJson.load(response.body)
-            if parsed_response.key?('syslog_drain_url') && !service.requires.include?('syslog_drain')
+            if !parsed_response['syslog_drain_url'].nil? && !service.requires.include?('syslog_drain')
               raise Errors::ServiceBrokerInvalidSyslogDrainUrl.new(uri, method, response)
             end
             @validator.validate(method: method, uri: uri, code: code, response: response)


### PR DESCRIPTION
Service binding validation should assert syslog_drain_url is empty rather than whether it's present or not.

Many service brokers (noteably the ones using https://github.com/cloudfoundry-community/spring-boot-cf-service-broker will error out at service binding time because they return a null value for syslog_drain_url.

[#101927804]