### PR TITLE
Add validation for volume mount data in service broker bind responses.

### DIFF
--- a/app/actions/service_binding_create.rb
+++ b/app/actions/service_binding_create.rb
@@ -8,6 +8,7 @@ module VCAP::CloudController
     class ServiceBrokerInvalidSyslogDrainUrl < StandardError; end
     class InvalidServiceBinding < StandardError; end
     class VolumeMountServiceDisabled < StandardError; end
+    class InvalidVolumeMount < StandardError; end
 
     include VCAP::CloudController::LockCheck
 
@@ -39,6 +40,7 @@ module VCAP::CloudController
       rescue => e
         logger.error "Failed to save state of create for service binding #{service_binding.guid} with exception: #{e}"
         mitigate_orphan(service_binding)
+        raise InvalidVolumeMount if e.instance_of?(ServiceBindingModel::InvalidVolumeMount)
         raise e
       end
 

--- a/app/controllers/services/lifecycle/service_instance_binding_manager.rb
+++ b/app/controllers/services/lifecycle/service_instance_binding_manager.rb
@@ -12,6 +12,7 @@ module VCAP::CloudController
     class AppNotFound < StandardError; end
     class RouteServiceDisabled < StandardError; end
     class VolumeMountServiceDisabled < StandardError; end
+    class InvalidVolumeMount < StandardError; end
 
     include VCAP::CloudController::LockCheck
 
@@ -97,6 +98,7 @@ module VCAP::CloudController
       rescue => e
         @logger.error "Failed to save state of create for service binding #{service_binding.guid} with exception: #{e}"
         mitigate_orphan(service_binding)
+        raise InvalidVolumeMount if e.instance_of?(ServiceBinding::InvalidVolumeMount)
         raise e
       end
 

--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -41,6 +41,8 @@ module VCAP::CloudController
       raise CloudController::Errors::ApiError.new_from_details('AppNotFound', @request_attrs['app_guid'])
     rescue ServiceInstanceBindingManager::VolumeMountServiceDisabled
       raise CloudController::Errors::ApiError.new_from_details('VolumeMountServiceDisabled')
+    rescue ServiceInstanceBindingManager::InvalidVolumeMount
+      raise CloudController::Errors::ApiError.new_from_details('InvalidVolumeMount')
     end
 
     delete path_guid, :delete

--- a/app/controllers/v3/service_bindings_controller.rb
+++ b/app/controllers/v3/service_bindings_controller.rb
@@ -31,6 +31,8 @@ class ServiceBindingsController < ApplicationController
       raise CloudController::Errors::ApiError.new_from_details('ServiceBindingAppServiceTaken', "#{app.guid} #{service_instance.guid}")
     rescue ServiceBindingCreate::VolumeMountServiceDisabled
       raise CloudController::Errors::ApiError.new_from_details('VolumeMountServiceDisabled')
+    rescue ServiceBindingCreate::InvalidVolumeMount
+      raise CloudController::Errors::ApiError.new_from_details('InvalidVolumeMount')
     end
   end
 

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -67,7 +67,7 @@ module VCAP::CloudController
       raise InvalidVolumeMount.new("required field 'device.volume_id' must be a non-empty string") unless
           mount_hash['device']['volume_id'].class == String && !mount_hash['device']['volume_id'].empty?
       raise InvalidVolumeMount.new("field 'device.mount_config' must be an object if it is defined") unless
-          !mount_hash['device'].key?('mount_config') || mount_hash['device']['mount_config'].class == Hash
+          !mount_hash['device'].key?('mount_config') || mount_hash['device']['mount_config'].nil? || mount_hash['device']['mount_config'].class == Hash
     end
 
     def validate_cannot_change_binding

