### PR TITLE
Make cc.nginx.ip configurable

### DIFF
--- a/bosh/jobs/cloud_controller_ng/monit
+++ b/bosh/jobs/cloud_controller_ng/monit
@@ -28,7 +28,11 @@ check process cloud_controller_ng
   if totalmem > <%= p("cc.thresholds.api.alert_if_above_mb") %> Mb for 3 cycles then alert
   if totalmem > <%= p("cc.thresholds.api.restart_if_consistently_above_mb") %> Mb for 15 cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
   if totalmem > <%= p("cc.thresholds.api.restart_if_above_mb") %> Mb for 3 cycles then exec "/var/vcap/jobs/cloud_controller_ng/bin/restart_drain"
+<% if p('cc.nginx.ip').empty? %>
   if failed host <%= discover_external_ip %> port <%= p("cc.external_port") %> protocol http
+<% else %>
+  if failed host <%= p('cc.nginx.ip') %> port <%= p("cc.external_port") %> protocol http
+<% end %>
       and request '/v2/info'
       with timeout 60 seconds for 5 cycles
   then restart

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -112,6 +112,9 @@ properties:
   cc.info.custom:
     description: "Custom attribute keys and values for /v2/info endpoint"
 
+  cc.nginx.ip:
+    description: "IP for nginx"
+    default: ""
   cc.external_port:
     description: "External Cloud Controller port"
     default: 9022

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -19,7 +19,11 @@
 %>
 ---
 #Actually NGX host and port
+<% if p('cc.nginx.ip').empty? %>
 local_route: <%= discover_external_ip %>
+<% else %>
+local_route: <%= p('cc.nginx.ip') %>
+<% end %>
 external_port: <%= p("cc.external_port") %>
 internal_service_hostname: <%= p("cc.internal_service_hostname") %>
 

--- a/bosh/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -49,7 +49,12 @@ http {
   }
 
   server {
+  <% if p("cc.nginx.ip").empty? %>
     listen    <%= p("cc.external_port") %>;
+  <% else %>
+    listen    <%= p("cc.nginx.ip") %>:<%= p("cc.external_port") %>;
+  <% end %>
+
     server_name  _;
     server_name_in_redirect off;
     <% if p("request_timeout_in_seconds").to_i > 0 %>


### PR DESCRIPTION
* A short explanation of the proposed change:
Allow nginx to bind to specific address

* An explanation of the use cases your change solves
We would like to bind nginx to localhost instead of all interfaces

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run CF Acceptance Tests on bosh lite

@mdelillo @aemengo