### PR TITLE
Add user role events at space, org creation time

### DIFF
--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -285,9 +285,26 @@ module VCAP::CloudController
     end
 
     def after_create(organization)
-      return if SecurityContext.admin?
-      organization.add_user(user)
-      organization.add_manager(user)
+      unless SecurityContext.admin?
+        organization.add_user(user)
+        organization.add_manager(user)
+      end
+
+      organization.users.each do |user|
+        @user_event_repository.record_organization_role_add(organization, user, 'user', UserAuditInfo.from_context(SecurityContext), request_attrs)
+      end
+
+      organization.auditors.each do |auditor|
+        @user_event_repository.record_organization_role_add(organization, auditor, 'auditor', UserAuditInfo.from_context(SecurityContext), request_attrs)
+      end
+
+      organization.billing_managers.each do |billing_manager|
+        @user_event_repository.record_organization_role_add(organization, billing_manager, 'billing_manager', UserAuditInfo.from_context(SecurityContext), request_attrs)
+      end
+
+      organization.managers.each do |manager|
+        @user_event_repository.record_organization_role_add(organization, manager, 'manager', UserAuditInfo.from_context(SecurityContext), request_attrs)
+      end
     end
   end
 end

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -264,6 +264,18 @@ module VCAP::CloudController
 
     def after_create(space)
       @space_event_repository.record_space_create(space, UserAuditInfo.from_context(SecurityContext), request_attrs)
+
+      space.managers.each do |mgr|
+        @user_event_repository.record_space_role_add(space, mgr, 'manager', UserAuditInfo.from_context(SecurityContext), request_attrs)
+      end
+
+      space.auditors.each do |auditor|
+        @user_event_repository.record_space_role_add(space, auditor, 'auditor', UserAuditInfo.from_context(SecurityContext), request_attrs)
+      end
+
+      space.developers.each do |developer|
+        @user_event_repository.record_space_role_add(space, developer, 'developer', UserAuditInfo.from_context(SecurityContext), request_attrs)
+      end
     end
 
     def after_update(space)

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -315,6 +315,75 @@ module VCAP::CloudController
           end
         end
       end
+
+      context 'setting roles at org creation time' do
+        let(:other_user) { User.make }
+        let(:name) { 'myorg' }
+
+        before do
+          set_current_user_as_admin
+        end
+
+        context 'assigning an org manager' do
+          it 'records an event of type audit.user.organization_manager_add' do
+            event = Event.find(type: 'audit.user.organization_manager_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, manager_guids: [other_user.guid] }.to_json
+            post '/v2/organizations', request_body
+
+            expect(last_response).to have_status_code(201)
+
+            event = Event.find(type: 'audit.user.organization_manager_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'assigning an auditor' do
+          it 'records an event of type audit.user.organization_auditor_add' do
+            event = Event.find(type: 'audit.user.organization_auditor_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, auditor_guids: [other_user.guid] }.to_json
+            post '/v2/organizations', request_body
+
+            expect(last_response).to have_status_code(201)
+
+            event = Event.find(type: 'audit.user.organization_auditor_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'assigning a billing manager' do
+          it 'records an event of type audit.user.organization_billing_manager_add' do
+            event = Event.find(type: 'audit.user.organization_billing_manager_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, billing_manager_guids: [other_user.guid] }.to_json
+            post '/v2/organizations', request_body
+
+            expect(last_response).to have_status_code(201)
+
+            event = Event.find(type: 'audit.user.organization_billing_manager_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'assigning a user' do
+          it 'records an event of type audit.user.organization_user_add' do
+            event = Event.find(type: 'audit.user.organization_user_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, user_guids: [other_user.guid] }.to_json
+            post '/v2/organizations', request_body
+
+            expect(last_response).to have_status_code(201)
+
+            event = Event.find(type: 'audit.user.organization_user_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+      end
     end
 
     describe 'GET /v2/organizations/:guid/user_roles' do


### PR DESCRIPTION
The features to record events for role assignment both missed the cases where the assignments are done as part of the POST (create) and PUT (update) requests on the org/space.  This provides the POST function, PUT will be a separate PR.