--- a/app/models/v3/persistence/service_binding_model.rb
+++ b/app/models/v3/persistence/service_binding_model.rb
@@ -74,7 +74,7 @@ module VCAP::CloudController
       raise InvalidVolumeMount.new("required field 'device.volume_id' must be a non-empty string") unless
           mount_hash['device']['volume_id'].class == String && !mount_hash['device']['volume_id'].empty?
       raise InvalidVolumeMount.new("field 'device.mount_config' must be an object if it is defined") unless
-          !mount_hash['device'].key?('mount_config') || mount_hash['device']['mount_config'].class == Hash
+          !mount_hash['device'].key?('mount_config') || mount_hash['device']['mount_config'].nil? || mount_hash['device']['mount_config'].class == Hash
     end
 
     def validate_cannot_change_binding

--- a/app/models/v3/persistence/service_binding_model.rb
+++ b/app/models/v3/persistence/service_binding_model.rb
@@ -1,6 +1,7 @@
 module VCAP::CloudController
   class ServiceBindingModel < Sequel::Model(:v3_service_bindings)
     include Serializer
+    class InvalidVolumeMount < StandardError; end
 
     many_to_one :service_instance
     many_to_one :app, class: 'VCAP::CloudController::AppModel'
@@ -25,6 +26,7 @@ module VCAP::CloudController
       validate_cannot_change_binding
 
       validates_max_length 65_535, :volume_mounts if !volume_mounts.nil?
+      validate_volume_mounts(volume_mounts)
     end
 
     def required_parameters
@@ -48,6 +50,31 @@ module VCAP::CloudController
       unless service_instance.space == app.space
         errors.add(:service_instance, :space_mismatch)
       end
+    end
+
+    def validate_volume_mounts(mounts_blob)
+      return unless mounts_blob
+      mounts = mounts_blob if mounts_blob.class == Array
+      mounts = JSON.parse(mounts_blob.to_s) unless mounts_blob.class == Array
+      return unless mounts
+
+      raise InvalidVolumeMount.new('volume_mounts must be an Array but is ' + mounts.class.to_s) unless mounts.class == Array
+      mounts.map! { |x| validate_mount(x) }
+    end
+
+    def validate_mount(mount_hash)
+      raise InvalidVolumeMount.new('volume_mounts element must be an object but is ' + mount_hash.class.to_s) unless mount_hash.class == Hash
+      %w(device_type device mode container_dir driver).each do |key|
+        raise InvalidVolumeMount.new("missing required field '#{key}'") unless mount_hash.key?(key)
+      end
+      %w(device_type mode container_dir driver).each do |key|
+        raise InvalidVolumeMount.new("required field '#{key}' must be a non-empty string") unless mount_hash[key].class == String && !mount_hash[key].empty?
+      end
+      raise InvalidVolumeMount.new("required field 'device' must be an object but is " + mount_hash['device'].class.to_s) unless mount_hash['device'].class == Hash
+      raise InvalidVolumeMount.new("required field 'device.volume_id' must be a non-empty string") unless
+          mount_hash['device']['volume_id'].class == String && !mount_hash['device']['volume_id'].empty?
+      raise InvalidVolumeMount.new("field 'device.mount_config' must be an object if it is defined") unless
+          !mount_hash['device'].key?('mount_config') || mount_hash['device']['mount_config'].class == Hash
     end
 
     def validate_cannot_change_binding

--- a/spec/request/service_bindings_spec.rb
+++ b/spec/request/service_bindings_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'v3 service bindings' do
           fb                  = FakeServiceBrokerV2Client.new(*args, **kwargs, &block)
           fb.credentials      = { 'username' => 'managed_username' }
           fb.syslog_drain_url = 'syslog://mydrain.example.com'
-          fb.volume_mounts    = [{ 'stuff' => 'thing', 'container_dir' => 'some-path' }]
+          fb.volume_mounts    = [{ 'driver' => 'a', 'container_dir' => 'a', 'mode' => 'rw', 'device_type' => 'shared', 'device' => { 'volume_id' => 'a' } }]
           fb
         end
       end
