### PR TITLE
Update AddConstraintName Rubocop linter to account for additional Sequel methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,6 +104,13 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Migration/AddConstraintName:
+  Include:
+    - 'db/migrations/**/*'
+  Exclude:
+    # skip old migration files since we do not want to fix them after they are in the wild
+    - !ruby/regexp /db/migrations/201([0-6]|70[1-6]).+\.rb$/
+
 Performance/Casecmp:
   Enabled: false
 

--- a/spec/linters/migration/add_constraint_name.rb
+++ b/spec/linters/migration/add_constraint_name.rb
@@ -3,11 +3,15 @@ module RuboCop
     module Migration
       class AddConstraintName < RuboCop::Cop::Cop
         # Postgres and MySQL have different naming conventions, so if we need to remove them we cannot predict accurately what the constraint name would be.
-        MSG = 'Please name your constraint.'.freeze
+        MSG = 'Please explicitly name your index or constraint.'.freeze
+        CONSTRAINT_METHODS = %i{
+          add_unique_constraint add_constraint add_foreign_key add_index add_primary_key add_full_text_index add_spatial_index
+          unique_constraint constraint foreign_key index primary_key full_text_index spatial_index
+        }.freeze
 
         def on_block(node)
           node.each_descendant(:send) do |send_node|
-            next if method_name(send_node) != :add_unique_constraint
+            next unless CONSTRAINT_METHODS.include?(method_name(send_node))
 
             opts = send_node.children.last
             has_named_constraint = false

--- a/spec/linters/migration/add_constraint_name_spec.rb
+++ b/spec/linters/migration/add_constraint_name_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'rubocop'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/config'
+require 'linters/migration/add_constraint_name'
+
+RSpec.describe RuboCop::Cop::Migration::AddConstraintName do
+  include CopHelper
+
+  RSpec.shared_examples 'a cop that validates explicit names are added to the index' do |method_name|
+    it 'registers an offense if index is called without a name' do
+      inspect_source(cop, [
+        'create_table :jobs do',
+        "#{method_name} :foo",
+        'end'
+      ])
+
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq(['Please explicitly name your index or constraint.'])
+    end
+
+    it 'does not register an offense if index is called with a name' do
+      inspect_source(cop, [
+        'create_table :jobs do',
+        "#{method_name} :foo, name: :bar",
+        'end'
+      ])
+
+      expect(cop.offenses.size).to eq(0)
+      expect(cop.messages).to be_empty
+    end
+  end
+
+  subject(:cop) { described_class.new(RuboCop::Config.new({})) }
+
+  context 'when the method is add_unique_constraint' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :add_unique_constraint
+  end
+
+  context 'when the method is add_constraint' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :add_constraint
+  end
+
+  context 'when the method is add_foreign_key' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :add_foreign_key
+  end
+
+  context 'when the method is add_index' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :add_index
+  end
+
+  context 'when the method is add_primary_key' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :add_primary_key
+  end
+
+  context 'when the method is add_full_text_index' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :add_full_text_index
+  end
+
+  context 'when the method is add_spatial_index' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :add_spatial_index
+  end
+
+  context 'when the method is unique_constraint' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :unique_constraint
+  end
+
+  context 'when the method is constraint' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :constraint
+  end
+
+  context 'when the method is foreign_key' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :foreign_key
+  end
+
+  context 'when the method is index' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :index
+  end
+
+  context 'when the method is primary_key' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :primary_key
+  end
+
+  context 'when the method is full_text_index' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :full_text_index
+  end
+
+  context 'when the method is spatial_index' do
+    it_behaves_like 'a cop that validates explicit names are added to the index', :spatial_index
+  end
+end


### PR DESCRIPTION
- The linter now checks additional Sequel methods that can add indices
  or constraints to make sure that we are explicitly setting a name
- Added exclusion for preexisting migrations since we do not want to
  edit any indices in them after they have already been ran in user
  environments

[#148173629]

