### PR TITLE
Add service broker create binding schema

### DIFF
--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -6,11 +6,32 @@ module VCAP::CloudController
 
     add_association_dependencies service_plan_visibilities: :destroy
 
-    export_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public, :bindable, :active, :create_instance_schema, :update_instance_schema
+    export_attributes :name,
+                      :free,
+                      :description,
+                      :service_guid,
+                      :extra,
+                      :unique_id,
+                      :public,
+                      :bindable,
+                      :active,
+                      :create_instance_schema,
+                      :update_instance_schema,
+                      :create_binding_schema
 
     export_attributes_from_methods bindable: :bindable?
 
-    import_attributes :name, :free, :description, :service_guid, :extra, :unique_id, :public, :bindable, :create_instance_schema, :update_instance_schema
+    import_attributes :name,
+                      :free,
+                      :description,
+                      :service_guid,
+                      :extra,
+                      :unique_id,
+                      :public,
+                      :bindable,
+                      :create_instance_schema,
+                      :update_instance_schema,
+                      :create_binding_schema
 
     strip_attributes :name
 

--- a/app/presenters/v2/service_plan_presenter.rb
+++ b/app/presenters/v2/service_plan_presenter.rb
@@ -13,6 +13,7 @@ module CloudController
           entity.merge!(schemas)
           entity.delete('create_instance_schema')
           entity.delete('update_instance_schema')
+          entity.delete('create_binding_schema')
 
           entity
         end
@@ -22,6 +23,7 @@ module CloudController
         def present_schemas(plan)
           create_instance_schema = parse_schema(plan.create_instance_schema)
           update_instance_schema = parse_schema(plan.update_instance_schema)
+          create_binding_schema = parse_schema(plan.create_binding_schema)
           {
             'schemas' => {
               'service_instance' => {
@@ -29,7 +31,12 @@ module CloudController
                   'parameters' => create_instance_schema
                 },
                 'update' => {
-                    'parameters' => update_instance_schema
+                  'parameters' => update_instance_schema
+                }
+              },
+              'service_binding' => {
+                'create' => {
+                  'parameters' => create_binding_schema
                 }
               }
             }

--- a/db/migrations/20170724090255_add_binding_create_schema_to_service_plans.rb
+++ b/db/migrations/20170724090255_add_binding_create_schema_to_service_plans.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :service_plans, :create_binding_schema, :text, null: true
+  end
+end

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -66,7 +66,8 @@ module VCAP::Services::ServiceBrokers
           active:      true,
           extra:       catalog_plan.metadata.try(:to_json),
           create_instance_schema: catalog_plan.schemas.create_instance.try(:to_json),
-          update_instance_schema: catalog_plan.schemas.update_instance.try(:to_json)
+          update_instance_schema: catalog_plan.schemas.update_instance.try(:to_json),
+          create_binding_schema: catalog_plan.schemas.create_binding.try(:to_json)
         })
         @services_event_repository.with_service_plan_event(plan) do
           plan.save(changed: true)

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'vcap/digester'
 
 RSpec.describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = '5d13e2d3b8855457ad523efceb8cee63e94bbda8'.freeze
+  API_FOLDER_CHECKSUM = '9a4720033354f38ccd572307341c5e930e6e7315'.freeze
 
   it 'tells the developer if the API specs change' do
     api_folder = File.expand_path('..', __FILE__)

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -623,7 +623,8 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         active:                 true,
         bindable:               true,
         create_instance_schema: '{}',
-        update_instance_schema: '{}'
+        update_instance_schema: '{}',
+        create_binding_schema:  '{}'
       )
       service_event_repository.with_service_plan_event(new_plan) do
         new_plan.save
@@ -650,7 +651,8 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
           'active'                 => new_plan.active,
           'bindable'               => new_plan.bindable,
           'create_instance_schema' => new_plan.create_instance_schema,
