### PR TITLE
Fix http stage

### DIFF
--- a/lib/cloud_controller/dea/app_stager_task.rb
+++ b/lib/cloud_controller/dea/app_stager_task.rb
@@ -50,7 +50,9 @@ module VCAP::CloudController
         StagingMessage.new(@config, @blobstore_url_generator).staging_request(@app, task_id)
       end
 
-      def handle_http_response(response)
+      def handle_http_response(response, &callback)
+        @completion_callback = callback
+
         check_staging_failed!
         check_staging_error!(response)
         process_http_response(response)

--- a/lib/cloud_controller/dea/stager.rb
+++ b/lib/cloud_controller/dea/stager.rb
@@ -16,7 +16,9 @@ module VCAP::CloudController
       end
 
       def staging_complete(_, response)
-        stager_task.handle_http_response(response)
+        stager_task.handle_http_response(response) do |staging_result|
+          @runners.runner_for_app(@app).start(staging_result)
+        end
       end
 
       def stop_stage

--- a/lib/cloud_controller/dea/staging_response.rb
+++ b/lib/cloud_controller/dea/staging_response.rb
@@ -4,6 +4,10 @@ module VCAP::CloudController::Dea
       @response = response
     end
 
+    def dea_id
+      @response['dea_id']
+    end
+
     def log
       @response['task_log']
     end

--- a/spec/unit/controllers/internal/dea/staging_completion_controller_spec.rb
+++ b/spec/unit/controllers/internal/dea/staging_completion_controller_spec.rb
@@ -12,6 +12,7 @@ module VCAP::CloudController
       let(:start_command) { '/usr/bin/letsparty' }
       let(:procfile) { '/path/to/procfile' }
       let(:staging_error) { nil }
+      let(:dea_id) { 'dea_id' }
 
       let(:staging_response) do
         {
@@ -21,10 +22,11 @@ module VCAP::CloudController
           'droplet_sha1' => droplet_sha1,
           'detected_start_command' => start_command,
           'procfile' => procfile,
-          'error' => staging_error
+          'error' => staging_error,
+          'dea_id' => dea_id,
         }
       end
-      #
+
       def make_dea_app(package_state, app_state)
         AppFactory.make.tap do |app|
           app.package_state = package_state
@@ -33,7 +35,7 @@ module VCAP::CloudController
           app.save
         end
       end
-      #
+
       let(:v2_app) { make_dea_app('PENDING', 'STOPPED') }
       let(:app_guid) { v2_app.guid }
       let(:task_id) { v2_app.staging_task_id }

--- a/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
@@ -118,7 +118,7 @@ module VCAP::CloudController
     end
 
     describe '#handle_http_response' do
-      let(:response) { reply_json }
+      let(:response) { reply_json.merge({ 'dea_id' => dea_advertisement.dea_id }) }
 
       before do
         allow(Dea::Client).to receive(:enabled?).and_return(true)
@@ -209,7 +209,7 @@ module VCAP::CloudController
           end
 
           it 'marks app started in dea pool' do
-            expect(dea_pool).to receive(:mark_app_started).with({ dea_id: stager_id, app_id: app.guid })
+            expect(dea_pool).to receive(:mark_app_started).with({ dea_id: dea_advertisement.dea_id, app_id: app.guid })
             staging_task.handle_http_response(response)
           end
 

--- a/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/app_stager_task_spec.rb
@@ -215,15 +215,11 @@ module VCAP::CloudController
 
           context 'when callback is not nil' do
             before do
-              allow(Dea::Client).to receive(:enabled?).and_return(true)
               @callback_options = nil
-              staging_task.stage { |options| @callback_options = options }
-
-              expect(@callback_options).to be_nil
             end
 
             it 'calls provided callback' do
-              staging_task.handle_http_response(response)
+              staging_task.handle_http_response(response) { |options| @callback_options = options }
               expect(@callback_options[:started_instances]).to equal(1)
             end
           end

--- a/spec/unit/lib/cloud_controller/dea/stager_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/stager_spec.rb
@@ -22,7 +22,7 @@ module VCAP::CloudController
       let(:runner) { double(:Runner) }
 
       subject(:stager) do
-        Stager.new(thing_to_stage, config, message_bus, dea_pool, runners)
+        Stager.new(app, config, message_bus, dea_pool, runners)
       end
 
       let(:stager_task) do
@@ -54,17 +54,17 @@ module VCAP::CloudController
 
       let(:response) { reply_json }
 
-      let(:thing_to_stage) { AppFactory.make }
+      let(:app) { AppFactory.make }
 
       it_behaves_like 'a stager' do
-        let(:thing_to_stage) { nil }
+        let(:app) { nil }
       end
 
       describe '#stage' do
         before do
           allow(AppStagerTask).to receive(:new).and_return(stager_task)
           allow(stager_task).to receive(:stage).and_yield('fake-staging-result').and_return('fake-stager-response')
-          allow(runners).to receive(:runner_for_app).with(thing_to_stage).and_return(runner)
+          allow(runners).to receive(:runner_for_app).with(app).and_return(runner)
           allow(runner).to receive(:start).with('fake-staging-result')
         end
 
@@ -73,7 +73,7 @@ module VCAP::CloudController
           expect(stager_task).to have_received(:stage)
           expect(AppStagerTask).to have_received(:new).with(config,
                                                             message_bus,
-                                                            thing_to_stage,
+                                                            app,
                                                             dea_pool,
                                                             an_instance_of(CloudController::Blobstore::UrlGenerator))
         end
@@ -85,22 +85,31 @@ module VCAP::CloudController
 
         it 'records the stager response on the app' do
           stager.stage
-          expect(thing_to_stage.last_stager_response).to eq('fake-stager-response')
+          expect(app.last_stager_response).to eq('fake-stager-response')
         end
       end
 
       describe '#staging_complete' do
         before do
           allow(AppStagerTask).to receive(:new).and_return(stager_task)
-          allow(stager_task).to receive(:stage).and_yield('fake-staging-result').and_return('fake-stager-response')
-          allow(runners).to receive(:runner_for_app).with(thing_to_stage).and_return(runner)
-          allow(runner).to receive(:start).with('fake-staging-result')
-          stager.stage
         end
 
         it 'invokes AppStagerTask#handle_http_response for response handling' do
           expect(stager_task).to receive(:handle_http_response).with(response)
           stager.staging_complete(nil, response)
+        end
+
+        context 'when the callback is invoked' do
+          before do
+            allow(stager_task).to receive(:handle_http_response).and_yield('fake-staging-result').and_return('fake-stager-response')
+            allow(runners).to receive(:runner_for_app).with(app).and_return(runner)
+            allow(runner).to receive(:start).with('fake-staging-result')
+          end
+
+          it 'starts the app with the returned staging result' do
+            expect(runner).to receive(:start).with('fake-staging-result')
+            stager.staging_complete(nil, response)
+          end
         end
       end
     end


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Properly handle the asynchronous staging work flow over http.

* An explanation of the use cases your change solves
Pushing apps, and starting multiple instances over HTTP no longer error

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite
