### PR TITLE
Cache buildpack information

### DIFF
--- a/app/controllers/internal/listbuildpacks_controller.rb
+++ b/app/controllers/internal/listbuildpacks_controller.rb
@@ -1,0 +1,21 @@
+module VCAP::CloudController
+  class ListBuildpacksController < RestController::BaseController
+    # Endpoint does its own (non-standard) auth
+    allow_unauthenticated_access
+
+    def initialize(*)
+      super
+      auth = Rack::Auth::Basic::Request.new(env)
+      unless auth.provided? && auth.basic? && auth.credentials == InternalApi.credentials
+        raise Errors::ApiError.new_from_details('NotAuthenticated')
+      end
+    end
+
+    get '/internal/buildpacks', :list
+    def list
+      dependency_locator = CloudController::DependencyLocator.instance
+      buildpacks_presenter = dependency_locator.buildpacks_presenter
+      [HTTP::OK, MultiJson.dump(buildpacks_presenter.to_staging_message_array)]
+    end
+  end
+end

--- a/lib/cloud_controller/admin_buildpacks_presenter.rb
+++ b/lib/cloud_controller/admin_buildpacks_presenter.rb
@@ -1,20 +1,37 @@
 module VCAP::CloudController
   class AdminBuildpacksPresenter
-    def initialize(blobstore_url_generator)
+    def initialize(blobstore_url_generator, buildpack_blobstore)
       @blobstore_url_generator = blobstore_url_generator
+      @buildpack_blobstore = buildpack_blobstore
+      @blobcache = {}
     end
 
     def to_staging_message_array
-      Buildpack.list_admin_buildpacks.
-        select(&:enabled).
-        collect { |buildpack| admin_buildpack_entry(buildpack) }.
-        select { |entry| entry[:url] }
+      buildpacks = Buildpack.list_admin_buildpacks.
+        select(&:enabled)
+
+      new_cache = {}
+      entries = buildpacks.inject([]) do |array, buildpack|
+        entry = admin_buildpack_entry(buildpack)
+        if entry[:blob]
+          new_cache[buildpack.key] = entry
+          array << {
+            key: buildpack.key,
+            url: @blobstore_url_generator.admin_buildpack_blob_download_url(entry[:blob], entry[:guid])
+          }
+        end
+        array
+      end
+      @blobcache = new_cache
+      entries
     end
 
+    private
+
     def admin_buildpack_entry(buildpack)
