### PR TITLE
Add network info to staging tasks

### DIFF
--- a/lib/cloud_controller/diego/task_recipe_builder.rb
+++ b/lib/cloud_controller/diego/task_recipe_builder.rb
@@ -59,6 +59,7 @@ module VCAP::CloudController
           log_guid:                         staging_details.package.app_guid,
           log_source:                       STAGING_LOG_SOURCE,
           memory_mb:                        staging_details.staging_memory_in_mb,
+          network:                          generate_network(staging_details.package),
           privileged:                       config.get(:diego, :use_privileged_containers_for_staging),
           result_file:                      STAGING_RESULT_FILE,
           trusted_system_certificates_path: STAGING_TRUSTED_SYSTEM_CERT_PATH,

--- a/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
@@ -29,6 +29,16 @@ module VCAP::CloudController
           }
         end
         let(:package) { PackageModel.make(app: app) }
+        let(:expected_network) do
+          ::Diego::Bbs::Models::Network.new(
+            properties: [
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'policy_group_id', value: app.guid),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'app_id', value: app.guid),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
+            ]
+          )
+        end
         let(:config) do
           Config.new({
             tls_port: tls_port,
@@ -244,6 +254,11 @@ module VCAP::CloudController
           it 'sets the disk' do
             result = task_recipe_builder.build_staging_task(config, staging_details)
             expect(result.disk_mb).to eq(51)
+          end
+
+          it 'sets the network information' do
+            result = task_recipe_builder.build_staging_task(config, staging_details)
+            expect(result.network). to eq(expected_network)
           end
 
           it 'sets the egress rules' do


### PR DESCRIPTION
Network information have been recently added to the bbs task recipe.
However, they have been added to app tasks only. This patch adds
network information to staging tasks as well.

Note that the data will be added to the task info sent to the
BBS only when temporary_local_staging is set to True; otherwise
the stager service should be made aware of task network info as
well, which is outside the scope of this work.

Issue #911
Related to #149967957

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the master branch
* [X] I have run all the unit tests using bundle exec rake
* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
* Network info for staging tasks have been verified with cfdot, and attaching
  to the task event stream