### PR TITLE
Execute bpm from /var/vcap/jobs/bpm/bin

### DIFF
--- a/bosh/jobs/cloud_controller_clock/monit
+++ b/bosh/jobs/cloud_controller_clock/monit
@@ -1,8 +1,8 @@
 <% if p("bpm.enabled") %>
 check process cloud_controller_clock
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_clock/cloud_controller_clock.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start cloud_controller_clock"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop cloud_controller_clock"
+  start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_clock"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_clock"
   group vcap
 <% else %>
 check process cloud_controller_clock

--- a/bosh/jobs/cloud_controller_clock/templates/drain.sh.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/drain.sh.erb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 <% if p("bpm.enabled") %>
-/var/vcap/packages/bpm/bin/bpm stop cloud_controller_clock 1>&2
+/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_clock 1>&2
 echo 0
 exit 0
 <% else %>

--- a/bosh/jobs/cloud_controller_ng/monit
+++ b/bosh/jobs/cloud_controller_ng/monit
@@ -21,8 +21,8 @@
 <% if p("bpm.enabled") %>
 check process cloud_controller_ng
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_ng/cloud_controller_ng.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start cloud_controller_ng"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop cloud_controller_ng"
+  start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng"
   group vcap
 <% if p('cc.nginx.ip').empty? %>
   if failed host <%= discover_external_ip %> port <%= p("cc.external_port") %> protocol http
@@ -36,23 +36,23 @@ check process cloud_controller_ng
 <% (1..(p("cc.jobs.local.number_of_workers"))).each do |index| %>
 check process cloud_controller_worker_local_<%= index %>
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_ng/local_worker_<%= index %>.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start cloud_controller_ng -p local_worker_<%= index %> -c /var/vcap/jobs/cloud_controller_ng/config/bpm/local_worker.yml"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop cloud_controller_ng -p local_worker_<%= index %>"
+  start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng -p local_worker_<%= index %> -c /var/vcap/jobs/cloud_controller_ng/config/bpm/local_worker.yml"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng -p local_worker_<%= index %>"
   group vcap
 <% end %>
 
 check process nginx_cc
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_ng/nginx.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start cloud_controller_ng -p nginx"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop cloud_controller_ng -p nginx"
+  start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng -p nginx"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng -p nginx"
   depends on cloud_controller_ng
   group vcap
 
 <% if_p("cc.newrelic.license_key") do %>
 check process nginx_newrelic_plugin
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_ng/nginx_newrelic_plugin.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start cloud_controller_ng -p nginx_newrelic_plugin"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop cloud_controller_ng -p nginx_newrelic_plugin"
+  start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_ng -p nginx_newrelic_plugin"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng -p nginx_newrelic_plugin"
   group vcap
 <% end %>
 

--- a/bosh/jobs/cloud_controller_ng/templates/drain.sh.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/drain.sh.erb
@@ -3,10 +3,10 @@
 <% if p("bpm.enabled") %>
 
 for i in {1..<%=p("cc.jobs.local.number_of_workers")%>}; do
-  /var/vcap/packages/bpm/bin/bpm stop cloud_controller_ng -p "local_worker_${i}" 1>&2
+  /var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng -p "local_worker_${i}" 1>&2
 done
 
-/var/vcap/packages/bpm/bin/bpm stop cloud_controller_ng -p nginx 1>&2
+/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_ng -p nginx 1>&2
 
 echo 0 # tell bosh not wait for anything
 exit 0

--- a/bosh/jobs/cloud_controller_worker/monit
+++ b/bosh/jobs/cloud_controller_worker/monit
@@ -2,8 +2,8 @@
 <% if p("bpm.enabled") %>
 check process cloud_controller_worker_<%= index %>
   with pidfile /var/vcap/sys/run/bpm/cloud_controller_worker/worker_<%= index %>.pid
-  start program "/var/vcap/packages/bpm/bin/bpm start cloud_controller_worker -p worker_<%= index %> -c /var/vcap/jobs/cloud_controller_worker/config/bpm/cloud_controller_worker.yml"
-  stop program "/var/vcap/packages/bpm/bin/bpm stop cloud_controller_worker -p worker_<%= index %>"
+  start program "/var/vcap/jobs/bpm/bin/bpm start cloud_controller_worker -p worker_<%= index %> -c /var/vcap/jobs/cloud_controller_worker/config/bpm/cloud_controller_worker.yml"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop cloud_controller_worker -p worker_<%= index %>"
   group vcap
 <% else %>
 check process cloud_controller_worker_<%= index %>

--- a/bosh/jobs/cloud_controller_worker/templates/drain.sh.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/drain.sh.erb
@@ -3,7 +3,7 @@
 <% if p("bpm.enabled") %>
 
 for i in {1..<%=p("cc.jobs.generic.number_of_workers")%>}; do
-  /var/vcap/packages/bpm/bin/bpm stop cloud_controller_worker -p "worker_${i}" 1>&2
+  /var/vcap/jobs/bpm/bin/bpm stop cloud_controller_worker -p "worker_${i}" 1>&2
 done
 
 echo 0 # tell bosh not wait for anything


### PR DESCRIPTION
This is the recommended approach suggested by BOSH as /var/vcap/packages
should only be used internally by the job that provides them. For more
information see: https://www.pivotaltracker.com/story/show/150503041