### PR TITLE
Isolation Segment cleanup from merge. Also behavior changes for Diego.

### DIFF
--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -59,6 +59,8 @@ module VCAP::CloudController
           raise CloudController::Errors::ApiError.new_from_details('InvalidRelation',
             "Organization does not have access to Isolation Segment with guid: #{request_attrs['default_isolation_segment_guid']}")
         end
+
+        obj.check_spaces_without_isolation_segments_empty!('Setting')
       end
 
       super(obj)

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -200,6 +200,8 @@ module VCAP::CloudController
       space = find_guid(guid)
       check_isolation_segment_access!(space)
 
+      check_space_is_empty!(space)
+
       space.db.transaction do
         space.lock!
         space.update(isolation_segment_guid: nil)
@@ -213,6 +215,8 @@ module VCAP::CloudController
       if request_attrs['isolation_segment_guid']
         check_isolation_segment_access!(obj)
 
+        check_space_is_empty!(obj)
+
         isolation_segment_guids = obj.organization.isolation_segment_models.map(&:guid)
         unless isolation_segment_guids.include?(request_attrs['isolation_segment_guid'])
           raise CloudController::Errors::ApiError.new_from_details('UnableToPerform',
@@ -225,6 +229,13 @@ module VCAP::CloudController
     end
 
     private
+
+    def check_space_is_empty!(space)
+      raise CloudController::Errors::ApiError.new_from_details(
+        'UnableToPerform',
+        'Adding the Isolation Segment to the Space',
+        'Cannot change the Isolation Segment for a Space containing Apps') unless space.app_models.empty?
+    end
 
     def after_create(space)
       @space_event_repository.record_space_create(space, SecurityContext.current_user, SecurityContext.current_user_email, request_attrs)

--- a/app/messages/isolation_segment_relationship_org_message.rb
+++ b/app/messages/isolation_segment_relationship_org_message.rb
@@ -1,13 +1,13 @@
 require 'messages/base_message'
 
 module VCAP::CloudController
-  class IsolationSegmentAssignOrgMessage < BaseMessage
+  class IsolationSegmentRelationshipOrgMessage < BaseMessage
     ALLOWED_KEYS = [:data].freeze
 
     attr_accessor(*ALLOWED_KEYS)
 
     def self.create_from_http_request(body)
-      IsolationSegmentAssignOrgMessage.new(body.symbolize_keys)
+      IsolationSegmentRelationshipOrgMessage.new(body.symbolize_keys)
     end
 
     validates_with NoAdditionalKeysValidator

--- a/app/presenters/v2/organization_presenter.rb
+++ b/app/presenters/v2/organization_presenter.rb
@@ -12,7 +12,7 @@ module CloudController
             'billing_enabled' => org.billing_enabled,
             'quota_definition_guid' => org.quota_definition_guid,
             'status' => org.status,
-            'default_isolation_segment_guid' => org.isolation_segment_model ? org.isolation_segment_model.guid : nil
+            'default_isolation_segment_guid' => org.default_isolation_segment_model ? org.default_isolation_segment_model.guid : nil
           }
 
           entity['isolation_segment_url'] = "/v2/organizations/#{org.guid}/isolation_segments" unless org.isolation_segment_models.empty?

--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -179,7 +179,7 @@ properties:
       Name of the shared isolation segment created at startup.
       This field can be updated, but subject to the following caveat:
          Using the name of an existing IS other than the default one will cause a deployment to fail.
-         To recover, redeploy using the old (current) name of the previous Isolation Segment.
+         To recover, redeploy using the last valid Shared Isolation Segment name.
 
   cc.stacks:
     default:

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -232,7 +232,7 @@ properties:
       Name of the shared isolation segment created at startup.
       This field can be updated, but subject to the following caveat:
          Using the name of an existing IS other than the default one will cause a deployment to fail.
-         To recover, redeploy using the old (current) name of the previous Isolation Segment.
+         To recover, redeploy using the last valid Shared Isolation Segment name.
 
   cc.stacks:
     default:

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -187,7 +187,7 @@ properties:
       Name of the shared isolation segment created at startup.
       This field can be updated, but subject to the following caveat:
          Using the name of an existing IS other than the default one will cause a deployment to fail.
-         To recover, redeploy using the old (current) name of the previous Isolation Segment.
+         To recover, redeploy using the last valid Shared Isolation Segment name.
 
   cc.stacks:
     default:

--- a/spec/api/documentation/organizations_api_spec.rb
+++ b/spec/api/documentation/organizations_api_spec.rb
@@ -19,7 +19,7 @@ RSpec.resource 'Organizations', type: [:api, :legacy_api] do
       field :status, 'Status of the organization'
       field :quota_definition_guid, 'The guid of quota to associate with this organization', example_values: ['org-quota-def-guid']
       field :billing_enabled, 'If billing is enabled for this organization', deprecated: true
