### PR TITLE
Allow global auditor to access all applications logs

### DIFF
--- a/app/controllers/internal/log_access_controller.rb
+++ b/app/controllers/internal/log_access_controller.rb
@@ -7,7 +7,7 @@ module VCAP::CloudController
     def lookup(guid)
       check_read_permissions!
 
-      if roles.admin?
+      if roles.admin? || roles.global_auditor?
         found = LogAccessFetcher.new.app_exists?(guid)
       else
         allowed_space_guids = membership.space_guids_for_roles([Membership::SPACE_DEVELOPER, Membership::SPACE_MANAGER, Membership::SPACE_AUDITOR, Membership::ORG_MANAGER])


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

Linked Issue https://github.com/cloudfoundry/cloud_controller_ng/issues/875

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
