### PR TITLE
make services queryable by id provided by the service broker

### DIFF
--- a/app/controllers/services/services_controller.rb
+++ b/app/controllers/services/services_controller.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
       to_many :service_plans
     end
 
-    query_parameters :active, :label, :provider, :service_broker_guid
+    query_parameters :active, :label, :provider, :service_broker_guid, :unique_id
 
     def self.dependencies
       [:services_event_repository]

--- a/spec/unit/controllers/services/services_controller_spec.rb
+++ b/spec/unit/controllers/services/services_controller_spec.rb
@@ -15,6 +15,7 @@ module VCAP::CloudController
       it { expect(described_class).to be_queryable_by(:label) }
       it { expect(described_class).to be_queryable_by(:provider) }
       it { expect(described_class).to be_queryable_by(:service_broker_guid) }
+      it { expect(described_class).to be_queryable_by(:unique_id) }
     end
 
     describe 'Attributes' do


### PR DESCRIPTION
We need to fetch the service from the CC api, using the identifier provided in the service catalog, so adding unique_id to be a query-able parameter. 

Thoughts?