### PR TITLE
Add option to overwrite security groups when seeding

### DIFF
--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -534,11 +534,11 @@ properties:
       description: "Set of buildpacks to install during deploy"
 
   cc.security_group_definitions:
-    description: "Array of security groups that will be seeded into CloudController."
+    description: "Array of security groups that will be seeded into CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
   cc.default_running_security_groups:
-    description: "The default running security groups that will be seeded in CloudController."
+    description: "The default running security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
   cc.default_staging_security_groups:
-    description: "The default staging security groups that will be seeded in CloudController."
+    description: "The default staging security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
 
   cc.thresholds.api.alert_if_above_mb:
     description: "The cc will alert if memory remains above this threshold for 3 monit cycles"

--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -534,11 +534,14 @@ properties:
       description: "Set of buildpacks to install during deploy"
 
   cc.security_group_definitions:
-    description: "Array of security groups that will be seeded into CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+    description: "Array of security groups that will be seeded into CloudController. Note: security groups are only seeded on the first deploy (unless overwrite_security_groups is true), after which they should be managed via the API"
   cc.default_running_security_groups:
-    description: "The default running security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+    description: "The default running security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy (unless overwrite_security_groups is true), after which they should be managed via the API"
   cc.default_staging_security_groups:
-    description: "The default staging security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+    description: "The default staging security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy (unless overwrite_security_groups is true), after which they should be managed via the API"
+  cc.overwrite_security_groups:
+    description: "If set to true, it will not only create the security groups on first deploy, but also update them on later deploys."
+    default: false
 
   cc.thresholds.api.alert_if_above_mb:
     description: "The cc will alert if memory remains above this threshold for 3 monit cycles"

