### PR TITLE
Add internal hm9000 stop controller

### DIFF
--- a/app/controllers/internal/dea/hm9000_stop_controller.rb
+++ b/app/controllers/internal/dea/hm9000_stop_controller.rb
@@ -1,0 +1,44 @@
+require 'sinatra'
+require 'controllers/base/base_controller'
+require 'cloud_controller/internal_api'
+
+module VCAP::CloudController
+  module Dea
+    class HM9000StopController < RestController::BaseController
+      allow_unauthenticated_access
+
+      def initialize(*)
+        super
+        auth = Rack::Auth::Basic::Request.new(env)
+        unless auth.provided? && auth.basic? && auth.credentials == InternalApi.credentials
+          raise CloudController::Errors::ApiError.new_from_details('NotAuthenticated')
+        end
+      end
+
+      post '/internal/dea/hm9000/stop/:app_guid', :stop
+
+      def stop(app_guid)
+        raise CloudController::Errors::ApiError.new_from_details('NotFound') unless App.find(guid: app_guid)
+        logger.info('dea.hm9000.stop', app_guid: app_guid)
+        SubSystem.hm9000_respondent.process_hm9000_stop(read_body)
+
+        [200, '{}']
+      end
+
+      private
+
+      def read_body
+        stop_message = {}
+        begin
+          payload = body.read
+          stop_message = MultiJson.load(payload, symbolize_keys: false)
+        rescue MultiJson::ParseError => pe
+          logger.error('dea.hm9000.stop.parse-error', payload: payload, error: pe.to_s)
+          raise CloudController::Errors::ApiError.new_from_details('MessageParseError', payload)
+        end
+
+        stop_message
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/dea/sub_system.rb
+++ b/lib/cloud_controller/dea/sub_system.rb
@@ -1,16 +1,20 @@
 module VCAP::CloudController
   module Dea
     module SubSystem
-      def self.setup!(message_bus)
-        Client.run
+      class << self
+        attr_reader :hm9000_respondent, :dea_respondent
 
-        LegacyBulk.register_subscription
+        def setup!(message_bus)
+          Client.run
 
-        hm9000_respondent = HM9000::Respondent.new(Client, message_bus)
-        hm9000_respondent.handle_requests
+          LegacyBulk.register_subscription
 
-        dea_respondent = Respondent.new(message_bus)
-        dea_respondent.start
+          @hm9000_respondent = HM9000::Respondent.new(Client, message_bus)
+          @hm9000_respondent.handle_requests
+
+          @dea_respondent = Respondent.new(message_bus)
+          @dea_respondent.start
+        end
       end
     end
   end