-      field :isolation_segment_guid, 'The guid for the default isolation segment', experimental: true
+      field :default_isolation_segment_guid, 'The guid for the default isolation segment', experimental: true
     end
 
     standard_model_list :organization, VCAP::CloudController::OrganizationsController do

--- a/spec/request/isolation_segments_spec.rb
+++ b/spec/request/isolation_segments_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'IsolationSegmentModels' do
     end
   end
 
-  describe 'GET /v3/isolation_segments/:guid/organizations' do
+  describe 'GET /v3/isolation_segments/:guid/relationships/organizations' do
     let(:org1) { VCAP::CloudController::Organization.make }
     let(:org2) { VCAP::CloudController::Organization.make }
     let(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }
@@ -65,7 +65,7 @@ RSpec.describe 'IsolationSegmentModels' do
     end
   end
 
-  describe 'GET /v3/isolation_segments/:guid/spaces' do
+  describe 'GET /v3/isolation_segments/:guid/relationships/spaces' do
     let(:space1) { VCAP::CloudController::Space.make }
     let(:space2) { VCAP::CloudController::Space.make }
     let(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }
@@ -147,6 +147,7 @@ RSpec.describe 'IsolationSegmentModels' do
       delete "/v3/isolation_segments/#{isolation_segment.guid}/relationships/organizations", unassign_request, user_header
 
       expect(last_response.status).to eq(204)
+      expect(isolation_segment.organizations).to include(org1)
     end
   end
 

--- a/spec/unit/actions/isolation_segment_assign_spec.rb
+++ b/spec/unit/actions/isolation_segment_assign_spec.rb
@@ -5,26 +5,39 @@ module VCAP::CloudController
   RSpec.describe IsolationSegmentAssign do
     let(:isolation_segment_model) { IsolationSegmentModel.make }
     let(:org) { Organization.make }
+    let(:org2) { Organization.make }
 
-    context 'when the segment is not already assigned to the org' do
-      it 'adds a segment to the allowed list' do
-        subject.assign(isolation_segment_model, org)
-        expect(org.isolation_segment_models).to include(isolation_segment_model)
+    it 'sorts the organizations passed in for assignment' do
+      org.update(guid: 'b')
+      org2.update(guid: 'a')
+
+      org.reload
+      org2.reload
+
+      expect(isolation_segment_model).to receive(:add_organization).with(org2).ordered
+      expect(isolation_segment_model).to receive(:add_organization).with(org).ordered
+      subject.assign(isolation_segment_model, [org, org2])
+    end
+
+    context 'when an isolation segment is not assigned to any orgs' do
+      it 'adds the organization to the isolation segment' do
+        subject.assign(isolation_segment_model, [org, org2])
+        expect(isolation_segment_model.organizations).to include(org, org2)
       end
 
-      it 'sets the first isolation segment added as the default' do
-        subject.assign(isolation_segment_model, org)
-        expect(org.isolation_segment_model).to eq(isolation_segment_model)
+      it 'does not set the default isolation segment for the org' do
+        subject.assign(isolation_segment_model, [org])
+        expect(org.default_isolation_segment_model).to be_nil
       end
     end
 
     context 'and the segment is already assigned to the org' do
       before do
-        subject.assign(isolation_segment_model, org)
+        subject.assign(isolation_segment_model, [org])
       end
 
       it 'is idempotent' do
-        subject.assign(isolation_segment_model, org)
+        subject.assign(isolation_segment_model, [org])
         expect(org.isolation_segment_models).to eq([isolation_segment_model])
       end
     end
@@ -33,20 +46,39 @@ module VCAP::CloudController
       let(:isolation_segment_model2) { IsolationSegmentModel.make }
 
       before do
-        subject.assign(isolation_segment_model, org)
+        subject.assign(isolation_segment_model, [org])
       end
 
       it 'adds the segment to the allowed list' do
-        subject.assign(isolation_segment_model2, org)
+        subject.assign(isolation_segment_model2, [org])
         expect(org.isolation_segment_models).to match_array([
           isolation_segment_model,
           isolation_segment_model2
         ])
       end
+    end
 
-      it 'does not change the default isolation segment for the org' do
-        subject.assign(isolation_segment_model2, org)
-        expect(org.isolation_segment_model).to eq(isolation_segment_model)
+    context 'when assigning the shared isolation segment' do
+      let(:shared_segment) { IsolationSegmentModel.first(guid: VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID) }
+
+      context 'and the org does not already have a default isolation segment set' do
+        it 'sets the shared segment as the organizational default' do
+          subject.assign(shared_segment, [org])
+          expect(org.default_isolation_segment_model).to eq(shared_segment)
+        end
+      end
+
+      context 'and the org has another isolation segment set as the default' do
+        before do
+          subject.assign(isolation_segment_model, [org])
+          org.update(default_isolation_segment_model: isolation_segment_model)
+          org.reload
+        end
+
+        it 'does not change the default isolation segment' do
+          subject.assign(shared_segment, [org])
+          expect(org.default_isolation_segment_model).to eq(isolation_segment_model)
+        end
       end
     end
   end