-      {
-        key: buildpack.key,
-        url: @blobstore_url_generator.admin_buildpack_download_url(buildpack)
+      @blobcache[buildpack.key] || {
+        guid: buildpack.guid,
+        blob: @buildpack_blobstore.blob(buildpack.key)
       }
     end
   end

--- a/lib/cloud_controller/blobstore/url_generator.rb
+++ b/lib/cloud_controller/blobstore/url_generator.rb
@@ -30,6 +30,10 @@ module CloudController
         generate_download_url(@admin_buildpack_blobstore, "/v2/buildpacks/#{buildpack.guid}/download", buildpack.key)
       end
 
+      def admin_buildpack_blob_download_url(buildpack_blob, buildpack_guid)
+        generate_download_url(@admin_buildpack_blobstore, "/v2/buildpacks/#{buildpack_guid}/download", buildpack_guid, buildpack_blob)
+      end
+
       def droplet_download_url(app)
         droplet = app.current_droplet
         return nil unless droplet
@@ -78,8 +82,8 @@ module CloudController
 
       private
 
-      def generate_download_url(store, path, blobstore_key)
-        uri = store.download_uri(blobstore_key)
+      def generate_download_url(store, path, blobstore_key, blob=nil)
+        uri = blob ? blob.download_url : store.download_uri(blobstore_key)
         return nil unless uri
         store.local? ? staging_uri(path) : uri
       end

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -279,8 +279,7 @@ module VCAP::CloudController
         dependency_locator.register(:upload_handler, UploadHandler.new(config))
         dependency_locator.register(:app_event_repository, Repositories::Runtime::AppEventRepository.new)
 
-        blobstore_url_generator = dependency_locator.blobstore_url_generator
-        stager_pool = Dea::StagerPool.new(@config, message_bus, blobstore_url_generator)
+        stager_pool = Dea::StagerPool.new(@config, message_bus, dependency_locator.buildpacks_presenter)
         dea_pool = Dea::Pool.new(@config, message_bus)
         runners = Runners.new(@config, message_bus, dea_pool, stager_pool)
         stagers = Stagers.new(@config, message_bus, dea_pool, stager_pool, runners)
@@ -290,6 +289,7 @@ module VCAP::CloudController
         dependency_locator.register(:instances_reporters, InstancesReporters.new(tps_client, hm_client))
         dependency_locator.register(:index_stopper, IndexStopper.new(runners))
 
+        blobstore_url_generator = dependency_locator.blobstore_url_generator
         Dea::Client.configure(@config, message_bus, dea_pool, stager_pool, blobstore_url_generator)
 
         AppObserver.configure(stagers, runners)

--- a/lib/cloud_controller/dea/app_stager_task.rb
+++ b/lib/cloud_controller/dea/app_stager_task.rb
@@ -8,13 +8,14 @@ module VCAP::CloudController
       attr_reader :config
       attr_reader :message_bus
 
-      def initialize(config, message_bus, app, dea_pool, stager_pool, blobstore_url_generator)
+      def initialize(config, message_bus, app, dea_pool, stager_pool, blobstore_url_generator, buildpack_blobstore)
         @config = config
         @message_bus = message_bus
         @app = app
         @dea_pool = dea_pool
         @stager_pool = stager_pool
         @blobstore_url_generator = blobstore_url_generator
+        @buildpack_blobstore = buildpack_blobstore
       end
 
       def task_id
@@ -65,7 +66,7 @@ module VCAP::CloudController
 
       # We never stage if there is not a start request
       def staging_request
-        StagingMessage.new(@config, @blobstore_url_generator).staging_request(@app, task_id)
+        StagingMessage.new(@config, @blobstore_url_generator, @buildpack_blobstore).staging_request(@app, task_id)
       end
 
       private

--- a/lib/cloud_controller/dea/stager.rb
+++ b/lib/cloud_controller/dea/stager.rb
@@ -12,7 +12,8 @@ module VCAP::CloudController
 
       def stage
         blobstore_url_generator = CloudController::DependencyLocator.instance.blobstore_url_generator
-        task = AppStagerTask.new(@config, @message_bus, @app, @dea_pool, @stager_pool, blobstore_url_generator)
+        buildpack_blobstore = CloudController::DependencyLocator.instance.buildpack_blobstore
+        task = AppStagerTask.new(@config, @message_bus, @app, @dea_pool, @stager_pool, blobstore_url_generator, buildpack_blobstore)
 
         @app.last_stager_response = task.stage do |staging_result|
           @runners.runner_for_app(@app).start(staging_result)

--- a/lib/cloud_controller/dea/stager_pool.rb
+++ b/lib/cloud_controller/dea/stager_pool.rb
@@ -5,12 +5,12 @@ module VCAP::CloudController
     class StagerPool
       attr_reader :config, :message_bus
 
-      def initialize(config, message_bus, blobstore_url_generator)
+      def initialize(config, message_bus, buildpacks_presenter)
         @advertise_timeout = config[:dea_advertisement_timeout_in_seconds]
         @percentage_of_top_stagers = (config[:placement_top_stager_percentage] || 0) / 100.0
         @message_bus = message_bus
         @stager_advertisements = []
-        @blobstore_url_generator = blobstore_url_generator
+        @buildpacks_presenter = buildpacks_presenter
         register_subscriptions
       end
 
@@ -51,7 +51,7 @@ module VCAP::CloudController
       end
 
       def admin_buildpacks
-        AdminBuildpacksPresenter.new(@blobstore_url_generator).to_staging_message_array
+        @buildpacks_presenter.to_staging_message_array
       end
 
       def validate_stack_availability(stack)

--- a/lib/cloud_controller/dea/stager_pool.rb
+++ b/lib/cloud_controller/dea/stager_pool.rb
@@ -16,7 +16,6 @@ module VCAP::CloudController
 
       def process_advertise_message(msg)
         advertisement = NatsMessages::StagerAdvertisement.new(msg, Time.now.utc.to_i + @advertise_timeout)
-        publish_buildpacks unless stager_in_pool?(advertisement.stager_id)
 
         mutex.synchronize do
           remove_advertisement_for_id(advertisement.stager_id)
@@ -44,10 +43,6 @@ module VCAP::CloudController
         message_bus.subscribe('staging.advertise') do |msg|
           process_advertise_message(msg)
         end
-      end
-
-      def publish_buildpacks
-        message_bus.publish('buildpacks', admin_buildpacks)
       end
 
       def admin_buildpacks

--- a/lib/cloud_controller/dea/staging_message.rb
+++ b/lib/cloud_controller/dea/staging_message.rb
@@ -1,8 +1,9 @@
 module VCAP::CloudController
   module Dea
     class StagingMessage
-      def initialize(config, blobstore_url_generator)
+      def initialize(config, blobstore_url_generator, buildpack_blobstore)
         @blobstore_url_generator = blobstore_url_generator
+        @buildpack_blobstore = buildpack_blobstore
         @config = config
       end
 
@@ -58,7 +59,7 @@ module VCAP::CloudController
       end
 
       def admin_buildpacks
-        AdminBuildpacksPresenter.new(@blobstore_url_generator).to_staging_message_array
+        AdminBuildpacksPresenter.new(@blobstore_url_generator, @buildpack_blobstore).to_staging_message_array
       end
 
       def start_app_message(app)

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -188,6 +188,10 @@ module CloudController
       DropletPresenter.new
     end
 
+    def buildpacks_presenter
+      @buildpacks_presenter ||= AdminBuildpacksPresenter.new(blobstore_url_generator, buildpack_blobstore)
+    end
+
     def object_renderer
       eager_loader = VCAP::CloudController::RestController::SecureEagerLoader.new
       serializer   = VCAP::CloudController::RestController::PreloadedObjectSerializer.new

--- a/spec/unit/controllers/internal/listbuildpacks_controller_spec.rb
+++ b/spec/unit/controllers/internal/listbuildpacks_controller_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  describe ListBuildpacksController do
+    let(:blobstore) { CloudController::DependencyLocator.instance.buildpack_blobstore }
+
+    let(:url) { '/internal/buildpacks' }
+
+    def create_buildpack(key, position, file)
+      blobstore.cp_to_blobstore(file, key)
+      Buildpack.make(key: key, position: position)
+    end
+
+    before do
+      @internal_user = 'internal_user'
+      @internal_password = 'internal_password'
+      authorize @internal_user, @internal_password
+    end
+
+    describe 'authentication' do
+      context 'when missing authentication' do
+        it 'fails with authentication required' do
+          header('Authorization', nil)
+          get url
+          expect(last_response.status).to eq(401)
+        end
+      end
+
+      context 'when using invalid credentials' do
+        it 'fails with authenticatiom required' do
+          authorize 'bar', 'foo'
+          get url
+          expect(last_response.status).to eq(401)
+        end
+      end
+
+      context 'when using valid credentials' do
+        it 'succeeds' do
+          get url
+          expect(last_response.status).to eq(200)
+        end
+      end
+    end
+
+    context 'with a set of buildpacks' do
+      include TempFileCreator
+
+      let(:file) { temp_file_with_content }
+
+      before do
+        create_buildpack('third-buildpack', 3, file)
+        create_buildpack('first-buildpack', 1, file)
+        create_buildpack('second-buildpack', 2, file)
+      end
+
+      it 'returns all the buildpacks' do
+        get url
+        buildpacks = decoded_response
+
+        expect(last_response.status).to eq(200)
+        expect(buildpacks).to have(3).items
+        buildpacks.each { |b| expect(b).to include('key', 'url') }
+        expect(buildpacks.collect { |b| b['key'] }).to eq(['first-buildpack', 'second-buildpack', 'third-buildpack'])
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cloud_controller/admin_buildpack_presenter_spec.rb
+++ b/spec/unit/lib/cloud_controller/admin_buildpack_presenter_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 module VCAP::CloudController
   describe AdminBuildpacksPresenter do
-    let(:url_generator) { double(:url_generator) }
+    let(:url_generator) { CloudController::DependencyLocator.instance.blobstore_url_generator }
+    let(:blobstore) { CloudController::DependencyLocator.instance.buildpack_blobstore }
 
-    subject { described_class.new(url_generator) }
+    subject { described_class.new(url_generator, blobstore) }
 
-    before do
-      allow(url_generator).to receive(:admin_buildpack_download_url) do |bp|
-        "http://blobstore/#{bp.key}"
-      end
+    def create_buildpack(key, position, file)
+      blobstore.cp_to_blobstore(file, key)
+      Buildpack.make(key: key, position: position)
     end
 
     describe '#to_staging_message_array' do
@@ -20,17 +20,22 @@ module VCAP::CloudController
       end
 
       context 'when there are buildpacks' do
+        include TempFileCreator
+
+        let(:file) { temp_file_with_content }
+
         before do
-          Buildpack.make(key: 'third-buildpack', position: 3)
-          Buildpack.make(key: 'first-buildpack', position: 1)
-          Buildpack.make(key: 'second-buildpack', position: 2)
+          create_buildpack('third-buildpack', 3, file)
+          create_buildpack('first-buildpack', 1, file)
+          create_buildpack('second-buildpack', 2, file)
         end
 
         it 'returns the buildpacks as an ordered array of hashes' do
+          allow(url_generator).to receive(:admin_buildpack_blob_download_url).and_return('a-url')
           expect(subject.to_staging_message_array).to eq([
-            { key: 'first-buildpack', url: 'http://blobstore/first-buildpack' },
-            { key: 'second-buildpack', url: 'http://blobstore/second-buildpack' },
-            { key: 'third-buildpack', url: 'http://blobstore/third-buildpack' },
+            { key: 'first-buildpack', url: 'a-url' },
+            { key: 'second-buildpack', url: 'a-url' },
+            { key: 'third-buildpack', url: 'a-url' },
           ])
         end
 
@@ -41,6 +46,65 @@ module VCAP::CloudController
 
           it 'does not include them' do
             expect(subject.to_staging_message_array).not_to include(include(key: 'disabled'))
+          end
+        end
+
+        context 'when there is no url' do
+          before do
+            Buildpack.make(key: 'no-url', position: 5)
+          end
+
+          it 'does not include them' do
+            expect(subject.to_staging_message_array).not_to include(include(key: 'no-url'))
+          end
+        end
+
+        context 'caching' do
+          after do
+            Fog::Time.now = Time.now
+          end
+
+          it 'generates new urls' do
+            first = subject.to_staging_message_array
+
+            Fog::Time.now = Time.now + 60
+            second = subject.to_staging_message_array
+
+            expect(first).to_not eq(second)
+          end
+
+          context 'with the same buildpacks' do
+            it 'does not call the blobstore' do
+              subject.to_staging_message_array
+
+              expect(blobstore).not_to receive(:blob)
+              subject.to_staging_message_array
+            end
+          end
+
+          context 'with buildpack changes' do
+            before do
+              subject.to_staging_message_array
+
+              buildpacks = Buildpack.list_admin_buildpacks
+              buildpacks[0].delete
+              buildpacks[1].key = 'updated-second-buildpack'
+              @updated_buildpack = buildpacks[1].save
+              blobstore.cp_to_blobstore(file, 'updated-second-buildpack')
+              @new_buildpack = create_buildpack('new-first-buildpack', 1, file)
+            end
+
+            it 'generates urls for any change' do
+              allow(url_generator).to receive(:admin_buildpack_blob_download_url).and_return('a-url')
+
+              expect(blobstore).to receive(:blob).with(@new_buildpack.key).ordered.and_call_original
+              expect(blobstore).to receive(:blob).with(@updated_buildpack.key).ordered.and_call_original
+              expect(subject.to_staging_message_array).to eq([
+                { key: 'new-first-buildpack', url: 'a-url' },
+                { key: 'updated-second-buildpack', url: 'a-url' },
+                { key: 'third-buildpack', url: 'a-url' },
+              ])
+            end
           end
         end
       end

--- a/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
@@ -18,9 +18,10 @@ module VCAP::CloudController
     end
     let(:stager_id) { 'my_stager' }
     let(:blobstore_url_generator) { CloudController::DependencyLocator.instance.blobstore_url_generator }
+    let(:blobstore) { CloudController::DependencyLocator.instance.buildpack_blobstore }
 
     let(:options) { {} }
-    subject(:staging_task) { Dea::AppStagerTask.new(config_hash, message_bus, app, dea_pool, stager_pool, blobstore_url_generator) }
+    subject(:staging_task) { Dea::AppStagerTask.new(config_hash, message_bus, app, dea_pool, stager_pool, blobstore_url_generator, blobstore) }
 
     let(:first_reply_json_error) { nil }
     let(:task_streaming_log_url) { 'task-streaming-log-url' }

--- a/spec/unit/lib/cloud_controller/dea/stager_pool_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/stager_pool_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 module VCAP::CloudController
   describe VCAP::CloudController::Dea::StagerPool do
     let(:message_bus) { CfMessageBus::MockMessageBus.new }
-    let(:url_generator) { double(:url_generator) }
+    let(:buildpack_array) { double(:generated_buildpack_arrray) }
+    let(:buildpacks_presenter) { double(:buildpacks_presenter, to_staging_message_array: buildpack_array) }
     let(:staging_advertise_msg) do
       {
         'id' => 'staging-id',
@@ -13,7 +14,7 @@ module VCAP::CloudController
       }
     end
 
-    subject { Dea::StagerPool.new(TestConfig.config, message_bus, url_generator) }
+    subject { Dea::StagerPool.new(TestConfig.config, message_bus, buildpacks_presenter) }
 
     describe '#register_subscriptions' do
       let!(:stager_pool) { subject }
@@ -179,9 +180,6 @@ module VCAP::CloudController
         }
       end
 
