### PR TITLE
Fallback to NATs if staging over http isn't there

### DIFF
--- a/lib/cloud_controller/dea/app_stager_task.rb
+++ b/lib/cloud_controller/dea/app_stager_task.rb
@@ -63,7 +63,8 @@ module VCAP::CloudController
       private
 
       def stage_with_http(url, msg)
-        Dea::Client.stage(url, msg)
+        success = Dea::Client.stage(url, msg)
+        stage_with_nats(msg) unless success
       rescue => e
         @app.mark_as_failed_to_stage('StagingError')
         logger.error e.message

--- a/lib/cloud_controller/dea/client.rb
+++ b/lib/cloud_controller/dea/client.rb
@@ -44,12 +44,17 @@ module VCAP::CloudController
         def stage(url, msg)
           raise ApiError.new_from_details('StagerError', 'Client not HTTP enabled') unless enabled?
 
+          status = 999
           begin
             response = @http_client.post("#{url}/v1/stage", header: { 'Content-Type' => 'application/json' }, body: MultiJson.dump(msg))
+            status = response.status
+            return true if status == 202
+            return false if status == 404
           rescue => e
             raise ApiError.new_from_details('StagerError', "url: #{url}/v1/stage, error: #{e.message}")
           end
-          raise ApiError.new_from_details('StagerError', "received #{response.status} from #{url}/v1/stage") unless response.status == 202
+
+          raise ApiError.new_from_details('StagerError', "received #{status} from #{url}/v1/stage")
         end
 
         def start(app, options={})

--- a/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
@@ -61,6 +61,16 @@ module VCAP::CloudController
       }
     end
 
+    def stage(&blk)
+      stub_schedule_sync do
+        @before_staging_completion.call if @before_staging_completion
+        message_bus.respond_to_request("staging.#{stager_id}.start", first_reply_json)
+      end
+
+      response = staging_task.stage(&blk)
+      response
+    end
+
     before do
       expect(app.staged?).to be false
 
@@ -85,8 +95,19 @@ module VCAP::CloudController
           expect(app).to receive(:update).with({ package_state: 'PENDING', staging_task_id: staging_task.task_id })
           expect(message_bus).to receive(:publish).with('staging.stop', { app_id: app.guid })
           expect(dea_pool).to receive(:reserve_app_memory).with(stager_id, app.memory)
-          expect(Dea::Client).to receive(:stage).with(dea_advertisement.url, staging_message)
+          expect(Dea::Client).to receive(:stage).with(dea_advertisement.url, staging_message).and_return(true)
+          expect(message_bus).not_to receive(:publish).with('staging.my_stager.start', staging_task.staging_request)
           staging_task.stage
+        end
+
+        context 'when staging is not supported' do
+          it 'failsover to NATs' do
+            expect(message_bus).to receive(:publish).with('staging.stop', { app_id: app.guid })
+            expect(Dea::Client).to receive(:stage).with(dea_advertisement.url, staging_message).and_return(false)
+            expect(message_bus).to receive(:publish).with('staging.my_stager.start', staging_task.staging_request)
+
+            stage
+          end
         end
 
         context 'when an error occurs' do
@@ -441,16 +462,6 @@ module VCAP::CloudController
 
     describe 'staging' do
       describe 'receiving the first response from the stager (the staging setup completion message)' do
-        def stage(&blk)
-          stub_schedule_sync do
-            @before_staging_completion.call if @before_staging_completion
-            message_bus.respond_to_request("staging.#{stager_id}.start", first_reply_json)
-          end
-
-          response = staging_task.stage(&blk)
-          response
-        end
-
         context 'it sets up the app' do
           before do
             allow(app).to receive(:update).and_call_original


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
When staging over http isn't supported on the DEA, fallback to NATs

* An explanation of the use cases your change solves
Rolling upgrade when CC supports staging and the DEAs don't yet.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

[#118970125]