### PR TITLE
add compatibility test for volume mounts

### DIFF
--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.10_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.10_spec.rb
@@ -12,7 +12,49 @@ RSpec.describe 'Service Broker API integration' do
       @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
     end
 
-    # NOTE: the only changes in 2.10 so far are for experimental volume mounts.  Since we do not guarantee backward
-    # compatibility on volume mounts, we won't add tests for that feature just yet.
+    describe 'Binding' do
+      let(:broker_response_status) { 200 }
+      let(:broker_response_body) do
+        {
+            'volume_mounts' => [{
+                 'device_type' => 'shared',
+                 'other' => 'stuff',
+                 'device' => { 'volume_id' => 'foo', 'mount_config' => { 'extra' => 'garbage' } },
+                 'mode' => 'rw',
+                 'container_dir' => '/var/vcap/data/foo',
+                 'driver' => 'mydriver'
+             }]
+        }.to_json
+      end
+      let(:app_guid) { @app_guid }
+      let(:service_instance_guid) { @service_instance_guid }
+      let(:catalog) { default_catalog(requires: ['volume_mount']) }
+
+      before do
+        provision_service
+        create_app
+      end
+
+      after do
+        delete_broker
+      end
+
+      describe 'service binding response with volume_mounts' do
+        before do
+          stub_request(:put, %r{/v2/service_instances/#{service_instance_guid}/service_bindings/#{guid_pattern}}).
+            to_return(status: broker_response_status, body: broker_response_body)
+        end
+
+        it 'displays the volume mount information to the user' do
+          post('/v2/service_bindings',
+               { app_guid: app_guid, service_instance_guid: service_instance_guid }.to_json,
+               json_headers(admin_headers))
+
+          parsed_body = MultiJson.load(last_response.body)
+
+          expect(parsed_body['entity']['volume_mounts']).to match_array([{ 'device_type' => 'shared', 'mode' => 'rw', 'container_dir' => '/var/vcap/data/foo' }])
+        end
+      end
+    end
   end
 end

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.7_spec.rb' => '6ac3a8f83f3bc2492715b42a8fecb2a0',
       'broker_api_v2.8_spec.rb' => '54c9fe10b8a3127c18d28ddf4a1bce9b',
       'broker_api_v2.9_spec.rb' => '9de8ebbdc0e2b60b791c6f7db4e1c8ee',
-      'broker_api_v2.10_spec.rb' => '18b42894a7a310c3718736e7a98a174e',
+      'broker_api_v2.10_spec.rb' => 'e0e22844e576d69067c4891c8ada611c',
     }
   end
   let(:digester) { Digester.new(algorithm: Digest::MD5) }


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This adds a compatibility test for volume mounts on the service broker API, as well as the updated checksum on the broker API spec. 

* An explanation of the use cases your change solves

This is so that volume mounts are no longer experimental. 

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

[#130244039]

Signed-off-by: Jeff Pak <jeffrey.pak@emc.com>