### PR TITLE
Use 'CELL/SSHD' as log source for diego-sshd

### DIFF
--- a/lib/cloud_controller/diego/app_recipe_builder.rb
+++ b/lib/cloud_controller/diego/app_recipe_builder.rb
@@ -179,6 +179,7 @@ module VCAP::CloudController
                  ],
                  env:             environment_variables,
                  resource_limits: ::Diego::Bbs::Models::ResourceLimits.new(nofile: file_descriptor_limit),
+                 log_source:      SSHD_LOG_SOURCE,
         ))
       end
 

--- a/lib/cloud_controller/diego/constants.rb
+++ b/lib/cloud_controller/diego/constants.rb
@@ -17,6 +17,7 @@ module VCAP::CloudController
     TASK_LOG_SOURCE                  = 'CELL'.freeze
     APP_LOG_SOURCE                   = 'APP'.freeze
     HEALTH_LOG_SOURCE                = 'HEALTH'.freeze
+    SSHD_LOG_SOURCE                  = "#{LRP_LOG_SOURCE}/SSHD".freeze
 
     APP_LRP_DOMAIN     = 'cf-apps'.freeze
     APP_LRP_DOMAIN_TTL = 2.minutes

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -717,6 +717,7 @@ module VCAP::CloudController
                   ],
                   resource_limits: ::Diego::Bbs::Models::ResourceLimits.new(nofile: expected_file_descriptor_limit),
                   env:             expected_action_environment_variables,
+                  log_source: 'CELL/SSHD',
                 )
               )
             end


### PR DESCRIPTION
This log source will help developers more easily distinguish between application errors and errors with the system-provided in-container SSH server.

---

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

 Show me a CAT that fails because of this change, and I'll show you a CAT that's too brittle.