### PR TITLE
Service plan bindable option

### DIFF
--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -6,9 +6,11 @@ module VCAP::CloudController
 
     add_association_dependencies service_plan_visibilities: :destroy
 
-    export_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public, :active
+    export_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public, :bindable, :active
 
-    import_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public
+    export_attributes_from_methods bindable: :bindable?
+
+    import_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public, :bindable
 
     strip_attributes :name
 
@@ -54,6 +56,7 @@ module VCAP::CloudController
     end
 
     def bindable?
+      return bindable unless bindable.nil?
       service.bindable?
     end
 

--- a/db/migrations/20161114113512_add_bindable_to_service_plans.rb
+++ b/db/migrations/20161114113512_add_bindable_to_service_plans.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :service_plans, :bindable, TrueClass, null: true
+  end
+end

--- a/docs/v2/events/list_service_plan_create_events.html
+++ b/docs/v2/events/list_service_plan_create_events.html
@@ -571,7 +571,8 @@ Cookie: </pre>
           "extra": null,
           "unique_id": "guid",
           "public": true,
-          "active": true
+          "active": true,
+          "bindable": true
         },
         "space_guid": "",
         "organization_guid": ""

--- a/docs/v2/service_plans/list_all_service_plans.html
+++ b/docs/v2/service_plans/list_all_service_plans.html
@@ -313,6 +313,7 @@ Cookie: </pre>
         "unique_id": "1bc2884c-ee3d-4f82-a78b-1a657f79aeac",
         "public": true,
         "active": true,
+        "bindable": true,
         "service_url": "/v2/services/1ccab853-87c9-45a6-bf99-603032d17fe5",
         "service_instances_url": "/v2/service_plans/6fecf53b-7553-4cb3-b97e-930f9c4e3385/service_instances"
       }

--- a/docs/v2/service_plans/retrieve_a_particular_service_plan.html
+++ b/docs/v2/service_plans/retrieve_a_particular_service_plan.html
@@ -163,6 +163,7 @@ Cookie: </pre>
     "unique_id": "35c56e06-f0c6-4abe-b158-b7c24c889905",
     "public": true,
     "active": true,
+    "bindable": true,
     "service_url": "/v2/services/a00cacc0-0ca6-422e-91d3-6b22bcd33450",
     "service_instances_url": "/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332/service_instances"
   }

--- a/docs/v2/service_plans/updating_a_service_plan.html
+++ b/docs/v2/service_plans/updating_a_service_plan.html
@@ -170,6 +170,7 @@ Cookie: </pre>
     "unique_id": "f2c4842f-ae62-443f-a308-956d90431b87",
     "public": false,
     "active": true,
+    "bindable": true,
     "service_url": "/v2/services/518cf8f5-9002-4c63-aab1-6ad2737444b1",
     "service_instances_url": "/v2/service_plans/078cb2c1-e036-4dca-a3b7-ad7f3f36f9cc/service_instances"
   }

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -62,6 +62,7 @@ module VCAP::Services::ServiceBrokers
           name:        catalog_plan.name,
           description: catalog_plan.description,
           free:        catalog_plan.free,
+          bindable:    catalog_plan.bindable,
           active:      true,
           extra:       catalog_plan.metadata ? catalog_plan.metadata.to_json : nil
         })

--- a/lib/services/service_brokers/v2/catalog_plan.rb
+++ b/lib/services/service_brokers/v2/catalog_plan.rb
@@ -2,7 +2,7 @@ module VCAP::Services::ServiceBrokers::V2
   class CatalogPlan
     include CatalogValidationHelper
 
-    attr_reader :broker_provided_id, :name, :description, :metadata, :catalog_service, :errors, :free
+    attr_reader :broker_provided_id, :name, :description, :metadata, :catalog_service, :errors, :free, :bindable
 
     def initialize(catalog_service, attrs)
       @catalog_service    = catalog_service
@@ -12,6 +12,7 @@ module VCAP::Services::ServiceBrokers::V2
       @description        = attrs['description']
       @errors             = VCAP::Services::ValidationErrors.new
       @free               = attrs['free'].nil? ? true : attrs['free']
