### PR TITLE
Make staging response controller respond correctly

### DIFF
--- a/app/controllers/internal/dea/staging_completion_controller.rb
+++ b/app/controllers/internal/dea/staging_completion_controller.rb
@@ -38,7 +38,8 @@ module VCAP::CloudController
           stagers.stager_for_app(app).staging_complete(nil, staging_response)
         rescue CloudController::Errors::ApiError => api_err
           logger.error('dea.staging.completion-controller-error', error: api_err)
-          raise api_err
+          raise CloudController::Errors::ApiError.new_from_details('ServerError', name: api_err.name, message: api_err.message) if api_err.name.eql? 'StagingError'
+          return [200, '{}']
         rescue => e
           logger.error('dea.staging.completion-controller-error', error: e)
           raise CloudController::Errors::ApiError.new_from_details('ServerError')

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -80,7 +80,7 @@ module VCAP::CloudController
 
     APP_STATES = %w(STOPPED STARTED).map(&:freeze).freeze
     PACKAGE_STATES = %w(PENDING STAGED FAILED).map(&:freeze).freeze
-    STAGING_FAILED_REASONS = %w(StagingError StagingTimeExpired NoAppDetectedError BuildpackCompileFailed
+    STAGING_FAILED_REASONS = %w(StagerError StagingError StagingTimeExpired NoAppDetectedError BuildpackCompileFailed
                                 BuildpackReleaseFailed InsufficientResources NoCompatibleCell).map(&:freeze).freeze
     HEALTH_CHECK_TYPES = %w(port none process).map(&:freeze).freeze
 

--- a/lib/cloud_controller/dea/app_stager_task.rb
+++ b/lib/cloud_controller/dea/app_stager_task.rb
@@ -152,11 +152,11 @@ module VCAP::CloudController
 
       def error_type(response)
         if response.is_a?(String) || response.nil?
-          'StagingError'
+          'StagerError'
         elsif response['error_info']
           response['error_info']['type']
         elsif response['error']
-          'StagingError'
+          'StagerError'
         end
       end
 

--- a/spec/unit/controllers/internal/dea/staging_completion_controller_spec.rb
+++ b/spec/unit/controllers/internal/dea/staging_completion_controller_spec.rb
@@ -93,12 +93,11 @@ module VCAP::CloudController
           expect(last_response.status).to eq(200)
         end
 
-        it 'propagates api errors from staging_response' do
-          expect_any_instance_of(Dea::Stager).to receive(:staging_complete).and_raise(CloudController::Errors::ApiError.new_from_details('JobTimeout'))
+        it 'returns a 200 when the response includes an error from the DEA' do
+          expect_any_instance_of(Dea::Stager).to receive(:staging_complete).and_raise(CloudController::Errors::ApiError.new_from_details('StagerError'))
 
           post url, MultiJson.dump(staging_response)
-          expect(last_response.status).to eq(524)
-          expect(last_response.body).to match /JobTimeout/
+          expect(last_response.status).to eq(200)
         end
 
         it 'raises a ServerError for non-api errors from staging_response' do

--- a/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
@@ -291,7 +291,7 @@ module VCAP::CloudController
         it 'leaves the app with a generic staging failed reason' do
           expect {
             ignore_staging_error { staging_task.handle_http_response(response) }
-          }.to change { app.staging_failed_reason }.to('StagingError')
+          }.to change { app.staging_failed_reason }.to('StagerError')
         end
       end
 
@@ -366,10 +366,10 @@ module VCAP::CloudController
         context 'when a staging error is not present' do
           let(:reply_error_info) { nil }
 
-          it 'sets staging failed reason to StagingError' do
+          it 'sets staging failed reason to StagerError' do
             expect {
               ignore_staging_error { staging_task.handle_http_response(response) }
-            }.to change { app.staging_failed_reason }.to('StagingError')
+            }.to change { app.staging_failed_reason }.to('StagerError')
           end
         end
       end
@@ -826,7 +826,7 @@ module VCAP::CloudController
           end
 
           it 'leaves the app with a generic staging failed reason' do
-            expect { stage }.to change { app.staging_failed_reason }.to('StagingError')
+            expect { stage }.to change { app.staging_failed_reason }.to('StagerError')
           end
         end
 
@@ -882,7 +882,7 @@ module VCAP::CloudController
             let(:reply_error_info) { nil }
 
             it 'sets a generic staging failed reason' do
-              expect { stage }.to change { app.staging_failed_reason }.to('StagingError')
+              expect { stage }.to change { app.staging_failed_reason }.to('StagerError')
             end
           end
         end
@@ -947,7 +947,7 @@ module VCAP::CloudController
     def ignore_staging_error
       yield
     rescue CloudController::Errors::ApiError => e
-      raise e unless e.name == 'StagingError' || e.name == 'NoAppDetectedError'
+      raise e unless e.name == 'StagingError' || e.name == 'NoAppDetectedError' || e.name == 'StagerError'
     end
   end
 end


### PR DESCRIPTION
Currently the CC returns a 400 (incorrectly) when the DEA sends a staging response including an error over http.  This fixes that (should be a 200) and fixes any other errors not resulting from a bad request to be 500s.

* [Yes ] I have viewed signed and have submitted the Contributor License Agreement

* [ Yes] I have made this pull request to the `master` branch

* [ Yes] I have run all the unit tests using `bundle exec rake`

* [ Yes] I have run CF Acceptance Tests on bosh lite

- return 200 when DEA response contains error
- return 500 (not 400) for all CC errors

[#112002909]

Signed-off-by: Dan Lavine <dlavine@us.ibm.com>