### PR TITLE
Add audit event support for routes

### DIFF
--- a/app/controllers/runtime/routes_controller.rb
+++ b/app/controllers/runtime/routes_controller.rb
@@ -15,12 +15,13 @@ module VCAP::CloudController
     query_parameters :host, :domain_guid, :organization_guid, :path, :port
 
     def self.dependencies
-      [:routing_api_client]
+      [:routing_api_client, :route_event_repository]
     end
 
     def inject_dependencies(dependencies)
       super
       @routing_api_client = dependencies.fetch(:routing_api_client)
+      @route_event_repository = dependencies.fetch(:route_event_repository)
     end
 
     def self.translate_validation_exception(e, attributes)
@@ -71,6 +72,7 @@ module VCAP::CloudController
       route = model.create_from_hash(request_attrs)
       validate_access(:create, route, request_attrs)
 
+      after_create(route)
       [
         HTTP::CREATED,
         { 'Location' => "#{self.class.path}/#{route.guid}" },
@@ -83,6 +85,8 @@ module VCAP::CloudController
       if !recursive_delete? && route.service_instance.present?
         raise VCAP::Errors::ApiError.new_from_details('AssociationNotEmpty', 'service_instance', route.class.table_name)
       end
+
+      @route_event_repository.record_route_delete_request(route, SecurityContext.current_user, SecurityContext.current_user_email, recursive_delete?)
 
       do_delete(route)
     end
@@ -130,12 +134,20 @@ module VCAP::CloudController
       validate_route(domain_guid)
     end
 
+    def after_create(route)
+      @route_event_repository.record_route_create(route, SecurityContext.current_user, SecurityContext.current_user_email, request_attrs)
+    end
+
     def before_update(route)
       super
 
       return if request_attrs['app']
 
       validate_route(route.domain.guid) if request_attrs['port'] != route.port
+    end
+
+    def after_update(route)
+      @route_event_repository.record_route_update(route, SecurityContext.current_user, SecurityContext.current_user_email, request_attrs)
     end
 
     define_messages

--- a/app/repositories/runtime/route_event_repository.rb
+++ b/app/repositories/runtime/route_event_repository.rb
@@ -1,0 +1,59 @@
+module VCAP::CloudController
+  module Repositories
+    module Runtime
+      class RouteEventRepository
+        def record_route_create(route, actor, actor_name, request_attrs)
+          Event.create(
+            space: route.space,
+            type: 'audit.route.create',
+            actee: route.guid,
+            actee_type: 'route',
+            actee_name: route.host,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+            metadata: {
+              request: request_attrs
+            }
+          )
+        end
+
+        def record_route_update(route, actor, actor_name, request_attrs)
+          Event.create(
+            space: route.space,
+            type: 'audit.route.update',
+            actee: route.guid,
+            actee_type: 'route',
+            actee_name: route.host,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+            metadata: {
+              request: request_attrs
+            }
+          )
+        end
+
+        def record_route_delete_request(route, actor, actor_name, recursive)
+          Event.create(
+            type: 'audit.route.delete-request',
+            actee: route.guid,
+            actee_type: 'route',
+            actee_name: route.host,
+            actor: actor.guid,
+            actor_type: 'user',
+            actor_name: actor_name,
+            timestamp: Sequel::CURRENT_TIMESTAMP,
+            space_guid: route.space.guid,
+            organization_guid: route.space.organization.guid,
+            metadata: {
+              request: { recursive: recursive }
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -1,5 +1,6 @@
 require 'repositories/runtime/app_event_repository'
 require 'repositories/runtime/space_event_repository'
+require 'repositories/runtime/route_event_repository'
 require 'cloud_controller/rest_controller/object_renderer'
 require 'cloud_controller/rest_controller/paginated_collection_renderer'
 require 'cloud_controller/upload_handler'
@@ -154,6 +155,10 @@ module CloudController
 
     def space_event_repository
       Repositories::Runtime::SpaceEventRepository.new
+    end
+
+    def route_event_repository
+      Repositories::Runtime::RouteEventRepository.new
     end
 
     def services_event_repository

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'vcap/digester'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = '2ad6d6b3d5dc0c51f2e299e8c52163c4ec696275'
+  API_FOLDER_CHECKSUM = '0614b0b284840d5caeee8dbe6f14b17cbf8e3226'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.46.0')

--- a/spec/unit/repositories/runtime/route_event_repository_spec.rb
+++ b/spec/unit/repositories/runtime/route_event_repository_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Repositories::Runtime
+    describe RouteEventRepository do
+      let(:user) { User.make }
+      let(:route) { Route.make }
+      let(:request_attrs) { { 'host' => 'dora', 'domain_guid' => route.domain.guid, 'space_guid' => route.space.guid } }
+      let(:user_email) { 'some@email.com' }
+
+      subject(:route_event_repository) { RouteEventRepository.new }
+
+      describe '#record_route_create' do
+        it 'records event correctly' do
+          event = route_event_repository.record_route_create(route, user, user_email, request_attrs)
+          event.reload
+          expect(event.space).to eq(route.space)
+          expect(event.type).to eq('audit.route.create')
+          expect(event.actee).to eq(route.guid)
+          expect(event.actee_type).to eq('route')
+          expect(event.actee_name).to eq(route.host)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.metadata).to eq({ 'request' => request_attrs })
+        end
+
+        context 'when the user email is unknown' do
+          it 'leaves actor name empty' do
+            event = route_event_repository.record_route_create(route, user, nil, request_attrs)
+            event.reload
+            expect(event.actor_name).to eq(nil)
+          end
+        end
+      end
+
+      describe '#record_route_update' do
+        it 'records event correctly' do
+          event = route_event_repository.record_route_update(route, user, user_email, request_attrs)
+          event.reload
+          expect(event.space).to eq(route.space)
+          expect(event.type).to eq('audit.route.update')
+          expect(event.actee).to eq(route.guid)
+          expect(event.actee_type).to eq('route')
+          expect(event.actee_name).to eq(route.host)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.metadata).to eq({ 'request' => request_attrs })
+        end
+      end
+
+      describe '#record_route_delete' do
+        let(:recursive) { true }
+
+        before do
+          route.destroy
+        end
+
+        it 'records event correctly' do
+          event = route_event_repository.record_route_delete_request(route, user, user_email, recursive)
+          event.reload
+          expect(event.space).to eq(route.space)
+          expect(event.type).to eq('audit.route.delete-request')
+          expect(event.actee).to eq(route.guid)
+          expect(event.actee_type).to eq('route')
+          expect(event.actee_name).to eq(route.host)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.metadata).to eq({ 'request' => { 'recursive' => true } })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The following provides audit event support for routes. This will allow audit events to be created when routes are created, updated and deleted. Delete will audit the delete request since it's async. 

