### PR TITLE
Make the number of droplets to keep in the v2 API obey the same count as v3

### DIFF
--- a/app/jobs/runtime/droplet_upload.rb
+++ b/app/jobs/runtime/droplet_upload.rb
@@ -4,9 +4,10 @@ module VCAP::CloudController
       class DropletUpload < VCAP::CloudController::Jobs::CCJob
         attr_reader :local_path, :app_id
 
-        def initialize(local_path, app_id)
+        def initialize(local_path, app_id, config=Config.config)
           @local_path = local_path
           @app_id = app_id
+          @droplets_storage_count = config[:droplets][:max_staged_droplets_stored] || 2
         end
 
         def perform
@@ -17,7 +18,7 @@ module VCAP::CloudController
 
           if app
             blobstore = CloudController::DependencyLocator.instance.droplet_blobstore
-            CloudController::DropletUploader.new(app, blobstore).upload(local_path)
+            CloudController::DropletUploader.new(app, blobstore).upload(local_path, @droplets_storage_count)
           end
 
           FileUtils.rm_f(local_path)

--- a/lib/cloud_controller/bits_expiration.rb
+++ b/lib/cloud_controller/bits_expiration.rb
@@ -4,8 +4,8 @@ module VCAP::CloudController
       config = {}
       config[:packages] = input_config[:packages] || {}
       config[:droplets] = input_config[:droplets] || {}
-      @droplets_storage_count = config[:packages][:max_valid_packages_stored] || 5
-      @packages_storage_count = config[:droplets][:max_staged_droplets_stored] || 5
+      @packages_storage_count = config[:packages][:max_valid_packages_stored] || 5
+      @droplets_storage_count = config[:droplets][:max_staged_droplets_stored] || 5
     end
 
     attr_reader :droplets_storage_count, :packages_storage_count


### PR DESCRIPTION
This lets v2 droplets hang around in the same way the v3 ones do.

Also fixes a copy-and-paste error in v3 droplet/package expiration where the two used each other's configuration.
- [x] I have viewed signed and have submitted the Contributor License Agreement
- [x] I have made this pull request to the `master` branch
- [x] I have run all the unit tests using `bundle exec rake`
- [x] I have run CF Acceptance Tests on bosh lite
