### PR TITLE
use https instead of http to harmonize with cloud_controller_ng job t…

### DIFF
--- a/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/cloud_controller_worker.yml.erb
@@ -395,7 +395,7 @@ uaa :
   ca_file: /var/vcap/jobs/cloud_controller_worker/config/certs/uaa_ca.crt
 
 routing_api:
-  url: <%= "http://api.#{system_domain}/routing" %>
+  url: <%= "https://api.#{system_domain}/routing" %>
   routing_client_name: "cc_routing"
   routing_client_secret: <%= p("uaa.clients.cc_routing.secret") %>
 <% end %>


### PR DESCRIPTION
* A short explanation of the proposed change:
https should be the default for all urls (and it is the default in the same section of the cloud_controller_ng job template)

* An explanation of the use cases your change solves
Make it work in environments where plain http is disabled.

* Links to any other associated PRs
none

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [-] I have run all the unit tests using `bundle exec rake`

* [-] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
