### PR TITLE
Add bits-service signing credentials to cc worker/clock config

### DIFF
--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -548,3 +548,9 @@ properties:
   cc.bits_service.private_endpoint:
     description: "Private url for the bits-service service"
     default: ""
+  cc.bits_service.username:
+    description: "Username for the bits-service"
+    default: ""
+  cc.bits_service.password:
+    description: "Password for the bits-service"
+    default: ""

--- a/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
@@ -337,4 +337,6 @@ bits_service:
   <% if p("cc.bits_service.enabled") %>
   public_endpoint: <%= p("cc.bits_service.public_endpoint") %>
   private_endpoint: <%= p("cc.bits_service.private_endpoint") %>
+  username: <%= p("cc.bits_service.username") %>
+  password: <%= p("cc.bits_service.password") %>
   <% end %>

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -572,6 +572,12 @@ properties:
   cc.bits_service.private_endpoint:
     description: "Private url for the bits-service service"
     default: ""
+  cc.bits_service.username:
+    description: "Username for the bits-service"
+    default: ""
+  cc.bits_service.password:
+    description: "Password for the bits-service"
+    default: ""
 
   cc.diego.bbs.url:
     description: "URL of the BBS Server"

--- a/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
@@ -338,6 +338,8 @@ bits_service:
   <% if p("cc.bits_service.enabled") %>
   public_endpoint: <%= p("cc.bits_service.public_endpoint") %>
   private_endpoint: <%= p("cc.bits_service.private_endpoint") %>
+  username: <%= p("cc.bits_service.username") %>
+  password: <%= p("cc.bits_service.password") %>
   <% end %>
 
 diego:


### PR DESCRIPTION
As [proposed]( https://github.com/cloudfoundry/cloud_controller_ng/pull/721#issuecomment-261123213)  by @zrob in #721 

* A short explanation of the proposed change:
    See PR title.

* An explanation of the use cases your change solves
    We are preparing a change in the bits-service that makes requires CC to use basic auth when requesting signed URLs from bits-service. In preparation,  we'd like to add the necessary configuration to CC.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

Signed-off-by: Peter Goetz <peter.gtz@gmail.com>

/cc @smoser-ibm @suhlig 