### PR TITLE
Use hm9000 internal address when making requests

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -197,6 +197,7 @@ uaa:
 
 hm9000:
   url: <%= p("hm9000.url", "https://hm9000.#{system_domain}") %>
+  internal_url: <%= "http://hm9000.service.cf.internal:#{p('hm9000.port')}" %>
 
 <% if p("routing_api.enabled") %>
 routing_api:

--- a/bosh-templates/cloud_controller_clock.yml.erb
+++ b/bosh-templates/cloud_controller_clock.yml.erb
@@ -174,6 +174,7 @@ uaa:
 
 hm9000:
   url: <%= p("hm9000.url", "https://hm9000.#{system_domain}") %>
+  internal_url: <%= "http://hm9000.service.cf.internal:#{p('hm9000.port')}" %>
 
 # App staging parameters
 staging:

--- a/bosh-templates/cloud_controller_worker.yml.erb
+++ b/bosh-templates/cloud_controller_worker.yml.erb
@@ -170,6 +170,7 @@ uaa:
 
 hm9000:
   url: <%= p("hm9000.url", "https://hm9000.#{system_domain}") %>
+  internal_url: <%= "http://hm9000.service.cf.internal:#{p('hm9000.port')}" %>
 
 # App staging parameters
 staging:

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -87,6 +87,7 @@ uaa:
 
 hm9000:
   url: "http://localhost:5155"
+  internal_url: "https://localhost:5155/internal"
 
 routing_api:
   url: "http://localhost:3000"

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -59,7 +59,8 @@ module VCAP::CloudController
         },
 
         :hm9000 => {
-          url: String
+          url: String,
+          internal_url: String
         },
 
         optional(:dea_client) => {

--- a/spec/fixtures/config/default_overriding_config.yml
+++ b/spec/fixtures/config/default_overriding_config.yml
@@ -43,6 +43,7 @@ broker_client_max_async_poll_duration_minutes: 10080
 
 hm9000:
   url: "http://localhost:5155"
+  internal_url: "http://localhost:5155/internal"
 
 uaa:
   url: "http://localhost:8080/uaa"

--- a/spec/fixtures/config/minimal_config.yml
+++ b/spec/fixtures/config/minimal_config.yml
@@ -43,6 +43,7 @@ broker_client_max_async_poll_duration_minutes: 10080
 
 hm9000:
   url: "http://localhost:5155"
+  internal_url: "http://localhost:5155/internal"
 
 uaa:
   url: "http://localhost:8080/uaa"

--- a/spec/fixtures/config/non_default_message_bus.yml
+++ b/spec/fixtures/config/non_default_message_bus.yml
@@ -44,6 +44,7 @@ maximum_app_disk_in_mb: 2048
 
 hm9000:
   url: "http://localhost:5155"
+  internal_url: "http://localhost:5155/internal"
 
 uaa:
   url: "http://localhost:8080/uaa"

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -47,6 +47,7 @@ broker_client_max_async_poll_duration_minutes: 10080
 
 hm9000:
   url: "http://localhost:5155"
+  internal_url: "http://localhost:5155/internal"
 
 uaa:
   url: "http://localhost:8080/uaa"

--- a/spec/fixtures/config/port_8182_config.yml
+++ b/spec/fixtures/config/port_8182_config.yml
@@ -43,6 +43,7 @@ broker_client_max_async_poll_duration_minutes: 10080
 
 hm9000:
   url: "http://localhost:5155"
+  internal_url: "http://localhost:5155/internal"
 
 uaa:
   url: "http://localhost:8080/uaa"

--- a/spec/unit/lib/cloud_controller/hm9000_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/hm9000_client_spec.rb
@@ -17,26 +17,98 @@ def generate_hm_api_response(app, running_instances, crash_counts=[])
 
   running_instances.each do |running_instance|
     result[:instance_heartbeats].push({
-                                        droplet: app.guid,
-                                        version: app.version,
-                                        instance: running_instance[:instance_guid] || Sham.guid,
-                                        index: running_instance[:index],
-                                        state: running_instance[:state],
-                                        state_timestamp: 3.141
-                                      })
+      droplet: app.guid,
+      version: app.version,
+      instance: running_instance[:instance_guid] || Sham.guid,
+      index: running_instance[:index],
+      state: running_instance[:state],
+      state_timestamp: 3.141
+    })
   end
 
   crash_counts.each do |crash_count|
     result[:crash_counts].push({
-                                  droplet: app.guid,
-                                  version: app.version,
-                                  instance_index: crash_count[:instance_index],
-                                  crash_count: crash_count[:crash_count],
-                                  created_at: 1234567
-                               })
+      droplet: app.guid,
+      version: app.version,
+      instance_index: crash_count[:instance_index],
+      crash_count: crash_count[:crash_count],
+      created_at: 1234567
+    })
   end
 
   JSON.parse(result.to_json)
