### PR TITLE
Service Broker API 2.10 updates

### DIFF
--- a/app/presenters/message_bus/service_binding_presenter.rb
+++ b/app/presenters/message_bus/service_binding_presenter.rb
@@ -1,7 +1,7 @@
 require 'presenters/message_bus/service_instance_presenter'
 
 class ServiceBindingPresenter
-  WHITELISTED_VOLUME_FIELDS = ['container_dir', 'mode', 'device_type']
+  WHITELISTED_VOLUME_FIELDS = ['container_dir', 'mode', 'device_type'].freeze
 
   def initialize(service_binding, include_instance: false)
     @service_binding = service_binding

--- a/app/presenters/message_bus/service_binding_presenter.rb
+++ b/app/presenters/message_bus/service_binding_presenter.rb
@@ -1,6 +1,8 @@
 require 'presenters/message_bus/service_instance_presenter'
 
 class ServiceBindingPresenter
+  WHITELISTED_VOLUME_FIELDS = ['container_dir', 'mode', 'device_type']
+
   def initialize(service_binding, include_instance: false)
     @service_binding = service_binding
     @include_instance = include_instance
@@ -14,9 +16,8 @@ class ServiceBindingPresenter
 
   def self.censor_volume_mounts(volume_mounts)
     return [] unless volume_mounts.is_a?(Array)
-
     volume_mounts.map do |mount_info|
-      mount_info.reject { |k, _v| k == 'private' }
+      mount_info.reject { |k, _v| !WHITELISTED_VOLUME_FIELDS.include?(k) }
     end
   end
 

--- a/lib/cloud_controller/diego/protocol/app_volume_mounts.rb
+++ b/lib/cloud_controller/diego/protocol/app_volume_mounts.rb
@@ -7,31 +7,7 @@ module VCAP::CloudController
         end
 
         def as_json(_options={})
-          @app.service_bindings.map(&:volume_mounts).reject(&:nil?).flat_map(&method(:translate_volume_mounts))
-        end
-
-        private
-
-        def translate_volume_mounts(volume_mounts)
-          volume_mounts.map do |mount|
-            {
-              'driver'         => mount['private']['driver'],
-              'volume_id'      => mount['private']['group_id'],
-              'container_path' => mount['container_path'],
-              'mode'           => map_mode(mount['mode']),
-              'config'         => Base64.encode64(mount['private']['config']),
-            }
-          end
-        end
-
-        MODE_MAP = {
-          'r'  => 0,
-          'rw' => 1,
-          'wr' => 1
-        }.freeze
-
-        def map_mode(mode)
-          MODE_MAP[mode.downcase]
+          @app.service_bindings.map(&:volume_mounts).reject(&:nil?).flatten
         end
       end
     end

