### PR TITLE
Start Perm integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,11 @@ before_install:
   - wget https://github.com/nats-io/gnatsd/releases/download/v0.9.4/gnatsd-v0.9.4-linux-amd64.zip -O /tmp/gnatsd.zip
   - unzip /tmp/gnatsd.zip
   - export PATH=$PATH:$PWD/gnatsd-v0.9.4-linux-amd64
-  - docker pull cfperm/perm:alpha
 
 before_script:
   - bundle exec rake db:create
   - DB=mysql bundle exec rake parallel:create
   - DB=postgres bundle exec rake parallel:create
-  - docker run -d -p 6283:6283 cfperm/perm:alpha
 
 script:
   - bundle exec rake $TASKS
@@ -37,7 +35,6 @@ after_script:
 services:
   - mysql
   - postgresql
-  - docker
 
 addons:
   code_climate:
@@ -46,8 +43,7 @@ addons:
 env:
   global:
     - secure: "ikEVVNPGAX1NqgBPXdjxcPJ3ihO9TyTtaN4iX3d2Wv0GdlSKgRqtCXrWuttVfYGqSoHHWwvCR3qum7N44akLsntrkcIQXGu6CsTsvqDC+vAKHtC31TVmuTEXZyIYA7455+B+a8nMsrO5LjX1ylucV1ZhGLzA84lMRQYkr6PklK0=" # CODECLIMATE_REPO_TOKEN
-    - PERM_RPC_HOST=localhost:6283
-    - CF_RUN_PERM_SPECS=true
+    - CF_RUN_PERM_SPECS=false
 
   matrix:
     - COVERAGE=true DB=postgres TASKS=spec:all

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ env:
   global:
     - secure: "ikEVVNPGAX1NqgBPXdjxcPJ3ihO9TyTtaN4iX3d2Wv0GdlSKgRqtCXrWuttVfYGqSoHHWwvCR3qum7N44akLsntrkcIQXGu6CsTsvqDC+vAKHtC31TVmuTEXZyIYA7455+B+a8nMsrO5LjX1ylucV1ZhGLzA84lMRQYkr6PklK0=" # CODECLIMATE_REPO_TOKEN
     - PERM_RPC_HOST=localhost:6283
+    - CF_RUN_PERM_SPECS=true
 
   matrix:
     - COVERAGE=true DB=postgres TASKS=spec:all

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,13 @@ before_install:
   - wget https://github.com/nats-io/gnatsd/releases/download/v0.9.4/gnatsd-v0.9.4-linux-amd64.zip -O /tmp/gnatsd.zip
   - unzip /tmp/gnatsd.zip
   - export PATH=$PATH:$PWD/gnatsd-v0.9.4-linux-amd64
+  - docker pull cfperm/perm:alpha
 
 before_script:
   - bundle exec rake db:create
   - DB=mysql bundle exec rake parallel:create
   - DB=postgres bundle exec rake parallel:create
+  - docker run -d -p 6283:6283 cfperm/perm:alpha
 
 script:
   - bundle exec rake $TASKS
@@ -35,6 +37,7 @@ after_script:
 services:
   - mysql
   - postgresql
+  - docker
 
 addons:
   code_climate:
@@ -43,6 +46,7 @@ addons:
 env:
   global:
     - secure: "ikEVVNPGAX1NqgBPXdjxcPJ3ihO9TyTtaN4iX3d2Wv0GdlSKgRqtCXrWuttVfYGqSoHHWwvCR3qum7N44akLsntrkcIQXGu6CsTsvqDC+vAKHtC31TVmuTEXZyIYA7455+B+a8nMsrO5LjX1ylucV1ZhGLzA84lMRQYkr6PklK0=" # CODECLIMATE_REPO_TOKEN
+    - PERM_RPC_HOST=localhost:6283
 
   matrix:
     - COVERAGE=true DB=postgres TASKS=spec:all

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'bits_service_client'
 gem 'cf-uaa-lib', '~> 3.11.0'
 gem 'vcap-concurrency', git: 'https://github.com/cloudfoundry/vcap-concurrency.git', ref: '2a5b0179'
 
