### PR TITLE
Fix to make validate_add_shared_organization being called

### DIFF
--- a/app/models/runtime/domain.rb
+++ b/app/models/runtime/domain.rb
@@ -67,7 +67,7 @@ module VCAP::CloudController
       join_table: 'organizations_private_domains',
       left_key: :private_domain_id,
       right_key: :organization_id,
-      before_set: :validate_add_shared_organization
+      before_add: :validate_add_shared_organization
     )
 
     add_association_dependencies(
@@ -158,7 +158,7 @@ module VCAP::CloudController
     end
 
     def validate_add_shared_organization(organization)
-      !shared? && !owned_by(organization)
+      !shared? && !owned_by?(organization)
     end
   end
 end


### PR DESCRIPTION
* A short explanation of the proposed change:
  * The method `validate_add_shared_organization` is actually not called
because `before_set` is supported only for one_to_one and many_to_one.  
cf. http://sequel.jeremyevans.net/rdoc/files/doc/advanced_associations_rdoc.html#label-Association+callbacks
  * From its name, the method should be called on adding,so its hook is
changed to `before_add`.
  * Additionally, a method name typo is found in the method thanks to
making the method effective. The typo is also fixed.

* An explanation of the use cases your change solves
  * This is a bug (IMHO) fix.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite
