### PR TITLE
Consume bits_service_client from rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'nats', git: 'https://github.com/nats-io/ruby-nats', ref: '8571cf9d685b60630
 gem 'vcap-concurrency', git: 'https://github.com/cloudfoundry/vcap-concurrency.git', ref: '2a5b0179'
 gem 'cf-uaa-lib', '~> 3.1.0', git: 'https://github.com/cloudfoundry/cf-uaa-lib.git', ref: 'b1e11235dc6cd7d8d4680e005526de37201305ea'
 gem 'cf-message-bus', '~> 0.3.0'
-gem 'bits_service_client', git: 'https://github.com/cloudfoundry-incubator/bits-service-client.git'
+gem 'bits_service_client'
 
 group :db do
   gem 'mysql2', '0.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/cloudfoundry-incubator/bits-service-client.git
-  revision: 1f8f88c586ed5d10636841707a6e79b828baec7a
-  specs:
-    bits_service_client (0.2.0)
-      activesupport
-      steno
-
-GIT
   remote: https://github.com/cloudfoundry/cf-uaa-lib.git
   revision: b1e11235dc6cd7d8d4680e005526de37201305ea
   ref: b1e11235dc6cd7d8d4680e005526de37201305ea
@@ -89,6 +81,9 @@ GEM
     awesome_print (1.7.0)
     backports (3.6.8)
     beefcake (1.0.0)
+    bits_service_client (0.2.1)
+      activesupport
+      steno
     builder (3.2.2)
     byebug (9.0.6)
     cf-message-bus (0.3.4)
@@ -478,7 +473,7 @@ DEPENDENCIES
   addressable
   allowy
   awesome_print
-  bits_service_client!
+  bits_service_client
   byebug
   cf-message-bus (~> 0.3.0)
   cf-uaa-lib (~> 3.1.0)!

--- a/spec/unit/controllers/runtime/info_controller_spec.rb
+++ b/spec/unit/controllers/runtime/info_controller_spec.rb
@@ -34,10 +34,16 @@ module VCAP::CloudController
       end
 
       it 'includes bits_endpoint when bits service is enabled' do
-        TestConfig.override(bits_service: { enabled: true, public_endpoint: 'bits-service.example.com' })
+        TestConfig.override(bits_service: {
+          enabled: true,
+          public_endpoint: 'http://public-bits-service.example.com',
+          private_endpoint: 'http://private-bits-service.example.com',
+          username: 'some-username',
+          password: 'some-password',
+        })
         get '/v2/info'
         hash = MultiJson.load(last_response.body)
-        expect(hash['bits_endpoint']).to eq('bits-service.example.com')
+        expect(hash['bits_endpoint']).to eq('http://public-bits-service.example.com')
       end
 
       it 'does not include bits_service when bits service is not enabled' do

--- a/spec/unit/controllers/runtime/resource_matches_controller_spec.rb
+++ b/spec/unit/controllers/runtime/resource_matches_controller_spec.rb
@@ -91,7 +91,10 @@ module VCAP::CloudController
         {
           bits_service: {
             enabled: true,
-            private_endpoint: 'https://bits-service.service.cf.internal'
+            public_endpoint: 'https://public-bits-service.example.com',
+            private_endpoint: 'https://bits-service.service.cf.internal',
+            username: 'some-username',
+            password: 'some-password',
           }
         }
       end


### PR DESCRIPTION
* A short explanation of the proposed change:

    The bits_service_client gem is now published on https://rubygems.org/gems/bits_service_client and can be consumed from there instead of github.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite

/cc @smoser-ibm @suhlig 