-      let(:buildpack_array) { double(:generated_buildpack_arrray) }
-      let(:buildpacks_presenter) { double(:buildpacks_presenter, to_staging_message_array: buildpack_array) }
-
       before do
         subject.process_advertise_message(stager_advertise_msg)
       end
@@ -195,7 +193,6 @@ module VCAP::CloudController
 
       context 'when the stager is seen for the first time' do
         it 'publishes a buildpack advertisement' do
-          expect(AdminBuildpacksPresenter).to receive(:new).with(url_generator).and_return buildpacks_presenter
           expect(message_bus).to receive(:publish).with('buildpacks', buildpack_array)
 
           subject.process_advertise_message(stager_advertise_msg.merge('id' => '123'))

--- a/spec/unit/lib/cloud_controller/dea/stager_pool_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/stager_pool_spec.rb
@@ -169,35 +169,5 @@ module VCAP::CloudController
         }.from(nil).to('staging-id')
       end
     end
-
-    describe 'pre-warming buildpack caches' do
-      let(:stager_advertise_msg) do
-        {
-          'id' => 'staging-id',
-          'stacks' => ['stack-name'],
-          'available_memory' => 1024,
-          'available_disk' => 512
-        }
-      end
-
-      before do
-        subject.process_advertise_message(stager_advertise_msg)
-      end
-
-      context 'when the stager is already in the pool' do
-        it 'does not send an buildpack advertisement' do
-          expect(message_bus).not_to receive(:publish)
-          subject.process_advertise_message(stager_advertise_msg)
-        end
-      end
-
-      context 'when the stager is seen for the first time' do
-        it 'publishes a buildpack advertisement' do
-          expect(message_bus).to receive(:publish).with('buildpacks', buildpack_array)
-
-          subject.process_advertise_message(stager_advertise_msg.merge('id' => '123'))
-        end
-      end
-    end
   end
 end

