### PR TITLE
Explicitly set the correct virtualization environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@
 language: ruby
 bundler_args: --deployment --without development
 cache: bundler
+sudo: required
 
 # Travis cannot find the binary for Ruby 2.3, so we specifically choose 2.3.1
 # instead of using the .ruby-version file


### PR DESCRIPTION
Refers to #739

* A short explanation of the proposed change:

Default has been changed, forks are now use the wrong environment and test fail.
Source: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`


Not necessary to run CATs, the only change is about travis configuration.

