### PR TITLE
Introduce nginx configuration for rate limiting

### DIFF
--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -583,6 +583,23 @@ properties:
     description: "The lowest severity nginx log level to capture in the error log."
     default: error
 
+  cc.nginx_rate_limit_general:
+    description: "The rate limiting and burst value to use for '/'"
+    example: |
+      limit: 100r/s
+      burst: 500
+  cc.nginx_rate_limit_zones:
+    description: "Array of zones to do rate limiting for. "
+    example: |
+      - name: apps
+        location: /v2/apps
+        limit: 10r/s
+        burst: 50
+      - name: spaces
+        location: ~ ^/v2/spaces/(.*)
+        limit: 10r/s
+        burst: 100
+
   cc.jobs.local.number_of_workers:
     default: 2
     description: "Number of local cloud_controller_worker workers"

--- a/bosh/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -23,6 +23,17 @@ http {
 
   keepalive_timeout  75 20; #inherited from router
 
+  <% if_p("cc.nginx_rate_limit_general") do %>
+  limit_req_zone $http_authorization zone=all:10m rate=<%=p("cc.nginx_rate_limit_general")['limit'] %>;
+  <% end %>
+
+  <% if_p("cc.nginx_rate_limit_zones") do %>
+    <% p("cc.nginx_rate_limit_zones").each do |zone| %>
+  limit_req_zone $http_authorization zone=<%= zone['name'] %>:10m rate=<%= zone['limit'] %>;
+    <% end %>
+  <% end %>
+  limit_req_status 429;
+
   client_max_body_size <%= p("cc.client_max_body_size") %>; #already enforced upstream/but doesn't hurt.
 
   client_body_temp_path /var/vcap/data/nginx_cc/tmp/client_body_temp;
@@ -54,6 +65,18 @@ http {
       proxy_redirect              off;
       proxy_connect_timeout       10;
       proxy_pass                  http://cloud_controller;
+
+      <% if_p("cc.nginx_rate_limit_general") do %>
+      limit_req zone=all burst=<%= p("cc.nginx_rate_limit_general")['burst'] %> nodelay;
+      <% end %>
+
+      <% if_p("cc.nginx_rate_limit_zones") do %>
+        <% p("cc.nginx_rate_limit_zones").each do |zone| %>
+      location <%= zone['location'] %> {
+        limit_req zone=<%= zone['name'] %> burst=<%= zone['burst'] %> nodelay;
+      }
+        <% end %>
+      <% end %>
     }
 
 <% if p("cc.packages.blobstore_type").downcase == "fog" && p("cc.packages.fog_connection.provider", "").downcase == "local" %>


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
  
  This change introduces rate limiting to API calls to the Cloud Controller by exposing the [limit_req](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html ) nginx configuration setting. The rate limiting proposed is applied per user, using nginx' `$http_authorization` variable.

* An explanation of the use cases your change solves

  It will prevent overloading the cloud controller with too many requests. It protects legit requests by applying the limit per-user.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

Please note that the change was implemented by @petergtz and @jordanj.

@smoser-ibm & @suhlig from the Flintstone team
