### PR TITLE
Pass encryption headers on copy.

### DIFF
--- a/lib/cloud_controller/blobstore/fog/fog_client.rb
+++ b/lib/cloud_controller/blobstore/fog/fog_client.rb
@@ -86,12 +86,12 @@ module CloudController
         source_file = file(source_key)
         raise FileNotFound if source_file.nil?
 
-        source_file.copy(@directory_key, partitioned_key(destination_key))
+        options = @encryption ? { 'x-amz-server-side-encryption' => @encryption } : {}
+        source_file.copy(@directory_key, partitioned_key(destination_key), options)
 
         dest_file = file(destination_key)
         dest_file.public = 'public-read' if local?
-
-        @encryption ? dest_file.save({ 'x-amz-server-side-encryption' => @encryption }) : dest_file.save
+        dest_file.save(options)
       end
 
       def delete_all(page_size=DEFAULT_BATCH_SIZE)

--- a/spec/unit/lib/cloud_controller/blobstore/fog/fog_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/blobstore/fog/fog_client_spec.rb
@@ -446,7 +446,9 @@ module CloudController
             context 'when encryption type is specified' do
               it 'passes the encryption options to aws' do
                 client.cp_file_between_keys(src_key, dest_key)
-                expect(dest_file).to have_received(:save).with('x-amz-server-side-encryption' => 'my-algo')
+                options = { 'x-amz-server-side-encryption' => 'my-algo' }
+                expect(src_file).to have_received(:copy).with('a-directory-key', 'xy/z7/xyz789', options)
+                expect(dest_file).to have_received(:save).with(options)
               end
             end
 
@@ -455,7 +457,8 @@ module CloudController
 
               it 'passes the encryption options to aws' do
                 client.cp_file_between_keys(src_key, dest_key)
-                expect(dest_file).to have_received(:save).with(no_args)
+                expect(src_file).to have_received(:copy).with('a-directory-key', 'xy/z7/xyz789', {})
+                expect(dest_file).to have_received(:save).with({})
               end
             end
           end


### PR DESCRIPTION
This patch updates `FogClient.cp_file_between_keys` to both copy and save files with the specified encryption options. This handles the edge case where encryption is mandatory for an S3 bucket--to ensure that all of our files are encrypted, we configure our buckets to reject any PUTs without encryption set. With this patch, S3 objects are encrypted at all times, instead of copying an object unencrypted and then re-encrypting it afterwards.