### PR TITLE
Fix race condition in app object presentation

### DIFF
--- a/app/presenters/v2/app_presenter.rb
+++ b/app/presenters/v2/app_presenter.rb
@@ -41,9 +41,16 @@ module CloudController
           }
 
           entity.merge!(RelationsPresenter.new.to_hash(controller, app, opts, depth, parents, orphans))
+        rescue NoMethodError => e
+          logger.info("Error presenting app: no associated object: #{e}")
+          nil
         end
 
         private
+
+        def logger
+          @logger ||= Steno.logger('cc.presenter.app')
+        end
 
         def buildpack_name_or_url(buildpack)
           if buildpack.class == VCAP::CloudController::CustomBuildpack

--- a/lib/cloud_controller/rest_controller/paginated_collection_renderer.rb
+++ b/lib/cloud_controller/rest_controller/paginated_collection_renderer.rb
@@ -100,7 +100,8 @@ module VCAP::CloudController::RestController
       transform_opts = opts[:transform_opts] || {}
       collection_transformer.transform(dataset_records, transform_opts) if collection_transformer
 
-      dataset_records.map { |obj| @serializer.serialize(controller, obj, opts, orphans) }
+      serialized_records = dataset_records.map { |obj| @serializer.serialize(controller, obj, opts, orphans) }
+      serialized_records.select { |obj| !obj.nil? }
     end
 
     def default_visibility_filter

--- a/spec/unit/presenters/v2/app_presenter_spec.rb
+++ b/spec/unit/presenters/v2/app_presenter_spec.rb
@@ -87,6 +87,23 @@ module CloudController::Presenters::V2
         expect(relations_presenter).to have_received(:to_hash).with(controller, app, opts, depth, parents, orphans)
       end
 
+      describe 'nil associated objects' do
+        context 'when an associated object is not present' do
+          before do
+            parent_app = app.app
+            app.destroy
+            parent_app.packages.map(&:destroy)
+            parent_app.droplets.map(&:destroy)
+            parent_app.destroy
+          end
+
+          it 'returns nil' do
+            actual_entity_hash = app_presenter.entity_hash(controller, app, opts, depth, parents, orphans)
+            expect(actual_entity_hash).to be_nil
+          end
+        end
+      end
+
       describe 'buildpacks' do
         context 'with a custom buildpack' do
           it 'displays the correct url' do


### PR DESCRIPTION
There is a race condition in app presentation with app deletion.  If the `process` object is fetched, and then the app is deleted from underneath it before it is serialized for presentation, this will cause a null pointer exception.

Tracker story: https://www.pivotaltracker.com/n/projects/966314/stories/140964377

* [x ] I have viewed signed and have submitted the Contributor License Agreement

* [x ] I have made this pull request to the `master` branch

* [x ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run CF Acceptance Tests on bosh lite
