### PR TITLE
Use hashdiff to show smaller diffs in hashes in failing tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 group :test do
   gem 'codeclimate-test-reporter', require: false
   gem 'fakefs', require: 'fakefs/safe'
+  gem 'hashdiff'
   gem 'machinist', '~> 1.0.6'
   gem 'parallel_tests'
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,7 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
+    hashdiff (0.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
@@ -435,6 +436,7 @@ DEPENDENCIES
   fog-local
   fog-openstack
   google-api-client (~> 0.8.6)
+  hashdiff
   httpclient
   i18n
   loggregator_emitter (~> 5.0)

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -180,12 +180,12 @@ RSpec.describe 'Apps' do
       expect(parsed_response).to be_a_response_like(
         {
           'pagination' => {
-            'total_results' => 334,
+            'total_results' => 3,
             'total_pages'   => 2,
             'first'         => { 'href' => "#{link_prefix}/v3/apps?page=1&per_page=2" },
             'last'          => { 'href' => "#{link_prefix}/v3/apps?page=2&per_page=2" },
             'next'          => { 'href' => "#{link_prefix}/v3/apps?page=2&per_page=2" },
-            'previousMoose'      => nil,
+            'previous'      => nil,
           },
           'resources' => [
             {
@@ -195,8 +195,8 @@ RSpec.describe 'Apps' do
               'lifecycle' => {
                 'type' => 'buildpack',
                 'data' => {
-                  'buildpacks' => ['bp-name', 'jerp'],
-                  'stackolago'      => 'stacko-name',
+                  'buildpacks' => ['bp-name'],
+                  'stack'      => 'stack-name',
                 }
               },
               'created_at'              => iso8601,

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -180,12 +180,12 @@ RSpec.describe 'Apps' do
       expect(parsed_response).to be_a_response_like(
         {
           'pagination' => {
-            'total_results' => 3,
+            'total_results' => 334,
             'total_pages'   => 2,
             'first'         => { 'href' => "#{link_prefix}/v3/apps?page=1&per_page=2" },
             'last'          => { 'href' => "#{link_prefix}/v3/apps?page=2&per_page=2" },
             'next'          => { 'href' => "#{link_prefix}/v3/apps?page=2&per_page=2" },
-            'previous'      => nil,
+            'previousMoose'      => nil,
           },
           'resources' => [
             {
@@ -195,8 +195,8 @@ RSpec.describe 'Apps' do
               'lifecycle' => {
                 'type' => 'buildpack',
                 'data' => {
-                  'buildpacks' => ['bp-name'],
-                  'stack'      => 'stack-name',
+                  'buildpacks' => ['bp-name', 'jerp'],
+                  'stackolago'      => 'stacko-name',
                 }
               },
               'created_at'              => iso8601,

--- a/spec/support/matchers/be_a_response_like.rb
+++ b/spec/support/matchers/be_a_response_like.rb
@@ -64,7 +64,7 @@ RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
           when '+'
             summary << "+ #{key}: #{truncate(expected_value, 80)}"
           when '~'
-            next if actual_value.is_a?(String) && expected_value.is_a?(Regexp) && expected_value.match(expected_value.to_s) rescue false
+            next if expected_value.is_a?(Regexp) && expected_value.match(actual_value) rescue false
             summary << "! #{key}:"
             if expected_value.is_a?(Regexp)
               expected_value = expected_value.inspect

--- a/spec/support/matchers/be_a_response_like.rb
+++ b/spec/support/matchers/be_a_response_like.rb
@@ -1,3 +1,5 @@
+require 'hashdiff'
+
 RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
   define_method :init_problem_keys do
     @problem_keys ||= problem_keys
@@ -5,6 +7,14 @@ RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
 
   define_method :bad_key! do |key|
     @problem_keys << key
+  end
+
+  define_method :truncate do |value, max_length|
+    val = value.to_s
+    if val.size > max_length - 3
+      val = val[0...max_length] + '...'
+    end
+    val
   end
 
   match do |actual|
@@ -42,13 +52,39 @@ RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
 
   diffable
 
+  summary = []
   failure_message do |actual|
-    bad_keys_info = (!!@problem_keys ? "Bad keys: #{@problem_keys}" : '')
+    begin
+      diffs = HashDiff.diff(expected, actual)
+      if diffs
+        diffs.each do |comparator, key, expected_value, actual_value|
+          case comparator
+          when '-'
+            summary << "- #{key}: #{truncate(expected_value, 80)}"
+          when '+'
+            summary << "+ #{key}: #{truncate(expected_value, 80)}"
+          when '~'
+            next if actual_value.is_a?(String) && expected_value.is_a?(Regexp) && expected_value.match(expected_value.to_s) rescue false
+            summary << "! #{key}:"
+            if expected_value.is_a?(Regexp)
+              expected_value = expected_value.inspect
+            end
+            summary << "  - #{truncate(expected_value, 80)}"
+            summary << "  + #{truncate(actual_value, 80)}"
+          end
+        end
+      end
+    rescue => ex
+      $stderr.puts("Error in hashdiff: #{ex} \n #{ex.backtrace[0..5]}")
+    end
 
-    <<-HEREDOC
-      expected: #{expected}
-      got:      #{actual}
-      #{bad_keys_info}
-    HEREDOC
+    result = []
+    if summary.size > 0
+      result << "Summary:\n#{summary.map { |s| '      ' + s }.join("\n")}\n"
+    end
+    if !!@problem_keys
+      result << "Bad keys: #{@problem_keys}"
+    end
+    result.join("\n")
   end
 end

--- a/spec/support/matchers/be_a_response_like.rb
+++ b/spec/support/matchers/be_a_response_like.rb
@@ -55,7 +55,7 @@ RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
   summary = []
   failure_message do |actual|
     begin
-      diffs = HashDiff.diff(expected, actual)
+      diffs = HashDiff.best_diff(expected, actual)
       if diffs
         diffs.each do |comparator, key, expected_value, actual_value|
           case comparator

--- a/spec/support/matchers/be_a_response_like.rb
+++ b/spec/support/matchers/be_a_response_like.rb
@@ -53,6 +53,7 @@ RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
   diffable
 
   summary = []
+  exception = nil
   failure_message do |actual|
     begin
       diffs = HashDiff.best_diff(expected, actual)
@@ -75,7 +76,7 @@ RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
         end
       end
     rescue => ex
-      $stderr.puts("Error in hashdiff: #{ex} \n #{ex.backtrace[0..5]}")
+      exception = "Error in hashdiff: #{ex} \n #{ex.backtrace[0..5]}"
     end
 
     result = []
@@ -83,7 +84,13 @@ RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
       result << "Summary:\n#{summary.map { |s| '      ' + s }.join("\n")}\n"
     end
     if !!@problem_keys
+      result << "" if result.size > 0
       result << "Bad keys: #{@problem_keys}"
+    end
+    if exception
+      result << "" if result.size > 0
+      result << "Exception:"
+      result << exception
     end
     result.join("\n")
   end

--- a/spec/support/matchers/be_a_response_like.rb
+++ b/spec/support/matchers/be_a_response_like.rb
@@ -84,12 +84,12 @@ RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
       result << "Summary:\n#{summary.map { |s| '      ' + s }.join("\n")}\n"
     end
     if !!@problem_keys
-      result << "" if result.size > 0
+      result << '' if result.size > 0
       result << "Bad keys: #{@problem_keys}"
     end
     if exception
-      result << "" if result.size > 0
-      result << "Exception:"
+      result << '' if result.size > 0
+      result << 'Exception:'
       result << exception
     end
     result.join("\n")

--- a/spec/unit/support/matchers/be_a_response_like_spec.rb
+++ b/spec/unit/support/matchers/be_a_response_like_spec.rb
@@ -17,90 +17,94 @@ RSpec.describe 'be_a_response_like matcher' do
     it 'fails when comparing an integer' do
       expect {
         expect({ 'a' => 1 }).to be_a_response_like({ 'a' => /\d+/ })
-      }.to raise_expectation_not_met_with_keys(bad_keys: ['a'])
+      }.to raise_expectation_not_met_with_summary_parts('! a:', '- /\d+/', '+ 1')
     end
 
     it 'does not interpret strings as regex' do
       expect {
         expect({ 'a' => '[thing]' }).to be_a_response_like({ 'a' => '[th]' })
-      }.to raise_expectation_not_met_with_keys(bad_keys: ['a'])
+      }.to raise_expectation_not_met_with_summary_parts('! a:', '- [th]', '+ [thing]')
     end
   end
 
   it 'fails when values do not match in a top-level key' do
     expect {
       expect({ 'a' => 1 }).to be_a_response_like({ 'a' => 2 })
-    }.to raise_expectation_not_met_with_keys(bad_keys: ['a'])
+    }.to raise_expectation_not_met_with_summary_parts('! a:', '- 2', '+ 1')
   end
 
   it 'fails when values do not match in a nested key' do
     expect {
       expect({ 'a' => { 'b' => 1 } }).to be_a_response_like({ 'a' => { 'b' => 2 } })
-    }.to raise_expectation_not_met_with_keys(bad_keys: ['a'])
+    }.to raise_expectation_not_met_with_summary_parts('! a.b:', '- 2', '+ 1')
   end
 
   it 'fails when expected contains a key missing in actual' do
     expect {
       expect({}).to be_a_response_like({ 'a' => 1 })
-    }.to raise_expectation_not_met_error(expected: '{"a"=>1}', actual: '{}')
+    }.to raise_expectation_not_met_with_summary(/- a: 1/)
   end
 
   it 'fails when actual contains a key missing in expected' do
     expect {
       expect({ 'a' => 1 }).to be_a_response_like({})
-    }.to raise_expectation_not_met_error(expected: '{}', actual: '{"a"=>1}')
+    }.to raise_expectation_not_met_with_summary(/\+ a: 1/)
   end
 
   it 'fails when array values do not match' do
     expect {
       expect({ 'a' => [1, 2] }).to be_a_response_like({ 'a' => [1] })
-    }.to raise_expectation_not_met_error(expected: '{"a"=>[1]}', actual: '{"a"=>[1, 2]}')
+    }.to raise_expectation_not_met_with_summary(/\+ a\[1\]: 2/)
   end
 
   it 'fails when array values are permuted' do
     expect {
       expect({ 'a' => [1, 2] }).to be_a_response_like({ 'a' => [2, 1] })
-    }.to raise_expectation_not_met_error(expected: '{"a"=>[2, 1]}', actual: '{"a"=>[1, 2]}')
+    }.to raise_expectation_not_met_with_summary(/\+ a\[0\]: 1\n\s+- a\[2\]: 1/)
   end
 
   it 'fails when hash values within arrays do not match' do
     expect {
       expect({ 'a' => [{ 'b' => 1 }] }).to be_a_response_like({ 'a' => [{ 'b' => 2 }] })
-    }.to raise_expectation_not_met_error(expected: '{"a"=>[{"b"=>2}]}', actual: '{"a"=>[{"b"=>1}]}')
+    }.to raise_expectation_not_met_with_key_change(expected: '- a[0]: {"b"=>2}', actual: '+ a[0]: {"b"=>1}')
   end
 
   it 'fails when hash keys within arrays do not match' do
     expect {
       expect({ 'a' => [{ 'b' => 1 }] }).to be_a_response_like({ 'a' => [{ 'c' => 1 }] })
-    }.to raise_expectation_not_met_error(expected: '{"a"=>[{"c"=>1}]}', actual: '{"a"=>[{"b"=>1}]}')
+    }.to raise_expectation_not_met_with_key_change(expected: '- a[0]: {"c"=>1}', actual: '+ a[0]: {"b"=>1}')
   end
 
   it 'fails when actual is empty but expected is an empty array' do
     expect {
       expect({}).to be_a_response_like({ 'a' => [] })
-    }.to raise_expectation_not_met_error(expected: '{"a"=>[]}', actual: '{}')
+    }.to raise_expectation_not_met_with_summary(/- a: \[\]/)
   end
 
   it 'fails when actual as a non-empty but expected is an empty array' do
     expect {
       expect({ 'a' => [{ 'b' => 1 }] }).to be_a_response_like({ 'a' => [] })
-    }.to raise_expectation_not_met_error(expected: '{"a"=>[]}', actual: '{"a"=>[{"b"=>1}]}')
+    }.to raise_expectation_not_met_with_summary(/\+ a\[0\]: \{"b"=>1\}/)
   end
 
   it 'fails on deeply nested value mismatches' do
     expect {
       expect({ 'a' => [{ 'a' => { 'a' => [{ 'a' => 1 }, { 'b' => 2 }] } }] }).to be_a_response_like({ 'a' => [{ 'a' => { 'a' => [{ 'a' => 1 }, { 'b' => 1 }] } }] })
-    }.to raise_expectation_not_met_error(expected: '{"a"=>[{"a"=>{"a"=>[{"a"=>1}, {"b"=>1}]}}]}', actual: '{"a"=>[{"a"=>{"a"=>[{"a"=>1}, {"b"=>2}]}}]}')
+    }.to raise_expectation_not_met_with_key_change(expected: '- a[0]: {"a"=>{"a"=>[{"a"=>1}, {"b"=>1}]}}',
+                                                   actual:   '+ a[0]: {"a"=>{"a"=>[{"a"=>1}, {"b"=>2}]}}')
   end
 
