### PR TITLE
Blobstore: retry on S3 500 and 503 errors

### DIFF
--- a/lib/cloud_controller/blobstore/client_provider.rb
+++ b/lib/cloud_controller/blobstore/client_provider.rb
@@ -38,7 +38,10 @@ module CloudController
 
           # work around https://github.com/fog/fog/issues/3137
           # and Fog raising an EOFError SocketError intermittently
-          errors = [Excon::Errors::BadRequest, Excon::Errors::SocketError, SystemCallError]
+          # and https://github.com/fog/fog-aws/issues/264
+          # and https://github.com/fog/fog-aws/issues/265
+          errors = [Excon::Errors::BadRequest, Excon::Errors::SocketError, SystemCallError,
+                    Excon::Errors::InternalServerError, Excon::Errors::ServiceUnavailable]
           retryable_client = RetryableClient.new(client: client, errors: errors, logger: logger)
 
           Client.new(ErrorHandlingClient.new(SafeDeleteClient.new(retryable_client, root_dir)))


### PR DESCRIPTION
* A short explanation of the proposed change:

AWS documentation [1] recommends that client retries on 500 and 503 errors.
Extend retryable_client list to also retry on these kinds of errors
until FOG implements the functionality directly [2][3].

[1] http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
[2] https://github.com/fog/fog-aws/issues/264
[3] https://github.com/fog/fog-aws/issues/265

* An explanation of the use cases your change solves

This would retry on occasional S3 500 and 503 errors, preventing failures reaching the users (e.g. staging/deploy error due to failure to upload/retrieve a droplet from blobstore).

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite