### PR TITLE
Modify validations on service broker schemas

### DIFF
--- a/lib/services/service_brokers/v2/schema.rb
+++ b/lib/services/service_brokers/v2/schema.rb
@@ -8,7 +8,9 @@ module VCAP::Services::ServiceBrokers::V2
     MAX_SCHEMA_SIZE = 65_536
 
     validates_length_of :to_json, maximum: MAX_SCHEMA_SIZE, message: 'Must not be larger than 64KB'
-    validate :validate_metaschema_conforms_to_json_draft, :validate_open_service_broker_restrictions
+    validate :validate_metaschema_provided,
+      :validate_metaschema_conforms_to_json_draft,
+      :validate_open_service_broker_restrictions
 
     def initialize(schema)
       @schema = schema
@@ -19,6 +21,11 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     private
+
+    def validate_metaschema_provided
+      return unless errors.blank?
+      add_schema_error_msg('Schema must have $schema key but was not present') unless @schema['$schema']
+    end
 
     def validate_metaschema_conforms_to_json_draft
       return unless errors.blank?

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe 'Service Broker API integration' do
 
     describe 'configuration parameter schemas' do
       let(:draft_schema) { "http://json-schema.org/#{version}/schema#" }
-      let(:create_instance_schema) { { '$schema' => draft_schema, 'type' => 'object' } }
-      let(:update_instance_schema) { { '$schema' => draft_schema, 'type' => 'object' } }
-      let(:create_binding_schema) { { '$schema' => draft_schema, 'type' => 'object' } }
+      let(:create_instance_schema) { { '$schema' => draft_schema } }
+      let(:update_instance_schema) { { '$schema' => draft_schema } }
+      let(:create_binding_schema) { { '$schema' => draft_schema } }
       let(:schemas) {
         {
           'service_instance' => {
@@ -42,12 +42,7 @@ RSpec.describe 'Service Broker API integration' do
 
         context 'when a broker catalog defines a service instance' do
           context 'with a valid create schema' do
-            let(:create_instance_schema) {
-              {
-                '$schema' => draft_schema,
-                'type' => 'object'
-              }
-            }
+            let(:create_instance_schema) { { '$schema' => draft_schema } }
 
             it 'responds with the schema for a service plan entry' do
               get("/v2/service_plans/#{@plan_guid}",
@@ -56,23 +51,14 @@ RSpec.describe 'Service Broker API integration' do
 
               parsed_body = MultiJson.load(last_response.body)
               create_schema = parsed_body['entity']['schemas']['service_instance']['create']
-              expect(create_schema).to eq(
-                {
-                  'parameters' =>
-                    {
-                      '$schema' => draft_schema,
-                      'type' => 'object'
-                    }
-                }
-              )
+              expect(create_schema).to eq({ 'parameters' => { '$schema' => draft_schema } })
             end
           end
 
           context 'with a valid update schema' do
             let(:update_instance_schema) {
               {
-                '$schema' => draft_schema,
-                'type' => 'object'
+                '$schema' => draft_schema
               }
             }
 
@@ -83,15 +69,7 @@ RSpec.describe 'Service Broker API integration' do
 
               parsed_body = MultiJson.load(last_response.body)
               update_schema = parsed_body['entity']['schemas']['service_instance']['update']
-              expect(update_schema).to eq(
-                {
-                  'parameters' =>
-                    {
-                      '$schema' => draft_schema,
-                      'type' => 'object'
-                    }
-                }
-              )
+              expect(update_schema).to eq({ 'parameters' => { '$schema' => draft_schema } })
             end
           end
 
@@ -124,12 +102,7 @@ RSpec.describe 'Service Broker API integration' do
 
         context 'when a broker catalog defines a service binding' do
           context 'with a valid create schema' do
-            let(:create_binding_schema) {
-              {
-                '$schema' => draft_schema,
-                'type' => 'object'
-              }
-            }
+            let(:create_binding_schema) { { '$schema' => draft_schema } }
 
             it 'responds with the schema for a service plan entry' do
               get("/v2/service_plans/#{@plan_guid}",
@@ -138,15 +111,7 @@ RSpec.describe 'Service Broker API integration' do
 
               parsed_body = MultiJson.load(last_response.body)
               create_schema = parsed_body['entity']['schemas']['service_binding']['create']
-              expect(create_schema).to eq(
-                {
-                  'parameters' =>
-                    {
-                      '$schema' => draft_schema,
-                      'type' => 'object'
-                    }
-                }
-              )
+              expect(create_schema).to eq({ 'parameters' => { '$schema' => draft_schema } })
             end
           end
 
@@ -199,12 +164,7 @@ RSpec.describe 'Service Broker API integration' do
 
         context 'when a broker catalog defines a service instance' do
           context 'with a valid create schema' do
-            let(:create_instance_schema) {
-              {
-                '$schema' => draft_schema,
-                'type' => 'object'
-              }
-            }
+            let(:create_instance_schema) { { '$schema' => draft_schema } }
 
             it 'responds with the schema for a service plan entry' do
               get("/v2/service_plans/#{@plan_guid}",
@@ -213,23 +173,14 @@ RSpec.describe 'Service Broker API integration' do
 
               parsed_body = MultiJson.load(last_response.body)
               create_schema = parsed_body['entity']['schemas']['service_instance']['create']
-              expect(create_schema).to eq(
-                {
-                  'parameters' =>
-                    {
-                      '$schema' => draft_schema,
-                      'type'    => 'object'
-                    }
-                }
-              )
+              expect(create_schema).to eq({ 'parameters' => { '$schema' => draft_schema } })
             end
           end
 
           context 'with a valid update schema' do
             let(:update_instance_schema) {
               {
-                '$schema' => draft_schema,
-                'type' => 'object'
+                '$schema' => draft_schema
               }
             }
 
@@ -240,15 +191,7 @@ RSpec.describe 'Service Broker API integration' do
 
               parsed_body = MultiJson.load(last_response.body)
               update_schema = parsed_body['entity']['schemas']['service_instance']['update']
-              expect(update_schema).to eq(
-                {
-                  'parameters' =>
-                    {
-                      '$schema' => draft_schema,
-                      'type'    => 'object'
-                    }
-                }
-              )
+              expect(update_schema).to eq({ 'parameters' => { '$schema' => draft_schema } })
             end
           end
 

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -587,50 +587,6 @@ RSpec.describe 'Service Broker' do
           expect(plan['entity']['schemas']).to eq(schema)
         end
       end
-
-      context 'when the schemas are invalid' do
-        let(:schema) {
-          {
-            'service_instance' => {
-              'create' => { 'parameters' => { 'type' => 'string' } },
-              'update' => { 'parameters' => { 'type' => 'string' } }
-            },
-            'service_binding' => {
-              'create' => { 'parameters' => { 'type' => 'string' } },
-            }
-          }
-        }
-
-        it 'reponds with validation errors' do
-          expect(last_response.status).to eq(502)
-          expect(decoded_response['code']).to eql(270012)
-          expect(decoded_response['description']).to eql(
-            "Service broker catalog is invalid: \n" \
-            "Service MySQL\n" \
-            "  Plan plan1\n" \
-            "    Schemas\n" \
-            "      Schema service_instance.create.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "      Schema service_instance.update.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "      Schema service_binding.create.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "  Plan plan2\n" \
-            "    Schemas\n" \
-            "      Schema service_instance.create.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "      Schema service_instance.update.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "      Schema service_binding.create.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "Service MySQL-2\n" \
-            "  Plan plan3\n" \
-            "    Schemas\n" \
-            "      Schema service_instance.create.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "      Schema service_instance.update.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "      Schema service_binding.create.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "  Plan plan4\n" \
-            "    Schemas\n" \
-            "      Schema service_instance.create.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "      Schema service_instance.update.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-            "      Schema service_binding.create.parameters is not valid. must have field \"type\", with value \"object\"\n" \
-          )
-        end
-      end
     end
   end
 

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Service Broker' do
                   schemas: {
                     service_instance: {
                       create: {
-                        parameters: { type: 'object', properties: true }
+                        parameters: { '$schema': 'http://json-schema.org/draft-04/schema#', properties: true }
                       }
                     }
                   }
@@ -329,7 +329,26 @@ RSpec.describe 'Service Broker' do
             end
           end
 
-          context "of type #{test[:type]} and action #{schema_action} has an invalid type" do
+          context "of type #{test[:type]} and action #{schema_action} has a valid schema" do
+            let(:schema) { { (test[:type]).to_s => { schema_action => { 'parameters' => { '$schema': 'http://json-schema.org/draft-04/schema#', 'type': 'object' } } } } }
+
+            before do
+              stub_catalog_fetch(200, default_catalog(plan_schemas: schema))
+            end
+
+            it 'succeeds' do
+              post('/v2/service_brokers', {
+                name: 'some-guid',
+                broker_url: 'http://broker-url',
+                auth_username: 'username',
+                auth_password: 'password'
+              }.to_json, admin_headers)
+
+              expect(last_response.status).to eql(201)
+            end
+          end
+
+          context "of type #{test[:type]} and action #{schema_action} is not a JSON object" do
             {
               "#{test[:type]}.#{schema_action}": { (test[:type]).to_s => { schema_action => true } },
               "#{test[:type]}.#{schema_action}.parameters": { (test[:type]).to_s => { schema_action => { 'parameters' => true } } },
@@ -362,7 +381,7 @@ RSpec.describe 'Service Broker' do
 
           context "of type #{test[:type]} and action #{schema_action} does not conform to JSON Schema Draft 04 (experimental support for later versions)" do
             let(:path) { "#{test[:type]}.#{schema_action}.parameters" }
-            let(:schema) { { (test[:type]).to_s => { schema_action => { 'parameters' => { 'type': 'object', 'properties': true } } } } }
+            let(:schema) { { (test[:type]).to_s => { schema_action => { 'parameters' => { '$schema': 'http://json-schema.org/draft-04/schema#', 'properties': true } } } } }
 
             before do
               stub_catalog_fetch(200, default_catalog(plan_schemas: schema))
@@ -390,7 +409,18 @@ RSpec.describe 'Service Broker' do
 
           context "of type #{test[:type]} and action #{schema_action} does not conform to JSON Schema Draft 04 (experimental support for later versions) with multiple problems" do
             let(:path) { "#{test[:type]}.#{schema_action}.parameters" }
-            let(:schema) { { (test[:type]).to_s => { schema_action => { 'parameters' => { 'type': 'object', 'properties': true, 'anyOf': true } } } } }
+            let(:schema) {
+              {
+                (test[:type]).to_s => {
+                schema_action => {
+                  'parameters' => {
+                    '$schema': 'http://json-schema.org/draft-04/schema#',
+                    'properties': true,
+                    'anyOf': true }
+                  }
+                }
+              }
+            }
 
             before do
               stub_catalog_fetch(200, default_catalog(plan_schemas: schema))
@@ -447,7 +477,18 @@ RSpec.describe 'Service Broker' do
 
           context "of type #{test[:type]} and action #{schema_action} has an external uri reference" do
             let(:path) { "#{test[:type]}.#{schema_action}.parameters" }
-            let(:schema) { { (test[:type]).to_s => { schema_action => { 'parameters' => { 'type': 'object', '$ref': 'http://example.com/ref' } } } } }
+            let(:schema) {
+              {
+                (test[:type]).to_s => {
+                  schema_action => {
+                    'parameters' => {
+                      '$schema': 'http://json-schema.org/draft-04/schema#',
+                      '$ref': 'http://example.com/ref'
+                    }
+                  }
+                }
+              }
+            }
 
             before do
               stub_catalog_fetch(200, default_catalog(plan_schemas: schema))
@@ -471,6 +512,34 @@ RSpec.describe 'Service Broker' do
               )
             end
           end
+
+          context "of type #{test[:type]} and action #{schema_action} has no $schema" do
+            let(:path) { "#{test[:type]}.#{schema_action}.parameters" }
+            let(:schema) { { (test[:type]).to_s => { schema_action => { 'parameters' => { 'type': 'object' } } } } }
+
+            before do
+              stub_catalog_fetch(200, default_catalog(plan_schemas: schema))
+            end
+
+            it 'responds with invalid' do
+              post('/v2/service_brokers', {
+                name: 'some-guid',
+                broker_url: 'http://broker-url',
+                auth_username: 'username',
+                auth_password: 'password'
+              }.to_json, admin_headers)
+
+              expect(last_response.status).to eql(502)
+              expect(decoded_response['code']).to eql(270012)
+              expect(decoded_response['description']).to eql(
+                "Service broker catalog is invalid: \n" \
+                "Service MySQL\n" \
+                "  Plan small\n" \
+                "    Schemas\n" \
+                "      Schema #{path} is not valid. Schema must have $schema key but was not present\n"
+              )
+            end
+          end
         end
       end
     end
@@ -479,11 +548,11 @@ RSpec.describe 'Service Broker' do
       let(:schema) {
         {
           'service_instance' => {
-            'create' => { 'parameters' => { 'type': 'object', '$ref': 'http://example.com/create' } },
-            'update' => { 'parameters' => { 'type': 'object', '$ref': 'http://example.com/update' } }
+            'create' => { 'parameters' => { '$schema': 'http://json-schema.org/draft-04/schema#', '$ref': 'http://example.com/create' } },
+            'update' => { 'parameters' => { '$schema': 'http://json-schema.org/draft-04/schema#', '$ref': 'http://example.com/update' } }
           },
           'service_binding' => {
-            'create' => { 'parameters' => { 'type': 'object', '$ref': 'http://example.com/binding' } },
+            'create' => { 'parameters' => { '$schema': 'http://json-schema.org/draft-04/schema#', '$ref': 'http://example.com/binding' } },
           }
         }
       }
@@ -518,11 +587,11 @@ RSpec.describe 'Service Broker' do
       let(:schema) {
         {
           'service_instance' => {
-            'create' => { 'parameters' => { 'type' => 'object' } },
-            'update' => { 'parameters' => { 'type' => 'object' } }
+            'create' => { 'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#' } },
+            'update' => { 'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#' } }
           },
           'service_binding' => {
-            'create' => { 'parameters' => { 'type' => 'object' } },
+            'create' => { 'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#' } },
           }
         }
       }

--- a/spec/unit/lib/services/service_brokers/v2/parameters_schema_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/parameters_schema_spec.rb
@@ -6,7 +6,7 @@ module VCAP::Services::ServiceBrokers::V2
 
     describe 'validations' do
       context 'schema' do
-        let(:parameters) { { 'parameters' => { 'type' => 'object' } } }
+        let(:parameters) { { 'parameters' => { '$schema' => 'http://json-schema.org/draft-04/schema#' } } }
 
         it 'should be valid' do
           expect(parameters_schema).to be_valid

--- a/spec/unit/lib/services/service_brokers/v2/schema_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/schema_spec.rb
@@ -24,250 +24,281 @@ module VCAP::Services::ServiceBrokers::V2
       let(:draft_schema) { "http://json-schema.org/#{version}/schema#" }
       let(:raw_schema) { { '$schema' => draft_schema } }
 
-      context 'JSON Schema draft04 validations' do
+      context 'when the schema is compliant to JSON Schema draft04' do
         let(:version) { 'draft-04' }
+        let(:raw_schema) { { '$schema' => draft_schema } }
 
-        context 'when the schema has the minimum required fields' do
-          let(:raw_schema) { { '$schema' => draft_schema } }
-
-          it 'should be valid' do
-            expect(schema.validate).to be true
-            expect(schema.errors.full_messages.length).to be 0
-          end
+        it 'should be valid' do
+          expect(schema.validate).to be true
+          expect(schema.errors.full_messages.length).to be 0
         end
+      end
 
-        context 'when the schema has an internal reference' do
-          let(:raw_schema) {
-            {
-              'properties': {
-                'foo': { 'type': 'integer' },
-                'bar': { '$ref': '#/properties/foo' }
-              }
+      context 'when the schema is compliant to JSON Schema draft06' do
+        let(:version) { 'draft-06' }
+        let(:raw_schema) { { '$schema' => draft_schema } }
+
+        it 'should be valid' do
+          expect(schema.validate).to be true
+          expect(schema.errors.full_messages.length).to eq 0
+        end
+      end
+
+      context 'when the schema has an internal reference' do
+        let(:raw_schema) {
+          {
+            '$schema' => 'http://json-schema.org/draft-04/schema#',
+            'properties': {
+              'foo': { 'type': 'integer' },
+              'bar': { '$ref': '#/properties/foo' }
             }
           }
+        }
 
-          it 'should be valid' do
-            expect(schema.validate).to be true
-            expect(schema.errors.full_messages.length).to be 0
+        it 'should be valid' do
+          expect(schema.validate).to be true
+          expect(schema.errors.full_messages.length).to be 0
+        end
+      end
+
+      describe 'metaschema errors' do
+        context 'when JSON::Validator returns an error' do
+          let(:raw_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'properties': true } }
+
+          before do
+            allow(JSON::Validator).to receive(:fully_validate).and_return([{ message: 'whoops' }])
+          end
+
+          it 'add a schema error message with a wrapped error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to eq 'Must conform to JSON Schema Draft 04 (experimental support for later versions): whoops' \
           end
         end
 
-        context 'errors' do
-          context 'metaschema' do
-            context 'when JSON::Validator returns an error' do
-              let(:raw_schema) { { 'properties': true } }
+        context 'when JSON::Validator raises an error' do
+          let(:raw_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'properties': true } }
 
-              before do
-                allow(JSON::Validator).to receive(:fully_validate).and_return([{ message: 'whoops' }])
-              end
+          before do
+            allow(JSON::Validator).to receive(:fully_validate).and_raise('uh oh')
+          end
 
-              it 'add a schema error message with a wrapped error' do
-                expect(schema.validate).to be false
-                expect(schema.errors.full_messages.length).to eq 1
-                expect(schema.errors.full_messages.first).to eq 'Must conform to JSON Schema Draft 04 (experimental support for later versions): whoops' \
-              end
-            end
+          it 'add a schema error message with the error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to eq 'uh oh'
+          end
+        end
 
-            context 'when JSON::Validator raises an error' do
-              let(:raw_schema) { { 'properties': true } }
+        context 'when there are multiple errors' do
+          let(:raw_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', 'properties': true, 'anyOf': true } }
 
-              before do
-                allow(JSON::Validator).to receive(:fully_validate).and_raise('uh oh')
-              end
+          it 'should have more than one error message' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 2
+            expect(schema.errors.full_messages.first).to eq 'Must conform to JSON Schema Draft 04 (experimental support for later versions): ' \
+              'The property \'#/properties\' of type boolean did not match the following type: object in schema http://json-schema.org/draft-04/schema#'
+            expect(schema.errors.full_messages.last).to eq 'Must conform to JSON Schema Draft 04 (experimental support for later versions): ' \
+              'The property \'#/anyOf\' of type boolean did not match the following type: array in schema http://json-schema.org/draft-04/schema#'
+          end
+        end
+      end
 
-              it 'add a schema error message with the error' do
-                expect(schema.validate).to be false
-                expect(schema.errors.full_messages.length).to eq 1
-                expect(schema.errors.full_messages.first).to eq 'uh oh'
-              end
-            end
+      describe 'open service broker restrictions' do
+        context 'when the schema raises a SchemaError' do
+          let(:raw_schema) { { '$schema' => 'blahblahblah' } }
 
-            context 'when there are multiple errors' do
-              let(:raw_schema) { { 'properties': true, 'anyOf': true } }
+          it 'should a schema error message with the error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to eq 'Custom meta schemas are not supported.'
+          end
+        end
 
-              it 'should have more than one error message' do
-                expect(schema.validate).to be false
-                expect(schema.errors.full_messages.length).to eq 2
-                expect(schema.errors.full_messages.first).to eq 'Must conform to JSON Schema Draft 04 (experimental support for later versions): ' \
-                  'The property \'#/properties\' of type boolean did not match the following type: object in schema http://json-schema.org/draft-04/schema#'
-                expect(schema.errors.full_messages.last).to eq 'Must conform to JSON Schema Draft 04 (experimental support for later versions): ' \
-                  'The property \'#/anyOf\' of type boolean did not match the following type: array in schema http://json-schema.org/draft-04/schema#'
-              end
+        context 'when the schema includes an external reference' do
+          context 'when $ref is an external reference' do
+            let(:raw_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', '$ref' => 'http://example.com/ref' } }
+
+            it 'should add a schema error message with the error' do
+              expect(schema.validate).to be false
+              expect(schema.errors.full_messages.length).to eq 1
+              expect(schema.errors.full_messages.first).to eq 'No external references are allowed: Read of URI at http://example.com/ref refused'
             end
           end
 
-          context 'open service broker restrictions' do
-            context 'when the schema raises a SchemaError' do
-              let(:raw_schema) { { '$schema' => 'blahblahblah' } }
+          context 'when custom schema is not recognized by the library' do
+            let(:raw_schema) { { '$schema' => 'http://example.com/schema' } }
 
-              it 'should a schema error message with the error' do
-                expect(schema.validate).to be false
-                expect(schema.errors.full_messages.length).to eq 1
-                expect(schema.errors.full_messages.first).to eq 'Custom meta schemas are not supported.'
-              end
-            end
-
-            context 'when the schema includes an external reference' do
-              context 'when $ref is an external reference' do
-                let(:raw_schema) { { '$ref' => 'http://example.com/ref' } }
-
-                it 'should add a schema error message with the error' do
-                  expect(schema.validate).to be false
-                  expect(schema.errors.full_messages.length).to eq 1
-                  expect(schema.errors.full_messages.first).to eq 'No external references are allowed: Read of URI at http://example.com/ref refused'
-                end
-              end
-
-              context 'when custom schema is not recognized by the library' do
-                let(:raw_schema) { { '$schema': 'http://example.com/schema' } }
-
-                it 'should not be valid' do
-                  expect(schema.validate).to be false
-                  expect(schema.errors.full_messages.length).to eq 1
-                  expect(schema.errors.full_messages.first).to match 'Custom meta schemas are not supported.'
-                end
-              end
-            end
-
-            context 'when the schema has an external file reference' do
-              let(:raw_schema) { { '$ref': 'path/to/schema.json' } }
-
-              it 'should not be valid' do
-                expect(schema.validate).to be false
-                expect(schema.errors.full_messages.length).to eq 1
-                expect(schema.errors.full_messages.first).to match 'No external references are allowed.+path/to/schema.json'
-              end
-            end
-
-            context 'when the schema has an unknown parse error' do
-              before do
-                allow(JSON::Validator).to receive(:validate!).and_raise('some unknown error')
-              end
-
-              it 'should a schema error message with the error' do
-                expect(schema.validate).to be false
-                expect(schema.errors.full_messages.length).to eq 1
-                expect(schema.errors.full_messages.first).to eq 'some unknown error'
-              end
-            end
-          end
-
-          describe 'validation ordering' do
-            context 'when an invalid schema fails multiple validations' do
-              context 'schema size and schema type' do
-                let(:raw_schema) { create_schema_of_size(64 * 1024) }
-                before { raw_schema['type'] = 'notobject' }
-
-                it 'returns one error' do
-                  expect(schema.validate).to be false
-                  expect(schema.errors.full_messages.length).to eq 1
-                  expect(schema.errors.full_messages.first).to match 'Must not be larger than 64KB'
-                end
-              end
-
-              context 'schema size and external reference' do
-                let(:raw_schema) { create_schema_of_size(64 * 1024) }
-                before { raw_schema['$ref'] = 'http://example.com/ref' }
-
-                it 'returns one error' do
-                  expect(schema.validate).to be false
-                  expect(schema.errors.full_messages.length).to eq 1
-                  expect(schema.errors.full_messages.first).to match 'Must not be larger than 64KB'
-                end
-              end
-
-              context 'schema size and does not conform to Json Schema Draft 4' do
-                let(:raw_schema) { create_schema_of_size(64 * 1024) }
-                before { raw_schema['properties'] = true }
-
-                it 'returns one error' do
-                  expect(schema.validate).to be false
-                  expect(schema.errors.full_messages.length).to eq 1
-                  expect(schema.errors.full_messages.first).to match 'Must not be larger than 64KB'
-                end
-              end
-
-              context 'does not conform to JSON Schema Draft 4 and external references' do
-                let(:raw_schema) { { 'properties' => true, '$ref' => 'http://example.com/ref' } }
-
-                it 'returns one error' do
-                  expect(schema.validate).to be false
-                  expect(schema.errors.full_messages.length).to eq 1
-                  expect(schema.errors.full_messages.first).to match 'Must conform to JSON Schema Draft 04 (experimental support for later versions): ' \
-                    'The property \'#/properties\' of type boolean did not match the following type: ' \
-                    'object in schema http://json-schema.org/draft-04/schema#'
-                end
-              end
+            it 'should not be valid' do
+              expect(schema.validate).to be false
+              expect(schema.errors.full_messages.length).to eq 1
+              expect(schema.errors.full_messages.first).to match 'Custom meta schemas are not supported.'
             end
           end
         end
 
-        describe 'schema sizes' do
-          context 'that are valid' do
-            {
-              'well below the limit': 1,
-              'just below the limit': 63,
-              'on the limit': 64,
-            }.each do |desc, size_in_kb|
-              context "when the schema json is #{desc}" do
-                let(:raw_schema) { create_schema_of_size(size_in_kb * 1024) }
+        context 'when the schema has an external file reference' do
+          let(:raw_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#', '$ref': 'path/to/schema.json' } }
 
-                it 'should be valid' do
-                  expect(schema.validate).to be true
-                  expect(schema.errors.full_messages.length).to eq 0
-                end
-              end
-            end
-          end
-
-          context 'that are invalid' do
-            {
-              'just above the limit': 65,
-              'well above the limit': 10 * 1024,
-            }.each do |desc, size_in_kb|
-              context "when the schema json is #{desc}" do
-                let(:raw_schema) { create_schema_of_size(size_in_kb * 1024) }
-
-                it 'returns one error' do
-                  expect(schema.validate).to be false
-                  expect(schema.errors.full_messages.length).to eq 1
-                  expect(schema.errors.full_messages.first).to match 'Must not be larger than 64KB'
-                end
-              end
-            end
+          it 'should not be valid' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to match 'No external references are allowed.+path/to/schema.json'
           end
         end
 
-        def create_schema_of_size(bytes)
-          surrounding_bytes = 26
+        context 'when the schema has an unknown parse error' do
+          let(:raw_schema) { { '$schema' => 'http://json-schema.org/draft-04/schema#' } }
+
+          before do
+            allow(JSON::Validator).to receive(:validate!).and_raise('some unknown error')
+          end
+
+          it 'should a schema error message with the error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to eq 'some unknown error'
+          end
+        end
+      end
+
+      describe 'validation ordering' do
+        context 'when an invalid schema has size/schema/draft04/reference validations errors' do
+          let(:raw_schema) do
+            schema = create_schema_of_size(65 * 1024)
+            schema.delete('$schema')
+            schema['properties'] = true
+            schema['$raw'] = 'https://example.com/ref'
+            schema
+          end
+
+          it 'only returns schema size error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to match 'Must not be larger than 64KB'
+          end
+        end
+
+        context 'when an invalid schema has schema/draft04/reference validations errors' do
+          let(:raw_schema) do
+            schema = create_schema_of_size(1024)
+            schema.delete('$schema')
+            schema['properties'] = true
+            schema['$raw'] = 'https://example.com/ref'
+            schema
+          end
+
+          it 'only returns schema not present error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to match 'Schema must have $schema key but was not present'
+          end
+        end
+
+        context 'when an invalid schema has draft04/reference validations errors' do
+          let(:raw_schema) do
+            schema = create_schema_of_size(1024)
+            schema['properties'] = true
+            schema['$ref'] = 'https://example.com/ref'
+            schema
+          end
+
+          it 'only returns draft04 error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to match 'Must conform to JSON Schema Draft 04'
+          end
+        end
+
+        context 'when an invalid schema has reference validations errors' do
+          let(:raw_schema) do
+            schema = create_schema_of_size(1024)
+            schema['$ref'] = 'https://example.com/ref'
+            schema
+          end
+
+          it 'only returns external reference error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to match 'No external references are allowed'
+          end
+        end
+      end
+
+      describe 'schema sizes' do
+        context 'that are valid' do
           {
-            'foo' => 'x' * (bytes - surrounding_bytes)
-          }
+            'well below the limit': 1,
+            'just below the limit': 63,
+            'on the limit': 64,
+          }.each do |desc, size_in_kb|
+            context "when the schema json is #{desc}" do
+              let(:raw_schema) { create_schema_of_size(size_in_kb * 1024) }
+
+              it 'should be valid' do
+                expect(schema.validate).to be true
+                expect(schema.errors.full_messages.length).to eq 0
+              end
+            end
+          end
         end
-      end
 
-      context 'JSON Schema draft06 validations' do
-        let(:version) { 'draft-06' }
+        context 'that are invalid' do
+          {
+            'just above the limit': 65,
+            'well above the limit': 10 * 1024,
+          }.each do |desc, size_in_kb|
+            context "when the schema json is #{desc}" do
+              let(:raw_schema) { create_schema_of_size(size_in_kb * 1024) }
 
-        context 'when the schema has multiple valid constraints ' do
-          let(:raw_schema) { { '$schema' => draft_schema } }
-
-          it 'should be valid' do
-            expect(schema.validate).to be true
-            expect(schema.errors.full_messages.length).to eq 0
+              it 'returns one error' do
+                expect(schema.validate).to be false
+                expect(schema.errors.full_messages.length).to eq 1
+                expect(schema.errors.full_messages.first).to match 'Must not be larger than 64KB'
+              end
+            end
           end
         end
       end
 
-      context 'when neither draft6 nor draft4 schema has been specified' do
-        let(:version) { 'some-random-schema' }
+      context 'when neither draft06 nor draft04 schema has been specified' do
+        context 'when the schema is a different draft version' do
+          let(:version) { 'some-random-schema' }
 
-        it 'should return a helpful error' do
-          expect(schema.validate).to be false
-          expect(schema.errors.full_messages.length).to eq 1
-          expect(schema.errors.full_messages.first).to match 'Custom meta schemas are not supported'
+          it 'should return a helpful error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to match 'Custom meta schemas are not supported'
+          end
+        end
+
+        context 'when no schema has been specified' do
+          let(:raw_schema) { {} }
+
+          it 'should return a helpful error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to match 'Schema must have $schema key but was not present'
+          end
+        end
+
+        context 'when an unknown schema has been specified' do
+          let(:draft_schema) { 'http://example.com/someschema' }
+
+          it 'should return a helpful error' do
+            expect(schema.validate).to be false
+            expect(schema.errors.full_messages.length).to eq 1
+            expect(schema.errors.full_messages.first).to match 'Custom meta schemas are not supported'
+          end
         end
       end
+    end
+    def create_schema_of_size(bytes)
+      surrounding_bytes = 62
+      {
+        '$schema' => 'http://json-schema.org/draft-04/schema#',
+        'foo' => 'x' * (bytes - surrounding_bytes)
+      }
     end
   end
 end


### PR DESCRIPTION
## What
This PR modifies two validation rules used when the CC validates the JSON schema provided by service brokers. First, we are removing the requirement that the schema have a `"type":"object"` field. Secondly, we are now requiring that all schemas have a `"$schema"` key.

## Why
Details for these changes can be found in the following tracker stories:

[As a SBA, I can register a JSON schema without the type field](https://www.pivotaltracker.com/story/show/150877576)

[As a SBA, I cannot register a JSON schema without the $schema field](https://www.pivotaltracker.com/story/show/150969868)

These changes reflect the latest requirements set forth in the [Open Service Broker API Spec](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#schema-object).

## PR
* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks,
Jen and @Samze 