### PR TITLE
ContainerNetworkInfo use v3 App guid vs Process guid

### DIFF
--- a/lib/cloud_controller/diego/protocol/container_network_info.rb
+++ b/lib/cloud_controller/diego/protocol/container_network_info.rb
@@ -11,10 +11,10 @@ module VCAP::CloudController
         def to_h
           {
             'properties' => {
-              'policy_group_id' => process.guid,
-              'app_id' => process.guid,
-              'space_id' => process.space.guid,
-              'org_id' => process.organization.guid,
+              'policy_group_id' => process.app.guid,
+              'app_id' => process.app.guid,
+              'space_id' => process.app.space.guid,
+              'org_id' => process.app.organization.guid,
             },
           }
         end

--- a/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
@@ -5,15 +5,16 @@ module VCAP::CloudController
     class Protocol
       RSpec.describe ContainerNetworkInfo do
         subject(:container_info) { ContainerNetworkInfo.new(process).to_h }
-        let(:process) { AppFactory.make(diego: true) }
+        let(:process) { App.make(app: parent_app) }
+        let(:parent_app) { AppModel.make }
 
         it 'returns the container network information hash' do
           expect(container_info).to eq({
             'properties' => {
-              'policy_group_id' => process.guid,
-              'app_id' => process.guid,
-              'space_id' => process.space.guid,
-              'org_id' => process.organization.guid,
+              'policy_group_id' => parent_app.guid,
+              'app_id' => parent_app.guid,
+              'space_id' => parent_app.space.guid,
+              'org_id' => parent_app.organization.guid,
             },
           })
         end


### PR DESCRIPTION
CF Container Networking team change for ContainerNetworkInfo in desired app message.
Instead of setting the `app_id` and `policy_group_id` as the v3 Process guid (formerly known as v2 app guid),  we want to use the v3 App guid.

For more information, see related [story](https://www.pivotaltracker.com/story/show/131324419) in Container Networking tracker.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

cc @rosenhouse 
