### PR TITLE
Add a switch to control writing to /proc/sys

### DIFF
--- a/bosh-templates/cloud_controller_api_ctl.erb
+++ b/bosh-templates/cloud_controller_api_ctl.erb
@@ -71,7 +71,9 @@ case $1 in
     # Configure the core file location
     mkdir -p /var/vcap/sys/cores
     chown vcap:vcap /var/vcap/sys/cores
-    echo /var/vcap/sys/cores/core-%e-%s-%p-%t > /proc/sys/kernel/core_pattern
+    <% if p("cc.core_file_pattern") %>
+    echo <%= p("cc.core_file_pattern") %> > /proc/sys/kernel/core_pattern
+    <% end %>
 
     ulimit -c unlimited
 


### PR DESCRIPTION
Not all environments allow writing to /proc/sys, allow these to be
controlled via config setting added in https://github.com/cloudfoundry/capi-release/pull/3.

