### PR TITLE
Perm/purge roles on delete

### DIFF
--- a/app/actions/perm_roles_delete.rb
+++ b/app/actions/perm_roles_delete.rb
@@ -1,0 +1,32 @@
+module VCAP::CloudController
+  class PermRolesDelete
+    def initialize(client, enabled, delete_action, role_prefixes)
+      @client = client
+      @enabled = enabled
+      @delete_action = delete_action
+      @role_prefixes = role_prefixes
+    end
+
+    def delete(dataset)
+      if enabled
+        dataset.each do |org|
+          role_prefixes.each do |prefix|
+            role_name = "#{prefix}-#{org.guid}"
+
+            client.delete_role(role_name)
+          end
+        end
+      end
+
+      delete_action.delete(dataset)
+    end
+
+    def timeout_error(dataset)
+      delete_action.timeout_error(dataset)
+    end
+
+    private
+
+    attr_reader :client, :enabled, :delete_action, :role_prefixes
+  end
+end

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 require 'spec_helper'
 require 'perm'
 

--- a/spec/unit/actions/perm_roles_delete_spec.rb
+++ b/spec/unit/actions/perm_roles_delete_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  RSpec.describe PermRolesDelete do
+    let(:org_delete_action) { spy('org_delete_action') }
+    let(:perm_client) { spy('perm_client') }
+    let(:role_prefixes) { ['foo-bar', 'bar-baz'] }
+
+    let!(:org_1) { Organization.make }
+    let!(:org_2) { Organization.make }
+
+    let!(:org_dataset) { Organization.where(guid: [org_1.guid, org_2.guid]) }
+    let(:user) { User.make }
+
+    describe '#delete' do
+      context 'when not enabled' do
+        it 'just calls to the underlying action' do
+          perm_roles_delete = PermRolesDelete.new(perm_client, false, org_delete_action, role_prefixes)
+
+          expect(perm_client).not_to receive(:delete_role)
+          expect(org_delete_action).to receive(:delete).with(org_dataset)
+
+          perm_roles_delete.delete(org_dataset)
+        end
+      end
+
+      context 'when enabled' do
+        it 'uses the client to delete all of the roles made from prefixes and the guid' do
+          perm_roles_delete = PermRolesDelete.new(perm_client, true, org_delete_action, role_prefixes)
+
+          expect(perm_client).to receive(:delete_role).with("foo-bar-#{org_1.guid}")
+          expect(perm_client).to receive(:delete_role).with("foo-bar-#{org_2.guid}")
+          expect(perm_client).to receive(:delete_role).with("bar-baz-#{org_1.guid}")
+          expect(perm_client).to receive(:delete_role).with("bar-baz-#{org_2.guid}")
+          expect(org_delete_action).to receive(:delete).with(org_dataset)
+
+          perm_roles_delete.delete(org_dataset)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

This propagates role deletion to Perm when an org or space is deleted.

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
