### PR TITLE
Add CFisms to context object in service broker api

### DIFF
--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -3,6 +3,7 @@ require 'jobs/services/service_instance_state_fetch'
 module VCAP::Services::ServiceBrokers::V2
   class Client
     CATALOG_PATH = '/v2/catalog'.freeze
+    PLATFORM = 'cloudfoundry'.freeze
 
     attr_reader :orphan_mitigator, :attrs
 
@@ -27,6 +28,11 @@ module VCAP::Services::ServiceBrokers::V2
         plan_id: instance.service_plan.broker_provided_id,
         organization_guid: instance.organization.guid,
         space_guid: instance.space.guid,
+        context: {
+          platform: PLATFORM,
+          organization_guid: instance.organization.guid,
+          space_guid: instance.space.guid
+        }
       }
 
       body[:parameters] = arbitrary_parameters if arbitrary_parameters.present?
@@ -186,7 +192,12 @@ module VCAP::Services::ServiceBrokers::V2
       body = {
         service_id: instance.service.broker_provided_id,
         plan_id: plan.broker_provided_id,
-        previous_values: previous_values
+        previous_values: previous_values,
+        context: {
+          platform: PLATFORM,
+          organization_guid: instance.organization.guid,
+          space_guid: instance.space.guid
+        }
       }
       body[:parameters] = arbitrary_parameters if arbitrary_parameters
       response = @http_client.patch(path, body)

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.12_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.12_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.describe 'Service Broker API integration' do
+  describe 'v2.12' do
+    include VCAP::CloudController::BrokerApiHelper
+
+    let(:catalog) { default_catalog(plan_updateable: true) }
+
+    before do
+      setup_cc
+      setup_broker(catalog)
+      @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+    end
+
+    context 'service provision request' do
+      before do
+        provision_service
+      end
+
+      it 'receives a context object' do
+        expected_body = hash_including(:context)
+        expect(
+          a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}}).with(body: expected_body)
+        ).to have_been_made
+      end
+
+      it 'receives the correct attributes in the context' do
+        expected_body = hash_including(context: {
+          platform: 'cloudfoundry',
+          organization_guid: @org_guid,
+          space_guid: @space_guid,
+        })
+
+        expect(
+          a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}}).with(body: expected_body)
+        ).to have_been_made
+      end
+    end
+
+    context 'service update request' do
+      before do
+        provision_service
+        upgrade_service_instance(200)
+      end
+
+      it 'receives a context object' do
+        expected_body = hash_including(:context)
+
+        expect(
+          a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with(body: expected_body)
+        ).to have_been_made
+      end
+
+      it 'receives the correct attributes in the context' do
+        expected_body = hash_including(context: {
+          platform: 'cloudfoundry',
+          organization_guid: @org_guid,
+          space_guid: @space_guid,
+        })
+
+        expect(
+          a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with(body: expected_body)
+        ).to have_been_made
+      end
+    end
+  end
+end

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -136,7 +136,12 @@ module VCAP::Services::ServiceBrokers::V2
           service_id:        instance.service.broker_provided_id,
           plan_id:           instance.service_plan.broker_provided_id,
           organization_guid: instance.organization.guid,
-          space_guid:        instance.space.guid
+          space_guid:        instance.space.guid,
+          context: {
+            platform: 'cloudfoundry',
+            organization_guid: instance.organization.guid,
+            space_guid: instance.space_guid
+          }
         )
       end
 
@@ -501,6 +506,20 @@ module VCAP::Services::ServiceBrokers::V2
         expect(http_client).to have_received(:patch).with(anything,
           hash_including({
             service_id: instance.service.broker_provided_id,
+          })
+        )
+      end
+
+      it 'makes a patch request with the correct context in the body' do
+        client.update(instance, new_plan, previous_values: { plan_id: '1234' })
+
+        expect(http_client).to have_received(:patch).with(anything,
+          hash_including({
+            context: {
+              platform: 'cloudfoundry',
+              organization_guid: instance.organization.guid,
+              space_guid: instance.space_guid
+            }
           })
         )
       end


### PR DESCRIPTION
Services API Tracker story [#144206883](https://www.pivotaltracker.com/story/show/144206883)

## Why

This PR includes the Cloud Controller changes required to conform to the proposed `Remove CF-isms` changes to the Service Broker API spec. These changes have been discussed by the OpenServiceBroker working group in this [issue](https://github.com/openservicebrokerapi/servicebroker/issues/115) and are in the validation through implementation phase.

## What

This change adds platform specific fields, org guid and space guid, to a new opaque context object. Platform specific fields outside of this context object are considered deprecated and will be removed in future major version of the spec.

Example provision request body

```
{
  "context": {
    "platform": "cloudfoundry",
     "organization_guid": "org-guid-here",
     "space_guid": "space-guid-here",
  },
  "service_id": "service-guid-here",
  "plan_id": "plan-guid-here",
  "organization_guid": "org-guid-here", #Deprecated
  "space_guid": "space-guid-here", #Deprecated
  "parameters": {
    "parameter1": 1,
    "parameter2": "foo"
  }
}
```

Example update request body:

```
{
  "context": {
    "platform": "cloudfoundry",
    "organization_id": "org-guid-here",
    "space_id": "space-guid-here"
  },
  "service_id": "service-guid-here",
  "plan_id": "plan-guid-here",
  "parameters": {
    "parameter1": 1,
    "parameter2": "foo"
  },
  "previous_values": {
    "plan_id": "old-plan-guid-here",
    "service_id": "service-guid-here",
    "organization_id": "org-guid-here", #Deprecated
    "space_id": "space-guid-here" #Deprecated
  }
}
```

Changes:
* Added Context object to provision and update request - preserving existing fields.
* Added broker acceptance test for v2.12 and unit tests

## Notes

This does not include bumping the `X-Broker-Api-Version` to v2.12. This will be a separate PR once the group have fully agreed upon the change. This is tracked [here](#144682123).

For Update, the org and space values that were in `previous_values` have been duplicated in the new context object. The current spec cannot contain both old and new org or space guids, so it was misleading that they were previous values to start with. In the future if platform specific previous values need to be supported then they can be placed in the context object.

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-
acceptance-tests-cats) on bosh lite

## Links
[Open Service Broker Issue](https://github.com/openservicebrokerapi/servicebroker/issues/115)
[Open Service Broker branch with spec changes in full](https://github.com/duglin/servicebroker/tree/CFisms)

@Samze  & @ablease

cc: @matthewmcnew