+      @bindable           = attrs['bindable']
     end
 
     def cc_plan
@@ -34,6 +35,7 @@ module VCAP::Services::ServiceBrokers::V2
       validate_string!(:description, description, required: true)
       validate_hash!(:metadata, metadata) if metadata
       validate_bool!(:free, free) if free
+      validate_bool!(:bindable, bindable) if bindable
     end
 
     def human_readable_attr_name(name)
@@ -42,7 +44,8 @@ module VCAP::Services::ServiceBrokers::V2
         name:               'Plan name',
         description:        'Plan description',
         metadata:           'Plan metadata',
-        free:               'Plan free'
+        free:               'Plan free',
+        bindable:           'Plan bindable',
       }.fetch(name) { raise NotImplementedError }
     end
   end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.11_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.11_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+RSpec.describe 'Service Broker API integration' do
+  describe 'v2.11' do
+    include VCAP::CloudController::BrokerApiHelper
+
+    let(:catalog) do
+      catalog = default_catalog(plan_updateable: true)
+      catalog[:services].first[:plans].first[:bindable] = plan_bindable
+      catalog[:services].first[:bindable] = service_bindable
+      catalog
+    end
+
+    before do
+      setup_cc
+      setup_broker(catalog)
+      @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+      provision_service
+      create_app
+    end
+
+    shared_examples 'a bindable plan' do
+      it 'can be bound' do
+        bind_service
+
+        expect(a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+})).
+          to have_been_made.once
+      end
+    end
+
+    shared_examples 'an unbindable plan' do
+      it 'cannot be bound' do
+        bind_service
+
+        expect(a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+})).
+          to have_not_been_made
+      end
+    end
+
+    context 'when the service is set as bindable' do
+      let(:service_bindable) { true }
+
+      context 'and the plan does not specify whether it is bindable' do
+        let(:plan_bindable) { nil }
+
+        it_behaves_like 'a bindable plan'
+      end
+
+      context 'and the plan is explicitly set as bindable' do
+        let(:plan_bindable) { true }
+
+        it_behaves_like 'a bindable plan'
+      end
+
+      context 'and the plan is explicitly set as not bindable' do
+        let(:plan_bindable) { false }
+
+        it_behaves_like 'an unbindable plan'
+      end
+    end
+
+    context 'when the service is set as not bindable' do
+      let(:service_bindable) { false }
+
+      context 'and the plan does not specify whether it is bindable' do
+        let(:plan_bindable) { nil }
+
+        it_behaves_like 'an unbindable plan'
+      end
+
+      context 'and the plan is explicitly set as bindable' do
+        let(:plan_bindable) { true }
+
+        it_behaves_like 'a bindable plan'
+      end
+
+      context 'and the plan is explicitly set as not bindable' do
+        let(:plan_bindable) { false }
+
+        it_behaves_like 'an unbindable plan'
+      end
+    end
+  end
+end

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'vcap/digester'
 
 RSpec.describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = 'b937a5c188c469baded64cb1f2cccbf2412abe99'.freeze
+  API_FOLDER_CHECKSUM = '9094ac88c30bacbc5571323d653ec8fbb94b7c11'.freeze
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.66.0')

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -519,7 +519,8 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         unique_id:   'guid',
         free:        true,
         public:      true,
-        active:      true
+        active:      true,
+        bindable:    true
       )
       service_event_repository.with_service_plan_event(new_plan) do
         new_plan.save
@@ -543,7 +544,8 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
           'extra'        => new_plan.extra,
           'unique_id'    => new_plan.unique_id,
           'public'       => new_plan.public,
-          'active'       => new_plan.active
+          'active'       => new_plan.active,
+          'bindable'     => new_plan.bindable
         }
       }
     end

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -221,7 +221,8 @@ module VCAP::CloudController::BrokerApiHelper
          json_headers(admin_headers)
     )
 
-    @binding_id = JSON.parse(last_response.body)['metadata']['guid']
+    metadata = JSON.parse(last_response.body).fetch('metadata', {})
+    @binding_id = metadata.fetch('guid', nil)
   end
 
   def unbind_service

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3059,6 +3059,21 @@ module VCAP::CloudController
         end
       end
 
