### PR TITLE
Operation state for service broker requests

### DIFF
--- a/db/migrations/20160601165902_add_broker_provided_operation_to_instance_last_operation.rb
+++ b/db/migrations/20160601165902_add_broker_provided_operation_to_instance_last_operation.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :service_instance_operations do
+      add_column :broker_provided_operation, String, text: true
+    end
+  end
+end

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -170,8 +170,9 @@ module VCAP::Services::ServiceBrokers::V2
         last_operation: {
           type: 'delete',
           description: last_operation_hash['description'] || '',
-          state: state || 'succeeded'
-        }
+          state: state || 'succeeded',
+          broker_provided_operation: parsed_response['operation']
+        }.compact
       }
     rescue VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerConflict => e
       raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceDeprovisionFailed', e.message)

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -42,6 +42,7 @@ module VCAP::Services::ServiceBrokers::V2
         last_operation: {
           type: 'create',
           description: last_operation_hash['description'] || '',
+          broker_provided_operation: parsed_response['operation']
         }
       }
 
@@ -237,7 +238,9 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     def service_instance_last_operation_path(instance)
-      "#{service_instance_resource_path(instance)}/last_operation?plan_id=#{instance.service_plan.broker_provided_id}&service_id=#{instance.service.broker_provided_id}"
+      url = "#{service_instance_resource_path(instance)}/last_operation?plan_id=#{instance.service_plan.broker_provided_id}&service_id=#{instance.service.broker_provided_id}"
+      url += "&operation=#{instance.last_operation.broker_provided_operation}" if instance.last_operation.broker_provided_operation
+      url
     end
 
     def service_binding_resource_path(binding_guid, service_instance_guid)

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -200,6 +200,7 @@ module VCAP::Services::ServiceBrokers::V2
           type: 'update',
           state: state,
           description: last_operation_hash['description'] || '',
+          broker_provided_operation: parsed_response['operation']
         },
       }
 

--- a/spec/support/service_broker_helpers.rb
+++ b/spec/support/service_broker_helpers.rb
@@ -114,7 +114,9 @@ module ServiceBrokerHelpers
   end
 
   def last_operation_state_url(service_instance)
-    "#{service_instance_url(service_instance)}/last_operation?plan_id=#{service_instance.service_plan.broker_provided_id}&service_id=#{service_instance.service.broker_provided_id}"
+    params = "plan_id=#{service_instance.service_plan.broker_provided_id}&service_id=#{service_instance.service.broker_provided_id}"
+    params = "operation=#{service_instance.last_operation.broker_provided_operation}&" + params if service_instance.last_operation.broker_provided_operation
+    "#{service_instance_url(service_instance)}/last_operation?" + params
   end
 
   def service_instance_url(service_instance, query=nil)

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -1188,6 +1188,25 @@ module VCAP::Services::ServiceBrokers::V2
               }
             })
           end
+
+          context 'when the broker provides a operation' do
+            let(:response_data) do
+              { operation: 'a_broker_operation_identifier' }
+            end
+
+            it 'return immediately with the broker response' do
+              attributes, _ = client.deprovision(instance, accepts_incomplete: true)
+
+              expect(attributes).to eq({
+                last_operation: {
+                  type: 'delete',
+                  state: 'in progress',
+                  description: '',
+                  broker_provided_operation: 'a_broker_operation_identifier'
+                }
+              })
+            end
+          end
         end
 
         context 'when the broker returns a 200' do

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -571,6 +571,21 @@ module VCAP::Services::ServiceBrokers::V2
             expect(attributes[:last_operation][:description]).to eq('')
             expect(error).to be_nil
           end
+
+          context 'when the broker returns an operation' do
+            let(:response_data) do
+              { operation: 'a_broker_operation_identifier' }
+            end
+
+            it 'return immediately with the broker response' do
+              attributes, _, error = client.update(instance, new_plan, accepts_incomplete: true)
+
+              expect(attributes[:last_operation][:type]).to eq('update')
+              expect(attributes[:last_operation][:state]).to eq('in progress')
+              expect(attributes[:last_operation][:broker_provided_operation]).to eq('a_broker_operation_identifier')
+              expect(error).to be_nil
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Support for a optional `operation` field from service brokers, while async provisioning, updating and deleting of services. The operation filed is sent to the broker on last operation invocations. 

- [X] Provisioning
- [x] Updating
- [x] De-provisioning

Tracker stories:
https://www.pivotaltracker.com/n/projects/966314/stories/120654839
https://www.pivotaltracker.com/n/projects/966314/stories/120595477
https://www.pivotaltracker.com/n/projects/966314/stories/120595531

Paring with @Dagrol