### PR TITLE
Allow bits service when running locally

### DIFF
--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -748,6 +748,12 @@ properties:
   cc.bits_service.private_endpoint:
     description: "Private url for the bits-service service"
     default: ""
+  cc.bits_service.username:
+    description: "Username for the bits-service"
+    default: ""
+  cc.bits_service.password:
+    description: "Password for the bits-service"
+    default: ""
 
   cc.rate_limiter.enabled:
     description: "Enable rate limiting for UAA-authenticated endpoints per user or client"

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -403,6 +403,8 @@ bits_service:
   <% if p("cc.bits_service.enabled") %>
   public_endpoint: <%= p("cc.bits_service.public_endpoint") %>
   private_endpoint: <%= p("cc.bits_service.private_endpoint") %>
+  username: <%= p("cc.bits_service.username") %>
+  password: <%= p("cc.bits_service.password") %>
   <% end %>
 
 rate_limiter:

--- a/config/bosh-lite.yml
+++ b/config/bosh-lite.yml
@@ -286,3 +286,10 @@ diego:
     ca_file: /var/vcap/jobs/cloud_controller_ng/config/certs/bbs_ca.crt
 
 shared_isolation_segment_name: shared
+
+bits_service:
+  enabled: false
+  public_endpoint: http://bits-service.bosh-lite.com
+  private_endpoint: http://bits-service.service.cf.internal
+  username: admin
+  password: admin

--- a/scripts/restore-bosh-lite-cc.sh
+++ b/scripts/restore-bosh-lite-cc.sh
@@ -13,3 +13,15 @@ line_number=$(cat /etc/hosts | grep -n "blobstore.service.cf.internal" | cut -d 
 if [[ -n "${line_number}" ]]; then
   sed "${line_number}d" /etc/hosts | sudo tee /etc/hosts > /dev/null
 fi
+
+line_number=$(cat /etc/hosts | grep -n "bits-service.service.cf.internal" | cut -d : -f 1)
+
+if [[ -n "${line_number}" ]]; then
+  sed "${line_number}d" /etc/hosts | sudo tee /etc/hosts > /dev/null
+fi
+
+line_number=$(cat /etc/hosts | grep -n "bits-service.bosh-lite.com" | cut -d : -f 1)
+
+if [[ -n "${line_number}" ]]; then
+  sed "${line_number}d" /etc/hosts | sudo tee /etc/hosts > /dev/null
+fi

--- a/scripts/setup-local-cc.sh
+++ b/scripts/setup-local-cc.sh
@@ -12,3 +12,11 @@ if ! cat /etc/hosts | grep "blobstore.service.cf.internal" > /dev/null; then
   echo "10.244.0.130 blobstore.service.cf.internal" | sudo tee -a /etc/hosts > /dev/null
   echo "10.244.16.2 bbs.service.cf.internal" | sudo tee -a /etc/hosts > /dev/null
 fi
+
+if ! cat /etc/hosts | grep "bits-service.service.cf.internal" > /dev/null; then
+  echo "10.244.0.74 bits-service.service.cf.internal" | sudo tee -a /etc/hosts > /dev/null
+fi
+
+if ! cat /etc/hosts | grep "bits-service.bosh-lite.com" > /dev/null; then
+  echo "10.244.0.74 bits-service.bosh-lite.com" | sudo tee -a /etc/hosts > /dev/null
+fi


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
    This change makes it possible to run CC locally on the dev machine and use bits-service as a blobstore backend.    

    Note: this PR also contains the commit from #721.
* An explanation of the use cases your change solves
    This helps us during bits-service development and testing.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

/cc @smoser-ibm @suhlig 