### PR TITLE
Update Broker API version to 2.11

### DIFF
--- a/lib/services/service_brokers/v2/http_client.rb
+++ b/lib/services/service_brokers/v2/http_client.rb
@@ -152,7 +152,7 @@ module VCAP::Services
 
       def default_headers
         {
-          VCAP::Request::HEADER_BROKER_API_VERSION => '2.10',
+          VCAP::Request::HEADER_BROKER_API_VERSION => '2.11',
           VCAP::Request::HEADER_NAME => VCAP::Request.current_id,
           'Accept' => 'application/json',
           VCAP::Request::HEADER_API_INFO_LOCATION => "#{VCAP::CloudController::Config.config[:external_domain]}/v2/info"

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.8_spec.rb' => '54c9fe10b8a3127c18d28ddf4a1bce9b',
       'broker_api_v2.9_spec.rb' => '9de8ebbdc0e2b60b791c6f7db4e1c8ee',
       'broker_api_v2.10_spec.rb' => 'e0e22844e576d69067c4891c8ada611c',
+      'broker_api_v2.11_spec.rb' => '99e61dc50ceb635b09b3bd16901a4fa6',
     }
   end
   let(:digester) { Digester.new(algorithm: Digest::MD5) }

--- a/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
@@ -42,7 +42,7 @@ module VCAP::Services::ServiceBrokers::V2
         make_request
         expect(a_request(http_method, full_url).
           with(query: hash_including({})).
-          with(headers: { 'X-Broker-Api-Version' => '2.10' })).
+          with(headers: { 'X-Broker-Api-Version' => '2.11' })).
           to have_been_made
       end
 
@@ -74,7 +74,7 @@ module VCAP::Services::ServiceBrokers::V2
         make_request
         expect(fake_logger).to have_received(:debug).with(match(%r{Accept"=>"application/json}))
         expect(fake_logger).to have_received(:debug).with(match(/X-VCAP-Request-ID"=>"[[:alnum:]-]+/))
-        expect(fake_logger).to have_received(:debug).with(match(/X-Broker-Api-Version"=>"2\.10/))
+        expect(fake_logger).to have_received(:debug).with(match(/X-Broker-Api-Version"=>"2\.11/))
         expect(fake_logger).to have_received(:debug).with(match(%r{X-Api-Info-Location"=>"api2\.vcap\.me/v2/info}))
       end
 


### PR DESCRIPTION
Services API Tracker story [#144874487](https://www.pivotaltracker.com/story/show/144874487)

## Why

Service Broker API v2.11 included adding bindable at the plan level. The implementation, corresponding [compatibility test](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/spec/acceptance/broker_api_compatibility/broker_api_v2.11_spec.rb) and the [docs](https://docs.cloudfoundry.org/services/api.html) were added, however the version header sent by CAPI to service brokers was not updated.

## What

Update X-Broker-Api-Version header from 2.10 to 2.11.

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Sam & @ablease

cc: @matthewmcnew