--- a/spec/unit/actions/isolation_segment_unassign_spec.rb
+++ b/spec/unit/actions/isolation_segment_unassign_spec.rb
@@ -7,118 +7,127 @@ module VCAP::CloudController
     let(:assigner) { IsolationSegmentAssign.new }
     let(:isolation_segment_model) { IsolationSegmentModel.make }
     let(:org) { Organization.make }
+    let(:org2) { Organization.make }
 
-    context 'when the segment is not assigned to the org' do
+    it 'sorts the organizations passed in for unassignment' do
+      org.update(guid: 'b')
+      org2.update(guid: 'a')
+
+      org.reload
+      org2.reload
+
+      expect(isolation_segment_model).to receive(:remove_organization).with(org2).ordered
+      expect(isolation_segment_model).to receive(:remove_organization).with(org).ordered
+      subject.unassign(isolation_segment_model, [org, org2])
+    end
+
+    context 'when an Isolation Segment is not assigned to any Orgs' do
       it 'is idempotent' do
-        subject.unassign(isolation_segment_model, org)
+        subject.unassign(isolation_segment_model, [org])
         expect(org.isolation_segment_models).to eq([])
-      end
-
-      context 'when there are other segments assigned to the org' do
-        let(:isolation_segment_model2) { IsolationSegmentModel.make }
-        before do
-          assigner.assign(isolation_segment_model2, org)
-          expect(org.isolation_segment_model).to eq(isolation_segment_model2)
-        end
-
-        it 'does not remove any other assigned segments' do
-          subject.unassign(isolation_segment_model, org)
-          expect(org.isolation_segment_models).to eq([isolation_segment_model2])
-        end
-
-        it "does not change the org's default isolation segment" do
-          subject.unassign(isolation_segment_model, org)
-          expect(org.isolation_segment_model).to eq(isolation_segment_model2)
-        end
       end
     end
 
-    context 'and the segment is assigned to the org' do
+    context 'when Organizations have been assigned to an Isolation Segment' do
       before do
-        assigner.assign(isolation_segment_model, org)
+        assigner.assign(isolation_segment_model, [org, org2])
       end
 
-      it "removes the segment from the org's allowed list" do
-        subject.unassign(isolation_segment_model, org)
-        expect(org.isolation_segment_models).to eq([])
+      it 'can remove a single org form the Isolation Segment' do
+        subject.unassign(isolation_segment_model, [org])
+        expect(isolation_segment_model.organizations).to eq([org2])
       end
 
-      it 'unsets the default isolation segment for the org' do
-        subject.unassign(isolation_segment_model, org)
-        expect(org.isolation_segment_model).to be_nil
+      it 'can remove multiple Organizations from the Isolation Segment' do
+        subject.unassign(isolation_segment_model, [org, org2])
+        expect(isolation_segment_model.organizations).to eq([])
       end
 
-      context 'and the segment has been assigned to a space owned by the org' do
-        let(:space) { Space.make(organization: org) }
-
+      context 'and the Organization has the Isolation segment as the default' do
         before do
-          space.update(isolation_segment_model: isolation_segment_model)
-          space.save
-          space.reload
+          org.update(default_isolation_segment_model: isolation_segment_model)
         end
 
-        it 'does not remove the segment from the allowed list' do
-          expect {
-            subject.unassign(isolation_segment_model, org)
-          }.to raise_error IsolationSegmentUnassign::IsolationSegmentUnassignError, 'Please delete the Space associations for your Isolation Segment.'
-
-          expect(org.isolation_segment_models).to eq([isolation_segment_model])
-        end
-      end
-
-      context 'when there are other segments assigned to the org' do
-        let(:isolation_segment_model2) { IsolationSegmentModel.make }
-        before do
-          assigner.assign(isolation_segment_model2, org)
+        it 'can remove the Organization from the isolation segment' do
+          subject.unassign(isolation_segment_model, [org])
+          expect(isolation_segment_model.organizations).to eq([org2])
         end
 
-        it 'does not remove any other assigned segments' do
-          subject.unassign(isolation_segment_model2, org)
-          expect(org.isolation_segment_models).to eq([isolation_segment_model])
+        it "removes the organization's default Isolation Segment" do
+          subject.unassign(isolation_segment_model, [org])
+          expect(org.default_isolation_segment_model).to be_nil
         end
 
-        it "does not change the org's default isolation segment" do
-          org.isolation_segment_model = isolation_segment_model2
-          subject.unassign(isolation_segment_model, org)
+        context 'and the Organization has a space assigned' do
+          let!(:space) { Space.make(organization: org) }
 
