### PR TITLE
Upgrade rubocop to 0.31 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,9 +5,6 @@ AllCops:
   Exclude:
     - vendor/**/*
 
-RegexpLiteral:
-  MaxSlashes: 1
-
 UnusedMethodArgument:
   Enabled: false
 
@@ -25,7 +22,7 @@ LineLength:
 
 MethodLength:
   Max: 60
- 
+
 Metrics/AbcSize:
   Max: 30
 
@@ -38,7 +35,7 @@ CyclomaticComplexity:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Style/Blocks:
+Style/BlockDelimiters:
   Enabled: false
 
 Style/TrailingComma:
@@ -133,4 +130,10 @@ Style/EachWithObject:
   Enabled: false
 
 StructInheritance:
+  Enabled: false
+
+Performance/Sample:
+  Enabled: false
+
+ClosingParenthesisIndentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
     - Rakefile
   Exclude:
     - vendor/**/*
+    - db/migrations/**/*
 
 UnusedMethodArgument:
   Enabled: false
@@ -136,4 +137,10 @@ Performance/Sample:
   Enabled: false
 
 ClosingParenthesisIndentation:
+  Enabled: false
+
+ModuleLength:
+  Enabled: false
+
+Style/TrailingUnderscoreVariable:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ group :test do
   gem 'rspec-its'
   gem 'rspec-rails'
   gem 'rubocop'
-  gem 'astrolabe'
   gem 'timecop'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.30.1)