+end
+
+shared_examples 'post_bulk_app_state request' do |method, args_array|
+  let(:legacy_return_value) { double(:legacy_return_value) }
+
+  before do
+    @args = if args_array
+              [app0]
+            else
+              app0
+            end
+  end
+
+  context 'when the request status is not 2XX' do
+    before do
+      stub_request(:post, "#{hm9000_url}/bulk_app_state").
+        to_return(status: 500)
+      stub_request(:post, "#{hm9000_external_url}/bulk_app_state").to_return(status: 500)
+    end
+
+    it 'retries 3 times' do
+      subject.send(method, @args)
+      assert_requested(:post, "#{hm9000_url}/bulk_app_state", times: 3) do |req|
+        req.body = { droplet: app0.guid, version: app0.version }
+      end
+    end
+
+    context 'after 3 retries' do
+      before do
+        subject.send(method, @args)
+      end
+
+      it 'tries the external address' do
+        assert_requested(:post, "#{hm9000_external_url}/bulk_app_state") do |req|
+          req.body = { droplet: app0.guid, version: app0.version }
+        end
+      end
+
+      it 'does try to use the internal address again on the next request' do
+        subject.send(method, @args)
+
+        # 3 times for the first call, 3 times for the next call
+        assert_requested(:post, "#{hm9000_url}/bulk_app_state", times: 6) do |req|
+          req.body = { droplet: app0.guid, version: app0.version }
+        end
+
+        # once for the first call and once for the second call
+        assert_requested(:post, "#{hm9000_external_url}/bulk_app_state", times: 2) do |req|
+          req.body = { droplet: app0.guid, version: app0.version }
+        end
+      end
+    end
+  end
+
+  context 'when the hm9000 http api is not present' do
+    before do
+      stub_request(:post, "#{hm9000_url}/bulk_app_state").to_return(status: 404)
+      stub_request(:post, "#{hm9000_external_url}/bulk_app_state").to_return(status: 404)
+    end
+
+    it 'retries 3 times' do
+      subject.send(method, @args)
+      assert_requested(:post, "#{hm9000_url}/bulk_app_state", times: 3) do |req|
+        req.body = { droplet: app0.guid, version: app0.version }
+      end
+    end
+
+    it 'calls through the legacy nats client' do
+      actual_return_value = hm9000_client.send(method, @args)
+      expect(actual_return_value).to eq(legacy_return_value)
+    end
+  end
 end
 
 module VCAP::CloudController
@@ -46,12 +118,16 @@ module VCAP::CloudController
     let(:app1) { AppFactory.make(instances: 1) }
     let(:app2) { AppFactory.make(instances: 1) }
     let(:app0_request_should_fail) { false }
+    let(:hm9000_external_url) { 'https://myuser:mypass@some-hm9000-api:9492' }
+    let(:skip_cert_verify) { nil }
 
     let(:hm9000_config) do
       {
+        skip_cert_verify: skip_cert_verify,
         flapping_crash_count_threshold: 3,
         hm9000: {
-          url: 'https://some-hm9000-api:9492'
+          url: 'https://some-hm9000-api:9492',
+          internal_url: 'https://hm9000.service.cf.internal:9492',
         },
         internal_api: {
           auth_user: 'myuser',
@@ -64,7 +140,7 @@ module VCAP::CloudController
     let(:app_1_api_response) { generate_hm_api_response(app1, [{ index: 0, state: 'CRASHED' }]) }
     let(:app_2_api_response) { generate_hm_api_response(app2, [{ index: 0, state: 'RUNNING' }]) }
 
-    let(:hm9000_url) { 'https://myuser:mypass@some-hm9000-api:9492' }
+    let(:hm9000_url) { 'https://myuser:mypass@hm9000.service.cf.internal:9492' }
     let(:legacy_client) { double(:legacy_client) }
 
     subject(:hm9000_client) { VCAP::CloudController::Dea::HM9000::Client.new(legacy_client, hm9000_config) }
@@ -92,6 +168,14 @@ module VCAP::CloudController
 
           3.times { expect(hm9000_client.healthy_instances(app0)).to eq(-1) }
         end
+      end
+
+      context 'post_bulk_app_state behaviors' do
+        before do
+          allow(legacy_client).to receive(:healthy_instances).with(app0).and_return(legacy_return_value)
+        end
+
+        it_behaves_like 'post_bulk_app_state request', :healthy_instances, false
       end
 
       context 'with multiple desired instances' do
@@ -198,6 +282,14 @@ module VCAP::CloudController
           })
         end
       end
+
+      context 'post_bulk_app_state behaviors' do
+        before do
+          allow(legacy_client).to receive(:healthy_instances_bulk).with([app0]).and_return(legacy_return_value)
+        end
+
+        it_behaves_like 'post_bulk_app_state request', :healthy_instances_bulk, true
+      end
     end
 
     describe 'find_crashes' do
@@ -210,11 +302,22 @@ module VCAP::CloudController
       end
 
       context 'when the request fails' do
-        it 'should return an empty array' do
+        before do
           stub_request(:post, "#{hm9000_url}/bulk_app_state").
             to_return(status: 500)
