### PR TITLE
preserve existing connection_options passed in from manifest yml

### DIFF
--- a/lib/cloud_controller/blobstore/fog/fog_client.rb
+++ b/lib/cloud_controller/blobstore/fog/fog_client.rb
@@ -186,8 +186,9 @@ module CloudController
         options = @connection_config
         blobstore_timeout = options.delete(:blobstore_timeout)
         options = options.merge(endpoint: '') if local?
-        options = options.merge({ connection_options: { read_timeout: blobstore_timeout,
-                                                        write_timeout: blobstore_timeout } })
+        connection_options = options[:connection_options] || {}
+        connection_options = connection_options.merge(read_timeout: blobstore_timeout, write_timeout: blobstore_timeout)
+        options = options.merge(connection_options: connection_options)
         @connection ||= Fog::Storage.new(options)
       end
 


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* [x] I have viewed signed and have submitted the Contributor License Agreement

I tried but the link (https://www.cloudfoundry.org/individualcontribution.pdf) gives 404

* [ YES] I have made this pull request to the `master` branch

* [YES ] I have run all the unit tests using `bundle exec rake`

* [ NO] I have run CF Acceptance Tests on bosh lite

