### PR TITLE
More restrictions updating Isolation Segments

### DIFF
--- a/app/actions/isolation_segment_unassign.rb
+++ b/app/actions/isolation_segment_unassign.rb
@@ -30,9 +30,14 @@ module VCAP::CloudController
     def unset_default_segment(isolation_segment, organization)
       if is_default_segment?(isolation_segment, organization)
         organization.check_spaces_without_isolation_segments_empty!('Removing')
+        default_isolation_error! unless organization.isolation_segment_models.length == 1
 
         organization.update(default_isolation_segment_guid: nil)
       end
+    end
+
+    def default_isolation_error!
+      raise IsolationSegmentUnassignError.new('Please change the default Isolation Segment for your Organization before attempting to remove the default.')
     end
 
     def space_association_error!

--- a/app/actions/isolation_segment_update.rb
+++ b/app/actions/isolation_segment_update.rb
@@ -5,11 +5,43 @@ module VCAP::CloudController
     def update(isolation_segment, message)
       isolation_segment.db.transaction do
         isolation_segment.lock!
+
+        check_not_shared!(isolation_segment)
+        check_no_apps_in_segment!(isolation_segment)
+
         isolation_segment.name = message.name if message.requested?(:name)
         isolation_segment.save
       end
     rescue Sequel::ValidationFailed => e
       raise InvalidIsolationSegment.new(e.message)