+gem 'cf-perm', git: 'https://github.com/cloudfoundry-incubator/perm-rb.git'
+
 group :db do
   gem 'mysql2', '0.4.8'
   gem 'pg', '0.19.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/cloudfoundry-incubator/perm-rb.git
+  revision: 0cfd33c3d82ef6a1558efc68ed6fde0c057ec678
+  specs:
+    cf-perm (0.0.0)
+      grpc (~> 1.0)
+
+GIT
   remote: https://github.com/cloudfoundry/vcap-concurrency.git
   revision: 2a5b0179642cb3d3e7f912a6453ec5731979d115
   ref: 2a5b0179
@@ -180,6 +187,7 @@ GEM
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
+    google-protobuf (3.4.0.2)
     googleauth (0.5.1)
       faraday (~> 0.9)
       jwt (~> 1.4)
@@ -188,6 +196,9 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
+    grpc (1.6.0)
+      google-protobuf (~> 3.1)
+      googleauth (~> 0.5.1)
     hashdiff (0.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -420,6 +431,7 @@ DEPENDENCIES
   awesome_print
   bits_service_client
   byebug
+  cf-perm!
   cf-uaa-lib (~> 3.11.0)
   clockwork
   cloudfront-signer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
       retriable (~> 1.4)
       signet (~> 0.6)
     google-protobuf (3.4.0.2)
+    google-protobuf (3.4.0.2-universal-darwin)
+    google-protobuf (3.4.0.2-x86_64-linux)
     googleauth (0.5.1)
       faraday (~> 0.9)
       jwt (~> 1.4)
@@ -197,6 +199,12 @@ GEM
       os (~> 0.9)
       signet (~> 0.7)
     grpc (1.6.0)
+      google-protobuf (~> 3.1)
+      googleauth (~> 0.5.1)
+    grpc (1.6.0-universal-darwin)
+      google-protobuf (~> 3.1)
+      googleauth (~> 0.5.1)
+    grpc (1.6.0-x86_64-linux)
       google-protobuf (~> 3.1)
       googleauth (~> 0.5.1)
     hashdiff (0.3.4)
@@ -421,6 +429,8 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-16
+  x86_64-linux
 
 DEPENDENCIES
   actionpack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/cloudfoundry-incubator/perm-rb.git
-  revision: 0cfd33c3d82ef6a1558efc68ed6fde0c057ec678
+  revision: d4847952436b83b2663e5e7c95214af21ddb4f1c
   specs:
     cf-perm (0.0.0)
       grpc (~> 1.0)

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -9,7 +9,8 @@ module VCAP::CloudController
         :uaa_client,
         :services_event_repository,
         :user_event_repository,
-        :organization_event_repository
+        :organization_event_repository,
+        :perm_client
       ]
     end
 
@@ -20,6 +21,7 @@ module VCAP::CloudController
       @services_event_repository = dependencies.fetch(:services_event_repository)
       @user_event_repository = dependencies.fetch(:user_event_repository)
       @organization_event_repository = dependencies.fetch(:organization_event_repository)
+      @perm_client = dependencies.fetch(:perm_client)
     end
 
     define_attributes do
@@ -322,7 +324,14 @@ module VCAP::CloudController
       user.username = username
 
       org = find_guid_and_validate_access(:update, guid)
+
+
+      ###
+      r = @perm_client.create_role("org-#{role}-#{guid}")
+      @perm_client.assign_role(user_id, r.id)
+
       org.send("add_#{role}", user)
+      ###
 
       @user_event_repository.record_organization_role_add(org, user, role, UserAuditInfo.from_context(SecurityContext), request_attrs)
 

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -325,13 +325,12 @@ module VCAP::CloudController
 
       org = find_guid_and_validate_access(:update, guid)
 
-
-      ###
-      r = @perm_client.create_role("org-#{role}-#{guid}")
-      @perm_client.assign_role(user_id, r.id)
+      if config.get(:perm, :enabled)
+        r = @perm_client.create_role("org-#{role}-#{guid}")
+        @perm_client.assign_role(user_id, r.id)
+      end
 
       org.send("add_#{role}", user)
-      ###
 
       @user_event_repository.record_organization_role_add(org, user, role, UserAuditInfo.from_context(SecurityContext), request_attrs)
 

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
   class SpacesController < RestController::ModelController
     def self.dependencies
       [:space_event_repository, :username_and_roles_populating_collection_renderer, :uaa_client,
-       :services_event_repository, :user_event_repository, :app_event_repository, :route_event_repository]
+       :services_event_repository, :user_event_repository, :app_event_repository, :route_event_repository, :perm_client]
     end
 
     define_attributes do
@@ -51,6 +51,7 @@ module VCAP::CloudController
       @services_event_repository = dependencies.fetch(:services_event_repository)
       @app_event_repository = dependencies.fetch(:app_event_repository)
       @route_event_repository = dependencies.fetch(:route_event_repository)
+      @perm_client = dependencies.fetch(:perm_client)
     end
 
     get '/v2/spaces/:guid/user_roles', :enumerate_user_roles
@@ -293,6 +294,12 @@ module VCAP::CloudController
       user.username = username
 
       space = find_guid_and_validate_access(:update, guid)
+
+      if config.get(:perm, :enabled)
+        r = @perm_client.create_role("space-#{role}-#{guid}")
+        @perm_client.assign_role(user_id, r.id)
+      end
+
       space.send("add_#{role}", user)
 
       @user_event_repository.record_space_role_add(space, user, role, UserAuditInfo.from_context(SecurityContext), request_attrs)

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -68,6 +68,9 @@ consumes:
 - name: cc_uploader
   type: cc_uploader
   optional: true
+- name: perm
+  type: perm
+  optional: true
 
 properties:
   bpm.enabled:

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -825,3 +825,7 @@ properties:
   cc.loggregator.internal_url:
     description: "Internal url used to communicate with traffic_controller"
     default: "http://loggregator-trafficcontroller.service.cf.internal:8081"
+
+  perm.enabled:
+    description: "Enable CF Permissions external service. Requires perm link to take effect"
+    default: false

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -379,5 +379,9 @@ diego:
 
 <% if_link("perm") do |perm| %>
 perm:
+  enabled: <%= p("perm.enabled") %>
   host: <%= "#{perm.instances[0].address}:#{perm.p("listen_port")}" %>
+<% end.else do %>
+perm:
+  enabled: false
 <% end %>

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -376,3 +376,8 @@ diego:
   tps_url: <%= p("cc.diego.tps_url") %>
   use_privileged_containers_for_running: <%= p("cc.diego.use_privileged_containers_for_running") %>
   use_privileged_containers_for_staging: <%= p("cc.diego.use_privileged_containers_for_staging") %>
+
+<% if_link("perm") do |perm| %>
+perm:
+  host: <%= "#{perm.instances[0].address}:#{perm.p("listen_port")}" %>
+<% end %>

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -338,4 +338,5 @@ pending_builds:
   frequency_in_seconds: 300
 
 perm:
+  enabled: false
   host: perm.service.cf.internal

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -336,3 +336,6 @@ pending_droplets:
 pending_builds:
   expiration_in_seconds: 42
   frequency_in_seconds: 300
+
+perm:
+  host: perm.service.cf.internal

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -54,6 +54,7 @@ module VCAP::CloudController
         config[:rate_limiter] ||= { enabled: false }
         config[:rate_limiter][:general_limit] ||= 2000
         config[:rate_limiter][:reset_interval_in_minutes] ||= 60
+        config[:perm] ||= { enabled: false }
 
         unless config.key?(:users_can_select_backend)
           config[:users_can_select_backend] = true

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -280,6 +280,10 @@ module VCAP::CloudController
             optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
             optional(:blobstore_delete) => { timeout_in_seconds: Integer },
             optional(:diego_sync) => { timeout_in_seconds: Integer },
+          },
+
+          perm: {
+            optional(:host) => String
           }
         }
       end

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -283,6 +283,7 @@ module VCAP::CloudController
           },
 
           perm: {
+            enabled: bool,
             optional(:host) => String
           }
         }

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -113,6 +113,10 @@ module CloudController
       @dependencies[:index_stopper] || register(:index_stopper, IndexStopper.new(runners))
     end
 
+    def perm_client
+      @dependencies[:perm_client] || register(:perm_client, build_perm_client)
+    end
+
     def droplet_blobstore
       options = config.get(:droplets)
 
@@ -401,6 +405,10 @@ module CloudController
         max_inline_relations_depth: max_inline_relations_depth,
         collection_transformer: collection_transformer
       })
+    end
+
+    def build_perm_client
+      CloudFoundry::Perm::V1::Client.new(@config[:perm][:host])
     end
   end
 end

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -28,6 +28,8 @@ require 'cloud_controller/packager/bits_service_packer'
 
 require 'bits_service_client'
 
+require 'perm'
+
 module CloudController
   class DependencyLocator
     include Singleton
@@ -408,7 +410,7 @@ module CloudController
     end
 
     def build_perm_client
-      CloudFoundry::Perm::V1::Client.new(@config[:perm][:host])
+      CloudFoundry::Perm::V1::Client.new(config.get(:perm, :host))
     end
   end
 end

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -221,3 +221,7 @@ pending_droplets:
 pending_builds:
   expiration_in_seconds: 42
   frequency_in_seconds: 300
+
+perm:
+  enabled: false
+  host: perm.service.cf.internal

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -36,4 +36,61 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
       end
     end
   end
+
+  describe 'PUT /v2/organizations/:guid/auditors/:user_guid' do
+    let(:org_auditor) { VCAP::CloudController::User.make }
+
+    context 'as an admin' do
+      it 'assigns the specified user to the org auditor role' do
+        set_current_user_as_admin
+
+        expect(client.list_actor_roles(org_auditor.guid)).to be_empty
+
+        put "/v2/organizations/#{org.guid}/auditors/#{org_auditor.guid}"
+        expect(last_response.status).to eq(201)
+
+        roles = client.list_actor_roles(org_auditor.guid)
+        expect(roles).not_to be_empty
+        expect(roles[0].name).to eq "org-auditor-#{org.guid}"
+      end
+    end
+  end
+
+  describe 'PUT /v2/organizations/:guid/billing_managers/:user_guid' do
+    let(:org_billing_manager) { VCAP::CloudController::User.make }
+
+    context 'as an admin' do
+      it 'assigns the specified user to the org billing manager role' do
+        set_current_user_as_admin
+
+        expect(client.list_actor_roles(org_billing_manager.guid)).to be_empty
+
+        put "/v2/organizations/#{org.guid}/billing_managers/#{org_billing_manager.guid}"
+        expect(last_response.status).to eq(201)
+
+        roles = client.list_actor_roles(org_billing_manager.guid)
+        expect(roles).not_to be_empty
+        expect(roles[0].name).to eq "org-billing_manager-#{org.guid}"
+      end
+    end
+  end
+
+  describe 'PUT /v2/organizations/:guid/users/:user_guid' do
+    let(:org_user) { VCAP::CloudController::User.make }
+
+    context 'as an admin' do
+      it 'assigns the specified user to the org billing manager role' do
+        set_current_user_as_admin
+
+        expect(client.list_actor_roles(org_user.guid)).to be_empty
+
+        put "/v2/organizations/#{org.guid}/users/#{org_user.guid}"
+        expect(last_response.status).to eq(201)
+
+        roles = client.list_actor_roles(org_user.guid)
+        expect(roles).not_to be_empty
+        expect(roles[0].name).to eq "org-user-#{org.guid}"
+      end
+    end
+  end
 end

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'perm'
 
-RSpec.describe 'Perm', type: :integration, :skip => ENV.fetch('CF_RUN_PERM_SPECS') { 'false' } != 'true' do
+RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') { 'false' } != 'true' do
   include ControllerHelpers
 
   let(:org) { VCAP::CloudController::Organization.make }

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -4,9 +4,8 @@ require 'perm'
 RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') { 'false' } != 'true' do
   include ControllerHelpers
 
-  let(:org) { VCAP::CloudController::Organization.make }
   let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
