### PR TITLE
Service Broker Create Service Instance Schema Validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'eventmachine', '~> 1.0.9'
 gem 'google-api-client', '~> 0.8.6' # required for fog-google
 gem 'httpclient'
 gem 'i18n'
+gem 'json-schema'
 gem 'loggregator_emitter', '~> 5.0'
 gem 'membrane', '~> 1.0'
 gem 'mime-types', '~> 2.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,8 @@ GEM
     i18n (0.7.0)
     ipaddress (0.8.3)
     json (1.8.3)
+    json-schema (2.8.0)
+      addressable (>= 2.4)
     json_pure (1.8.6)
     jwt (1.5.6)
     launchy (2.4.3)
@@ -437,6 +439,7 @@ DEPENDENCIES
   google-api-client (~> 0.8.6)
   httpclient
   i18n
+  json-schema
   loggregator_emitter (~> 5.0)
   machinist (~> 1.0.6)
   membrane (~> 1.0)

--- a/lib/services/service_brokers/v2/catalog_schemas.rb
+++ b/lib/services/service_brokers/v2/catalog_schemas.rb
@@ -1,3 +1,5 @@
+require 'json-schema'
+
 module VCAP::Services::ServiceBrokers::V2
   class CatalogSchemas
     attr_reader :errors, :create_instance
@@ -32,7 +34,24 @@ module VCAP::Services::ServiceBrokers::V2
         end
       end
 
+      validate_no_external_references(attrs)
       @create_instance = attrs
+    end
+
+    def validate_no_external_references(schema)
+      JSON::Validator.schema_reader = JSON::Schema::Reader.new(accept_uri: false, accept_file: false)
+
+      begin
+        JSON::Validator.validate!(schema, {})
+      rescue JSON::Schema::SchemaError => e
+        errors.add("Schema not valid. Custom meta schemas are not supported. #{e}")
+      rescue JSON::Schema::ReadRefused => e
+        errors.add("Schema not valid. No external references are allowed: #{e}")
+      rescue JSON::Schema::ValidationError
+        # We only care that there are no external references.
+      rescue => e
+        errors.add("Schema not valid. #{e}")
+      end
     end
   end
 end

--- a/lib/services/service_brokers/v2/catalog_schemas.rb
+++ b/lib/services/service_brokers/v2/catalog_schemas.rb
@@ -47,14 +47,14 @@ module VCAP::Services::ServiceBrokers::V2
       metaschema = JSON::Validator.validator_for_name('draft4').metaschema
 
       begin
-        valid = JSON::Validator.validate(metaschema, schema)
+        errors = JSON::Validator.fully_validate(metaschema, schema)
       rescue => e
         add_schema_error_msg(path, e)
         return nil
       end
 
-      if !valid
-        add_schema_error_msg(path, 'Must conform to JSON Schema Draft 04')
+      errors.each do |error|
+        add_schema_error_msg(path, "Must conform to JSON Schema Draft 04: #{error}")
       end
     end
 
@@ -64,7 +64,7 @@ module VCAP::Services::ServiceBrokers::V2
       begin
         JSON::Validator.validate!(schema, {})
       rescue JSON::Schema::SchemaError => e
-        add_schema_error_msg(path, "Custom meta schemas are not supported. #{e}")
+        add_schema_error_msg(path, "Custom meta schemas are not supported: #{e}")
       rescue JSON::Schema::ReadRefused => e
         add_schema_error_msg(path, "No external references are allowed: #{e}")
       rescue JSON::Schema::ValidationError

--- a/lib/services/service_brokers/v2/catalog_schemas.rb
+++ b/lib/services/service_brokers/v2/catalog_schemas.rb
@@ -43,8 +43,10 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     def validate_metaschema(path, schema)
-      JSON::Validator.schema_reader = JSON::Schema::Reader.new(accept_uri: false, accept_file: true)
-      metaschema = JSON::Validator.validator_for_name('draft4').metaschema
+      JSON::Validator.schema_reader = JSON::Schema::Reader.new(accept_uri: false, accept_file: false)
+      file = File.read(JSON::Validator.validator_for_name('draft4').metaschema)
+
+      metaschema = JSON.parse(file)
 
       begin
         errors = JSON::Validator.fully_validate(metaschema, schema)

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Service Broker API integration' do
   describe 'v2.13' do
     include VCAP::CloudController::BrokerApiHelper
 
