### PR TITLE
Adding documentation for service plan schemas.

### DIFF
--- a/docs/v2/events/list_service_plan_create_events.html
+++ b/docs/v2/events/list_service_plan_create_events.html
@@ -590,7 +590,16 @@ Cookie: </pre>
           "unique_id": "guid",
           "public": true,
           "active": true,
-          "bindable": true
+          "bindable": true,
+          "schemas": {
+            "service_instance": {
+              "create": {},
+              "update": {}
+            },
+            "service_binding": {
+              "create": {}
+            }
+          }
         },
         "space_guid": "",
         "organization_guid": ""

--- a/docs/v2/service_plans/list_all_service_plans.html
+++ b/docs/v2/service_plans/list_all_service_plans.html
@@ -315,7 +315,16 @@ Cookie: </pre>
         "active": true,
         "bindable": true,
         "service_url": "/v2/services/1ccab853-87c9-45a6-bf99-603032d17fe5",
-        "service_instances_url": "/v2/service_plans/6fecf53b-7553-4cb3-b97e-930f9c4e3385/service_instances"
+        "service_instances_url": "/v2/service_plans/6fecf53b-7553-4cb3-b97e-930f9c4e3385/service_instances",
+        "schemas": {
+          "service_instance": {
+            "create": {},
+            "update": {}
+          },
+          "service_binding": {
+            "create": {}
+          }
+        }
       }
     }
   ]

--- a/docs/v2/service_plans/retrieve_a_particular_service_plan.html
+++ b/docs/v2/service_plans/retrieve_a_particular_service_plan.html
@@ -165,7 +165,16 @@ Cookie: </pre>
     "active": true,
     "bindable": true,
     "service_url": "/v2/services/a00cacc0-0ca6-422e-91d3-6b22bcd33450",
-    "service_instances_url": "/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332/service_instances"
+    "service_instances_url": "/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332/service_instances",
+    "schemas": {
+      "service_instance": {
+        "create": {},
+        "update": {}
+      },
+      "service_binding": {
+        "create": {}
+      }
+    }
   }
 }</pre>
 

--- a/docs/v2/service_plans/updating_a_service_plan.html
+++ b/docs/v2/service_plans/updating_a_service_plan.html
@@ -110,8 +110,7 @@
               <td class=" ">
                 <span class="name">public</span>
               </td>
-              <td>
-                <span class="description">A boolean describing that the plan is visible to the all users</span>
+              <td> <span class="description">A boolean describing that the plan is visible to the all users</span>
               </td>
               <td>
                 <span class="default">true</span>
@@ -172,7 +171,16 @@ Cookie: </pre>
     "active": true,
     "bindable": true,
     "service_url": "/v2/services/518cf8f5-9002-4c63-aab1-6ad2737444b1",
-    "service_instances_url": "/v2/service_plans/078cb2c1-e036-4dca-a3b7-ad7f3f36f9cc/service_instances"
+    "service_instances_url": "/v2/service_plans/078cb2c1-e036-4dca-a3b7-ad7f3f36f9cc/service_instances",
+    "schemas": {
+      "service_instance": {
+        "create": {},
+        "update": {}
+      },
+      "service_binding": {
+        "create": {}
+      }
+    }
   }
 }</pre>
 

--- a/docs/v2/services/list_all_service_plans_for_the_service.html
+++ b/docs/v2/services/list_all_service_plans_for_the_service.html
@@ -295,7 +295,16 @@ Cookie: </pre>
         "public": true,
         "active": true,
         "service_url": "/v2/services/66039cd9-3d8b-46b3-8d70-62eb197b7a39",
-        "service_instances_url": "/v2/service_plans/377cf4c4-3987-4fdb-aa65-1104cec440d6/service_instances"
+        "service_instances_url": "/v2/service_plans/377cf4c4-3987-4fdb-aa65-1104cec440d6/service_instances",
+        "schemas": {
+          "service_instance": {
+            "create": {},
+            "update": {}
+          },
+          "service_binding": {
+            "create": {}
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
As part of the service plan schemas work we updated some of the responses.
In order to keep the documentation up to date we did some modifications.
The associated PRs are:

- https://github.com/cloudfoundry/cloud_controller_ng/pull/834
- https://github.com/cloudfoundry/cloud_controller_ng/pull/842
- https://github.com/cloudfoundry/cloud_controller_ng/pull/847
- https://github.com/cloudfoundry/cloud_controller_ng/pull/865
- https://github.com/cloudfoundry/cloud_controller_ng/pull/866


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
