### PR TITLE
Send Isolation Segments as part of the staging and running requests

### DIFF
--- a/app/actions/droplet_create.rb
+++ b/app/actions/droplet_create.rb
@@ -102,6 +102,16 @@ module VCAP::CloudController
       staging_details.environment_variables = environment_variables
       staging_details.lifecycle             = lifecycle
 
+      shared_segment = VCAP::CloudController::IsolationSegmentModel.shared_segment
+
+      if space.isolation_segment_model
+        if space.isolation_segment_model.guid != shared_segment.guid
+          staging_details.isolation_segment = space.isolation_segment_model.name
+        end
+      elsif org.default_isolation_segment_model && org.default_isolation_segment_model.guid != shared_segment.guid
+        staging_details.isolation_segment = org.default_isolation_segment_model.name
+      end
+
       staging_details
     end
 

--- a/app/models/v3/persistence/isolation_segment_model.rb
+++ b/app/models/v3/persistence/isolation_segment_model.rb
@@ -27,5 +27,9 @@ module VCAP::CloudController
       raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Organization', 'Isolation Segment') unless organizations.empty?
       super
     end
+
+    def self.shared_segment
+      @shared_segment ||= IsolationSegmentModel.first(guid: SHARED_ISOLATION_SEGMENT_GUID)
+    end
   end
 end

--- a/lib/cloud_controller/diego/staging_details.rb
+++ b/lib/cloud_controller/diego/staging_details.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   module Diego
     class StagingDetails
       attr_accessor :droplet, :staging_memory_in_mb, :staging_disk_in_mb, :package,
-        :environment_variables, :lifecycle, :start_after_staging
+        :environment_variables, :lifecycle, :start_after_staging, :isolation_segment
     end
   end
 end

--- a/lib/cloud_controller/diego/staging_request.rb
+++ b/lib/cloud_controller/diego/staging_request.rb
@@ -1,7 +1,7 @@
 module VCAP::CloudController
   module Diego
     class StagingRequest
-      attr_accessor :app_id, :file_descriptors, :memory_mb, :disk_mb, :environment
+      attr_accessor :app_id, :file_descriptors, :memory_mb, :disk_mb, :environment, :isolation_segment
       attr_accessor :egress_rules, :timeout, :log_guid, :lifecycle, :lifecycle_data, :completion_callback
 
       def message
@@ -18,6 +18,7 @@ module VCAP::CloudController
         }
         message[:lifecycle_data] = lifecycle_data if lifecycle_data
         message[:egress_rules]   = egress_rules if egress_rules
+        message[:isolation_segment] = isolation_segment if isolation_segment
 
         schema.validate(message)
         message
@@ -41,6 +42,7 @@ module VCAP::CloudController
             lifecycle:                String,
             optional(:lifecycle_data) => Hash,
             completion_callback:      String,
+            optional(:isolation_segment) => String,
           }
         end
       end

--- a/lib/cloud_controller/diego/task_protocol.rb
+++ b/lib/cloud_controller/diego/task_protocol.rb
@@ -46,6 +46,17 @@ module VCAP::CloudController
           )
         end
 
+        shared_segment = VCAP::CloudController::IsolationSegmentModel.shared_segment
+
+        if task.space.isolation_segment_model
+          if task.space.isolation_segment_model.guid != shared_segment.guid
+            result['isolation_segment'] = task.space.isolation_segment_model.name
+          end
+        elsif task.space.organization.default_isolation_segment_model &&
+          task.space.organization.default_isolation_segment_model.guid != shared_segment.guid
+          result['isolation_segment'] = task.space.organization.default_isolation_segment_model.name
+        end
+
         result.to_json
       end
 

--- a/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require_relative 'lifecycle_protocol_shared'
+require 'isolation_segment_assign'
 
 module VCAP::CloudController
   module Diego
@@ -67,6 +68,7 @@ module VCAP::CloudController
         let(:external_port) { '7777' }
         let(:user) { 'user' }
         let(:password) { 'password' }
+        let(:result) { protocol.stage_package_request(config, staging_details) }
 
         before do
           allow(LifecycleProtocol).to receive(:protocol_for_type).and_return(fake_lifecycle_protocol)
@@ -74,8 +76,6 @@ module VCAP::CloudController
         end
 
         it 'contains the correct payload for staging a package' do
-          result = protocol.stage_package_request(config, staging_details)
-
           expect(result).to eq({
             app_id:              staging_details.droplet.guid,
             log_guid:            app.guid,
@@ -182,6 +182,78 @@ module VCAP::CloudController
             },
             'volume_mounts' => an_instance_of(Array)
           }.merge(fake_lifecycle_protocol.desired_app_message(double(:app))))
+        end
+
+        describe 'isolation segments' do
+          let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
+          let(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }
+          let(:isolation_segment_model_2) { VCAP::CloudController::IsolationSegmentModel.make }
+          let(:shared_isolation_segment) { VCAP::CloudController::IsolationSegmentModel.shared_segment }
+
+          context 'when the org has a default' do
+            context 'and the default is the shared isolation segments' do
+              before do
+                assigner.assign(shared_isolation_segment, [process.space.organization])
+              end
+
+              it 'does not set an isolation segment' do
+                expect(message['isolation_segment']).to be_nil
+              end
+            end
+
+            context 'and the default is not the shared isolation segment' do
+              before do
+                assigner.assign(isolation_segment_model, [process.space.organization])
+                process.space.organization.update(default_isolation_segment_model: isolation_segment_model)
+              end
+
+              it 'sets the isolation segment' do
+                expect(message['isolation_segment']).to eq(isolation_segment_model.name)
+              end
+
+              context 'and the space from that org has an isolation segment' do
+                context 'and the isolation segment is the shared isolation segment' do
+                  before do
+                    assigner.assign(shared_isolation_segment, [process.space.organization])
+                    process.space.isolation_segment_model = shared_isolation_segment
+                    process.space.save
+                  end
+
+                  it 'does not set the isolation segment' do
+                    expect(message['isolation_segment']).to be_nil
+                  end
+                end
+
+                context 'and the isolation segment is not the shared or the default' do
+                  before do
+                    assigner.assign(isolation_segment_model_2, [process.space.organization])
+                    process.space.isolation_segment_model = isolation_segment_model_2
+                    process.space.save
+                  end
+
+                  it 'sets the IS from the space' do
+                    expect(message['isolation_segment']).to eq(isolation_segment_model_2.name)
+                  end
+                end
+              end
+            end
+          end
+
+          context 'when the org does not have a default' do
+            context 'and the space from that org has an isolation segment' do
+              context 'and the isolation segment is not the shared isolation segment' do
+                before do
+                  assigner.assign(isolation_segment_model, [process.space.organization])
+                  process.space.isolation_segment_model = isolation_segment_model
+                  process.space.save
+                end
+
+                it 'sets the isolation segment' do
+                  expect(message['isolation_segment']).to eq(isolation_segment_model.name)
+                end
+              end
+            end
+          end
         end
 
         context 'when app does not have ports defined' do


### PR DESCRIPTION
This PR enables CC to use Isolation Segments. It can be merged as is, but also requires the PRs to nsync, stager, and runtime_schema to take effect.

Signed-off-by: Sandy Cash <scarlet.tanager@gmail.com>