### PR TITLE
Fix log message to include error details

### DIFF
--- a/lib/cloud_controller/dea/hm9000/client.rb
+++ b/lib/cloud_controller/dea/hm9000/client.rb
@@ -109,7 +109,7 @@ module VCAP::CloudController
               end
             rescue SocketError => se
               internal_address_errored = true
-              logger.error('failed to connect to hm9000 via consul', { error: se })
+              logger.error('failed to connect to hm9000 via consul', { error: se.message })
               break
             end
 


### PR DESCRIPTION
Fix the logging in lib/cloud_controller/dea/hm9000/client.rb so that the actual error message is logged in case of a SocketError.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite

[#118507195]

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>