-          'update_instance_schema' => new_plan.update_instance_schema
+          'update_instance_schema' => new_plan.update_instance_schema,
+          'create_binding_schema'  => new_plan.create_binding_schema
         }
       }
     end

--- a/spec/api/documentation/service_plans_api_spec.rb
+++ b/spec/api/documentation/service_plans_api_spec.rb
@@ -11,7 +11,7 @@ RSpec.resource 'Service Plans', type: [:api, :legacy_api] do
     field :guid, 'The guid of the service plan', required: false
     field :public, 'A boolean describing that the plan is visible to the all users', required: false, default: true
 
-    expected_attributes = VCAP::CloudController::ServicePlan.new.export_attrs - [:create_instance_schema] - [:update_instance_schema] + [:schemas]
+    expected_attributes = VCAP::CloudController::ServicePlan.new.export_attrs - [:create_instance_schema] - [:update_instance_schema] - [:create_binding_schema] + [:schemas]
 
     standard_model_list(:service_plans, VCAP::CloudController::ServicePlansController, export_attributes: expected_attributes)
     standard_model_get(:service_plans, export_attributes: expected_attributes)

--- a/spec/api/documentation/services_api_spec.rb
+++ b/spec/api/documentation/services_api_spec.rb
@@ -72,7 +72,7 @@ RSpec.resource 'Services', type: [:api, :legacy_api] do
         VCAP::CloudController::ServicePlan.make(service: service)
       end
 
-      expected_attributes = VCAP::CloudController::ServicePlan.new.export_attrs - [:create_instance_schema] - [:update_instance_schema] + [:schemas]
+      expected_attributes = VCAP::CloudController::ServicePlan.new.export_attrs - [:create_instance_schema] - [:update_instance_schema] - [:create_binding_schema] + [:schemas]
       standard_model_list :service_plan, VCAP::CloudController::ServicePlansController, { outer_model: :service, export_attributes: expected_attributes }
     end
   end

--- a/spec/unit/controllers/services/service_plans_controller_spec.rb
+++ b/spec/unit/controllers/services/service_plans_controller_spec.rb
@@ -181,7 +181,17 @@ module VCAP::CloudController
         schemas = decoded_response.fetch('entity')['schemas']
 
         expect(schemas).to_not be_nil
-        expect(schemas).to eq({ 'service_instance' => { 'create' => { 'parameters' => {} }, 'update' => { 'parameters' => {} } } })
+        expect(schemas).to eq(
+          {
+            'service_instance' => {
+              'create' => { 'parameters' => {} },
+              'update' => { 'parameters' => {} }
+            },
+            'service_binding' => {
+              'create' => { 'parameters' => {} }
+            }
+          }
+                           )
       end
 
       context 'when the plan does not set bindable' do

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -46,6 +46,13 @@ module VCAP::Services::ServiceBrokers
                           'type' => 'object'
                       }
                   }
+              },
+              'service_binding' => {
+                'create' => {
+                  'parameters' => {
+                    '$schema' => 'http://json-schema.org/draft-04/schema', 'type' => 'object'
+                  }
+                }
               }
           }
       }
@@ -135,7 +142,7 @@ module VCAP::Services::ServiceBrokers
         expect(event.actee_name).to eq(service_name)
         expect(event.space_guid).to eq('')
         expect(event.organization_guid).to eq('')
