### PR TITLE
cloud_controller can find database address from a link

### DIFF
--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -29,6 +29,9 @@ consumes:
 - name: nats
   type: nats
   optional: true
+- name: database
+  type: database
+  optional: true
 
 properties:
   ssl.skip_cert_verify:

--- a/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/cloud_controller_clock.yml.erb
@@ -169,8 +169,16 @@ loggregator:
 
 <% db = p("ccdb.databases").find { |db| db["tag"] == "cc" } %>
 <% db_role = p("ccdb.roles").find { |role| role["tag"] == "admin" } %>
+<%
+  database_address = nil
+  if_p('ccdb.address') do |host|
+    database_address = host
+  end.else do
+    database_address = link('database').instances[0].address
+  end
+%>
 db: &db
-  database: <%= p("ccdb.db_scheme") == "mysql" ? "mysql2" : p("ccdb.db_scheme") %>://<%= db_role["name"] %>:<%= db_role["password"] %>@<%= p("ccdb.address") %>:<%= p("ccdb.port") %>/<%= db["name"] %>
+  database: <%= p("ccdb.db_scheme") == "mysql" ? "mysql2" : p("ccdb.db_scheme") %>://<%= db_role["name"] %>:<%= db_role["password"] %>@<%= database_address %>:<%= p("ccdb.port") %>/<%= db["name"] %>
   max_connections: <%= p("ccdb.max_connections") %>
   pool_timeout: <%= p("ccdb.pool_timeout") %>
   log_level: <%= p("cc.db_logging_level") %>

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -57,6 +57,9 @@ consumes:
 - name: nats
   type: nats
   optional: true
+- name: database
+  type: database
+  optional: true
 
 properties:
   ssl.skip_cert_verify:

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_api.yml.erb
@@ -196,8 +196,16 @@ doppler:
 
 <% db = p("ccdb.databases").find { |db| db["tag"] == "cc" } %>
 <% db_role = p("ccdb.roles").find { |role| role["tag"] == "admin" } %>
+<%
+  database_address = nil
+  if_p('ccdb.address') do |host|
+    database_address = host
+  end.else do
+    database_address = link('database').instances[0].address
+  end
+%>
 db: &db
-  database: <%= p("ccdb.db_scheme") == "mysql" ? "mysql2" : p("ccdb.db_scheme") %>://<%= db_role["name"] %>:<%= CGI.escape(db_role["password"]) %>@<%= p("ccdb.address") %>:<%= p("ccdb.port") %>/<%= db["name"] %>
+  database: <%= p("ccdb.db_scheme") == "mysql" ? "mysql2" : p("ccdb.db_scheme") %>://<%= db_role["name"] %>:<%= CGI.escape(db_role["password"]) %>@<%= database_address %>:<%= p("ccdb.port") %>/<%= db["name"] %>
   max_connections: <%= p("ccdb.max_connections") %>
   pool_timeout: <%= p("ccdb.pool_timeout") %>
   log_level: <%= p("cc.db_logging_level") %>

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -35,6 +35,9 @@ consumes:
 - name: nats
   type: nats
   optional: true
+- name: database
+  type: database
+  optional: true
 
 properties:
   ssl.skip_cert_verify:

--- a/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
@@ -162,8 +162,16 @@ loggregator:
 
 <% db = p("ccdb.databases").find { |db| db["tag"] == "cc" } %>
 <% db_role = p("ccdb.roles").find { |role| role["tag"] == "admin" } %>
+<%
+  database_address = nil
+  if_p('ccdb.address') do |host|
+    database_address = host
+  end.else do
+    database_address = link('database').instances[0].address
+  end
+%>
 db: &db
-  database: <%= p("ccdb.db_scheme") == "mysql" ? "mysql2" : p("ccdb.db_scheme") %>://<%= db_role["name"] %>:<%= db_role["password"] %>@<%= p("ccdb.address") %>:<%= p("ccdb.port") %>/<%= db["name"] %>
+  database: <%= p("ccdb.db_scheme") == "mysql" ? "mysql2" : p("ccdb.db_scheme") %>://<%= db_role["name"] %>:<%= db_role["password"] %>@<%= database_address %>:<%= p("ccdb.port") %>/<%= db["name"] %>
   max_connections: <%= p("ccdb.max_connections") %>
   pool_timeout: <%= p("ccdb.pool_timeout") %>
   log_level: <%= p("cc.db_logging_level") %>


### PR DESCRIPTION
By (optionally) consuming a database link, deployment manifests
do not need to specify explicit database addresses in their
manifest, which allows the manifest to be simpler and more
automatable.

This currently only looks for address because that is the
only property consistent in database links. When database links
begin providing more-comprehensive properties, the consumption
can be updated.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
