### PR TITLE
Add option to install buildpacks when not bootstrapping

### DIFF
--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -387,6 +387,9 @@ properties:
     description: "Key pair name for signed download URIs"
     default: ""
 
+  cc.run_buildpacks_install:
+    description: "Indicate whether to install buildpacks."
+    default: false
   cc.buildpacks.blobstore_type:
     description: "The type of blobstore backing to use. Valid values: ['fog', 'webdav']"
     default: "fog"

--- a/bosh/jobs/cloud_controller_ng/templates/post-start.sh.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/post-start.sh.erb
@@ -15,7 +15,7 @@ source /var/vcap/packages/capi_utils/syslog_utils.sh
 tee_output_to_sys_log "cloud_controller_ng.$(basename "$0")"
 
 function install_buildpacks {
-  <% if spec.bootstrap %>
+  <% if p('cc.run_buildpacks_install') || spec.bootstrap %>
   pushd "${CC_PACKAGE_DIR}/cloud_controller_ng" > /dev/null
     chpst -u vcap:vcap bundle exec rake buildpacks:install
 


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
A manifest property allowing buildpacks to be installed.

* An explanation of the use cases your change solves
We would like buildpacks to be installed on our VM but spec.bootstrap is false.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite

Signed-off-by: Mark DeLillo <mdelillo@pivotal.io>