### PR TITLE
Added new events table index on timestamp and id.

### DIFF
--- a/db/migrations/20150825075900_add_events_index.rb
+++ b/db/migrations/20150825075900_add_events_index.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  up do
+    add_index :events, [:timestamp, :id]
+    drop_index :events, :timestamp
+  end
+
+  down do
+    add_index :events, :timestamp
+    drop_index :events, [:timestamp, :id]
+  end
+end


### PR DESCRIPTION
removed timestamp only index as now it is not required.

Cloud controller now added "id" to the order by in /v2/events we need to update the index so that queries on large tables do not do a seq scan and offline disk sort.  Now it will use the index to get the sorted results.