### PR TITLE
HCF-516: Make the name of the CCNG hostname configurable

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -21,7 +21,7 @@
 #Actually NGX host and port
 local_route: <%= discover_external_ip %>
 external_port: <%= p("cc.external_port") %>
-internal_service_hostname: cloud-controller-ng.service.cf.internal
+internal_service_hostname: <%= p("cc.internal_service_hostname") %>
 
 pid_filename: /var/vcap/sys/run/cloud_controller_ng/cloud_controller_ng.pid
 newrelic_enabled: <%= !!properties.cc.newrelic.license_key || p("cc.development_mode") %>

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -21,7 +21,7 @@
 #Actually NGX host and port
 local_route: <%= discover_external_ip %>
 external_port: <%= p("cc.external_port") %>
-internal_service_hostname: cloud-controller-ng.service.cf.internal
+internal_service_hostname: <%= p("cc.internal_service_hostname") %>
 
 pid_filename: /var/vcap/sys/run/cloud_controller_clock/cloud_controller_ng.pid
 newrelic_enabled: false

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -21,7 +21,7 @@
 #Actually NGX host and port
 local_route: <%= discover_external_ip %>
 external_port: <%= p("cc.external_port") %>
-internal_service_hostname: cloud-controller-ng.service.cf.internal
+internal_service_hostname: <%= p("cc.internal_service_hostname") %>
 
 pid_filename: /this/isnt/used/by/the/worker
 newrelic_enabled: <%= !!properties.cc.newrelic.license_key %>


### PR DESCRIPTION
This allows HCF to not depend on consul to do DNS resolution. Also it's the
only hardwired hostname in cf.  Works with cf-release PR https://github.com/cloudfoundry/cf-release/pull/915