-          expect(org.isolation_segment_model).to eq(isolation_segment_model2)
-        end
-
-        context 'and the segment is the default for the org' do
-          before do
-            org.isolation_segment_model = isolation_segment_model
+          it 'allows the isolation segment to remove the organization' do
+            subject.unassign(isolation_segment_model, [org])
+            expect(isolation_segment_model.organizations).to eq([org2])
           end
 
-          it 'does not remove the default segment from the allowed list' do
-            expect {
-              subject.unassign(isolation_segment_model, org)
-            }.to raise_error IsolationSegmentUnassign::IsolationSegmentUnassignError, /This operation can only be completed if another Isolation Segment is set as the default/
+          context 'and the space is assigned the Isolation Segment' do
+            before do
+              space.update(isolation_segment_model: isolation_segment_model)
+            end
 
-            expect(org.isolation_segment_models).to match_array([
-              isolation_segment_model,
-              isolation_segment_model2
-            ])
+            it 'does not remove the org from the Isolation Segment' do
+              expect {
+                subject.unassign(isolation_segment_model, [org])
+              }.to raise_error IsolationSegmentUnassign::IsolationSegmentUnassignError, 'Please delete the Space associations for your Isolation Segment.'
+
+              expect(isolation_segment_model.organizations).to include(org, org2)
+            end
+          end
+
+          context 'and the space has no assigned isolation segment' do
+            context 'and the space has an app' do
+              before do
+                AppModel.make(space: space)
+              end
+
+              it 'does not remove the org from the Isolation Segment' do
+                expect {
+                  subject.unassign(isolation_segment_model, [org])
+                }.to raise_error CloudController::Errors::ApiError, /Removing default Isolation Segment could not be completed/
+
+                expect(isolation_segment_model.organizations).to include(org, org2)
+              end
+            end
           end
         end
+      end
 
-        context 'and the segment has been assigned to a space owned by the org' do
-          let(:space) { Space.make(organization: org) }
+      context 'and the Organaization has a space assigned' do
+        let!(:space) { Space.make(organization: org) }
 
+        it 'allows the isolation segment to remove the organization' do
+          subject.unassign(isolation_segment_model, [org])
+          expect(isolation_segment_model.organizations).to eq([org2])
+        end
+
+        context 'and the space is assigned the Isolation Segment' do
           before do
             space.update(isolation_segment_model: isolation_segment_model)
-            space.save
-            space.reload
           end
 
-          it 'does not remove the segment from the allowed list' do
+          it 'does not remove the org from the Isolation Segment' do
             expect {
-              subject.unassign(isolation_segment_model, org)
+              subject.unassign(isolation_segment_model, [org])
             }.to raise_error IsolationSegmentUnassign::IsolationSegmentUnassignError, 'Please delete the Space associations for your Isolation Segment.'
 
-            expect(org.isolation_segment_models).to match_array([
-              isolation_segment_model,
-              isolation_segment_model2
-            ])
+            expect(isolation_segment_model.organizations).to include(org, org2)
+          end
+        end
+
+        context 'and the space has an app' do
+          before do
+            AppModel.make(space: space)
+          end
+
+          it 'removes the Organization form the Isolation Segment' do
+            subject.unassign(isolation_segment_model, [org])
+            expect(isolation_segment_model.organizations).to include(org2)
           end
         end
       end

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -1268,75 +1268,103 @@ module VCAP::CloudController
       let(:space) { Space.make(organization: organization) }
 
       context 'associating an isolation_segment' do
-        context 'when the owning organization has access to the segment' do
+        context 'when the space contains no apps' do
+          context 'when the owning organization has access to the segment' do
+            before do
+              isolation_segment_model.add_organization(organization)
+            end
+
+            context 'as an admin who is not a manager' do
+              before do
+                set_current_user_as_admin
+              end
+
+              it 'associates the isolation segment' do
+                put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
+                expect(last_response.status).to eq 201
+
+                space.reload
+                expect(space.isolation_segment_model).to eq(isolation_segment_model)
+              end
+            end
+
+            context 'as an org manager' do
+              before do
+                space.organization.add_manager(user)
+              end
+
+              it 'associates the isolation segment' do
+                put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
+                expect(last_response.status).to eq 201
+
+                space.reload
+                expect(space.isolation_segment_model).to eq(isolation_segment_model)
+              end
+            end
+
+            context 'as a developer' do
+              before do
+                space.organization.add_user(user)
+                space.add_developer(user)
+              end
+
+              it 'fails with a 403' do
+                put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
+                expect(last_response.status).to eq 403
+                expect(space.isolation_segment_model).to be_nil
+              end
+            end
+
+            context 'as a space manager' do
+              before do
+                space.organization.add_user(user)
+                space.add_manager(user)
+              end
+
+              it 'fails with a 403' do
+                put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
+                expect(last_response.status).to eq 403
+                expect(space.isolation_segment_model).to be_nil
+              end
+            end
+
+            context 'as an auditor' do
+              before do
+                space.organization.add_user(user)
+                space.add_auditor(user)
+              end
+
+              it 'fails with a 403' do
+                put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
+                expect(last_response.status).to eq 403
+                expect(space.isolation_segment_model).to be_nil
+              end
+            end
+          end
+        end
+
+        context 'when the space contains apps' do
           before do