+    rubocop (0.31.0)
       astrolabe (~> 1.3)
       parser (>= 2.2.2.1, < 3.0)
       powerpack (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,9 +62,9 @@ GEM
     allowy (1.0.0)
       activesupport (>= 3.2)
       i18n
-    ast (2.0.0)
-    astrolabe (1.3.0)
-      parser (>= 2.2.0.pre.3, < 3.0)
+    ast (2.2.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     awesome_print (1.2.0)
     backports (3.6.4)
     beefcake (1.0.0)
@@ -246,9 +246,8 @@ GEM
     parallel (1.3.3)
     parallel_tests (1.0.7)
       parallel
-    parser (2.2.0.1)
-      ast (>= 1.1, < 3.0)
-      slop (~> 3.4, >= 3.4.5)
+    parser (2.3.0.1)
+      ast (~> 2.2)
     pg (0.16.0)
     posix-spawn (0.3.9)
     powerpack (0.1.1)
@@ -310,9 +309,9 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.29.0)
+    rubocop (0.30.1)
       astrolabe (~> 1.3)
-      parser (>= 2.2.0.1, < 3.0)
+      parser (>= 2.2.2.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
@@ -391,7 +390,6 @@ DEPENDENCIES
   activemodel
   addressable
   allowy
-  astrolabe
   awesome_print
   byebug
   cf-message-bus (~> 0.3.0)

--- a/app/access/domain_access.rb
+++ b/app/access/domain_access.rb
@@ -24,8 +24,11 @@ module VCAP::CloudController
     private
 
     def actual_access(domain)
-      domain.owning_organization ? PrivateDomainAccess.new(context) :
+      if domain.owning_organization
+        PrivateDomainAccess.new(context)
+      else
         SharedDomainAccess.new(context)
+      end
     end
   end
 end

--- a/app/controllers/base/base_controller.rb
+++ b/app/controllers/base/base_controller.rb
@@ -143,7 +143,7 @@ module VCAP::CloudController::RestController
     end
 
     def unversioned_api?
-      !(env['PATH_INFO'] =~ /^\/v\d/)
+      !(env['PATH_INFO'] =~ %r{^/v\d})
     end
 
     def recursive_delete?

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -72,7 +72,8 @@ module VCAP::CloudController
     def enumerate_services(guid)
       org = find_guid_and_validate_access(:read, guid)
 
-      associated_controller, associated_model = ServicesController, Service
+      associated_controller = ServicesController
+      associated_model = Service
 
       filtered_dataset = Query.filtered_dataset_from_query_params(
         associated_model,

--- a/app/controllers/runtime/stagings_controller.rb
+++ b/app/controllers/runtime/stagings_controller.rb
@@ -1,6 +1,7 @@
 require 'cloudfront-signer'
 require 'cloud_controller/blobstore/client'
 require 'presenters/api/staging_job_presenter'
+require 'utils/hash_utils'
 
 module VCAP::CloudController
   class StagingsController < RestController::BaseController
@@ -203,18 +204,11 @@ module VCAP::CloudController
 
     def upload_path
       @upload_path ||=
-          if get_from_hash_tree(config, :nginx, :use_nginx)
+          if HashUtils.dig(config, :nginx, :use_nginx)
             params['droplet_path']
-          elsif (tempfile = get_from_hash_tree(params, 'upload', 'droplet', :tempfile))
+          elsif (tempfile = HashUtils.dig(params, 'upload', 'droplet', :tempfile))
             tempfile.path
           end
-    end
-
-    def get_from_hash_tree(hash, *path)
-      path.reduce(hash) do |here, seg|
-        return unless here && here.is_a?(Hash)
-        here[seg]
-      end
     end
 
     def check_app_exists(app, guid)

--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -24,8 +24,11 @@ class AppsV3Controller < ApplicationController
     pagination_options = PaginationOptions.from_params(query_params)
     invalid_param!(pagination_options.errors.full_messages) unless pagination_options.valid?
 
-    paginated_result = roles.admin? ? AppListFetcher.new.fetch_all(pagination_options, message) :
-      VCAP::CloudController::AppListFetcher.new.fetch(pagination_options, message, allowed_space_guids)
+    paginated_result = if roles.admin?
+                         AppListFetcher.new.fetch_all(pagination_options, message)
+                       else
+                         VCAP::CloudController::AppListFetcher.new.fetch(pagination_options, message, allowed_space_guids)
+                       end
 
     render status: :ok, json: AppPresenter.new.present_json_list(paginated_result, message)
   end

--- a/app/controllers/v3/errors_controller.rb
+++ b/app/controllers/v3/errors_controller.rb
@@ -1,4 +1,4 @@
-class ErrorsController <  ApplicationController
+class ErrorsController < ApplicationController
   def not_found
     error =  VCAP::Errors::ApiError.new_from_details('NotFound')
     presenter = ErrorPresenter.new(error, Rails.env.test?)

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController
     def after_initialize
       default_instances = db_schema[:instances][:default].to_i
 
-      self.instances ||=  default_instances
+      self.instances ||= default_instances
       self.memory ||= VCAP::CloudController::Config.config[:default_app_memory]
     end
 
@@ -221,7 +221,6 @@ module VCAP::CloudController
 
     def needs_package_in_current_state?
       started?
-      # started? && ((column_changed?(:state)) || (!new? && footprint_changed?))
     end
 
     def in_suspended_org?

--- a/db/migrations/20141210194308_add_name_col_v3_apps.rb
+++ b/db/migrations/20141210194308_add_name_col_v3_apps.rb
@@ -8,7 +8,7 @@ Sequel.migration do
       set_column_type :name, String, case_insensitive: true
     end
     if self.class.name.match /mysql/i
-      table_name = tables.select { |t| t =~ /apps_v3/ }.first
+      table_name = tables.find { |t| t =~ /apps_v3/ }
       run "ALTER TABLE `#{table_name}` CONVERT TO CHARACTER SET utf8;"
     end
   end

--- a/db/migrations/20160114182148_create_tasks.rb
+++ b/db/migrations/20160114182148_create_tasks.rb
@@ -14,7 +14,7 @@ Sequel.migration do
       foreign_key [:droplet_id], :v3_droplets, name: :fk_tasks_droplet_id
 
       if self.class.name.match /mysql/i
-        table_name = tables.select { |t| t =~ /tasks/ }.first
+        table_name = tables.find { |t| t =~ /tasks/ }
         run "ALTER TABLE `#{table_name}` CONVERT TO CHARACTER SET utf8;"
       end
     end

--- a/lib/cloud_controller/bits_expiration.rb
+++ b/lib/cloud_controller/bits_expiration.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
       config = {}
       config[:packages] = input_config[:packages] || {}
       config[:droplets] = input_config[:droplets] || {}
-      @droplets_storage_count = config[:packages][:max_valid_packages_stored]  || 5
+      @droplets_storage_count = config[:packages][:max_valid_packages_stored] || 5
       @packages_storage_count = config[:droplets][:max_staged_droplets_stored] || 5
     end
 

--- a/lib/cloud_controller/metrics/periodic_updater.rb
+++ b/lib/cloud_controller/metrics/periodic_updater.rb
@@ -50,7 +50,7 @@ module VCAP::CloudController::Metrics
 
       total                      = 0
       pending_job_count_by_queue = jobs_by_queue_with_count.each_with_object({}) do |row, hash|
-        total                    += row[:count]
+        total += row[:count]
         hash[row[:queue].to_sym] = row[:count]
       end
 
@@ -68,7 +68,7 @@ module VCAP::CloudController::Metrics
 
       total                = 0
       failed_jobs_by_queue = jobs_by_queue_with_count.each_with_object({}) do |row, hash|
-        total                    += row[:count]
+        total += row[:count]
         hash[row[:queue].to_sym] = row[:count]
       end
 

--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -20,8 +20,8 @@ module VCAP::CloudController
       def complete_request(status)
         VCAP::Component.varz.synchronize do
           VCAP::Component.varz[:vcap_sinatra][:requests][:outstanding] -= 1
-          VCAP::Component.varz[:vcap_sinatra][:requests][:completed]   += 1
-          VCAP::Component.varz[:vcap_sinatra][:http_status][status]    += 1
+          VCAP::Component.varz[:vcap_sinatra][:requests][:completed] += 1
+          VCAP::Component.varz[:vcap_sinatra][:http_status][status] += 1
         end
 
         @statsd.batch do |batch|

--- a/lib/cloud_controller/paging/pagination_options.rb
+++ b/lib/cloud_controller/paging/pagination_options.rb
@@ -32,9 +32,9 @@ module VCAP::CloudController
     def initialize(params)
       super(params)
 
-      @page            ||= PAGE_DEFAULT
-      @per_page        ||= PER_PAGE_DEFAULT
-      @order_by        ||= ORDER_DEFAULT
+      @page ||= PAGE_DEFAULT
+      @per_page ||= PER_PAGE_DEFAULT
+      @order_by ||= ORDER_DEFAULT
       @order_direction ||= DIRECTION_DEFAULT
     end
 

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -140,7 +140,7 @@ module VCAP::Services::ServiceBrokers
 
       def add(plan)
         @nested_warnings[plan.service.label] ||= []
-        @broker_url                          ||= plan.service_broker.broker_url
+        @broker_url ||= plan.service_broker.broker_url
         @nested_warnings[plan.service.label] << plan.name
       end
 

--- a/lib/utils/hash_utils.rb
+++ b/lib/utils/hash_utils.rb
@@ -1,0 +1,7 @@
+module HashUtils
+  def self.dig(hash, *path)
+    path.inject(hash) do |location, key|
+      location.is_a?(Hash) ? location[key] : nil
+    end
+  end
+end

--- a/spec/support/matchers/match_object.rb
+++ b/spec/support/matchers/match_object.rb
@@ -4,13 +4,12 @@ RSpec::Matchers.define :match_object do |expected|
   end
 
   failure_message do |actual|
+    break if actual == expected
     object_eq(actual, expected)
     @error_message.join("\n")
   end
 
   def object_eq(actual, expected, path=[])
-    return if actual == expected
-
     @error_message ||= []
 
     types = [actual, expected].map(&:class).uniq
@@ -30,23 +29,23 @@ RSpec::Matchers.define :match_object do |expected|
 
     elsif types.size == 1 # same class
       @error_message << "Mismatched values in #{path}:"
-      @error_message <<  "\t  actual=#{actual}"
-      @error_message <<  "\texpected=#{expected}"
+      @error_message << "\t  actual=#{actual}"
+      @error_message << "\texpected=#{expected}"
 
     else
-      @error_message <<  "Mismatched types in #{path}:"
-      @error_message <<  "\t  actual=#{types[0]} value=#{actual.inspect}"
-      @error_message <<  "\texpected=#{types[1]} value=#{expected.inspect}"
+      @error_message << "Mismatched types in #{path}:"
+      @error_message << "\t  actual=#{types[0]} value=#{actual.inspect}"
+      @error_message << "\texpected=#{types[1]} value=#{expected.inspect}"
     end
   end
 
   def compare_arrays(actual, expected, path, context=actual)
     if expected.size != actual.size
-      @error_message <<  "Extra/missing elements in #{path}:"
-      @error_message <<  "\tactual=#{actual.size} expected=#{expected.size}"
-      @error_message <<  "\textra=#{actual - expected}"
-      @error_message <<  "\tmissing=#{expected - actual}"
-      @error_message <<  "\tcontext=#{context}"
+      @error_message << "Extra/missing elements in #{path}:"
+      @error_message << "\tactual=#{actual.size} expected=#{expected.size}"
+      @error_message << "\textra=#{actual - expected}"
+      @error_message << "\tmissing=#{expected - actual}"
+      @error_message << "\tcontext=#{context}"
       false
     else
       true

--- a/spec/unit/access/space_access_spec.rb
+++ b/spec/unit/access/space_access_spec.rb
@@ -101,7 +101,7 @@ module VCAP::CloudController
 
     context 'a user that isnt logged in (defensive)' do
       let(:user) { nil }
-      let(:roles) { double(:roles, :admin? => false, :none? => true, :present? => false) }
+      let(:roles) { double(:roles, admin?: false, none?: true, present?: false) }
       it_behaves_like :no_access
     end
 

--- a/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
@@ -321,8 +321,8 @@ module VCAP::CloudController
                 expect {
                   put "/v2/apps/#{app_obj.guid}/bits?async=true", req_body, headers_for(user)
                 }.to change {
-                    Delayed::Job.count
-                  }.by(1)
+                       Delayed::Job.count
+                     }.by(1)
 
                 successes, failures = Delayed::Worker.new.work_off
                 expect([successes, failures]).to eq [0, 1]
@@ -340,8 +340,8 @@ module VCAP::CloudController
                 expect {
                   put "/v2/apps/#{app_obj.guid}/bits?async=true", req_body, headers_for(user)
                 }.to change {
-                    Delayed::Job.count
-                  }.by(1)
+                       Delayed::Job.count
+                     }.by(1)
 
                 successes, failures = Delayed::Worker.new.work_off
                 expect([successes, failures]).to eq [0, 1]

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -869,7 +869,7 @@ module VCAP::CloudController
 
                 expect(Delayed::Worker.new.work_off).to eq([1, 0])
                 expect(a_request(:delete, service_broker_url_regex)).to have_been_made.times(1)
-                expect(a_request(:get, /#{service_broker_url_regex}\/last_operation/)).not_to have_been_made.times(1)
+                expect(a_request(:get, %r{#{service_broker_url_regex}/last_operation})).not_to have_been_made.times(1)
 
                 expect(Delayed::Job.count).to eq 0
               end

--- a/spec/unit/lib/safe_zipper_spec.rb
+++ b/spec/unit/lib/safe_zipper_spec.rb
@@ -31,7 +31,7 @@ describe SafeZipper do
         [
           "Archive:\n Filename\n ---\n 0  09-15-15 17:44 foo\n ---\n10000000001 1 file\n",
           nil,
-          double('status', :success? => true)]
+          double('status', success?: true)]
       )
       expect(SafeZipper.unzip(zip_path, zip_destination)).to eq 10_000_000_001
     end

--- a/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
@@ -72,7 +72,7 @@ module VCAP::Services::ServiceBrokers::V2
 
       it 'logs the default headers' do
         make_request
-        expect(fake_logger).to have_received(:debug).with(match(/Accept"=>"application\/json/))
+        expect(fake_logger).to have_received(:debug).with(match(%r{Accept"=>"application/json}))
         expect(fake_logger).to have_received(:debug).with(match(/X-VCAP-Request-ID"=>"[[:alnum:]-]+/))
         expect(fake_logger).to have_received(:debug).with(match(/X-Broker-Api-Version"=>"2\.8/))
         expect(fake_logger).to have_received(:debug).with(match(%r{X-Api-Info-Location"=>"api2\.vcap\.me/v2/info}))
@@ -383,7 +383,7 @@ module VCAP::Services::ServiceBrokers::V2
 
         it 'logs the Content-Type Header' do
           make_request
-          expect(fake_logger).to have_received(:debug).with(match(/"Content-Type"=>"application\/json"/))
+          expect(fake_logger).to have_received(:debug).with(match(%r{"Content-Type"=>"application/json"}))
         end
 
         it 'has a content body' do
@@ -452,7 +452,7 @@ module VCAP::Services::ServiceBrokers::V2
 
         it 'logs the Content-Type Header' do
           make_request
-          expect(fake_logger).to have_received(:debug).with(match(/"Content-Type"=>"application\/json"/))
+          expect(fake_logger).to have_received(:debug).with(match(%r{"Content-Type"=>"application/json"}))
         end
 
         it 'has a content body' do

--- a/spec/unit/lib/utils/hash_utils_spec.rb
+++ b/spec/unit/lib/utils/hash_utils_spec.rb
@@ -1,0 +1,30 @@
+require 'utils/hash_utils'
+
+describe HashUtils do
+  describe 'dig' do
+    it 'returns nested value' do
+      hash = { foo: { bar: { baz: { qux: true } } } }
+      expect(HashUtils.dig(hash, :foo, :bar, :baz, :qux)).to be_truthy
+    end
+
+    it 'returns partial digs' do
+      hash = { foo: { bar: { baz: { qux: true } } } }
+      expect(HashUtils.dig(hash, :foo, :bar)).to eq({ baz: { qux: true } })
+    end
+
+    it 'works for string and symbol keys' do
+      hash = { foo: { bar: { 'baz' => { qux: true } } } }
+      expect(HashUtils.dig(hash, :foo, :bar, 'baz', :qux)).to be_truthy
+    end
+
+    it 'returns nil if there is a missing key' do
+      hash = { foo: { bar: { baz: { qux: true } } } }
+      expect(HashUtils.dig(hash, :foo, :bar, :pants, :qux)).to be_nil
+    end
+
+    it 'returns nil if you dig too deep' do
+      hash = { foo: { bar: { baz: { qux: true } } } }
+      expect(HashUtils.dig(hash, :foo, :bar, :baz, :qux, :the_core)).to be_nil
+    end
+  end
+end

--- a/spec/unit/models/runtime/app_spec.rb
+++ b/spec/unit/models/runtime/app_spec.rb
@@ -371,7 +371,7 @@ module VCAP::CloudController
 
         context 'app update' do
           def act_as_cf_admin(&block)
-            allow(VCAP::CloudController::SecurityContext).to receive_messages(:admin? => true)
+            allow(VCAP::CloudController::SecurityContext).to receive_messages(admin?: true)
             block.call
           ensure
             allow(VCAP::CloudController::SecurityContext).to receive(:admin?).and_call_original


### PR DESCRIPTION
**Don't look at this until #506 has been addressed**

- Disable rubocop for migrations. Modifying old migrations could be
  dangerous and style isn't as important for code that should
  (hopefully) never need to change.
- Disable module length check. It would be great to have reasonable
  modules, but this is a much larger undertaking than can be
  accomblished in this PR.
- Disable trailing underscore variable check (a, b, _ = foo()). The
  suggested style is less clear (a, b, = foo())