-    let(:create_instance_schema) { {} }
+    let(:create_instance_schema) { { 'type': 'object' } }
     let(:schemas) {
       {
         'service_instance' => {

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Service Broker API integration' do
     context 'when a broker catalog defines plan schemas' do
       let(:create_instance_schema) {
         {
-          '$schema' => 'http://example.com/schema',
+          '$schema' => 'http://json-schema.org/draft-04/schema#',
           'type' => 'object'
         }
       }

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -205,7 +205,9 @@ RSpec.describe 'Service Broker' do
           "  Service id must be a string, but has value 12345\n" \
           "  Plan small\n" \
           "    Schemas\n" \
-          "      Schema service_instance.create.parameters is not valid. Must conform to JSON Schema Draft 04\n" \
+          '      Schema service_instance.create.parameters is not valid. Must conform to JSON Schema Draft 04: '\
+          "The property '#/properties' of type boolean did not match the following type: object in schema "\
+          "http://json-schema.org/draft-04/schema#\n" \
           "Service service-2\n" \
           "  Plan ids must be unique within a service. Service service-2 already has a plan with id 'plan-b'\n" \
           "  Plan large\n" \

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -123,7 +123,14 @@ RSpec.describe 'Service Broker' do
                 {
                   id: 'plan-1',
                   name: 'small',
-                  description: 'A small shared database with 100mb storage quota and 10 connections'
+                  description: 'A small shared database with 100mb storage quota and 10 connections',
+                  schemas: {
+                    service_instance: {
+                      create: {
+                        parameters: { properties: true }
+                      }
+                    }
+                  }
                 }, {
                   id: 'plan-2',
                   name: 'large',
@@ -196,6 +203,9 @@ RSpec.describe 'Service Broker' do
           "Service dashboard_client id must be unique\n" \
           "Service service-1\n" \
           "  Service id must be a string, but has value 12345\n" \
+          "  Plan small\n" \
+          "    Schemas\n" \
+          "      Schema service_instance.create.parameters is not valid. Must conform to JSON Schema Draft 04\n" \
           "Service service-2\n" \
           "  Plan ids must be unique within a service. Service service-2 already has a plan with id 'plan-b'\n" \
           "  Plan large\n" \

--- a/spec/request/v2/service_brokers_spec.rb
+++ b/spec/request/v2/service_brokers_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe 'ServiceBrokers' do
+  describe 'POST /v2/service_brokers' do
+    service_name = 'myservice'
+    plan_name = 'myplan'
+
+    before do
+      allow(VCAP::Services::ServiceBrokers::V2::Client).to receive(:new) do |*args, **kwargs, &block|
+        fb = FakeServiceBrokerV2Client.new(*args, **kwargs, &block)
+        fb.service_name = service_name
+        fb.plan_name = plan_name
+        fb
+      end
+    end
+
+    it 'should register the service broker' do
+      req_body = {
+        name: 'service-broker-name',
+        broker_url: 'https://broker.example.com',
+        auth_username: 'admin',
+        auth_password: 'secretpassw0rd'
+      }
+
+      post '/v2/service_brokers', req_body.to_json, admin_headers
+      expect(last_response.status).to eq(201)
+
+      broker = VCAP::CloudController::ServiceBroker.last
+      expect(broker.name).to eq(req_body[:name])
+      expect(broker.broker_url).to eq(req_body[:broker_url])
+      expect(broker.auth_username).to eq(req_body[:auth_username])
+      expect(broker.auth_password).to eq(req_body[:auth_password])
+
+      service = VCAP::CloudController::Service.last
+      expect(service.label).to eq(service_name)
+
+      plan = VCAP::CloudController::ServicePlan.last
+      expect(plan.name).to eq(plan_name)
+    end
+  end
+end

--- a/spec/request/v2/service_brokers_spec.rb
+++ b/spec/request/v2/service_brokers_spec.rb
@@ -37,5 +37,40 @@ RSpec.describe 'ServiceBrokers' do
       plan = VCAP::CloudController::ServicePlan.last
       expect(plan.name).to eq(plan_name)
     end
+
+    context 'for brokers with schemas' do
+      big_string = 'x' * 65 * 1024
+
+      schemas = {
+      'service_instance' => {
+        'create' =>  {
+          'parameters' => {
+              'type' => 'object',
+              'foo' => big_string
+            }
+          }
+        }
+      }
+
+      before do
+        allow(VCAP::Services::ServiceBrokers::V2::Client).to receive(:new) do |*args, **kwargs, &block|
+          fb = FakeServiceBrokerV2Client.new(*args, **kwargs, &block)
+          fb.plan_schemas = schemas
+          fb
+        end
+      end
+
+      it 'should not allow schema bigger than 64KB' do
+        req_body = {
+          name: 'service-broker-name',
+          broker_url: 'https://broker.example.com',
+          auth_username: 'admin',
+          auth_password: 'secretpassw0rd'
+        }
+
+        post '/v2/service_brokers', req_body.to_json, admin_headers
+        expect(last_response.status).to eq(502)
+      end
+    end
   end
 end

--- a/spec/support/fakes/fake_service_broker_v2_client.rb
+++ b/spec/support/fakes/fake_service_broker_v2_client.rb
@@ -2,23 +2,27 @@ class FakeServiceBrokerV2Client
   attr_accessor :credentials
   attr_accessor :syslog_drain_url
   attr_accessor :volume_mounts
+  attr_accessor :service_name
+  attr_accessor :plan_name
 
   def initialize(_attrs)
     @credentials = { 'username' => 'cool_user' }
     @syslog_drain_url = 'syslog://drain.example.com'
     @volume_mounts = []
+    @service_name = 'service_name'
+    @plan_name = 'fake_plan_name'
   end
 
   def catalog
     {
       'services' => [{
         'id'          => 'service_id',
-        'name'        => 'service_name',
+        'name'        => service_name,
         'description' => 'some description',
         'bindable'    => true,
         'plans'       => [{
           'id'          => 'fake_plan_id',
-          'name'        => 'fake_plan_name',
+          'name'        => plan_name,
           'description' => 'fake_plan_description'
         }]
       }]

--- a/spec/support/fakes/fake_service_broker_v2_client.rb
+++ b/spec/support/fakes/fake_service_broker_v2_client.rb
@@ -4,6 +4,7 @@ class FakeServiceBrokerV2Client
   attr_accessor :volume_mounts
   attr_accessor :service_name
   attr_accessor :plan_name
+  attr_accessor :plan_schemas
 
   def initialize(_attrs)
     @credentials = { 'username' => 'cool_user' }
@@ -11,6 +12,7 @@ class FakeServiceBrokerV2Client
     @volume_mounts = []
     @service_name = 'service_name'
     @plan_name = 'fake_plan_name'
+    @plan_schemas = nil
   end
 
   def catalog
@@ -23,7 +25,8 @@ class FakeServiceBrokerV2Client
         'plans'       => [{
           'id'          => 'fake_plan_id',
           'name'        => plan_name,
-          'description' => 'fake_plan_description'
+          'description' => 'fake_plan_description',
+          'schemas'     => plan_schemas
         }]
       }]
     }

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -33,7 +33,17 @@ module VCAP::Services::ServiceBrokers
       }
     end
     let(:plan_schemas_hash) do
-      { 'schemas' => { 'service_instance' => { 'create' => { 'parameters' => { '$schema': 'example.com/schema' } } } } }
+      {
+          'schemas' => {
+              'service_instance' => {
+                  'create' => {
+                      'parameters' => {
+                          '$schema' => 'http://json-schema.org/draft-04/schema', 'type' => 'object'
+                      }
+                  }
+              }
+          }
+      }
     end
 
     let(:catalog_hash) do
@@ -161,7 +171,7 @@ module VCAP::Services::ServiceBrokers
           'public' => service_plan.public,
           'active' => service_plan.active,
           'bindable' => true,
-          'create_instance_schema' => '{"$schema":"example.com/schema"}',
+          'create_instance_schema' => '{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}',
         })
       end
 
@@ -196,7 +206,7 @@ module VCAP::Services::ServiceBrokers
           expect(plan.name).to eq(plan_name)
           expect(plan.description).to eq(plan_description)
           expect(JSON.parse(plan.extra)).to eq({ 'cost' => '0.0' })
-          expect(plan.create_instance_schema).to eq('{"$schema":"example.com/schema"}')
+          expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
 
           expect(plan.free).to be false
         end
@@ -336,7 +346,7 @@ module VCAP::Services::ServiceBrokers
             expect(plan.description).to eq(plan_description)
             expect(plan.free).to be false
             expect(plan.bindable).to be true
-            expect(plan.create_instance_schema).to eq('{"$schema":"example.com/schema"}')
+            expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
           end
 
           it 'creates service audit events for each service plan updated' do
@@ -361,7 +371,7 @@ module VCAP::Services::ServiceBrokers
               'extra' => '{"cost":"0.0"}',
               'bindable' => true,
               'free' => false,
-              'create_instance_schema' => '{"$schema":"example.com/schema"}',
+              'create_instance_schema' => '{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}',
             })
           end
 

--- a/spec/unit/lib/services/service_brokers/v2/catalog_schemas_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_schemas_spec.rb
@@ -67,8 +67,16 @@ module VCAP::Services::ServiceBrokers::V2
         its(:valid?) { should be false }
         its('errors.messages') { should have(1).items }
         its('errors.messages.first') {
-          should match 'Schema service_instance.create.parameters is not valid\. Must conform to JSON Schema Draft 04'
+          should match 'Schema service_instance.create.parameters is not valid\. Must conform to JSON Schema Draft 04.+properties'
         }
