### PR TITLE
Introducing idempotency to service instance deletion.

### DIFF
--- a/app/actions/services/service_instance_delete.rb
+++ b/app/actions/services/service_instance_delete.rb
@@ -1,5 +1,6 @@
 require 'actions/services/service_binding_delete'
 require 'actions/services/locks/deleter_lock'
+require 'sequel'
 
 module VCAP::CloudController
   class ServiceInstanceDelete
@@ -33,6 +34,10 @@ module VCAP::CloudController
 
     def delete_service_instance(service_instance)
       errors = []
+
+      if !service_instance.exists? # for idempotency purposes
+        return []
+      end
 
       begin
         lock = DeleterLock.new(service_instance)

--- a/spec/unit/actions/services/service_instance_delete_spec.rb
+++ b/spec/unit/actions/services/service_instance_delete_spec.rb
@@ -318,6 +318,17 @@ module VCAP::CloudController
           expect(errors[0].message).to eq 'BOOM'
         end
       end
+
+      context 'when deleting already deleted service instance' do
+        it 'does not throw errors as element is missing anyway' do
+          expect(ServiceInstance.count).to eq 2
+          service_instance_delete.delete([service_instance_1])
+          errors = service_instance_delete.delete([service_instance_1])
+          expect(ServiceInstance.count).to eq 1
+
+          expect(errors.count).to eq(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Deleting already deleted service instance does not return error.

Fixes following scenario:
While very vast space is deleted, one can delete service instance manually/independently in meantime.
This will end with error when cloud controller tries to remove instance again.
As service instance is missing why to return errors from delete_service_instance method?

==== Addditional notes ====
This situation occurred on CF instance I use on daily basis and is fully reproducible.
I got following error:
Deletion of space X failed because one or more resources within could not be deleted.nntRecord not found
Response from cloud controller HTTP Bad Gateway (502)

If this problem will be solved in other way in the future, please let me know.
There can be more elegant way to fix this problem, also. I am open to suggestions.