### PR TITLE
Change how to present Isolation Segments from Orgs.

### DIFF
--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -235,20 +235,6 @@ module VCAP::CloudController
       [HTTP::MOVED_PERMANENTLY, headers, 'Use DELETE /v2/private_domains/:domain_guid']
     end
 
-    get '/v2/organizations/:guid/isolation_segments', :list_isolation_segments
-    def list_isolation_segments(guid)
-      org = find_guid_and_validate_access(:read, guid)
-
-      dataset = IsolationSegmentModel.dataset.where(organizations: org)
-      message = IsolationSegmentsListMessage.from_params(@params)
-
-      [HTTP::OK, MultiJson.dump(Presenters::V3::PaginatedListPresenter.new(
-        dataset: dataset,
-        path: "/v2/organizations/#{org.guid}/isolation_segments",
-        message: message
-      ).to_hash)]
-    end
-
     define_messages
     define_routes
 

--- a/app/messages/isolation_segments_list_message.rb
+++ b/app/messages/isolation_segments_list_message.rb
@@ -2,7 +2,7 @@ require 'messages/list_message'
 
 module VCAP::CloudController
   class IsolationSegmentsListMessage < ListMessage
-    ALLOWED_KEYS = [:names, :guids, :page, :per_page, :order_by, :order_direction].freeze
+    ALLOWED_KEYS = [:names, :guids, :page, :per_page, :order_by, :order_direction, :organization_guids].freeze
 
     attr_accessor(*ALLOWED_KEYS)
 
@@ -10,6 +10,7 @@ module VCAP::CloudController
 
     validates :names, array: true, allow_nil: true
     validates :guids, array: true, allow_nil: true
+    validates :organization_guids, array: true, allow_nil: true
 
     def initialize(params={})
       super(params.symbolize_keys)
@@ -21,7 +22,7 @@ module VCAP::CloudController
 
     def self.from_params(params)
       opts = params.dup
-      %w(names guids).each do |attribute|
+      %w(names guids organization_guids).each do |attribute|
         to_array! opts, attribute
       end
       new(opts.symbolize_keys)

--- a/app/presenters/v2/organization_presenter.rb
+++ b/app/presenters/v2/organization_presenter.rb
@@ -15,7 +15,7 @@ module CloudController
             'default_isolation_segment_guid' => org.default_isolation_segment_model ? org.default_isolation_segment_model.guid : nil
           }
 
-          entity['isolation_segment_url'] = "/v2/organizations/#{org.guid}/isolation_segments" unless org.isolation_segment_models.empty?
+          entity['isolation_segment_url'] = "/v3/isolation_segments?organization_guids=#{org.guid}" unless org.isolation_segment_models.empty?
 
           entity.merge!(RelationsPresenter.new.to_hash(controller, org, opts, depth, parents, orphans))
 

--- a/app/queries/isolation_segment_list_fetcher.rb
+++ b/app/queries/isolation_segment_list_fetcher.rb
@@ -25,6 +25,10 @@ module VCAP::CloudController
         dataset = dataset.where("#{IsolationSegmentModel.table_name}__name".to_sym => @message.names)
       end
 
+      if @message.requested?(:organization_guids)
+        dataset = dataset.where(organizations: Organization.where(guid: @message.organization_guids))
+      end
+
       dataset
     end
   end

--- a/spec/api/documentation/organizations_api_spec.rb
+++ b/spec/api/documentation/organizations_api_spec.rb
@@ -91,52 +91,6 @@ RSpec.resource 'Organizations', type: [:api, :legacy_api] do
       end
     end
 
