### PR TITLE
Isolation segments cleanup

### DIFF
--- a/app/actions/droplet_create.rb
+++ b/app/actions/droplet_create.rb
@@ -102,13 +102,11 @@ module VCAP::CloudController
       staging_details.environment_variables = environment_variables
       staging_details.lifecycle             = lifecycle
 
-      shared_segment = VCAP::CloudController::IsolationSegmentModel.shared_segment
-
       if space.isolation_segment_model
-        if space.isolation_segment_model.guid != shared_segment.guid
+        if !space.isolation_segment_model.is_shared_segment?
           staging_details.isolation_segment = space.isolation_segment_model.name
         end
-      elsif org.default_isolation_segment_model && org.default_isolation_segment_model.guid != shared_segment.guid
+      elsif org.default_isolation_segment_model && !org.default_isolation_segment_model.is_shared_segment?
         staging_details.isolation_segment = org.default_isolation_segment_model.name
       end
 

--- a/app/actions/isolation_segment_assign.rb
+++ b/app/actions/isolation_segment_assign.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
           isolation_segment.add_organization(org)
 
           if org.default_isolation_segment_model.nil?
-            if isolation_segment.guid.eql?(VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
+            if isolation_segment.is_shared_segment?
               org.update(default_isolation_segment_model: isolation_segment)
             end
           end

--- a/app/actions/isolation_segment_assign.rb
+++ b/app/actions/isolation_segment_assign.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
       isolation_segment.db.transaction do
         isolation_segment.lock!
 
-        organizations.sort! { |o1, o2| o1.guid <=> o2.guid }.each do |org|
+        organizations.sort! { |o1, o2| o1.id <=> o2.id }.each do |org|
           org.lock!
           isolation_segment.add_organization(org)
 

--- a/app/actions/isolation_segment_delete.rb
+++ b/app/actions/isolation_segment_delete.rb
@@ -1,7 +1,7 @@
 module VCAP::CloudController
   class IsolationSegmentDelete
     def delete(isolation_segment_model)
-      if isolation_segment_model.guid.eql?(VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
+      if isolation_segment_model.is_shared_segment?
         raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity',
           "Cannot delete the #{isolation_segment_model.name} Isolation Segment")
       end

--- a/app/actions/isolation_segment_delete.rb
+++ b/app/actions/isolation_segment_delete.rb
@@ -1,0 +1,18 @@
+module VCAP::CloudController
+  class IsolationSegmentDelete
+    def delete(isolation_segment_model)
+      if isolation_segment_model.guid.eql?(VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
+        raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity',
+          "Cannot delete the #{isolation_segment_model.name} Isolation Segment")
+      end
+
+      raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Space', 'Isolation Segment') unless isolation_segment_model.spaces.empty?
+      raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Organization', 'Isolation Segment') unless isolation_segment_model.organizations.empty?
+
+      isolation_segment_model.db.transaction do
+        isolation_segment_model.lock!
+        isolation_segment_model.destroy
+      end
+    end
+  end
+end

--- a/app/actions/isolation_segment_delete.rb
+++ b/app/actions/isolation_segment_delete.rb
@@ -6,9 +6,6 @@ module VCAP::CloudController
           "Cannot delete the #{isolation_segment_model.name} Isolation Segment")
       end
 
-      raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Space', 'Isolation Segment') unless isolation_segment_model.spaces.empty?
-      raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Organization', 'Isolation Segment') unless isolation_segment_model.organizations.empty?
-
       isolation_segment_model.db.transaction do
         isolation_segment_model.lock!
         isolation_segment_model.destroy

--- a/app/actions/isolation_segment_unassign.rb
+++ b/app/actions/isolation_segment_unassign.rb
@@ -29,15 +29,8 @@ module VCAP::CloudController
 
     def unset_default_segment(isolation_segment, organization)
       if is_default_segment?(isolation_segment, organization)
-        organization.check_spaces_without_isolation_segments_empty!('Removing')
-        default_isolation_error! unless organization.isolation_segment_models.length == 1
-
-        organization.update(default_isolation_segment_guid: nil)
+        organization.update(default_isolation_segment_model: nil)
       end
-    end
-
-    def default_isolation_error!
-      raise IsolationSegmentUnassignError.new('Please change the default Isolation Segment for your Organization before attempting to remove the default.')
     end
 
     def space_association_error!

--- a/app/actions/isolation_segment_unassign.rb
+++ b/app/actions/isolation_segment_unassign.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
       isolation_segment.db.transaction do
         isolation_segment.lock!
 
-        organizations.sort! { |o1, o2| o1.guid <=> o2.guid }.each do |org|
+        organizations.sort! { |o1, o2| o1.id <=> o2.id }.each do |org|
           org.lock!
           space_association_error! if segment_associated_with_space?(isolation_segment, org)
 

--- a/app/actions/isolation_segment_update.rb
+++ b/app/actions/isolation_segment_update.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
     private
 
     def check_not_shared!(isolation_segment)
