### PR TITLE
Remove 'builders' Test Suite From Rake Task.

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -44,7 +44,6 @@ namespace :spec do
     fast_suites = %w[
         access
         actions
-        builders
         collection_transformers
         jobs
         messages


### PR DESCRIPTION
This PR removes the `builders` test suite from the Rake `spec` task.  It looks like all the `builders` specs were removed in e4bdb4b, causing `bundle exec rake spec` to fail with the following error:

```sh
Randomized with seed 45379

bundle exec rspec spec/unit/builders --require rspec/instafail --format RSpec::Instafail
/Users/ivan.sim/.gem/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load': cannot load such file -- /Users/ivan.sim/cloud_controller_ng/spec/unit/builders (LoadError)
	from /Users/ivan.sim/.gem/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `block in load_spec_files'
	from /Users/ivan.sim/.gem/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `each'
	from /Users/ivan.sim/.gem/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `load_spec_files'
	from /Users/ivan.sim/.gem/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:102:in `setup'
	from /Users/ivan.sim/.gem/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'
	from /Users/ivan.sim/.gem/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'
	from /Users/ivan.sim/.gem/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'
	from /Users/ivan.sim/.gem/gems/rspec-core-3.3.2/exe/rspec:4:in `<top (required)>'
	from /Users/ivan.sim/.gem/bin/rspec:23:in `load'
	from /Users/ivan.sim/.gem/bin/rspec:23:in `<main>'
rake aborted!
Command failed with status (1): [bundle exec rspec spec/unit/builders --req...]
/Users/ivan.sim/cloud_controller_ng/lib/tasks/spec.rake:83:in `run_specs'
/Users/ivan.sim/cloud_controller_ng/lib/tasks/spec.rake:59:in `block (4 levels) in <top (required)>'
Tasks: TOP => spec => spec:unit:fast => spec:unit:builders
(See full trace by running task with --trace)
```