### PR TITLE
Report bits-service endpoint, when bits-service is enabled

### DIFF
--- a/app/controllers/runtime/info_controller.rb
+++ b/app/controllers/runtime/info_controller.rb
@@ -20,6 +20,10 @@ module VCAP::CloudController
         app_ssh_oauth_client: @config[:info][:app_ssh_oauth_client],
       }
 
+      if @config[:bits_service][:enabled]
+        info[:bits_endpoint] = @config[:bits_service][:public_endpoint]
+      end
+
       if @config[:routing_api] && @config[:routing_api][:url]
         info[:routing_endpoint] = @config[:routing_api][:url]
       end

--- a/spec/unit/controllers/runtime/info_controller_spec.rb
+++ b/spec/unit/controllers/runtime/info_controller_spec.rb
@@ -33,6 +33,26 @@ module VCAP::CloudController
         expect(hash['app_ssh_oauth_client']).to eq(TestConfig.config[:info][:app_ssh_oauth_client])
       end
 
+      it 'includes bits_endpoint when bits service is enabled' do
+        TestConfig.override(bits_service: { enabled: true, public_endpoint: 'bits-service.example.com' })
+        get '/v2/info'
+        hash = MultiJson.load(last_response.body)
+        expect(hash['bits_endpoint']).to eq('bits-service.example.com')
+      end
+
+      it 'does not include bits_service when bits service is not enabled' do
+        get '/v2/info'
+        hash = MultiJson.load(last_response.body)
+        expect(hash).to_not include('bits_endpoint')
+      end
+
+      it 'does not include bits_endpoint when bits service is not enabled, despite a configured public endpoint' do
+        TestConfig.override(bits_service: { public_endpoint: 'bits-service.example.com' })
+        get '/v2/info'
+        hash = MultiJson.load(last_response.body)
+        expect(hash).to_not include('bits_endpoint')
+      end
+
       it 'includes login url when configured' do
         TestConfig.override(login: { url: 'login_url' })
         get '/v2/info'


### PR DESCRIPTION
* A short explanation of the proposed change:
    In /v2/info, report bits-service endpoint, when bits-service is enabled

* An explanation of the use cases your change solves
    With this change, a client can see if CC uses the bits-service, and if so, what its public endpoint is. This will help with the migration to new protocols between cf cli, CC and bits-service.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

