### PR TITLE
Make minimum candidate stagers configurable

### DIFF
--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -377,6 +377,7 @@ module VCAP::CloudController
         config[:broker_client_default_async_poll_interval_seconds] ||= 60
         config[:packages][:max_valid_packages_stored] ||= 5
         config[:droplets][:max_staged_droplets_stored] ||= 5
+        config[:minimum_candidate_stagers] ||= 5
 
         unless config.key?(:users_can_select_backend)
           config[:users_can_select_backend] = true

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -237,6 +237,7 @@ module VCAP::CloudController
 
         optional(:dea_advertisement_timeout_in_seconds) => Integer,
         optional(:placement_top_stager_percentage) => Integer,
+        optional(:minimum_candidate_stagers) => Integer,
 
         optional(:diego_stager_url) => String,
         optional(:diego_tps_url) => String,

--- a/lib/cloud_controller/dea/pool.rb
+++ b/lib/cloud_controller/dea/pool.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
         @message_bus = message_bus
         @percentage_of_top_stagers = (config[:placement_top_stager_percentage] || 0) / 100.0
         @dea_advertisements = {}
-        @min_candidate_stagers = (config[:minimum_candidate_stagers] ? config[:minimum_candidate_stagers] : 5)
+        @min_candidate_stagers = config[:minimum_candidate_stagers]
       end
 
       def register_subscriptions

--- a/lib/cloud_controller/dea/pool.rb
+++ b/lib/cloud_controller/dea/pool.rb
@@ -9,6 +9,7 @@ module VCAP::CloudController
         @message_bus = message_bus
         @percentage_of_top_stagers = (config[:placement_top_stager_percentage] || 0) / 100.0
         @dea_advertisements = {}
+        @min_candidate_stagers = (config[:minimum_candidate_stagers] ? config[:minimum_candidate_stagers] : 5)
       end
 
       def register_subscriptions
@@ -98,7 +99,7 @@ module VCAP::CloudController
           ad.meets_needs?(memory, stack) && ad.has_sufficient_disk?(disk)
         }.sort_by { |id, ad|
           ad.available_memory
-        }.last([5, @percentage_of_top_stagers * @dea_advertisements.size].max.to_i)
+        }.last([@min_candidate_stagers, @percentage_of_top_stagers * @dea_advertisements.size].max.to_i)
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/config_spec.rb
+++ b/spec/unit/lib/cloud_controller/config_spec.rb
@@ -90,6 +90,10 @@ module VCAP::CloudController
         it ' sets a default value for num_of_staged_droplets_per_app_to_store' do
           expect(config[:droplets][:max_staged_droplets_stored]).to eq(5)
         end
+
+        it 'sets a default value for the minimum number of candidate stagers' do
+          expect(config[:minimum_candidate_stagers]).to eq(5)
+        end
       end
 
       context 'when config values are provided' do


### PR DESCRIPTION
Make the minimum number of candidate stagers configurable.  Addresses https://github.com/cloudfoundry/cloud_controller_ng/issues/598

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite

[#119362989]

Signed-off-by: Jonathan Berkhahn <jaberkha@us.ibm.com>