### PR TITLE
Add internal-routes to the route info.

### DIFF
--- a/lib/cloud_controller/diego/app_recipe_builder.rb
+++ b/lib/cloud_controller/diego/app_recipe_builder.rb
@@ -121,6 +121,10 @@ module VCAP::CloudController
           ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
             key:   TCP_ROUTES_KEY,
             value: MultiJson.dump((info['tcp_routes'] || []))
+          ),
+          ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
+            key:   INTERNAL_ROUTES_KEY,
+            value: MultiJson.dump((info['internal_routes'] || []))
           )
         ]
       end

--- a/lib/cloud_controller/diego/constants.rb
+++ b/lib/cloud_controller/diego/constants.rb
@@ -25,9 +25,10 @@ module VCAP::CloudController
     TASKS_DOMAIN     = 'cf-tasks'.freeze
     TASKS_DOMAIN_TTL = 2.minutes
 
-    CF_ROUTES_KEY  = 'cf-router'.freeze
-    TCP_ROUTES_KEY = 'tcp-router'.freeze
-    SSH_ROUTES_KEY = 'diego-ssh'.freeze
+    CF_ROUTES_KEY       = 'cf-router'.freeze
+    TCP_ROUTES_KEY      = 'tcp-router'.freeze
+    SSH_ROUTES_KEY      = 'diego-ssh'.freeze
+    INTERNAL_ROUTES_KEY = 'internal-router'.freeze
 
     BULKER_TASK_FAILURE = 'Unable to determine completion status'.freeze
 

--- a/lib/cloud_controller/diego/protocol/routing_info.rb
+++ b/lib/cloud_controller/diego/protocol/routing_info.rb
@@ -39,6 +39,7 @@ module VCAP::CloudController
           route_info = {}
           route_info['http_routes'] = http_info unless http_info.blank?
           route_info['tcp_routes'] = tcp_info unless tcp_info.blank?
+          route_info['internal_routes'] = [{ 'hostname' => "#{process.guid}.sd-local"}]
           route_info
         rescue RoutingApi::RoutingApiDisabled
           raise CloudController::Errors::ApiError.new_from_details('RoutingApiDisabled')

--- a/lib/cloud_controller/diego/protocol/routing_info.rb
+++ b/lib/cloud_controller/diego/protocol/routing_info.rb
@@ -39,7 +39,7 @@ module VCAP::CloudController
           route_info = {}
           route_info['http_routes'] = http_info unless http_info.blank?
           route_info['tcp_routes'] = tcp_info unless tcp_info.blank?
-          route_info['internal_routes'] = [{ 'hostname' => "#{process.guid}.sd-local"}]
+          route_info['internal_routes'] = [{ 'hostname' => "#{process.guid}.sd-local" }]
           route_info
         rescue RoutingApi::RoutingApiDisabled
           raise CloudController::Errors::ApiError.new_from_details('RoutingApiDisabled')

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -520,6 +520,11 @@ module VCAP::CloudController
                     'external_port'     => 789,
                     'container_port'    => 987
                   },
+                ],
+                'internal_routes' => [
+                  {
+                    'hostname' => 'app-guid.sd-local',
+                  }
                 ]
               }
 
@@ -562,6 +567,14 @@ module VCAP::CloudController
                         'container_port'    => 987
                       }
                     ].to_json
+                  ),
+                  ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
+                    key:   'internal-router',
+                    value: [
+                      {
+                        'hostname' => 'app-guid.sd-local',
+                      }
+                    ].to_json
                   )
                 ]
               )
@@ -585,6 +598,11 @@ module VCAP::CloudController
                       'external_port'     => 789,
                       'container_port'    => 987
                     },
+                  ],
+                  'internal_routes' => [
+                    {
+                      'hostname' => 'app-guid.sd-local',
+                    }
                   ]
                 }
 
@@ -614,6 +632,14 @@ module VCAP::CloudController
                           'container_port'    => 987
                         }
                       ].to_json
+                    ),
+                    ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
+                      key: 'internal-router',
+                      value: [
+                        {
+                          'hostname' => 'app-guid.sd-local',
+                        }
+                      ].to_json
                     )
                   ]
                 )
@@ -637,6 +663,12 @@ module VCAP::CloudController
                       'port'              => 8080,
                       'route_service_url' => 'https://potatosarebetter.example.com'
                     }
+
+                  ],
+                  'internal_routes' => [
+                    {
+                      'hostname' => 'app-guid.sd-local',
+                    }
                   ]
                 }
 