-        expect(event.metadata).to include({
+        expect(event.metadata).to eq({
           'service_broker_guid' => service.service_broker.guid,
           'unique_id' => service_id,
           'provider' => service.provider,
@@ -166,7 +173,7 @@ module VCAP::Services::ServiceBrokers
         expect(event.actee_name).to eq(plan_name)
         expect(event.space_guid).to eq('')
         expect(event.organization_guid).to eq('')
-        expect(event.metadata).to include({
+        expect(event.metadata).to eq({
           'name' => service_plan.name,
           'free' => service_plan.free,
           'description' => service_plan.description,
@@ -174,10 +181,11 @@ module VCAP::Services::ServiceBrokers
           'extra' => '{"cost":"0.0"}',
           'unique_id' => service_plan.unique_id,
           'public' => service_plan.public,
-          'active' => service_plan.active,
           'bindable' => true,
+          'active' => service_plan.active,
           'create_instance_schema' => '{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}',
-          'update_instance_schema' => '{"type":"object"}'
+          'update_instance_schema' => '{"type":"object"}',
+          'create_binding_schema' => '{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}'
         })
       end
 
@@ -214,6 +222,7 @@ module VCAP::Services::ServiceBrokers
           expect(JSON.parse(plan.extra)).to eq({ 'cost' => '0.0' })
           expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
           expect(plan.update_instance_schema).to eq('{"type":"object"}')
+          expect(plan.create_binding_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
 
           expect(plan.free).to be false
         end
@@ -253,6 +262,7 @@ module VCAP::Services::ServiceBrokers
           plan = VCAP::CloudController::ServicePlan.last
           expect(plan.create_instance_schema).to be_nil
           expect(plan.update_instance_schema).to be_nil
+          expect(plan.create_binding_schema).to be_nil
         end
       end
 
@@ -264,6 +274,7 @@ module VCAP::Services::ServiceBrokers
           plan = VCAP::CloudController::ServicePlan.last
           expect(plan.create_instance_schema).to be_nil
           expect(plan.update_instance_schema).to be_nil
+          expect(plan.create_binding_schema).to be_nil
         end
       end
 
@@ -275,6 +286,7 @@ module VCAP::Services::ServiceBrokers
           plan = VCAP::CloudController::ServicePlan.last
           expect(plan.create_instance_schema).to be_nil
           expect(plan.update_instance_schema).to be_nil
+          expect(plan.create_binding_schema).to be_nil
         end
       end
 
@@ -348,6 +360,7 @@ module VCAP::Services::ServiceBrokers
             expect(plan.bindable).to be false
             expect(plan.create_instance_schema).to be_nil
             expect(plan.update_instance_schema).to be_nil
+            expect(plan.create_binding_schema).to be_nil
 
             expect {
               service_manager.sync_services_and_plans(catalog)
@@ -360,6 +373,7 @@ module VCAP::Services::ServiceBrokers
             expect(plan.bindable).to be true
             expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
             expect(plan.update_instance_schema).to eq('{"type":"object"}')
+            expect(plan.create_binding_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
           end
 
           it 'creates service audit events for each service plan updated' do
@@ -385,7 +399,8 @@ module VCAP::Services::ServiceBrokers
               'bindable' => true,
               'free' => false,
               'create_instance_schema' => '{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}',
-              'update_instance_schema' => '{"type":"object"}'
+              'update_instance_schema' => '{"type":"object"}',
+              'create_binding_schema' => '{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}'
             })
           end
 

--- a/spec/unit/lib/services/service_brokers/v2/catalog_schemas_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_schemas_spec.rb
@@ -9,20 +9,35 @@ module VCAP::Services::ServiceBrokers::V2
         catalog_schema
       end
 
+      context 'when schemas are not set' do
+        {
+          'Schemas is nil': nil,
+          'Schemas is empty': {},
+        }.each do |name, test|
+          context "for property #{name}" do
+            let(:schemas) { test }
+
+            its(:create_instance) { should be_nil }
+            its(:update_instance) { should be_nil }
+            its(:errors) { should be_empty }
+            its(:valid?) { should be true }
+          end
+        end
+      end
+
       context 'service instance' do
         context 'when catalog has schemas' do
           let(:schemas) { { 'service_instance' => {} } }
 
-          context 'when schemas is not set' do
+          context 'when schemas are not set' do
             {
-                'Schemas is nil': nil,
-                'Schemas is empty': {},
-                'Schemas service_instance is nil': { 'service_instance' => nil },
-                'Schemas service_instance is empty': { 'service_instance' => {} },
+              'Schemas service_instance is nil': { 'service_instance' => nil },
+              'Schemas service_instance is empty': { 'service_instance' => {} },
             }.each do |name, test|
               context "for property #{name}" do
                 let(:schemas) { test }
 
+                its(:create_instance) { should be_nil }
                 its(:update_instance) { should be_nil }
                 its(:errors) { should be_empty }
                 its(:valid?) { should be true }
@@ -32,8 +47,8 @@ module VCAP::Services::ServiceBrokers::V2
 
           context 'when schemas is invalid' do
             {
-                'Schemas': true,
-                'Schemas service_instance': { 'service_instance' => true }
+              'Schemas': true,
+              'Schemas service_instance': { 'service_instance' => true }
             }.each do |name, test|
               context "for property #{name}" do
                 let(:schemas) { test }
@@ -55,8 +70,8 @@ module VCAP::Services::ServiceBrokers::V2
 
           context 'and it has nil value' do
             {
-                'Schemas service_instance.create': { 'service_instance' => { 'create' => nil } },
-                'Schemas service_instance.create.parameters': { 'service_instance' => { 'create' => { 'parameters' => nil } } },
+              'Schemas service_instance.create': { 'service_instance' => { 'create' => nil } },
+              'Schemas service_instance.create.parameters': { 'service_instance' => { 'create' => { 'parameters' => nil } } },
             }.each do |name, test|
               context "for property #{name}" do
                 let(:schemas) { test }
@@ -71,11 +86,11 @@ module VCAP::Services::ServiceBrokers::V2
           context 'when the create instance schema is not valid' do
             let(:schemas) {
               {
-                  'service_instance' => {
-                      'create' => {
-                          'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object', 'properties' => true }
-                      }
+                'service_instance' => {
+                  'create' => {
+                    'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object', 'properties' => true }
                   }
+                }
               }
             }
             let(:path) { 'service_instance.create.parameters' }
@@ -87,7 +102,7 @@ module VCAP::Services::ServiceBrokers::V2
 
           context 'when schemas have a missing key' do
             {
-                'Schemas service_instance.create': { 'service_instance' => { 'create' => {} } },
+              'Schemas service_instance.create': { 'service_instance' => { 'create' => {} } },
             }.each do |name, test|
               context "for property #{name}" do
                 let(:schemas) { test }
@@ -101,8 +116,8 @@ module VCAP::Services::ServiceBrokers::V2
 
           context 'when schemas have an invalid type' do
             {
-                'Schemas service_instance.create': { 'service_instance' => { 'create' => true } },
-                'Schemas service_instance.create.parameters': { 'service_instance' => { 'create' => { 'parameters' => true } } },
+              'Schemas service_instance.create': { 'service_instance' => { 'create' => true } },
+              'Schemas service_instance.create.parameters': { 'service_instance' => { 'create' => { 'parameters' => true } } },
             }.each do |name, test|
               context "for property #{name}" do
                 let(:schemas) { test }
@@ -119,11 +134,11 @@ module VCAP::Services::ServiceBrokers::V2
             let(:path) { 'service_instance.create.parameters' }
             let(:schemas) {
               {
-                  'service_instance' => {
-                      'create' => {
-                          'parameters' => 'https://example.com/hax0r'
-                      }
+                'service_instance' => {
+                  'create' => {
+                    'parameters' => 'https://example.com/hax0r'
                   }
+                }
               }
             }
 
@@ -138,11 +153,11 @@ module VCAP::Services::ServiceBrokers::V2
           context 'and the schema structure is valid' do
             let(:schemas) {
               {
-                  'service_instance' => {
-                      'update' => {
-                          'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' }
-                      }
+                'service_instance' => {
+                  'update' => {
+                    'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' }
                   }
+                }
               }
             }
 
@@ -151,8 +166,8 @@ module VCAP::Services::ServiceBrokers::V2
 
           context 'when schemas have nil value' do
             {
-                'Schemas service_instance.update': { 'service_instance' => { 'update' => nil } },
-                'Schemas service_instance.update.parameters': { 'service_instance' => { 'update' => { 'parameters' => nil } } },
+              'Schemas service_instance.update': { 'service_instance' => { 'update' => nil } },
+              'Schemas service_instance.update.parameters': { 'service_instance' => { 'update' => { 'parameters' => nil } } },
             }.each do |name, test|
               context "for property #{name}" do
                 let(:schemas) { test }
@@ -167,11 +182,11 @@ module VCAP::Services::ServiceBrokers::V2
           context 'when the update instance schema is not valid' do
             let(:schemas) {
               {
-                  'service_instance' => {
-                      'update' => {
-                          'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object', 'properties' => true }
-                      }
+                'service_instance' => {
+                  'update' => {
+                    'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object', 'properties' => true }
                   }
+                }
               }
             }
             let(:path) { 'service_instance.update.parameters' }
@@ -183,7 +198,7 @@ module VCAP::Services::ServiceBrokers::V2
 
           context 'when schemas have a missing key' do
             {
-                'Schemas service_instance.update': { 'service_instance' => { 'update' => {} } },
+              'Schemas service_instance.update': { 'service_instance' => { 'update' => {} } },
             }.each do |name, test|
               context "for property #{name}" do
                 let(:schemas) { test }
@@ -197,8 +212,8 @@ module VCAP::Services::ServiceBrokers::V2
 
           context 'when schemas have an invalid type' do
             {
-                'Schemas service_instance.update': { 'service_instance' => { 'update' => true } },
-                'Schemas service_instance.update.parameters': { 'service_instance' => { 'update' => { 'parameters' => true } } },
+              'Schemas service_instance.update': { 'service_instance' => { 'update' => true } },
+              'Schemas service_instance.update.parameters': { 'service_instance' => { 'update' => { 'parameters' => true } } },
             }.each do |name, test|
               context "for property #{name}" do
                 let(:schemas) { test }
@@ -211,21 +226,145 @@ module VCAP::Services::ServiceBrokers::V2
             end
           end
 
-          # TODO: Look into schema path is not valid error tests
-
           context 'when schemas has a potentially dangerous uri' do
             let(:path) { 'service_instance.update.parameters' }
             let(:schemas) {
               {
-                  'service_instance' => {
-                      'update' => {
-                          'parameters' => 'https://example.com/hax0r'
-                      }
+                'service_instance' => {
+                  'update' => {
+                    'parameters' => 'https://example.com/hax0r'
                   }
+                }
               }
             }
 
             its(:update_instance) { should be_nil }
+            its('errors.messages') { should have(1).items }
+            its('errors.messages.first') { should eq "Schemas #{path} must be a hash, but has value \"https://example.com/hax0r\"" }
+            its(:valid?) { should be false }
+          end
+        end
+      end
+
+      context 'service binding' do
+        context 'when catalog has schemas' do
+          let(:schemas) { { 'service_binding' => {} } }
+
+          context 'when schema is not set' do
+            {
+              'Schemas service_binding is nil': { 'service_binding' => nil },
+              'Schemas service_binding is empty': { 'service_binding' => {} },
+            }.each do |name, test|
+              context "for property #{name}" do
+                let(:schemas) { test }
+
+                its(:create_instance) { should be_nil }
+                its(:update_instance) { should be_nil }
+                its(:create_binding) { should be_nil }
+                its(:errors) { should be_empty }
+                its(:valid?) { should be true }
+              end
+            end
+          end
+
+          context 'when schemas is invalid' do
+            {
+              'Schemas': true,
+              'Schemas service_binding': { 'service_binding' => true }
+            }.each do |name, test|
+              context "for property #{name}" do
+                let(:schemas) { test }
+
+                its('errors.messages') { should have(1).items }
+                its('errors.messages.first') { should eq "#{name} must be a hash, but has value true" }
+                its(:valid?) { should be false }
+              end
+            end
+          end
+        end
+
+        context 'when catalog has a create schema' do
+          context 'and the schema structure is valid' do
+            let(:schemas) { { 'service_binding' => { 'create' => { 'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } } } } }
+
+            its(:create_binding) { should be_a(Schema) }
+          end
+
+          context 'and it has nil value' do
+            {
+              'Schemas service_binding.create': { 'service_binding' => { 'create' => nil } },
+              'Schemas service_binding.create.parameters': { 'service_binding' => { 'create' => { 'parameters' => nil } } },
+            }.each do |name, test|
+              context "for property #{name}" do
+                let(:schemas) { test }
+
+                its(:create_binding) { should be_nil }
+                its(:errors) { should be_empty }
+                its(:valid?) { should be true }
+              end
+            end
+          end
+
+          context 'when the create binding schema is not valid' do
+            let(:schemas) {
+              {
+                'service_binding' => {
+                  'create' => {
+                    'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object', 'properties' => true }
+                  }
+                }
+              }
+            }
+            let(:path) { 'service_binding.create.parameters' }
+
+            its('errors.messages') { should have(1).items }
+            its('errors.messages.first') { should match "Schema #{path} is not valid" }
+            its(:valid?) { should be false }
+          end
+
+          context 'when schemas have a missing key' do
+            {
+              'Schemas service_binding.create': { 'service_binding' => { 'create' => {} } },
+            }.each do |name, test|
+              context "for property #{name}" do
+                let(:schemas) { test }
+
+                its(:create_binding) { should be_nil }
+                its(:errors) { should be_empty }
+                its(:valid?) { should be true }
+              end
+            end
+          end
+
+          context 'when schemas have an invalid type' do
+            {
+              'Schemas service_binding.create': { 'service_binding' => { 'create' => true } },
+              'Schemas service_binding.create.parameters': { 'service_binding' => { 'create' => { 'parameters' => true } } },
+            }.each do |name, test|
+              context "for property #{name}" do
+                let(:schemas) { test }
+
+                its(:create_binding) { should be_nil }
+                its('errors.messages') { should have(1).items }
+                its('errors.messages.first') { should eq "#{name} must be a hash, but has value true" }
+                its(:valid?) { should be false }
+              end
+            end
+          end
+
+          context 'when schemas has a potentially dangerous uri' do
+            let(:path) { 'service_binding.create.parameters' }
+            let(:schemas) {
+              {
+                'service_binding' => {
+                  'create' => {
+                    'parameters' => 'https://example.com/hax0r'
+                  }
+                }
+              }
+            }
+
+            its(:create_binding) { should be_nil }
             its('errors.messages') { should have(1).items }
             its('errors.messages.first') { should eq "Schemas #{path} must be a hash, but has value \"https://example.com/hax0r\"" }
             its(:valid?) { should be false }

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -56,7 +56,8 @@ module VCAP::CloudController
                                          :bindable,
                                          :active,
                                          :create_instance_schema,
-                                         :update_instance_schema
+                                         :update_instance_schema,
+                                         :create_binding_schema
       end
 
       it 'imports these attributes' do
@@ -69,7 +70,8 @@ module VCAP::CloudController
                                          :public,
                                          :bindable,
                                          :create_instance_schema,
-                                         :update_instance_schema
+                                         :update_instance_schema,
+                                         :create_binding_schema
       end
     end
 

--- a/spec/unit/presenters/v2/service_plan_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_plan_presenter_spec.rb
@@ -18,11 +18,13 @@ module CloudController::Presenters::V2
 
       let(:service_plan) do
         VCAP::CloudController::ServicePlan.make(create_instance_schema: create_instance_schema,
-                                                update_instance_schema: update_instance_schema)
+                                                update_instance_schema: update_instance_schema,
+                                                create_binding_schema: create_binding_schema)
       end
 
       let(:create_instance_schema) { nil }
       let(:update_instance_schema) { nil }
+      let(:create_binding_schema) { nil }
 
       before do
         allow(RelationsPresenter).to receive(:new).and_return(relations_presenter)
@@ -41,8 +43,11 @@ module CloudController::Presenters::V2
            'relationship_url' => 'http://relationship.example.com',
            'schemas' => {
                'service_instance' => {
-                'create' => { 'parameters' => {} },
-                'update' => { 'parameters' => {} }
+                   'create' => { 'parameters' => {} },
+                   'update' => { 'parameters' => {} }
+               },
+               'service_binding' => {
+                   'create' => { 'parameters' => {} }
                }
            },
            'service_guid' => service_plan.service_guid,
@@ -51,9 +56,10 @@ module CloudController::Presenters::V2
         )
       end
 
-      context 'when the plan create_instance_schema and update_instance_schema are nil' do
+      context 'when the plan create_instance_schema, update_instance_schema and create_binding_schema are nil' do
         let(:create_instance_schema) { nil }
         let(:update_instance_schema) { nil }
+        let(:create_binding_schema) { nil }
         it 'returns an empty schema in the correct format' do
           expect(subject.entity_hash(controller, service_plan, opts, depth, parents, orphans)).to include(
             {
@@ -61,6 +67,9 @@ module CloudController::Presenters::V2
                 'service_instance' => {
                   'create' => { 'parameters' => {} },
                   'update' => { 'parameters' => {} }
+                },
+                'service_binding' => {
+                  'create' => { 'parameters' => {} }
                 }
               }
             }
@@ -73,7 +82,17 @@ module CloudController::Presenters::V2
         let(:create_instance_schema) { schema.to_json }
         it 'returns the service plan entity with the schema in the correct format' do
           expect(subject.entity_hash(controller, service_plan, opts, depth, parents, orphans)).to include(
-            { 'schemas' => { 'service_instance' => { 'create' => { 'parameters' => schema }, 'update' => { 'parameters' => {} } } } }
+            {
+              'schemas' => {
+                'service_instance' => {
+                  'create' => { 'parameters' => schema },
+                  'update' => { 'parameters' => {} }
+                },
+                'service_binding' => {
+                  'create' => { 'parameters' => {} }
+                }
+              }
+            }
           )
         end
       end
@@ -82,7 +101,17 @@ module CloudController::Presenters::V2
         let(:create_instance_schema) { '{' }
         it 'returns an empty schema in the correct format' do
           expect(subject.entity_hash(controller, service_plan, opts, depth, parents, orphans)).to include(
-            { 'schemas' => { 'service_instance' => { 'create' => { 'parameters' => {} }, 'update' => { 'parameters' => {} } } } }
+            {
+              'schemas' => {
+                'service_instance' => {
+                  'create' => { 'parameters' => {} },
+                  'update' => { 'parameters' => {} }
+                },
+                'service_binding' => {
+                  'create' => { 'parameters' => {} }
+                }
+              }
+            }
           )
         end
       end
@@ -92,7 +121,23 @@ module CloudController::Presenters::V2
         let(:update_instance_schema) { schema.to_json }
         it 'returns the service plan entity with the schema in the correct format' do
           expect(subject.entity_hash(controller, service_plan, opts, depth, parents, orphans)).to include(
-            { 'schemas' => { 'service_instance' => { 'create' => { 'parameters' => {} }, 'update' => { 'parameters' => schema } } } }
+            {
+              'schemas' => {
+                'service_instance' => {
+                  'create' => {
+                    'parameters' => {}
+                  },
+                  'update' => {
+                    'parameters' => schema
+                  }
+                },
+                'service_binding' => {
+                  'create' => {
+                    'parameters' => {}
+                  }
+                }
+              }
+            }
           )
         end
       end
@@ -101,7 +146,43 @@ module CloudController::Presenters::V2
         let(:update_instance_schema) { '{' }
         it 'returns an empty schema in the correct format' do
           expect(subject.entity_hash(controller, service_plan, opts, depth, parents, orphans)).to include(
-            { 'schemas' => { 'service_instance' => { 'create' => { 'parameters' => {} }, 'update' => { 'parameters' => {} } } } }
+            {
+              'schemas' => {
+                'service_instance' => {
+                  'create' => { 'parameters' => {} },
+                  'update' => { 'parameters' => {} }
+                },
+                'service_binding' => {
+                  'create' => { 'parameters' => {} }
+                }
+              }
+            }
+          )
+        end
+      end
+
+      context 'when the plan create_binding_schema is valid json' do
+        schema = { '$schema' => 'example.com/schema' }
+        let(:create_binding_schema) { schema.to_json }
+        it 'returns the service plan entity with the schema in the correct format' do
+          expect(subject.entity_hash(controller, service_plan, opts, depth, parents, orphans)).to include(
+            {
+              'schemas' => {
+                'service_instance' => {
+                  'create' => {
+                    'parameters' => {}
+                  },
+                  'update' => {
+                    'parameters' => {}
+                  }
+                },
+                'service_binding' => {
+                  'create' => {
+                    'parameters' => schema
+                  }
+                }
+              }
+            }
           )
         end
       end


### PR DESCRIPTION
## Why
The Open Service Broker API is [proposing](https://github.com/openservicebrokerapi/servicebroker/issues/59) allowing brokers to define JSON schema for their configuration parameters. This will allow tooling to validate parameters and UIs to auto generate forms.

Schemas are to be defined as part of the catalog on a plan and support create/update parameters on a service instance and create parameters on a service binding (update does not exist yet).

The updated spec can be found [here](https://github.com/avade/servicebroker/blob/method-attached-schemas/spec.md#schema-object).

Example of what a new catalog with schemas will look like:
```
{
     ....
	"plans": [{
		"name": "fake-plan-1",
		"id": "d3031751-XXXX-XXXX-XXXX-a42377d3320e",
		"description": "Shared fake Server, 5tb persistent disk, 40 max concurrent connections",
		"schemas": {
			"service_instance": {
				"create": {
					"parameters": {
						"$schema": "http://json-schema.org/draft-04/schema#",
						"type": "object",
						"properties": {
							"billing-account": {
								"description": "Billing account number used to charge use of shared fake server.",
								"type": "string"
							}
						}
					}
				},
				"update": {
					"parameters": {
						"$schema": "http://json-schema.org/draft-04/schema#",
						"type": "object",
						"properties": {
							"billing-account": {
								"description": "Billing account number used to charge use of shared fake server.",
								"type": "string"
							}
						}
					}
				}
			},
			"service_binding": {
				"create": {
					"parameters": {
						"$schema": "http://json-schema.org/draft-04/schema#",
						"type": "object",
						"properties": {
							"billing-account": {
								"description": "Billing account number used to charge use of shared fake server.",
								"type": "string"
							}
						}
					}
				}
			}
		}
	}]
}
```
## What
This PR just adds basic support for create binding schemas (create instance schemas functionality merged in #834 & update instance schema merged in #865). Schemas are parsed during registration, stored in the service plan model and retrieved on the /v2/service_plan/:guid api endpoint. If a broker does not provide a schema, then we default to an empty schema.
* Add `create_binding_schema` to plan model object
* Add migration to service_plans to include text blob for `create_binding_schema`
* Add support for create binding schema to catalog objects retrieved from broker.
* Change service_plans presenter to support create binding schemas
* Added create binding schema tests to the 2.13 service broker api spec

## Notes
1. This PR is an extension of the #834 & #847 & #865 
1. We have no updated the *docs* yet as this is still an experimental change.
Feedback appreciated!
## PR
* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
Sam 