+      context 'when attempting to bind to an unbindable service plan' do
+        before do
+          service_instance.service_plan.bindable = false
+          service_instance.service_plan.save
+
+          put "/v2/service_instances/#{service_instance.guid}/routes/#{route.guid}"
+        end
+
+        it 'raises UnbindableService error' do
+          hash_body = JSON.parse(last_response.body)
+          expect(hash_body['error_code']).to eq('CF-UnbindableService')
+          expect(last_response).to have_status_code(400)
+        end
+      end
+
       context 'when the instance operation is in progress' do
         before do
           service_instance.save_with_new_operation({}, { type: 'delete', state: 'in progress' })

--- a/spec/unit/controllers/services/service_plans_controller_spec.rb
+++ b/spec/unit/controllers/services/service_plans_controller_spec.rb
@@ -165,6 +165,22 @@ module VCAP::CloudController
         entity = decoded_response.fetch('entity')
         expect(entity['service_guid']).to eq service_plan.service.guid
       end
+
+      context 'when the plan does not set bindable' do
+        let(:service_plan) { ServicePlan.make(bindable: nil) }
+
+        it 'inherits bindable from the service' do
+          set_current_user_as_admin
+
+          get "/v2/service_plans/#{service_plan.guid}"
+
+          expect(last_response.status).to eq 200
+
+          bindable = decoded_response.fetch('entity')['bindable']
+          expect(bindable).to_not be_nil
+          expect(bindable).to eq service_plan.service.bindable
+        end
+      end
     end
 
     describe 'GET', '/v2/service_plans' do

--- a/spec/unit/controllers/services/service_plans_controller_spec.rb
+++ b/spec/unit/controllers/services/service_plans_controller_spec.rb
@@ -149,6 +149,24 @@ module VCAP::CloudController
       end
     end
 
+    describe 'GET', '/v2/service_plans/:guid' do
+      let(:service_plan) { ServicePlan.make }
+
+      it 'returns the plan' do
+        set_current_user_as_admin
+
+        get "/v2/service_plans/#{service_plan.guid}"
+
+        expect(last_response.status).to eq 200
+
+        metadata = decoded_response.fetch('metadata')
+        expect(metadata['guid']).to eq service_plan.guid
+
+        entity = decoded_response.fetch('entity')
+        expect(entity['service_guid']).to eq service_plan.service.guid
+      end
+    end
+
     describe 'GET', '/v2/service_plans' do
       before do
         @services = {

--- a/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
@@ -9,13 +9,14 @@ module VCAP::Services::ServiceBrokers::V2
         'metadata'    => opts[:metadata] || {},
         'name'        => opts[:name] || 'service-plan-name',
         'description' => opts[:description] || 'The description of the service plan',
-        'free'        => opts.fetch(:free, true)
+        'free'        => opts.fetch(:free, true),
+        'bindable'    => opts[:bindable]
       }
     end
 
     describe 'initializing' do
       let(:catalog_service) { instance_double(VCAP::Services::ServiceBrokers::V2::CatalogService) }
-      subject { CatalogPlan.new(catalog_service, build_valid_plan_attrs(free: false)) }
+      subject { CatalogPlan.new(catalog_service, build_valid_plan_attrs(free: false, bindable: true)) }
 
       its(:broker_provided_id) { should eq 'broker-provided-plan-id' }
       its(:name) { should eq 'service-plan-name' }
@@ -23,6 +24,7 @@ module VCAP::Services::ServiceBrokers::V2
       its(:metadata) { should eq({}) }
       its(:catalog_service) { should eq catalog_service }
       its(:free) { should be false }
+      its(:bindable) { should be true }
       its(:errors) { should be_empty }
 
       it 'defaults free field to true' do
@@ -100,6 +102,14 @@ module VCAP::Services::ServiceBrokers::V2
         plan.valid?
 
         expect(plan.errors.messages).to include 'Plan free must be a boolean, but has value "true"'