-    describe 'Isolation Segments (experimental)' do
-      let(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }
-
-      before do
-        organization.add_manager(everything_user)
-        isolation_segment_model.add_organization(organization)
-      end
-
-      get '/v2/organizations/:guid/isolation_segments (experimental)' do
-        let(:scheme) { TestConfig.config[:external_protocol] }
-        let(:host) { TestConfig.config[:external_domain] }
-        let(:link_prefix) { "#{scheme}://#{host}" }
-
-        example 'get the associated Isolation Segments for the Organization' do
-          client.get "v2/organizations/#{organization.guid}/isolation_segments", {}, headers
-          expect(status).to eq(200)
-
-          expected_response = {
-            'pagination' => {
-              'total_results' =>  1,
-              'total_pages'   =>  1,
-              'first'         =>  { 'href' => "#{link_prefix}/v2/organizations/#{organization.guid}/isolation_segments?page=1&per_page=50" },
-              'last'          =>  { 'href' => "#{link_prefix}/v2/organizations/#{organization.guid}/isolation_segments?page=1&per_page=50" },
-              'next'          =>  nil,
-              'previous'      =>  nil
-            },
-            'resources' => [
-              {
-                'name'        => isolation_segment_model.name,
-                'guid'        => isolation_segment_model.guid,
-                'created_at'  => iso8601,
-                'updated_at'  => iso8601,
-                'links'       => {
-                  'self'          => { 'href' => "#{link_prefix}/v3/isolation_segments/#{isolation_segment_model.guid}" },
-                  'organizations' => { 'href' => "#{link_prefix}/v3/isolation_segments/#{isolation_segment_model.guid}/relationships/organizations" },
-                  'spaces'        => { 'href' => "#{link_prefix}/v3/isolation_segments/#{isolation_segment_model.guid}/relationships/spaces" },
-                }
-              }
-            ]
-          }
-
-          expect(parsed_response).to be_a_response_like(expected_response)
-        end
-      end
-    end
-
     describe 'Spaces' do
       before do
         VCAP::CloudController::Space.make(organization: organization)

--- a/spec/request/isolation_segments_spec.rb
+++ b/spec/request/isolation_segments_spec.rb
@@ -343,6 +343,32 @@ RSpec.describe 'IsolationSegmentModels' do
         expect(parsed_response['resources'].map { |r| r['name'] }).to eq([models[3].name, models[5].name])
         expect(parsed_response['pagination']).to eq(expected_pagination)
       end
+
+      context 'and isolation segments are assigned to orgs' do
+        before do
+          assigner.assign(models[1], [org1])
+          assigner.assign(models[2], [org2])
+        end
+
+        it 'filters by organization guids' do
+          get "/v3/isolation_segments?organization_guids=#{org1.guid}%2C#{org2.guid}", nil, user_header
+
+          expected_pagination = {
+            'total_results' =>  2,
+            'total_pages'   =>  1,
+            'first'         =>  { 'href' => "#{link_prefix}/v3/isolation_segments?organization_guids=#{org1.guid}%2C#{org2.guid}&page=1&per_page=50" },
+            'last'          =>  { 'href' => "#{link_prefix}/v3/isolation_segments?organization_guids=#{org1.guid}%2C#{org2.guid}&page=1&per_page=50" },
+            'next'          =>  nil,
+            'previous'      =>  nil
+          }
+
+          parsed_response = MultiJson.load(last_response.body)
+
+          expect(last_response.status).to eq(200)
+          expect(parsed_response['resources'].map { |r| r['name'] }).to eq([models[1].name, models[2].name])
+          expect(parsed_response['pagination']).to eq(expected_pagination)
+        end
+      end
     end
   end
 

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -145,61 +145,6 @@ module VCAP::CloudController
       end
     end
 
-    describe 'GET /v2/organizations/:guid/isolation_segments' do
-      let(:space) { Space.make(organization: org) }
-      let(:user) { make_developer_for_space(space) }
-
-      before do
-        set_current_user(user)
-      end
-
-      it 'returns Unauthorized when the user cannot read from the org' do
-        set_current_user(User.make)
-        get "/v2/organizations/#{org.guid}/isolation_segments"
-
-        expect(last_response.status).to eq(403)
-        expect(decoded_response['error_code']).to match(/CF-NotAuthorized/)
-      end
-
-      context 'when no isolation segments have been assigned' do
-        it 'returns an empty list' do
-          get "/v2/organizations/#{org.guid}/isolation_segments"
-
-          expect(last_response.status).to eq(200)
-
-          expect(decoded_response['resources']).to be_empty
-        end
-      end
-
-      context 'when isolation segments have been assigned' do
-        let(:is1) { IsolationSegmentModel.make }
-        let(:is2) { IsolationSegmentModel.make }
-
-        before do
-          is1.add_organization(org)
-          is2.add_organization(org)
-        end
-
-        it 'returns list of the isolation segments' do
-          get "/v2/organizations/#{org.guid}/isolation_segments"
-
-          expect(last_response.status).to eq(200)
-
-          response_guids = decoded_response['resources'].map { |r| r['guid'] }
-          expect(response_guids).to eq([is1.guid, is2.guid])
-        end
-
-        it 'allows pagination of the response' do
-          get "/v2/organizations/#{org.guid}/isolation_segments?per_page=1"
-
-          expect(last_response.status).to eq(200)
-
-          response_guids = decoded_response['resources'].map { |r| r['guid'] }
-          expect(response_guids).to eq([is1.guid])
-        end
-      end
-    end
-
     describe 'setting the default isolation segment' do
       let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
 