-      if isolation_segment.guid.eql?(VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
+      if isolation_segment.is_shared_segment?
         raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', 'Cannot update the shared Isolation Segment')
       end
     end

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -54,13 +54,9 @@ module VCAP::CloudController
 
     def before_update(obj)
       if request_attrs['default_isolation_segment_guid']
-        isolation_segment_guids = obj.isolation_segment_models.map(&:guid)
-        unless isolation_segment_guids.include?(request_attrs['default_isolation_segment_guid'])
-          raise CloudController::Errors::ApiError.new_from_details('InvalidRelation',
-            "Organization does not have access to Isolation Segment with guid: #{request_attrs['default_isolation_segment_guid']}")
-        end
-
-        obj.check_spaces_without_isolation_segments_empty!('Setting')
+        raise CloudController::Errors::ApiError.new_from_details(
+          'ResourceNotFound',
+          'Could not find Isolation Segment to set as the default.') unless IsolationSegmentModel.first(guid: request_attrs['default_isolation_segment_guid'])
       end
 
       super(obj)

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -1,6 +1,5 @@
 require 'actions/organization_delete'
 require 'queries/organization_user_roles_fetcher'
-require 'messages/isolation_segments_list_message'
 
 module VCAP::CloudController
   class OrganizationsController < RestController::ModelController

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -199,44 +199,28 @@ module VCAP::CloudController
     delete '/v2/spaces/:guid/isolation_segment', :delete_isolation_segment
     def delete_isolation_segment(guid)
       space = find_guid(guid)
-      check_isolation_segment_access!(space)
-
-      check_space_is_empty!(space, 'Removing')
+      check_org_update_access!(space)
 
       space.db.transaction do
         space.lock!
-        space.update(isolation_segment_guid: nil)
-        space.save
+        space.update(isolation_segment_model: nil)
       end
 
       [HTTP::OK, object_renderer.render_json(self.class, space, @opts)]
     end
 
-    def before_update(obj)
+    def before_update(space)
       if request_attrs['isolation_segment_guid']
-        check_isolation_segment_access!(obj)
+        check_org_update_access!(space)
 
-        check_space_is_empty!(obj, 'Adding')
-
-        isolation_segment_guids = obj.organization.isolation_segment_models.map(&:guid)
-        unless isolation_segment_guids.include?(request_attrs['isolation_segment_guid'])
-          raise CloudController::Errors::ApiError.new_from_details('UnableToPerform',
-                                                                   'Adding the Isolation Segment to the Space',
-                                                                   "Only Isolation Segments in the Organization's allowed list can be used.")
-        end
+        raise CloudController::Errors::ApiError.new_from_details('ResourceNotFound', 'Isolation Segment not found') if
+          IsolationSegmentModel.where(guid: request_attrs['isolation_segment_guid']).empty?
       end
 
-      super(obj)
+      super(space)
     end
 
     private
-
-    def check_space_is_empty!(space, action)
-      raise CloudController::Errors::ApiError.new_from_details(
-        'UnableToPerform',
-        "#{action} the Isolation Segment to the Space",
-        'Cannot change the Isolation Segment for a Space containing Apps') unless space.app_models.empty?
-    end
 
     def after_create(space)
       @space_event_repository.record_space_create(space, SecurityContext.current_user, SecurityContext.current_user_email, request_attrs)
@@ -252,7 +236,7 @@ module VCAP::CloudController
       end
     end
 
-    def check_isolation_segment_access!(space)
+    def check_org_update_access!(space)
       validate_access(:update, space.organization, nil)
     end
 

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -213,8 +213,9 @@ module VCAP::CloudController
       if request_attrs['isolation_segment_guid']
         check_org_update_access!(space)
 
-        raise CloudController::Errors::ApiError.new_from_details('ResourceNotFound', 'Isolation Segment not found') if
-          IsolationSegmentModel.where(guid: request_attrs['isolation_segment_guid']).empty?
+        if IsolationSegmentModel.where(guid: request_attrs['isolation_segment_guid']).empty?
+          raise CloudController::Errors::ApiError.new_from_details('ResourceNotFound', 'Isolation Segment not found')
+        end
       end
 
       super(space)

--- a/app/controllers/v3/isolation_segments_controller.rb
+++ b/app/controllers/v3/isolation_segments_controller.rb
@@ -1,6 +1,7 @@
 require 'actions/isolation_segment_assign'
 require 'actions/isolation_segment_unassign'
 require 'actions/isolation_segment_update'
+require 'actions/isolation_segment_delete'
 
 require 'messages/isolation_segment_relationship_org_message'
 require 'messages/isolation_segment_create_message'
@@ -60,14 +61,7 @@ class IsolationSegmentsController < ApplicationController
     unauthorized! unless roles.admin?
 
     isolation_segment_model = find_isolation_segment(params[:guid])
-
-    unprocessable!("Cannot delete the #{isolation_segment_model.name} Isolation Segment") if
-      isolation_segment_model.guid.eql?(VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
-
-    isolation_segment_model.db.transaction do
-      isolation_segment_model.lock!
-      isolation_segment_model.destroy
-    end
+    IsolationSegmentDelete.new.delete(isolation_segment_model)
 
     head :no_content
   end

--- a/app/models/runtime/organization.rb
+++ b/app/models/runtime/organization.rb
@@ -155,7 +155,12 @@ module VCAP::CloudController
     end
 
     def before_destroy
-      update(default_isolation_segment_model: nil)
+      @destroying = true
+
+      # This is a Database.update(default_isolation_segment_guid), not a
+      # Model.update(default_isolation_segment_model). This way our model guards
+      # do not block us from removing the default_isolation_segment.
+      update(default_isolation_segment_guid: nil)
       remove_all_isolation_segment_models
       super
     end
@@ -175,6 +180,10 @@ module VCAP::CloudController
       validates_unique :name
       validates_format ORG_NAME_REGEX, :name
       validates_includes ORG_STATUS_VALUES, :status, allow_missing: true
+
+      if column_changed?(:default_isolation_segment_guid)
+        validate_default_isolation_segment(default_isolation_segment_model) unless @destroying
+      end
     end
 
     def has_remaining_memory(mem)
@@ -215,6 +224,35 @@ module VCAP::CloudController
     end
 
     private
+
+    def validate_default_isolation_segment(isolation_segment_model)
+      if isolation_segment_model
+        validate_default_isolation_segment_set(isolation_segment_model)
+      else
+        validate_default_isolation_segment_unset
+      end
+    end
+
+    def validate_default_isolation_segment_set(isolation_segment_model)
+      isolation_segment_guids = isolation_segment_models.map(&:guid)
+      unless isolation_segment_guids.include?(isolation_segment_model.guid)
+        raise CloudController::Errors::ApiError.new_from_details('InvalidRelation',
+                                                                 "Could not find Isolation Segment with guid: #{isolation_segment_model.guid}")
+      end
+
+      check_spaces_without_isolation_segments_empty!('Setting')
+    end
+
+    def validate_default_isolation_segment_unset
+      if isolation_segment_models.length > 1
+        raise CloudController::Errors::ApiError.new_from_details(
+          'UnableToPerform',
+          'Cannot unset the Default Isolation Segment.',
+          'Please change the Default Isolation Segment for your Organization before attempting to remove the default.')
+      end
+
+      check_spaces_without_isolation_segments_empty!('Removing')
+    end
 
     def validate_quota_on_create
       return if quota_definition

--- a/app/models/runtime/organization.rb
+++ b/app/models/runtime/organization.rb
@@ -16,6 +16,9 @@ module VCAP::CloudController
       right_key: :isolation_segment_guid,
       right_primary_key: :guid,
       join_table: :organizations_isolation_segments,
+      # These are needed because we do not set the default isolation segment
+      # for an organization. This happens as part of the action on an
+      # Isolation Segment.
       before_add: proc { cannot_create! },
       before_remove: proc { cannot_update! }
 
@@ -214,6 +217,8 @@ module VCAP::CloudController
       billing_enabled
     end
 
+    private
+
     def check_spaces_without_isolation_segments_empty!(action)
       Space.dataset.where(isolation_segment_guid: nil, organization: self).each do |space|
         raise CloudController::Errors::ApiError.new_from_details(
@@ -222,8 +227,6 @@ module VCAP::CloudController
           "Please delete all Apps from Space #{space.name} first.") unless space.app_models.empty?
       end
     end
-
-    private
 
     def validate_default_isolation_segment(isolation_segment_model)
       if isolation_segment_model

--- a/app/models/runtime/organization.rb
+++ b/app/models/runtime/organization.rb
@@ -243,7 +243,8 @@ module VCAP::CloudController
                                                                  "Could not find Isolation Segment with guid: #{isolation_segment_model.guid}")
       end
 
-      check_spaces_without_isolation_segments_empty!('Setting')
+      check_spaces_without_isolation_segments_empty!('Setting') unless initial_value(:default_isolation_segment_guid).eql?(nil) &&
+        isolation_segment_model.is_shared_segment?
     end
 
     def validate_default_isolation_segment_unset

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -250,17 +250,17 @@ module VCAP::CloudController
     end
 
     def validate_isolation_segment_set(isolation_segment_model)
-      raise CloudController::Errors::ApiError.new_from_details(
-        'UnableToPerform',
-        'Adding the Isolation Segment to the Space',
-        'Cannot change the Isolation Segment for a Space containing Apps') unless app_models.empty?
-
       isolation_segment_guids = organization.isolation_segment_models.map(&:guid)
       unless isolation_segment_guids.include?(isolation_segment_model.guid)
         raise CloudController::Errors::ApiError.new_from_details('UnableToPerform',
                                                                  'Adding the Isolation Segment to the Space',
                                                                  "Only Isolation Segments in the Organization's allowed list can be used.")
       end
+
+      raise CloudController::Errors::ApiError.new_from_details(
+        'UnableToPerform',
+        'Adding the Isolation Segment to the Space',
+        'Cannot change the Isolation Segment for a Space containing Apps') unless app_models.empty?
     end
 
     def validate_isolation_segment_unset

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -13,8 +13,7 @@ module VCAP::CloudController
 
     many_to_one :isolation_segment_model,
        primary_key: :guid,
-       key: :isolation_segment_guid,
-       before_set: :validate_isolation_segment
+       key: :isolation_segment_guid
 
     define_user_group :developers, reciprocal: :spaces, before_add: :validate_developer
     define_user_group :managers, reciprocal: :managed_spaces, before_add: :validate_manager
@@ -161,6 +160,10 @@ module VCAP::CloudController
 
       if space_quota_definition && space_quota_definition.organization.guid != organization.guid
         errors.add(:space_quota_definition, :invalid_organization)
+      end
+
+      if column_changed?(:isolation_segment_guid)
+        validate_isolation_segment(isolation_segment_model)
       end
     end
 

--- a/app/models/v3/persistence/isolation_segment_model.rb
+++ b/app/models/v3/persistence/isolation_segment_model.rb
@@ -25,6 +25,7 @@ module VCAP::CloudController
     def before_destroy
       raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Space', 'Isolation Segment') unless spaces.empty?
       raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Organization', 'Isolation Segment') unless organizations.empty?
+      super
     end
 
     def is_shared_segment?

--- a/app/models/v3/persistence/isolation_segment_model.rb
+++ b/app/models/v3/persistence/isolation_segment_model.rb
@@ -22,8 +22,8 @@ module VCAP::CloudController
       validates_unique [:name], message: Sequel.lit('Isolation Segment names are case insensitive and must be unique')
     end
 
-    def self.shared_segment
-      @shared_segment ||= IsolationSegmentModel.first(guid: SHARED_ISOLATION_SEGMENT_GUID)
+    def is_shared_segment?
+      guid == SHARED_ISOLATION_SEGMENT_GUID
     end
   end
 end

--- a/app/models/v3/persistence/isolation_segment_model.rb
+++ b/app/models/v3/persistence/isolation_segment_model.rb
@@ -22,6 +22,11 @@ module VCAP::CloudController
       validates_unique [:name], message: Sequel.lit('Isolation Segment names are case insensitive and must be unique')
     end
 
+    def before_destroy
+      raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Space', 'Isolation Segment') unless spaces.empty?
+      raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Organization', 'Isolation Segment') unless organizations.empty?
+    end
+
     def is_shared_segment?
       guid == SHARED_ISOLATION_SEGMENT_GUID
     end

--- a/app/models/v3/persistence/isolation_segment_model.rb
+++ b/app/models/v3/persistence/isolation_segment_model.rb
@@ -22,12 +22,6 @@ module VCAP::CloudController
       validates_unique [:name], message: Sequel.lit('Isolation Segment names are case insensitive and must be unique')
     end
 
-    def before_destroy
-      raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'space', 'isolation segment') unless spaces.empty?
-      raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'Organization', 'Isolation Segment') unless organizations.empty?
-      super
-    end
-
     def self.shared_segment
       @shared_segment ||= IsolationSegmentModel.first(guid: SHARED_ISOLATION_SEGMENT_GUID)
     end

