### PR TITLE
Add option to overwrite quota definitions when seeding

### DIFF
--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -218,7 +218,7 @@ properties:
           total_reserved_route_ports: 10
 
   cc.overwrite_quota_definitions:
-    description: "If set to true, it will not only create quota definitions when not existing, but update existing quotas when their definition in quota_definitions changes.".
+    description: "If set to true, it will not only create quota definitions when not existing, but update existing quotas when their definition in quota_definitions changes."
     default: false
 
   cc.default_quota_definition:

--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -207,7 +207,7 @@ properties:
     description: "User's password used to access internal endpoints of Cloud Controller to upload files when staging"
 
   cc.quota_definitions:
-    description: "Hash of default quota definitions to be seeded. This property can be used to add quotas with subsequent deploys, but not to update existing ones."
+    description: "Hash of default quota definitions to be seeded. This property can be used to add quotas with subsequent deploys, but not to update existing ones (unless overwrite_quota_definitions is true)."
     example: |
       - example-quota:
           memory_limit: 10240
@@ -216,6 +216,10 @@ properties:
           total_service_keys: 1000
           total_services: 100
           total_reserved_route_ports: 10
+
+  cc.overwrite_quota_definitions:
+    description: "If set to true, it will not only create quota definitions when not existing, but update existing quotas when their definition in quota_definitions changes.".
+    default: false
 
   cc.default_quota_definition:
     default: default

--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -207,11 +207,19 @@ properties:
     description: "User's password used to access internal endpoints of Cloud Controller to upload files when staging"
 
   cc.quota_definitions:
-    description: "Hash of default quota definitions. Overriden by custom quota definitions."
+    description: "Hash of default quota definitions to be seeded. This property can be used to add quotas with subsequent deploys, but not to update existing ones."
+    example: |
+      - example-quota:
+          memory_limit: 10240
+          non_basic_services_allowed: true
+          total_routes: 1000
+          total_service_keys: 1000
+          total_services: 100
+          total_reserved_route_ports: 10
 
   cc.default_quota_definition:
     default: default
-    description: "Local to use a local (NFS) file system.  AWS to use AWS."
+    description: "The name of the quota definition CC will fallback on for org and space limits from the list of quota definitions."
 
   cc.resource_pool.blobstore_type:
     description: "The type of blobstore backing to use. Valid values: ['fog', 'webdav']"

--- a/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
@@ -219,6 +219,7 @@ quota_definitions:
     <%= key %>: <%= value %><% end %>
   <% end %>
 
+overwrite_quota_definitions: <%= p("cc.overwrite_quota_definitions") %>
 default_quota_definition: <%= p("cc.default_quota_definition") %>
 
 # TODO: we believe these blobstore properties are not used by the clock, but our Config parser requires these properties

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -282,7 +282,7 @@ properties:
           total_reserved_route_ports: 10
 
   cc.overwrite_quota_definitions:
-    description: "If set to true, it will not only create quota definitions when not existing, but update existing quotas when their definition in quota_definitions changes.".
+    description: "If set to true, it will not only create quota definitions when not existing, but update existing quotas when their definition in quota_definitions changes."
     default: false
 
   cc.default_quota_definition:

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -271,7 +271,7 @@ properties:
     description: "User's password used to access internal endpoints of Cloud Controller to upload files when staging"
 
   cc.quota_definitions:
-    description: "Hash of default quota definitions to be seeded. This property can be used to add quotas with subsequent deploys, but not to update existing ones."
+    description: "Hash of default quota definitions to be seeded. This property can be used to add quotas with subsequent deploys, but not to update existing ones (unless overwrite_quota_definitions is true)."
     example: |
       - example-quota:
           memory_limit: 10240
@@ -280,6 +280,10 @@ properties:
           total_service_keys: 1000
           total_services: 100
           total_reserved_route_ports: 10
+
+  cc.overwrite_quota_definitions:
+    description: "If set to true, it will not only create quota definitions when not existing, but update existing quotas when their definition in quota_definitions changes.".
+    default: false
 
   cc.default_quota_definition:
     default: default

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -253,6 +253,7 @@ quota_definitions:
     <%= key %>: <%= value %><% end %>
   <% end %>
 
