### PR TITLE
Update fingerprint description with list of supported hashes

### DIFF
--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -78,7 +78,7 @@ properties:
         router_group_name: default-tcp
 
   app_ssh.host_key_fingerprint:
-    description: "MD5 fingerprint of the host key of the SSH proxy that brokers connections to application instances"
+    description: "Fingerprint of the host key of the SSH proxy that brokers connections to application instances. SHA256, SHA1 and MD5 hashes are supported."
     default: ~
   app_ssh.port:
     description: "External port for SSH access to application instances"


### PR DESCRIPTION
The current version of the CF CLI supports MD5 and SHA1. The forthcoming version will support SHA256 hash verification.