--- a/lib/cloud_controller/diego/protocol.rb
+++ b/lib/cloud_controller/diego/protocol.rb
@@ -69,13 +69,11 @@ module VCAP::CloudController
           'volume_mounts'                   => AppVolumeMounts.new(process.app)
         }.merge(LifecycleProtocol.protocol_for_type(process.app.lifecycle_type).desired_app_message(process))
 
-        shared_segment = VCAP::CloudController::IsolationSegmentModel.shared_segment
-
         if process.space.isolation_segment_model
-          if process.space.isolation_segment_model.guid != shared_segment.guid
+          if !process.space.isolation_segment_model.is_shared_segment?
             msg['isolation_segment'] = process.space.isolation_segment_model.name
           end
-        elsif process.space.organization.default_isolation_segment_model && process.space.organization.default_isolation_segment_model.guid != shared_segment.guid
+        elsif process.space.organization.default_isolation_segment_model && !process.space.organization.default_isolation_segment_model.is_shared_segment?
           msg['isolation_segment'] = process.space.organization.default_isolation_segment_model.name
         end
 

--- a/lib/cloud_controller/diego/task_protocol.rb
+++ b/lib/cloud_controller/diego/task_protocol.rb
@@ -46,14 +46,12 @@ module VCAP::CloudController
           )
         end
 
-        shared_segment = VCAP::CloudController::IsolationSegmentModel.shared_segment
-
         if task.space.isolation_segment_model
-          if task.space.isolation_segment_model.guid != shared_segment.guid
+          if !task.space.isolation_segment_model.is_shared_segment?
             result['isolation_segment'] = task.space.isolation_segment_model.name
           end
         elsif task.space.organization.default_isolation_segment_model &&
-          task.space.organization.default_isolation_segment_model.guid != shared_segment.guid
+          !task.space.organization.default_isolation_segment_model.is_shared_segment?
           result['isolation_segment'] = task.space.organization.default_isolation_segment_model.name
         end
 

--- a/lib/cloud_controller/seeds.rb
+++ b/lib/cloud_controller/seeds.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
       end
 
       def create_seed_shared_isolation_segment(config)
