### PR TITLE
CC stages over HTTPS

### DIFF
--- a/app/controllers/internal/dea/staging_completion_controller.rb
+++ b/app/controllers/internal/dea/staging_completion_controller.rb
@@ -1,0 +1,68 @@
+require 'sinatra'
+require 'controllers/base/base_controller'
+require 'cloud_controller/internal_api'
+
+module VCAP::CloudController
+  module Dea
+    class StagingCompletionController < RestController::BaseController
+      def self.dependencies
+        [:stagers]
+      end
+
+      allow_unauthenticated_access
+
+      def initialize(*)
+        super
+        auth = Rack::Auth::Basic::Request.new(env)
+        unless auth.provided? && auth.basic? && auth.credentials == InternalApi.credentials
+          raise CloudController::Errors::ApiError.new_from_details('NotAuthenticated')
+        end
+      end
+
+      def inject_dependencies(dependencies)
+        super
+        @stagers = dependencies.fetch(:stagers)
+      end
+
+      post '/internal/dea/staging/:app_guid/completed', :completed
+
+      def completed(app_guid)
+        staging_response = read_body
+
+        app = App.find(guid: app_guid)
+        raise CloudController::Errors::ApiError.new_from_details('NotFound') unless app
+
+        raise CloudController::Errors::ApiError.new_from_details('InvalidRequest') unless app.staging_task_id == staging_response['task_id']
+
+        begin
+          stagers.stager_for_app(app).staging_complete(nil, staging_response)
+        rescue CloudController::Errors::ApiError => api_err
+          logger.error('dea.staging.completion-controller-error', error: api_err)
+          raise api_err
+        rescue => e
+          logger.error('dea.staging.completion-controller-error', error: e)
+          raise CloudController::Errors::ApiError.new_from_details('ServerError')
+        end
+
+        [200, '{}']
+      end
+
+      private
+
+      attr_reader :stagers
+
+      def read_body
+        staging_response = {}
+        begin
+          payload = body.read
+          staging_response = MultiJson.load(payload, symbolize_keys: false)
+        rescue MultiJson::ParseError => pe
+          logger.error('dea.staging.parse-error', payload: payload, error: pe.to_s)
+          raise CloudController::Errors::ApiError.new_from_details('MessageParseError', payload)
+        end
+
+        staging_response
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -62,6 +62,12 @@ module VCAP::CloudController
           url: String
         },
 