--- a/lib/services/service_brokers/v2/http_client.rb
+++ b/lib/services/service_brokers/v2/http_client.rb
@@ -144,7 +144,7 @@ module VCAP::Services
 
       def default_headers
         {
-          VCAP::Request::HEADER_BROKER_API_VERSION => '2.9',
+          VCAP::Request::HEADER_BROKER_API_VERSION => '2.10',
           VCAP::Request::HEADER_NAME => VCAP::Request.current_id,
           'Accept' => 'application/json',
           VCAP::Request::HEADER_API_INFO_LOCATION => "#{VCAP::CloudController::Config.config[:external_domain]}/v2/info"

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.10_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.10_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe 'Service Broker API integration' do
+  describe 'v2.10' do
+    include VCAP::CloudController::BrokerApiHelper
+
+    let(:catalog) { default_catalog(plan_updateable: true) }
+
+    before do
+      setup_cc
+      setup_broker(catalog)
+      @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+    end
+
+    # NOTE: the only changes in 2.10 so far are for experimental volume mounts.  Since we do not guarantee backward
+    # compatibility on volume mounts, we won't add tests for that feature just yet.
+  end
+end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.9_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.9_spec.rb
@@ -90,57 +90,5 @@ RSpec.describe 'Service Broker API integration' do
         end
       end
     end
-
-    describe 'Binding' do
-      let(:broker_response_status) { 200 }
-      let(:broker_response_body) do
-        {
-          volume_mounts: [
-            {
-              public_property: 'public value',
-              private: {
-                private_property: 'private value'
-              }
-            }
-          ]
-        }.to_json
-      end
-      let(:app_guid) { @app_guid }
-      let(:service_instance_guid) { @service_instance_guid }
-      let(:catalog) { default_catalog(requires: ['volume_mount']) }
-
-      before do
-        provision_service
-        create_app
-      end
-
-      after do
-        delete_broker
-      end
-
-      describe 'service binding response with volume_mounts' do
-        before do
-          stub_request(:put, %r{/v2/service_instances/#{service_instance_guid}/service_bindings/#{guid_pattern}}).
-            to_return(status: broker_response_status, body: broker_response_body)
-        end
-
-        it 'displays the volume mount information to the user' do
-          post('/v2/service_bindings',
-            { app_guid: app_guid, service_instance_guid: service_instance_guid }.to_json,
-            json_headers(admin_headers))
-
-          parsed_body = MultiJson.load(last_response.body)
-
-          expect(VCAP::CloudController::ServiceBinding.last.volume_mounts).to match_array(
-            [
-              {
-                'public_property' => 'public value',
-                'private' => { 'private_property' => 'private value' }
-              }
-            ])
-          expect(parsed_body['entity']['volume_mounts']).to match_array([{ 'public_property' => 'public value' }])
-        end
-      end
-    end
   end
 end

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.6_spec.rb' => 'd814f5d1665d1be3ae36e673d288161b',
       'broker_api_v2.7_spec.rb' => '6ac3a8f83f3bc2492715b42a8fecb2a0',
       'broker_api_v2.8_spec.rb' => '54c9fe10b8a3127c18d28ddf4a1bce9b',
-      'broker_api_v2.9_spec.rb' => '06e4c8297a315a35205cc53ea84594be',
+      'broker_api_v2.9_spec.rb' => '9de8ebbdc0e2b60b791c6f7db4e1c8ee',
     }
   end
   let(:digester) { Digester.new(algorithm: Digest::MD5) }

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.7_spec.rb' => '6ac3a8f83f3bc2492715b42a8fecb2a0',
       'broker_api_v2.8_spec.rb' => '54c9fe10b8a3127c18d28ddf4a1bce9b',
       'broker_api_v2.9_spec.rb' => '9de8ebbdc0e2b60b791c6f7db4e1c8ee',
+      'broker_api_v2.10_spec.rb' => '18b42894a7a310c3718736e7a98a174e',
     }
   end
   let(:digester) { Digester.new(algorithm: Digest::MD5) }

--- a/spec/request/service_bindings_spec.rb
+++ b/spec/request/service_bindings_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'v3 service bindings' do
           fb                  = FakeServiceBrokerV2Client.new(*args, **kwargs, &block)
           fb.credentials      = { 'username' => 'managed_username' }
           fb.syslog_drain_url = 'syslog://mydrain.example.com'
-          fb.volume_mounts    = [{ 'stuff' => 'thing', 'private' => { 'secret-stuff' => 'secret-thing' } }]
+          fb.volume_mounts    = [{ 'stuff' => 'thing', 'container_dir' => 'some-path' }]
           fb
         end
       end
@@ -45,7 +45,7 @@ RSpec.describe 'v3 service bindings' do
             'syslog_drain_url' => 'syslog://mydrain.example.com',
             'volume_mounts' => [
               {
-                'stuff' => 'thing'
+                'container_dir' => 'some-path',
               }
             ]
           },
@@ -225,7 +225,7 @@ RSpec.describe 'v3 service bindings' do
         app:              app_model,
         credentials:      { 'username' => 'managed_username' },
         syslog_drain_url: 'syslog://mydrain.example.com',
-        volume_mounts:    [{ 'stuff' => 'thing', 'private' => { 'secret-stuff' => 'secret-thing' } }],
+        volume_mounts:    [{ 'stuff' => 'thing', 'container_dir' => 'some-path' }],
       )
     end
 
@@ -242,7 +242,7 @@ RSpec.describe 'v3 service bindings' do
             'username' => 'managed_username'
           },
           'syslog_drain_url' => 'syslog://mydrain.example.com',
-          'volume_mounts' => [{ 'stuff' => 'thing' }]
+          'volume_mounts' => [{ 'container_dir' => 'some-path' }]
         },
         'created_at' => iso8601,
         'updated_at' => nil,