--- a/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
@@ -346,6 +346,7 @@ app_bits_upload_grace_period_in_seconds: <%= p("cc.app_bits_upload_grace_period_
 security_group_definitions: <%= p("cc.security_group_definitions").to_json %>
 default_running_security_groups: <%= p("cc.default_running_security_groups").to_json %>
 default_staging_security_groups: <%= p("cc.default_staging_security_groups").to_json %>
+overwrite_security_groups: <%= p("cc.overwrite_security_groups") %>
 
 system_hostnames: <%= p("cc.system_hostnames") %>
 

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -702,11 +702,14 @@ properties:
     default: 1200
 
   cc.security_group_definitions:
-    description: "Array of security groups that will be seeded into CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+    description: "Array of security groups that will be seeded into CloudController. Note: security groups are only seeded on the first deploy (unless overwrite_security_groups is true), after which they should be managed via the API"
   cc.default_running_security_groups:
-    description: "The default running security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+    description: "The default running security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy (unless overwrite_security_groups is true), after which they should be managed via the API"
   cc.default_staging_security_groups:
-    description: "The default staging security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+    description: "The default staging security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy (unless overwrite_security_groups is true), after which they should be managed via the API"
+  cc.overwrite_security_groups:
+    description: "If set to true, it will not only create the security groups on first deploy, but also update them on later deploys."
+    default: false
 
   cc.feature_disabled_message:
     description: "Custom message to use for a disabled feature."

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -388,6 +388,7 @@ app_bits_upload_grace_period_in_seconds: <%= p("cc.app_bits_upload_grace_period_
 security_group_definitions: <%= p("cc.security_group_definitions").to_json %>
 default_running_security_groups: <%= p("cc.default_running_security_groups").to_json %>
 default_staging_security_groups: <%= p("cc.default_staging_security_groups").to_json %>
+overwrite_security_groups: <%= p("cc.overwrite_security_groups") %>
 
 <% if_p("cc.feature_disabled_message") do %>
 feature_disabled_message: <%= p("cc.feature_disabled_message") %>

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -546,11 +546,11 @@ properties:
     description: "Set of buildpacks to install during deploy"
 
   cc.security_group_definitions:
-    description: "Array of security groups that will be seeded into CloudController."
+    description: "Array of security groups that will be seeded into CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
   cc.default_running_security_groups:
-    description: "The default running security groups that will be seeded in CloudController."
+    description: "The default running security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
   cc.default_staging_security_groups:
-    description: "The default staging security groups that will be seeded in CloudController."
+    description: "The default staging security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
 
   cc.thresholds.worker.alert_if_above_mb:
     description: "The cc will alert if memory remains above this threshold for 3 monit cycles"

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -546,11 +546,14 @@ properties:
     description: "Set of buildpacks to install during deploy"
 
   cc.security_group_definitions:
-    description: "Array of security groups that will be seeded into CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+    description: "Array of security groups that will be seeded into CloudController. Note: security groups are only seeded on the first deploy (unless overwrite_security_groups is true), after which they should be managed via the API"
   cc.default_running_security_groups:
-    description: "The default running security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+    description: "The default running security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy (unless overwrite_security_groups is true), after which they should be managed via the API"
   cc.default_staging_security_groups:
-    description: "The default staging security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy, after which they should be managed via the API"
+    description: "The default staging security groups that will be seeded in CloudController. Note: security groups are only seeded on the first deploy (unless overwrite_security_groups is true), after which they should be managed via the API"
+  cc.overwrite_security_groups:
+    description: "If set to true, it will not only create the security groups on first deploy, but also update them on later deploys."
+    default: false
 
   cc.thresholds.worker.alert_if_above_mb:
     description: "The cc will alert if memory remains above this threshold for 3 monit cycles"

--- a/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
@@ -340,6 +340,7 @@ app_bits_upload_grace_period_in_seconds: <%= p("cc.app_bits_upload_grace_period_
 security_group_definitions: <%= p("cc.security_group_definitions").to_json %>
 default_running_security_groups: <%= p("cc.default_running_security_groups").to_json %>
 default_staging_security_groups: <%= p("cc.default_staging_security_groups").to_json %>
+overwrite_security_groups: <%= p("cc.overwrite_security_groups") %>
 
 system_hostnames: <%= p("cc.system_hostnames") %>
 

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -170,6 +170,7 @@ module VCAP::CloudController
         ],
         :default_staging_security_groups => [String],
         :default_running_security_groups => [String],
+        optional(:overwrite_security_groups) => bool,
 
         :resource_pool => {
           optional(:maximum_size) => Integer,

--- a/spec/unit/lib/cloud_controller/seeds_spec.rb
+++ b/spec/unit/lib/cloud_controller/seeds_spec.rb
@@ -536,7 +536,7 @@ module VCAP::CloudController
 
         it 'updates already existing security groups with new attributes' do
           staging_def = config[:security_group_definitions][0]
-          staging_def['rules'] = [{'destination' => '0.0.0.0-9.255.255.255', 'protocol' => 'all'}]
+          staging_def['rules'] = [{ 'destination' => '0.0.0.0-9.255.255.255', 'protocol' => 'all' }]
           config[:default_staging_security_groups].delete(staging_def['name'])
           config[:default_running_security_groups] << staging_def['name']
 


### PR DESCRIPTION
In the current implementation of the CC, security groups specified in the configuration are created in the database **only** on the first deploy. On subsequent deploys, any changes in the configuration are not applied to the database.

In our use case, we'd like to have the CC configuration/CF deployment manifest as a single source of truth for some security groups, i.e. the global ones like public_networks, services, dns.

Currently, we specify these security groups on the initial CF deploy.
When we change them after this, we have to update them manually using the CF API (which is ok).
But the security groups specified in the CF deployment manifest are now outdated (which leads to confusion), so we need to update them there as well.

This PR adds an option that, if enabled, applies the security group definition from the CC configuration on every deploy. This allows us do manage the global security groups only using the CC config.

We're aware that not all security groups will be in the CC configuration (i.e. those created for specific spaces only), but we'd still to manage the set of global security groups using the deployment manifest alone. Also, the case that old security groups might be left in the database if removed from the config definition is fine for our use case since we most probably won't delete them ever.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [ ] I have run CF Acceptance Tests on bosh lite

I was not able to run the CF Acceptance tests successfully on my laptop - even the current master branch had some failures (mostly due to timeouts - the whole suite took almost 3 hours). I did test it intensely on bosh-lite though and I'm pretty confident it doesn't break stuff. 