### PR TITLE
Make minimum candidate stagers configurable in template

### DIFF
--- a/bosh-templates/cloud_controller_api.yml.erb
+++ b/bosh-templates/cloud_controller_api.yml.erb
@@ -366,6 +366,7 @@ allowed_cors_domains: <%= p("cc.allowed_cors_domains").to_json %>
 
 dea_advertisement_timeout_in_seconds: <%= p("dea_next.advertise_interval_in_seconds") * 3 %>
 placement_top_stager_percentage: <%= p("cc.placement_top_stager_percentage") %>
+minimum_candidate_stagers: <%= p("cc.minimum_candidate_stagers") %>
 
 statsd_host: <%= p("cc.statsd_host") %>
 statsd_port: <%= p("cc.statsd_port") %>


### PR DESCRIPTION
Expose the minimum_candidate_stagers config property in the bosh template.  https://github.com/cloudfoundry/capi-release/pull/13 adds this to the appropriate spec.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite

[#119362989]

Signed-off-by: Dan Lavine <dlavine@us.ibm.com>