-  let(:user_email) { VCAP::CloudController::Sham.email }
+  let(:assignee) { VCAP::CloudController::User.make }
 
   let(:perm_host) { ENV.fetch('PERM_RPC_HOST') { 'localhost:6283' } }
   let(:client) { CloudFoundry::Perm::V1::Client.new(perm_host) }
@@ -16,80 +15,139 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
       enabled: true,
       host: perm_host
     }
+
+    allow_any_instance_of(VCAP::CloudController::UaaClient).to receive(:usernames_for_ids).with([assignee.guid]).and_return({ assignee.guid => assignee.username })
   end
 
-  describe 'PUT /v2/organizations/:guid/managers/:user_guid' do
-    let(:org_manager) { VCAP::CloudController::User.make }
+  describe 'assigning organization roles' do
+    let(:org) { VCAP::CloudController::Organization.make }
 
-    context 'as an admin' do
-      it 'assigns the specified user to the org manager role' do
-        set_current_user_as_admin
+    describe 'PUT /v2/organizations/:guid/managers/:user_guid' do
+      context 'as an admin' do
+        it 'assigns the specified user to the org manager role' do
+          set_current_user_as_admin
 
-        expect(client.list_actor_roles(org_manager.guid)).to be_empty
+          expect(client.list_actor_roles(assignee.guid)).to be_empty
 
-        put "/v2/organizations/#{org.guid}/managers/#{org_manager.guid}"
-        expect(last_response.status).to eq(201)
+          put "/v2/organizations/#{org.guid}/managers/#{assignee.guid}"
+          expect(last_response.status).to eq(201)
 
-        roles = client.list_actor_roles(org_manager.guid)
-        expect(roles).not_to be_empty
-        expect(roles[0].name).to eq "org-manager-#{org.guid}"
+          roles = client.list_actor_roles(assignee.guid)
+          expect(roles).not_to be_empty
+          expect(roles[0].name).to eq "org-manager-#{org.guid}"
+        end
+      end
+    end
+
+    describe 'PUT /v2/organizations/:guid/auditors/:user_guid' do
+      context 'as an admin' do
+        it 'assigns the specified user to the org auditor role' do
+          set_current_user_as_admin
+
+          expect(client.list_actor_roles(assignee.guid)).to be_empty
+
+          put "/v2/organizations/#{org.guid}/auditors/#{assignee.guid}"
+          expect(last_response.status).to eq(201)
+
+          roles = client.list_actor_roles(assignee.guid)
+          expect(roles).not_to be_empty
+          expect(roles[0].name).to eq "org-auditor-#{org.guid}"
+        end
+      end
+    end
+
+    describe 'PUT /v2/organizations/:guid/billing_managers/:user_guid' do
+      context 'as an admin' do
+        it 'assigns the specified user to the org billing manager role' do
+          set_current_user_as_admin
+
+          expect(client.list_actor_roles(assignee.guid)).to be_empty
+
+          put "/v2/organizations/#{org.guid}/billing_managers/#{assignee.guid}"
+          expect(last_response.status).to eq(201)
+
+          roles = client.list_actor_roles(assignee.guid)
+          expect(roles).not_to be_empty
+          expect(roles[0].name).to eq "org-billing_manager-#{org.guid}"
+        end
+      end
+    end
+
+    describe 'PUT /v2/organizations/:guid/users/:user_guid' do
+      context 'as an admin' do
+        it 'assigns the specified user to the org user role' do
+          set_current_user_as_admin
+
+          expect(client.list_actor_roles(assignee.guid)).to be_empty
+
+          put "/v2/organizations/#{org.guid}/users/#{assignee.guid}"
+          expect(last_response.status).to eq(201)
+
+          roles = client.list_actor_roles(assignee.guid)
+          expect(roles).not_to be_empty
+          expect(roles[0].name).to eq "org-user-#{org.guid}"
+        end
       end
     end
   end
 
-  describe 'PUT /v2/organizations/:guid/auditors/:user_guid' do
-    let(:org_auditor) { VCAP::CloudController::User.make }
+  describe 'assigning space roles' do
+    let(:org) { VCAP::CloudController::Organization.make(user_guids: [assignee.guid]) }
+    let(:space) {
+      VCAP::CloudController::Space.make(
+        organization: org,
+      )
+    }
 
