### PR TITLE
add windows2016 as a default stack

### DIFF
--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -626,6 +626,7 @@ properties:
     default:
       "buildpack/cflinuxfs2": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
+      "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"
 
   cc.diego.temporary_local_staging:

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -844,6 +844,7 @@ properties:
     default:
       "buildpack/cflinuxfs2": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
+      "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"
   cc.diego.insecure_docker_registry_list:
     description: "An array of insecure Docker registries in the form of <HOSTNAME|IP>:PORT"

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -644,6 +644,7 @@ properties:
     default:
       "buildpack/cflinuxfs2": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
+      "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
       "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"
 
   cc.diego.temporary_local_staging:

--- a/config/bosh-lite.yml
+++ b/config/bosh-lite.yml
@@ -284,6 +284,7 @@ diego:
   lifecycle_bundles:
     "buildpack/cflinuxfs2": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
     "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
+    "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
     "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"
   insecure_docker_registry_list: []
   docker_staging_stack: 'cflinuxfs2'

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -243,6 +243,7 @@ diego:
   lifecycle_bundles:
     "buildpack/cflinuxfs2": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
     "buildpack/windows2012R2": "windows_app_lifecycle/windows_app_lifecycle.tgz"
+    "buildpack/windows2016": "buildpack_app_lifecycle/buildpack_app_lifecycle.tgz"
     "docker": "docker_app_lifecycle/docker_app_lifecycle.tgz"
   insecure_docker_registry_list: []
   docker_staging_stack: 'cflinuxfs2'


### PR DESCRIPTION
This PR adds the `windows2016` stack as a default stack (akin to `cflinuxfs2` and `windows2012R2` stacks) and the Buildpack App Lifecycle as its app lifecycle.

**Note:** This PR and the PR to `capi-release` may touch some deprecated or soon to be deprecated components. We just added the `windows2016` stack everywhere `windows2012R2` was configured so let us know if some of these additions don't make sense and we can remove changes that are unnecessary.

Goes with https://github.com/cloudfoundry/capi-release/pull/54