### PR TITLE
Add Originating Identity header to requests to Service Brokers

### DIFF
--- a/lib/cloud_controller/security_context.rb
+++ b/lib/cloud_controller/security_context.rb
@@ -15,6 +15,10 @@ module VCAP::CloudController
       Thread.current[:vcap_user]
     end
 
+    def self.current_user_guid
+      current_user.guid if current_user
+    end
+
     def self.admin?
       roles.admin?
     end

--- a/lib/services/service_brokers/v2/http_client.rb
+++ b/lib/services/service_brokers/v2/http_client.rb
@@ -126,6 +126,9 @@ module VCAP::Services
 
         client.default_header = default_headers
         opts[:header]['Content-Type'] = content_type if content_type
+
+        user_guid = VCAP::CloudController::SecurityContext.current_user_guid
+        opts[:header][VCAP::Request::HEADER_BROKER_API_ORIGINATING_IDENTITY] = originating_identity(user_guid) if user_guid
         headers = default_headers.merge(opts[:header])
 
         logger.debug "Sending #{method} to #{uri}, BODY: #{body.inspect}, HEADERS: #{headers}"
@@ -157,6 +160,10 @@ module VCAP::Services
           'Accept' => 'application/json',
           VCAP::Request::HEADER_API_INFO_LOCATION => "#{VCAP::CloudController::Config.config[:external_domain]}/v2/info"
         }
+      end
+
+      def originating_identity(user_guid)
+        "cloudfoundry #{Base64.strict_encode64({ user_id: user_guid }.to_json)}"
       end
 
       def verify_certs?

--- a/lib/vcap/request.rb
+++ b/lib/vcap/request.rb
@@ -3,6 +3,7 @@ module VCAP
     HEADER_NAME = 'X-VCAP-Request-ID'.freeze
     HEADER_BROKER_API_VERSION = 'X-Broker-Api-Version'.freeze
     HEADER_API_INFO_LOCATION = 'X-Api-Info-Location'.freeze
+    HEADER_BROKER_API_ORIGINATING_IDENTITY = 'X-Broker-Api-Originating-Identity'.freeze
 
     class << self
       def current_id=(request_id)

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -4,185 +4,425 @@ RSpec.describe 'Service Broker API integration' do
   describe 'v2.13' do
     include VCAP::CloudController::BrokerApiHelper
 