+      end
+
+      it 'validates that @bindable is a boolean' do
+        attrs = build_valid_plan_attrs(bindable: 'true')
+        plan = CatalogPlan.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
+        plan.valid?
+
+        expect(plan.errors.messages).to include 'Plan bindable must be a boolean, but has value "true"'
       end
 
       describe '#valid?' do

--- a/spec/unit/models/services/managed_service_instance_spec.rb
+++ b/spec/unit/models/services/managed_service_instance_spec.rb
@@ -487,17 +487,16 @@ module VCAP::CloudController
     end
 
     describe '#bindable?' do
-      let(:service_instance) { ManagedServiceInstance.make(service_plan: service_plan) }
-      let(:service_plan) { ServicePlan.make(service: service) }
+      let(:service_instance) { ManagedServiceInstance.make }
 
-      context 'when the service is bindable' do
-        let(:service) { Service.make(bindable: true) }
+      context 'when the service plan is bindable' do
+        before { expect(service_instance.service_plan).to receive(:bindable?).and_return(true) }
 
         specify { expect(service_instance).to be_bindable }
       end
 
-      context 'when the service is not bindable' do
-        let(:service) { Service.make(bindable: false) }
+      context 'when the service plan is not bindable' do
+        before { expect(service_instance.service_plan).to receive(:bindable?).and_return(false) }
 
         specify { expect(service_instance).not_to be_bindable }
       end

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -45,8 +45,8 @@ module VCAP::CloudController
     end
 
     describe 'Serialization' do
-      it { is_expected.to export_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public, :active }
-      it { is_expected.to import_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public }
+      it { is_expected.to export_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public, :bindable, :active }
+      it { is_expected.to import_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public, :bindable }
     end
 
     describe '#save' do
@@ -190,16 +190,48 @@ module VCAP::CloudController
     end
 
     describe '#bindable?' do
-      let(:service_plan) { ServicePlan.make(service: service) }
+      let(:service_plan) { ServicePlan.make(service: service, bindable: plan_bindable) }
 
-      context 'when the service is bindable' do
-        let(:service) { Service.make(bindable: true) }
-        specify { expect(service_plan).to be_bindable }
+      context 'when the plan does not specify if it is bindable' do
+        let(:plan_bindable) { nil }
+
+        context 'and the service is bindable' do
+          let(:service) { Service.make(bindable: true) }
+          specify { expect(service_plan).to be_bindable }
+        end
+
+        context 'and the service is unbindable' do
+          let(:service) { Service.make(bindable: false) }
+          specify { expect(service_plan).not_to be_bindable }
+        end
       end
 
-      context 'when the service is unbindable' do
-        let(:service) { Service.make(bindable: false) }
-        specify { expect(service_plan).not_to be_bindable }
+      context 'when the plan is explicitly set to not be bindable' do
+        let(:plan_bindable) { false }
+
+        context 'and the service is bindable' do
+          let(:service) { Service.make(bindable: true) }
+          specify { expect(service_plan).not_to be_bindable }
+        end
+
+        context 'and the service is unbindable' do
+          let(:service) { Service.make(bindable: false) }
+          specify { expect(service_plan).not_to be_bindable }
+        end
+      end
+
+      context 'when the plan is explicitly set to be bindable' do
+        let(:plan_bindable) { true }
+
+        context 'and the service is bindable' do
+          let(:service) { Service.make(bindable: true) }
+          specify { expect(service_plan).to be_bindable }
+        end
+
+        context 'and the service is unbindable' do
+          let(:service) { Service.make(bindable: false) }
+          specify { expect(service_plan).to be_bindable }
+        end
       end
     end
 

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -371,7 +371,7 @@
 90005:
   name: UnbindableService
   http_code: 400
-  message: "The service doesn't support binding."
+  message: "The service instance doesn't support binding."
 
 90006:
   name: InvalidLoggingServiceBinding


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Plans should have control over whether they are bindable ([see story](https://www.pivotaltracker.com/story/show/134136079))

* An explanation of the use cases your change solves
As a service author I want to be able to flag bindable at the plan level, so I can have granular control

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

Here's the corresponding PR to docs-services: https://github.com/cloudfoundry/docs-services/pull/149