### PR TITLE
scripts/which_cf.sh uses CF_RELEASE_DIR environment variable in more places

### DIFF
--- a/scripts/which-cf.sh
+++ b/scripts/which-cf.sh
@@ -63,7 +63,7 @@ function first_release_with_sha {
   local tag
   release=""
 
-  pushd ~/workspace/cf-release > /dev/null
+  pushd "${CF_RELEASE_DIR}" > /dev/null
     for tag in $(git tag | grep -E "v[0-9]{3}$" | sort -n -t v -k 2); do
       exists_on_ref "${tag}" "${sha}"
 


### PR DESCRIPTION
The which_cf script wasn't always respecting CF_RELEASE_DIR. This fixes that.

There are no tests around this, so they have not been run.