### PR TITLE
Use login.protocol instead of uaa.no_ssl

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -173,7 +173,7 @@ db: &db
   pool_timeout: <%= p("ccdb.pool_timeout") %>
   log_level: <%= p("cc.db_logging_level") %>
 
-<% scheme = p("uaa.no_ssl") ? "http" : "https"
+<% scheme = p("login.protocol")
    domain = p("domain") %>
 
 <% if p("login.enabled") %>

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -151,7 +151,7 @@ db: &db
   pool_timeout: <%= p("ccdb.pool_timeout") %>
   log_level: <%= p("cc.db_logging_level") %>
 
-<% scheme = p("uaa.no_ssl") ? "http" : "https"
+<% scheme = p("login.protocol")
    domain = p("domain") %>
 
 <% if p("login.enabled") %>

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -147,7 +147,7 @@ db: &db
   pool_timeout: <%= p("ccdb.pool_timeout") %>
   log_level: <%= p("cc.db_logging_level") %>
 
-<% scheme = p("uaa.no_ssl") ? "http" : "https"
+<% scheme = p("login.protocol")
    domain = p("domain") %>
 
 <% if p("login.enabled") %>


### PR DESCRIPTION
We have consolidated these two properties and now there is just one property `login.protocol` that should be used for building external facing urls. Once this change has been merged in the cloud_controller_ng, cloud_controller_clock and cloud_controller_worker job specs in cf-release will need to be changed to include login.protocol instead of uaa.no_ssl. 