### PR TITLE
specify certificate_properties on task and lrp definitions

### DIFF
--- a/lib/cloud_controller/diego/app_recipe_builder.rb
+++ b/lib/cloud_controller/diego/app_recipe_builder.rb
@@ -66,6 +66,9 @@ module VCAP::CloudController
           PlacementTags:                    [IsolationSegmentSelector.for_space(process.space)],
           routes:                           ::Diego::Bbs::Models::ProtoRoutes.new(routes: routes),
           max_pids:                         @config[:diego][:pid_limit],
+          certificate_properties:           ::Diego::Bbs::Models::CertificateProperties.new(
+            organizational_unit: ["app:#{process.app.guid}"]
+          ),
         )
       end
 

--- a/lib/cloud_controller/diego/task_recipe_builder.rb
+++ b/lib/cloud_controller/diego/task_recipe_builder.rb
@@ -37,6 +37,9 @@ module VCAP::CloudController
           root_fs:                          task_action_builder.stack,
           environment_variables:            task_action_builder.task_environment_variables,
           PlacementTags:                    [VCAP::CloudController::IsolationSegmentSelector.for_space(task.space)],
+          certificate_properties:           ::Diego::Bbs::Models::CertificateProperties.new(
+            organizational_unit: ["app:#{task.app.guid}"]
+          ),
         )
       end
 
@@ -62,6 +65,9 @@ module VCAP::CloudController
           cached_dependencies:              action_builder.cached_dependencies,
           PlacementTags:                    find_staging_isolation_segment(staging_details),
           max_pids:                         config[:diego][:pid_limit],
+          certificate_properties:           ::Diego::Bbs::Models::CertificateProperties.new(
+            organizational_unit: ["app:#{staging_details.package.app_guid}"]
+          ),
         )
       end
 

--- a/lib/diego/bbs/models/certificate_properties.pb.rb
+++ b/lib/diego/bbs/models/certificate_properties.pb.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf/message'
+
+module Diego
+  module Bbs
+    module Models
+
+      ##
+      # Message Classes
+      #
+      class CertificateProperties < ::Protobuf::Message; end
+
+
+      ##
+      # Message Fields
+      #
+      class CertificateProperties
+        repeated :string, :organizational_unit, 1
+      end
+
+    end
+
+  end
+
+end
+

--- a/lib/diego/bbs/models/desired_lrp.pb.rb
+++ b/lib/diego/bbs/models/desired_lrp.pb.rb
@@ -10,13 +10,14 @@ require 'protobuf/message'
 # Imports
 #
 require 'github.com/gogo/protobuf/gogoproto/gogo.pb'
-require 'modification_tag.pb'
 require 'actions.pb'
 require 'cached_dependency.pb'
-require 'security_group.pb'
+require 'certificate_properties.pb'
 require 'environment_variables.pb'
-require 'volume_mount.pb'
+require 'modification_tag.pb'
 require 'network.pb'
+require 'security_group.pb'
+require 'volume_mount.pb'
 
 module Diego
   module Bbs
@@ -72,6 +73,7 @@ module Diego
         repeated ::Diego::Bbs::Models::VolumeMount, :volume_mounts, 17
         optional ::Diego::Bbs::Models::Network, :network, 18
         optional :int64, :start_timeout_ms, 19
+        optional ::Diego::Bbs::Models::CertificateProperties, :certificate_properties, 20
       end
 
       class ProtoRoutes
@@ -132,6 +134,7 @@ module Diego
         optional ::Diego::Bbs::Models::Network, :network, 26
         repeated :string, :PlacementTags, 28
         optional :int32, :max_pids, 29
+        optional ::Diego::Bbs::Models::CertificateProperties, :certificate_properties, 30
       end
 
     end

--- a/lib/diego/bbs/models/desired_lrp_requests.pb.rb
+++ b/lib/diego/bbs/models/desired_lrp_requests.pb.rb
@@ -45,6 +45,7 @@ module Diego
 
       class DesiredLRPsRequest
         optional :string, :domain, 1
+        repeated :string, :process_guids, 2
       end
 
       class DesiredLRPResponse

--- a/lib/diego/bbs/models/error.pb.rb
+++ b/lib/diego/bbs/models/error.pb.rb
@@ -50,6 +50,7 @@ module Diego
           define :Deserialize, 27
           define :Deadlock, 28
           define :Unrecoverable, 29
+          define :LockCollision, 30
         end
 
       end

--- a/lib/diego/bbs/models/google/protobuf/descriptor.pb.rb
+++ b/lib/diego/bbs/models/google/protobuf/descriptor.pb.rb
@@ -195,7 +195,7 @@ module Google
       optional :string, :java_package, 1
       optional :string, :java_outer_classname, 8
       optional :bool, :java_multiple_files, 10, :default => false
