### PR TITLE
Service Broker API 2.9 compatibility specs

### DIFF
--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.9_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.9_spec.rb
@@ -12,19 +12,41 @@ describe 'Service Broker API integration' do
       @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
     end
 
-    describe 'Last Operation' do
+    describe 'provision' do
+      it 'calls the last operation endpoint with state that was returned in provision' do
+        operation_data = 'some_operation_data'
+        async_provision_service(operation_data: operation_data)
+        stub_async_last_operation(operation_data: operation_data)
+
+        expect(a_request(:put, provision_url_for_broker(@broker, accepts_incomplete: true))).to have_been_made
+
+        service_instance = VCAP::CloudController::ManagedServiceInstance.find(guid: @service_instance_guid)
+        Delayed::Worker.new.work_off
+
+        expect(a_request(
+                 :get,
+          "#{service_instance_url(service_instance)}/last_operation?operation=#{operation_data}&plan_id=plan1-guid-here&service_id=service-guid-here"
+        )).to have_been_made
+      end
+    end
+
+    describe 'Last Operation for instances that have already been provisioned' do
       let(:broker_response_status) { 200 }
       let(:broker_response_body) { { state: 'succeeded' }.to_json }
       let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space_guid: @space_guid, service_plan_guid: @plan_guid) }
-      let(:service_instance_guid) { service_instance.guid }
+      let(:operation_data) { nil }
 
       let(:expected_request) {
-        "http://#{stubbed_broker_username}:#{stubbed_broker_password}@#{stubbed_broker_host}" \
-        "/v2/service_instances/#{service_instance_guid}/last_operation?plan_id=plan1-guid-here&service_id=service-guid-here"
+        url = "http://#{stubbed_broker_username}:#{stubbed_broker_password}@#{stubbed_broker_host}" \
+        "/v2/service_instances/#{service_instance.guid}/last_operation?plan_id=plan1-guid-here&service_id=service-guid-here"
+        if !operation_data.nil?
+          url += "&operation=#{operation_data}"
+        end
+        url
       }
 
       before do
-        @service_instance_guid = service_instance_guid
+        @service_instance_guid = service_instance.guid
       end
 
       describe 'an endpoint that polls a service broker last_operation' do
@@ -39,6 +61,32 @@ describe 'Service Broker API integration' do
 
           expect(a_request(:get, expected_request)).
             to have_been_made.once
+        end
+      end
+
+      context 'when the broker returns operation data' do
+        let(:operation_data) { 'some_operation_data' }
+
+        it 'calls the endpoint with state that was returned in delete' do
+          async_delete_service(operation_data: operation_data)
+          stub_async_last_operation(operation_data: operation_data)
+
+          expect(a_request(:delete, deprovision_url(service_instance, accepts_incomplete: true))).to have_been_made
+
+          Delayed::Worker.new.work_off
+
+          expect(a_request(:get, expected_request)).to have_been_made.once
+        end
+
+        it 'calls the endpoint with state that was returned in update' do
+          async_update_service(operation_data: operation_data)
+          stub_async_last_operation(operation_data: operation_data)
+
+          expect(a_request(:patch, update_url_for_broker(@broker, accepts_incomplete: true))).to have_been_made
+
+          Delayed::Worker.new.work_off
+
+          expect(a_request(:get, expected_request)).to have_been_made.once
         end
       end
     end


### PR DESCRIPTION
As discussed in [tracker](https://www.pivotaltracker.com/story/show/121395851), we've added some service broker API compatibility tests for when a broker returns `operation` data from provision, update, and delete endpoints.

cc @avade 