+        optional(:dea_client) => {
+          :ca_file    => String,
+          :cert_file  => String,
+          :key_file   => String,
+        },
+
         :uaa => {
           :url                => String,
           :resource_id        => String,

--- a/lib/cloud_controller/dea/app_stager_task.rb
+++ b/lib/cloud_controller/dea/app_stager_task.rb
@@ -21,11 +21,9 @@ module VCAP::CloudController
       end
 
       def stage(&completion_callback)
-        @stager_id = @dea_pool.find_stager(@app.stack.name, staging_task_memory_mb, staging_task_disk_mb)
-        raise CloudController::Errors::ApiError.new_from_details('StagingError', 'no available stagers') unless @stager_id
-
-        subject = "staging.#{@stager_id}.start"
-        @multi_message_bus_request = MultiResponseMessageBusRequest.new(@message_bus, subject)
+        stager = @dea_pool.find_stager(@app.stack.name, staging_task_memory_mb, staging_task_disk_mb)
+        raise CloudController::Errors::ApiError.new_from_details('StagingError', 'no available stagers') unless stager
+        @stager_id = stager.dea_id
 
         # Save the current staging task
         @app.update(package_state: 'PENDING', staging_task_id: task_id)
@@ -39,6 +37,13 @@ module VCAP::CloudController
 
         logger.info('staging.begin', app_guid: @app.guid)
         staging_msg = staging_request
+
+        if stager.url && Client.enabled?
+          return stage_with_http(stager.url, staging_msg)
+        end
+
+        subject = "staging.#{@stager_id}.start"
+        @multi_message_bus_request = MultiResponseMessageBusRequest.new(@message_bus, subject)
 
         staging_result = EM.schedule_sync do |promise|
           # First response is blocking stage_app.
@@ -66,11 +71,29 @@ module VCAP::CloudController
         StagingMessage.new(@config, @blobstore_url_generator).staging_request(@app, task_id)
       end
 
+      def handle_http_response(response)
+        ensure_staging_is_current!
+        check_staging_error!(response)
+        process_response(response)
+      rescue => e
+        Loggregator.emit_error(@app.guid, "Encountered error: #{e.message}")
+        logger.error "Encountered error on stager with id #{@stager_id}: #{e}\n#{e.backtrace.join("\n")}"
+        raise e
+      end
+
       private
 
+      def stage_with_http(url, msg)
+        Dea::Client.stage(url, msg)
+      rescue => e
+        @app.mark_as_failed_to_stage('StagingError')
+        logger.error e.message
+        raise e
+      end
+
       def handle_first_response(response, error, promise)
-        ensure_staging_is_current!
-        check_staging_error!(response, error)
+        ensure_staging_is_current!(false)
+        check_staging_error!(response)
         promise.deliver(StagingResponse.new(response))
       rescue => e
         Loggregator.emit_error(@app.guid, "exception handling first response #{e.message}")
@@ -80,8 +103,8 @@ module VCAP::CloudController
 
       def handle_second_response(response, error)
         @multi_message_bus_request.ignore_subsequent_responses
-        ensure_staging_is_current!
-        check_staging_error!(response, error)
+        ensure_staging_is_current!(false)
+        check_staging_error!(response)
         process_response(response)
       rescue => e
         Loggregator.emit_error(@app.guid, "encountered error: #{e.message}")
@@ -101,7 +124,7 @@ module VCAP::CloudController
         end
       end
 
-      def check_staging_error!(response, error)
+      def check_staging_error!(response)
         type = error_type(response)
         message = error_message(response)
 
@@ -131,7 +154,7 @@ module VCAP::CloudController
         end
       end
 
-      def ensure_staging_is_current!
+      def ensure_staging_is_current!(use_http=true)
         begin
           # Reload to find other updates of staging task id
           # which means that there was a new staging process initiated
@@ -142,12 +165,16 @@ module VCAP::CloudController
           raise CloudController::Errors::ApiError.new_from_details('StagingError', "failed to stage application: can't retrieve staging status")
         end
 
-        if @app.staging_task_id != task_id
-          raise CloudController::Errors::ApiError.new_from_details('StagingError', 'failed to stage application: another staging request was initiated')
-        end
+        check_task_id unless use_http
 
         if @app.staging_failed?
           raise CloudController::Errors::ApiError.new_from_details('StagingError', STAGING_ALREADY_FAILURE_MSG)
+        end
+      end
+
+      def check_task_id
+        if @app.staging_task_id != task_id
+          raise CloudController::Errors::ApiError.new_from_details('StagingError', 'failed to stage application: another staging request was initiated')
         end
       end
 

--- a/lib/cloud_controller/dea/pool.rb
+++ b/lib/cloud_controller/dea/pool.rb
@@ -59,7 +59,7 @@ module VCAP::CloudController
 
           prune_stale_deas
           best_ad = top_n_stagers_for(memory, disk, stack).sample
-          best_ad && best_ad[0]
+          best_ad && best_ad[1]
         end
       end
 

--- a/lib/cloud_controller/dea/stager.rb
+++ b/lib/cloud_controller/dea/stager.rb
@@ -10,20 +10,23 @@ module VCAP::CloudController
       end
 
       def stage
-        blobstore_url_generator = CloudController::DependencyLocator.instance.blobstore_url_generator
-        task = AppStagerTask.new(@config, @message_bus, @app, @dea_pool, blobstore_url_generator)
-
-        @app.last_stager_response = task.stage do |staging_result|
+        @app.last_stager_response = stager_task.stage do |staging_result|
           @runners.runner_for_app(@app).start(staging_result)
         end
       end
 
-      def staging_complete(_, _)
-        raise NotImplementedError
+      def staging_complete(_, response)
+        stager_task.handle_http_response(response)
       end
 
       def stop_stage
         nil
+      end
+
+      private
+
+      def stager_task
+        @task ||= AppStagerTask.new(@config, @message_bus, @app, @dea_pool, CloudController::DependencyLocator.instance.blobstore_url_generator)
       end
     end
   end

--- a/lib/cloud_controller/dea/staging_message.rb
+++ b/lib/cloud_controller/dea/staging_message.rb
@@ -20,6 +20,7 @@ module VCAP::CloudController
           start_message:                start_app_message(app),
           admin_buildpacks:             admin_buildpacks,
           egress_network_rules:         staging_egress_rules,
+          accepts_http:                 @config[:dea_client] ? true : false
         }
       end
 