-        shared_isolation_segment_model = IsolationSegmentModel.find(guid: IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
+        shared_isolation_segment_model = IsolationSegmentModel.first(guid: IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
 
         if shared_isolation_segment_model
           if !shared_isolation_segment_model.name.eql?(config[:shared_isolation_segment_name])

--- a/spec/api/documentation/spaces_api_spec.rb
+++ b/spec/api/documentation/spaces_api_spec.rb
@@ -352,10 +352,11 @@ RSpec.resource 'Spaces', type: [:api, :legacy_api] do
       let(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }
       let(:isolation_segment_model2) { VCAP::CloudController::IsolationSegmentModel.make }
       let(:org_manager) { VCAP::CloudController::User.make }
+      let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
 
       before do
-        isolation_segment_model.add_organization(space.organization)
-        isolation_segment_model2.add_organization(space.organization)
+        assigner.assign(isolation_segment_model, [space.organization])
+        assigner.assign(isolation_segment_model2, [space.organization])
         space.isolation_segment_guid = isolation_segment_model.guid
         space.organization.add_manager(org_manager)
         allow_any_instance_of(VCAP::CloudController::UaaClient).to receive(:usernames_for_ids).and_return({ org_manager.guid => 'manager@example.com' })

--- a/spec/request/isolation_segments_spec.rb
+++ b/spec/request/isolation_segments_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe 'IsolationSegmentModels' do
     let(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }
 
     before do
+      assigner.assign(isolation_segment_model, [space1.organization, space2.organization])
       isolation_segment_model.add_space(space1)
       isolation_segment_model.add_space(space2)
     end
@@ -181,8 +182,8 @@ RSpec.describe 'IsolationSegmentModels' do
       let(:user_header) { headers_for(user) }
 
       before do
-        space.isolation_segment_guid = isolation_segment_model.guid
-        space.save
+        assigner.assign(isolation_segment_model, [space.organization])
+        space.update(isolation_segment_guid: isolation_segment_model.guid)
         space.organization.add_user(user)
         space.add_developer(user)
       end

--- a/spec/request/v2/spaces_spec.rb
+++ b/spec/request/v2/spaces_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Spaces' do
+  let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
   let(:isolation_segment) { VCAP::CloudController::IsolationSegmentModel.make }
   let(:user) { VCAP::CloudController::User.make }
   let(:org) { VCAP::CloudController::Organization.make }
@@ -15,42 +16,48 @@ RSpec.describe 'Spaces' do
     end
 
     context 'as admin' do
-      it 'creates a space and associates the isolation segment' do
-        post '/v2/spaces', opts, admin_headers_for(user)
+      context 'and the organization has an ioslation segment' do
+        before do
+          assigner.assign(isolation_segment, [org])
+        end
 
-        expect(last_response.status).to eq(201)
-        parsed_response = MultiJson.load(last_response.body)
+        it 'creates a space and associates the isolation segment' do
+          post '/v2/spaces', opts, admin_headers_for(user)
 
-        space = VCAP::CloudController::Space.last
+          expect(last_response.status).to eq(201)
+          parsed_response = MultiJson.load(last_response.body)
 
-        expect(parsed_response).to be_a_response_like({
-          'metadata' => {
-            'guid' => space.guid,
-            'url' => "/v2/spaces/#{space.guid}",
-            'created_at' => iso8601,
-            'updated_at' => iso8601
-          },
-          'entity' => {
-            'name' => space.name,
-            'organization_guid' => org.guid,
-            'space_quota_definition_guid' => nil,
-            'isolation_segment_guid' => isolation_segment.guid,
-            'allow_ssh' => true,
-            'organization_url' => "/v2/organizations/#{org.guid}",
-            'isolation_segment_url' => "/v3/isolation_segments/#{isolation_segment.guid}",
-            'developers_url' => "/v2/spaces/#{space.guid}/developers",
-            'managers_url' => "/v2/spaces/#{space.guid}/managers",
-            'auditors_url' => "/v2/spaces/#{space.guid}/auditors",
-            'apps_url' => "/v2/spaces/#{space.guid}/apps",
-            'routes_url' => "/v2/spaces/#{space.guid}/routes",
-            'domains_url' => "/v2/spaces/#{space.guid}/domains",
-            'service_instances_url' => "/v2/spaces/#{space.guid}/service_instances",
-            'app_events_url' => "/v2/spaces/#{space.guid}/app_events",
-            'events_url' => "/v2/spaces/#{space.guid}/events",
-            'security_groups_url' => "/v2/spaces/#{space.guid}/security_groups",
-            'staging_security_groups_url' => "/v2/spaces/#{space.guid}/staging_security_groups"
-          }
-        })
+          space = VCAP::CloudController::Space.last
+
+          expect(parsed_response).to be_a_response_like({
+            'metadata' => {
+              'guid' => space.guid,
+              'url' => "/v2/spaces/#{space.guid}",
+              'created_at' => iso8601,
+              'updated_at' => iso8601
+            },
+            'entity' => {
+              'name' => space.name,
+              'organization_guid' => org.guid,
+              'space_quota_definition_guid' => nil,
+              'isolation_segment_guid' => isolation_segment.guid,
+              'allow_ssh' => true,
+              'organization_url' => "/v2/organizations/#{org.guid}",
+              'isolation_segment_url' => "/v3/isolation_segments/#{isolation_segment.guid}",
+              'developers_url' => "/v2/spaces/#{space.guid}/developers",
+              'managers_url' => "/v2/spaces/#{space.guid}/managers",
+              'auditors_url' => "/v2/spaces/#{space.guid}/auditors",
+              'apps_url' => "/v2/spaces/#{space.guid}/apps",
+              'routes_url' => "/v2/spaces/#{space.guid}/routes",
+              'domains_url' => "/v2/spaces/#{space.guid}/domains",
+              'service_instances_url' => "/v2/spaces/#{space.guid}/service_instances",
+              'app_events_url' => "/v2/spaces/#{space.guid}/app_events",
+              'events_url' => "/v2/spaces/#{space.guid}/events",
+              'security_groups_url' => "/v2/spaces/#{space.guid}/security_groups",
+              'staging_security_groups_url' => "/v2/spaces/#{space.guid}/staging_security_groups"
+            }
+          })
+        end
       end
     end
   end
@@ -61,6 +68,7 @@ RSpec.describe 'Spaces' do
       let(:space) { VCAP::CloudController::Space.make(organization: org) }
 
       before do
+        assigner.assign(isolation_segment, [org])
         isolation_segment.add_space(space)
 
         space.organization.add_user(user)
@@ -117,6 +125,7 @@ RSpec.describe 'Spaces' do
       let(:space) { VCAP::CloudController::Space.make(organization: org) }
 
       before do
+        assigner.assign(isolation_segment, [org])
         isolation_segment.add_space(space)
 
         space.organization.add_user(user)

--- a/spec/unit/actions/droplet_create_spec.rb
+++ b/spec/unit/actions/droplet_create_spec.rb
@@ -19,9 +19,10 @@ module VCAP::CloudController
 
     let(:lifecycle) { BuildpackLifecycle.new(package, staging_message) }
     let(:package) { PackageModel.make(app: app, state: PackageModel::READY_STATE) }
-    let(:app) { AppModel.make }
-    let(:space) { app.space }
+
+    let(:space) { Space.make }
     let(:org) { space.organization }
+    let(:app) { AppModel.make(space: space) }
 
     let(:staging_message) { DropletCreateMessage.create_from_http_request(request) }
 
@@ -114,7 +115,9 @@ module VCAP::CloudController
           let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
           let(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }
           let(:isolation_segment_model_2) { VCAP::CloudController::IsolationSegmentModel.make }
-          let(:shared_isolation_segment) { VCAP::CloudController::IsolationSegmentModel.shared_segment }
+          let(:shared_isolation_segment) {
+            VCAP::CloudController::IsolationSegmentModel.first(guid: VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
+          }
 
           context 'when the org has a default' do
             context 'and the default is the shared isolation segments' do

--- a/spec/unit/actions/isolation_segment_assign_spec.rb
+++ b/spec/unit/actions/isolation_segment_assign_spec.rb
@@ -8,14 +8,22 @@ module VCAP::CloudController
     let(:org2) { Organization.make }
 
     it 'sorts the organizations passed in for assignment' do
-      org.update(guid: 'b')
-      org2.update(guid: 'a')
+      rval = Random.new.rand(1..2)
 
-      org.reload
-      org2.reload
+      if (rval == 1)
+        org2.reload
+        org.reload
 
-      expect(isolation_segment_model).to receive(:add_organization).with(org2).ordered
-      expect(isolation_segment_model).to receive(:add_organization).with(org).ordered
+        expect(isolation_segment_model).to receive(:add_organization).with(org2).ordered
+        expect(isolation_segment_model).to receive(:add_organization).with(org).ordered
+      else
+        org.reload
+        org2.reload
+
+        expect(isolation_segment_model).to receive(:add_organization).with(org).ordered
+        expect(isolation_segment_model).to receive(:add_organization).with(org2).ordered
+      end
+
       subject.assign(isolation_segment_model, [org, org2])
     end
 

--- a/spec/unit/actions/isolation_segment_assign_spec.rb
+++ b/spec/unit/actions/isolation_segment_assign_spec.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
     it 'sorts the organizations passed in for assignment' do
       rval = Random.new.rand(1..2)
 
-      if (rval == 1)
+      if rval == 1
         org2.reload
         org.reload
 

--- a/spec/unit/actions/isolation_segment_assign_spec.rb
+++ b/spec/unit/actions/isolation_segment_assign_spec.rb
@@ -7,24 +7,18 @@ module VCAP::CloudController
     let(:org) { Organization.make }
     let(:org2) { Organization.make }
 
-    it 'sorts the organizations passed in for assignment' do
-      rval = Random.new.rand(1..2)
-
-      if rval == 1
-        org2.reload
-        org.reload
-
+    describe 'sorting the organizations passed in for assignment' do
+      it 'sorts them correctly when org2 has a lower index than org' do
         expect(isolation_segment_model).to receive(:add_organization).with(org2).ordered
         expect(isolation_segment_model).to receive(:add_organization).with(org).ordered
-      else
-        org.reload
-        org2.reload
-
-        expect(isolation_segment_model).to receive(:add_organization).with(org).ordered
-        expect(isolation_segment_model).to receive(:add_organization).with(org2).ordered
+        subject.assign(isolation_segment_model, [org, org2])
       end
 
-      subject.assign(isolation_segment_model, [org, org2])
+      it 'sorts them correctly when org has a lower index than org2' do
+        expect(isolation_segment_model).to receive(:add_organization).with(org).ordered
+        expect(isolation_segment_model).to receive(:add_organization).with(org2).ordered
+        subject.assign(isolation_segment_model, [org, org2])
+      end
     end
 
     context 'when an isolation segment is not assigned to any orgs' do

--- a/spec/unit/actions/isolation_segment_delete_spec.rb
+++ b/spec/unit/actions/isolation_segment_delete_spec.rb
@@ -19,33 +19,5 @@ module VCAP::CloudController
         subject.delete(shared_isolation_segment_model)
       }.to raise_error /Cannot delete the #{shared_isolation_segment_model.name}/
     end
-
-    context 'when the isolation segment has an organization' do
-      let(:assigner) { IsolationSegmentAssign.new }
-      let(:org) { Organization.make }
-
-      before do
-        assigner.assign(isolation_segment_model, [org])
-        isolation_segment_model.reload
-      end
-
-      it 'raises an AssociationNotEmpty error' do
-        expect {
-          subject.delete(isolation_segment_model)
-        }.to raise_error(CloudController::Errors::ApiError, /Please delete the Organization associations for your Isolation Segment/)
-      end
-
-      context 'when the isolation segment has been assigned a space' do
-        before do
-          Space.make(organization: org, isolation_segment_model: isolation_segment_model)
-        end
-
-        it 'raises an AssociationNotEmpty error' do
-          expect {
-            subject.delete(isolation_segment_model)
-          }.to raise_error(CloudController::Errors::ApiError, /Please delete the Space associations for your Isolation Segment/)
-        end
-      end
-    end
   end
 end

--- a/spec/unit/actions/isolation_segment_delete_spec.rb
+++ b/spec/unit/actions/isolation_segment_delete_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'isolation_segment_delete'
+require 'isolation_segment_assign'
+
+module VCAP::CloudController
+  RSpec.describe IsolationSegmentDelete do
+    let(:isolation_segment_model) { IsolationSegmentModel.make }
+    let(:shared_isolation_segment_model) { IsolationSegmentModel.first(guid: VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID) }
+
+    it 'can delete isolation segments' do
+      subject.delete(isolation_segment_model)
+      expect {
+        isolation_segment_model.reload
+      }.to raise_error(Sequel::Error, 'Record not found')
+    end
+
+    it 'raises a 422 when deleteing the shared isolation segment' do
+      expect {
+        subject.delete(shared_isolation_segment_model)
+      }.to raise_error /Cannot delete the #{shared_isolation_segment_model.name}/
+    end
+
+    context 'when the isolation segment has an organization' do
+      let(:assigner) { IsolationSegmentAssign.new }
+      let(:org) { Organization.make }
+
+      before do
+        assigner.assign(isolation_segment_model, [org])
+        isolation_segment_model.reload
+      end
+
+      it 'raises an AssociationNotEmpty error' do
+        expect {
+          subject.delete(isolation_segment_model)
+        }.to raise_error(CloudController::Errors::ApiError, /Please delete the Organization associations for your Isolation Segment/)
+      end
+
+      context 'when the isolation segment has been assigned a space' do
+        before do
+          Space.make(organization: org, isolation_segment_model: isolation_segment_model)
+        end
+
+        it 'raises an AssociationNotEmpty error' do
+          expect {
+            subject.delete(isolation_segment_model)
+          }.to raise_error(CloudController::Errors::ApiError, /Please delete the Space associations for your Isolation Segment/)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/actions/isolation_segment_unassign_spec.rb
+++ b/spec/unit/actions/isolation_segment_unassign_spec.rb
@@ -11,14 +11,22 @@ module VCAP::CloudController
     let(:org2) { Organization.make }
 
     it 'sorts the organizations passed in for unassignment' do
-      org.update(guid: 'b')
-      org2.update(guid: 'a')
+      rval = Random.new.rand(1..2)
 
-      org.reload
-      org2.reload
+      if (rval == 1)
+        org.reload
+        org2.reload
 
-      expect(isolation_segment_model).to receive(:remove_organization).with(org2).ordered
-      expect(isolation_segment_model).to receive(:remove_organization).with(org).ordered
+        expect(isolation_segment_model).to receive(:remove_organization).with(org).ordered
+        expect(isolation_segment_model).to receive(:remove_organization).with(org2).ordered
+      else
+        org2.reload
+        org.reload
+
+        expect(isolation_segment_model).to receive(:remove_organization).with(org2).ordered
+        expect(isolation_segment_model).to receive(:remove_organization).with(org).ordered
+      end
+
       subject.unassign(isolation_segment_model, [org, org2])
     end
 

--- a/spec/unit/actions/isolation_segment_unassign_spec.rb
+++ b/spec/unit/actions/isolation_segment_unassign_spec.rb
@@ -10,24 +10,18 @@ module VCAP::CloudController
     let(:org) { Organization.make }
     let(:org2) { Organization.make }
 
-    it 'sorts the organizations passed in for unassignment' do
-      rval = Random.new.rand(1..2)
-
-      if rval == 1
-        org.reload
-        org2.reload
-
-        expect(isolation_segment_model).to receive(:remove_organization).with(org).ordered
-        expect(isolation_segment_model).to receive(:remove_organization).with(org2).ordered
-      else
-        org2.reload
-        org.reload
-
+    describe 'sorting the organizations passed in for assignment' do
+      it 'sorts them correctly when org2 has a lower index than org' do
         expect(isolation_segment_model).to receive(:remove_organization).with(org2).ordered
         expect(isolation_segment_model).to receive(:remove_organization).with(org).ordered
+        subject.unassign(isolation_segment_model, [org, org2])
       end
 
-      subject.unassign(isolation_segment_model, [org, org2])
+      it 'sorts them correctly when org has a lower index than org2' do
+        expect(isolation_segment_model).to receive(:remove_organization).with(org).ordered
+        expect(isolation_segment_model).to receive(:remove_organization).with(org2).ordered
+        subject.unassign(isolation_segment_model, [org, org2])
+      end
     end
 
     context 'when an Isolation Segment is not assigned to any Orgs' do

--- a/spec/unit/actions/isolation_segment_unassign_spec.rb
+++ b/spec/unit/actions/isolation_segment_unassign_spec.rb
@@ -69,7 +69,7 @@ module VCAP::CloudController
           it 'cannot remove the Organization from the isolation segment' do
             expect {
               subject.unassign(isolation_segment_model, [org])
-            }.to raise_error IsolationSegmentUnassign::IsolationSegmentUnassignError, /Please change the default Isolation Segment/
+            }.to raise_error CloudController::Errors::ApiError, /Cannot unset the Default Isolation Segment/
 
             expect(isolation_segment_model.organizations).to contain_exactly(org, org2)
           end
@@ -77,8 +77,9 @@ module VCAP::CloudController
           it "does not remove the organization's default Isolation Segment" do
             expect {
               subject.unassign(isolation_segment_model, [org])
-            }.to raise_error IsolationSegmentUnassign::IsolationSegmentUnassignError, /Please change the default Isolation Segment/
+            }.to raise_error CloudController::Errors::ApiError, /Cannot unset the Default Isolation Segment/
 
