### PR TITLE
Fix the rubocop raked tasks for changed and local

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,11 +14,6 @@ rescue LoadError
   # this isn't needed in a production environment so the gem will not exist
 end
 
-task default: ['spec:all', :rubocop_autocorrect]
+task default: ['spec:all', 'rubocop:changed']
 
-task :rubocop_autocorrect do
-  require 'rubocop'
-  cli = RuboCop::CLI.new
-  exit_code = cli.run(%w(--auto-correct))
-  exit(exit_code) if exit_code != 0
-end
+task rubocop_autocorrect: ['rubocop:changed']


### PR DESCRIPTION
If no .rb files are dirty, have rubocop do nothing (with a helpful message).

2 problems going on here:
1. The default rubocop task is to examine all contained .rb files.
2. There are two tasks that are intended to look only at changed paths (first
locally, second against origin), but if `rubocop.cli.run` is called with zero paths, 
it assumes you want to have it examine everything.  So `0 changed file` ==> `check all`.

Also, note that in :local we weren't looking for files that had been
deleted on local but not origin, so rubocop was complaining about files
that we should no longer care about.

Note default task is now `['spec:all', 'rubocop:changed']`.  To rubocop
all files, run `bundle exec rake rubocop:all`.