--- a/spec/unit/controllers/internal/dea/staging_completion_controller_spec.rb
+++ b/spec/unit/controllers/internal/dea/staging_completion_controller_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+require 'membrane'
+# require 'cloud_controller/diego/staging_guid'
+
+module VCAP::CloudController
+  module Dea
+    describe StagingCompletionController do
+      let(:buildpack) { Buildpack.make }
+      let(:buildpack_key) { buildpack.key }
+      let(:detected_buildpack) { 'detected_buildpack' }
+      let(:droplet_sha1) { 'gobbledygook' }
+      let(:start_command) { '/usr/bin/letsparty' }
+      let(:procfile) { '/path/to/procfile' }
+      let(:staging_error) { nil }
+
+      let(:staging_response) do
+        {
+          'task_id' => task_id,
+          'detected_buildpack' => detected_buildpack,
+          'buildpack_key' => buildpack_key,
+          'droplet_sha1' => droplet_sha1,
+          'detected_start_command' => start_command,
+          'procfile' => procfile,
+          'error' => staging_error
+        }
+      end
+      #
+      def make_dea_app(package_state, app_state)
+        AppFactory.make.tap do |app|
+          app.package_state = package_state
+          app.state = app_state
+          app.staging_task_id = Sham.guid
+          app.save
+        end
+      end
+      #
+      let(:v2_app) { make_dea_app('PENDING', 'STOPPED') }
+      let(:app_guid) { v2_app.guid }
+      let(:task_id) { v2_app.staging_task_id }
+      let(:url) { "/internal/dea/staging/#{app_guid}/completed" }
+
+      before do
+        @internal_user = 'internal_user'
+        @internal_password = 'internal_password'
+        authorize @internal_user, @internal_password
+      end
+
+      describe 'authentication' do
+        context 'when missing authentication' do
+          it 'fails with authentication required' do
+            header('Authorization', nil)
+            post url, MultiJson.dump(staging_response)
+            expect(last_response.status).to eq(401)
+          end
+        end
+
+        context 'when using invalid credentials' do
+          it 'fails with authenticatiom required' do
+            authorize 'bar', 'foo'
+            post url, MultiJson.dump(staging_response)
+            expect(last_response.status).to eq(401)
+          end
+        end
+
+        context 'when using valid credentials' do
+          before do
+            allow_any_instance_of(Dea::Stager).to receive(:staging_complete)
+          end
+
+          it 'succeeds' do
+            post url, MultiJson.dump(staging_response)
+            expect(last_response.status).to eq(200)
+          end
+        end
+      end
+
+      describe 'validation' do
+        context 'when sending invalid json' do
+          it 'fails with a 400' do
+            post url, 'this is not json'
+
+            expect(last_response.status).to eq(400)
+            expect(last_response.body).to match /MessageParseError/
+          end
+        end
+      end
+
+      context 'with a valid app' do
+        it 'calls the stager with the staging guid and response' do
+          expect_any_instance_of(Dea::Stager).to receive(:staging_complete).with(nil, staging_response)
+
+          post url, MultiJson.dump(staging_response)
+          expect(last_response.status).to eq(200)
+        end
+
+        it 'propagates api errors from staging_response' do
+          expect_any_instance_of(Dea::Stager).to receive(:staging_complete).and_raise(CloudController::Errors::ApiError.new_from_details('JobTimeout'))
+
+          post url, MultiJson.dump(staging_response)
+          expect(last_response.status).to eq(524)
+          expect(last_response.body).to match /JobTimeout/
+        end
+
+        it 'raises a ServerError for non-api errors from staging_response' do
+          expect_any_instance_of(Dea::Stager).to receive(:staging_complete).and_raise('something')
+
+          post url, MultiJson.dump(staging_response)
+          expect(last_response.status).to eq(500)
+          expect(last_response.body).to match /ServerError/
+        end
+      end
+
+      context 'when the app does not exist' do
+        before { v2_app.delete }
+
+        it 'fails with a 404' do
+          post url, MultiJson.dump(staging_response)
+
+          expect(last_response.status).to eq(404)
+        end
+      end
+
+      context 'when the task_id does not match the app' do
+        let(:task_id) { 'bogus_task_id' }
+
+        it 'discards the response and fails with a 400' do
+          expect_any_instance_of(Dea::Stager).to_not receive(:staging_complete)
+
+          post url, MultiJson.dump(staging_response)
+          expect(last_response.status).to eq(400)
+          expect(last_response.body).to match /InvalidRequest/
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
@@ -5,17 +5,21 @@ module VCAP::CloudController
     let(:message_bus) { CfMessageBus::MockMessageBus.new }
     let(:dea_pool) { double(:dea_pool, reserve_app_memory: nil) }
     let(:config_hash) { { staging: { timeout_in_seconds: 360 } } }