@@ -286,7 +286,7 @@ RSpec.describe 'v3 service bindings' do
       app:              app_model,
       credentials:      { 'binding1' => 'shtuff' },
       syslog_drain_url: 'syslog://binding1.example.com',
-      volume_mounts:    [{ 'stuff' => 'thing', 'private' => { 'secret-stuff' => 'secret-thing' } }],
+      volume_mounts:    [{ 'stuff' => 'thing', 'container_dir' => 'some-path' }],
     )
     }
     let!(:service_binding2) { VCAP::CloudController::ServiceBindingModel.make(
@@ -294,7 +294,7 @@ RSpec.describe 'v3 service bindings' do
       app:              app_model,
       credentials:      { 'binding2' => 'things' },
       syslog_drain_url: 'syslog://binding2.example.com',
-      volume_mounts:    [{ 'stuff2' => 'thing2', 'private' => { 'secret-stuff' => 'secret-thing' } }],
+      volume_mounts:    [{ 'stuff2' => 'thing2', 'container_dir' => 'some-path' }],
     )
     }
 
@@ -321,7 +321,7 @@ RSpec.describe 'v3 service bindings' do
                 'redacted_message' => '[PRIVATE DATA HIDDEN IN LISTS]'
               },
               'syslog_drain_url' => 'syslog://binding1.example.com',
-              'volume_mounts' => [{ 'stuff' => 'thing' }]
+              'volume_mounts' => [{ 'container_dir' => 'some-path' }]
             },
             'created_at' => iso8601,
             'updated_at' => nil,
@@ -345,7 +345,7 @@ RSpec.describe 'v3 service bindings' do
                 'redacted_message' => '[PRIVATE DATA HIDDEN IN LISTS]'
               },
               'syslog_drain_url' => 'syslog://binding2.example.com',
-              'volume_mounts' => [{ 'stuff2' => 'thing2' }]
+              'volume_mounts' => [{ 'container_dir' => 'some-path' }]
             },
             'created_at' => iso8601,
             'updated_at' => nil,
@@ -378,7 +378,7 @@ RSpec.describe 'v3 service bindings' do
                                                           app: app_model2,
                                                           credentials: { 'utako' => 'secret' },
                                                           syslog_drain_url: 'syslog://example.com',
-                                                          volume_mounts:    [{ 'stuff' => 'thing', 'private' => { 'secret-stuff' => 'secret-thing' } }],
+                                                          volume_mounts:    [{ 'stuff' => 'thing', 'container_dir' => 'some-path' }],
                                                          )
         end
         let(:app_model3) { VCAP::CloudController::AppModel.make(space: space) }
@@ -387,7 +387,7 @@ RSpec.describe 'v3 service bindings' do
                                                           app: app_model3,
                                                           credentials: { 'amelia' => 'apples' },
                                                           syslog_drain_url: 'www.neopets.com',
-                                                          volume_mounts:    [{ 'stuff2' => 'thing2', 'private' => { 'secret-stuff' => 'secret-thing' } }],
+                                                          volume_mounts:    [{ 'stuff2' => 'thing2', 'container_dir' => 'some-path' }],
                                                          )
         end
 

--- a/spec/unit/lib/cloud_controller/diego/protocol/app_volume_mounts_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/app_volume_mounts_spec.rb
@@ -14,24 +14,26 @@ module VCAP::CloudController
         let(:multiple_volume_mounts) do
           [
             {
-              container_path: '/data/images',
-              mode:           'r',
-              private:        {
-                driver:   'cephfs',
-                group_id: 'abc',
-                config:   'something',
-              },
+                container_dir: '/data/images',
+                mode: 'r',
+                device_type: 'shared',
+                device: {
+                    driver: 'cephfs',
+                    volume_id: 'abc',
+                    mount_config: {
+                        key: 'value'
+                    }
+                }
             },
             {
-              container_path: '/data/scratch',
-              mode:           'rw',
-              private:        {
-                driver:   'localscratch',
-                group_id: '123',
-                config:   'something else',
-                tags:     { "iops": ['10k'] },
-                size_mb:  512,
-              }
+                container_dir: '/data/scratch',
+                mode: 'rw',
+                device_type: 'shared',
+                device: {
+                    driver: 'local',
+                    volume_id: 'def',
+                    mount_config: {}
+                }
             }
           ]
         end
