### PR TITLE
Remove dependency on hm9000.port property

### DIFF
--- a/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
@@ -178,7 +178,7 @@ uaa:
 
 hm9000:
   url: <%= p("hm9000.url", "https://hm9000.#{system_domain}") %>
-  internal_url: <%= "http://hm9000.service.cf.internal:#{p('hm9000.port')}" %>
+  internal_url: <%= "http://hm9000.service.cf.internal:5155" %>
 
 # App staging parameters
 staging:

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -205,7 +205,7 @@ uaa:
 
 hm9000:
   url: <%= p("hm9000.url", "https://hm9000.#{system_domain}") %>
-  internal_url: <%= "http://hm9000.service.cf.internal:#{p('hm9000.port')}" %>
+  internal_url: <%= "http://hm9000.service.cf.internal:5155" %>
 
 <% if p("routing_api.enabled") %>
 routing_api:

--- a/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
@@ -177,7 +177,7 @@ uaa:
 
 hm9000:
   url: <%= p("hm9000.url", "https://hm9000.#{system_domain}") %>
-  internal_url: <%= "http://hm9000.service.cf.internal:#{p('hm9000.port')}" %>
+  internal_url: <%= "http://hm9000.service.cf.internal:5155" %>
 
 # App staging parameters
 staging:


### PR DESCRIPTION
The current templates depend on the presence of the hm9000.port property in the manifest.  But in a diego deployment, there is no need for hm9000, so we are removing this dependency from the templates.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite

[#124374541]

Signed-off-by: Jonathan Berkhahn <jaberkha@us.ibm.com>