+    let(:droplet_sha1) { nil }
     let(:app) do
       AppFactory.make(
         package_hash:  'abc',
-        droplet_hash:  nil,
+        droplet_hash:  droplet_sha1,
         package_state: 'PENDING',
         state:         'STARTED',
         instances:     1,
         disk_quota:    1024
       )
     end
-    let(:stager_id) { 'my_stager' }
+
+    let(:dea_advertisement) { Dea::NatsMessages::DeaAdvertisement.new({ 'id' => 'my_stager' }, nil) }
+    let(:stager_id) { dea_advertisement.dea_id }
+
     let(:blobstore_url_generator) { CloudController::DependencyLocator.instance.blobstore_url_generator }
 
     let(:options) { {} }
@@ -61,15 +65,318 @@ module VCAP::CloudController
       expect(app.staged?).to be false
 
       allow(VCAP).to receive(:secure_uuid) { 'some_task_id' }
-      allow(dea_pool).to receive(:find_stager).with(app.stack.name, 1024, anything).and_return(stager_id)
+      allow(dea_pool).to receive(:find_stager).with(app.stack.name, 1024, anything).and_return(dea_advertisement)
 
       allow(EM).to receive(:add_timer)
       allow(EM).to receive(:defer).and_yield
       allow(EM).to receive(:schedule_sync)
     end
 