+            org.reload
             expect(org.default_isolation_segment_model).to eq(isolation_segment_model)
           end
         end

--- a/spec/unit/actions/isolation_segment_unassign_spec.rb
+++ b/spec/unit/actions/isolation_segment_unassign_spec.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
     it 'sorts the organizations passed in for unassignment' do
       rval = Random.new.rand(1..2)
 
-      if (rval == 1)
+      if rval == 1
         org.reload
         org2.reload
 

--- a/spec/unit/actions/isolation_segment_update_spec.rb
+++ b/spec/unit/actions/isolation_segment_update_spec.rb
@@ -78,11 +78,9 @@ module VCAP::CloudController
           end
 
           context 'and a space contains apps' do
-            before do
-              AppModel.make(space: space)
-            end
-
             it 'fails' do
+              AppModel.make(space: space)
+
               message = IsolationSegmentUpdateMessage.new
               expect {
                 subject.update isolation_segment, message
@@ -95,7 +93,8 @@ module VCAP::CloudController
               before do
                 assigner.assign(isolation_segment2, [org])
                 space.update(isolation_segment_guid: isolation_segment2.guid)
-                space.reload
+
+                AppModel.make(space: space)
               end
 
               it 'updates the name of the isolation segment' do

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::OrganizationsController do
     let(:org) { Organization.make }
+    let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
 
     describe 'Query Parameters' do
       it { expect(described_class).to be_queryable_by(:name) }
@@ -146,7 +147,6 @@ module VCAP::CloudController
     end
 
     describe 'setting the default isolation segment' do
-      let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
 
       let(:isolation_segment) { IsolationSegmentModel.make }
       let(:isolation_segment2) { IsolationSegmentModel.make }
@@ -156,7 +156,7 @@ module VCAP::CloudController
         let!(:user) { set_current_user(make_developer_for_space(space)) }
 
         before do
-          isolation_segment.add_organization(org)
+          assigner.assign(isolation_segment, [org])
         end
 
         it 'returns a 403' do
@@ -251,8 +251,8 @@ module VCAP::CloudController
 
         before do
           set_current_user_as_admin
-          isolation_segment.add_organization(org)
-          isolation_segment2.add_organization(org)
+          assigner.assign(isolation_segment, [org])
+          assigner.assign(isolation_segment2, [org])
         end
 
         it 'sets the isolation segment as the org default' do

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::OrganizationsController do

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pry'
 
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::OrganizationsController do
@@ -176,12 +177,12 @@ module VCAP::CloudController
         end
 
         context 'when the isolation segment does not exist' do
-          it 'returns a 400' do
+          it 'returns a 404' do
             put "/v2/organizations/#{org.guid}", MultiJson.dump({
               default_isolation_segment_guid: 'bogus-guid'
             })
 
-            expect(last_response.status).to eq(400)
+            expect(last_response.status).to eq(404)
           end
         end
 
@@ -221,23 +222,6 @@ module VCAP::CloudController
               })
 
               expect(last_response.status).to eq(201)
