### PR TITLE
Remove deprecated endpoint for loggregator

### DIFF
--- a/app/controllers/runtime/info_controller.rb
+++ b/app/controllers/runtime/info_controller.rb
@@ -28,10 +28,6 @@ module VCAP::CloudController
         info[:routing_endpoint] = @config[:routing_api][:url]
       end
 
-      if @config[:loggregator] && @config[:loggregator][:url]
-        info[:logging_endpoint] = @config[:loggregator][:url]
-      end
-
       if @config[:doppler][:enabled]
         info[:doppler_logging_endpoint] = @config[:doppler][:url]
       end

--- a/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
@@ -150,7 +150,6 @@ logging:
 <% if_p("metron_endpoint.host", "metron_endpoint.port") do |host, port| %>
 loggregator:
   router: <%= host %>:<%= port %>
-  url: ws<%= "s" if p("logger_endpoint.use_ssl") %>://loggregator.<%= p("system_domain") %>:<%= p("logger_endpoint.port") %>
 <% end %>
 
 <% db = p("ccdb.databases").find { |db| db["tag"] == "cc" } %>

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -168,6 +168,11 @@ logging:
   level: <%= p("cc.logging_level") %>
   max_retries: <%= p("cc.logging_max_retries") %>
 
+<% if_p("metron_endpoint.host", "metron_endpoint.port") do |host, port| %>
+loggregator:
+  router: <%= host %>:<%= port %>
+<% end %>
+
 doppler:
   enabled: <%= p("doppler.enabled") %>
   <% if p("doppler.enabled") %>

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -168,12 +168,6 @@ logging:
   level: <%= p("cc.logging_level") %>
   max_retries: <%= p("cc.logging_max_retries") %>
 
-<% if_p("metron_endpoint.host", "metron_endpoint.port") do |host, port| %>
-loggregator:
-  router: <%= host %>:<%= port %>
-  url: ws<%= "s" if p("logger_endpoint.use_ssl") %>://loggregator.<%= p("system_domain") %>:<%= p("logger_endpoint.port") %>
-<% end %>
-
 doppler:
   enabled: <%= p("doppler.enabled") %>
   <% if p("doppler.enabled") %>

--- a/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
@@ -149,7 +149,6 @@ logging:
 <% if_p("metron_endpoint.host", "metron_endpoint.port") do |host, port| %>
 loggregator:
   router: <%= host %>:<%= port %>
-  url: ws<%= "s" if p("logger_endpoint.use_ssl") %>://loggregator.<%= p("system_domain") %>:<%= p("logger_endpoint.port") %>
 <% end %>
 
 <% db = p("ccdb.databases").find { |db| db["tag"] == "cc" } %>

--- a/config/bosh-lite.yml
+++ b/config/bosh-lite.yml
@@ -82,7 +82,6 @@ logging:
 
 loggregator:
   router: 127.0.0.1:3457
-  url: wss://loggregator.bosh-lite.com:443
 
 doppler:
   enabled: false

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -71,7 +71,6 @@ logging:
 
 loggregator:
   router: "127.0.0.1:3456"
-  url: "ws://loggregator.vcap.me:80"
 
 doppler:
   enabled: false

--- a/spec/unit/controllers/runtime/info_controller_spec.rb
+++ b/spec/unit/controllers/runtime/info_controller_spec.rb
@@ -60,13 +60,6 @@ module VCAP::CloudController
         expect(hash['authorization_endpoint']).to eq('login_url')
       end
 
-      it 'includes the logging endpoint when configured' do
-        TestConfig.override(loggregator: { url: 'loggregator_url' })
-        get '/v2/info'
-        hash = MultiJson.load(last_response.body)
-        expect(hash['logging_endpoint']).to eq('loggregator_url')
-      end
-
       it 'includes the routing api endpoint when configured' do
         TestConfig.override(routing_api: { url: 'some_routing_api' })
         get '/v2/info'


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

_Removes the legacy loggregator `logging_endpoint` from being exposed in `cf curl /v2/info`_

* An explanation of the use cases your change solves

_We are deprecating all the legacy endpoints from Traffic Controllers._

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