@@ -39,13 +41,16 @@ module VCAP::CloudController
         let(:single_volume_mount) do
           [
             {
-              container_path: '/data/videos',
-              mode:           'wr',
-              private:        {
-                driver:   'cephfs',
-                group_id: '123',
-                config:   'something other'
-              }
+                container_dir: '/data/videos',
+                mode: 'rw',
+                device_type: 'shared',
+                device: {
+                    driver: 'local',
+                    volume_id: 'ghi',
+                    mount_config: {
+                        foo: 'bar'
+                    }
+                }
             }
           ]
         end
@@ -56,25 +61,40 @@ module VCAP::CloudController
 
           expect(mounts.as_json).to match_array([
             {
-              'driver'         => 'cephfs',
-              'volume_id'      => 'abc',
-              'container_path' => '/data/images',
-              'mode'           => 0,
-              'config'         => Base64.encode64('something')
+                'container_dir' => '/data/images',
+                'mode' => 'r',
+                'device_type' => 'shared',
+                'device' => {
+                    'driver' => 'cephfs',
+                    'volume_id' => 'abc',
+                    'mount_config' => {
+                        'key' => 'value',
+                    },
+                },
             },
             {
-              'driver'         => 'localscratch',
-              'volume_id'      => '123',
-              'container_path' => '/data/scratch',
-              'mode'           => 1,
-              'config'         => Base64.encode64('something else')
+                'container_dir' => '/data/scratch',
+                'mode' => 'rw',
+                'device_type' => 'shared',
+                'device' => {
+                    'driver' => 'local',
+                    'volume_id' => 'def',
+                    'mount_config' => {},
+                },
             },
             {
-              'driver'         => 'cephfs',
-              'volume_id'      => '123',
-              'container_path' => '/data/videos',
-              'mode'           => 1,
-              'config'         => Base64.encode64('something other')
+
+                'container_dir' => '/data/videos',
+                'mode' => 'rw',
+
+                'device_type' => 'shared',
+                'device' => {
+                  'driver' => 'local',
+                  'volume_id' => 'ghi',
+                  'mount_config' => {
+                      'foo' => 'bar',
+                  },
+                },
             }
           ])
         end
@@ -85,11 +105,17 @@ module VCAP::CloudController
 
           expect(mounts.as_json).to match_array([
             {
-              'driver'         => 'cephfs',
-              'volume_id'      => '123',
-              'container_path' => '/data/videos',
-              'mode'           => 1,
-              'config'         => Base64.encode64('something other')
+                'container_dir' => '/data/videos',
+                'mode' => 'rw',
+
+                'device_type' => 'shared',
+                'device' => {
+                    'driver' => 'local',
+                    'volume_id' => 'ghi',
+                    'mount_config' => {
+                        'foo' => 'bar',
+                    },
+                },
             }
           ])
         end

--- a/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
@@ -42,7 +42,7 @@ module VCAP::Services::ServiceBrokers::V2
         make_request
         expect(a_request(http_method, full_url).
           with(query: hash_including({})).
-          with(headers: { 'X-Broker-Api-Version' => '2.9' })).
+          with(headers: { 'X-Broker-Api-Version' => '2.10' })).
           to have_been_made
       end
 
@@ -74,7 +74,7 @@ module VCAP::Services::ServiceBrokers::V2
         make_request
         expect(fake_logger).to have_received(:debug).with(match(%r{Accept"=>"application/json}))
         expect(fake_logger).to have_received(:debug).with(match(/X-VCAP-Request-ID"=>"[[:alnum:]-]+/))
-        expect(fake_logger).to have_received(:debug).with(match(/X-Broker-Api-Version"=>"2\.9/))
+        expect(fake_logger).to have_received(:debug).with(match(/X-Broker-Api-Version"=>"2\.10/))
         expect(fake_logger).to have_received(:debug).with(match(%r{X-Api-Info-Location"=>"api2\.vcap\.me/v2/info}))
       end
 