+            AppModel.make(space: space)
+            set_current_user_as_admin
             isolation_segment_model.add_organization(organization)
           end
 
-          context 'as an admin who is not a manager' do
-            before do
-              set_current_user_as_admin
-            end
-
-            it 'associates the isolation segment' do
+          context 'when the space is not already associated with an isolation segment' do
+            it 'returns a 400' do
               put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
-              expect(last_response.status).to eq 201
-
-              space.reload
-              expect(space.isolation_segment_model).to eq(isolation_segment_model)
+              expect(last_response.status).to eq 400
             end
           end
 
-          context 'as an org manager' do
+          context 'when the space is already associated with an isolation segment' do
             before do
-              space.organization.add_manager(user)
+              space.isolation_segment_model = isolation_segment_model
             end
 
-            it 'associates the isolation segment' do
+            it 'returns a 400' do
               put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
-              expect(last_response.status).to eq 201
-
-              space.reload
-              expect(space.isolation_segment_model).to eq(isolation_segment_model)
-            end
-          end
-
-          context 'as a developer' do
-            before do
-              space.organization.add_user(user)
-              space.add_developer(user)
-            end
-
-            it 'fails with a 403' do
-              put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
-              expect(last_response.status).to eq 403
-              expect(space.isolation_segment_model).to be_nil
-            end
-          end
-
-          context 'as a space manager' do
-            before do
-              space.organization.add_user(user)
-              space.add_manager(user)
-            end
-
-            it 'fails with a 403' do
-              put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
-              expect(last_response.status).to eq 403
-              expect(space.isolation_segment_model).to be_nil
-            end
-          end
-
-          context 'as an auditor' do
-            before do
-              space.organization.add_user(user)
-              space.add_auditor(user)
-            end
-
-            it 'fails with a 403' do
-              put "/v2/spaces/#{space.guid}", MultiJson.dump({ isolation_segment_guid: isolation_segment_model.guid })
-              expect(last_response.status).to eq 403
-              expect(space.isolation_segment_model).to be_nil
+              expect(last_response.status).to eq 400
             end
           end
         end
@@ -1553,76 +1581,157 @@ module VCAP::CloudController
           space.save
         end
 
-        context 'as an admin who is not a manager' do
-          before do
-            set_current_user_as_admin
+        context 'when the space does not contain apps' do
+          context 'as an admin who is not a manager' do
+            before do
+              set_current_user_as_admin
+            end
+
+            it 'successfully removes the isolation segment' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 200
+
+              space.reload
+              expect(space.isolation_segment_model).to be_nil
+            end
           end
 
-          it 'successfully removes the isolation segment' do
-            delete "/v2/spaces/#{space.guid}/isolation_segment"
-            expect(last_response.status).to eq 200
+          context 'as an org manager' do
+            before do
+              organization.add_manager(user)
+            end
 
-            space.reload
-            expect(space.isolation_segment_model).to be_nil
+            it 'successfully removes the isolation segment' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 200
+
+              space.reload
+              expect(space.isolation_segment_model).to be_nil
+            end
+          end
+
+          context 'as a developer' do
+            before do
+              space.organization.add_user(user)
+              space.add_developer(user)
+            end
+
+            it 'fails with a 403' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 403
+
+              space.reload
+              expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
+          end
+
+          context 'as a space manager' do
+            before do
+              space.organization.add_user(user)
+              space.add_manager(user)
+            end
+
+            it 'fails with a 403' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 403
+
+              space.reload
+              expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
+          end
+
+          context 'as an auditor' do
+            before do
+              space.organization.add_user(user)
+              space.add_auditor(user)
+            end
+
+            it 'fails with a 403' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 403
+
+              space.reload
+              expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
           end
         end
 
-        context 'as an org manager' do
+        context 'when the space contains apps' do
           before do
-            organization.add_manager(user)
+            AppModel.make(space: space)
           end
 
-          it 'successfully removes the isolation segment' do
-            delete "/v2/spaces/#{space.guid}/isolation_segment"
-            expect(last_response.status).to eq 200
+          context 'as an admin who is not a manager' do
+            before do
+              set_current_user_as_admin
+            end
 
-            space.reload
-            expect(space.isolation_segment_model).to be_nil
-          end
-        end
+            it 'returns a 400' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 400
 
-        context 'as a developer' do
-          before do
-            space.organization.add_user(user)
-            space.add_developer(user)
-          end
-
-          it 'fails with a 403' do
-            delete "/v2/spaces/#{space.guid}/isolation_segment"
-            expect(last_response.status).to eq 403
-
-            space.reload
-            expect(space.isolation_segment_model).to eq(isolation_segment_model)
-          end
-        end
-
-        context 'as a space manager' do
-          before do
-            space.organization.add_user(user)
-            space.add_manager(user)
+              space.reload
+              expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
           end
 