+    context 'when http is enabled' do
+      context 'when the dea supports http' do
+        let(:dea_advertisement) { Dea::NatsMessages::DeaAdvertisement.new({ 'id' => 'my_stager', 'url' => 'https://adea.dea' }, nil) }
+        let(:staging_message) { 'message' }
+        before do
+          allow(Dea::Client).to receive(:enabled?).and_return(true)
+          allow(staging_task).to receive(:staging_request).and_return(staging_message)
+        end
+
+        it 'uses http' do
+          expect(app).to receive(:update).with({ package_state: 'PENDING', staging_task_id: staging_task.task_id })
+          expect(message_bus).to receive(:publish).with('staging.stop', { app_id: app.guid })
+          expect(dea_pool).to receive(:reserve_app_memory).with(stager_id, app.memory)
+          expect(Dea::Client).to receive(:stage).with(dea_advertisement.url, staging_message)
+          staging_task.stage
+        end
+
+        context 'when an error occurs' do
+          let(:logger) { double(Steno) }
+
+          before do
+            allow(staging_task).to receive(:logger).and_return(logger)
+            allow(Dea::Client).to receive(:stage).and_raise 'failure'
+            allow(logger).to receive(:info)
+          end
+
+          it 'marks app as failed and raises an error' do
+            expect(app).to receive(:mark_as_failed_to_stage).with('StagingError')
+            expect(logger).to receive(:error).with(/failure/)
+            expect { staging_task.stage }.to raise_error 'failure'
+          end
+        end
+      end
+
+      context 'when the dea does not support http' do
+        it 'uses nats' do
+          expect(app).to receive(:update).with({ package_state: 'PENDING', staging_task_id: staging_task.task_id })
+          expect(message_bus).to receive(:publish).with('staging.stop', { app_id: app.guid })
+          expect(dea_pool).to receive(:reserve_app_memory).with(stager_id, app.memory)
+          expect(staging_task).not_to receive(:stage_with_http)
+          staging_task.stage
+        end
+      end
+    end
+
+    describe '#handle_http_response' do
+      let(:response) { reply_json }
+
+      before do
+        allow(Dea::Client).to receive(:enabled?).and_return(true)
+        staging_task.stage
+      end
+
+      context 'when the DEA sends a staging success response' do
+        let(:detected_buildpack) { 'buildpack detect output' }
+
+        context 'when no other staging has happened' do
+          before do
+            allow(dea_pool).to receive(:mark_app_started)
+          end
+
+          it 'marks the app as staged' do
+            expect { staging_task.handle_http_response(response) }.to change { app.refresh.staged? }.to(true)
+          end
+
+          it 'saves the detected buildpack' do
+            expect { staging_task.handle_http_response(response) }.to change { app.refresh.detected_buildpack }.from(nil)
+          end
+
+          context 'and the droplet has been uploaded' do
+            let(:droplet_sha1) { 'Abc' }
+            it 'saves the detected start command' do
+              expect { staging_task.handle_http_response(response) }.to change {
+                app.current_droplet.refresh
+                app.detected_start_command
+              }.from('').to('wait_for_godot')
+            end
+          end
+
+          context 'when the droplet somehow has not been uploaded (defensive)' do
+            it 'does not change the start command' do
+              expect { staging_task.handle_http_response(response) }.not_to change {
+                app.detected_start_command
+              }.from('')
+            end
+          end
+
+          context 'when detected_start_command is not returned' do
+            let(:response) do
+              {
+                'task_id'                => 'task-id',
+                'task_log'               => 'task-log',
+                'task_streaming_log_url' => nil,
+                'detected_buildpack'     => detected_buildpack,
+                'buildpack_key'          => buildpack_key,
+                'error'                  => reply_json_error,
+                'error_info'             => reply_error_info,
+                'droplet_sha1'           => 'droplet-sha1'
+              }
+            end
+
+            let(:droplet_sha1) { 'Abc' }
+
+            it 'does not change the detected start command' do
+              expect { staging_task.handle_http_response(response) }.not_to change {
+                app.current_droplet.refresh
+                app.detected_start_command
+              }.from('')
+            end
+          end
+
+          context 'when an admin buildpack is used' do
+            let(:admin_buildpack) { Buildpack.make(name: 'buildpack-name') }
+            let(:buildpack_key) { admin_buildpack.key }
+            before do
+              app.buildpack = admin_buildpack.name
+            end
+
+            it 'saves the detected buildpack guid' do
+              expect { staging_task.handle_http_response(response) }.to change { app.refresh.detected_buildpack_guid }.from(nil)
+            end
+          end
+
+          it 'does not clobber other attributes that changed between staging' do
+            # fake out the app refresh as the race happens after it
+            allow(app).to receive(:refresh)
+
+            other_app_ref         = App.find(guid: app.guid)
+            other_app_ref.command = 'some other command'
+            other_app_ref.save
+
+            expect { staging_task.handle_http_response(response) }.to_not change {
+              other_app_ref.refresh.command
+            }
+          end
+
+          it 'marks app started in dea pool' do
+            expect(dea_pool).to receive(:mark_app_started).with({ dea_id: stager_id, app_id: app.guid })
+            staging_task.handle_http_response(response)
+          end
+
+          context 'when callback is not nil' do
+            before do
+              allow(Dea::Client).to receive(:enabled?).and_return(true)
+              @callback_options = nil
+              staging_task.stage { |options| @callback_options = options }
+
+              expect(@callback_options).to be_nil
+            end
+
+            it 'calls provided callback' do
+              staging_task.handle_http_response(response)
+              expect(@callback_options[:started_instances]).to equal(1)
+            end
+          end
+        end
+
+        context 'when staging was already marked as failed' do
+          before do
+            app.mark_as_failed_to_stage
+          end
+
+          it 'does not mark the app as staged' do
+            expect {
+              ignore_staging_error { staging_task.handle_http_response(response) }
+            }.not_to change { app.refresh.staged? }
+          end
+
+          it 'raises a StagingError' do
+            expect {
+              staging_task.handle_http_response(response)
+            }.to raise_error(
+              CloudController::Errors::ApiError,
+              /staging had already been marked as failed, this could mean that staging took too long/
+            )
+          end
+        end
+      end
+
+      context 'when the response is empty' do
+        let(:response) { nil }
+        let(:logger) { double(Steno).as_null_object }
+
+        before do
+          allow(staging_task).to receive(:logger).and_return(logger)
+        end
+
+        it 'logs StagingError' do
+          expect(logger).to receive(:error).with(/Encountered error on stager with id #{stager_id}/)
+          ignore_staging_error { staging_task.handle_http_response(response) }
+        end
+
+        it 'keeps the app as not staged' do
+          expect {
+            ignore_staging_error { staging_task.handle_http_response(response) }
+          }.to_not change { app.staged? }.from(false)
+        end
+
+        context 'when it has a callback' do
+          before do
+            @callback_called = false
+            staging_task.stage { @callback_called = true }
+            expect(@callback_called).to be false
+          end
+          it 'does not call provided callback (not yet)' do
+            ignore_staging_error { staging_task.handle_http_response(response) }
+            expect(@callback_called).to be false
+          end
+        end
+
+        it 'marks the app as having failed to stage' do
+          expect {
+            ignore_staging_error { staging_task.handle_http_response(response) }
+          }.to change { app.staging_failed? }.to(true)
+        end
+
+        it 'leaves the app with a generic staging failed reason' do
+          expect {
+            ignore_staging_error { staging_task.handle_http_response(response) }
+          }.to change { app.staging_failed_reason }.to('StagingError')
+        end
+      end
+
+      context 'when app staging returned an error response' do
+        let(:reply_json_error) { 'staging failed' }
+        let(:logger) { double(Steno).as_null_object }
+
+        before do
+          allow(staging_task).to receive(:logger).and_return(logger)
+        end
+
+        it 'logs StagingError' do
+          expect(logger).to receive(:error) do |msg|
+            expect(msg).to match(/Encountered error on stager with id #{stager_id}/)
+          end
+
+          ignore_staging_error { staging_task.handle_http_response(response) }
+        end
+
+        it 'keeps the app as not staged' do
+          expect {
+            ignore_staging_error { staging_task.handle_http_response(response) }
+          }.to_not change { app.staged? }.from(false)
+        end
+
+        it 'does not save the detected buildpack' do
+          expect {
+            ignore_staging_error { staging_task.handle_http_response(response) }
+          }.to_not change { app.detected_buildpack }.from(nil)
+        end
+
+        it 'does not save the detected buildpack guid' do
+          expect {
+            ignore_staging_error { staging_task.handle_http_response(response) }
+          }.to_not change { app.detected_buildpack_guid }.from(nil)
+        end
+
+        it 'does not save the detected start command' do
+          expect {
+            ignore_staging_error { staging_task.handle_http_response(response) }
+          }.to_not change { app.detected_start_command }.from('')
+        end
+
+        context 'when it has a callback' do
+          before do
+            @callback_called = false
+            staging_task.stage { @callback_called = true }
+            expect(@callback_called).to be false
+          end
+          it 'does not call provided callback (not yet)' do
+            ignore_staging_error { staging_task.handle_http_response(response) }
+            expect(@callback_called).to be false
+          end
+        end
+
+        it 'marks the app as having failed to stage' do
+          expect {
+            ignore_staging_error { staging_task.handle_http_response(response) }
+          }.to change { app.staging_failed? }.to(true)
+        end
+
+        context 'when a staging error is present' do
+          let(:reply_error_info) { { 'type' => 'NoAppDetectedError', 'message' => 'uh oh' } }
+
+          it 'sets the staging failed reason to the specified value' do
+            expect {
+              ignore_staging_error { staging_task.handle_http_response(response) }
+            }.to change { app.staging_failed_reason }.to('NoAppDetectedError')
+          end
+        end
+
+        context 'when a staging error is not present' do
+          let(:reply_error_info) { nil }
+
+          it 'sets staging failed reason to StagingError' do
+            expect {
+              ignore_staging_error { staging_task.handle_http_response(response) }
+            }.to change { app.staging_failed_reason }.to('StagingError')
+          end
+        end
+      end
+    end
+
     context 'when no stager can be found' do
-      let(:stager_id) { nil }
+      let(:dea_advertisement) { nil }
 
       it 'should raise an error' do
         expect {
@@ -89,7 +396,7 @@ module VCAP::CloudController
       context 'when the app memory requirement exceeds the staging memory requirement (1024)' do
         it 'should request a stager with the app memory requirement' do
           app.memory = 1025
-          expect(dea_pool).to receive(:find_stager).with(app.stack.name, 1025, anything).and_return(stager_id)
+          expect(dea_pool).to receive(:find_stager).with(app.stack.name, 1025, anything).and_return(dea_advertisement)
           staging_task.stage
         end
       end
@@ -97,7 +404,7 @@ module VCAP::CloudController
       context 'when the app memory requirement is less than the staging memory requirement' do
         it 'requests the staging memory requirement' do
           config_hash[:staging][:minimum_staging_memory_mb] = 2048
-          expect(dea_pool).to receive(:find_stager).with(app.stack.name, 2048, anything).and_return(stager_id)
+          expect(dea_pool).to receive(:find_stager).with(app.stack.name, 2048, anything).and_return(dea_advertisement)
           staging_task.stage
         end
       end
@@ -108,7 +415,7 @@ module VCAP::CloudController
         it 'should request a stager with enough disk' do
           app.disk_quota                                  = 12
           config_hash[:staging][:minimum_staging_disk_mb] = 1025
-          expect(dea_pool).to receive(:find_stager).with(app.stack.name, anything, 1025).and_return(stager_id)
+          expect(dea_pool).to receive(:find_stager).with(app.stack.name, anything, 1025).and_return(dea_advertisement)
           staging_task.stage
         end
       end
@@ -117,7 +424,7 @@ module VCAP::CloudController
         it 'should request a stager with enough disk' do
           app.disk_quota                                  = 123
           config_hash[:staging][:minimum_staging_disk_mb] = nil
-          expect(dea_pool).to receive(:find_stager).with(app.stack.name, anything, 4096).and_return(stager_id)
+          expect(dea_pool).to receive(:find_stager).with(app.stack.name, anything, 4096).and_return(dea_advertisement)
           staging_task.stage
         end
       end
@@ -126,7 +433,7 @@ module VCAP::CloudController
         it 'should request a stager with enough disk' do
           app.disk_quota                                  = 123
           config_hash[:staging][:minimum_staging_disk_mb] = 122
-          expect(dea_pool).to receive(:find_stager).with(app.stack.name, anything, 123).and_return(stager_id)
+          expect(dea_pool).to receive(:find_stager).with(app.stack.name, anything, 123).and_return(dea_advertisement)
           staging_task.stage
         end
       end
@@ -583,7 +890,7 @@ module VCAP::CloudController
 
       describe 'reserve app memory' do
         before do
-          allow(dea_pool).to receive(:find_stager).with(app.stack.name, 1025, 4096).and_return(stager_id)
+          allow(dea_pool).to receive(:find_stager).with(app.stack.name, 1025, 4096).and_return(dea_advertisement)
         end
 
         context 'when app memory is less when configured minimum_staging_memory_mb' do
@@ -640,7 +947,7 @@ module VCAP::CloudController
     def ignore_staging_error
       yield
     rescue CloudController::Errors::ApiError => e
-      raise e unless e.name == 'StagingError'
+      raise e unless e.name == 'StagingError' || e.name == 'NoAppDetectedError'
     end
   end
 end

--- a/spec/unit/lib/cloud_controller/dea/pool_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/pool_spec.rb
@@ -409,7 +409,7 @@ module VCAP::CloudController
         it 'only finds registered stagers' do
           expect { subject.find_stager('stack', 0, 0) }.to raise_error(CloudController::Errors::ApiError, /The stack could not be found/)
           subject.process_advertise_message(dea_advertise_msg)
-          expect(subject.find_stager('stack', 0, 0)).to eq('dea-id')
+          expect(subject.find_stager('stack', 0, 0).dea_id).to eq('dea-id')
         end
       end
 
@@ -440,7 +440,7 @@ module VCAP::CloudController
             subject.process_advertise_message(dea_advertise_msg)
 
             Timecop.travel(9)
-            expect(subject.find_stager('stack', 1024, 0)).to eq('dea-id')
+            expect(subject.find_stager('stack', 1024, 0).dea_id).to eq('dea-id')
 
             Timecop.travel(1)
             expect(subject.find_stager('stack', 1024, 0)).to be_nil
@@ -455,7 +455,7 @@ module VCAP::CloudController
               subject.process_advertise_message(dea_advertise_msg)
 
               Timecop.travel(11)
-              expect(subject.find_stager('stack', 1024, 0)).to eq('dea-id')
+              expect(subject.find_stager('stack', 1024, 0).dea_id).to eq('dea-id')
 
               Timecop.travel(5)
               expect(subject.find_stager('stack', 1024, 0)).to be_nil
@@ -468,7 +468,7 @@ module VCAP::CloudController
         it 'only finds stagers that can satisfy memory request' do
           subject.process_advertise_message(dea_advertise_msg)
           expect(subject.find_stager('stack', 1025, 0)).to be_nil
-          expect(subject.find_stager('stack', 1024, 0)).to eq('dea-id')
+          expect(subject.find_stager('stack', 1024, 0).dea_id).to eq('dea-id')
         end
 
         it 'samples out of the top 5 stagers with enough memory' do
@@ -483,7 +483,7 @@ module VCAP::CloudController
           correct_stagers = (5..9).map { |i| "staging-id-#{i}" }
 
           10.times do
-            expect(correct_stagers).to include(subject.find_stager('stack-name', 1024, 0))
+            expect(correct_stagers).to include(subject.find_stager('stack-name', 1024, 0).dea_id)
           end
         end
       end
@@ -492,7 +492,7 @@ module VCAP::CloudController
         it 'only finds deas that can satisfy stack request' do
           subject.process_advertise_message(dea_advertise_msg)
           expect { subject.find_stager('unknown-stack-name', 0, 0) }.to raise_error(CloudController::Errors::ApiError, /The stack could not be found/)
-          expect(subject.find_stager('stack', 0, 0)).to eq('dea-id')
+          expect(subject.find_stager('stack', 0, 0).dea_id).to eq('dea-id')
         end
       end
 

--- a/spec/unit/lib/cloud_controller/dea/staging_message_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/staging_message_spec.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
         end
       end
 
-      it 'includes app guid, task id, download/upload uris and stack name' do
+      it 'includes app guid, task id, download/upload uris, stack name, and accepts_http flag' do
         allow(blobstore_url_generator).to receive(:app_package_download_url).with(app).and_return('http://www.app.uri')
         allow(blobstore_url_generator).to receive(:droplet_upload_url).with(app).and_return('http://www.droplet.upload.uri')
         allow(blobstore_url_generator).to receive(:buildpack_cache_download_url).with(app).and_return('http://www.buildpack.cache.download.uri')
@@ -40,6 +40,7 @@ module VCAP::CloudController
         expect(request[:buildpack_cache_upload_uri]).to eq('http://www.buildpack.cache.upload.uri')
         expect(request[:buildpack_cache_download_uri]).to eq('http://www.buildpack.cache.download.uri')
         expect(request[:stack]).to eq(app.stack.name)
+        expect(request[:accepts_http]).to be false
       end
 
       it 'includes misc app properties' do
@@ -239,6 +240,15 @@ module VCAP::CloudController
 
           request = staging_message.staging_request(app, task_id)
           expect(request[:properties][:environment]).to include('KEY=value')
+        end
+      end
+
+      context 'when http is enabled for DEAs' do
+        let(:config_hash) { { dea_client: { cert_file: 'some/file', key_file: 'another/file' } } }
+
+        it 'sets the staging request accepts https to true' do
+          request = staging_message.staging_request(app, task_id)
+          expect(request[:accepts_http]).to equal(true)
         end
       end
     end


### PR DESCRIPTION
This is a change to allow the CC to send staging requests to DEAs over https instead of NATS.  The behavior is configurable and can be determined on a per-DEA basis (meaning we support a mixed deployment of some DEAs supporting NATS, some support HTTPS).

* [ YES] I have viewed signed and have submitted the Contributor License Agreement

* [YES ] I have made this pull request to the `master` branch

* [ YES] I have run all the unit tests using `bundle exec rake`

* [ YES] I have run CF Acceptance Tests on bosh lite

[#112002909]

Thanks,

@ScarletTanager & @jberkhahn CF RuntimeOG team