### PR TITLE
blobstore dir list: Don't include explicit attribs

### DIFF
--- a/lib/cloud_controller/blobstore/directory.rb
+++ b/lib/cloud_controller/blobstore/directory.rb
@@ -11,7 +11,7 @@ module CloudController
       end
 
       def get
-        @connection.directories.get(@key, 'limit' => 1, max_keys: 1)
+        @connection.directories.get(@key, max_keys: 1)
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/blobstore/directory_spec.rb
+++ b/spec/unit/lib/cloud_controller/blobstore/directory_spec.rb
@@ -30,7 +30,7 @@ module CloudController
 
       describe '#get' do
         it 'retrieves the directory' do
-          expect(directories).to receive(:get).with(directory_key, 'limit' => 1, max_keys: 1).and_return(fog_directory)
+          expect(directories).to receive(:get).with(directory_key, max_keys: 1).and_return(fog_directory)
           expect(directory.get).to eq(fog_directory)
         end
       end


### PR DESCRIPTION
When you include explicit 'limit' attribute, you make OpenStack SWIFT
work, but you break compatibility with other storage providers, like
Google Cloud Storage. Revert this again. Fog should support remapping
max_keys into limit specifically for SWIFT. Fog issue risen here:
https://github.com/fog/fog/issues/3723

This should be merged when the Fog issue is fixed. Until then a workaround would be to add a vendor specific code (if provider is openstack then include limit).