-          it 'fails with a 403' do
-            delete "/v2/spaces/#{space.guid}/isolation_segment"
-            expect(last_response.status).to eq 403
+          context 'as an org manager' do
+            before do
+              organization.add_manager(user)
+            end
 
-            space.reload
-            expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            it 'returns a 400' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 400
+
+              space.reload
+              expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
           end
-        end
 
-        context 'as an auditor' do
-          before do
-            space.organization.add_user(user)
-            space.add_auditor(user)
+          context 'as a developer' do
+            before do
+              space.organization.add_user(user)
+              space.add_developer(user)
+            end
+
+            it 'fails with a 403' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 403
+
+              space.reload
+              expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
           end
 
-          it 'fails with a 403' do
-            delete "/v2/spaces/#{space.guid}/isolation_segment"
-            expect(last_response.status).to eq 403
+          context 'as a space manager' do
+            before do
+              space.organization.add_user(user)
+              space.add_manager(user)
+            end
 
-            space.reload
-            expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            it 'fails with a 403' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 403
+
+              space.reload
+              expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
+          end
+
+          context 'as an auditor' do
+            before do
+              space.organization.add_user(user)
+              space.add_auditor(user)
+            end
+
+            it 'fails with a 403' do
+              delete "/v2/spaces/#{space.guid}/isolation_segment"
+              expect(last_response.status).to eq 403
+
+              space.reload
+              expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
           end
         end
       end

--- a/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
+++ b/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe IsolationSegmentsController, type: :controller do
 
     context 'when the segment has been assigned to orgs' do
       before do
-        assigner.assign(isolation_segment_model, org1)
-        assigner.assign(isolation_segment_model, org2)
+        assigner.assign(isolation_segment_model, [org1, org2])
       end
 
       context 'when the user is an admin' do
@@ -145,8 +144,7 @@ RSpec.describe IsolationSegmentsController, type: :controller do
 
     context 'when the segment has been associated with spaces' do
       before do
-        assigner.assign(isolation_segment_model, org1)
-        assigner.assign(isolation_segment_model, org2)
+        assigner.assign(isolation_segment_model, [org1, org2])
         isolation_segment_model.add_space(space1)
         isolation_segment_model.add_space(space2)
         isolation_segment_model.add_space(space3)
@@ -283,34 +281,18 @@ RSpec.describe IsolationSegmentsController, type: :controller do
           }
         end
 
-        it 'does not assign any of the valid orgs' do
+        it 'does not assign any of the valid orgs and returns a 404' do
           post :assign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
           expect(response.status).to eq 404
 
           expect(isolation_segment_model.organizations).to be_empty