--- a/spec/unit/models/services/service_binding_spec.rb
+++ b/spec/unit/models/services/service_binding_spec.rb
@@ -307,24 +307,20 @@ module VCAP::CloudController
         binding = described_class.new
         binding.volume_mounts = [
           {
-            hash1: 'val1',
-            private: {
-              hash1_private: 'val1_private'
-            }
+            container_dir: 'val1',
+            mode: 'val2',
+            device_type: 'val3',
+            hash1_private: 'val1_private'
           },
           {
             hash2: 'val2',
-            private: {
-              hash2_private: 'val2_private'
-            }
+            hash2_private: 'val2_private'
           }
         ]
 
         expect(binding.censor_volume_mounts).to match_array(
-          [
-            { 'hash1' => 'val1' },
-            { 'hash2' => 'val2' }
-          ])
+          [{ 'container_dir' => 'val1', 'mode' => 'val2', 'device_type' => 'val3' }, {}]
+        )
       end
 
       it 'handles nil volume_mounts' do

--- a/spec/unit/presenters/system_env_presenter_spec.rb
+++ b/spec/unit/presenters/system_env_presenter_spec.rb
@@ -46,12 +46,25 @@ module VCAP::CloudController
                 app: app,
                 service_instance: service_instance,
                 syslog_drain_url: 'logs.go-here.com',
-                volume_mounts: [{ foo: 'bar', private: { stuff: 'stays private' } }]
+                volume_mounts: [{
+                                    container_dir: '/data/images',
+                                    mode: 'r',
+                                    device_type: 'shared',
+                                    device: {
+                                        driver: 'cephfs',
+                                        volume_id: 'abc',
+                                        mount_config: {
+                                            key: 'value'
+                                        }
+                                    }
+                                }]
               )
             end
 
             it 'includes only the public volume information' do
-              expect(system_env_presenter.system_env[:VCAP_SERVICES][service.label.to_sym][0].to_hash[:volume_mounts]).to eq(['foo' => 'bar'])
+              expect(system_env_presenter.system_env[:VCAP_SERVICES][service.label.to_sym][0].to_hash[:volume_mounts]).to eq(['container_dir' => '/data/images',
+                                                                                                                              'mode' => 'r',
+                                                                                                                              'device_type' => 'shared'])
             end
           end
 

--- a/spec/unit/presenters/v3/service_binding_model_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_binding_model_presenter_spec.rb
@@ -5,8 +5,8 @@ module VCAP::CloudController::Presenters::V3
   RSpec.describe ServiceBindingModelPresenter do
     let(:presenter) { ServiceBindingModelPresenter.new(service_binding) }
     let(:credentials) { { 'very-secret' => 'password' }.to_json }
-    let(:volume_mounts) { [{ 'not-secret' => 'normal stuff', 'private': { 'very-secret' => 'password' } }] }
-    let(:censored_volume_mounts) { [{ 'not-secret' => 'normal stuff' }] }
+    let(:volume_mounts) { [{ 'container_dir' => '/a/reasonable/path', 'device' => { 'very-secret' => 'password' } }] }
+    let(:censored_volume_mounts) { [{ 'container_dir' => '/a/reasonable/path' }] }
     let(:service_binding) { VCAP::CloudController::ServiceBindingModel.make(
       created_at: Time.at(1),
       updated_at: Time.at(2),


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This pull request should happen in conjunction with a bump to the latest bbs library, and 5 other pull requests to other repositories.  Most of the changes are small changes due to bbs client api changes which affect the expected API calls in tests, but we also updated the docs, rolled the service broker API to 2.10 and made the requisite changes to NSYNC to convert service broker api json payloads into the format expected by BBS protobuf models.

Ancillary PRs:
https://github.com/cloudfoundry/tps/pull/6
https://github.com/cloudfoundry/runtimeschema/pull/11
https://github.com/cloudfoundry/nsync/pull/10
https://github.com/cloudfoundry/docs-services/pull/135
https://github.com/cloudfoundry/stager/pull/10

* An explanation of the use cases your change solves: details in the [tracker story here](https://www.pivotaltracker.com/story/show/119780891) and [Ted's proposal here](https://docs.google.com/document/d/1aiKQgKLLPFD8vkXXazhAgGzJKW6nRwwWkEJc_xc5tOg/edit#)

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite
![cute animal photo](https://camo.githubusercontent.com/a2197ef26f640c8e1a3dcd62cf741468dc16bfff/68747470733a2f2f732d6d656469612d63616368652d616b302e70696e696d672e636f6d2f323336782f34662f34332f62312f34663433623138316566353431393436313339346661326664393564306263662e6a7067)
