### PR TITLE
Should not fail if target to be deleted is already gone

### DIFF
--- a/lib/cloud_controller/blobstore/webdav/dav_client.rb
+++ b/lib/cloud_controller/blobstore/webdav/dav_client.rb
@@ -158,7 +158,9 @@ module CloudController
         response = with_error_handling { @client.delete(url, header: @headers) }
         return if response.status == 204
 
-        raise FileNotFound.new("Could not find object '#{URI(url).path}', #{response.status}/#{response.content}") if response.status == 404
+        # requesting to delete something which is already gone is ok
+        return if response.status == 404
+
         raise BlobstoreError.new("Could not delete all in path, #{response.status}/#{response.content}")
       end
 

--- a/spec/unit/lib/cloud_controller/blobstore/webdav/dav_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/blobstore/webdav/dav_client_spec.rb
@@ -555,11 +555,9 @@ module CloudController
           expect(httpclient).to have_received(:delete).with('http://localhost/admin/droplets/buildpack_cache/fo/ob/foobar/', header: {})
         end
 
-        it 'raises FileNotfound when the server returns 404' do
+        it 'does not fail when the collection does not exist' do
           allow(httpclient).to receive(:delete).and_return(instance_double(HTTP::Message, status: 404, content: ''))
-          expect {
-            client.delete_all_in_path('foobar')
-          }.to raise_error(FileNotFound, /Could not find object/)
+          client.delete_all_in_path('foobar')
           expect(httpclient).to have_received(:delete).with('http://localhost/admin/droplets/buildpack_cache/fo/ob/foobar/', header: {})
         end
 


### PR DESCRIPTION
BuildpacksCacheController#delete removes all entries of the buildpack_cache. With
a DavClient this will create an issue as soon as an app is deleted, because the
delete_all_in_path method (called when the buildpack_cache for the app is removed)
will raise after not finding the app guid in the first place.

This is not an issue with FogClient, which just silently returns. We believe this
is the correct behavior because the target state (app_guid and children are gone)
has already been reached.

BuildpacksCacheController#delete removes all entries of the buildpack_cache. With
fog_client.delete_all_in_path and dav_client.delete_all_in_path behave
differently:

* fog_client will not attempt to delete anything if the given path does not exist.
It will not fail or raise an exeption.
* dav_client will raise an exception when to path to be deleted does not exist.

Note: This is only an issue when using the CC v3 API.

This commit brings the behavior of DavClient in line with FogClient when attempting
to delete a resource that already is gone.

thx,
@suhlig and @MarcSchunk