--- a/spec/unit/controllers/internal/dea/hm9000_stop_controller_spec.rb
+++ b/spec/unit/controllers/internal/dea/hm9000_stop_controller_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+require 'membrane'
+
+module VCAP::CloudController
+  module Dea
+    describe HM9000StopController do
+      let(:respondent) { instance_double(HM9000::Respondent, process_hm9000_stop: nil) }
+
+      def make_dea_app(app_state)
+        AppFactory.make.tap do |app|
+          # app.package_state = package_state
+          app.state = app_state
+          # app.staging_task_id = Sham.guid
+          app.save
+        end
+      end
+
+      let(:v2_app) { make_dea_app('STARTED') }
+      let(:app_guid) { v2_app.guid }
+      let(:url) { "/internal/dea/hm9000/stop/#{app_guid}" }
+
+      let(:stop_message) {
+        {
+          'droplet' => app_guid,
+          'version' => '1',
+          'instance_guid' => 'heebity',
+          'instance_index' => '0',
+          'is_duplicate' => false,
+        }
+      }
+
+      before do
+        allow(SubSystem).to receive(:hm9000_respondent).and_return(respondent)
+
+        @internal_user = 'internal_user'
+        @internal_password = 'internal_password'
+        authorize @internal_user, @internal_password
+      end
+
+      describe 'authentication' do
+        context 'when missing authentication' do
+          it 'fails with authentication required' do
+            header('Authorization', nil)
+            post url, MultiJson.dump(stop_message)
+            expect(last_response.status).to eq(401)
+          end
+        end
+
+        context 'when using invalid credentials' do
+          it 'fails with authenticatiom required' do
+            authorize 'bar', 'foo'
+            post url, MultiJson.dump(stop_message)
+            expect(last_response.status).to eq(401)
+          end
+        end
+
+        context 'when using valid credentials' do
+          before do
+            allow_any_instance_of(Dea::Stager).to receive(:staging_complete)
+          end
+
+          it 'succeeds' do
+            post url, MultiJson.dump(stop_message)
+            expect(last_response.status).to eq(200)
+          end
+        end
+      end
+
+      describe 'validation' do
+        context 'when sending invalid json' do
+          it 'fails with a 400' do
+            post url, 'this is not json'
+
+            expect(last_response.status).to eq(400)
+            expect(last_response.body).to match /MessageParseError/
+          end
+        end
+      end
+
+      context 'when the app does not exist' do
+        before { v2_app.delete }
+
+        it 'fails with a 404' do
+          post url, MultiJson.dump(stop_message)
+
+          expect(last_response.status).to eq(404)
+        end
+      end
+
+      context 'with a valid app' do
+        it 'returns a 200 and calls the respondent' do
+          expect(respondent).to receive(:process_hm9000_stop).with(stop_message)
+
+          post url, MultiJson.dump(stop_message)
+
+          expect(last_response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/controllers/internal/dea/staging_completion_controller_spec.rb
+++ b/spec/unit/controllers/internal/dea/staging_completion_controller_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'membrane'
-# require 'cloud_controller/diego/staging_guid'
 
 module VCAP::CloudController
   module Dea

--- a/spec/unit/lib/cloud_controller/dea/hm9000/respondent_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/hm9000/respondent_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'cloud_controller/dea/hm9000/respondent'
+
+module VCAP::CloudController
+  module Dea
+    module HM9000
+      describe Respondent do
+        let(:message_bus) { CfMessageBus::MockMessageBus.new }
+        let(:dea_client) { double(VCAP::CloudController::Dea::Client) }
+
+        subject(:respondent) { Dea::HM9000::Respondent.new(dea_client, message_bus) }
+
+        # Fill this in
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cloud_controller/dea/hm9000/respondent_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/hm9000/respondent_spec.rb
@@ -9,8 +9,6 @@ module VCAP::CloudController
         let(:dea_client) { double(VCAP::CloudController::Dea::Client) }
 
         subject(:respondent) { Dea::HM9000::Respondent.new(dea_client, message_bus) }
-
-        # Fill this in
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/dea/sub_system_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/sub_system_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  module Dea
+    describe SubSystem do
+      let(:message_bus) { CfMessageBus::MockMessageBus.new }
+      let(:dea_respondent) { instance_double(Respondent, start: nil) }
+      let(:hm9000_respondent) { instance_double(HM9000::Respondent, handle_requests: nil) }
+
+      before do
+        allow(Client).to receive(:run)
+        allow(LegacyBulk).to receive(:register_subscription)
+        allow(Respondent).to receive(:new).and_return(dea_respondent)
+        allow(HM9000::Respondent).to receive(:new).and_return(hm9000_respondent)
+      end
+
+      describe '#self.setup!' do
+        it 'starts the correct respondents' do
+          expect(Client).to receive(:run)
+          expect(LegacyBulk).to receive(:register_subscription)
+          expect(dea_respondent).to receive(:start)
+          expect(hm9000_respondent).to receive(:handle_requests)
+
+          subject.setup!(message_bus)
+
+          expect(subject.dea_respondent).to eq(dea_respondent)
+          expect(subject.hm9000_respondent).to eq(hm9000_respondent)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are converting hm9000 to use http rather than NATS for hm9000.stop messages.  This adds the required controller into the CC.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite

[#112003161]

Signed-off-by: Jonathan Berkhahn <jaberkha@us.ibm.com>