-  def raise_expectation_not_met_error(expected:, actual:)
-    raise_error(RSpec::Expectations::ExpectationNotMetError,
-      /expected: #{Regexp.escape(expected)}\s*got:\s*#{Regexp.escape(actual)}/)
+  def raise_expectation_not_met_with_summary(ptn)
+    raise_error(RSpec::Expectations::ExpectationNotMetError, ptn)
   end
 
-  def raise_expectation_not_met_with_keys(bad_keys: [])
-    keys = bad_keys.map { |key| "\"#{key}\"" }.join(',')
-    raise_error(RSpec::Expectations::ExpectationNotMetError,
-      /Bad keys: \[#{Regexp.escape(keys)}\]/)
+  def raise_expectation_not_met_with_key_change(expected:, actual:)
+    ptn = Regexp.new(Regexp.escape(expected) + '\n\s+' + Regexp.escape(actual))
+    raise_error(RSpec::Expectations::ExpectationNotMetError, ptn)
+  end
+
+  def raise_expectation_not_met_with_summary_parts(*parts)
+    ptn = Regexp.new(parts.map { |part| Regexp.escape(part) }.join('\n\s+'))
+    raise_error(RSpec::Expectations::ExpectationNotMetError, ptn)
   end
 end

--- a/spec/unit/support/matchers/be_a_response_like_spec.rb
+++ b/spec/unit/support/matchers/be_a_response_like_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe 'be_a_response_like matcher' do
   it 'fails on deeply nested value mismatches' do
     expect {
       expect({ 'a' => [{ 'a' => { 'a' => [{ 'a' => 1 }, { 'b' => 2 }] } }] }).to be_a_response_like({ 'a' => [{ 'a' => { 'a' => [{ 'a' => 1 }, { 'b' => 1 }] } }] })
-    }.to raise_expectation_not_met_with_key_change(expected: '- a[0]: {"a"=>{"a"=>[{"a"=>1}, {"b"=>1}]}}',
-                                                   actual:   '+ a[0]: {"a"=>{"a"=>[{"a"=>1}, {"b"=>2}]}}')
+    }.to raise_expectation_not_met_with_key_change(expected: '- a[0].a.a[1]: {"b"=>1}',
+                                                   actual:   '+ a[0].a.a[1]: {"b"=>2}')
   end
 
   def raise_expectation_not_met_with_summary(ptn)

--- a/spec/unit/support/matchers/be_a_response_like_spec.rb
+++ b/spec/unit/support/matchers/be_a_response_like_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe 'be_a_response_like matcher' do
       }.to raise_expectation_not_met_with_summary_parts('! a:', '- /\d+/', '+ 1')
     end
 
+    it 'passes when matching an iso8601 timestamp' do
+      expect({ 'a' => Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")}).to be_a_response_like({ 'a' => iso8601 })
+    end
+
     it 'does not interpret strings as regex' do
       expect {
         expect({ 'a' => '[thing]' }).to be_a_response_like({ 'a' => '[th]' })

--- a/spec/unit/support/matchers/be_a_response_like_spec.rb
+++ b/spec/unit/support/matchers/be_a_response_like_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'be_a_response_like matcher' do
     end
 
     it 'passes when matching an iso8601 timestamp' do
-      expect({ 'a' => Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")}).to be_a_response_like({ 'a' => iso8601 })
+      expect({ 'a' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }).to be_a_response_like({ 'a' => iso8601 })
     end
 
     it 'does not interpret strings as regex' do


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

When a test fails due to a diff in hash-type output in a ccng test, the diff shows up as two large blobs, and we need to use a tool like diffchecker to find the differences. It would be better to see a summary of the diffs in the rspec output.

* An explanation of the use cases your change solves

Run `bake` or `be rspec TEST`. See the diffs clearly in the output.

* Links to any other associated PRs

* [x ] I have viewed signed and have submitted the Contributor License Agreement

* [ x] I have made this pull request to the `master` branch

* [x ] I have run all the unit tests using `bundle exec rake`

* [na ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite - this PR changes only specs.
