### PR TITLE
Reduce cc.logging_level default from debug2 to info

### DIFF
--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -156,7 +156,7 @@ properties:
     description: "Log level for cc database operations"
 
   cc.logging_level:
-    default: "debug2"
+    default: "info"
     description: "Log level for cc"
   cc.logging_max_retries:
     default: 1

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -200,7 +200,7 @@ properties:
     description: "Log level for cc database operations"
 
   cc.logging_level:
-    default: "debug2"
+    default: "info"
     description: "Log level for cc"
   cc.logging_max_retries:
     default: 1

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -161,7 +161,7 @@ properties:
     description: "Log level for cc database operations"
 
   cc.logging_level:
-    default: "debug2"
+    default: "info"
     description: "Log level for cc"
   cc.logging_max_retries:
     default: 1


### PR DESCRIPTION
CC should ship with a default value that is safe and unsurprising for
production deployments, where you want to:

- be able to see errors and warnings without scrolling through lots of debug
  information that may not be relevant
- reduce the throughput and volume of logs that are going into centralised
  stores like Logsearch
- be confident that sensitive information like credentials aren't being
  captured in logs under normal circumstances

cloudfoundry/cf-release may also need updating after this is merged because
the value is repeated in `templates/` and `spec/fixtures/`.

I haven't modified `db_logging_level` because I think `logging_level` takes
precedence and there are some outstanding issues described in:

- cloudfoundry/cloud_controller_ng#572
- cloudfoundry/cloud_controller_ng#617

---

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite