### PR TITLE
Fix for rate limiting. nginx sublocations do not inherit all parameters from upper locations

### DIFF
--- a/bosh/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -77,6 +77,7 @@ http {
         <% p("cc.nginx_rate_limit_zones").each do |zone| %>
       location <%= zone['location'] %> {
         limit_req zone=<%= zone['name'] %> burst=<%= zone['burst'] %> nodelay;
+        proxy_pass                  http://cloud_controller;
       }
         <% end %>
       <% end %>


### PR DESCRIPTION
Thanks for contributing to the cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

See pull request #657. I worked on this together with @suhlig and @petergtz. We noticed that when rate limiting is activated, this breaks the nginx config. Reason is that nginx does not document for each parameter if it is inherited by sub locations. The proxy_pass parameter is not inherited and thus must be duplicated for sublocations.

* An explanation of the use cases your change solves

This fix adds the duplication for the proxy_pass parameter to the sublocations. Do you also require a test to ensure that this is working correctly? To test this, a CF installation is neccessary with properties for the rate limiting added to the deployment manifest. 

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

FYI, @smoser-ibm. @petergtz, @suhlig, do you want to comment? 