### PR TITLE
Don't rely on permission on  /tmp

### DIFF
--- a/lib/cloud_controller/file_path_checker.rb
+++ b/lib/cloud_controller/file_path_checker.rb
@@ -1,7 +1,7 @@
 module VCAP
   module CloudController
     class FilePathChecker
-      def self.safe_path?(child_path, root_path=Dir.tmpdir)
+      def self.safe_path?(child_path, root_path='/root_path')
         expanded_path = File.expand_path(child_path, root_path)
 
         !!expanded_path.match(/^#{root_path}/)


### PR DESCRIPTION
Depending on the permissions for `/tmp`, calling the Dir.tmpdir method can [sometimes raise an error](https://blog.diacode.com/fixing-temporary-dir-problems-with-ruby-2). And root_path does not have to be exist at all.