-              org.reload
-              expect(org.default_isolation_segment_model).to eq(isolation_segment)
-            end
-          end
-
-          context 'when the org has a space with no assigned segment and the space contains apps' do
-            before do
-              space = Space.make(organization: org)
-              AppModel.make(space: space)
-            end
-
-            it 'returns a 400 and does not change the default isolation segment' do
-              put "/v2/organizations/#{org.guid}", MultiJson.dump({
-                default_isolation_segment_guid: isolation_segment2.guid
-              })
-
-              expect(last_response.status).to eq(400)
               org.reload
               expect(org.default_isolation_segment_model).to eq(isolation_segment)
             end

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -147,7 +147,6 @@ module VCAP::CloudController
     end
 
     describe 'setting the default isolation segment' do
-
       let(:isolation_segment) { IsolationSegmentModel.make }
       let(:isolation_segment2) { IsolationSegmentModel.make }
 

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -1269,12 +1269,13 @@ module VCAP::CloudController
       let(:isolation_segment_model) { IsolationSegmentModel.make }
       let(:organization) { Organization.make }
       let(:space) { Space.make(organization: organization) }
+      let(:assigner) { IsolationSegmentAssign.new }
 
       context 'associating an isolation_segment' do
         context 'when the space contains no apps' do
           context 'when the owning organization has access to the segment' do
             before do
-              isolation_segment_model.add_organization(organization)
+              assigner.assign(isolation_segment_model, [organization])
             end
 
             context 'as an admin who is not a manager' do
@@ -1350,7 +1351,7 @@ module VCAP::CloudController
           before do
             AppModel.make(space: space)
             set_current_user_as_admin
-            isolation_segment_model.add_organization(organization)
+            assigner.assign(isolation_segment_model, [organization])
           end
 
           context 'when the space is not already associated with an isolation segment' do
@@ -1509,13 +1510,14 @@ module VCAP::CloudController
     end
 
     describe 'DELETE /v2/spaces/:guid/isolation_segment' do
+      let(:assigner) { IsolationSegmentAssign.new }
       let(:user) { set_current_user(User.make) }
       let(:isolation_segment_model) { IsolationSegmentModel.make }
       let(:organization) { Organization.make }
       let(:space) { Space.make(organization: organization) }
 
       before do
-        isolation_segment_model.add_organization(organization)
+        assigner.assign(isolation_segment_model, [organization])
       end
 
       context 'when the space is not associated to an isolation segment' do

--- a/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
+++ b/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe IsolationSegmentsController, type: :controller do
 
         expect(response.status).to eq 201
         expect(parsed_body['guid']).to eq(isolation_segment_model.guid)
-        expect(isolation_segment_model.organizations).to include(org)
+        expect(isolation_segment_model.organizations).to contain_exactly(org)
       end
 
       it 'assigns multiple organizations to the isolation segment' do
@@ -242,11 +242,9 @@ RSpec.describe IsolationSegmentsController, type: :controller do
 
         expect(parsed_body['guid']).to eq(isolation_segment_model.guid)
 
-        # need to reload the orgs because the default isolation segment get set
-        # This also means that the updated at time is on our ors
         org.reload
         org_2.reload
-        expect(isolation_segment_model.organizations).to include(org, org_2)
+        expect(isolation_segment_model.organizations).to contain_exactly(org, org_2)
       end
 
       context 'when the isolation segment does not exist' do

--- a/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
+++ b/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
@@ -755,7 +755,7 @@ RSpec.describe IsolationSegmentsController, type: :controller do
 
   describe 'default shared isolation segment' do
     let(:shared_segment) do
-      VCAP::CloudController::IsolationSegmentModel[guid: VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID]
+      VCAP::CloudController::IsolationSegmentModel.first(guid: VCAP::CloudController::IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID)
     end
 
     let!(:original_name) { shared_segment.name }
@@ -774,7 +774,7 @@ RSpec.describe IsolationSegmentsController, type: :controller do
       delete :destroy, guid: shared_segment.guid
 
       expect(response.status).to eq 422
-      expect(VCAP::CloudController::IsolationSegmentModel[guid: shared_segment.guid].exists?).to be true
+      expect(VCAP::CloudController::IsolationSegmentModel.first(guid: shared_segment.guid).exists?).to be true
     end
 
     it 'cannot be updated via API' do

--- a/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
+++ b/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
@@ -741,20 +741,6 @@ RSpec.describe IsolationSegmentsController, type: :controller do
           expect(response.status).to eq 404
         end
       end
-
-      context 'when the isolation segment is still associated to spaces' do
-        before do
-          VCAP::CloudController::Space.make(isolation_segment_guid: isolation_segment_model1.guid)
-        end
-
-        it 'returns a 400' do
-          delete :destroy, guid: isolation_segment_model1.guid
-
-          expect(response.status).to eq 400
-          expect(parsed_body['errors'].first['title']).to eq('CF-AssociationNotEmpty')
-          expect(parsed_body['errors'].first['detail']).to eq('Please delete the space associations for your isolation segment.')
-        end
-      end
     end
 
     context 'when the user is not admin' do

--- a/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
+++ b/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
@@ -484,28 +484,28 @@ RSpec.describe IsolationSegmentsController, type: :controller do
           expect(parsed_body['guid']).to eq(isolation_segment.guid)
           expect(parsed_body['name']).to eq(isolation_segment.name)
         end
-      end
 
-      context 'and the user is registered to a space' do
-        before do
-          allow_user_read_access(user, space: space)
-          stub_readable_space_guids_for(user, space)
-        end
-
-        context 'and the space is associated to an isolation segment' do
+        context 'and the user is registered to a space' do
           before do
-            isolation_segment.add_space(space)
+            allow_user_read_access(user, space: space)
+            stub_readable_space_guids_for(user, space)
           end
 
-          it 'allows the user to see the isolation segment' do
-            get :show, guid: isolation_segment.guid
+          context 'and the space is associated to an isolation segment' do
+            before do
+              isolation_segment.add_space(space)
+            end
 
