### PR TITLE
Service brokers receive context object when creating a service binding

### DIFF
--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -87,7 +87,12 @@ module VCAP::Services::ServiceBrokers::V2
       path = service_binding_resource_path(key.guid, key.service_instance.guid)
       body = {
           service_id:  key.service.broker_provided_id,
-          plan_id:     key.service_plan.broker_provided_id
+          plan_id:     key.service_plan.broker_provided_id,
+          context: {
+            platform: PLATFORM,
+            organization_guid: key.service_instance.organization.guid,
+            space_guid: key.service_instance.space.guid
+          }
       }
 
       body[:parameters] = arbitrary_parameters if arbitrary_parameters.present?
@@ -111,7 +116,12 @@ module VCAP::Services::ServiceBrokers::V2
         service_id:    binding.service.broker_provided_id,
         plan_id:       binding.service_plan.broker_provided_id,
         app_guid:      binding.try(:app_guid),
-        bind_resource: binding.required_parameters
+        bind_resource: binding.required_parameters,
+        context: {
+          platform: PLATFORM,
+          organization_guid: binding.service_instance.organization.guid,
+          space_guid: binding.service_instance.space.guid
+        }
       }
       body = body.reject { |_, v| v.nil? }
       body[:parameters] = arbitrary_parameters if arbitrary_parameters.present?

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe 'Service Broker API integration' do
   describe 'v2.13' do
     include VCAP::CloudController::BrokerApiHelper
 
+    let(:catalog) { default_catalog }
+
+    before do
+      setup_cc
+      setup_broker(catalog)
+      @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+    end
+
     describe 'configuration parameter schemas' do
       let(:draft_schema) { "http://json-schema.org/#{version}/schema#" }
       let(:create_instance_schema) { { '$schema' => draft_schema, 'type' => 'object' } }
@@ -28,12 +36,6 @@ RSpec.describe 'Service Broker API integration' do
       }
 
       let(:catalog) { default_catalog(plan_schemas: schemas) }
-
-      before do
-        setup_cc
-        setup_broker(catalog)
-        @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
-      end
 
       context 'v4' do
         let(:version) { 'draft-04' }
@@ -281,12 +283,6 @@ RSpec.describe 'Service Broker API integration' do
 
     describe 'originating header' do
       let(:catalog) { default_catalog(plan_updateable: true) }
-
-      before do
-        setup_cc
-        setup_broker(catalog)
-        @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
-      end
 
       context 'service broker registration' do
         let(:user) { VCAP::CloudController::User.make }

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -516,5 +516,88 @@ RSpec.describe 'Service Broker API integration' do
         end
       end
     end
+
+    describe 'service binding contains context object' do
+      context 'for binding to an application' do
+        before do
+          provision_service
+          create_app
+          bind_service
+        end
+
+        it 'receives a context object' do
+          expected_body = hash_including(:context)
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+          ).to have_been_made
+        end
+
+        it 'receives the correct attributes in the context' do
+          expected_body = hash_including(context: {
+            platform: 'cloudfoundry',
+            organization_guid: @org_guid,
+            space_guid: @space_guid,
+          })
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+          ).to have_been_made
+        end
+      end
+
+      context 'for create service key' do
+        before do
+          provision_service
+          create_service_key
+        end
+
+        it 'receives a context object' do
+          expected_body = hash_including(:context)
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+          ).to have_been_made
+        end
+
+        it 'receives the correct attributes in the context' do
+          expected_body = hash_including(context: {
+            platform: 'cloudfoundry',
+            organization_guid: @org_guid,
+            space_guid: @space_guid,
+          })
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+          ).to have_been_made
+        end
+      end
+
+      context 'for bind route service' do
+        let(:catalog) { default_catalog(requires: ['route_forwarding']) }
+        let(:route) { VCAP::CloudController::Route.make(space: @space) }
+        before do
+          provision_service
+          create_route_binding(route)
+        end
+
+        it 'receives a context object' do
+          expected_body = hash_including(:context)
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+          ).to have_been_made
+        end
+
+        it 'receives the correct attributes in the context' do
+          expected_body = hash_including(context: {
+            platform: 'cloudfoundry',
+            organization_guid: @org_guid,
+            space_guid: @space_guid,
+          })
+
+          expect(
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+          ).to have_been_made
+        end
+      end
+    end
   end
 end

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -342,4 +342,15 @@ module VCAP::CloudController::BrokerApiHelper
            headers
     )
   end