@@ -45,7 +45,9 @@ RSpec.describe 'v3 service bindings' do
             'syslog_drain_url' => 'syslog://mydrain.example.com',
             'volume_mounts' => [
               {
-                'container_dir' => 'some-path',
+                'device_type' => 'shared',
+                'container_dir' => 'a',
+                'mode' => 'rw'
               }
             ]
           },
@@ -225,7 +227,7 @@ RSpec.describe 'v3 service bindings' do
         app:              app_model,
         credentials:      { 'username' => 'managed_username' },
         syslog_drain_url: 'syslog://mydrain.example.com',
-        volume_mounts:    [{ 'stuff' => 'thing', 'container_dir' => 'some-path' }],
+        volume_mounts:    [{ 'driver' => 'a', 'container_dir' => 'a', 'mode' => 'rw', 'device_type' => 'shared', 'device' => { 'volume_id' => 'a' } }],
       )
     end
 
@@ -242,7 +244,11 @@ RSpec.describe 'v3 service bindings' do
             'username' => 'managed_username'
           },
           'syslog_drain_url' => 'syslog://mydrain.example.com',
-          'volume_mounts' => [{ 'container_dir' => 'some-path' }]
+          'volume_mounts' => [{
+            'device_type' => 'shared',
+            'container_dir' => 'a',
+            'mode' => 'rw'
+          }]
         },
         'created_at' => iso8601,
         'updated_at' => nil,
@@ -286,7 +292,7 @@ RSpec.describe 'v3 service bindings' do
       app:              app_model,
       credentials:      { 'binding1' => 'shtuff' },
       syslog_drain_url: 'syslog://binding1.example.com',
-      volume_mounts:    [{ 'stuff' => 'thing', 'container_dir' => 'some-path' }],
+      volume_mounts:    [],
     )
     }
     let!(:service_binding2) { VCAP::CloudController::ServiceBindingModel.make(
@@ -294,7 +300,7 @@ RSpec.describe 'v3 service bindings' do
       app:              app_model,
       credentials:      { 'binding2' => 'things' },
       syslog_drain_url: 'syslog://binding2.example.com',
-      volume_mounts:    [{ 'stuff2' => 'thing2', 'container_dir' => 'some-path' }],
+      volume_mounts:    [],
     )
     }
 
@@ -321,7 +327,7 @@ RSpec.describe 'v3 service bindings' do
                 'redacted_message' => '[PRIVATE DATA HIDDEN IN LISTS]'
               },
               'syslog_drain_url' => 'syslog://binding1.example.com',
-              'volume_mounts' => [{ 'container_dir' => 'some-path' }]
+              'volume_mounts' => []
             },
             'created_at' => iso8601,
             'updated_at' => nil,
@@ -345,7 +351,7 @@ RSpec.describe 'v3 service bindings' do
                 'redacted_message' => '[PRIVATE DATA HIDDEN IN LISTS]'
               },
               'syslog_drain_url' => 'syslog://binding2.example.com',
-              'volume_mounts' => [{ 'container_dir' => 'some-path' }]
+              'volume_mounts' => []
             },
             'created_at' => iso8601,
             'updated_at' => nil,
@@ -378,7 +384,7 @@ RSpec.describe 'v3 service bindings' do
                                                           app: app_model2,
                                                           credentials: { 'utako' => 'secret' },
                                                           syslog_drain_url: 'syslog://example.com',
-                                                          volume_mounts:    [{ 'stuff' => 'thing', 'container_dir' => 'some-path' }],
+                                                          volume_mounts:    [],
                                                          )
         end
         let(:app_model3) { VCAP::CloudController::AppModel.make(space: space) }
@@ -387,7 +393,7 @@ RSpec.describe 'v3 service bindings' do
                                                           app: app_model3,
                                                           credentials: { 'amelia' => 'apples' },
                                                           syslog_drain_url: 'www.neopets.com',
