### PR TITLE
Add last operation type to broker API request

### DIFF
--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -237,7 +237,7 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     def service_instance_last_operation_path(instance)
-      "#{service_instance_resource_path(instance)}/last_operation"
+      "#{service_instance_resource_path(instance)}/last_operation?operation=#{instance.last_operation.type}"
     end
 
     def service_binding_resource_path(binding_guid, service_instance_guid)

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -10,8 +10,8 @@ describe 'Broker API Versions' do
       'broker_api_v2.4_spec.rb' => '5ad08dddf1869af9f5918bdd9d1736e8',
       'broker_api_v2.5_spec.rb' => '5babf49a7cee063016bb6bc024b8d290',
       'broker_api_v2.6_spec.rb' => '13f4c11e90402cf4ca4c32e3f1145771',
-      'broker_api_v2.7_spec.rb' => 'b72fe6905c45443e770ba00af1bfa6eb',
-      'broker_api_v2.8_spec.rb' => '5489f6ffafcb8b320e8eaf2360ca03ef',
+      'broker_api_v2.7_spec.rb' => 'eab25e00812568c933b9ab6abbae4cdf',
+      'broker_api_v2.8_spec.rb' => '8d423850ae6a6d089f548a0a853bb489',
     }
   end
   let(:digester) { Digester.new(algorithm: Digest::MD5) }

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -126,7 +126,7 @@ module VCAP::CloudController::BrokerApiHelper
     @service_instance_guid = response['metadata']['guid']
   end
 
-  def stub_async_last_operation(state: 'succeeded')
+  def stub_async_last_operation(state: 'succeeded', operation:)
     fetch_body = {
       state: state
 
@@ -134,6 +134,7 @@ module VCAP::CloudController::BrokerApiHelper
 
     stub_request(:get,
       "http://#{stubbed_broker_username}:#{stubbed_broker_password}@#{stubbed_broker_host}/v2/service_instances/#{@service_instance_guid}/last_operation").
+      with(query: { 'operation': operation }).
       to_return(
         status: 200,
         body: fetch_body.to_json)

--- a/spec/support/service_broker_helpers.rb
+++ b/spec/support/service_broker_helpers.rb
@@ -114,7 +114,7 @@ module ServiceBrokerHelpers
   end
 
   def last_operation_state_url(service_instance)
-    "#{service_instance_url(service_instance)}/last_operation"
+    "#{service_instance_url(service_instance)}/last_operation?operation=#{service_instance.last_operation.type}"
   end
 
   def service_instance_url(service_instance, query=nil)

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -328,9 +328,10 @@ module VCAP::Services::ServiceBrokers::V2
       let(:response_body) { response_data.to_json }
       let(:code) { '200' }
       let(:message) { 'OK' }
+      let(:operation_type) { 'some_operation' }
 
       before do
-        instance.save_with_new_operation({}, { type: 'create' })
+        instance.save_with_new_operation({}, { type: operation_type })
         allow(http_client).to receive(:get).and_return(response)
       end
 
@@ -338,7 +339,7 @@ module VCAP::Services::ServiceBrokers::V2
         client.fetch_service_instance_state(instance)
 
         expect(http_client).to have_received(:get).
-          with("/v2/service_instances/#{instance.guid}/last_operation")
+          with("/v2/service_instances/#{instance.guid}/last_operation?operation=#{operation_type}")
       end
 
       it 'returns the attributes to update the service instance model' do


### PR DESCRIPTION
We have added a query parameter, `operation` to the service broker API `last_operation` request. The parameter can take one of 3 values: `create`, `delete`, or `update`.

This allows service broker developers to avoid duplicating service instance lifecycle state between Cloud Controller and the broker.

We were unsure of how to structure the broker API acceptance tests: the test suites for the 2.7 and 2.8 API compatibility needed to change even though our API change is non-breaking to reflect new stubbing for webmock. If we had added a 2.9/2.10 test file, it would contain an exact copy-paste of that block in 2.8/2.7. We are open to suggestions on how to proceed here.

We have not submitted a PR to [the broker API docs](https://github.com/cloudfoundry/docs-services) as the change is so small that it seemed more pragmatic to wait until this is merged, and then we/you can make that PR?

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have not run CF Acceptance Tests on bosh lite. We weren't able to bump `cloud_controller_ng` inside `capi-release` inside `cf-release` without significant work.

Cheers!

cc @avade @utako 