### PR TITLE
Refines Blobstore::Directory#get options

### DIFF
--- a/lib/cloud_controller/blobstore/fog/directory.rb
+++ b/lib/cloud_controller/blobstore/fog/directory.rb
@@ -11,7 +11,9 @@ module CloudController
       end
 
       def get
-        @connection.directories.get(@key, 'limit' => 1, max_keys: 1)
+        options = { max_keys: 1 }
+        options['limit'] = 1 if @connection.service == Fog::Storage::OpenStack
+        @connection.directories.get(@key, options)
       end
     end
   end


### PR DESCRIPTION
The OpenStack storage provider expects a 'limit' parameter, in place of the more common 'max_keys'. There is an open PR regarding that matter [here](https://github.com/fog/fog-openstack/issues/51). AWS and Google Cloud Storage use 'max_limit' but, whereas AWS will simply ignore unrecognized params, GCS will error.

This change enables GCS blob storage, in S3-compatibility mode (using the 'AWS' provider).

* [x] I have viewed signed and have submitted the Contributor License Agreement
  (I am an employee of Pivotal)
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [x] I have run CF Acceptance Tests on bosh lite