-                                                          volume_mounts:    [{ 'stuff2' => 'thing2', 'container_dir' => 'some-path' }],
+                                                          volume_mounts:    [],
                                                          )
         end
 

--- a/spec/support/shared_examples/models/encrypted_attribute.rb
+++ b/spec/support/shared_examples/models/encrypted_attribute.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
     end
 
     let(:model_class) { described_class }
-    let(:value_to_encrypt) { 'this-is-a-secret' }
+    let(:value_to_encrypt) { '[]' }
     let!(:model) { new_model }
     let(:storage_column) { encrypted_attr }
     let(:attr_salt) { "#{encrypted_attr}_salt" }

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -519,6 +519,18 @@ module VCAP::CloudController
               expect(orphan_mitigation_job).to be_a_fully_wrapped_job_of Jobs::Services::DeleteOrphanedBinding
             end
           end
+
+          context 'when the broker returns a volume_mount that is poorly formatted' do
+            let(:instance) { ManagedServiceInstance.make(:volume_mount, space: space) }
+            let(:bind_body) { { 'volume_mounts' => [{ 'thing': 'other thing' }] } }
+
+            it 'returns CF-InvalidVolumeMount' do
+              make_request
+              expect(last_response).to have_status_code 502
+              expect(decoded_response['error_code']).to eq 'CF-InvalidVolumeMount'
+              post '/v2/service_bindings', req.to_json
+            end
+          end
         end
       end
     end

--- a/spec/unit/lib/cloud_controller/diego/protocol/app_volume_mounts_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/app_volume_mounts_spec.rb
@@ -17,8 +17,8 @@ module VCAP::CloudController
                 container_dir: '/data/images',
                 mode: 'r',
                 device_type: 'shared',
