### PR TITLE
Improve DEA queries when determining app health

### DIFF
--- a/lib/cloud_controller/backends/runners.rb
+++ b/lib/cloud_controller/backends/runners.rb
@@ -73,31 +73,93 @@ module VCAP::CloudController
       query.all
     end
 
-    def dea_apps_hm9k(batch_size, last_id)
-      query = App.select_all(App.table_name).
-              runnable.
-              dea.
-              where("#{App.table_name}.id > ?", last_id).
-              order("#{App.table_name}__id".to_sym).
-              limit(batch_size).
-              eager(:latest_droplet, :latest_package, current_droplet: :package)
+    def dea_apps_hm9k
+      # query 1
+      # get all process information where the process is STARTED and running on the DEA
+      process_query = App.db["Select p.id, p.app_guid, p.instances, p.version, apps.droplet_guid from processes p
+                      inner join apps ON (apps.guid = p.app_guid AND p.state ='STARTED' AND p.diego IS FALSE)"]
+      processes = process_query.all
 
-      apps = query.all.reject { |a| a.package_state == 'FAILED' }
+      # query 2
+      # get all necessary droplet information. This includes:
+      #    where the droplet's associated process is running on the DEA and the process is STARTED
+      #    Finding only the latest droplet associated with the process
+      droplets_query = App.db["select d.id, d.guid, d.app_guid, d.created_at, d.package_guid, d.state from droplets d
+                              join processes p ON (d.app_guid = p.app_guid AND p.state ='STARTED' AND p.diego IS FALSE)
+                              inner join (select app_guid, max(created_at) as _max from droplets group by app_guid) as x
+                              ON d.app_guid = x.app_guid and d.created_at=x._max"]
+      latest_droplets = latest(droplets_query.all)
 
-      app_hashes = apps.map do |app|
-        {
-          'id'            => app.guid,
-          'instances'     => app.instances,
-          'state'         => app.state,
-          'memory'        => app.memory,
-          'version'       => app.version,
-          'updated_at'    => app.updated_at || app.created_at,
-          'package_state' => app.package_state,
-        }
+      # query 3
+      # get all necessary package information. This includes:
+      #   where the package's associated process is running on the DEA and the process is STARTED
+      #   finding only the latest package associated with the process
+      packages_query = App.db["select pkg.id, pkg.guid, pkg.app_guid, pkg.created_at, pkg.state from packages pkg
+                              join processes proc ON
+                                (pkg.app_guid = proc.app_guid AND proc.state ='STARTED' AND proc.diego IS FALSE)
+                              inner join (select app_guid, max(created_at) as _max from packages group by app_guid) as x
+                              ON pkg.app_guid = x.app_guid and pkg.created_at = x._max"]
+      latest_packages = latest(packages_query.all)
+
+      process_list = []
+      largest_id = 0
+
+      processes.each do |process|
+        app_guid = process[:app_guid]
+
+        pkg_state = package_state(app_guid, process[:droplet_guid], latest_droplets[app_guid], latest_packages[app_guid])
+        next if pkg_state == 'FAILED'
+
+        if process[:id] > largest_id
+          largest_id = process[:id]
+        end
+
+        process_list.push({
+          'id'            => app_guid,
+          'instances'     => process[:instances],
+          'state'         => 'STARTED',
+          'version'       => process[:version],
+          'package_state' => pkg_state,
+        })
       end
 
-      id_for_next_token = apps.empty? ? nil : apps.last.id
-      [app_hashes, id_for_next_token]
+      [process_list, largest_id]
+    end
+
+    def latest(items)
+      current = {}
+
+      items.each do |item|
+        c = current[item[:app_guid]]
+        if c.nil? || (item[:created_at] == c[:created_at] && item[:id] > c[:id])
+          current[item[:app_guid]] = item
+        end
+      end
+
+      current
+    end
+
+    def package_state(app_guid, current_droplet_guid, latest_droplet, latest_package)
+      if latest_droplet
+        return 'FAILED' if latest_droplet[:state] == DropletModel::FAILED_STATE
+
+        # Process of staging
+        return 'PENDING' if current_droplet_guid != latest_droplet[:guid]
+
+        if latest_package
+          return 'STAGED' if latest_droplet[:package_guid] == latest_package[:guid] || latest_droplet[:created_at] > latest_package[:created_at]
+          return 'FAILED' if latest_package[:state] == PackageModel::FAILED_STATE
+          return 'PENDING'
+        end
+
+        return 'STAGED'
+      end
+
+      return 'FAILED' if latest_package && latest_package[:state] == PackageModel::FAILED_STATE
+
+      # At this point you could have no package on an app
+      # At this point you have a latest package, but no droplet. So staging has not occured
+      'PENDING'
     end
 
     private

--- a/spec/unit/controllers/runtime/legacy_bulk_spec.rb
+++ b/spec/unit/controllers/runtime/legacy_bulk_spec.rb
@@ -48,38 +48,30 @@ module VCAP::CloudController
           authorize @bulk_user, @bulk_password
         end
 
-        it 'requires a token in query string' do
-          get '/bulk/apps'
-          expect(last_response.status).to eq(400)
-        end
-
-        it 'returns nil bulk_token for the initial request' do
-          get '/bulk/apps'
-          expect(decoded_response['bulk_token']).to be_nil
-        end
-
-        it 'returns a populated bulk_token for the initial request (which has an empty bulk token)' do
+        it 'ignores the batch_size parameter' do
           get '/bulk/apps', {
-            'batch_size' => 20,
+            'batch_size' => 'woopty_doo',
             'bulk_token' => '{}',
           }
-          expect(decoded_response['bulk_token']).not_to be_nil
+
+          expect(last_response.status).to eq(200)
+          expect(decoded_response['results']).not_to be_nil
         end
 
         it 'returns results in the response body' do
           get '/bulk/apps', {
-            'batch_size' => 20,
-            'bulk_token' => '{"id":20}',
+            'bulk_token' => '{}'
           }
+
           expect(last_response.status).to eq(200)
           expect(decoded_response['results']).not_to be_nil
         end
 
         it 'returns results that are valid json' do
           get '/bulk/apps', {
-            'batch_size' => 100,
-            'bulk_token' => '{"id":0}',
+            'bulk_token' => '{}'
           }
+
           expect(last_response.status).to eq(200)
           decoded_response['results'].each { |key, value|
             expect(value).to be_kind_of Hash
@@ -88,65 +80,22 @@ module VCAP::CloudController
           }
         end
 
-        it 'respects the batch_size parameter' do
-          [3, 5].each { |size|
-            get '/bulk/apps', {
-              'batch_size' => size,
-              'bulk_token' => '{"id":0}',
-            }
-            expect(decoded_response['results'].size).to eq(size)
-          }
-        end
-
-        it 'returns non-intersecting results when token is supplied' do
+        it 'returns empty results on requests after the initial one' do
           get '/bulk/apps', {
-            'batch_size' => 2,
-            'bulk_token' => '{"id":0}',
+            'bulk_token' => '{"id":1}'
           }
-          saved_results = decoded_response['results'].dup
-          expect(saved_results.size).to eq(2)
 
-          get '/bulk/apps', {
-            'batch_size' => 2,
-            'bulk_token' => MultiJson.dump(decoded_response['bulk_token']),
-          }
-          new_results = decoded_response['results'].dup
-          expect(new_results.size).to eq(2)
-          saved_results.each do |saved_result|
-            expect(new_results).not_to include(saved_result)
-          end
-        end
-
-        it 'should eventually return entire collection, batch after batch' do
-          apps = {}
-          total_size = App.count
-
-          token = '{}'
-          while apps.size < total_size
-            get '/bulk/apps', {
-              'batch_size' => 2,
-              'bulk_token' => MultiJson.dump(token),
-            }
-            expect(last_response.status).to eq(200)
-            token = decoded_response['bulk_token']
-            apps.merge!(decoded_response['results'])
-          end
-
-          expect(apps.size).to eq(total_size)
-          get '/bulk/apps', {
-            'batch_size' => 2,
-            'bulk_token' => MultiJson.dump(token),
-          }
-          expect(decoded_response['results'].size).to eq(0)
+          expect(last_response.status).to eq(200)
+          expect(decoded_response['results']).to be_empty
         end
 
         it 'does not include diego apps' do
           app = AppFactory.make(state: 'STARTED', diego: true)
 
           get '/bulk/apps', {
-                              'batch_size' => 20,
-                              'bulk_token' => '{}',
-                          }
+            'bulk_token' => '{}'
+          }
+
           expect(last_response.status).to eq(200)
           expect(decoded_response['results']).to_not include(app.guid)
           expect(decoded_response['results'].size).to eq(5)

--- a/spec/unit/lib/cloud_controller/backends/runners_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends/runners_spec.rb
@@ -326,15 +326,10 @@ module VCAP::CloudController
 
         batch, _ = runners.dea_apps_hm9k
 
-        found = false
-        batch.each do |item|
-          if item['id'] == staging_pending_app.guid
-            expect(item['package_state']).to eq('PENDING')
-            found = true
-          end
-        end
-
-        expect(found).to be true
+        expect(batch).to include(hash_including({
+          'id' => staging_pending_app.guid,
+          'package_state' => 'PENDING'
+        }))
       end
 
       it 'returns the largest process id from the query' do

--- a/spec/unit/lib/cloud_controller/dea/instances_reporter_spec.rb
+++ b/spec/unit/lib/cloud_controller/dea/instances_reporter_spec.rb
@@ -57,6 +57,7 @@ module VCAP::CloudController
         context 'and the app failed to stage' do
           before do
             app.latest_package.update(state: 'FAILED')
+            app.app.update(droplet_guid: nil)
           end
 
           it 'returns 0' do
@@ -69,29 +70,43 @@ module VCAP::CloudController
     end
 
     describe '#number_of_starting_and_running_instances_for_processes' do
-      let(:running_apps) do
+      let(:space_with_running_apps) { Space.make }
+      let(:space_with_stopped_apps) { Space.make }
+      let(:space_with_failed_apps) { Space.make }
+      let(:space_with_pending_apps) { Space.make }
+
+      let!(:running_apps) do
         Array.new(3) do
-          AppFactory.make(state: 'STARTED')
+          AppFactory.make(state: 'STARTED', space: space_with_running_apps)
         end
       end
 
-      let(:stopped_apps) do
+      let!(:stopped_apps) do
         Array.new(3) do
-          AppFactory.make(state: 'STOPPED')
+          AppFactory.make(state: 'STOPPED', space: space_with_stopped_apps)
         end
       end
 
-      let(:failed_apps) do
-        a = AppFactory.make(state: 'STARTED')
+      let!(:failed_apps) do
+        a = AppFactory.make(state: 'STARTED', space: space_with_failed_apps)
         a.latest_package.update(state: 'FAILED')
+        a.app.update(droplet_guid: nil)
         [a]
       end
 
-      let(:pending_apps) do
-        [App.make(state: 'STARTED')]
+      let!(:pending_apps) do
+        a = AppFactory.make(state: 'STARTED', space: space_with_pending_apps)
+        a.latest_package.update(state: VCAP::CloudController::PackageModel::PENDING_STATE)
+        a.app.update(droplet_guid: nil)
+        [a]
       end
 
-      let(:apps) { running_apps + stopped_apps + failed_apps + pending_apps }
+      context 'when there are no proccess' do
+        it 'returns an empty array' do
+          result = subject.number_of_starting_and_running_instances_for_processes(Space.make.apps)
+          expect(result).to eq([])
+        end
+      end
 
       describe 'stopped apps' do
         before do
@@ -153,6 +168,8 @@ module VCAP::CloudController
       describe 'running apps' do
         before do
           allow(health_manager_client).to receive(:healthy_instances_bulk) do |apps|
+            running_apps.each { |running| expect(apps).to include(running) }
+
             apps.each_with_object({}) do |app, hash|
               hash[app.guid] = 3
             end
@@ -160,7 +177,7 @@ module VCAP::CloudController
         end
 
         it 'should ask the health manager for active instances for running apps' do
-          expect(health_manager_client).to receive(:healthy_instances_bulk).with(running_apps)
+          expect(health_manager_client).to receive(:healthy_instances_bulk)
 
           result = subject.number_of_starting_and_running_instances_for_processes(running_apps)
           expect(result.length).to be(3)
@@ -169,10 +186,13 @@ module VCAP::CloudController
       end
 
       describe 'started apps that failed to stage' do
+        let(:space) { Space.make }
+
         let!(:staging_failed_apps) do
           Array.new(3) do
-            AppFactory.make(state: 'STARTED').tap do |a|
+            AppFactory.make(state: 'STARTED', space: space).tap do |a|
               a.latest_package.update(state: 'FAILED')
+              a.app.update(droplet_guid: nil)
             end
           end
         end


### PR DESCRIPTION
* improve HM9k bulk/app requests by collecting all information in three
  queries for package state.
* improve lookup for processes in the running state.
* improve lookup for processes in the starting or running state.
* The previous 2 bullet points rely on the fact that a process's
  current droplet is set to nil as part of the staging process and only
  gets set when staging a package is successful.

Signed-off-by: Dan Lavine <dlavine@us.ibm.com>