### PR TITLE
Add Policy Group ID to Container Network Info

### DIFF
--- a/lib/cloud_controller/diego/protocol/container_network_info.rb
+++ b/lib/cloud_controller/diego/protocol/container_network_info.rb
@@ -11,6 +11,7 @@ module VCAP::CloudController
         def to_h
           {
             'properties' => {
+              'policy_group_id' => process.guid,
               'app_id' => process.guid,
               'space_id' => process.space.guid,
               'org_id' => process.organization.guid,

--- a/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
@@ -10,6 +10,7 @@ module VCAP::CloudController
         it 'returns the container network information hash' do
           expect(container_info).to eq({
             'properties' => {
+              'policy_group_id' => process.guid,
               'app_id' => process.guid,
               'space_id' => process.space.guid,
               'org_id' => process.organization.guid,

--- a/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
@@ -217,6 +217,7 @@ module VCAP::CloudController
             'ports' => [2222, 3333],
             'network' => {
               'properties' => {
+                'policy_group_id' => app.guid,
                 'app_id' => app.guid,
                 'space_id' => app.space.guid,
                 'org_id' => app.organization.guid,


### PR DESCRIPTION
Implements "policy groups" according to the current [Container Networking Policy design doc](https://docs.google.com/document/d/1HDS89TJKD7ACG6cqQHph5BdNSKLt8jvo6sPGBZ5DmsM)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [N/A] I have run CF Acceptance Tests on bosh lite  **[this code path is not covered by CATS]**

Story in Container Networking backlog: [#120882019](https://www.pivotaltracker.com/story/show/120882019)

cc: @rosenhouse, @SocalNick 