+
+  def create_route_binding(route, opts={})
+    stub_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).
+      to_return(status: 201, body: { route_service_url: 'https://example.com' }.to_json)
+    headers = opts[:user] ? admin_headers_for(opts[:user]) : admin_headers
+
+    put("/v2/service_instances/#{@service_instance_guid}/routes/#{route.guid}",
+      '{}',
+      headers
+    )
+  end
 end

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -342,15 +342,4 @@ module VCAP::CloudController::BrokerApiHelper
            headers
     )
   end
-
-  def create_route_binding(route, opts={})
-    stub_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).
-      to_return(status: 201, body: { route_service_url: 'https://example.com' }.to_json)
-    headers = opts[:user] ? admin_headers_for(opts[:user]) : admin_headers
-
-    put("/v2/service_instances/#{@service_instance_guid}/routes/#{route.guid}",
-      '{}',
-      headers
-    )
-  end
 end

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -207,7 +207,12 @@ module VCAP::CloudController
             service_id: instance.service.broker_provided_id,
             plan_id: instance.service_plan.broker_provided_id,
             app_guid: process.guid,
-            bind_resource: { app_guid: process.guid }
+            bind_resource: { app_guid: process.guid },
+            context: {
+              platform: 'cloudfoundry',
+              organization_guid: instance.organization.guid,
+              space_guid:        instance.space.guid
+            }
           }
 
           expect(a_request(:put, binding_endpoint).with(body: expected_body)).to have_been_made

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2914,7 +2914,7 @@ module VCAP::CloudController
         service             = binding.service
         service_binding_uri = service_binding_url(binding)
         expected_body       = { service_id: service.broker_provided_id, plan_id: service_plan.broker_provided_id, bind_resource: { route: route.uri } }
-        expect(a_request(:put, service_binding_uri).with(body: expected_body)).to have_been_made
+        expect(a_request(:put, service_binding_uri).with(body: hash_including(expected_body))).to have_been_made
       end
 
       context 'when the body is empty string' do

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -137,10 +137,10 @@ module VCAP::Services::ServiceBrokers::V2
           plan_id:           instance.service_plan.broker_provided_id,
           organization_guid: instance.organization.guid,
           space_guid:        instance.space.guid,
-          context: {
-            platform: 'cloudfoundry',
+          context:           {
+            platform:          'cloudfoundry',
             organization_guid: instance.organization.guid,
-            space_guid: instance.space_guid
+            space_guid:        instance.space_guid
           }
         )
       end
@@ -208,7 +208,7 @@ module VCAP::Services::ServiceBrokers::V2
           let(:message) { 'Accepted' }
 
           it 'return immediately with the operation from the broker response' do