-            expect(response.status).to eq 200
-            expect(parsed_body['guid']).to eq(isolation_segment.guid)
-            expect(parsed_body['name']).to eq(isolation_segment.name)
-            expect(parsed_body['links']['self']['href']).to eq("#{link_prefix}/v3/isolation_segments/#{isolation_segment.guid}")
-            expect(parsed_body['links']['organizations']['href']).to eq("#{link_prefix}/v3/isolation_segments/#{isolation_segment.guid}/relationships/organizations")
-            expect(parsed_body['links']['spaces']['href']).to eq("#{link_prefix}/v3/isolation_segments/#{isolation_segment.guid}/relationships/spaces")
+            it 'allows the user to see the isolation segment' do
+              get :show, guid: isolation_segment.guid
+
+              expect(response.status).to eq 200
+              expect(parsed_body['guid']).to eq(isolation_segment.guid)
+              expect(parsed_body['name']).to eq(isolation_segment.name)
+              expect(parsed_body['links']['self']['href']).to eq("#{link_prefix}/v3/isolation_segments/#{isolation_segment.guid}")
+              expect(parsed_body['links']['organizations']['href']).to eq("#{link_prefix}/v3/isolation_segments/#{isolation_segment.guid}/relationships/organizations")
+              expect(parsed_body['links']['spaces']['href']).to eq("#{link_prefix}/v3/isolation_segments/#{isolation_segment.guid}/relationships/spaces")
+            end
           end
         end
       end

--- a/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
+++ b/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe IsolationSegmentsController, type: :controller do
 
         context "and the user belongs to an org in the isolation segment's allowed list" do
           before do
-            isolation_segment_model.add_organization(org1)
+            assigner.assign(isolation_segment_model, [org1])
             org1.add_user(user)
             space.add_developer(user)
           end

--- a/spec/unit/lib/cloud_controller/diego/staging_request_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/staging_request_spec.rb
@@ -70,13 +70,11 @@ module VCAP::CloudController::Diego
 
       context "when the app's space is associated with an isolation segment" do
         before do
-          isolation_segment_model.add_space(app.space)
-          staging_payload[:isolation_segment] = app.space.isolation_segment_model.name
+          staging_request.isolation_segment = 'segment-name'
         end
 
         it 'includes the isolation_segment name in the message' do
-          staging_request.isolation_segment = app.space.isolation_segment_model.name
-          expect(staging_request.message[:isolation_segment]).to eq(staging_payload[:isolation_segment])
+          expect(staging_request.message[:isolation_segment]).to eq('segment-name')
         end
       end
 

--- a/spec/unit/models/runtime/organization_spec.rb
+++ b/spec/unit/models/runtime/organization_spec.rb
@@ -18,7 +18,6 @@ module VCAP::CloudController
       it { is_expected.to have_associated :billing_managers, class: User }
       it { is_expected.to have_associated :auditors, class: User }
       it { is_expected.to have_associated :space_quota_definitions, associated_instance: ->(org) { SpaceQuotaDefinition.make(organization: org) } }
-      it { is_expected.to have_associated :default_isolation_segment_model, class: IsolationSegmentModel }
 
       it 'has associated owned_private domains' do
         domain = PrivateDomain.make
@@ -129,30 +128,10 @@ module VCAP::CloudController
         end
       end
 
-      describe 'isolation segments' do
+      describe 'isolation_segments' do
         let(:isolation_segment_model) { IsolationSegmentModel.make }
         let(:isolation_segment_model2) { IsolationSegmentModel.make }
         let(:assigner) { IsolationSegmentAssign.new }
-
-        context 'when setting the default isolation segment' do
-          it 'raises an error if it is not in the allowed list' do
-            expect {
-              org.default_isolation_segment_model = isolation_segment_model
-              org.save
-            }.to raise_error(Sequel::ForeignKeyConstraintViolation)
-          end
-
-          it 'can be updated' do
-            assigner.assign(isolation_segment_model, [org])
-            org.update(default_isolation_segment_model: isolation_segment_model)
-            org.reload
-            expect(org.default_isolation_segment_model).to eq(isolation_segment_model)
-
-            assigner.assign(isolation_segment_model2, [org])
-            org.default_isolation_segment_model = isolation_segment_model2
-            expect(org.default_isolation_segment_model).to eq(isolation_segment_model2)
-          end
-        end
 
         context 'when adding isolation segments to the allowed list' do
           it 'raises an ApiError' do
@@ -268,6 +247,122 @@ module VCAP::CloudController
           expect {
             org.save
           }.to raise_error(Sequel::ValidationFailed)