-          expect(org.isolation_segment_model).to be_nil
-        end
-      end
-
-      context 'when the organization does not exist' do
-        let(:req_body) do
-          {
-            data: [
-              { guid: 'bogus-guid' }
-            ]
-          }
-        end
-
-        it 'returns a 404' do
-          post :assign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-          expect(response.status).to eq 404
-          expect(response.body).to match(/Organization guids: \[\\\"bogus-guid\\\"\] cannot be found/)
+          expect(org.default_isolation_segment_model).to be_nil
         end
       end
 
       context 'when the isolation segment has already been assigned to the specified organization' do
         before do
-          assigner.assign(isolation_segment_model, org)
+          assigner.assign(isolation_segment_model, [org])
         end
 
         it 'returns a 201 and leaves the existing assignment intact' do
@@ -353,113 +335,22 @@ RSpec.describe IsolationSegmentsController, type: :controller do
         set_current_user_as_admin
       end
 
-      context 'and no orgs have been assigned to the isolation segment' do
-        it 'removes the org from the isolation segment' do
-          post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-          expect(response.status).to eq 204
-        end
+      it 'unassigns Isolation Segments from the org' do
+        post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
+        expect(response.status).to eq 204
       end
 
-      context 'and an org has been assigned to the isolation segment' do
+      context 'when an IsolationSegmentUnassignError is raised from the action' do
+        let(:unassigner) { double('unassigner') }
+
         before do
-          assigner.assign(isolation_segment_model, org)
+          allow(VCAP::CloudController::IsolationSegmentUnassign).to receive(:new).and_return(unassigner)
+          allow(unassigner).to receive(:unassign).and_raise(VCAP::CloudController::IsolationSegmentUnassign::IsolationSegmentUnassignError.new('error'))
         end
 
-        it 'removes the org from the isolation segment' do
+        it 'returns an unprocessable error' do
           post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-          expect(response.status).to eq 204
-
-          isolation_segment_model.reload
-          org.reload
-          expect(isolation_segment_model.organizations).to be_empty
-          expect(org.isolation_segment_models).to be_empty
-          expect(org.isolation_segment_model).to be_nil
-        end
-
-        it 'removes all passed orgs in the request' do
-          assigner.assign(isolation_segment_model, org_2)
-          req_body[:data] << { guid: org_2.guid }
-          post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-          expect(response.status).to eq 204
-
-          isolation_segment_model.reload
-          expect(isolation_segment_model.organizations).to be_empty
-        end
-
-        it 'removes only the orgs passed in the request' do
-          assigner.assign(isolation_segment_model, org_2)
-          post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-          expect(response.status).to eq 204
-
-          isolation_segment_model.reload
-          expect(isolation_segment_model.organizations.map(&:guid)).to eq([org_2.guid])
-        end
-
-        context 'when there are multiple isolation segments in an organizations allowed list' do
-          before do
-            isolation_segment_model_2 = VCAP::CloudController::IsolationSegmentModel.make
-            assigner.assign(isolation_segment_model_2, org)
-          end
-
-          it 'cannot remove the default isolation segment' do
-            post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-            expect(response.status).to eq 422
-          end
-
-          context 'and we remove an isolation_segment that is not the default' do
-            let(:req_body) do
-              {
-                data: [
-                  { guid: org_2.guid }
-                ]
-              }
-            end
-
-            it 'succeeds' do
-              post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-              expect(response.status).to eq 204
-            end
-          end
-        end
-
-        context 'and a space belonging to the org is assigned the isolation segment' do
-          before do
-            space = VCAP::CloudController::Space.make(organization: org)
-            isolation_segment_model.add_space(space)
-          end
-
-          it 'returns a 422' do
-            post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-            expect(response.status).to eq 422
-          end
-        end
-
-        context 'and an organization in the request body does not exist' do
-          let(:req_body) do
-            {
-              data: [
-                { guid: 'bad-guid' }
-              ]
-            }
-          end
-
-          it 'fails with a 404' do
-            post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-            expect(response.status).to eq 404
-          end
-
-          it 'does not remove the valid assignments from the request body' do
-            req_body[:data] << { guid: org.guid }
-            post :unassign_allowed_organizations, guid: isolation_segment_model.guid, body: req_body
-            expect(response.status).to eq 404
-            expect(response.body).to match(/Organization guids: \[\\\"bad-guid\\\"\] cannot be found/)
-
-            isolation_segment_model.reload
-            org.reload
-            expect(isolation_segment_model.organizations).to eq([org])
-            expect(org.isolation_segment_models).to eq([isolation_segment_model])
-            expect(org.isolation_segment_model).to eq(isolation_segment_model)
-          end
+          expect(response.status).to eq 422
         end
       end
 
@@ -585,7 +476,7 @@ RSpec.describe IsolationSegmentsController, type: :controller do
       context "and the user is an org user for an org in the isolation segment's allowed list" do
         before do
           org1.add_user(user)
-          assigner.assign(isolation_segment, org1)
+          assigner.assign(isolation_segment, [org1])
         end
 
         it 'allows the user to see the isolation segment' do
@@ -703,8 +594,8 @@ RSpec.describe IsolationSegmentsController, type: :controller do
 
         context 'and the org is associated with an isolation segment' do
           before do
-            assigner.assign(isolation_segment1, org1)
-            assigner.assign(isolation_segment2, org1)
+            assigner.assign(isolation_segment1, [org1])
+            assigner.assign(isolation_segment2, [org1])
           end
 
           it 'allows the user to see only those isolation segments associated with their orgs' do

--- a/spec/unit/messages/isolation_segment_relationship_org_message_spec.rb
+++ b/spec/unit/messages/isolation_segment_relationship_org_message_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require 'messages/isolation_segment_assign_org_message'
+require 'messages/isolation_segment_relationship_org_message'
 
 module VCAP::CloudController
-  RSpec.describe IsolationSegmentAssignOrgMessage do
+  RSpec.describe IsolationSegmentRelationshipOrgMessage do
     describe '.create_from_http_request' do
       let(:body) {
         {
@@ -13,15 +13,15 @@ module VCAP::CloudController
         }
       }
 
-      it 'returns the correct IsolationSegmentAssignOrgMessage' do
-        message = IsolationSegmentAssignOrgMessage.create_from_http_request(body)
+      it 'returns the correct IsolationSegmentRelationshipOrgMessage' do
+        message = IsolationSegmentRelationshipOrgMessage.create_from_http_request(body)
 
-        expect(message).to be_a(IsolationSegmentAssignOrgMessage)
+        expect(message).to be_a(IsolationSegmentRelationshipOrgMessage)
         expect(message.guids).to eq(['some-guid', 'some-guid-2'])
       end
 
       it 'converts requested keys to symbols' do
-        message = IsolationSegmentAssignOrgMessage.create_from_http_request(body)
+        message = IsolationSegmentRelationshipOrgMessage.create_from_http_request(body)
 
         expect(message.requested?(:data)).to be_truthy
       end
@@ -36,7 +36,7 @@ module VCAP::CloudController
         end
 
         it 'returns an error' do
-          message = IsolationSegmentAssignOrgMessage.new(params)
+          message = IsolationSegmentRelationshipOrgMessage.new(params)
 
           expect(message).to_not be_valid
           expect(message.errors[:data]).to include("can't be blank")
@@ -51,7 +51,7 @@ module VCAP::CloudController
         end
 
         it 'returns an error' do
-          message = IsolationSegmentAssignOrgMessage.new(params)
+          message = IsolationSegmentRelationshipOrgMessage.new(params)
 
           expect(message).to_not be_valid
           expect(message.errors[:data]).to include('must be an array')
@@ -66,7 +66,7 @@ module VCAP::CloudController
         }
 
         it 'is not valid' do
-          message = IsolationSegmentAssignOrgMessage.new(params)
+          message = IsolationSegmentRelationshipOrgMessage.new(params)
 
           expect(message).to_not be_valid
           expect(message.errors[:base]).to include("Unknown field(s): 'unexpected'")
@@ -82,7 +82,7 @@ module VCAP::CloudController
           end
 
           it 'is not valid' do
-            message = IsolationSegmentAssignOrgMessage.new(params)
+            message = IsolationSegmentRelationshipOrgMessage.new(params)
 
             expect(message).not_to be_valid
             expect(message.errors[:data]).to include('32.77 not a string')

--- a/spec/unit/models/runtime/v3/persistence/isolation_segment_model_spec.rb
+++ b/spec/unit/models/runtime/v3/persistence/isolation_segment_model_spec.rb
@@ -61,8 +61,7 @@ module VCAP::CloudController
         let(:org_2) { Organization.make }
 
         it 'allows one isolation segment to be referenced by multiple organizations' do
-          assigner.assign(isolation_segment_model, org_1)
-          assigner.assign(isolation_segment_model, org_2)
+          assigner.assign(isolation_segment_model, [org_1, org_2])
 
           expect(isolation_segment_model.organizations).to include(org_1, org_2)
           expect(org_1.isolation_segment_models).to include(isolation_segment_model)
@@ -72,8 +71,8 @@ module VCAP::CloudController
         it 'allows multiple isolation segments to be applied to one organization' do
           isolation_segment_model_2 = IsolationSegmentModel.make
 
-          assigner.assign(isolation_segment_model, org_1)
-          assigner.assign(isolation_segment_model_2, org_1)
+          assigner.assign(isolation_segment_model, [org_1])
+          assigner.assign(isolation_segment_model_2, [org_1])
 
           expect(isolation_segment_model.organizations).to include(org_1)
           expect(isolation_segment_model_2.organizations).to include(org_1)
@@ -83,15 +82,15 @@ module VCAP::CloudController
         context 'when adding isolation segments to the allowed list' do
           context 'and one isolation segment is in allowed list' do
             before do
-              assigner.assign(isolation_segment_model, org)
+              assigner.assign(isolation_segment_model, [org])
             end
 
             it 'can be removed' do
-              unassigner.unassign(isolation_segment_model, org)
+              unassigner.unassign(isolation_segment_model, [org])
 
               expect(isolation_segment_model.organizations).to be_empty
               expect(org.isolation_segment_models).to be_empty
-              expect(org.isolation_segment_model).to be_nil
+              expect(org.default_isolation_segment_model).to be_nil
             end
           end
         end
@@ -162,7 +161,7 @@ module VCAP::CloudController
       let(:org) { Organization.make }
 
       it 'raises an error if still assigned to any orgs' do
-        assigner.assign(isolation_segment_model, org)
+        assigner.assign(isolation_segment_model, [org])
         expect { isolation_segment_model.destroy }.to raise_error(CloudController::Errors::ApiError, /Please delete the Organization associations for your Isolation Segment/)
       end
 

--- a/spec/unit/presenters/v2/organization_presenter_spec.rb
+++ b/spec/unit/presenters/v2/organization_presenter_spec.rb
@@ -47,7 +47,9 @@ module CloudController::Presenters::V2
         let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
 
         before do
-          assigner.assign(isolation_segment_model, org)
+          assigner.assign(isolation_segment_model, [org])
+          org.update(default_isolation_segment_model: isolation_segment_model)
+          org.reload
         end
 
         it 'displays the correct url' do


### PR DESCRIPTION
- Organization.isolation_segment_model -> Organization.default_isolation_segment_model
- Cannot change IS for a space containing apps
- Cannot change default IS assignment if spaces w/o IS have apps
- Assigning shared segment sets it as the default if nothing already set as default
- Cannot unassign an IS from the organization if it is assigned to any spaces
- Cannot unassign IS if default and there are spaces w/o an IS that have apps
- assign and unassign both take a list of orgs as second arg
- Update shared_isolation_segment spec wording

Signed-off-by: Sandy Cash <scarlet.tanager@gmail.com>