### PR TITLE
Add port to route uris if present

### DIFF
--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
     end
 
     def uri
-      "#{fqdn}#{path}"
+      "#{fqdn}#{path}#{":#{port}" if !port.nil?}"
     end
 
     def as_summary_json

--- a/spec/unit/models/runtime/route_spec.rb
+++ b/spec/unit/models/runtime/route_spec.rb
@@ -962,6 +962,18 @@ module VCAP::CloudController
             )
             expect(r.uri).to eq("www.#{domain.name}/path")
           end
+          context 'that has a port' do
+            it 'should return the fqdn with the path and port' do
+              r = Route.make(
+                host: 'www',
+                domain: domain,
+                space: space,
+                path: '/path'
+              )
+              r.port = 1041
+              expect(r.uri).to eq("www.#{domain.name}/path:1041")
+            end
+          end
         end
 
         context 'for a nil path' do


### PR DESCRIPTION
[#147569369]

Signed-off-by: Belinda Liu <bliu@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
- Change the route model to return route port as part of it's URI, mainly to include it for tcp routes in VCAP_APPLICATION

* An explanation of the use cases your change solves
For applications to register their uri for service discovery, the route port is necessary.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks,
CF Routing
@jberkhahn && @belinda-liu