+                driver: 'cephfs',
                 device: {
-                    driver: 'cephfs',
                     volume_id: 'abc',
                     mount_config: {
                         key: 'value'
@@ -29,8 +29,8 @@ module VCAP::CloudController
                 container_dir: '/data/scratch',
                 mode: 'rw',
                 device_type: 'shared',
+                driver: 'local',
                 device: {
-                    driver: 'local',
                     volume_id: 'def',
                     mount_config: {}
                 }
@@ -44,8 +44,8 @@ module VCAP::CloudController
                 container_dir: '/data/videos',
                 mode: 'rw',
                 device_type: 'shared',
+                driver: 'local',
                 device: {
-                    driver: 'local',
                     volume_id: 'ghi',
                     mount_config: {
                         foo: 'bar'
@@ -64,8 +64,8 @@ module VCAP::CloudController
                 'container_dir' => '/data/images',
                 'mode' => 'r',
                 'device_type' => 'shared',
+                'driver' => 'cephfs',
                 'device' => {
-                    'driver' => 'cephfs',
                     'volume_id' => 'abc',
                     'mount_config' => {
                         'key' => 'value',
@@ -76,8 +76,8 @@ module VCAP::CloudController
                 'container_dir' => '/data/scratch',
                 'mode' => 'rw',
                 'device_type' => 'shared',
+                'driver' => 'local',
                 'device' => {
-                    'driver' => 'local',
                     'volume_id' => 'def',
                     'mount_config' => {},
                 },
@@ -88,8 +88,8 @@ module VCAP::CloudController
                 'mode' => 'rw',
 
                 'device_type' => 'shared',
+                'driver' => 'local',
                 'device' => {
-                  'driver' => 'local',
                   'volume_id' => 'ghi',
                   'mount_config' => {
                       'foo' => 'bar',
@@ -109,8 +109,8 @@ module VCAP::CloudController
                 'mode' => 'rw',
 
                 'device_type' => 'shared',
+                'driver' => 'local',
                 'device' => {
-                    'driver' => 'local',
                     'volume_id' => 'ghi',
                     'mount_config' => {
                         'foo' => 'bar',

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -980,7 +980,14 @@ module VCAP::Services::ServiceBrokers::V2
 
         let(:response_data) do
           {
-            'volume_mounts' => [{ 'mount' => 'olympus' }, { 'mount' => 'everest' }]
+            'volume_mounts' => [
+              { 'device_type' => 'none',
+                'device' => { 'volume_id' => 'none', 'mount_config' => { 'key' => 'val' } },
+                'mode' => 'none',
+                'container_dir' => 'none',
+                'driver' => 'none'
+              }
+            ]
           }
         end
 
@@ -990,7 +997,7 @@ module VCAP::Services::ServiceBrokers::V2
           binding.set_all(attributes)
           binding.save
 
-          expect(binding.volume_mounts).to match_array([{ 'mount' => 'olympus' }, { 'mount' => 'everest' }])
+          expect(binding.volume_mounts).to match_array(response_data['volume_mounts'])
         end
 
         context 'when the volume mounts cause an error to be raised' do

--- a/spec/unit/models/runtime/v3/persistence/service_binding_model_spec.rb
+++ b/spec/unit/models/runtime/v3/persistence/service_binding_model_spec.rb
@@ -59,6 +59,22 @@ module VCAP::CloudController
         }.to raise_error(Sequel::ValidationFailed, /type presence/)
       end
 
+      it 'passes validation when mount config is null' do
+        good_mount = '[{"driver":"foo", "container_dir":"/", "mode":"rw", "device_type":"shared", "device":{"volume_id":"a", "mount_config":null}}]'
+
+        binding = ServiceBindingModel.make
+        binding.volume_mounts = good_mount
+        expect { binding.save }.not_to raise_error
+      end
+
+      it 'passes validation when mount config is missing' do
+        good_mount = '[{"driver":"foo", "container_dir":"/", "mode":"rw", "device_type":"shared", "device":{"volume_id":"a"}}]'
+
+        binding = ServiceBindingModel.make
+        binding.volume_mounts = good_mount
+        expect { binding.save }.not_to raise_error
+      end
+
       it 'validates max length of volume_mounts' do
         too_long = 'a' * 65_535
         bad_mount = '[{"driver":"foo", "container_dir":"/", "mode":"rw", "device_type":"shared", "device":{"volume_id":"a", "mount_config":{"a":"' +

--- a/spec/unit/models/runtime/v3/persistence/service_binding_model_spec.rb
+++ b/spec/unit/models/runtime/v3/persistence/service_binding_model_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module VCAP::CloudController
   RSpec.describe ServiceBindingModel do
     let(:credentials) { { 'secret' => 'password' }.to_json }
-    let(:volume_mounts) { [{ 'array' => 'hashes' }].to_json }
+    let(:volume_mounts) { [].to_json }
     let(:last_row) { ServiceBindingModel.dataset.naked.order_by(:id).last }
     let!(:service_binding) { ServiceBindingModel.make(credentials: credentials, volume_mounts: volume_mounts) }
 
@@ -60,12 +60,66 @@ module VCAP::CloudController
       end
 
       it 'validates max length of volume_mounts' do
-        too_long = 'a' * (65_535 + 1)
+        too_long = 'a' * 65_535
+        bad_mount = '[{"driver":"foo", "container_dir":"/", "mode":"rw", "device_type":"shared", "device":{"volume_id":"a", "mount_config":{"a":"' +
+            too_long + '"}}}]'
 
         binding = ServiceBindingModel.make
-        binding.volume_mounts = too_long
+        binding.volume_mounts = bad_mount
 
         expect { binding.save }.to raise_error(Sequel::ValidationFailed, /volume_mounts max_length/)
+      end
+
+      def verify_mount_option(bad_mount, exception, content)
+        binding = ServiceBindingModel.make
+        binding.volume_mounts = bad_mount
+        expect { binding.save }.to raise_error(exception, content)
+      end
+
+      it 'validates that volume_mounts have a device type' do
+        bad_mount = '[{"driver":"foo", "container_dir":"/", "mode":"rw", "device":{"volume_id":"a", "mount_config":{}}}]'
+
+        verify_mount_option(bad_mount, ServiceBindingModel::InvalidVolumeMount, /device_type/)
+      end
+      it 'validates that volume_mounts have a device' do
+        bad_mount = '[{"driver":"foo", "container_dir":"/", "device_type":"shared", "mode":"rw"}]'
+
+        verify_mount_option(bad_mount, ServiceBindingModel::InvalidVolumeMount, /'device'/)
+      end
+      it 'validates that volume_mounts have a mode' do
+        bad_mount = '[{"driver":"foo", "container_dir":"/", "device_type":"shared", "device":{"volume_id":"a", "mount_config":{}}}]'
+
+        verify_mount_option(bad_mount, ServiceBindingModel::InvalidVolumeMount, /mode/)
+      end
+      it 'validates that volume_mounts have a container_dir' do
+        bad_mount = '[{"driver":"foo", "device_type":"shared", "mode":"rw", "device":{"volume_id":"a", "mount_config":{}}}]'
+
+        verify_mount_option(bad_mount, ServiceBindingModel::InvalidVolumeMount, /container_dir/)
+      end
+      it 'validates that volume_mounts have a driver' do
+        bad_mount = '[{"container_dir":"/", "device_type":"shared", "mode":"rw", "device":{"volume_id":"a", "mount_config":{}}}]'
+
+        verify_mount_option(bad_mount, ServiceBindingModel::InvalidVolumeMount, /driver/)
+      end
+      it 'validates that volume_mounts is an array' do
+        bad_mount = '{"driver":"foo", "container_dir":"/", "device_type":"shared", "mode":"rw", "device":{"volume_id":"a", "mount_config":{}}}'
+
+        verify_mount_option(bad_mount, ServiceBindingModel::InvalidVolumeMount, /must be an Array/)
+      end
+      it 'validates that volume_mounts elements are json objects' do
+        bad_mount = '[{"driver":"foo", "container_dir":"/", "device_type":"shared", "mode":"rw", "device":{"volume_id":"a", "mount_config":{}}}, "extra junk"]'
+
+        verify_mount_option(bad_mount, ServiceBindingModel::InvalidVolumeMount, /must be an object/)
+      end
+      it 'validates that volume_mounts.device elements are json objects' do
+        bad_mount = '[{"driver":"foo", "container_dir":"/", "device_type":"shared", "mode":"rw", "device":"junk"}]'
+
+        verify_mount_option(bad_mount, ServiceBindingModel::InvalidVolumeMount, /must be an object/)
+      end
+      it 'validates that volume_mounts.device.mount_config elements are json objects' do
+        bad_mount = '[{"driver":"foo", "container_dir":"/", "device_type":"shared", "mode":"rw", "device":{"volume_id":"a", "mount_config":["junk"]}}]'
+
+        verify_mount_option(bad_mount, ServiceBindingModel::InvalidVolumeMount, /must be an object/)
       end
 
       describe 'changing the binding after creation' do

--- a/spec/unit/models/services/service_binding_spec.rb
+++ b/spec/unit/models/services/service_binding_spec.rb
@@ -15,6 +15,22 @@ module VCAP::CloudController
       it { is_expected.to validate_db_presence :credentials }
       it { is_expected.to validate_uniqueness [:app_id, :service_instance_id] }
 
+      it 'passes validation when mount config is null' do
+        good_mount = '[{"driver":"foo", "container_dir":"/", "mode":"rw", "device_type":"shared", "device":{"volume_id":"a", "mount_config":null}}]'
+
+        binding = ServiceBinding.make
+        binding.volume_mounts = good_mount
+        expect { binding.save }.not_to raise_error
+      end
+
+      it 'passes validation when mount config is missing' do
+        good_mount = '[{"driver":"foo", "container_dir":"/", "mode":"rw", "device_type":"shared", "device":{"volume_id":"a"}}]'
+
+        binding = ServiceBinding.make
+        binding.volume_mounts = good_mount
+        expect { binding.save }.not_to raise_error
+      end
+
       it 'validates max length of volume_mounts', focus: true do
         too_long = 'a' * 65_535
         bad_mount = '[{"driver":"foo", "container_dir":"/", "mode":"rw", "device_type":"shared", "device":{"volume_id":"a", "mount_config":{"a":"' +

--- a/spec/unit/presenters/system_env_presenter_spec.rb
+++ b/spec/unit/presenters/system_env_presenter_spec.rb
@@ -50,8 +50,8 @@ module VCAP::CloudController
                                     container_dir: '/data/images',
                                     mode: 'r',
                                     device_type: 'shared',
+                                    driver: 'cephfs',
                                     device: {
-                                        driver: 'cephfs',
                                         volume_id: 'abc',
                                         mount_config: {
                                             key: 'value'

--- a/spec/unit/presenters/v3/service_binding_model_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_binding_model_presenter_spec.rb
@@ -5,8 +5,14 @@ module VCAP::CloudController::Presenters::V3
   RSpec.describe ServiceBindingModelPresenter do
     let(:presenter) { ServiceBindingModelPresenter.new(service_binding) }
     let(:credentials) { { 'very-secret' => 'password' }.to_json }
-    let(:volume_mounts) { [{ 'container_dir' => '/a/reasonable/path', 'device' => { 'very-secret' => 'password' } }] }
-    let(:censored_volume_mounts) { [{ 'container_dir' => '/a/reasonable/path' }] }
+    let(:volume_mounts) { [{
+      'driver' => 'foo',
+      'container_dir' => '/',
+      'mode' => 'rw',
+      'device_type' => 'shared',
+      'device' => { 'volume_id' => 'a', 'mount_config' => { "a": 'b' } }
+    }] }
+    let(:censored_volume_mounts) { [{ 'device_type' => 'shared', 'container_dir' => '/', 'mode' => 'rw' }] }
     let(:service_binding) { VCAP::CloudController::ServiceBindingModel.make(
       created_at: Time.at(1),
       updated_at: Time.at(2),

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -363,6 +363,11 @@
   http_code: 502
   message: "The service is attempting to stream logs from your application, but is not registered as a logging service. Please contact the service provider."
 
+90007:
+  name: InvalidVolumeMount
+  http_code: 502
+  message: "The service broker responded to the bind request with a poorly formed or invalid volume mount. Please contact the service provider."
+
 100001:
   name: AppInvalid
   http_code: 400


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This change adds new validations during service binding to make sure that any volume_mounts returned by the service broker are formatted correctly to be consumed by NSYNC/bbs later on.

* An explanation of the use cases your change solves
Prior to this change, the bind operation would succeed even when the service broker returned a bad volume mount.  The application would then fail to start with json deserialization errors buried somewhere in the NSYNC logs.  We think it is particularly important to provide better feedback for this feature since the expected format from service brokers has changed from API 2.9 to API 2.10 and any volume service brokers out there are still experimental.  After this change, the bind operation will fail with directly with a message telling the user to contact the service provider.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

- Validate all required fields
- Validate that 'device' is a json object
- Validate that 'device.mount_config' is a json object if it is included
- Update test payloads in all tests to pass cleanly through new
validations
- add plumbing for v2 and v3 controllers to emit a meaningful message to
the end user in case of bad broker behavior.

In Tracker: [#126647149](https://www.pivotaltracker.com/story/show/126647149)

![CATS says yes](https://cloud.githubusercontent.com/assets/8484092/18369248/79ac9878-75d9-11e6-85e0-c3134c3e4261.gif)