-      optional :bool, :java_generate_equals_and_hash, 20, :deprecated => true
+      optional :bool, :java_generate_equals_and_hash, 20, :default => false
       optional :bool, :java_string_check_utf8, 27, :default => false
       optional ::Google::Protobuf::FileOptions::OptimizeMode, :optimize_for, 9, :default => ::Google::Protobuf::FileOptions::OptimizeMode::SPEED
       optional :string, :go_package, 11

--- a/lib/diego/bbs/models/task.pb.rb
+++ b/lib/diego/bbs/models/task.pb.rb
@@ -16,6 +16,7 @@ require 'security_group.pb'
 require 'cached_dependency.pb'
 require 'volume_mount.pb'
 require 'network.pb'
+require 'certificate_properties.pb'
 
 module Diego
   module Bbs
@@ -63,6 +64,7 @@ module Diego
         optional ::Diego::Bbs::Models::Network, :network, 19
         repeated :string, :PlacementTags, 20
         optional :int32, :max_pids, 21
+        optional ::Diego::Bbs::Models::CertificateProperties, :certificate_properties, 22
       end
 
       class Task

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -132,6 +132,12 @@ module VCAP::CloudController
           ]
         end
 
+        let(:expected_certificate_properties) do
+          ::Diego::Bbs::Models::CertificateProperties.new(
+            organizational_unit: ["app:#{process.app.guid}"],
+          )
+        end
+
         let(:lrp_builder_ports) { [4444, 5555] }
 
         let(:rule_dns_everywhere) do
@@ -263,6 +269,7 @@ module VCAP::CloudController
             expect(lrp.start_timeout_ms).to eq(12 * 1000)
             expect(lrp.trusted_system_certificates_path).to eq(RUNNING_TRUSTED_SYSTEM_CERT_PATH)
             expect(lrp.PlacementTags).to eq(['placement-tag'])
+            expect(lrp.certificate_properties).to eq(expected_certificate_properties)
           end
 
           context 'when a volume mount is provided' do
@@ -726,6 +733,7 @@ module VCAP::CloudController
             expect(lrp.start_timeout_ms).to eq(12 * 1000)
             expect(lrp.trusted_system_certificates_path).to eq(RUNNING_TRUSTED_SYSTEM_CERT_PATH)
             expect(lrp.PlacementTags).to eq(['placement-tag'])
+            expect(lrp.certificate_properties).to eq(expected_certificate_properties)
           end
 
           context 'cpu weight' do

--- a/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
@@ -64,6 +64,11 @@ module VCAP::CloudController
             log: true
           )
         end
+        let(:certificate_properties) do
+          ::Diego::Bbs::Models::CertificateProperties.new(
+            organizational_unit: ["app:#{app.guid}"],
+          )
+        end
 
         before do
           SecurityGroup.make(rules: [{ 'protocol' => 'udp', 'ports' => '53', 'destination' => '0.0.0.0/0' }], staging_default: true)
@@ -133,6 +138,7 @@ module VCAP::CloudController
             expect(result.cached_dependencies).to eq(lifecycle_cached_dependencies)
             expect(result.PlacementTags).to eq(['potato-segment'])
             expect(result.max_pids).to eq(100)
+            expect(result.certificate_properties).to eq(certificate_properties)
           end
 
           it 'gives the task a TrustedSystemCertificatesPath' do
@@ -265,6 +271,11 @@ module VCAP::CloudController
 
             expect(result.max_pids).to eq(100)
           end
+
+          it 'sets the certificate_properties' do
+            result = task_recipe_builder.build_staging_task(config, staging_details)
+            expect(result.certificate_properties).to eq(certificate_properties)
+          end
         end
       end
 
@@ -343,6 +354,12 @@ module VCAP::CloudController
         )]
         }
 
+        let(:certificate_properties) do
+          ::Diego::Bbs::Models::CertificateProperties.new(
+            organizational_unit: ["app:#{task.app.guid}"],
+          )
+        end
+
         context 'with a buildpack backend' do
           let(:droplet) { DropletModel.make(:buildpack, app: app) }
 
@@ -395,6 +412,7 @@ module VCAP::CloudController
             expect(result.cpu_weight).to eq(25)
             expect(result.PlacementTags).to eq([isolation_segment])
             expect(result.max_pids).to eq(100)
+            expect(result.certificate_properties).to eq(certificate_properties)
           end
 
           context 'when a volume mount is provided' do
@@ -528,6 +546,7 @@ module VCAP::CloudController
             expect(result.cpu_weight).to eq(25)
             expect(result.PlacementTags).to eq([isolation_segment])
             expect(result.max_pids).to eq(100)
+            expect(result.certificate_properties).to eq(certificate_properties)
           end
 
           context 'when a volume mount is provided' do


### PR DESCRIPTION
### Note: You will need to bump the BBS submodule in capi-release with this change as it updates the protobuf models.

https://www.pivotaltracker.com/story/show/140171589

* organizational_unit is the organization guid
* regenerate protobuf models

[#140171589]

Signed-off-by: Luan Santos <lsantos@pivotal.io>

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run CF Acceptance Tests on bosh lite