- New audit event types: 
  - audit.route.create
  - audit.route.update
  - audit.route.delete-request
- Update routes controller to create audit events for create, update and delete
- Update /v2/events to support new event types
- Update API specs

cc @shalako


### Examples:
Using dora and bosh-lite, below is examples of creating / deleting routes and example output.

#### Create Route
```
cf push dora
```
or

```
cf create-route dev bosh-lite.com -n dora
```

#### List Create Route Events
```
curl "http://api.bosh-lite.com/v2/events?q=type:audit.route.create" -H "Authorization: `cf oauth-token |grep bearer`"
```

```json
{
  "total_results": 1,
  "total_pages": 1,
  "prev_url": null,
  "next_url": null,
  "resources": [
    {
      "metadata": {
        "guid": "c89bf518-fc3a-4d4a-9308-041a7c623c2f",
        "url": "/v2/events/c89bf518-fc3a-4d4a-9308-041a7c623c2f",
        "created_at": "2015-12-23T02:06:58Z",
        "updated_at": null
      },
      "entity": {
        "type": "audit.route.create",
        "actor": "be476613-e95f-4400-a87d-1fb0efa75a27",
        "actor_type": "user",
        "actor_name": "admin",
        "actee": "0d352446-06a8-4827-868b-64d2df383e9d",
        "actee_type": "route",
        "actee_name": "dora",
        "timestamp": "2015-12-23T02:06:58Z",
        "metadata": {
          "request": {
            "host": "dora",
            "domain_guid": "c3f1b8dc-0cd0-4c50-a94f-58115fa90438",
            "space_guid": "5dba4d75-c98d-4900-8cb6-3a5a1632c2c9"
          }
        },
        "space_guid": "5dba4d75-c98d-4900-8cb6-3a5a1632c2c9",
        "organization_guid": "77e4881a-d849-4b6e-aa6e-59434069b0fa"
      }
    }
  ]
}
```


#### Delete Route
In the case of delete route it is an async job so we really audit the fact that we received and accepted the delete request (similar to delete space).

```
cf delete-route bosh-lite.com -n dora
```


#### List Delete Route Events
```
curl "http://api.bosh-lite.com/v2/events?q=type:audit.route.delete-request" -H "Authorization: `cf oauth-token | grep bearer`"
```

```json

    {
      "metadata": {
        "guid": "6487424a-aaa1-4daa-bd17-4da229598240",
        "url": "/v2/events/6487424a-aaa1-4daa-bd17-4da229598240",
        "created_at": "2015-12-23T02:30:34Z",
        "updated_at": null
      },
      "entity": {
        "type": "audit.route.delete-request",
        "actor": "be476613-e95f-4400-a87d-1fb0efa75a27",
        "actor_type": "user",
        "actor_name": "admin",
        "actee": "0d352446-06a8-4827-868b-64d2df383e9d",
        "actee_type": "route",
        "actee_name": "dora",
        "timestamp": "2015-12-23T02:30:34Z",
        "metadata": {
          "request": {
            "recursive": false
          }
        },
        "space_guid": "5dba4d75-c98d-4900-8cb6-3a5a1632c2c9",
        "organization_guid": "77e4881a-d849-4b6e-aa6e-59434069b0fa"
      }
    }
```


In the above example output
- top level metadata section is the metadata of the audit record itself (guid, timestamp, etc.)
- entity section represents the audit route event entity info
  - actor and actee info is similar to other audit events
    - actor is the user who is creating, updating or deleting the route
    - actee is the route (guid)
    - actee type is route
    - actee_name is the hostname of the route
  - entity.metadata contains the request info for the create, update or delete route request (i.e. POST / PUT / DELETE /v2/routes)
   
