### PR TITLE
Fix base 64 encoding of HTTP header in test

### DIFF
--- a/spec/integration/varz_spec.rb
+++ b/spec/integration/varz_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Cloud Controller', type: :integration do
 
   it 'responds to /varz with the expected keys' do
     varz_headers = {
-      'Authorization' => "Basic #{Base64.encode64('varz:password')}"
+      'Authorization' => "Basic #{Base64.strict_encode64('varz:password')}"
     }
 
     make_get_request('/varz', varz_headers, 7800).tap do |response|


### PR DESCRIPTION
In ruby 2.3.5 (possibly also 2.3.4), new validation rules have been
added when constructing an HTTP request to insure that an HTTP header
doesn't contain a newline. This change fixes the varz test to no longer
include a newline in a HTTP request header.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [N/A] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks,
Sam and @jenspinney 