+          stub_request(:post, "#{hm9000_external_url}/bulk_app_state").to_return(status: 500)
+        end
 
+        it 'should return an empty array' do
           expect(hm9000_client.find_crashes(app0)).to eq([])
+        end
+
+        context 'post_bulk_app_state behaviors' do
+          before do
+            allow(legacy_client).to receive(:find_crashes).with(app0).and_return(legacy_return_value)
+          end
+
+          it_behaves_like 'post_bulk_app_state request', :find_crashes, false
         end
       end
 
@@ -237,11 +340,22 @@ module VCAP::CloudController
       end
 
       context 'when the request fails' do
-        it 'should return an empty array' do
+        before do
           stub_request(:post, "#{hm9000_url}/bulk_app_state").
             to_return(status: 500)
+          stub_request(:post, "#{hm9000_external_url}/bulk_app_state").to_return(status: 500)
+        end
 
+        it 'should return an empty array' do
           expect(hm9000_client.find_flapping_indices(app0)).to eq([])
+        end
+
+        context 'post_bulk_app_state behaviors' do
+          before do
+            allow(legacy_client).to receive(:find_flapping_indices).with(app0).and_return(legacy_return_value)
+          end
+
+          it_behaves_like 'post_bulk_app_state request', :find_flapping_indices, false
         end
       end
 
@@ -258,43 +372,6 @@ module VCAP::CloudController
       end
     end
 
-    context 'when the hm9000 http api is not present' do
-      before { stub_request(:post, "#{hm9000_url}/bulk_app_state").to_return(status: 404) }
-      let(:legacy_return_value) { double(:legacy_return_value) }
-
-      describe 'healthy_instances' do
-        it 'calls through the legacy nats client' do
-          allow(legacy_client).to receive(:healthy_instances).with(app0).and_return(legacy_return_value)
-          actual_return_value = hm9000_client.healthy_instances(app0)
-          expect(actual_return_value).to eq(legacy_return_value)
-        end
-      end
-
-      describe 'healthy_instances_bulk' do
-        it 'calls through the legacy nats client' do
-          allow(legacy_client).to receive(:healthy_instances_bulk).with([app0]).and_return(legacy_return_value)
-          actual_return_value = hm9000_client.healthy_instances_bulk([app0])
-          expect(actual_return_value).to eq(legacy_return_value)
-        end
-      end
-
-      describe 'find_crashes' do
-        it 'calls through the legacy nats client' do
-          allow(legacy_client).to receive(:find_crashes).with(app0).and_return(legacy_return_value)
-          actual_return_value = hm9000_client.find_crashes(app0)
-          expect(actual_return_value).to eq(legacy_return_value)
-        end
-      end
-
-      describe 'find_flapping_indices' do
-        it 'calls through the legacy nats client' do
-          allow(legacy_client).to receive(:find_flapping_indices).with(app0).and_return(legacy_return_value)
-          actual_return_value = hm9000_client.find_flapping_indices(app0)
-          expect(actual_return_value).to eq(legacy_return_value)
-        end
-      end
-    end
-
     it 'uses the default certificate store' do
       stub_request(:post, "#{hm9000_url}/bulk_app_state").
         to_return(status: 200, body: {}.to_json)
@@ -305,19 +382,7 @@ module VCAP::CloudController
 
     describe 'ssl certificate validation' do
       context 'when skip_cert_verify is true' do
-        let(:hm9000_config) do
-          {
-            skip_cert_verify: true,
-            flapping_crash_count_threshold: 3,
-            hm9000: {
-              url: 'https://some-hm9000-api:9492'
-            },
-            internal_api: {
-              auth_user: 'myuser',
-              auth_password: 'mypass'
-            }
-          }
-        end
+        let(:skip_cert_verify) { true }
 
         it 'does not verify the cert' do
           stub_request(:post, "#{hm9000_url}/bulk_app_state").
@@ -330,19 +395,7 @@ module VCAP::CloudController
       end
 
       context 'when skip_cert_verify is false' do
-        let(:hm9000_config) do
-          {
-            skip_cert_verify: false,
-            flapping_crash_count_threshold: 3,
-            hm9000: {
-              url: 'https://some-hm9000-api:9492'
-            },
-            internal_api: {
-              auth_user: 'myuser',
-              auth_password: 'mypass'
-            }
-          }
-        end
+        let(:skip_cert_verify) { false }
 
         it 'does verify the cert' do
           stub_request(:post, "#{hm9000_url}/bulk_app_state").


### PR DESCRIPTION
This change enables the hm9000 client to use the internal (consul) address, falling back to the external address only when unable to reach the internal one.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite

  - add hm9000.internal_url to config
  - add retry for the internal endpoint
  - fallback to external endpoint
        if internal endpoint does not work
        (to work with rolling deployments)
  - Refactor hm9000_client_spec to use shared_example for testing post_bulk_app_state requests

[#118507195]

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>