### PR TITLE
Add bits-service signing credentials to cc config

### DIFF
--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -748,6 +748,12 @@ properties:
   cc.bits_service.private_endpoint:
     description: "Private url for the bits-service service"
     default: ""
+  cc.bits_service.username:
+    description: "Username for the bits-service"
+    default: ""
+  cc.bits_service.password:
+    description: "Password for the bits-service"
+    default: ""
 
   cc.rate_limiter.enabled:
     description: "Enable rate limiting for UAA-authenticated endpoints per user or client"

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -403,6 +403,8 @@ bits_service:
   <% if p("cc.bits_service.enabled") %>
   public_endpoint: <%= p("cc.bits_service.public_endpoint") %>
   private_endpoint: <%= p("cc.bits_service.private_endpoint") %>
+  username: <%= p("cc.bits_service.username") %>
+  password: <%= p("cc.bits_service.password") %>
   <% end %>
 
 rate_limiter:


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
    See PR title.

* An explanation of the use cases your change solves
    We are preparing a change in the bits-service that makes requires CC to use basic auth when requesting signed URLs from bits-service. In preparation,  we'd like to add the necessary configuration to CC.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

Signed-off-by: Peter Goetz <peter.gtz@gmail.com>

/cc @smoser-ibm @suhlig 