### PR TITLE
Add default for hm9000.port to make it optional

### DIFF
--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -391,6 +391,7 @@ properties:
     description: "URL of the hm9000 server"
   hm9000.port:
     description: "Port of the hm9000 Api Server"
+    default: 5155
 
   uaa.jwt.verification_key:
     default: ""

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -450,6 +450,7 @@ properties:
     description: "URL of the hm9000 server"
   hm9000.port:
     description: "Port of the hm9000 Api Server"
+    default: 5155
 
   uaa.jwt.verification_key:
     default: ""

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -396,6 +396,7 @@ properties:
     description: "URL of the hm9000 server"
   hm9000.port:
     description: "Port of the hm9000 Api Server"
+    default: 5155
 
   uaa.jwt.verification_key:
     default: ""


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add defaults for hm9000.port

* An explanation of the use cases your change solves
Makes hm9000 port optional when deploying CF without any hm9000 vms.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

[#124374541]

Signed-off-by: Sandy Cash <scarlet.tanager@gmail.com>