+        end
+      end
+
+      describe 'default_isolation_segment' do
+        let(:isolation_segment_model) { IsolationSegmentModel.make }
+        let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
+
+        context 'assigning the default isolation segment' do
+          context 'and the default is not in the allowed list' do
+            it 'raises an InvalidRelation' do
+              expect {
+                org.update(default_isolation_segment_model: isolation_segment_model)
+              }.to raise_error(CloudController::Errors::ApiError, /Could not find Isolation Segment with guid: #{isolation_segment_model.guid}/)
+
+              org.reload
+              expect(org.default_isolation_segment_model).to eq(nil)
+            end
+          end
+
+          context 'and the default is in the allowed list' do
+            before do
+              assigner.assign(isolation_segment_model, [org])
+            end
+
+            it 'sets the default isolation segment' do
+              org.update(default_isolation_segment_model: isolation_segment_model)
+              org.reload
+
+              expect(org.default_isolation_segment_model).to eq(isolation_segment_model)
+            end
+
+            context 'when there are spaces in the org' do
+              let!(:space) { Space.make(organization: org) }
+
+              it 'sets the default Isolation Segment' do
+                org.update(default_isolation_segment_model: isolation_segment_model)
+                org.reload
+
+                expect(org.default_isolation_segment_model).to eq(isolation_segment_model)
+              end
+
+              context 'and a space has an app' do
+                before do
+                  AppModel.make(space: space)
+                end
+
+                it 'raises an UnableToPerform exception and does not set the default' do
+                  expect {
+                    org.update(default_isolation_segment_guid: isolation_segment_model.guid)
+                  }.to raise_error(CloudController::Errors::ApiError, /Setting default Isolation Segment/)
+
+                  org.reload
+                  expect(org.default_isolation_segment_model).to eq(nil)
+                end
+              end
+            end
+          end
+        end
+
+        context 'unassigning the default isolation segment' do
+          before do
+            assigner.assign(isolation_segment_model, [org])
+            org.update(default_isolation_segment_model: isolation_segment_model)
+          end
+
+          context 'and there are no other isolation segments in the allowed list' do
+            it 'succeeds' do
+              org.update(default_isolation_segment_model: nil)
+              org.reload
+
+              expect(org.default_isolation_segment_guid).to be_nil
+            end
+
+            context 'and there are spaces in the organization' do
+              let!(:space) { Space.make(organization: org) }
+
+              it 'unassigns the default isolation segment' do
+                org.update(default_isolation_segment_model: nil)
+                org.reload
+
+                expect(org.default_isolation_segment_guid).to be_nil
+              end
+
+              context 'and the space has apps' do
+                before do
+                  AppModel.make(space: space)
+                end
+
+                it 'raises a 400 UnableToPerform' do
+                  expect {
+                    org.update(default_isolation_segment_model: nil)
+                  }.to raise_error(CloudController::Errors::ApiError, /Removing default Isolation Segment/)
+
+                  org.reload
+                  expect(org.default_isolation_segment_model).to eq(isolation_segment_model)
+                end
+              end
+            end
+          end
+
+          context 'and there are more that one isolation segments in the allowed list' do
+            let(:isolation_segment_model_2) { IsolationSegmentModel.make }
+
+            before do
+              assigner.assign(isolation_segment_model_2, [org])
+            end
+
+            it 'raises a 400 UnableToPerform' do
+              expect {
+                org.update(default_isolation_segment_model: nil)
+              }.to raise_error(CloudController::Errors::ApiError, /Please change the Default Isolation Segment for your Organization/)
+
+              org.reload
+              expect(org.default_isolation_segment_model).to eq(isolation_segment_model)
+            end
+          end
         end
       end
     end

--- a/spec/unit/models/runtime/space_spec.rb
+++ b/spec/unit/models/runtime/space_spec.rb
@@ -246,21 +246,6 @@ module VCAP::CloudController
         let(:isolation_segment_model) { IsolationSegmentModel.make }
 
         context 'adding an isolation segment' do
-          context 'and the space has apps' do
-            before do
-              AppModel.make(space: space)
-            end
-
-            it 'raises an error' do
-              expect {
-                space.update(isolation_segment_guid: isolation_segment_model.guid)
-              }.to raise_error(CloudController::Errors::ApiError, /Adding the Isolation Segment to the Space/)
-              space.reload
-
-              expect(space.isolation_segment_model).to be_nil
-            end
-          end
-
           context "and the Space's org does not have the isolation segment" do
             it 'raises UnableToPerform' do
               expect {
@@ -282,6 +267,21 @@ module VCAP::CloudController
               space.reload
 
               expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
+
+            context 'and the space has apps' do
+              before do
+                AppModel.make(space: space)
+              end
+
+              it 'raises an error' do
+                expect {
+                  space.update(isolation_segment_guid: isolation_segment_model.guid)
+                }.to raise_error(CloudController::Errors::ApiError, /Cannot change the Isolation Segment for a Space containing Apps/)
+                space.reload
+
+                expect(space.isolation_segment_model).to be_nil
+              end
             end
           end
         end
@@ -311,6 +311,12 @@ module VCAP::CloudController
               space.reload
 
               expect(space.isolation_segment_model).to eq(isolation_segment_model)
+            end
+
+            it 'can delete the space' do
+              expect {
+                space.destroy
+              }.to_not raise_error
             end
           end
         end

--- a/spec/unit/models/runtime/space_spec.rb
+++ b/spec/unit/models/runtime/space_spec.rb
@@ -253,7 +253,7 @@ module VCAP::CloudController
 
             it 'raises an error' do
               expect {
-                space.update(isolation_segment_model: isolation_segment_model)
+                space.update(isolation_segment_guid: isolation_segment_model.guid)
               }.to raise_error(CloudController::Errors::ApiError, /Adding the Isolation Segment to the Space/)
               space.reload
 

--- a/spec/unit/models/runtime/v3/persistence/isolation_segment_model_spec.rb
+++ b/spec/unit/models/runtime/v3/persistence/isolation_segment_model_spec.rb
@@ -6,6 +6,7 @@ require 'isolation_segment_unassign'
 module VCAP::CloudController
   RSpec.describe IsolationSegmentModel do
     let(:isolation_segment_model) { IsolationSegmentModel.make }
+    let(:isolation_segment_model_2) { IsolationSegmentModel.make }
 
     let(:assigner) { IsolationSegmentAssign.new }
     let(:unassigner) { IsolationSegmentUnassign.new }
@@ -14,6 +15,11 @@ module VCAP::CloudController
       describe 'spaces' do
         let(:space_1) { Space.make }
         let(:space_2) { Space.make }
+
+        before do
+          assigner.assign(isolation_segment_model, [space_1.organization, space_2.organization])
+          assigner.assign(isolation_segment_model_2, [space_1.organization, space_2.organization])
+        end
 
         it 'one isolation_segment can reference a single spaces' do
           isolation_segment_model.add_space(space_1)
@@ -32,8 +38,6 @@ module VCAP::CloudController
         end
 
         it 'multiple isolation_segments cannot reference the same space' do
-          isolation_segment_model_2 = IsolationSegmentModel.make
-
           isolation_segment_model.add_space(space_1)
           isolation_segment_model_2.add_space(space_1)
 

--- a/spec/unit/models/runtime/v3/persistence/isolation_segment_model_spec.rb
+++ b/spec/unit/models/runtime/v3/persistence/isolation_segment_model_spec.rb
@@ -156,5 +156,19 @@ module VCAP::CloudController
         }.to raise_error(Sequel::ValidationFailed)
       end
     end
+
+    describe '#is_shared_segment?' do
+      it 'returns false' do
+        expect(isolation_segment_model.is_shared_segment?).to be false
+      end
+
+      context 'when the guids match' do
+        let(:isolation_segment_model) { IsolationSegmentModel.first(guid: IsolationSegmentModel::SHARED_ISOLATION_SEGMENT_GUID) }
+
+        it 'returns true' do
+          expect(isolation_segment_model.is_shared_segment?).to be true
+        end
+      end
+    end
   end
 end

--- a/spec/unit/models/runtime/v3/persistence/isolation_segment_model_spec.rb
+++ b/spec/unit/models/runtime/v3/persistence/isolation_segment_model_spec.rb
@@ -156,19 +156,5 @@ module VCAP::CloudController
         }.to raise_error(Sequel::ValidationFailed)
       end
     end
-
-    describe '#before_destroy' do
-      let(:org) { Organization.make }
-
-      it 'raises an error if still assigned to any orgs' do
-        assigner.assign(isolation_segment_model, [org])
-        expect { isolation_segment_model.destroy }.to raise_error(CloudController::Errors::ApiError, /Please delete the Organization associations for your Isolation Segment/)
-      end
-
-      it 'raises an error if there are still spaces associated' do
-        Space.make(isolation_segment_guid: isolation_segment_model.guid)
-        expect { isolation_segment_model.destroy }.to raise_error(CloudController::Errors::ApiError, /Please delete the space/)
-      end
-    end
   end
 end

--- a/spec/unit/presenters/v2/space_presenter_spec.rb
+++ b/spec/unit/presenters/v2/space_presenter_spec.rb
@@ -10,6 +10,7 @@ module CloudController::Presenters::V2
     let(:orphans) { 'orphans' }
     let(:relations_presenter) { instance_double(RelationsPresenter, to_hash: relations_hash) }
     let(:relations_hash) { { 'relationship_key' => 'relationship_value' } }
+    let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
 
     describe '#entity_hash' do
       before do
@@ -25,10 +26,14 @@ module CloudController::Presenters::V2
           name: 'no_unicorns_no_rainbows',
           organization: organization,
           space_quota_definition: space_quota_definition,
-          isolation_segment_model: isolation_segment_model,
           allow_ssh: true
           )
         }
+
+        before do
+          assigner.assign(isolation_segment_model, [organization])
+          space.update(isolation_segment_model: isolation_segment_model)
+        end
 
         it 'returns the space entity and associated urls' do
           expected_entity_hash = {

--- a/spec/unit/queries/isolation_segment_organizations_fetcher_spec.rb
+++ b/spec/unit/queries/isolation_segment_organizations_fetcher_spec.rb
@@ -7,15 +7,15 @@ module VCAP::CloudController
 
     let!(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }
 
+    let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
+
     let(:org1) { VCAP::CloudController::Organization.make }
     let(:org2) { VCAP::CloudController::Organization.make }
     let(:org3) { VCAP::CloudController::Organization.make }
     let(:org4) { VCAP::CloudController::Organization.make }
 
     before do
-      isolation_segment_model.add_organization(org1)
-      isolation_segment_model.add_organization(org2)
-      isolation_segment_model.add_organization(org3)
+      assigner.assign(isolation_segment_model, [org1, org2, org3])
     end
 
     describe '#fetch_all' do

--- a/spec/unit/queries/isolation_segment_spaces_fetcher_spec.rb
+++ b/spec/unit/queries/isolation_segment_spaces_fetcher_spec.rb
@@ -14,9 +14,10 @@ module VCAP::CloudController
     let(:space2) { VCAP::CloudController::Space.make(organization: org2) }
     let(:space3) { VCAP::CloudController::Space.make(organization: org2) }
 
+    let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
+
     before do
-      isolation_segment_model.add_organization(org1)
-      isolation_segment_model.add_organization(org2)
+      assigner.assign(isolation_segment_model, [org1, org2])
       isolation_segment_model.add_space(space1)
       isolation_segment_model.add_space(space2)
       isolation_segment_model.add_space(space3)


### PR DESCRIPTION
- Move state logic to sequel validations
- refactor to accommodate recent changes to master
- cleanup of specs
- add IsolationSegmentDelete action
- add is_shared_segment? check for individual objects rather than re-query DB
- sort by organization id when doing POST bulk updates

Story reference https://www.pivotaltracker.com/story/show/133869287