### PR TITLE
Always use the broker client

### DIFF
--- a/app/jobs/services/service_instance_state_fetch.rb
+++ b/app/jobs/services/service_instance_state_fetch.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
         def perform
           service_instance = ManagedServiceInstance.first(guid: service_instance_guid)
           return if service_instance.nil?
-          client = VCAP::Services::ServiceBrokers::V2::Client.new(client_attrs)
+          client = service_instance.service_broker.client
 
           attrs_to_update = client.fetch_service_instance_state(service_instance)
           update_with_attributes(attrs_to_update, service_instance)

--- a/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
@@ -5,12 +5,11 @@ module VCAP::CloudController
   module Jobs
     module Services
       RSpec.describe ServiceInstanceStateFetch do
-        let(:broker) { ServiceBroker.make }
         let(:client_attrs) do
           {
-            url: broker.broker_url,
-            auth_username: broker.auth_username,
-            auth_password: broker.auth_password,
+            url: 'bogus-url',
+            auth_username: 'noone',
+            auth_password: 'bad-password',
           }
         end
 
@@ -95,6 +94,7 @@ module VCAP::CloudController
 
         describe '#perform' do
           before do
+            broker = service_instance.service_broker
             uri = URI(broker.broker_url)
             uri.user = broker.auth_username
             uri.password = broker.auth_password
@@ -302,6 +302,7 @@ module VCAP::CloudController
 
             context 'due to an HttpRequestError' do
               before do
+                broker = service_instance.service_broker
                 uri = URI(broker.broker_url)
                 uri.user = broker.auth_username
                 uri.password = broker.auth_password


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Always get the broker client from the Broker.

* An explanation of the use cases your change solves
If the broker credentials or url are updated, any outstanding async create will fail with a 401 or worse.

* [ x] I have viewed signed and have submitted the Contributor License Agreement

* [ x] I have made this pull request to the `master` branch

* [x ] I have run all the unit tests using `bundle exec rake`

* [x ] I have run CF Acceptance Tests on bosh lite

- Get the latest client in case the broker attributes have been updated

[#129486569]