@@ -652,11 +684,11 @@ module VCAP::CloudController
                       key:   'cf-router',
                       value: [
                         {
-                                 'hostnames'         => ['potato.example.com'],
-                                 'port'              => 8080,
-                                 'route_service_url' => nil,
-                                 'isolation_segment' => 'placement-tag',
-                               },
+                          'hostnames'         => ['potato.example.com'],
+                          'port'              => 8080,
+                          'route_service_url' => nil,
+                          'isolation_segment' => 'placement-tag',
+                        },
                         {
                           'hostnames'         => ['tomato.example.com'],
                           'port'              => 8080,
@@ -668,6 +700,14 @@ module VCAP::CloudController
                     ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
                       key:   'tcp-router',
                       value: [].to_json
+                    ),
+                    ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
+                      key: 'internal-router',
+                      value: [
+                        {
+                          'hostname' => 'app-guid.sd-local',
+                        }
+                      ].to_json
                     )
                   ]
                 )
@@ -1061,6 +1101,11 @@ module VCAP::CloudController
                   'external_port'     => 789,
                   'container_port'    => 987
                 },
+              ],
+              'internal_routes' => [
+                {
+                  'hostname' => 'app-guid.sd-local',
+                }
               ]
             }
 
@@ -1103,6 +1148,14 @@ module VCAP::CloudController
                       'container_port'    => 987
                     }
                   ].to_json
+                ),
+                ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
+                  key:   'internal-router',
+                  value: [
+                    {
+                      'hostname' => 'app-guid.sd-local',
+                    }
+                  ].to_json
                 )
               ]
             )
@@ -1126,6 +1179,11 @@ module VCAP::CloudController
                     'external_port'     => 789,
                     'container_port'    => 987
                   },
+                ],
+                'internal_routes' => [
+                  {
+                    'hostname' => 'app-guid.sd-local',
+                  }
                 ]
               }
 
@@ -1155,6 +1213,14 @@ module VCAP::CloudController
                         'container_port'    => 987
                       }
                     ].to_json
+                  ),
+                  ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
+                    key:   'internal-router',
+                    value: [
+                      {
+                        'hostname' => 'app-guid.sd-local',
+                      }
+                    ].to_json
                   )
                 ]
               )
@@ -1177,6 +1243,11 @@ module VCAP::CloudController
                     'hostname'          => 'tomato.example.com',
                     'port'              => 8080,
                     'route_service_url' => 'https://potatosarebetter.example.com'
+                  }
+                ],
+                'internal_routes' => [
+                  {
+                    'hostname' => 'app-guid.sd-local',
                   }
                 ]
               }
@@ -1209,6 +1280,14 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
                     key:   'tcp-router',
                     value: [].to_json
+                  ),
+                  ::Diego::Bbs::Models::ProtoRoutes::RoutesEntry.new(
+                    key:   'internal-router',
+                    value: [
+                      {
+                        'hostname' => 'app-guid.sd-local',
+                      }
+                    ].to_json
                   )
                 ]
               )

--- a/spec/unit/lib/cloud_controller/diego/protocol/routing_info_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/routing_info_spec.rb
@@ -51,7 +51,7 @@ module VCAP::CloudController
                     { 'hostname' => route_without_service.uri, 'port' => 8080 }
                   ]
 
-                  expect(ri.keys).to match_array ['http_routes']
+                  expect(ri.keys).to match_array ['http_routes', 'internal_routes']
                   expect(ri['http_routes']).to match_array expected_http
                 end
               end
@@ -65,7 +65,7 @@ module VCAP::CloudController
                     { 'hostname' => route_without_service.uri, 'port' => 7890 }
                   ]
 
-                  expect(ri.keys).to match_array ['http_routes']
+                  expect(ri.keys).to match_array ['http_routes', 'internal_routes']
                   expect(ri['http_routes']).to match_array expected_http
                 end
               end
@@ -97,7 +97,7 @@ module VCAP::CloudController
                       { 'hostname' => route_without_service.uri, 'port' => 8080 }
                     ]
 
-                    expect(ri.keys).to match_array ['http_routes']
+                    expect(ri.keys).to match_array ['http_routes', 'internal_routes']
                     expect(ri['http_routes']).to match_array expected_http
                   end
                 end
@@ -111,7 +111,7 @@ module VCAP::CloudController
                       { 'hostname' => route_without_service.uri, 'port' => 1024 }
                     ]
 
-                    expect(ri.keys).to match_array ['http_routes']
+                    expect(ri.keys).to match_array ['http_routes', 'internal_routes']
                     expect(ri['http_routes']).to match_array expected_http
                   end
                 end
@@ -127,7 +127,7 @@ module VCAP::CloudController
                   { 'hostname' => route_with_service.uri, 'route_service_url' => route_with_service.route_service_url, 'port' => 9090 },
                 ]
 
-                expect(ri.keys).to match_array ['http_routes']
+                expect(ri.keys).to match_array ['http_routes', 'internal_routes']
                 expect(ri['http_routes']).to match_array expected_http
               end
             end
@@ -143,7 +143,7 @@ module VCAP::CloudController
                   { 'hostname' => route_with_service.uri, 'route_service_url' => route_with_service.route_service_url, 'port' => 9090 },
                 ]
 
