### PR TITLE
Fix Isolation Segment Docs

### DIFF
--- a/docs/v3/source/includes/experimental_resources/isolation_segments/_assign.md.erb
+++ b/docs/v3/source/includes/experimental_resources/isolation_segments/_assign.md.erb
@@ -21,7 +21,7 @@ curl "https://api.example.org/v3/isolation_segments/[guid]/relationships/organiz
       { "guid":"org-guid-1" },
       { "guid":"org-guid-2" }
     ]
-  }' 
+  }'
 ```
 
 ```
@@ -33,7 +33,8 @@ HTTP/1.1 201 OK
 
 <%= yield_content :single_isolation_segment %>
 ```
-This endpoint entitles the specified organizations for the isolation segment.  Only Admins can entitle organizations for isolation segments.  If an organization is not already entitled for any other isolation segment, then this isolation segment automatically becomes the default for that organization.
+This endpoint entitles the specified organizations for the isolation segment.  Only Admins can entitle organizations for isolation segments.
+In the case where the specified isolation segment is the system-wide shared segment, and if an organization is not already entitled for any other isolation segment, then the shared isolation segment automatically gets assigned as the  default for that organization.
 
 #### Body Parameters
 

--- a/docs/v3/source/includes/experimental_resources/isolation_segments/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/isolation_segments/_list.md.erb
@@ -47,6 +47,8 @@ This endpoint retrieves all the isolation segments to which the user has access.
     <p class="method-list-item-description">Comma-delimited list of isolation segment names to filter by. <br>Example: <code>names=name1,name2</code></p>
   </li>
 
+<%= yield_content :organization_guids_query_param %>
+
 <%= yield_content :page_query_param %>
 
 <%= yield_content :per_page_query_param %>


### PR DESCRIPTION

- Clarify behavior on automatically setting an org default
- Add org guids to list of query params for ISes

Signed-off-by: Dan Lavine <dlavine@us.ibm.com>