-    context 'as an admin' do
-      it 'assigns the specified user to the org auditor role' do
-        set_current_user_as_admin
+    describe 'PUT /v2/spaces/:guid/managers/:user_guid' do
+      context 'as an admin' do
+        it 'assigns the specified user to the space manager role' do
+          set_current_user_as_admin
 
-        expect(client.list_actor_roles(org_auditor.guid)).to be_empty
+          expect(client.list_actor_roles(assignee.guid)).to be_empty
 
-        put "/v2/organizations/#{org.guid}/auditors/#{org_auditor.guid}"
-        expect(last_response.status).to eq(201)
+          put "/v2/spaces/#{space.guid}/managers/#{assignee.guid}"
+          expect(last_response.status).to eq(201)
 
-        roles = client.list_actor_roles(org_auditor.guid)
-        expect(roles).not_to be_empty
-        expect(roles[0].name).to eq "org-auditor-#{org.guid}"
+          roles = client.list_actor_roles(assignee.guid)
+          expect(roles).not_to be_empty
+          expect(roles[0].name).to eq "space-manager-#{space.guid}"
+        end
       end
     end
-  end
 
-  describe 'PUT /v2/organizations/:guid/billing_managers/:user_guid' do
-    let(:org_billing_manager) { VCAP::CloudController::User.make }
+    describe 'PUT /v2/spaces/:guid/auditors/:user_guid' do
+      context 'as an admin' do
+        it 'assigns the specified user to the space auditor role' do
+          set_current_user_as_admin
 
-    context 'as an admin' do
-      it 'assigns the specified user to the org billing manager role' do
-        set_current_user_as_admin
+          expect(client.list_actor_roles(assignee.guid)).to be_empty
 
-        expect(client.list_actor_roles(org_billing_manager.guid)).to be_empty
+          put "/v2/spaces/#{space.guid}/auditors/#{assignee.guid}"
+          expect(last_response.status).to eq(201)
 
-        put "/v2/organizations/#{org.guid}/billing_managers/#{org_billing_manager.guid}"
-        expect(last_response.status).to eq(201)
-
-        roles = client.list_actor_roles(org_billing_manager.guid)
-        expect(roles).not_to be_empty
-        expect(roles[0].name).to eq "org-billing_manager-#{org.guid}"
+          roles = client.list_actor_roles(assignee.guid)
+          expect(roles).not_to be_empty
+          expect(roles[0].name).to eq "space-auditor-#{space.guid}"
+        end
       end
     end
-  end
 
-  describe 'PUT /v2/organizations/:guid/users/:user_guid' do
-    let(:org_user) { VCAP::CloudController::User.make }
 
-    context 'as an admin' do
-      it 'assigns the specified user to the org billing manager role' do
-        set_current_user_as_admin
+    describe 'PUT /v2/spaces/:guid/developers/:user_guid' do
+      context 'as an admin' do
+        it 'assigns the specified user to the space developer role' do
+          set_current_user_as_admin
 
-        expect(client.list_actor_roles(org_user.guid)).to be_empty
+          expect(client.list_actor_roles(assignee.guid)).to be_empty
 
-        put "/v2/organizations/#{org.guid}/users/#{org_user.guid}"
-        expect(last_response.status).to eq(201)
+          put "/v2/spaces/#{space.guid}/developers/#{assignee.guid}"
+          expect(last_response.status).to eq(201), last_response.body
 
-        roles = client.list_actor_roles(org_user.guid)
-        expect(roles).not_to be_empty
-        expect(roles[0].name).to eq "org-user-#{org.guid}"
+          roles = client.list_actor_roles(assignee.guid)
+          expect(roles).not_to be_empty
+          expect(roles[0].name).to eq "space-developer-#{space.guid}"
+        end
       end
     end
   end

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -133,7 +133,6 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
       end
     end
 
-
     describe 'PUT /v2/spaces/:guid/developers/:user_guid' do
       context 'as an admin' do
         it 'assigns the specified user to the space developer role' do

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 require 'perm'
 
-include ControllerHelpers
-
 RSpec.describe 'Perm', type: :integration do
