### PR TITLE
Perm: Make roles when we make the resource and add role unassignment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'bits_service_client'
 gem 'cf-uaa-lib', '~> 3.11.0'
 gem 'vcap-concurrency', git: 'https://github.com/cloudfoundry/vcap-concurrency.git', ref: '2a5b0179'
 
-gem 'cf-perm', git: 'https://github.com/cloudfoundry-incubator/perm-rb.git'
+gem 'cf-perm', git: 'https://github.com/cloudfoundry-incubator/perm-rb.git', branch: 'master'
 
 group :db do
   gem 'mysql2', '0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/cloudfoundry-incubator/perm-rb.git
-  revision: 01e906525584212814afbedf49ec399ad215729a
+  revision: 5cdd529a8ec0329eb708f9c5be2c5bb5029ec3bd
   branch: master
   specs:
     cf-perm (0.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/cloudfoundry-incubator/perm-rb.git
-  revision: db7d4a210a52019b5db07306036f782df344c8b3
+  revision: 01e906525584212814afbedf49ec399ad215729a
+  branch: master
   specs:
     cf-perm (0.0.0)
       grpc (~> 1.0)

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -298,7 +298,11 @@ module VCAP::CloudController
       if config.get(:perm, :enabled)
         actor = CloudFoundry::Perm::V1::Models::Actor.new(id: user_id, issuer: SecurityContext.token['iss'])
 
-        @perm_client.assign_role(actor, "space-#{role}-#{guid}")
+        begin
+          @perm_client.assign_role(actor, "space-#{role}-#{guid}")
+        rescue GRPC::AlreadyExists
+          # ignored
+        end
       end
 
       space.send("add_#{role}", user)

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
 
     allow_any_instance_of(VCAP::CloudController::UaaClient).to receive(:usernames_for_ids).with([assignee.guid]).and_return({ assignee.guid => assignee.username })
     allow_any_instance_of(VCAP::CloudController::UaaTokenDecoder).to receive(:uaa_issuer).and_return(uaa_target)
+
+    set_current_user_as_admin(iss: uaa_target)
+  end
+
+  describe 'creating an organization with the V2 API' do
+    [:user, :manager, :auditor, :billing_manager].each do |role|
+      it "creates the org-#{role}-<org_id> role" do
+        post '/v2/organizations', { name: 'v2-org' }.to_json
+
+        expect(last_response.status).to eq(201)
+
+        json_body = JSON.parse(last_response.body)
+        org_id = json_body['metadata']['guid']
+        role_name = "org-#{role}-#{org_id}"
+
+        role = client.get_role(role_name)
+        expect(role.name).to eq(role_name)
+        expect(role.id).not_to be_nil
+      end
+    end
   end
 
   describe 'assigning organization roles' do
@@ -28,8 +48,6 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
     describe 'PUT /v2/organizations/:guid/managers/:user_guid' do
       context 'as an admin' do
         it 'assigns the specified user to the org manager role' do
-          set_current_user_as_admin(iss: uaa_target)
-
           expect(client.list_actor_roles(actor)).to be_empty
 
           put "/v2/organizations/#{org.guid}/managers/#{assignee.guid}"
@@ -45,8 +63,6 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
     describe 'PUT /v2/organizations/:guid/auditors/:user_guid' do
       context 'as an admin' do
         it 'assigns the specified user to the org auditor role' do
-          set_current_user_as_admin(iss: uaa_target)
-
           expect(client.list_actor_roles(actor)).to be_empty
 
           put "/v2/organizations/#{org.guid}/auditors/#{assignee.guid}"
@@ -62,8 +78,6 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
     describe 'PUT /v2/organizations/:guid/billing_managers/:user_guid' do
       context 'as an admin' do
         it 'assigns the specified user to the org billing manager role' do
-          set_current_user_as_admin(iss: uaa_target)
-
           expect(client.list_actor_roles(actor)).to be_empty
 
           put "/v2/organizations/#{org.guid}/billing_managers/#{assignee.guid}"
@@ -79,8 +93,6 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
     describe 'PUT /v2/organizations/:guid/users/:user_guid' do
       context 'as an admin' do
         it 'assigns the specified user to the org user role' do
-          set_current_user_as_admin(iss: uaa_target)
-
           expect(client.list_actor_roles(actor)).to be_empty
 
           put "/v2/organizations/#{org.guid}/users/#{assignee.guid}"
@@ -90,6 +102,29 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
           expect(roles).not_to be_empty
           expect(roles[0].name).to eq "org-user-#{org.guid}"
         end
+      end
+    end
+  end
+
+  describe 'creating a space with the V2 API' do
+    let(:org) { VCAP::CloudController::Organization.make(user_guids: [assignee.guid]) }
+
+    [:developer, :manager, :auditor].each do |role|
+      it "creates the space-#{role}-<space_id> role" do
+        post '/v2/spaces', {
+          name: 'v2-space',
+          organization_guid: org.guid
+        }.to_json
+
+        expect(last_response.status).to eq(201)
+
+        json_body = JSON.parse(last_response.body)
+        space_id = json_body['metadata']['guid']
+        role_name = "space-#{role}-#{space_id}"
+
+        role = client.get_role(role_name)
+        expect(role.name).to eq(role_name)
+        expect(role.id).not_to be_nil
       end
     end
   end
@@ -105,8 +140,6 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
     describe 'PUT /v2/spaces/:guid/managers/:user_guid' do
       context 'as an admin' do
         it 'assigns the specified user to the space manager role' do
-          set_current_user_as_admin(iss: uaa_target)
-
           expect(client.list_actor_roles(actor)).to be_empty
 
           put "/v2/spaces/#{space.guid}/managers/#{assignee.guid}"
@@ -122,8 +155,6 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
     describe 'PUT /v2/spaces/:guid/auditors/:user_guid' do
       context 'as an admin' do
         it 'assigns the specified user to the space auditor role' do
-          set_current_user_as_admin(iss: uaa_target)
-
           expect(client.list_actor_roles(actor)).to be_empty
 
           put "/v2/spaces/#{space.guid}/auditors/#{assignee.guid}"
@@ -139,8 +170,6 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
     describe 'PUT /v2/spaces/:guid/developers/:user_guid' do
       context 'as an admin' do
         it 'assigns the specified user to the space developer role' do
-          set_current_user_as_admin(iss: uaa_target)
-
           expect(client.list_actor_roles(actor)).to be_empty
 
           put "/v2/spaces/#{space.guid}/developers/#{assignee.guid}"

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Perm', type: :integration, skip: ENV.fetch('CF_RUN_PERM_SPECS') 
       end
 
       it 'does not allow the user to create an org that already exists' do
-        body = {name: 'v2-org'}.to_json
+        body = { name: 'v2-org' }.to_json
         post '/v2/organizations', body
 
         expect(last_response.status).to eq(201)


### PR DESCRIPTION
* A short explanation of the proposed change:

We centralized when roles get created, so that now they get created when you create the org/space (respectively). This was then removed from creation during role assignments.

We also made CAPI role unassignment trigger a Perm role unassignment.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