+      end
+
+      context 'when the schema does not conform to JSON Schema Draft 04 with multiple problems' do
+        let(:create_instance_schema) { { 'type': 'foo', 'properties': true } }
+        its(:valid?) { should be false }
+        its('errors.messages') { should have(2).items }
+        its('errors.messages.first') { should match 'properties' }
+        its('errors.messages.second') { should match 'type' }
       end
 
       context 'when the schema has an external schema' do

--- a/spec/unit/lib/services/service_brokers/v2/catalog_schemas_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_schemas_spec.rb
@@ -62,12 +62,21 @@ module VCAP::Services::ServiceBrokers::V2
         end
       end
 
+      context 'when the schema does not conform to JSON Schema Draft 04' do
+        let(:create_instance_schema) { { 'properties': true } }
+        its(:valid?) { should be false }
+        its('errors.messages') { should have(1).items }
+        its('errors.messages.first') {
+          should match 'Schema service_instance.create.parameters is not valid\. Must conform to JSON Schema Draft 04'
+        }
+      end
+
       context 'when the schema has an external schema' do
         let(:create_instance_schema) { { '$schema': 'http://example.com/schema' } }
         its(:valid?) { should be false }
         its('errors.messages') { should have(1).items }
         its('errors.messages.first') {
-          should match 'Schema not valid\. Custom meta schemas are not supported.+http://example.com/schema'
+          should match 'Schema service_instance.create.parameters is not valid\. Custom meta schemas are not supported.+http://example.com/schema'
         }
       end
 
@@ -76,7 +85,7 @@ module VCAP::Services::ServiceBrokers::V2
         its(:valid?) { should be false }
         its('errors.messages') { should have(1).items }
         its('errors.messages.first') {
-          should match 'Schema not valid\. No external references are allowed.+http://example.com/ref'
+          should match 'Schema service_instance.create.parameters is not valid\. No external references are allowed.+http://example.com/ref'
         }
       end
 
@@ -85,7 +94,7 @@ module VCAP::Services::ServiceBrokers::V2
         its(:valid?) { should be false }
         its('errors.messages') { should have(1).items }
         its('errors.messages.first') {
-          should match 'Schema not valid\. No external references are allowed.+path/to/schema.json'
+          should match 'Schema service_instance.create.parameters is not valid\. No external references are allowed.+path/to/schema.json'
         }
       end
 
@@ -103,14 +112,13 @@ module VCAP::Services::ServiceBrokers::V2
       end
 
       context 'when the schema has an unknown parse error' do
-        let(:create_instance_schema) { { '$ref': 'http://example.com/ref' } }
         before do
           allow(JSON::Validator).to receive(:validate!) { raise 'some unknown error' }
         end
 
         its(:valid?) { should be false }
         its('errors.messages') { should have(1).items }
-        its('errors.messages.first') { should match 'Schema not valid\.+ some unknown error' }
+        its('errors.messages.first') { should match 'Schema service_instance.create.parameters is not valid\.+ some unknown error' }
       end
 
       context 'when the schema has multiple valid constraints ' do


### PR DESCRIPTION
As a Service Broker Author, when I register a plan with a create service instance schema, I get fast feedback when my schema is invalid.
 [#146276815](https://www.pivotaltracker.com/story/show/146276815), [#146276747](https://www.pivotaltracker.com/story/show/146276747).


This PR follows from a previous [PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/834).

Why
---
The Open Service Broker API is proposing allowing brokers to define JSON schema for their configuration parameters. This will allow tooling to validate parameters and UIs to auto generate forms.

What
---
This PR improves support for create instance schemas. Schemas are parsed during registration, and validated against the following criteria:
1. Must conform to JSON schema Draft 04
1. Must contain the following property `"type": "object"`
1. Cannot be larger than 64kb
1. Cannot contain external references
1. Cannot contain file references

This PR address the 3 notes that were not implemented in the previous [PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/834).

Notable things that are not in this PR but are addressed in future stories are:

1. [Update Service Instance Schema support](https://www.pivotaltracker.com/story/show/146082131). 

Feedback appreciated!

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite