### PR TITLE
Rename experimental OCI URI scheme

### DIFF
--- a/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
 
         def root_fs
           if @config[:diego][:temporary_oci_buildpack_mode] == 'oci-phase-1'
-            "preloaded+droplet:#{@stack}?droplet=#{URI.encode(@droplet_uri)}"
+            "preloaded+layer:#{@stack}?layer=#{URI.encode(@droplet_uri)}"
           else
             "preloaded:#{@stack}"
           end

--- a/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
@@ -47,8 +47,8 @@ module VCAP::CloudController
           context 'when temporary_oci_buildpack_mode is set to oci-phase-1' do
             let(:temporary_oci_buildpack_mode) { 'oci-phase-1' }
 
-            it 'returns a constructed root_fs + droplet URI' do
-              expect(builder.root_fs).to eq('preloaded+droplet:potato-stack?droplet=http://droplet-uri.com:1234?token=&@home---%3E')
+            it 'returns a constructed root_fs + layer URI' do
+              expect(builder.root_fs).to eq('preloaded+layer:potato-stack?layer=http://droplet-uri.com:1234?token=&@home---%3E')
             end
           end
         end


### PR DESCRIPTION
Experimental OCI URI scheme changed to `preloaded+layer`, rather than `preloaded+droplet` after discussion with the Diego team.

Sorry for not figuring that out before submitting the last PR!

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
