### PR TITLE
Use the internal routing api endpoint

### DIFF
--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -730,6 +730,13 @@ properties:
     description: "Whether to expose the routing_endpoint listed at /v2/info. Enable this after deploying the Routing API"
     default: false
 
+  routing_api.uri:
+    description: "URL where the routing API can be reached internally"
+    default: http://routing-api.service.cf.internal
+  routing_api.port:
+    description: "Port on which Routing API is running."
+    default: 3000
+
   cc.reserved_private_domains:
     description: "File location of a list of reserved private domains (for file format, see https://publicsuffix.org/)"
     default: ~

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -216,6 +216,7 @@ hm9000:
 
 <% if p("routing_api.enabled") %>
 routing_api:
+  private_endpoint: <%= "#{p('routing_api.uri')}:#{p('routing_api.port')}" %>
   url: <%= "https://api.#{system_domain}/routing" %>
   routing_client_name: "cc_routing"
   routing_client_secret: <%= p("uaa.clients.cc_routing.secret") %>

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -97,6 +97,7 @@ hm9000:
 
 routing_api:
   url: "http://localhost:3000"
+  private_endpoint: "http://localhost:3000/internal"
   routing_client_name: 'routing-client'
   routing_client_secret: 'routing-secret'
 

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -250,7 +250,7 @@ module CloudController
       )
 
       skip_cert_verify = @config[:skip_cert_verify]
-      routing_api_url  = HashUtils.dig(@config, :routing_api, :url)
+      routing_api_url  = HashUtils.dig(@config, :routing_api, :private_endpoint)
       RoutingApi::Client.new(routing_api_url, uaa_client, skip_cert_verify)
     end
 

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -323,6 +323,7 @@ RSpec.describe CloudController::DependencyLocator do
     let(:config) do
       TestConfig.override(routing_api:
                           {
+        private_endpoint: 'routing-api-internal-url',
         url: 'routing-api-url',
         routing_client_name: 'routing-client',
         routing_client_secret: 'routing-secret',
@@ -355,7 +356,7 @@ RSpec.describe CloudController::DependencyLocator do
 
       expect(client).to be_an_instance_of(VCAP::CloudController::RoutingApi::Client)
       expect(client.uaa_client).to eq uaa_client
-      expect(client.routing_api_uri.to_s).to eq(config[:routing_api][:url])
+      expect(client.routing_api_uri.to_s).to eq(config[:routing_api][:private_endpoint])
       expect(client.skip_cert_verify).to eq(config[:skip_cert_verify])
     end
   end


### PR DESCRIPTION
Use the cluster's internal routing API endpoint rather than making a
hairpin through the router.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [x] I have run CF Acceptance Tests on bosh lite