+overwrite_quota_definitions: <%= p("cc.overwrite_quota_definitions") %>
 default_quota_definition: <%= p("cc.default_quota_definition") %>
 
 resource_pool:

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -208,11 +208,19 @@ properties:
     description: "User's password used to access internal endpoints of Cloud Controller to upload files when staging"
 
   cc.quota_definitions:
-    description: "Hash of default quota definitions. Overriden by custom quota definitions."
+    description: "Hash of default quota definitions to be seeded. This property can be used to add quotas with subsequent deploys, but not to update existing ones."
+    example: |
+      - example-quota:
+          memory_limit: 10240
+          non_basic_services_allowed: true
+          total_routes: 1000
+          total_service_keys: 1000
+          total_services: 100
+          total_reserved_route_ports: 10
 
   cc.default_quota_definition:
     default: default
-    description: "Local to use a local (NFS) file system.  AWS to use AWS."
+    description: "The name of the quota definition CC will fallback on for org and space limits from the list of quota definitions."
 
   cc.resource_pool.blobstore_type:
     description: "The type of blobstore backing to use. Valid values: ['fog', 'webdav']"

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -208,7 +208,7 @@ properties:
     description: "User's password used to access internal endpoints of Cloud Controller to upload files when staging"
 
   cc.quota_definitions:
-    description: "Hash of default quota definitions to be seeded. This property can be used to add quotas with subsequent deploys, but not to update existing ones."
+    description: "Hash of default quota definitions to be seeded. This property can be used to add quotas with subsequent deploys, but not to update existing ones (unless overwrite_quota_definitions is true)."
     example: |
       - example-quota:
           memory_limit: 10240
@@ -217,6 +217,10 @@ properties:
           total_service_keys: 1000
           total_services: 100
           total_reserved_route_ports: 10
+
+  cc.overwrite_quota_definitions:
+    description: "If set to true, it will not only create quota definitions when not existing, but update existing quotas when their definition in quota_definitions changes.".
+    default: false
 
   cc.default_quota_definition:
     default: default

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -219,7 +219,7 @@ properties:
           total_reserved_route_ports: 10
 
   cc.overwrite_quota_definitions:
-    description: "If set to true, it will not only create quota definitions when not existing, but update existing quotas when their definition in quota_definitions changes.".
+    description: "If set to true, it will not only create quota definitions when not existing, but update existing quotas when their definition in quota_definitions changes."
     default: false
 
   cc.default_quota_definition:

--- a/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
@@ -212,6 +212,7 @@ quota_definitions:
     <%= key %>: <%= value %><% end %>
   <% end %>
 
+overwrite_quota_definitions: <%= p("cc.overwrite_quota_definitions") %>
 default_quota_definition: <%= p("cc.default_quota_definition") %>
 
 resource_pool:

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -152,6 +152,7 @@ module VCAP::CloudController
         },
 
         :quota_definitions => Hash,
+        optional(:overwrite_quota_definitions) => bool,
         :default_quota_definition => String,
 
         :security_group_definitions => [

--- a/lib/cloud_controller/seeds.rb
+++ b/lib/cloud_controller/seeds.rb
@@ -31,7 +31,11 @@ module VCAP::CloudController
           if quota
             quota.set(values)
             if quota.modified?
-              Steno.logger('cc.seeds').warn('seeds.quota-collision', name: name, values: values)
+              if config[:overwrite_quota_definitions]
+                quota.save
+              else
+                Steno.logger('cc.seeds').warn('seeds.quota-collision', name: name, values: values)
+              end
             end
           else
             QuotaDefinition.create(values.merge(name: name.to_s))


### PR DESCRIPTION
Same use case as https://github.com/cloudfoundry/cloud_controller_ng/pull/800 but for quotas: We'd like to manage our default quotas using the CF deployment manifest as a single source of truth.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [ ] I have run CF Acceptance Tests on bosh lite

Unfortunately, I was not able to run them due to timeouts but tested them using bosh-lite.