-  let(:org) { Organization.make }
+  include ControllerHelpers
+
+  let(:org) { VCAP::CloudController::Organization.make }
   let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
-  let(:user_email) { Sham.email }
+  let(:user_email) { VCAP::CloudController::Sham.email }
 
   let(:perm_host) { ENV.fetch('PERM_RPC_HOST') { 'localhost:6283' } }
   let(:client) { CloudFoundry::Perm::V1::Client.new(perm_host) }
@@ -16,7 +16,7 @@ RSpec.describe 'Perm', type: :integration do
   end
 
   describe 'PUT /v2/organizations/:guid/managers/:user_guid' do
-    let(:org_manager) { User.make }
+    let(:org_manager) { VCAP::CloudController::User.make }
 
     describe 'removing the last org manager' do
       context 'as an admin' do

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'perm'
+
+RSpec.describe 'Perm', type: :integration do
+  let(:host) { ENV.fetch('PERM_RPC_HOST') { 'localhost:6283' } }
+  let(:client) { CloudFoundry::Perm::V1::Client.new(host) }
+
+  it 'can talk to Perm' do
+    role = client.create_role('cc-perm-integration-test' + SecureRandom.uuid)
+
+    expect(client.has_role?('some-actor', role.id)).to be false
+
+    client.assign_role('some-actor', role.id)
+
+    expect(client.has_role?('some-actor', role.id)).to be true
+  end
+end

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -21,20 +21,18 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
   describe 'PUT /v2/organizations/:guid/managers/:user_guid' do
     let(:org_manager) { VCAP::CloudController::User.make }
 
-    describe 'removing the last org manager' do
-      context 'as an admin' do
-        it 'is allowed' do
-          set_current_user_as_admin
+    context 'as an admin' do
+      it 'assigns the specified user to the org manager role' do
+        set_current_user_as_admin
 
-          expect(client.list_actor_roles(org_manager.guid)).to be_empty
+        expect(client.list_actor_roles(org_manager.guid)).to be_empty
 
-          put "/v2/organizations/#{org.guid}/managers/#{org_manager.guid}"
-          expect(last_response.status).to eq(201)
+        put "/v2/organizations/#{org.guid}/managers/#{org_manager.guid}"
+        expect(last_response.status).to eq(201)
 
-          roles = client.list_actor_roles(org_manager.guid)
-          expect(roles).not_to be_empty
-          expect(roles[0].name).to eq "org-manager-#{org.guid}"
-        end
+        roles = client.list_actor_roles(org_manager.guid)
+        expect(roles).not_to be_empty
+        expect(roles[0].name).to eq "org-manager-#{org.guid}"
       end
     end
   end

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'perm'
 
-RSpec.describe 'Perm', type: :integration do
+RSpec.describe 'Perm', type: :integration, :skip => ENV.fetch('CF_RUN_PERM_SPECS') { 'false' } != 'true' do
   include ControllerHelpers
 
   let(:org) { VCAP::CloudController::Organization.make }

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe 'Perm', type: :integration do
   let(:client) { CloudFoundry::Perm::V1::Client.new(perm_host) }
 
   before do
-    TestConfig.config[:perm][:host] = perm_host
+    TestConfig.config[:perm] = {
+      enabled: true,
+      host: perm_host
+    }
   end
 
   describe 'PUT /v2/organizations/:guid/managers/:user_guid' do

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -467,4 +467,10 @@ RSpec.describe CloudController::DependencyLocator do
       expect(locator.instances_reporters).to be_an_instance_of(VCAP::CloudController::InstancesReporters)
     end
   end
+
+  describe '#perm_client' do
+    it 'returns the perm client' do
+      expect(locator.perm_client).to be_an_instance_of(CloudFoundry::Perm::V1::Client)
+    end
+  end
 end


### PR DESCRIPTION
* A short explanation of the proposed change:

This starts the Perm integration. It should introduce no new behaviour for anyone who has not enabled and configured the Perm server with CAPI.

* An explanation of the use cases your change solves

The Perm service is going to eventually be the source of truth for all permission decisions. We started with notifying the Perm service whenever an org role is assigned.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