--- a/spec/unit/messages/isolation_segments_list_message_spec.rb
+++ b/spec/unit/messages/isolation_segments_list_message_spec.rb
@@ -8,6 +8,7 @@ module VCAP::CloudController
         {
           'names'              => 'name1,name2',
           'guids'              => 'guid1,guid2',
+          'organization_guids' => 'o-guid1,o-guid2',
           'page'               => 1,
           'per_page'           => 5,
           'order_by'           => 'created_at'
@@ -20,6 +21,7 @@ module VCAP::CloudController
         expect(message).to be_a(IsolationSegmentsListMessage)
         expect(message.names).to eq(['name1', 'name2'])
         expect(message.guids).to eq(['guid1', 'guid2'])
+        expect(message.organization_guids).to eq(['o-guid1', 'o-guid2'])
         expect(message.page).to eq(1)
         expect(message.per_page).to eq(5)
         expect(message.order_by).to eq('created_at')
@@ -30,6 +32,7 @@ module VCAP::CloudController
 
         expect(message.requested?(:names)).to be_truthy
         expect(message.requested?(:guids)).to be_truthy
+        expect(message.requested?(:organization_guids)).to be_truthy
         expect(message.requested?(:page)).to be_truthy
         expect(message.requested?(:per_page)).to be_truthy
         expect(message.requested?(:order_by)).to be_truthy
@@ -41,6 +44,7 @@ module VCAP::CloudController
         {
             names:              ['name1', 'name2'],
             guids:              ['guid1', 'guid2'],
+            organization_guids:  ['o-guid1', 'o-guid2'],
             page:               1,
             per_page:           5,
             order_by:           'created_at',
@@ -48,7 +52,7 @@ module VCAP::CloudController
       end
 
       it 'excludes the pagination keys' do
-        expected_params = [:names, :guids]
+        expected_params = [:names, :guids, :organization_guids]
         expect(IsolationSegmentsListMessage.new(opts).to_param_hash.keys).to match_array(expected_params)
       end
     end
@@ -59,6 +63,7 @@ module VCAP::CloudController
           IsolationSegmentsListMessage.new({
               names:              [],
               guids:              [],
+              organization_guids: [],
               page:               1,
               per_page:           5,
               order_by:           'created_at',

--- a/spec/unit/presenters/v2/organization_presenter_spec.rb
+++ b/spec/unit/presenters/v2/organization_presenter_spec.rb
@@ -56,7 +56,7 @@ module CloudController::Presenters::V2
           actual_entity_hash = org_presenter.entity_hash(controller, org, opts, depth, parents, orphans)
 
           expect(actual_entity_hash['default_isolation_segment_guid']).to eq(isolation_segment_model.guid)
-          expect(actual_entity_hash['isolation_segment_url']).to eq "/v2/organizations/#{org.guid}/isolation_segments"
+          expect(actual_entity_hash['isolation_segment_url']).to eq "/v3/isolation_segments?organization_guids=#{org.guid}"
           expect(relations_presenter).to have_received(:to_hash).with(controller, org, opts, depth, parents, orphans)
         end
       end


### PR DESCRIPTION
This PR attempts to provide a fix for the Organization Presenter that include the Isolation Segment presenter from the initial [PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/685).  See in particular the first comment in the PR discussion.

/v2/organizations/guid/isolation_segments -> /v3/isolation_segments?organization_guids=guid

Signed-off-by: Dan Lavine <dlavine@us.ibm.com>