-                expect(ri.keys).to match_array ['http_routes']
+                expect(ri.keys).to match_array ['http_routes', 'internal_routes']
                 expect(ri['http_routes']).to match_array expected_http
               end
             end
@@ -159,7 +159,7 @@ module VCAP::CloudController
                   { 'hostname' => route_with_service.uri, 'route_service_url' => route_with_service.route_service_url, 'port' => 9090 },
                 ]
 
-                expect(ri.keys).to match_array ['http_routes']
+                expect(ri.keys).to match_array ['http_routes', 'internal_routes']
                 expect(ri['http_routes']).to match_array expected_http
               end
             end
@@ -174,7 +174,7 @@ module VCAP::CloudController
                   { 'hostname' => route_without_service.uri, 'port' => 8080 },
                   { 'hostname' => route_with_service.uri, 'route_service_url' => route_with_service.route_service_url, 'port' => 9090 },
                 ]
-                expect(ri.keys).to match_array ['http_routes']
+                expect(ri.keys).to match_array ['http_routes', 'internal_routes']
                 expect(ri['http_routes']).to match_array expected_http
               end
             end
@@ -186,7 +186,7 @@ module VCAP::CloudController
               let!(:route_mapping) { RouteMappingModel.make(app: process.app, route: http_route) }
 
               it 'returns the router group guid in the http routing info' do
-                expect(ri.keys).to contain_exactly('http_routes')
+                expect(ri.keys).to contain_exactly('http_routes', 'internal_routes')
                 hr = ri['http_routes'][0]
                 expect(hr.keys).to contain_exactly('router_group_guid', 'port', 'hostname')
                 expect(hr['router_group_guid']).to eql(domain.router_group_guid)
@@ -209,7 +209,7 @@ module VCAP::CloudController
                   { 'router_group_guid' => domain.router_group_guid, 'external_port' => tcp_route.port, 'container_port' => 9090 },
                 ]
 
-                expect(ri.keys).to match_array ['tcp_routes']
+                expect(ri.keys).to match_array ['tcp_routes', 'internal_routes']
                 expect(ri['tcp_routes']).to match_array expected_tcp
               end
             end
@@ -225,7 +225,7 @@ module VCAP::CloudController
                   { 'router_group_guid' => domain.router_group_guid, 'external_port' => tcp_route.port, 'container_port' => 5555 },
                 ]
 
-                expect(ri.keys).to match_array ['tcp_routes']
+                expect(ri.keys).to match_array ['tcp_routes', 'internal_routes']
                 expect(ri['tcp_routes']).to match_array expected_tcp
               end
             end
@@ -242,7 +242,7 @@ module VCAP::CloudController
                   { 'router_group_guid' => domain.router_group_guid, 'external_port' => tcp_route_2.port, 'container_port' => 9090 },
                 ]
 
-                expect(ri.keys).to match_array ['tcp_routes']
+                expect(ri.keys).to match_array ['tcp_routes', 'internal_routes']
                 expect(ri['tcp_routes']).to match_array expected_routes
               end
             end
@@ -260,9 +260,20 @@ module VCAP::CloudController
                   { 'router_group_guid' => domain.router_group_guid, 'external_port' => tcp_route_2.port, 'container_port' => 5555 },
                 ]
 
-                expect(ri.keys).to match_array ['tcp_routes']
+                expect(ri.keys).to match_array ['tcp_routes', 'internal_routes']
                 expect(ri['tcp_routes']).to match_array expected_routes
               end
+            end
+          end
+
+          context 'internal routes' do
+            it 'returns the internal route hostname' do
+              expected_routes = [
+                { 'hostname' => process.guid + '.sd-local' },
+              ]
+
+              expect(ri.keys).to match_array ['internal_routes']
+              expect(ri['internal_routes']).to match_array expected_routes
             end
           end
 
@@ -305,7 +316,7 @@ module VCAP::CloudController
                 { 'router_group_guid' => tcp_domain.router_group_guid, 'external_port' => tcp_route.port, 'container_port' => 5555 },
               ]
 
-              expect(ri.keys).to match_array ['tcp_routes', 'http_routes']
+              expect(ri.keys).to match_array ['tcp_routes', 'http_routes', 'internal_routes']
               expect(ri['tcp_routes']).to match_array expected_tcp
               http_ports = ri['http_routes'].map { |hr| hr['port'] }
               expect(http_ports).to contain_exactly(8080, 9090)

--- a/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
@@ -181,6 +181,9 @@ module VCAP::CloudController
                   'route_service_url' => route_with_service.route_binding.route_service_url,
                   'port' => 2222,
                 }
+              ],
+              'internal_routes' => [
+                { 'hostname' => "#{process.guid}.sd-local" }
               ]
             },
             'egress_rules' => ['running_egress_rule'],


### PR DESCRIPTION
This adds internal routes to the routing_info. This information is generated for each app that is pushed and will be used to provide platform assigned names for service discovery.

[#151332695]

Signed-off-by: Angela Chin <achin@pivotal.io>