-            client = Client.new(client_attrs)
+            client        = Client.new(client_attrs)
             attributes, _ = client.provision(instance, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to eq('a_broker_operation_identifier')
@@ -218,7 +218,7 @@ module VCAP::Services::ServiceBrokers::V2
         context 'and the response is 200' do
           let(:code) { 200 }
           it 'ignores the operation' do
-            client = Client.new(client_attrs)
+            client        = Client.new(client_attrs)
             attributes, _ = client.provision(instance, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to be_nil
@@ -516,9 +516,9 @@ module VCAP::Services::ServiceBrokers::V2
         expect(http_client).to have_received(:patch).with(anything,
           hash_including({
             context: {
-              platform: 'cloudfoundry',
+              platform:          'cloudfoundry',
               organization_guid: instance.organization.guid,
-              space_guid: instance.space_guid
+              space_guid:        instance.space_guid
             }
           })
         )
@@ -635,7 +635,7 @@ module VCAP::Services::ServiceBrokers::V2
           let(:message) { 'Accepted' }
 
           it 'return immediately with the operation from the broker response' do
-            client = Client.new(client_attrs)
+            client        = Client.new(client_attrs)
             attributes, _ = client.update(instance, new_plan, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to eq('a_broker_operation_identifier')
@@ -645,7 +645,7 @@ module VCAP::Services::ServiceBrokers::V2
         context 'and the response is 200' do
           let(:code) { 200 }
           it 'ignores the operation' do
-            client = Client.new(client_attrs)
+            client        = Client.new(client_attrs)
             attributes, _ = client.update(instance, new_plan, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to be_nil
@@ -805,7 +805,12 @@ module VCAP::Services::ServiceBrokers::V2
         expect(http_client).to have_received(:put).
           with(anything,
             plan_id:    key.service_plan.broker_provided_id,
-            service_id: key.service.broker_provided_id
+            service_id: key.service.broker_provided_id,
+            context:    {
+              platform:          'cloudfoundry',
+              organization_guid: key.service_instance.organization.guid,
+              space_guid:        key.service_instance.space.guid
+            }
           )
       end
 
@@ -821,14 +826,14 @@ module VCAP::Services::ServiceBrokers::V2
       end
 
       context 'when the caller provides an arbitrary parameters in an optional request_attrs hash' do
-        it 'make a put request with correct message and arbitrary parameters' do
+        it 'make a put request with arbitrary parameters' do
           arbitrary_parameters = { 'name' => 'value' }
           client.create_service_key(key, arbitrary_parameters: arbitrary_parameters)
           expect(http_client).to have_received(:put).
             with(anything,
-              plan_id:    key.service_plan.broker_provided_id,
-              service_id: key.service.broker_provided_id,
-              parameters: arbitrary_parameters
+              hash_including(
+                parameters: arbitrary_parameters
+              )
             )
         end
       end
@@ -936,7 +941,12 @@ module VCAP::Services::ServiceBrokers::V2
             plan_id:       binding.service_plan.broker_provided_id,
             service_id:    binding.service.broker_provided_id,
             app_guid:      binding.app_guid,
-            bind_resource: binding.required_parameters
+            bind_resource: binding.required_parameters,
+            context:       {
+              platform:          'cloudfoundry',
+              organization_guid: instance.organization.guid,
+              space_guid:        instance.space_guid
+            }
           )
       end
 
@@ -955,15 +965,13 @@ module VCAP::Services::ServiceBrokers::V2
       context 'when the caller provides an arbitrary parameters in an optional request_attrs hash' do
         let(:arbitrary_parameters) { { 'name' => 'value' } }
 
-        it 'make a put request with correct message and arbitrary parameters' do
+        it 'make a put request with arbitrary parameters' do
           client.bind(binding, arbitrary_parameters)
           expect(http_client).to have_received(:put).
             with(anything,
-              plan_id:       binding.service_plan.broker_provided_id,
-              service_id:    binding.service.broker_provided_id,
-              app_guid:      binding.app_guid,
-              parameters:    arbitrary_parameters,
-              bind_resource: binding.required_parameters
+              hash_including(
+                parameters: arbitrary_parameters
+              )
             )
         end
       end
@@ -976,9 +984,7 @@ module VCAP::Services::ServiceBrokers::V2
 
           expect(http_client).to have_received(:put).
             with(anything,
-              plan_id:       binding.service_plan.broker_provided_id,
-              service_id:    binding.service.broker_provided_id,
-              bind_resource: binding.required_parameters
+              hash_excluding(:app_guid)
             )
         end
       end
@@ -1341,7 +1347,7 @@ module VCAP::Services::ServiceBrokers::V2
           let(:message) { 'Accepted' }
 
           it 'return immediately with the operation from the broker response' do
-            client = Client.new(client_attrs)
+            client     = Client.new(client_attrs)
             attributes = client.deprovision(instance)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to eq('a_broker_operation_identifier')
@@ -1351,7 +1357,7 @@ module VCAP::Services::ServiceBrokers::V2
         context 'and the response is 200' do
           let(:code) { 200 }
           it 'ignores the operation' do
-            client = Client.new(client_attrs)
+            client     = Client.new(client_attrs)
             attributes = client.deprovision(instance)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to be_nil


### PR DESCRIPTION
## Why
The OSBAPI specification considered that adding the context object will be helpful for some of the users: https://github.com/openservicebrokerapi/servicebroker/pull/289

## What
When provisioning service instances, a context object containing platform-specific information is sent in the request body.

## PR
* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
Luis & @AlbertoImpl 