### PR TITLE
Generate role events on updates to spaces and orgs

### DIFF
--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -69,6 +69,34 @@ module VCAP::CloudController
       )
     end
 
+    def update(guid)
+      json_msg = self.class::UpdateMessage.decode(body)
+      @request_attrs = json_msg.extract(stringify_keys: true)
+      logger.debug 'cc.update', guid: guid, attributes: redact_attributes(:update, request_attrs)
+      raise InvalidRequest unless request_attrs
+
+      space = find_guid(guid)
+
+      before_update(space)
+
+      current_role_guids = {}
+
+      model.db.transaction do
+        space.lock!
+
+        current_role_guids = get_current_role_guids(space)
+
+        validate_access(:read_for_update, space, request_attrs)
+        space.update_from_hash(request_attrs)
+        validate_access(:update, space, request_attrs)
+      end
+
+      generate_role_events_on_update(space, current_role_guids)
+      after_update(space)
+
+      [HTTP::CREATED, object_renderer.render_json(self.class, space, @opts)]
+    end
+
     get '/v2/spaces/:guid/services', :enumerate_services
     def enumerate_services(guid)
       space = find_guid_and_validate_access(:read, guid)
@@ -294,5 +322,65 @@ module VCAP::CloudController
 
     define_messages
     define_routes
