### PR TITLE
Exec processes inside internal bin scripts

### DIFF
--- a/bosh/jobs/cloud_controller_clock/templates/bin/cloud_controller_clock.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/bin/cloud_controller_clock.erb
@@ -2,4 +2,4 @@
 
 source /var/vcap/jobs/cloud_controller_clock/bin/ruby_version.sh
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
-bundle exec rake clock:start
+exec bundle exec rake clock:start

--- a/bosh/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/bin/cloud_controller_ng.erb
@@ -14,5 +14,5 @@ echo 'Running migrations and seeds'
 echo 'Finished migrations and seeds'
 <% end %>
 
-/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/bin/cloud_controller \
+exec /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/bin/cloud_controller \
   -c /var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml

--- a/bosh/jobs/cloud_controller_ng/templates/bin/local_worker.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/bin/local_worker.erb
@@ -12,4 +12,4 @@ source /var/vcap/jobs/cloud_controller_ng/bin/blobstore_waiter.sh
 wait_for_blobstore
 
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
-bundle exec rake "jobs:local[cc_api_worker.<%= spec.job.name %>.<%= spec.index %>.${INDEX}]"
+exec bundle exec rake "jobs:local[cc_api_worker.<%= spec.job.name %>.<%= spec.index %>.${INDEX}]"

--- a/bosh/jobs/cloud_controller_ng/templates/bin/nginx_newrelic_plugin.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/bin/nginx_newrelic_plugin.erb
@@ -3,4 +3,4 @@
 source /var/vcap/jobs/cloud_controller_ng/bin/ruby_version.sh
 
 cd /var/vcap/packages/nginx_newrelic_plugin
-/var/vcap/packages/nginx_newrelic_plugin/newrelic_nginx_agent
+exec /var/vcap/packages/nginx_newrelic_plugin/newrelic_nginx_agent

--- a/bosh/jobs/cloud_controller_worker/templates/bin/cloud_controller_worker.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/bin/cloud_controller_worker.erb
@@ -12,4 +12,4 @@ source /var/vcap/jobs/cloud_controller_worker/bin/blobstore_waiter.sh
 wait_for_blobstore
 
 cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
-bundle exec rake jobs:generic[cc_global_worker.<%= spec.job.name %>.<%= spec.index %>.${INDEX}]
+exec bundle exec rake jobs:generic[cc_global_worker.<%= spec.job.name %>.<%= spec.index %>.${INDEX}]


### PR DESCRIPTION
As part of a refactor to support BPM, shared functionality was moved into a set of internal bash scripts. These scripts must `exec` the long lived process in order to allow for proper signal handling and pidfile management. Without the `exec`, `monit` is able to spin up multiple instances of the processes.

[#150264913]

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite