### PR TITLE
Refactoring to use a Provider in ServiceBroker Clients

### DIFF
--- a/app/actions/service_binding_create.rb
+++ b/app/actions/service_binding_create.rb
@@ -49,8 +49,9 @@ module VCAP::CloudController
 
     private
 
-    def request_binding_from_broker(instance, binding, parameters)
-      instance.client.bind(binding, parameters).tap do |response|
+    def request_binding_from_broker(instance, service_binding, parameters)
+      client = VCAP::Services::ServiceClientProvider.provide(instance: instance)
+      client.bind(service_binding, parameters).tap do |response|
         response.delete(:route_service_url)
       end
     end

--- a/app/actions/service_binding_delete.rb
+++ b/app/actions/service_binding_delete.rb
@@ -43,7 +43,7 @@ module VCAP::CloudController
     end
 
     def remove_from_broker(service_binding)
-      client = VCAP::Services::ServiceClientProvider.provide(binding: service_binding)
+      client = VCAP::Services::ServiceClientProvider.provide(instance: service_binding.service_instance)
       client.unbind(service_binding)
     rescue => e
       logger.error("Failed unbinding #{service_binding.guid}: #{e.message}")

--- a/app/actions/services/service_instance_create.rb
+++ b/app/actions/services/service_instance_create.rb
@@ -13,7 +13,9 @@ module VCAP::CloudController
 
       service_instance = ManagedServiceInstance.new(request_params)
 
-      broker_response = service_instance.client.provision(
+      client = VCAP::Services::ServiceClientProvider.provide({ instance: service_instance })
+
+      broker_response = client.provision(
         service_instance,
         accepts_incomplete: accepts_incomplete,
         arbitrary_parameters: arbitrary_params
@@ -39,7 +41,6 @@ module VCAP::CloudController
     def setup_async_job(request_attrs, service_instance)
       job = VCAP::CloudController::Jobs::Services::ServiceInstanceStateFetch.new(
         'service-instance-state-fetch',
-        service_instance.client.attrs,
         service_instance.guid,
         @services_event_repository.user_audit_info,
         request_attrs,

--- a/app/actions/services/service_instance_update.rb
+++ b/app/actions/services/service_instance_update.rb
@@ -65,7 +65,9 @@ module VCAP::CloudController
                        service_instance.service_plan
                      end
 
-      response, err = service_instance.client.update(
+      client = VCAP::Services::ServiceClientProvider.provide({ instance: service_instance })
+
+      response, err = client.update(
         service_instance,
         service_plan,
         accepts_incomplete: accepts_incomplete,
@@ -98,10 +100,10 @@ module VCAP::CloudController
 
     def cache_previous_values(service_instance)
       {
-          plan_id: service_instance.service_plan.broker_provided_id,
-          service_id: service_instance.service.broker_provided_id,
-          organization_id: service_instance.organization.guid,
-          space_id: service_instance.space.guid
+        plan_id: service_instance.service_plan.broker_provided_id,
+        service_id: service_instance.service.broker_provided_id,
+        organization_id: service_instance.organization.guid,
+        space_id: service_instance.space.guid
       }
     end
 
@@ -112,7 +114,6 @@ module VCAP::CloudController
     def build_fetch_job(service_instance, request_attrs)
       VCAP::CloudController::Jobs::Services::ServiceInstanceStateFetch.new(
         'service-instance-state-fetch',
-        service_instance.client.attrs,
         service_instance.guid,
         @services_event_repository.user_audit_info,
         request_attrs,
@@ -131,10 +132,10 @@ module VCAP::CloudController
 
     def successful_sync_operation
       {
-          last_operation: {
-              state: 'succeeded',
-              description: nil
-          }
+        last_operation: {
+          state: 'succeeded',
+          description: nil
+        }
       }
     end
   end

--- a/app/actions/services/service_key_create.rb
+++ b/app/actions/services/service_key_create.rb
@@ -17,7 +17,8 @@ module VCAP::CloudController
 
         service_key = ServiceKey.new(key_attrs)
 
-        attributes_to_update = service_key.client.create_service_key(service_key, arbitrary_parameters: arbitrary_parameters)
+        client = VCAP::Services::ServiceClientProvider.provide(instance: service_instance)
+        attributes_to_update = client.create_service_key(service_key, arbitrary_parameters: arbitrary_parameters)
 
         begin
           service_key.set(attributes_to_update)
@@ -26,7 +27,7 @@ module VCAP::CloudController
           @logger.error "Failed to save state of create for service key #{service_key.guid} with exception: #{e}"
           orphan_mitigator = SynchronousOrphanMitigate.new(@logger)
           orphan_mitigator.attempt_delete_key(service_key)
-          raise e
+          raise
         end
       rescue => e
         errors << e

--- a/app/actions/services/service_key_delete.rb
+++ b/app/actions/services/service_key_delete.rb
@@ -15,11 +15,12 @@ module VCAP::CloudController
     def delete_service_binding(service_binding)
       errors = []
       service_instance = service_binding.service_instance
+      client = VCAP::Services::ServiceClientProvider.provide(instance: service_instance)
 
       begin
         raise_if_locked(service_instance)
 
-        service_instance.client.unbind(service_binding)
+        client.unbind(service_binding)
         service_binding.destroy
       rescue => e
         errors << e

--- a/app/actions/services/synchronous_orphan_mitigate.rb
+++ b/app/actions/services/synchronous_orphan_mitigate.rb
@@ -6,8 +6,7 @@ module VCAP::CloudController
 
     def attempt_deprovision_instance(service_instance)
       @logger.info "Attempting synchronous orphan mitigation for service instance #{service_instance.guid}"
-      client = VCAP::Services::ServiceClientProvider.provide(instance: service_instance)
-      client.deprovision(service_instance)
+      client(service_instance).deprovision(service_instance)
       @logger.info "Success deprovisioning orphaned service instance #{service_instance.guid}"
     rescue => e
       @logger.error "Unable to deprovision orphaned service instance #{service_instance.guid}: #{e}"
@@ -15,8 +14,8 @@ module VCAP::CloudController
 
     def attempt_delete_key(service_key)
       @logger.info "Attempting synchronous orphan mitigation for service key #{service_key.guid}"
-      client = VCAP::Services::ServiceClientProvider.provide(binding: service_key)
-      client.unbind(service_key)
+      service_instance = service_key.service_instance
+      client(service_instance).unbind(service_key)
       @logger.info "Success deleting orphaned service key #{service_key.guid}"
     rescue => e
       @logger.error "Unable to delete orphaned service key #{service_key.guid}: #{e}"
@@ -24,11 +23,17 @@ module VCAP::CloudController
 
     def attempt_unbind(service_binding)
       @logger.info "Attempting synchronous orphan mitigation for service binding #{service_binding.guid}"
-      client = VCAP::Services::ServiceClientProvider.provide(binding: service_binding)
-      client.unbind(service_binding)
+      service_instance = service_binding.service_instance
+      client(service_instance).unbind(service_binding)
       @logger.info "Success unbinding orphaned service binding #{service_binding.guid}"
     rescue => e
       @logger.error "Unable to delete orphaned service binding #{service_binding.guid}: #{e}"
+    end
+
+    private
+
+    def client(instance)
+      VCAP::Services::ServiceClientProvider.provide(instance: instance)
     end
   end
 end

--- a/app/actions/services/synchronous_orphan_mitigate.rb
+++ b/app/actions/services/synchronous_orphan_mitigate.rb
@@ -6,7 +6,8 @@ module VCAP::CloudController
 
     def attempt_deprovision_instance(service_instance)
       @logger.info "Attempting synchronous orphan mitigation for service instance #{service_instance.guid}"
-      service_instance.client.deprovision(service_instance)
+      client = VCAP::Services::ServiceClientProvider.provide(instance: service_instance)
+      client.deprovision(service_instance)
       @logger.info "Success deprovisioning orphaned service instance #{service_instance.guid}"
     rescue => e
       @logger.error "Unable to deprovision orphaned service instance #{service_instance.guid}: #{e}"
@@ -14,7 +15,8 @@ module VCAP::CloudController
 
     def attempt_delete_key(service_key)
       @logger.info "Attempting synchronous orphan mitigation for service key #{service_key.guid}"
-      service_key.client.unbind(service_key)
+      client = VCAP::Services::ServiceClientProvider.provide(binding: service_key)
+      client.unbind(service_key)
       @logger.info "Success deleting orphaned service key #{service_key.guid}"
     rescue => e
       @logger.error "Unable to delete orphaned service key #{service_key.guid}: #{e}"
@@ -22,7 +24,8 @@ module VCAP::CloudController
 
     def attempt_unbind(service_binding)
       @logger.info "Attempting synchronous orphan mitigation for service binding #{service_binding.guid}"
-      service_binding.client.unbind(service_binding)
+      client = VCAP::Services::ServiceClientProvider.provide(binding: service_binding)
+      client.unbind(service_binding)
       @logger.info "Success unbinding orphaned service binding #{service_binding.guid}"
     rescue => e
       @logger.error "Unable to delete orphaned service binding #{service_binding.guid}: #{e}"

--- a/app/controllers/services/lifecycle/service_instance_binding_manager.rb
+++ b/app/controllers/services/lifecycle/service_instance_binding_manager.rb
@@ -76,8 +76,9 @@ module VCAP::CloudController
     private
 
     def bind(binding_obj, arbitrary_parameters)
-      raise_if_locked(binding_obj.service_instance)
-      client = VCAP::Services::ServiceClientProvider.provide(binding: binding_obj)
+      service_instance = binding_obj.service_instance
+      raise_if_locked(service_instance)
+      client = VCAP::Services::ServiceClientProvider.provide(instance: service_instance)
       client.bind(binding_obj, arbitrary_parameters)
     end
 

--- a/app/controllers/services/lifecycle/service_instance_binding_manager.rb
+++ b/app/controllers/services/lifecycle/service_instance_binding_manager.rb
@@ -77,7 +77,8 @@ module VCAP::CloudController
 
     def bind(binding_obj, arbitrary_parameters)
       raise_if_locked(binding_obj.service_instance)
-      binding_obj.client.bind(binding_obj, arbitrary_parameters)
+      client = VCAP::Services::ServiceClientProvider.provide(binding: binding_obj)
+      client.bind(binding_obj, arbitrary_parameters)
     end
 
     def mitigate_orphan(binding)

--- a/app/controllers/services/lifecycle/service_key_manager.rb
+++ b/app/controllers/services/lifecycle/service_key_manager.rb
@@ -51,12 +51,6 @@ module VCAP::CloudController
 
     private
 
-    def safe_unbind_instance(service_key)
-      service_key.client.unbind(service_key)
-    rescue => e
-      @logger.error "Unable to unbind #{service_key}: #{e}"
-    end
-
     def validate_create_action(request_attrs)
       service_key = ServiceKey.new(request_attrs.except('parameters'))
       @access_validator.validate_access(:create, service_key)

--- a/app/jobs/services/service_instance_state_fetch.rb
+++ b/app/jobs/services/service_instance_state_fetch.rb
@@ -2,11 +2,10 @@ module VCAP::CloudController
   module Jobs
     module Services
       class ServiceInstanceStateFetch < VCAP::CloudController::Jobs::CCJob
-        attr_accessor :name, :client_attrs, :service_instance_guid, :services_event_repository, :request_attrs, :poll_interval, :end_timestamp
+        attr_accessor :name, :service_instance_guid, :services_event_repository, :request_attrs, :poll_interval, :end_timestamp
 
-        def initialize(name, client_attrs, service_instance_guid, user_audit_info, request_attrs, end_timestamp=nil)
+        def initialize(name, service_instance_guid, user_audit_info, request_attrs, end_timestamp=nil)
           @name                  = name
-          @client_attrs          = client_attrs
           @service_instance_guid = service_instance_guid
           @request_attrs         = request_attrs
           @end_timestamp         = end_timestamp || new_end_timestamp
@@ -17,7 +16,7 @@ module VCAP::CloudController
         def perform
           service_instance = ManagedServiceInstance.first(guid: service_instance_guid)
           return if service_instance.nil?
-          client = service_instance.service_broker.client
+          client = VCAP::Services::ServiceClientProvider.provide(instance: service_instance)
 
           attrs_to_update = client.fetch_service_instance_state(service_instance)
           update_with_attributes(attrs_to_update, service_instance)

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -19,8 +19,6 @@ module VCAP::CloudController
 
     serialize_attributes :json, :tags
 
-    delegate :client, to: :service_plan
-
     add_association_dependencies service_instance_operation: :destroy
 
     def validation_policies

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -85,9 +85,5 @@ module VCAP::CloudController
     def required_parameters
       { app_guid: app_guid }
     end
-
-    def unbind_from_broker
-      client.unbind(self)
-    end
   end
 end

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -24,8 +24,7 @@ module VCAP::CloudController
 
     import_attributes :app_guid, :service_instance_guid, :credentials, :syslog_drain_url
 
-    delegate :client, :service, :service_plan,
-      to: :service_instance
+    delegate :service, :service_plan, to: :service_instance
 
     def validate
       validates_presence :app

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
 
     import_attributes :name, :service_instance_guid, :credentials
 
-    delegate :client, :service, :service_plan, to: :service_instance
+    delegate :service, :service_plan, to: :service_instance
 
     plugin :after_initialize
 

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -75,13 +75,5 @@ module VCAP::CloudController
     def logger
       @logger ||= Steno.logger('cc.models.service_key')
     end
-
-    private
-
-    def safe_unbind
-      client.unbind(self)
-    rescue => unbind_e
-      logger.error "Unable to unbind #{self}: #{unbind_e}"
-    end
   end
 end

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -35,8 +35,6 @@ module VCAP::CloudController
 
     strip_attributes :name
 
-    delegate :client, to: :service
-
     alias_method :active?, :active
 
     alias_method :broker_provided_id, :unique_id

--- a/lib/cloud_controller/security_context.rb
+++ b/lib/cloud_controller/security_context.rb
@@ -15,6 +15,10 @@ module VCAP::CloudController
       Thread.current[:vcap_user]
     end
 
+    def self.current_user_guid
+      current_user.guid if current_user
+    end
+
     def self.admin?
       roles.admin?
     end

--- a/lib/services/service_brokers.rb
+++ b/lib/services/service_brokers.rb
@@ -4,6 +4,7 @@ require 'services/service_brokers/user_provided'
 require 'services/service_brokers/v2'
 
 require 'services/service_brokers/null_client'
+require 'services/service_brokers/service_client_provider'
 require 'services/service_brokers/service_manager'
 require 'services/service_brokers/service_broker_registration'
 require 'services/service_brokers/service_broker_remover'

--- a/lib/services/service_brokers/service_broker_registration.rb
+++ b/lib/services/service_brokers/service_broker_registration.rb
@@ -90,7 +90,8 @@ module VCAP::Services::ServiceBrokers
     end
 
     def catalog
-      @catalog ||= VCAP::Services::ServiceBrokers::V2::Catalog.new(broker, broker.client.catalog)
+      client = VCAP::Services::ServiceClientProvider.provide(broker: broker)
+      @catalog ||= VCAP::Services::ServiceBrokers::V2::Catalog.new(broker, client.catalog)
     end
 
     def formatter

--- a/lib/services/service_brokers/service_client_provider.rb
+++ b/lib/services/service_brokers/service_client_provider.rb
@@ -1,0 +1,34 @@
+module VCAP::Services
+  class ServiceClientProvider
+    def self.provide(opts={})
+      return provide_client_for_broker(opts[:broker]) if opts[:broker]
+      return provide_client_for_binding(opts[:binding]) if opts[:binding]
+      provide_client_for_instance(opts[:instance]) if opts[:instance]
+    end
+
+    class << self
+      private
+
+      def provide_client_for_binding(service_binding)
+        provide_client_for_instance(service_binding.service_instance)
+      end
+
+      def provide_client_for_instance(service_instance)
+        if service_instance.is_a? VCAP::CloudController::UserProvidedServiceInstance
+          VCAP::Services::ServiceBrokers::UserProvided::Client.new
+        else
+          provide_client_for_broker(service_instance.service_broker)
+        end
+      end
+
+      def provide_client_for_broker(service_broker)
+        client_attrs = {
+          url: service_broker.broker_url,
+          auth_username: service_broker.auth_username,
+          auth_password: service_broker.auth_password
+        }
+        VCAP::Services::ServiceBrokers::V2::Client.new(client_attrs)
+      end
+    end
+  end
+end

--- a/lib/services/service_brokers/service_client_provider.rb
+++ b/lib/services/service_brokers/service_client_provider.rb
@@ -2,16 +2,11 @@ module VCAP::Services
   class ServiceClientProvider
     def self.provide(opts={})
       return provide_client_for_broker(opts[:broker]) if opts[:broker]
-      return provide_client_for_binding(opts[:binding]) if opts[:binding]
       provide_client_for_instance(opts[:instance]) if opts[:instance]
     end
 
     class << self
       private
-
-      def provide_client_for_binding(service_binding)
-        provide_client_for_instance(service_binding.service_instance)
-      end
 
       def provide_client_for_instance(service_instance)
         if service_instance.is_a? VCAP::CloudController::UserProvidedServiceInstance

--- a/lib/services/service_brokers/v2/http_client.rb
+++ b/lib/services/service_brokers/v2/http_client.rb
@@ -126,6 +126,9 @@ module VCAP::Services
 
         client.default_header = default_headers
         opts[:header]['Content-Type'] = content_type if content_type
+
+        user_guid = VCAP::CloudController::SecurityContext.current_user_guid
+        opts[:header][VCAP::Request::HEADER_BROKER_API_ORIGINATING_IDENTITY] = originating_identity(user_guid) if user_guid
         headers = default_headers.merge(opts[:header])
 
         logger.debug "Sending #{method} to #{uri}, BODY: #{body.inspect}, HEADERS: #{headers}"
@@ -157,6 +160,10 @@ module VCAP::Services
           'Accept' => 'application/json',
           VCAP::Request::HEADER_API_INFO_LOCATION => "#{VCAP::CloudController::Config.config[:external_domain]}/v2/info"
         }
+      end
+
+      def originating_identity(user_guid)
+        "cloudfoundry #{Base64.strict_encode64({ user_id: user_guid }.to_json)}"
       end
 
       def verify_certs?

--- a/lib/vcap/request.rb
+++ b/lib/vcap/request.rb
@@ -3,6 +3,7 @@ module VCAP
     HEADER_NAME = 'X-VCAP-Request-ID'.freeze
     HEADER_BROKER_API_VERSION = 'X-Broker-Api-Version'.freeze
     HEADER_API_INFO_LOCATION = 'X-Api-Info-Location'.freeze
+    HEADER_BROKER_API_ORIGINATING_IDENTITY = 'X-Broker-Api-Originating-Identity'.freeze
 
     class << self
       def current_id=(request_id)

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -4,185 +4,425 @@ RSpec.describe 'Service Broker API integration' do
   describe 'v2.13' do
     include VCAP::CloudController::BrokerApiHelper
 
-    let(:create_instance_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
-    let(:update_instance_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
-    let(:create_binding_schema)  { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
-    let(:schemas) {
-      {
-        'service_instance' => {
-          'create' => {
-            'parameters' => create_instance_schema
+    describe 'configuration parameter schemas' do
+      let(:create_instance_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
+      let(:update_instance_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
+      let(:create_binding_schema)  { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'type' => 'object' } }
+      let(:schemas) {
+        {
+          'service_instance' => {
+            'create' => {
+              'parameters' => create_instance_schema
+            },
+            'update' => {
+              'parameters' => update_instance_schema
+            }
           },
-          'update' => {
-            'parameters' => update_instance_schema
-          }
-        },
-        'service_binding' => {
-          'create' => {
-            'parameters' => create_binding_schema
+          'service_binding' => {
+            'create' => {
+              'parameters' => create_binding_schema
+            }
           }
         }
       }
-    }
 
-    let(:catalog) { default_catalog(plan_schemas: schemas) }
+      let(:catalog) { default_catalog(plan_schemas: schemas) }
 
-    before do
-      setup_cc
-      setup_broker(catalog)
-      @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
-    end
+      before do
+        setup_cc
+        setup_broker(catalog)
+        @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+      end
 
-    context 'when a broker catalog defines a service instance' do
-      context 'with a valid create schema' do
-        let(:create_instance_schema) {
-          {
-            '$schema' => 'http://json-schema.org/draft-04/schema#',
-            'type' => 'object'
-          }
-        }
-
-        it 'responds with the schema for a service plan entry' do
-          get("/v2/service_plans/#{@plan_guid}",
-              {}.to_json,
-              json_headers(admin_headers))
-
-          parsed_body = MultiJson.load(last_response.body)
-          create_schema = parsed_body['entity']['schemas']['service_instance']['create']
-          expect(create_schema).to eq(
+      context 'when a broker catalog defines a service instance' do
+        context 'with a valid create schema' do
+          let(:create_instance_schema) {
             {
-              'parameters' =>
-              {
-                '$schema' => 'http://json-schema.org/draft-04/schema#',
-                'type' => 'object'
-              }
+              '$schema' => 'http://json-schema.org/draft-04/schema#',
+              'type' => 'object'
             }
-          )
-        end
-      end
-
-      context 'with a valid update schema' do
-        let(:update_instance_schema) {
-          {
-            '$schema' => 'http://json-schema.org/draft-04/schema#',
-            'type' => 'object'
           }
-        }
 
-        it 'responds with the schema for a service plan entry' do
-          get("/v2/service_plans/#{@plan_guid}",
-              {}.to_json,
-              json_headers(admin_headers))
+          it 'responds with the schema for a service plan entry' do
+            get("/v2/service_plans/#{@plan_guid}",
+                {}.to_json,
+                json_headers(admin_headers))
 
-          parsed_body = MultiJson.load(last_response.body)
-          update_schema = parsed_body['entity']['schemas']['service_instance']['update']
-          expect(update_schema).to eq(
-            {
-              'parameters' =>
+            parsed_body = MultiJson.load(last_response.body)
+            create_schema = parsed_body['entity']['schemas']['service_instance']['create']
+            expect(create_schema).to eq(
               {
-                '$schema' => 'http://json-schema.org/draft-04/schema#',
-                'type' => 'object'
+                'parameters' =>
+                {
+                  '$schema' => 'http://json-schema.org/draft-04/schema#',
+                  'type' => 'object'
+                }
               }
+            )
+          end
+        end
+
+        context 'with a valid update schema' do
+          let(:update_instance_schema) {
+            {
+              '$schema' => 'http://json-schema.org/draft-04/schema#',
+              'type' => 'object'
             }
-          )
-        end
-      end
-
-      context 'with an invalid create schema' do
-        before do
-          update_broker(default_catalog(plan_schemas: { 'service_instance' => { 'create' => true } }))
-        end
-
-        it 'returns an error' do
-          parsed_body = MultiJson.load(last_response.body)
-
-          expect(parsed_body['code']).to eq(270012)
-          expect(parsed_body['description']).to include('Schemas service_instance.create must be a hash, but has value true')
-        end
-      end
-
-      context 'with an invalid update schema' do
-        before do
-          update_broker(default_catalog(plan_schemas: { 'service_instance' => { 'update' => true } }))
-        end
-
-        it 'returns an error' do
-          parsed_body = MultiJson.load(last_response.body)
-
-          expect(parsed_body['code']).to eq(270012)
-          expect(parsed_body['description']).to include('Schemas service_instance.update must be a hash, but has value true')
-        end
-      end
-    end
-
-    context 'when a broker catalog defines a service binding' do
-      context 'with a valid create schema' do
-        let(:create_binding_schema) {
-          {
-            '$schema' => 'http://json-schema.org/draft-04/schema#',
-            'type' => 'object'
           }
-        }
 
-        it 'responds with the schema for a service plan entry' do
-          get("/v2/service_plans/#{@plan_guid}",
-              {}.to_json,
-              json_headers(admin_headers))
+          it 'responds with the schema for a service plan entry' do
+            get("/v2/service_plans/#{@plan_guid}",
+                {}.to_json,
+                json_headers(admin_headers))
 
-          parsed_body = MultiJson.load(last_response.body)
-          create_schema = parsed_body['entity']['schemas']['service_binding']['create']
-          expect(create_schema).to eq(
-            {
-              'parameters' =>
+            parsed_body = MultiJson.load(last_response.body)
+            update_schema = parsed_body['entity']['schemas']['service_instance']['update']
+            expect(update_schema).to eq(
               {
-                '$schema' => 'http://json-schema.org/draft-04/schema#',
-                'type' => 'object'
+                'parameters' =>
+                {
+                  '$schema' => 'http://json-schema.org/draft-04/schema#',
+                  'type' => 'object'
+                }
               }
-            }
-          )
+            )
+          end
+        end
+
+        context 'with an invalid create schema' do
+          before do
+            update_broker(default_catalog(plan_schemas: { 'service_instance' => { 'create' => true } }))
+          end
+
+          it 'returns an error' do
+            parsed_body = MultiJson.load(last_response.body)
+
+            expect(parsed_body['code']).to eq(270012)
+            expect(parsed_body['description']).to include('Schemas service_instance.create must be a hash, but has value true')
+          end
+        end
+
+        context 'with an invalid update schema' do
+          before do
+            update_broker(default_catalog(plan_schemas: { 'service_instance' => { 'update' => true } }))
+          end
+
+          it 'returns an error' do
+            parsed_body = MultiJson.load(last_response.body)
+
+            expect(parsed_body['code']).to eq(270012)
+            expect(parsed_body['description']).to include('Schemas service_instance.update must be a hash, but has value true')
+          end
         end
       end
 
-      context 'with an invalid create schema' do
-        before do
-          update_broker(default_catalog(plan_schemas: { 'service_binding' => { 'create' => true } }))
-        end
-
-        it 'returns an error' do
-          parsed_body = MultiJson.load(last_response.body)
-
-          expect(parsed_body['code']).to eq(270012)
-          expect(parsed_body['description']).to include('Schemas service_binding.create must be a hash, but has value true')
-        end
-      end
-    end
-
-    context 'when the broker catalog defines a plan without plan schemas' do
-      it 'responds with an empty schema' do
-        get("/v2/service_plans/#{@large_plan_guid}",
-            {}.to_json,
-            json_headers(admin_headers)
-           )
-
-        parsed_body = MultiJson.load(last_response.body)
-        expect(parsed_body['entity']['schemas']).
-          to eq(
+      context 'when a broker catalog defines a service binding' do
+        context 'with a valid create schema' do
+          let(:create_binding_schema) {
             {
-              'service_instance' => {
-                'create' => {
-                  'parameters' => {}
+              '$schema' => 'http://json-schema.org/draft-04/schema#',
+              'type' => 'object'
+            }
+          }
+
+          it 'responds with the schema for a service plan entry' do
+            get("/v2/service_plans/#{@plan_guid}",
+                {}.to_json,
+                json_headers(admin_headers))
+
+            parsed_body = MultiJson.load(last_response.body)
+            create_schema = parsed_body['entity']['schemas']['service_binding']['create']
+            expect(create_schema).to eq(
+              {
+                'parameters' =>
+                {
+                  '$schema' => 'http://json-schema.org/draft-04/schema#',
+                  'type' => 'object'
+                }
+              }
+            )
+          end
+        end
+
+        context 'with an invalid create schema' do
+          before do
+            update_broker(default_catalog(plan_schemas: { 'service_binding' => { 'create' => true } }))
+          end
+
+          it 'returns an error' do
+            parsed_body = MultiJson.load(last_response.body)
+
+            expect(parsed_body['code']).to eq(270012)
+            expect(parsed_body['description']).to include('Schemas service_binding.create must be a hash, but has value true')
+          end
+        end
+      end
+
+      context 'when the broker catalog defines a plan without plan schemas' do
+        it 'responds with an empty schema' do
+          get("/v2/service_plans/#{@large_plan_guid}",
+              {}.to_json,
+              json_headers(admin_headers)
+             )
+
+          parsed_body = MultiJson.load(last_response.body)
+          expect(parsed_body['entity']['schemas']).
+            to eq(
+              {
+                'service_instance' => {
+                  'create' => {
+                    'parameters' => {}
+                  },
+                  'update' => {
+                    'parameters' => {}
+                  }
                 },
-                'update' => {
-                  'parameters' => {}
-                }
-              },
-              'service_binding' => {
-                'create' => {
-                  'parameters' => {}
+                'service_binding' => {
+                  'create' => {
+                    'parameters' => {}
+                  }
                 }
               }
-            }
-        )
+          )
+        end
+      end
+    end
+
+    describe 'originating header' do
+      let(:catalog) { default_catalog(plan_updateable: true) }
+
+      before do
+        setup_cc
+        setup_broker(catalog)
+        @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+      end
+
+      context 'service broker registration' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          setup_broker_with_user(user)
+          @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:get, %r{/v2/catalog}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service provision request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service deprovision request' do
+        let(:user) { VCAP::CloudController::User.make }
+
+        before do
+          provision_service(user: user)
+          deprovision_service(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service update request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service(user: user)
+          upgrade_service_instance(200, user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service binding request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service
+          create_app
+          bind_service(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'service unbind request' do
+        let(:user) { VCAP::CloudController::User.make }
+
+        before do
+          provision_service
+          create_app
+          bind_service
+          unbind_service(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'create service key request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service
+          create_service_key(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'delete service key request' do
+        let(:user) { VCAP::CloudController::User.make }
+        before do
+          provision_service
+          create_service_key
+          delete_key(user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'create route binding' do
+        let(:catalog) { default_catalog(plan_updateable: true, requires: ['route_forwarding']) }
+        let(:user) { VCAP::CloudController::User.make }
+        let(:route) { VCAP::CloudController::Route.make(space: @space) }
+
+        before do
+          provision_service
+          create_route_binding(route, user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'delete route binding' do
+        let(:catalog) { default_catalog(plan_updateable: true, requires: ['route_forwarding']) }
+        let(:user) { VCAP::CloudController::User.make }
+        let(:route) { VCAP::CloudController::Route.make(space: @space) }
+
+        before do
+          provision_service
+          create_route_binding(route, user: user)
+          delete_route_binding(route, user: user)
+        end
+
+        it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
+          base64_encoded_user_id = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_id}"
+            end
+          ).to have_been_made
+        end
+      end
+
+      context 'when multiple users operate on a service instance' do
+        let(:user_a) { VCAP::CloudController::User.make }
+        let(:user_b) { VCAP::CloudController::User.make }
+        let(:user_c) { VCAP::CloudController::User.make }
+
+        before do
+          provision_service(user: user_a)
+          upgrade_service_instance(200, user: user_b)
+          deprovision_service(user: user_c)
+        end
+
+        it 'has the correct user ids for the requests' do
+          base64_encoded_user_a_id = Base64.strict_encode64("{\"user_id\":\"#{user_a.guid}\"}")
+          base64_encoded_user_b_id = Base64.strict_encode64("{\"user_id\":\"#{user_b.guid}\"}")
+          base64_encoded_user_c_id = Base64.strict_encode64("{\"user_id\":\"#{user_c.guid}\"}")
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_a_id}"
+            end
+          ).to have_been_made
+
+          expect(
+            a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_b_id}"
+            end
+          ).to have_been_made
+
+          expect(
+            a_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}}).with do |req|
+              req.headers['X-Broker-Api-Originating-Identity'] == "cloudfoundry #{base64_encoded_user_c_id}"
+            end
+          ).to have_been_made
+        end
       end
     end
   end

--- a/spec/unit/actions/service_binding_create_spec.rb
+++ b/spec/unit/actions/service_binding_create_spec.rb
@@ -10,6 +10,7 @@ module VCAP::CloudController
 
       let(:app) { AppModel.make }
       let(:service_instance) { ManagedServiceInstance.make(space: app.space) }
+      let(:client) { VCAP::Services::ServiceBrokers::V2::Client }
       let(:request) do
         {
           'type'          => 'app',
@@ -30,6 +31,9 @@ module VCAP::CloudController
       let(:arbitrary_parameters) { {} }
 
       before do
+        allow(VCAP::Services::ServiceClientProvider).to receive(:provide).and_return(client)
+        allow(client).to receive(:bind).and_return({})
+
         credentials          = { 'credentials' => '{}' }.to_json
         fake_service_binding = ServiceBinding.new(service_instance: service_instance, guid: '')
         opts                 = {
@@ -120,13 +124,13 @@ module VCAP::CloudController
       describe 'orphan mitigation situations' do
         context 'when the broker returns an error on creation' do
           before do
-            stub_bind(service_instance, status: 500)
+            allow(client).to receive(:bind).and_raise('meow')
           end
 
           it 'does not create a binding' do
             expect {
               service_binding_create.create(app, service_instance, message, volume_mount_services_enabled)
-            }.to raise_error VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerBadResponse
+            }.to raise_error 'meow'
 
             expect(ServiceBinding.count).to eq 0
           end
@@ -141,32 +145,33 @@ module VCAP::CloudController
             allow_any_instance_of(ServiceBinding).to receive(:save).and_raise('meow')
             allow(logger).to receive(:error)
             allow(logger).to receive(:info)
+          end
+
+          it 'immediately attempts to unbind the service instance' do
+            expect_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_unbind)
 
             expect {
               service_binding_create.create(app, service_instance, message, volume_mount_services_enabled)
             }.to raise_error('meow')
-          end
 
-          it 'immediately attempts to unbind the service instance' do
-            expect(a_request(:put, service_binding_url_pattern)).to have_been_made.times(1)
-            expect(a_request(:delete, service_binding_url_pattern)).to have_been_made.times(1)
+            expect(client).to have_received(:bind)
           end
 
           it 'does not try to enqueue a delayed job for orphan mitigation' do
+            expect {
+              service_binding_create.create(app, service_instance, message, volume_mount_services_enabled)
+            }.to raise_error('meow')
+
             orphan_mitigating_job = Delayed::Job.first
             expect(orphan_mitigating_job).to be_nil
           end
 
-          context 'when the orphan mitigation unbind fails' do
-            before do
-              stub_request(:delete, service_binding_url_pattern).
-                to_return(status: 500, body: {}.to_json)
-            end
+          it 'logs that the unbind failed' do
+            expect {
+              service_binding_create.create(app, service_instance, message, volume_mount_services_enabled)
+            }.to raise_error('meow')
 
-            it 'logs that the unbind failed' do
-              expect(logger).to have_received(:error).with /Failed to save/
-              expect(logger).to have_received(:error).with /Unable to delete orphaned service binding/
-            end
+            expect(logger).to have_received(:error).with /Failed to save/
           end
         end
       end

--- a/spec/unit/actions/services/locks/deleter_lock_spec.rb
+++ b/spec/unit/actions/services/locks/deleter_lock_spec.rb
@@ -73,7 +73,7 @@ module VCAP::CloudController
         end
 
         it 'enqueues the job' do
-          job = Jobs::Services::ServiceInstanceStateFetch.new(nil, nil, nil, nil, nil, nil)
+          job = Jobs::Services::ServiceInstanceStateFetch.new(nil, nil, nil, nil, nil)
           deleter_lock.enqueue_unlock!({}, job)
           expect(Delayed::Job.first).to be_a_fully_wrapped_job_of Jobs::Services::ServiceInstanceStateFetch
         end

--- a/spec/unit/actions/services/locks/updater_lock_spec.rb
+++ b/spec/unit/actions/services/locks/updater_lock_spec.rb
@@ -64,7 +64,7 @@ module VCAP::CloudController
 
       describe 'unlocking with a delayed job' do
         it 'enqueues the job' do
-          job = Jobs::Services::ServiceInstanceStateFetch.new(nil, nil, nil, nil, nil, nil)
+          job = Jobs::Services::ServiceInstanceStateFetch.new(nil, nil, nil, nil, nil)
           updater_lock.enqueue_unlock!(job)
           expect(Delayed::Job.first).to be_a_fully_wrapped_job_of Jobs::Services::ServiceInstanceStateFetch
         end

--- a/spec/unit/actions/services/service_instance_delete_spec.rb
+++ b/spec/unit/actions/services/service_instance_delete_spec.rb
@@ -112,7 +112,6 @@ module VCAP::CloudController
 
           inner_job = job.payload_object.handler.handler
           expect(inner_job.name).to eq 'service-instance-state-fetch'
-          expect(inner_job.client_attrs).to eq service_instance.client.attrs
           expect(inner_job.service_instance_guid).to eq service_instance.guid
           expect(inner_job.request_attrs).to eq({})
           expect(inner_job.poll_interval).to eq(60)

--- a/spec/unit/actions/services/service_key_create_spec.rb
+++ b/spec/unit/actions/services/service_key_create_spec.rb
@@ -3,73 +3,70 @@ require 'actions/services/service_key_create'
 
 module VCAP::CloudController
   RSpec.describe ServiceKeyCreate do
+    subject(:service_key_create) { ServiceKeyCreate.new(logger) }
     let(:service_instance) { ManagedServiceInstance.make }
     let(:service_binding_url_pattern) { %r{/v2/service_instances/#{service_instance.guid}/service_bindings/} }
+    let(:client) { VCAP::Services::ServiceBrokers::V2::Client }
 
     describe 'creating a service key' do
       let(:logger) { double(Steno::Logger) }
       let(:key_attrs) do
         {
-            'service_instance_guid' => service_instance.guid,
+          'name' => 'key-name',
+          'service_instance_guid' => service_instance.guid,
         }
       end
 
       before do
+        allow(VCAP::Services::ServiceClientProvider).to receive(:provide).
+          and_return(client)
+        allow(client).to receive(:create_service_key).and_return({ credentials: { foo: 'bar' } })
+
         allow(logger).to receive :error
         allow(logger).to receive :info
       end
 
-      it 'fails if the instance has another operation in progress' do
-        service_instance.service_instance_operation = ServiceInstanceOperation.make state: 'in progress'
+      it 'successfully sets service key credentials' do
         service_key_create = ServiceKeyCreate.new(logger)
-        _, errors = service_key_create.create(service_instance, key_attrs, {})
-        expect(errors.first).to be_instance_of CloudController::Errors::ApiError
+        key, errors = service_key_create.create(service_instance, key_attrs, {})
+        expect(errors).to be_empty
+        expect(key.credentials).to eq({ 'foo' => 'bar' })
       end
 
-      describe 'orphan mitigation situations' do
-        context 'when the broker returns an error on creation' do
-          before do
-            stub_bind(service_instance, status: 500)
-          end
+      context 'and the instance has another operation in progress' do
+        it 'fails' do
+          service_instance.service_instance_operation = ServiceInstanceOperation.make state: 'in progress'
+          service_key_create = ServiceKeyCreate.new(logger)
+          _, errors = service_key_create.create(service_instance, key_attrs, {})
+          expect(errors.first).to be_instance_of CloudController::Errors::ApiError
+        end
+      end
 
-          it 'does not create a key' do
-            ServiceKeyCreate.new(logger).create(service_instance, key_attrs, {})
-
-            expect(ServiceKey.count).to eq 0
-          end
+      context 'when the broker returns an error on creation' do
+        before do
+          allow(client).to receive(:create_service_key).and_raise('meow')
         end
 
-        context 'when broker request is successful but the database fails to save the key (Hail Mary)' do
-          before do
-            stub_bind(service_instance)
-            stub_request(:delete, service_binding_url_pattern)
+        it 'does not create a key' do
+          ServiceKeyCreate.new(logger).create(service_instance, key_attrs, {})
+          expect(ServiceKey.count).to eq 0
+        end
+      end
 
-            allow_any_instance_of(ServiceKey).to receive(:save).and_raise
+      context 'when broker request is successful but the database fails to save the key (hail mary)' do
+        before do
+          allow_any_instance_of(ServiceKey).to receive(:save).and_raise
+        end
 
-            ServiceKeyCreate.new(logger).create(service_instance, key_attrs, {})
-          end
+        it 'immediately attempts to unbind the service instance' do
+          expect_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_delete_key)
+          subject.create(service_instance, key_attrs, {})
+        end
 
-          it 'immediately attempts to unbind the service instance' do
-            expect(a_request(:put, service_binding_url_pattern)).to have_been_made.times(1)
-            expect(a_request(:delete, service_binding_url_pattern)).to have_been_made.times(1)
-          end
-
-          it 'does not try to enqueue an orphan mitigation job' do
-            orphan_mitigating_job = Delayed::Job.first
-            expect(orphan_mitigating_job).to be_nil
-          end
-
-          context 'when the orphan mitigation unbind fails' do
-            before do
-              stub_request(:delete, service_binding_url_pattern).
-                to_return(status: 500, body: {}.to_json)
-            end
-
-            it 'logs that the unbind failed' do
-              expect(logger).to have_received(:error).with /Failed to save/
-              expect(logger).to have_received(:error).with /Unable to delete orphaned service key/
-            end
-          end
+        it 'logs that the unbind failed' do
+          allow_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_delete_key)
+          subject.create(service_instance, key_attrs, {})
+          expect(logger).to have_received(:error).with /Failed to save/
         end
       end
     end

--- a/spec/unit/actions/services/synchronous_orphan_mitigate_spec.rb
+++ b/spec/unit/actions/services/synchronous_orphan_mitigate_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe 'Synchronous orphan mitigation' do
     it 'logs that it is attempting to orphan mitigate' do
       subject.attempt_deprovision_instance(service_instance)
 
-      expect(logger).to have_received(:info).with /Attempting.*#{service_instance_guid}/
+      expect(logger).to have_received(:info).with /Attempting.*service instance #{service_instance_guid}/
     end
 
     it 'logs when successful' do
       subject.attempt_deprovision_instance(service_instance)
 
-      expect(logger).to have_received(:info).with /Success.*#{service_instance_guid}/
+      expect(logger).to have_received(:info).with /Success.*service instance #{service_instance_guid}/
     end
 
     context 'when the orphan mitigation fails' do
@@ -48,21 +48,23 @@ RSpec.describe 'Synchronous orphan mitigation' do
       it 'logs that it failed' do
         subject.attempt_deprovision_instance(service_instance)
 
-        expect(logger).to have_received(:error).with /Unable.*#{service_instance_guid}/
+        expect(logger).to have_received(:error).with /Unable.*service instance #{service_instance_guid}/
       end
     end
   end
 
   describe 'for unbinding' do
     let(:service_binding) { instance_double(VCAP::CloudController::ServiceBinding) }
+    let(:service_instance) { instance_double(VCAP::CloudController::ServiceInstance) }
     let(:service_binding_guid) { '5' }
 
     before do
       allow(service_binding).to receive(:guid).and_return(service_binding_guid)
+      allow(service_binding).to receive(:service_instance).and_return(service_instance)
       allow(client).to receive(:unbind)
 
       allow(VCAP::Services::ServiceClientProvider).to receive(:provide).
-        with(hash_including(binding: service_binding)).and_return(client)
+        with(hash_including(instance: service_binding.service_instance)).and_return(client)
     end
 
     it 'attempts to unbind the binding' do
@@ -74,13 +76,13 @@ RSpec.describe 'Synchronous orphan mitigation' do
     it 'logs that it is attempting to orphan mitigate' do
       subject.attempt_unbind(service_binding)
 
-      expect(logger).to have_received(:info).with /Attempting.*#{service_binding_guid}/
+      expect(logger).to have_received(:info).with /Attempting.*service binding #{service_binding_guid}/
     end
 
     it 'logs when successful' do
       subject.attempt_unbind(service_binding)
 
-      expect(logger).to have_received(:info).with /Success.*#{service_binding_guid}/
+      expect(logger).to have_received(:info).with /Success.*service binding #{service_binding_guid}/
     end
 
     context 'when the orphan mitigation fails' do
@@ -91,21 +93,23 @@ RSpec.describe 'Synchronous orphan mitigation' do
       it 'logs that it failed' do
         subject.attempt_unbind(service_binding)
 
-        expect(logger).to have_received(:error).with /Unable.*#{service_binding_guid}/
+        expect(logger).to have_received(:error).with /Unable.*service binding #{service_binding_guid}/
       end
     end
   end
 
   describe 'for deleting service keys' do
     let(:service_key) { instance_double(VCAP::CloudController::ServiceKey) }
+    let(:service_instance) { instance_double(VCAP::CloudController::ServiceInstance) }
     let(:service_key_guid) { '5' }
 
     before do
       allow(service_key).to receive(:guid).and_return(service_key_guid)
+      allow(service_key).to receive(:service_instance).and_return(service_instance)
       allow(client).to receive(:unbind)
 
       allow(VCAP::Services::ServiceClientProvider).to receive(:provide).
-        with(hash_including(binding: service_key)).and_return(client)
+        with(hash_including(instance: service_key.service_instance)).and_return(client)
     end
 
     it 'attempts to unbind the service key' do
@@ -117,13 +121,13 @@ RSpec.describe 'Synchronous orphan mitigation' do
     it 'logs that it is attempting to orphan mitigate' do
       subject.attempt_delete_key(service_key)
 
-      expect(logger).to have_received(:info).with /Attempting.*#{service_key_guid}/
+      expect(logger).to have_received(:info).with /Attempting.*service key #{service_key_guid}/
     end
 
     it 'logs when successful' do
       subject.attempt_delete_key(service_key)
 
-      expect(logger).to have_received(:info).with /Success.*#{service_key_guid}/
+      expect(logger).to have_received(:info).with /Success.*service key #{service_key_guid}/
     end
 
     context 'when the orphan mitigation fails' do
@@ -134,7 +138,7 @@ RSpec.describe 'Synchronous orphan mitigation' do
       it 'logs that it failed' do
         subject.attempt_delete_key(service_key)
 
-        expect(logger).to have_received(:error).with /Unable.*#{service_key_guid}/
+        expect(logger).to have_received(:error).with /Unable.*service key #{service_key_guid}/
       end
     end
   end

--- a/spec/unit/actions/services/synchronous_orphan_mitigate_spec.rb
+++ b/spec/unit/actions/services/synchronous_orphan_mitigate_spec.rb
@@ -15,9 +15,11 @@ RSpec.describe 'Synchronous orphan mitigation' do
     let(:service_instance_guid) { '5' }
 
     before do
-      allow(service_instance).to receive(:client).and_return(client)
       allow(service_instance).to receive(:guid).and_return(service_instance_guid)
       allow(client).to receive(:deprovision)
+
+      allow(VCAP::Services::ServiceClientProvider).to receive(:provide).
+        with(hash_including(instance: service_instance)).and_return(client)
     end
 
     it 'attempts to deprovision the service instance' do
@@ -56,9 +58,11 @@ RSpec.describe 'Synchronous orphan mitigation' do
     let(:service_binding_guid) { '5' }
 
     before do
-      allow(service_binding).to receive(:client).and_return(client)
       allow(service_binding).to receive(:guid).and_return(service_binding_guid)
       allow(client).to receive(:unbind)
+
+      allow(VCAP::Services::ServiceClientProvider).to receive(:provide).
+        with(hash_including(binding: service_binding)).and_return(client)
     end
 
     it 'attempts to unbind the binding' do
@@ -97,9 +101,11 @@ RSpec.describe 'Synchronous orphan mitigation' do
     let(:service_key_guid) { '5' }
 
     before do
-      allow(service_key).to receive(:client).and_return(client)
       allow(service_key).to receive(:guid).and_return(service_key_guid)
       allow(client).to receive(:unbind)
+
+      allow(VCAP::Services::ServiceClientProvider).to receive(:provide).
+        with(hash_including(binding: service_key)).and_return(client)
     end
 
     it 'attempts to unbind the service key' do

--- a/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
@@ -19,14 +19,6 @@ module VCAP::CloudController
           service_instance
         end
         let(:broker) { service_instance.service_broker }
-        let(:client_attrs) do
-          {
-            url: broker.broker_url,
-            auth_username: broker.auth_username,
-            auth_password: broker.auth_password,
-          }
-        end
-
         let(:name) { 'fake-name' }
 
         let(:user) { User.make }
@@ -52,7 +44,6 @@ module VCAP::CloudController
         subject(:job) do
           VCAP::CloudController::Jobs::Services::ServiceInstanceStateFetch.new(
             name,
-            client_attrs,
             service_instance.guid,
             UserAuditInfo.new(user_guid: user.guid, user_email: user_email),
             request_attrs,

--- a/spec/unit/lib/services/service_brokers/service_client_provider_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_client_provider_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+RSpec.describe VCAP::Services::ServiceClientProvider do
+  describe '#provide' do
+    context 'service instances' do
+      context 'when the instance is a UserProvidedServiceInstance' do
+        let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make }
+
+        before do
+          allow(VCAP::Services::ServiceBrokers::UserProvided::Client).to receive(:new).and_call_original
+        end
+
+        it 'returns a client for a user provided service' do
+          VCAP::Services::ServiceClientProvider.provide(instance: service_instance)
+          expect(VCAP::Services::ServiceBrokers::UserProvided::Client).to have_received(:new)
+        end
+      end
+
+      context 'when the instance is a ManagedServiceInstance' do
+        let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make }
+        let(:expected_attrs) do
+          {
+            url: service_instance.service_broker.broker_url,
+            auth_username: service_instance.service_broker.auth_username,
+            auth_password: service_instance.service_broker.auth_password
+          }
+        end
+
+        before do
+          allow(VCAP::Services::ServiceBrokers::V2::Client).to receive(:new).and_call_original
+        end
+
+        it 'returns a service broker client' do
+          VCAP::Services::ServiceClientProvider.provide(instance: service_instance)
+          expect(VCAP::Services::ServiceBrokers::V2::Client).to have_received(:new).with(expected_attrs)
+        end
+      end
+    end
+
+    context 'service bindings' do
+      context 'when bound to a user provided service instance' do
+        let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make }
+        let(:binding) { VCAP::CloudController::ServiceBinding.make(service_instance: service_instance) }
+
+        before do
+          allow(VCAP::Services::ServiceBrokers::UserProvided::Client).to receive(:new).and_call_original
+        end
+
+        it 'returns a client for a user provided service' do
+          VCAP::Services::ServiceClientProvider.provide(binding: binding)
+          expect(VCAP::Services::ServiceBrokers::UserProvided::Client).to have_received(:new)
+        end
+      end
+
+      context 'when bound to a managed service instance' do
+        let(:binding) { VCAP::CloudController::ServiceBinding.make }
+        let(:expected_attrs) do
+          {
+            url: binding.service_instance.service_broker.broker_url,
+            auth_username: binding.service_instance.service_broker.auth_username,
+            auth_password: binding.service_instance.service_broker.auth_password
+          }
+        end
+
+        before do
+          allow(VCAP::Services::ServiceBrokers::V2::Client).to receive(:new).and_call_original
+        end
+
+        it 'return a service broker client' do
+          VCAP::Services::ServiceClientProvider.provide(binding: binding)
+          expect(VCAP::Services::ServiceBrokers::V2::Client).to have_received(:new).with(expected_attrs)
+        end
+      end
+    end
+
+    context 'service brokers' do
+      let(:broker) { VCAP::CloudController::ServiceBroker.make }
+      let(:expected_attrs) do
+        {
+          url: broker.broker_url,
+          auth_username: broker.auth_username,
+          auth_password: broker.auth_password
+        }
+      end
+
+      before do
+        allow(VCAP::Services::ServiceBrokers::V2::Client).to receive(:new).and_call_original
+      end
+
+      it 'returns a client for a broker' do
+        VCAP::Services::ServiceClientProvider.provide(broker: broker)
+        expect(VCAP::Services::ServiceBrokers::V2::Client).to have_received(:new).with(expected_attrs)
+      end
+    end
+
+    context 'when no binding or service instance' do
+      it 'returns nil' do
+        client = VCAP::Services::ServiceClientProvider.provide
+        expect(client).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/lib/services/service_brokers/service_client_provider_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_client_provider_spec.rb
@@ -37,42 +37,6 @@ RSpec.describe VCAP::Services::ServiceClientProvider do
       end
     end
 
-    context 'service bindings' do
-      context 'when bound to a user provided service instance' do
-        let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make }
-        let(:binding) { VCAP::CloudController::ServiceBinding.make(service_instance: service_instance) }
-
-        before do
-          allow(VCAP::Services::ServiceBrokers::UserProvided::Client).to receive(:new).and_call_original
-        end
-
-        it 'returns a client for a user provided service' do
-          VCAP::Services::ServiceClientProvider.provide(binding: binding)
-          expect(VCAP::Services::ServiceBrokers::UserProvided::Client).to have_received(:new)
-        end
-      end
-
-      context 'when bound to a managed service instance' do
-        let(:binding) { VCAP::CloudController::ServiceBinding.make }
-        let(:expected_attrs) do
-          {
-            url: binding.service_instance.service_broker.broker_url,
-            auth_username: binding.service_instance.service_broker.auth_username,
-            auth_password: binding.service_instance.service_broker.auth_password
-          }
-        end
-
-        before do
-          allow(VCAP::Services::ServiceBrokers::V2::Client).to receive(:new).and_call_original
-        end
-
-        it 'return a service broker client' do
-          VCAP::Services::ServiceClientProvider.provide(binding: binding)
-          expect(VCAP::Services::ServiceBrokers::V2::Client).to have_received(:new).with(expected_attrs)
-        end
-      end
-    end
-
     context 'service brokers' do
       let(:broker) { VCAP::CloudController::ServiceBroker.make }
       let(:expected_attrs) do

--- a/spec/unit/models/runtime/organization_spec.rb
+++ b/spec/unit/models/runtime/organization_spec.rb
@@ -561,10 +561,10 @@ module VCAP::CloudController
 
         before do
           service_instance = ManagedServiceInstance.make(:v2, space: space)
-          attrs = service_instance.client.attrs
-          uri = URI(attrs[:url])
-          uri.user = attrs[:auth_username]
-          uri.password = attrs[:auth_password]
+          broker = service_instance.service_broker
+          uri = URI(broker.broker_url)
+          uri.user = broker.auth_username
+          uri.password = broker.auth_password
 
           plan = service_instance.service_plan
           service = plan.service


### PR DESCRIPTION
## Why
We gained a lot of context while working on the [originating header work](https://github.com/cloudfoundry/cloud_controller_ng/pull/877) and we thought that some of those refactors should be taken separately for discussion.

## What
This PR replaces the `client` delegation across multiple entities i.e. `service_broker -> service_instance -> service_binding` and instead uses the `ServiceClientProvider` to build the client object.

* Service Binding Create/Delete
* Service Instance Create/Delete/Update
* Service Key Create/Delete
* Async Orphan Mitigate
* Service Broker Registration
* Removes unused methods from `Service Binding` Class
* Refactored Tests to work with these changes
* Deleting unused methods
* Removes client delegation (edited)
* Improve testing for SynchronousOrphanMitigate logging (edited)

## Notes
1. This PR builds on top of #877.
1. This PR doesn't change any functionality of Cloud Controller.

## PR
* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
Luis & @AlbertoImpl & @utako