### PR TITLE
added missing audit.app.upload-bits type

### DIFF
--- a/docs/v2/events/list_events_associated_with_an_app_since_january_1,_2014.html
+++ b/docs/v2/events/list_events_associated_with_an_app_since_january_1,_2014.html
@@ -309,6 +309,7 @@ Cookie: </pre>
                       <li>audit.app.stop</li>
                       <li>audit.app.unmap-route</li>
                       <li>audit.app.update</li>
+                      <li>audit.app.upload-bits</li>
                       <li>audit.route.create</li>
                       <li>audit.route.delete-request</li>
                       <li>audit.route.update</li>


### PR DESCRIPTION
Confirmed this one was returned by `cf events myapp` after a `cf push` using cf CLI 6.32.0 against A1 (CC API 2.97.0).