### PR TITLE
Emit error when consul is down.

### DIFF
--- a/lib/cloud_controller/dea/hm9000/client.rb
+++ b/lib/cloud_controller/dea/hm9000/client.rb
@@ -107,9 +107,9 @@ module VCAP::CloudController
               if response.ok?
                 break
               end
-            rescue SocketError
+            rescue SocketError => se
               internal_address_errored = true
-              logger.error('failed to connect to hm9000 via consul')
+              logger.error('failed to connect to hm9000 via consul', { error: se })
               break
             end
 


### PR DESCRIPTION
Small change to actually emit the error when consul is down. Should make it easier to diagnose what's going wrong if/when this happens.

Thanks,
@jberkhahn & @swetharepakula 
Runtime_OG