### PR TITLE
Add layer_{path,digest} to preloaded+layer URI

### DIFF
--- a/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
 
         def root_fs
           if @config[:diego][:temporary_oci_buildpack_mode] == 'oci-phase-1'
-            "preloaded+layer:#{@stack}?layer=#{URI.encode(@droplet_uri)}"
+            "preloaded+layer:#{@stack}?layer=#{URI.encode(@droplet_uri)}&layer_path=#{action_user_home}&layer_digest=#{@checksum_value}"
           else
             "preloaded:#{@stack}"
           end
@@ -45,7 +45,7 @@ module VCAP::CloudController
               from: @droplet_uri,
               to: '.',
               cache_key: "droplets-#{@process_guid}",
-              user: 'vcap',
+              user: action_user,
               checksum_algorithm: @checksum_algorithm,
               checksum_value: @checksum_value,
             )
@@ -74,6 +74,10 @@ module VCAP::CloudController
 
         def action_user
           'vcap'
+        end
+
+        def action_user_home
+          "/home/#{action_user}"
         end
       end
     end

--- a/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
@@ -48,7 +48,7 @@ module VCAP::CloudController
             let(:temporary_oci_buildpack_mode) { 'oci-phase-1' }
 
             it 'returns a constructed root_fs + layer URI' do
-              expect(builder.root_fs).to eq('preloaded+layer:potato-stack?layer=http://droplet-uri.com:1234?token=&@home---%3E')
+              expect(builder.root_fs).to eq('preloaded+layer:potato-stack?layer=http://droplet-uri.com:1234?token=&@home---%3E&layer_path=/home/vcap&layer_digest=checksum-value')
             end
           end
         end


### PR DESCRIPTION

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add layer_{path,digest} to preloaded+layer URI

* An explanation of the use cases your change solves
Enablement of oci-phase-1: https://www.pivotaltracker.com/story/show/149234807

* Links to any other associated PRs:
https://github.com/cloudfoundry/bbs/pull/23

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
