### PR TITLE
Add VCAP_APP_HOST environment variable to restore behavior as for DEAs

### DIFF
--- a/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
@@ -58,6 +58,7 @@ module VCAP::CloudController
           [
             ::Diego::Bbs::Models::EnvironmentVariable.new(name: 'PORT', value: ports.first.to_s),
             ::Diego::Bbs::Models::EnvironmentVariable.new(name: 'VCAP_APP_PORT', value: ports.first.to_s),
+            ::Diego::Bbs::Models::EnvironmentVariable.new(name: 'VCAP_APP_HOST', value: '0.0.0.0'),
           ]
         end
 

--- a/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
@@ -136,6 +136,7 @@ module VCAP::CloudController
             expect(builder.port_environment_variables).to match_array([
               ::Diego::Bbs::Models::EnvironmentVariable.new(name: 'PORT', value: '11'),
               ::Diego::Bbs::Models::EnvironmentVariable.new(name: 'VCAP_APP_PORT', value: '11'),
+              ::Diego::Bbs::Models::EnvironmentVariable.new(name: 'VCAP_APP_HOST', value: '0.0.0.0'),
             ])
           end
         end


### PR DESCRIPTION
This is the CC-bridge merge implementation of [this pr](https://github.com/cloudfoundry/nsync/pull/17) for nsync.