### PR TITLE
Respect DB_CONNECTION_STRING in integration tests

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -52,6 +52,39 @@ end
     DBMigrator.from_config(RakeConfig.config, db_logger).rollback(number_to_rollback)
   end
 
+  def parse_db_connection_string
+    host = port = passenv = ""
+    case ENV["DB"]
+    when "postgres"
+      user = "-U postgres"
+      pass = ""
+      if ENV["DB_CONNECTION_STRING"]
+        uri = URI.parse(ENV["DB_CONNECTION_STRING"])
+        host = "-h #{uri.host}"
+        port = "-p #{uri.port}" if uri.port
+        if uri.user
+          user = "-U #{uri.user}"
+        end
+        passenv = "PGPASSWORD=#{uri.password}" if uri.password
+      end
+    when "mysql"
+      user = "-u root"
+      pass = "--password=password"
+      if ENV["DB_CONNECTION_STRING"]
+        uri = URI.parse(ENV["DB_CONNECTION_STRING"])
+        host = "-h #{uri.host}"
+        port = "-P #{uri.port}" if uri.port
+        if uri.user
+          user = "-u #{uri.user}"
+        end
+        if uri.password
+          pass = "--password=#{uri.password}"
+        end
+      end
+    end
+    return host, port, user, pass, passenv
+  end
+
   desc "Rollback migrations to the database (one migration by default)"
   task :rollback, [:number_to_rollback] do |_, args|
     number_to_rollback = (args[:number_to_rollback] || 1).to_i
@@ -89,18 +122,19 @@ end
   task :create do
     require_relative "../../spec/support/bootstrap/db_config"
     db_config = DbConfig.new
+    host, port, user, pass, passenv = parse_db_connection_string
 
     case ENV["DB"]
       when "postgres"
-        sh "psql -U postgres -c 'create database #{db_config.name};'"
-        sh "psql -U postgres -d #{db_config.name} -c 'CREATE EXTENSION IF NOT EXISTS citext'"
-        sh "psql -U postgres -d #{db_config.name} -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto'"
-        sh "psql -U postgres -d #{db_config.name} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"'"
+        sh "#{passenv} psql #{host} #{port} #{user} -c 'create database #{db_config.name};'"
+        sh "#{passenv} psql #{host} #{port} #{user} -d #{db_config.name} -c 'CREATE EXTENSION IF NOT EXISTS citext'"
+        sh "#{passenv} psql #{host} #{port} #{user} -d #{db_config.name} -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto'"
+        sh "#{passenv} psql #{host} #{port} #{user} -d #{db_config.name} -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"'"
       when "mysql"
         if ENV["TRAVIS"] == "true"
           sh "mysql -e 'create database #{db_config.name};' -u root"
         else
-          sh "mysql -e 'create database #{db_config.name};' -u root --password=password"
+          sh "mysql #{host} #{port} #{user} #{pass} -e 'create database #{db_config.name};'"
         end
       else
         puts "rake db:create requires DB to be set to create a database"
@@ -111,15 +145,16 @@ end
   task :drop do
     require_relative "../../spec/support/bootstrap/db_config"
     db_config = DbConfig.new
+    host, port, user, pass, passenv = parse_db_connection_string
 
     case ENV["DB"]
       when "postgres"
-        sh "psql -U postgres -c 'drop database if exists #{db_config.name};'"
+        sh "#{passenv} psql #{host} #{port} #{user} -c 'drop database if exists #{db_config.name};'"
       when "mysql"
         if ENV["TRAVIS"] == "true"
           sh "mysql -e 'drop database if exists #{db_config.name};' -u root"
         else
-          sh "mysql -e 'drop database if exists #{db_config.name};' -u root --password=password"
+          sh "mysql #{host} #{port} #{user} #{pass} -e 'drop database if exists #{db_config.name};'"
         end
       else
         puts "rake db:drop requires DB to be set to create a database"


### PR DESCRIPTION
* A short explanation of the proposed change:
The current implementation of the integration tests ignores `DB_CONNECTION_STRING`,
so the tests fail if the database setting is different to the default.
It will be more convenient to respect `DB_CONNECTION_STRING` in the integration tests.

* An explanation of the use cases your change solves
  * When running the integration tests with a database having setttings other than the default, you will not get errors
  * When running all the tests with a database having setttings other than the default, you can run them at one time without errors

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [x] I have run CF Acceptance Tests on bosh lite
