### PR TITLE
Support Open Service Broker API v2.13

### DIFF
--- a/lib/services/service_brokers/v2/http_client.rb
+++ b/lib/services/service_brokers/v2/http_client.rb
@@ -155,7 +155,7 @@ module VCAP::Services
 
       def default_headers
         {
-          VCAP::Request::HEADER_BROKER_API_VERSION => '2.12',
+          VCAP::Request::HEADER_BROKER_API_VERSION => '2.13',
           VCAP::Request::HEADER_NAME => VCAP::Request.current_id,
           'Accept' => 'application/json',
           VCAP::Request::HEADER_API_INFO_LOCATION => "#{VCAP::CloudController::Config.config.get(:external_domain)}/v2/info"

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.10_spec.rb' => '27e81c4c540e39a4e4eac70c8efb14ba',
       'broker_api_v2.11_spec.rb' => '99e61dc50ceb635b09b3bd16901a4fa6',
       'broker_api_v2.12_spec.rb' => 'b9626f09abf20d9d1d0e71ef1ac0df70',
+      'broker_api_v2.13_spec.rb' => '8d43d25ba19d0728c0f2e1507af34ef0',
     }
   end
   let(:digester) { Digester.new(algorithm: Digest::MD5) }

--- a/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
@@ -42,7 +42,7 @@ module VCAP::Services::ServiceBrokers::V2
         make_request
         expect(a_request(http_method, full_url).
           with(query: hash_including({})).
-          with(headers: { 'X-Broker-Api-Version' => '2.12' })).
+          with(headers: { 'X-Broker-Api-Version' => '2.13' })).
           to have_been_made
       end
 
@@ -74,7 +74,7 @@ module VCAP::Services::ServiceBrokers::V2
         make_request
         expect(fake_logger).to have_received(:debug).with(match(%r{Accept"=>"application/json}))
         expect(fake_logger).to have_received(:debug).with(match(/X-VCAP-Request-ID"=>"[[:alnum:]-]+/))
-        expect(fake_logger).to have_received(:debug).with(match(/X-Broker-Api-Version"=>"2\.12/))
+        expect(fake_logger).to have_received(:debug).with(match(/X-Broker-Api-Version"=>"2\.13/))
         expect(fake_logger).to have_received(:debug).with(match(%r{X-Api-Info-Location"=>"api2\.vcap\.me/v2/info}))
       end
 


### PR DESCRIPTION
Story: [Cloud Controller reports v2.13 OSBAPI to service brokers](https://www.pivotaltracker.com/story/show/151221517)

## Why

The new Open Service Broker API v2.13 added support for [broker schemas](https://github.com/cloudfoundry/cloud_controller_ng/pull/894), [context on binding](https://github.com/cloudfoundry/cloud_controller_ng/pull/896) and [X-Originating-Header](https://github.com/cloudfoundry/cloud_controller_ng/pull/877) amongst other things. It is now ready to be accepted into the [OSBAPI spec](https://github.com/openservicebrokerapi/servicebroker/pull/318).

## What
This change updates cloud_controller to report to service brokers that it supports 2.13.

* Update X-Broker-Api-Version header from 2.12 to 2.13.
* Add 2.13 compatibility test to broker api version tests.

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks,
Sam & @jenspinney 

cc: @mattmcneeney