+
+    def get_current_role_guids(space)
+      current_role_guids = {}
+
+      %w(developer manager auditor).each do |role|
+        key = "#{role}_guids"
+
+        if request_attrs[key]
+          current_role_guids[role] = []
+          space.send(role.pluralize.to_sym).each do |user|
+            current_role_guids[role] << user.guid
+          end
+        end
+      end
+
+      current_role_guids
+    end
+
+    def generate_role_events_on_update(space, current_role_guids)
+      %w(manager auditor developer).each do |role|
+        key = "#{role}_guids"
+
+        user_guids_removed = []
+
+        if request_attrs[key]
+          user_guids_added = request_attrs[key]
+
+          if current_role_guids[role]
+            user_guids_added = request_attrs[key] - current_role_guids[role]
+            user_guids_removed = current_role_guids[role] - request_attrs[key]
+          end
+
+          user_guids_added.each do |user_id|
+            user = User.first(guid: user_id) || User.create(guid: user_id)
+            user.username = '' unless user.username
+
+            @user_event_repository.record_space_role_add(
+                space,
+                user,
+                role,
+                UserAuditInfo.from_context(SecurityContext),
+                request_attrs
+            )
+          end
+
+          user_guids_removed.each do |user_id|
+            user = User.first(guid: user_id)
+            user.username = '' unless user.username
+
+            @user_event_repository.record_space_role_remove(
+                space,
+                user,
+                role,
+                UserAuditInfo.from_context(SecurityContext),
+                request_attrs
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -291,18 +291,20 @@ module VCAP::CloudController
     end
 
     def after_create(space)
-      @space_event_repository.record_space_create(space, UserAuditInfo.from_context(SecurityContext), request_attrs)
+      user_audit_info = UserAuditInfo.from_context(SecurityContext)
+
+      @space_event_repository.record_space_create(space, user_audit_info, request_attrs)
 
       space.managers.each do |mgr|
-        @user_event_repository.record_space_role_add(space, mgr, 'manager', UserAuditInfo.from_context(SecurityContext), request_attrs)
+        @user_event_repository.record_space_role_add(space, mgr, 'manager', user_audit_info, request_attrs)
       end
 
       space.auditors.each do |auditor|
-        @user_event_repository.record_space_role_add(space, auditor, 'auditor', UserAuditInfo.from_context(SecurityContext), request_attrs)
+        @user_event_repository.record_space_role_add(space, auditor, 'auditor', user_audit_info, request_attrs)
       end
 
       space.developers.each do |developer|
-        @user_event_repository.record_space_role_add(space, developer, 'developer', UserAuditInfo.from_context(SecurityContext), request_attrs)
+        @user_event_repository.record_space_role_add(space, developer, 'developer', user_audit_info, request_attrs)
       end
     end
 
@@ -341,6 +343,8 @@ module VCAP::CloudController
     end
 
     def generate_role_events_on_update(space, current_role_guids)
+      user_audit_info = UserAuditInfo.from_context(SecurityContext)
+
       %w(manager auditor developer).each do |role|
         key = "#{role}_guids"
 
@@ -359,10 +363,10 @@ module VCAP::CloudController
             user.username = '' unless user.username
 
             @user_event_repository.record_space_role_add(
-                space,
+              space,
                 user,
                 role,
-                UserAuditInfo.from_context(SecurityContext),
+                user_audit_info,
                 request_attrs
             )
           end
@@ -372,10 +376,10 @@ module VCAP::CloudController
             user.username = '' unless user.username
 
             @user_event_repository.record_space_role_remove(
-                space,
+              space,
                 user,
                 role,
-                UserAuditInfo.from_context(SecurityContext),
+                user_audit_info,
                 request_attrs
             )
           end

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -440,7 +440,7 @@ module VCAP::CloudController
       context 'setting roles at org update time' do
         let(:other_user) { User.make }
         let(:name) { 'myorg' }
-        let(:uri) { "/v2/organizations/#{org.guid}"}
+        let(:uri) { "/v2/organizations/#{org.guid}" }
 
         before do
           set_current_user_as_admin
@@ -479,7 +479,6 @@ module VCAP::CloudController
               expect(event).to be_nil
             end
           end
-
         end
 
         context 'deassigning an org manager' do

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -436,6 +436,192 @@ module VCAP::CloudController
       end
     end
 
+    describe 'PUT /v2/organizations/:guid' do
+      context 'setting roles at org update time' do
+        let(:other_user) { User.make }
+        let(:name) { 'myorg' }
+        let(:uri) { "/v2/organizations/#{org.guid}"}
+
+        before do
+          set_current_user_as_admin
+        end
+
+        context 'assigning an org manager' do
+          it 'records an event of type audit.user.organization_manager_add' do
+            event = Event.find(type: 'audit.user.organization_manager_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, manager_guids: [other_user.guid] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+
+            expect(org.managers).to include(other_user)
+
+            event = Event.find(type: 'audit.user.organization_manager_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+
+          context 'when there is already another org manager' do
+            let(:mgr) { User.make }
+
+            before do
+              org.add_manager(mgr)
+            end
+
+            it 'does not record an event for existing org managers' do
+              request_body = { name: name, manager_guids: [other_user.guid, mgr.guid] }.to_json
+              put uri, request_body
+
+              expect(last_response).to have_status_code(201)
+
+              event = Event.find(type: 'audit.user.organization_manager_add', actee: mgr.guid)
+              expect(event).to be_nil
+            end
+          end
+
+        end
+
+        context 'deassigning an org manager' do
+          let(:another_user) { User.make }
+
+          before do
+            org.add_manager(other_user)
+            org.add_manager(another_user)
+          end
+
+          it 'records an event of type audit.user.organization_manager_remove' do
+            event = Event.find(type: 'audit.user.organization_manager_remove', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, manager_guids: [another_user.guid] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+            org.reload
+            expect(org.managers).to_not include(other_user)
+
+            event = Event.find(type: 'audit.user.organization_manager_remove', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'assigning an auditor' do
+          it 'records an event of type audit.user.organization_auditor_add' do
+            event = Event.find(type: 'audit.user.organization_auditor_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, auditor_guids: [other_user.guid] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+
+            expect(org.auditors).to include(other_user)
+
+            event = Event.find(type: 'audit.user.organization_auditor_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'deassigning an auditor' do
+          before do
+            org.add_auditor(other_user)
+          end
+
+          it 'records an event of type audit.user.organization_auditor_remove' do
+            event = Event.find(type: 'audit.user.organization_auditor_remove', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, auditor_guids: [] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+            org.reload
+            expect(org.auditors).to_not include(other_user)
+
+            event = Event.find(type: 'audit.user.organization_auditor_remove', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'assigning a billing manager' do
+          it 'records an event of type audit.user.organization_billing_manager_add' do
+            event = Event.find(type: 'audit.user.organization_billing_manager_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, billing_manager_guids: [other_user.guid] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+
+            expect(org.billing_managers).to include(other_user)
+
+            event = Event.find(type: 'audit.user.organization_billing_manager_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'deassigning a billing manager' do
+          before do
+            org.add_billing_manager(other_user)
+          end
+
+          it 'records an event of type audit.user.organization_billing_manager_remove' do
+            event = Event.find(type: 'audit.user.organization_billing_manager_remove', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, billing_manager_guids: [] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+            org.reload
+            expect(org.billing_managers).to_not include(other_user)
+
+            event = Event.find(type: 'audit.user.organization_billing_manager_remove', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'assigning a user' do
+          it 'records an event of type audit.user.organization_user_add' do
+            event = Event.find(type: 'audit.user.organization_user_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, user_guids: [other_user.guid] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+
+            expect(org.users).to include(other_user)
+
+            event = Event.find(type: 'audit.user.organization_user_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'removing a user' do
+          before do
+            org.add_user(other_user)
+          end
+
+          it 'records an event of type audit.user.organization_user_remove' do
+            event = Event.find(type: 'audit.user.organization_user_remove', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { name: name, user_guids: [] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+            org.reload
+            expect(org.users).to_not include(other_user)
+
+            event = Event.find(type: 'audit.user.organization_user_remove', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+      end
+    end
+
     describe 'GET /v2/organizations/:guid/user_roles' do
       context 'for an organization that does not exist' do
         it 'returns a 404' do
@@ -835,7 +1021,7 @@ module VCAP::CloudController
           expect(org.users).not_to include(user)
         end
 
-        it 'should not remove the user if they attempt to delete the user through an update' do
+        it 'should not remove the user if the user belongs to a space within the org' do
           org.add_space(org_space_full)
           put "/v2/organizations/#{org.guid}", MultiJson.dump('user_guids' => [])
           expect(last_response.status).to eql(400)

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -1458,7 +1458,7 @@ module VCAP::CloudController
 
       context 'setting roles at space update time' do
         let(:other_user) { User.make }
-        let(:uri) { "/v2/spaces/#{space.guid}"}
+        let(:uri) { "/v2/spaces/#{space.guid}" }
 
         before do
           set_current_user_as_admin
@@ -1499,7 +1499,6 @@ module VCAP::CloudController
               expect(event).to be_nil
             end
           end
-
         end
 
         context 'deassigning an space manager' do

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -1455,6 +1455,154 @@ module VCAP::CloudController
           end
         end
       end
+
+      context 'setting roles at space update time' do
+        let(:other_user) { User.make }
+        let(:uri) { "/v2/spaces/#{space.guid}"}
+
+        before do
+          set_current_user_as_admin
+          space.organization.add_user(other_user)
+        end
+
+        context 'assigning a space manager' do
+          it 'records an event of type audit.user.space_manager_add' do
+            event = Event.find(type: 'audit.user.space_manager_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { manager_guids: [other_user.guid] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+
+            expect(space.managers).to include(other_user)
+
+            event = Event.find(type: 'audit.user.space_manager_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+
+          context 'when there is already another space manager' do
+            let(:mgr) { User.make }
+
+            before do
+              space.organization.add_user(mgr)
+              space.add_manager(mgr)
+            end
+
+            it 'does not record an event for existing space managers' do
+              request_body = { manager_guids: [other_user.guid, mgr.guid] }.to_json
+              put uri, request_body
+
+              expect(last_response).to have_status_code(201)
+
+              event = Event.find(type: 'audit.user.space_manager_add', actee: mgr.guid)
+              expect(event).to be_nil
+            end
+          end
+
+        end
+
+        context 'deassigning an space manager' do
+          let(:another_user) { User.make }
+
+          before do
+            space.organization.add_user(another_user)
+            space.add_manager(other_user)
+            space.add_manager(another_user)
+          end
+
+          it 'records an event of type audit.user.space_manager_remove' do
+            event = Event.find(type: 'audit.user.space_manager_remove', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { manager_guids: [another_user.guid] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+            space.reload
+            expect(space.managers).to_not include(other_user)
+
+            event = Event.find(type: 'audit.user.space_manager_remove', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'assigning an auditor' do
+          it 'records an event of type audit.user.space_auditor_add' do
+            event = Event.find(type: 'audit.user.space_auditor_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { auditor_guids: [other_user.guid] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+
+            expect(space.auditors).to include(other_user)
+
+            event = Event.find(type: 'audit.user.space_auditor_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'deassigning an auditor' do
+          before do
+            space.add_auditor(other_user)
+          end
+
+          it 'records an event of type audit.user.space_auditor_remove' do
+            event = Event.find(type: 'audit.user.space_auditor_remove', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { auditor_guids: [] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+            space.reload
+            expect(space.auditors).to_not include(other_user)
+
+            event = Event.find(type: 'audit.user.space_auditor_remove', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'assigning a developer' do
+          it 'records an event of type audit.user.space_developer_add' do
+            event = Event.find(type: 'audit.user.space_developer_add', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { developer_guids: [other_user.guid] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+
+            expect(space.developers).to include(other_user)
+
+            event = Event.find(type: 'audit.user.space_developer_add', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+
+        context 'removing a developer' do
+          before do
+            space.add_developer(other_user)
+          end
+
+          it 'records an event of type audit.user.space_developer_remove' do
+            event = Event.find(type: 'audit.user.space_developer_remove', actee: other_user.guid)
+            expect(event).to be_nil
+
+            request_body = { developer_guids: [] }.to_json
+            put uri, request_body
+
+            expect(last_response).to have_status_code(201)
+            space.reload
+            expect(space.developers).to_not include(other_user)
+
+            event = Event.find(type: 'audit.user.space_developer_remove', actee: other_user.guid)
+            expect(event).not_to be_nil
+          end
+        end
+      end
     end
 
     describe 'DELETE /v2/spaces/:guid/isolation_segment' do


### PR DESCRIPTION
- Covers when the roles are enumerated in the request body

These are the last (I think) endpoints whereby user roles can be assigned in spaces/orgs, so making the behavior of them consistent with the others.  Long-term, all of these endpoints should be refactored to use a common code path, but that isn't part of this PR.