### PR TITLE
Increase ssl_verify_depth for more complex ca ceritficate validation

### DIFF
--- a/bosh/jobs/cloud_controller_ng/templates/nginx.conf.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/nginx.conf.erb
@@ -59,6 +59,7 @@ http {
     ssl_certificate_key    /var/vcap/jobs/cloud_controller_ng/config/certs/mutual_tls.key;
     ssl_client_certificate /var/vcap/jobs/cloud_controller_ng/config/certs/mutual_tls_ca.crt;
     ssl_verify_client      on;
+    ssl_verify_depth       2;
     ssl_protocols          TLSv1.2;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;


### PR DESCRIPTION
We use a more complex CA cert and we are seeing failures on the internal communication between TPS and CC as the client cert cannot be validated with the default value.

All tests pass as this is a very small change and does not effect current tests.

Did not add a new test as that would be more an integration level test to add new more complex certs.  This will allow us to support our deeper cert chain.