-    let(:create_instance_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
-    let(:update_instance_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
-    let(:create_binding_schema)  { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
-    let(:schemas) {
-      {
-        'service_instance' => {
-          'create' => {
-            'parameters' => create_instance_schema
+    describe 'configuration parameter schemas' do
+      let(:create_instance_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
+      let(:update_instance_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
+      let(:create_binding_schema)  { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
+      let(:schemas) {
+        {
+          'service_instance' => {
+            'create' => {
+              'parameters' => create_instance_schema
+            },
+            'update' => {
+              'parameters' => update_instance_schema
+            }
           },
-          'update' => {
-            'parameters' => update_instance_schema
-          }
-        },
-        'service_binding' => {
-          'create' => {
-            'parameters' => create_binding_schema
+          'service_binding' => {
+            'create' => {
+              'parameters' => create_binding_schema
+            }
           }
         }
       }
-    }
 
-    let(:catalog) { default_catalog(plan_schemas: schemas) }
+      let(:catalog) { default_catalog(plan_schemas: schemas) }
 
-    before do
-      setup_cc
-      setup_broker(catalog)
-      @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
-    end
+      before do
+        setup_cc
+        setup_broker(catalog)
+        @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+      end
 
-    context 'when a broker catalog defines a service instance' do
-      context 'with a valid create schema' do
-        let(:create_instance_schema) {
-          {
-            '$schema' => 'http://json-schema.org/draft-04/schema#',
-            'type' => 'object'
-          }
-        }
-
-        it 'responds with the schema for a service plan entry' do
-          get("/v2/service_plans/#{@plan_guid}",
-              {}.to_json,
-              json_headers(admin_headers))
-
-          parsed_body = MultiJson.load(last_response.body)
-          create_schema = parsed_body['entity']['schemas']['service_instance']['create']
-          expect(create_schema).to eq(
+      context 'when a broker catalog defines a service instance' do
+        context 'with a valid create schema' do
+          let(:create_instance_schema) {
             {
-              'parameters' =>
-              {
-                '$schema' => 'http://json-schema.org/draft-04/schema#',
-                'type' => 'object'
-              }
+              '$schema' => 'http://json-schema.org/draft-04/schema#',
+              'type' => 'object'
             }
-          )
-        end
-      end
-
-      context 'with a valid update schema' do
-        let(:update_instance_schema) {
-          {
-            '$schema' => 'http://json-schema.org/draft-04/schema#',
-            'type' => 'object'
           }
-        }
 
-        it 'responds with the schema for a service plan entry' do
-          get("/v2/service_plans/#{@plan_guid}",
-              {}.to_json,
-              json_headers(admin_headers))
+          it 'responds with the schema for a service plan entry' do
+            get("/v2/service_plans/#{@plan_guid}",
+                {}.to_json,
+                json_headers(admin_headers))
 
-          parsed_body = MultiJson.load(last_response.body)
-          update_schema = parsed_body['entity']['schemas']['service_instance']['update']
-          expect(update_schema).to eq(
-            {
-              'parameters' =>
+            parsed_body = MultiJson.load(last_response.body)
+            create_schema = parsed_body['entity']['schemas']['service_instance']['create']
+            expect(create_schema).to eq(
               {
-                '$schema' => 'http://json-schema.org/draft-04/schema#',
-                'type' => 'object'
+                'parameters' =>
+                {
+                  '$schema' => 'http://json-schema.org/draft-04/schema#',
+                  'type' => 'object'
+                }
               }
+            )
+          end
+        end
+
+        context 'with a valid update schema' do
+          let(:update_instance_schema) {
+            {
+              '$schema' => 'http://json-schema.org/draft-04/schema#',
+              'type' => 'object'
             }
-          )
-        end
-      end
-
-      context 'with an invalid create schema' do
-        before do
-          update_broker(default_catalog(plan_schemas: { 'service_instance' => { 'create' => true } }))
-        end
-
-        it 'returns an error' do
-          parsed_body = MultiJson.load(last_response.body)
-
-          expect(parsed_body['code']).to eq(270012)
-          expect(parsed_body['description']).to include('Schemas service_instance.create must be a hash, but has value true')
-        end
-      end
-
-      context 'with an invalid update schema' do
-        before do
-          update_broker(default_catalog(plan_schemas: { 'service_instance' => { 'update' => true } }))
-        end
-
-        it 'returns an error' do
-          parsed_body = MultiJson.load(last_response.body)
-
-          expect(parsed_body['code']).to eq(270012)
-          expect(parsed_body['description']).to include('Schemas service_instance.update must be a hash, but has value true')
-        end
-      end
-    end
-
-    context 'when a broker catalog defines a service binding' do
-      context 'with a valid create schema' do
-        let(:create_binding_schema) {
-          {
-            '$schema' => 'http://json-schema.org/draft-04/schema#',
-            'type' => 'object'
           }
-        }
 
-        it 'responds with the schema for a service plan entry' do
-          get("/v2/service_plans/#{@plan_guid}",
-              {}.to_json,
-              json_headers(admin_headers))
+          it 'responds with the schema for a service plan entry' do
+            get("/v2/service_plans/#{@plan_guid}",
+                {}.to_json,
+                json_headers(admin_headers))
 
-          parsed_body = MultiJson.load(last_response.body)
-          create_schema = parsed_body['entity']['schemas']['service_binding']['create']
-          expect(create_schema).to eq(
-            {
-              'parameters' =>
+            parsed_body = MultiJson.load(last_response.body)
+            update_schema = parsed_body['entity']['schemas']['service_instance']['update']
+            expect(update_schema).to eq(
               {
-                '$schema' => 'http://json-schema.org/draft-04/schema#',
-                'type' => 'object'
+                'parameters' =>
+                {
+                  '$schema' => 'http://json-schema.org/draft-04/schema#',
+                  'type' => 'object'
+                }
               }
-            }
-          )
+            )
+          end
+        end
+
+        context 'with an invalid create schema' do
+          before do
+            update_broker(default_catalog(plan_schemas: { 'service_instance' => { 'create' => true } }))
+          end
+
+          it 'returns an error' do
+            parsed_body = MultiJson.load(last_response.body)
+
+            expect(parsed_body['code']).to eq(270012)
+            expect(parsed_body['description']).to include('Schemas service_instance.create must be a hash, but has value true')
+          end
+        end
+
+        context 'with an invalid update schema' do
+          before do
+            update_broker(default_catalog(plan_schemas: { 'service_instance' => { 'update' => true } }))
+          end
+
+          it 'returns an error' do
+            parsed_body = MultiJson.load(last_response.body)
+
+            expect(parsed_body['code']).to eq(270012)
+            expect(parsed_body['description']).to include('Schemas service_instance.update must be a hash, but has value true')
+          end
         end
       end
 
-      context 'with an invalid create schema' do
-        before do
-          update_broker(default_catalog(plan_schemas: { 'service_binding' => { 'create' => true } }))
-        end
-
-        it 'returns an error' do
-          parsed_body = MultiJson.load(last_response.body)
-
-          expect(parsed_body['code']).to eq(270012)
-          expect(parsed_body['description']).to include('Schemas service_binding.create must be a hash, but has value true')
-        end
-      end
-    end
-
-    context 'when the broker catalog defines a plan without plan schemas' do
-      it 'responds with an empty schema' do
-        get("/v2/service_plans/#{@large_plan_guid}",
-            {}.to_json,
-            json_headers(admin_headers)
-           )
-
-        parsed_body = MultiJson.load(last_response.body)
-        expect(parsed_body['entity']['schemas']).
-          to eq(
+      context 'when a broker catalog defines a service binding' do
+        context 'with a valid create schema' do
+          let(:create_binding_schema) {
             {
-              'service_instance' => {
-                'create' => {
-                  'parameters' => {}
+              '$schema' => 'http://json-schema.org/draft-04/schema#',
+              'type' => 'object'
+            }
+          }
+
+          it 'responds with the schema for a service plan entry' do
+            get("/v2/service_plans/#{@plan_guid}",
+                {}.to_json,
+                json_headers(admin_headers))
+
+            parsed_body = MultiJson.load(last_response.body)
+            create_schema = parsed_body['entity']['schemas']['service_binding']['create']
+            expect(create_schema).to eq(
+              {
+                'parameters' =>
+                {
+                  '$schema' => 'http://json-schema.org/draft-04/schema#',
+                  'type' => 'object'
+                }
+              }
+            )
+          end
+        end
+
+        context 'with an invalid create schema' do
+          before do
+            update_broker(default_catalog(plan_schemas: { 'service_binding' => { 'create' => true } }))
+          end
+
+          it 'returns an error' do
+            parsed_body = MultiJson.load(last_response.body)
+
+            expect(parsed_body['code']).to eq(270012)
+            expect(parsed_body['description']).to include('Schemas service_binding.create must be a hash, but has value true')
+          end
+        end
+      end
+
+      context 'when the broker catalog defines a plan without plan schemas' do
+        it 'responds with an empty schema' do
+          get("/v2/service_plans/#{@large_plan_guid}",
+              {}.to_json,
+              json_headers(admin_headers)
+             )
+
+          parsed_body = MultiJson.load(last_response.body)
+          expect(parsed_body['entity']['schemas']).
+            to eq(
+              {
+                'service_instance' => {
+                  'create' => {
+                    'parameters' => {}
+                  },
+                  'update' => {
+                    'parameters' => {}
+                  }
                 },
-                'update' => {
-                  'parameters' => {}
-                }
-              },
-              'service_binding' => {
-                'create' => {
-                  'parameters' => {}
+                'service_binding' => {
+                  'create' => {
+                    'parameters' => {}
+                  }
                 }
               }
-            }
-        )
+          )
+        end
+      end
+    end
+
+    describe 'originating header' do
+      let(:catalog) { default_catalog(plan_updateable: true) }
+
+      before do
+        setup_cc
+        setup_broker(catalog)
+        @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+      end
+
+      context 'service broker registration' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          setup_broker_with_user(user)
+          @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:get, %r{/v2/catalog}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service provision request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service deprovision request' do
+        let(:user) { VCAP::CloudController::User.make }
+
+        before do
+          provision_service(user: user)
+          deprovision_service(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service update request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service(user: user)
+          upgrade_service_instance(200, user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service binding request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service
+          create_app
+          bind_service(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service unbind request' do
+        let(:user) { VCAP::CloudController::User.make }
+
+        before do
+          provision_service
+          create_app
+          bind_service
+          unbind_service(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'create service key request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service
+          create_service_key(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'delete service key request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service
+          create_service_key
+          delete_key(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'create route binding' do
+        let(:catalog) { default_catalog(plan_updateable: true, requires: ['route_forwarding']) }
+        let(:user) { VCAP::CloudController::User.make }
+        let(:route) { VCAP::CloudController::Route.make(space: @space) }
+
+        before do
+          provision_service
+          create_route_binding(route, user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'delete route binding' do
+        let(:catalog) { default_catalog(plan_updateable: true, requires: ['route_forwarding']) }
+        let(:user) { VCAP::CloudController::User.make }
+        let(:route) { VCAP::CloudController::Route.make(space: @space) }
+
+        before do
+          provision_service
+          create_route_binding(route, user: user)
+          delete_route_binding(route, user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'when multiple users operate on a service instance' do
+        let(:user_a) { VCAP::CloudController::User.make }
+        let(:user_b) { VCAP::CloudController::User.make }
+        let(:user_c) { VCAP::CloudController::User.make }
+
+        before do
+          provision_service(user: user_a)
+          upgrade_service_instance(200, user: user_b)
+          deprovision_service(user: user_c)
+        end
+
+        it 'has the correct user ids for the requests' do
+          base64_encoded_user_a_id = Base64.strict_encode64("{\"user_id\":\"#{user_a.guid}\"}")
+          base64_encoded_user_b_id = Base64.strict_encode64("{\"user_id\":\"#{user_b.guid}\"}")
+          base64_encoded_user_c_id = Base64.strict_encode64("{\"user_id\":\"#{user_c.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_a_id}"
+            end
+          ).to have_been_made
+
+          expect(
+            a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_b_id}"
+            end
+          ).to have_been_made
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_c_id}"
+            end
+          ).to have_been_made
+        end
       end
     end
   end


### PR DESCRIPTION
## Why
The Open Service Broker API is [proposing](https://github.com/openservicebrokerapi/servicebroker/pull/222) that requests to service brokers should contain an Originating User ID as a HTTP header.

The header should have the format:

```
X-Broker-API-Originating-Identity: cloudfoundry <value>
```

where _value_ should be Base64 encoded.

For example, a value of:

```
{
  "user_id": "683ea748-3092-4ff4-b656-39cacc4d5360"
}
```
would appear in the HTTP Header as

```
X-Broker-API-Originating-Identity: cloudfoundry 
eyANCiAgInVzZXJfaWQiOiAiNjgzZWE3NDgtMzA5Mi00ZmY0LWI2NTYtMzljYWNjNGQ1MzYwIiwNCiAgInVzZXJfbmFtZSI6ICJqb2VAZXhhbXBsZS5jb20iDQp9
```

## What
This PR makes a change to the service broker HTTP client, and provides that client with the necessary header. The value of the header set to the user who originated the request to the platform.

For requests where there is no originating user, such as last operation and orphan mitigation, the header is omitted. 

The user's id is contained in a JSON string which is base 64 encoded. 

For all cf CLI commands that can trigger calls to the service broker, we have added the appropriate broker acceptance tests:

-    `cf create-service-broker`
-    `cf create-service`
-    `cf update-service`
-    `cf bind-service`
-    `cf delete-service`
-    `cf unbind-service`
-    `cf create-service-key`
-    `cf delete-service-key`
-    `cf bind-route-service`
-    `cf unbind-route-service`

## Notes
1. Docs will be pulled from the OpenServiceBrokerAPI when we bump the version of the spec. 

## PR
* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Sam, @ablease @lurraca 