### PR TITLE
Config handles minimum_candidate_stagers set to < 1

### DIFF
--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -378,7 +378,7 @@ module VCAP::CloudController
         config[:broker_client_default_async_poll_interval_seconds] ||= 60
         config[:packages][:max_valid_packages_stored] ||= 5
         config[:droplets][:max_staged_droplets_stored] ||= 5
-        config[:minimum_candidate_stagers] ||= 5
+        config[:minimum_candidate_stagers] = (config[:minimum_candidate_stagers] && config[:minimum_candidate_stagers] > 0) ? config[:minimum_candidate_stagers] : 5
 
         unless config.key?(:users_can_select_backend)
           config[:users_can_select_backend] = true

--- a/spec/unit/lib/cloud_controller/config_spec.rb
+++ b/spec/unit/lib/cloud_controller/config_spec.rb
@@ -241,6 +241,7 @@ module VCAP::CloudController
             config_hash['app_bits_upload_grace_period_in_seconds'] = -2345
             config_hash['staging']['auth']['user'] = 'f@t:%a'
             config_hash['staging']['auth']['password'] = 'm@/n!'
+            config_hash['minimum_candidate_stagers'] = 0
 
             File.open(File.join(tmpdir, 'incorrect_overridden_config.yml'), 'w') do |f|
               YAML.dump(config_hash, f)
@@ -249,6 +250,10 @@ module VCAP::CloudController
 
           after do
             FileUtils.rm_r(tmpdir)
+          end
+
+          it 'resets minimum_candidate_stagers to the default of 5' do
+            expect(config_from_file[:minimum_candidate_stagers]).to eq(5)
           end
 
           it 'reset the negative value of app_bits_upload_grace_period_in_seconds to 0' do


### PR DESCRIPTION
If minimum_candidate_stagers is set to a value less than 1 in a manifest, reset it to the default value.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite

[#119362989]

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>