+    end
+
+    private
+
+    def check_not_shared!(isolation_segment)
+      if isolation_segment.guid.eql?(VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
+        raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', 'Cannot update the shared Isolation Segment')
+      end
+    end
+
+    # In this function we are using these lookup queries rather than doing something of the form
+    # isolation_segment.organizations.sort.each { ... }. Which would then also need to iterate over all
+    # of the spaces within each organization.
+    def check_no_apps_in_segment!(isolation_segment)
+      org_dataset = Organization.dataset.where(guid: isolation_segment.organizations.map(&:guid), default_isolation_segment_model: isolation_segment)
+
+      unless AppModel.dataset.where(space: Space.dataset.where(isolation_segment_guid: nil, organization: org_dataset)).empty?
+        raise CloudController::Errors::ApiError.new_from_details(
+          'UnableToPerform',
+          "Updating Isolation Segment with name #{isolation_segment.name}",
+          "Please delete all Apps from Spaces without assigned Isolation Segments in any Organization were #{isolation_segment.name} is the default.")
+      end
+
+      unless AppModel.dataset.where(space: Space.dataset.where(isolation_segment_guid: isolation_segment.guid)).empty?
+        raise CloudController::Errors::ApiError.new_from_details(
+          'UnprocessableEntity',
+          "Cannot update the #{isolation_segment.name} Isolation Segment when associated spaces contain apps")
+      end
     end
   end
 end

--- a/app/controllers/v3/isolation_segments_controller.rb
+++ b/app/controllers/v3/isolation_segments_controller.rb
@@ -76,8 +76,6 @@ class IsolationSegmentsController < ApplicationController
     unauthorized! unless roles.admin?
 
     isolation_segment_model = find_isolation_segment(params[:guid])
-    unprocessable!("Cannot update the #{isolation_segment_model.name} Isolation Segment") if
-      isolation_segment_model.guid.eql?(VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
 
     message = IsolationSegmentUpdateMessage.create_from_http_request(params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?

--- a/spec/unit/actions/isolation_segment_update_spec.rb
+++ b/spec/unit/actions/isolation_segment_update_spec.rb
@@ -12,6 +12,14 @@ module VCAP::CloudController
       expect(isolation_segment.name).to eq(new_name)
     end
 
+    it 'does not update the shared segment' do
+      shared_segment = IsolationSegmentModel.first(guid: IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
+      message = IsolationSegmentUpdateMessage.new
+      expect {
+        subject.update shared_segment, message
+      }.to raise_error(CloudController::Errors::ApiError, /Cannot update the shared Isolation Segment/)
+    end
+
     it 'does not update if the message does not request a name update' do
       message = IsolationSegmentUpdateMessage.new
       subject.update isolation_segment, message
@@ -28,6 +36,101 @@ module VCAP::CloudController
         expect {
           subject.update isolation_segment, message
         }.to raise_error(IsolationSegmentUpdate::InvalidIsolationSegment, 'booooooo')
+      end
+    end
+
+    context 'when the isolation segment is assigned to an org' do
+      let(:assigner) { IsolationSegmentAssign.new }
+      let(:org) { Organization.make }
+
+      before do
+        assigner.assign(isolation_segment, [org])
+      end
+
+      it 'updates the name of the isolation segment' do
+        new_name = 'New Name'
+        message = IsolationSegmentUpdateMessage.new name: new_name
+        subject.update isolation_segment, message
+        expect(isolation_segment.name).to eq(new_name)
+      end
+
+      context 'and it is the org default' do
+        before do
+          org.update(default_isolation_segment_model: isolation_segment)
+          org.reload
+        end
+
+        it 'updates the name of the isolation segment' do
+          new_name = 'New Name'
+          message = IsolationSegmentUpdateMessage.new name: new_name
+          subject.update isolation_segment, message
+          expect(isolation_segment.name).to eq(new_name)
+        end
+
+        context 'and there are spaces for that org' do
+          let!(:space) { Space.make(organization: org) }
+
+          it 'updates the name of the isolation segment' do
+            new_name = 'New Name'
+            message = IsolationSegmentUpdateMessage.new name: new_name
+            subject.update isolation_segment, message
+            expect(isolation_segment.name).to eq(new_name)
+          end
+
+          context 'and a space contains apps' do
+            before do
+              AppModel.make(space: space)
+            end
+
+            it 'fails' do
+              message = IsolationSegmentUpdateMessage.new
+              expect {
+                subject.update isolation_segment, message
+              }.to raise_error(CloudController::Errors::ApiError, /Updating Isolation Segment with name /)
+            end
+
+            context 'and the space has a different assigned isolation segment' do
+              let(:isolation_segment2) { IsolationSegmentModel.make }
+
+              before do
+                assigner.assign(isolation_segment2, [org])
+                space.update(isolation_segment_guid: isolation_segment2.guid)
+                space.reload
+              end
+
+              it 'updates the name of the isolation segment' do
+                new_name = 'New Name'
+                message = IsolationSegmentUpdateMessage.new name: new_name
+                subject.update isolation_segment, message
+                expect(isolation_segment.name).to eq(new_name)
+              end
+            end
+          end
+        end
+      end
+
+      context 'and the segment is assigned to a space in the org' do
+        let!(:space) { Space.make(organization: org, isolation_segment_guid: isolation_segment.guid) }
+
+        it 'succeeds' do
+          new_name = 'New Name'
+          message = IsolationSegmentUpdateMessage.new name: new_name
+          subject.update isolation_segment, message
+          expect(isolation_segment.name).to eq(new_name)
+        end
+
+        context 'and the space contains apps' do
+          before do
+            AppModel.make(space: space)
+          end
+
+          it 'fails' do
+            message = IsolationSegmentUpdateMessage.new
+            expect {
+              subject.update isolation_segment, message
+            }.to raise_error(CloudController::Errors::ApiError, /Cannot update/)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
1. Admins should not be able to unassign an org from an IS if the org has that IS set as its default.

The case where there are any apps in a space without an IS set blocks the removal of this IS, but it does not block operators from accidentally removing the default IS and unintentionally deploying their apps to the shared isolation segment.

2. Cannot update an Isolation Segment name if:
   A. The Isolation Segment is assigned to an Organization's  default and there is a space w/o out an Isolation Segment  containing apps.
  B. The Isolation Segment is assigned to any Space containing apps.

[finishes #131555045 #133867895]

Signed-off-by: Sandy Cash <scarlet.tanager@gmail.com>