--- a/spec/unit/lib/cloud_controller/dea/stager_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/stager_spec.rb
@@ -78,7 +78,8 @@ module VCAP::CloudController
                                                             thing_to_stage,
                                                             dea_pool,
                                                             stager_pool,
-                                                            an_instance_of(CloudController::Blobstore::UrlGenerator))
+                                                            an_instance_of(CloudController::Blobstore::UrlGenerator),
+                                                            an_instance_of(CloudController::Blobstore::Client))
         end
 
         it 'starts the app with the returned staging result' do

--- a/spec/unit/lib/cloud_controller/dea/staging_message_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/staging_message_spec.rb
@@ -3,11 +3,12 @@ require 'spec_helper'
 module VCAP::CloudController
   describe Dea::StagingMessage do
     let(:blobstore_url_generator) { CloudController::DependencyLocator.instance.blobstore_url_generator }
+    let(:blobstore) { CloudController::DependencyLocator.instance.buildpack_blobstore }
     let(:config_hash) { { staging: { timeout_in_seconds: 360 } } }
     let(:task_id) { 'somthing' }
     let(:droplet_guid) { 'abc123' }
     let(:log_id) { 'log-id' }
-    let(:staging_message) { Dea::StagingMessage.new(config_hash, blobstore_url_generator) }
+    let(:staging_message) { Dea::StagingMessage.new(config_hash, blobstore_url_generator, blobstore) }
 
     before do
       SecurityGroup.make(rules: [{ 'protocol' => 'udp', 'ports' => '8080-9090', 'destination' => '198.41.191.47/1' }], staging_default: true)

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -471,4 +471,14 @@ describe CloudController::DependencyLocator do
       expect(locator.instances_reporters).to be_an_instance_of(VCAP::CloudController::InstancesReporters)
     end
   end
+
+  describe '#buildpacks_presenter' do
+    it 'returns the buildpacks presenter' do
+      expect(locator.buildpacks_presenter).to be_an_instance_of(VCAP::CloudController::AdminBuildpacksPresenter)
+    end
+
+    it 'is a singleton' do
+      expect(locator.buildpacks_presenter).to equal(locator.buildpacks_presenter)
+    end
+  end
 end


### PR DESCRIPTION
To prevent a flurry of blobstore activity when constructing buildpack urls for
each DEA, just cache the info and rebuild when it changes.