### PR TITLE
Perm/swallow errors and log

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/cloudfoundry-incubator/perm-rb.git
-  revision: 21553f380ccebbd670fc264e0edfca45341405be
+  revision: 0d3830c7e7299e206c88da038d400c5ef0c5753a
   branch: master
   specs:
     cf-perm (0.0.0)

--- a/lib/cloud_controller/perm/client.rb
+++ b/lib/cloud_controller/perm/client.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
         @logger = logger
         if enabled
           trusted_cas = [File.open(ca_cert_path).read]
-          @client = CloudFoundry::Perm::V1::Client.new(hostname: hostname, port: port, trusted_cas: trusted_cas)
+          @client = CloudFoundry::Perm::V1::Client.new(hostname: hostname, port: port, trusted_cas: trusted_cas, timeout: 0.1)
         end
       end
 

--- a/lib/cloud_controller/perm/client.rb
+++ b/lib/cloud_controller/perm/client.rb
@@ -3,8 +3,9 @@ require 'perm'
 module VCAP::CloudController
   module Perm
     class Client
-      def initialize(hostname:, port:, enabled:, ca_cert_path:)
+      def initialize(hostname:, port:, enabled:, ca_cert_path:, logger: Steno.logger('perm.client'))
         @enabled = enabled
+        @logger = logger
         if enabled
           trusted_cas = [File.open(ca_cert_path).read]
           @client = CloudFoundry::Perm::V1::Client.new(hostname: hostname, port: port, trusted_cas: trusted_cas)
@@ -59,7 +60,7 @@ module VCAP::CloudController
 
       private
 
-      attr_reader :client, :enabled
+      attr_reader :client, :enabled, :logger
 
       def org_role(role, org_id)
         "org-#{role}-#{org_id}"
@@ -74,7 +75,9 @@ module VCAP::CloudController
           begin
             client.create_role(role)
           rescue GRPC::AlreadyExists
-            # ignored
+            logger.debug('create-role.role-already-exists', role: role)
+          rescue GRPC::BadStatus => e
+            logger.error('create-role.bad-status', role: role, status: e.class.to_s, code: e.code, details: e.details, metadata: e.metadata)
           end
         end
       end
@@ -84,7 +87,9 @@ module VCAP::CloudController
           begin
             client.delete_role(role)
           rescue GRPC::NotFound
-            # ignored
+            logger.debug('delete-role.role-does-not-exist', role: role)
+          rescue GRPC::BadStatus => e
+            logger.error('delete-role.bad-status', role: role, status: e.class.to_s, code: e.code, details: e.details, metadata: e.metadata)
           end
         end
       end
@@ -93,8 +98,12 @@ module VCAP::CloudController
         if enabled
           begin
             client.assign_role(role_name: role, actor_id: user_id, issuer: issuer)
-          rescue GRPC::AlreadyExists, GRPC::NotFound
-            # ignored
+          rescue GRPC::AlreadyExists
+            logger.debug('assign-role.assignment-already-exists', role: role, user_id: user_id, issuer: issuer)
+          rescue GRPC::NotFound
+            logger.error('assign-role.role-does-not-exist', role: role, user_id: user_id, issuer: issuer)
+          rescue GRPC::BadStatus => e
+            logger.error('assign-role.bad-status', role: role, user_id: user_id, issuer: issuer, status: e.class.to_s, code: e.code, details: e.details, metadata: e.metadata)
           end
         end
       end
@@ -103,8 +112,10 @@ module VCAP::CloudController
         if enabled
           begin
             client.unassign_role(role_name: role, actor_id: user_id, issuer: issuer)
-          rescue GRPC::NotFound
-            # ignored
+          rescue GRPC::NotFound => e
+            logger.error('unassign-role.resource-not-found', role: role, user_id: user_id, issuer: issuer, details: e.details, metadata: e.metadata)
+          rescue GRPC::BadStatus => e
+            logger.error('unassign-role.bad-status', role: role, user_id: user_id, issuer: issuer, status: e.class.to_s, code: e.code, details: e.details, metadata: e.metadata)
           end
         end
       end

--- a/spec/unit/lib/perm/client_spec.rb
+++ b/spec/unit/lib/perm/client_spec.rb
@@ -52,7 +52,13 @@ module VCAP::CloudController::Perm
 
         expect { subject.create_org_role(role: 'developer', org_id: org_id) }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('create-role.bad-status', status: 'GRPC::Unavailable', role: "org-developer-#{org_id}", code: anything, details: anything, metadata: anything)
+        expect(logger).to have_received(:error).with(
+          'create-role.bad-status',
+          role: "org-developer-#{org_id}",
+          status: 'GRPC::Unavailable',
+          code: anything,
+          details: anything,
+          metadata: anything)
       end
     end
 
@@ -82,7 +88,13 @@ module VCAP::CloudController::Perm
 
         expect { subject.delete_org_role(role: 'developer', org_id: org_id) }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('delete-role.bad-status', status: 'GRPC::Unavailable', role: "org-developer-#{org_id}", code: anything, metadata: anything, details: anything)
+        expect(logger).to have_received(:error).with(
+          'delete-role.bad-status',
+          role: "org-developer-#{org_id}",
+          status: 'GRPC::Unavailable',
+          code: anything,
+          metadata: anything,
+          details: anything)
       end
     end
 
@@ -127,7 +139,15 @@ module VCAP::CloudController::Perm
           subject.assign_org_role(role: 'developer', org_id: org_id, user_id: user_id, issuer: issuer)
         }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('assign-role.bad-status', role: "org-developer-#{org_id}", user_id: user_id, issuer: issuer, status: 'GRPC::Unavailable', code: anything, details: anything, metadata: anything)
+        expect(logger).to have_received(:error).with(
+          'assign-role.bad-status',
+          role: "org-developer-#{org_id}",
+          user_id: user_id,
+          issuer: issuer,
+          status: 'GRPC::Unavailable',
+          code: anything,
+          details: anything,
+          metadata: anything)
       end
     end
 
@@ -146,7 +166,13 @@ module VCAP::CloudController::Perm
           subject.unassign_org_role(role: 'developer', org_id: org_id, user_id: user_id, issuer: issuer)
         }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('unassign-role.resource-not-found', role: "org-developer-#{org_id}", user_id: user_id, issuer: issuer, details: anything, metadata: anything)
+        expect(logger).to have_received(:error).with(
+          'unassign-role.resource-not-found',
+          role: "org-developer-#{org_id}",
+          user_id: user_id,
+          issuer: issuer,
+          details: anything,
+          metadata: anything)
       end
 
       it 'does nothing when disabled' do
@@ -162,7 +188,15 @@ module VCAP::CloudController::Perm
           subject.unassign_org_role(role: 'developer', org_id: org_id, user_id: user_id, issuer: issuer)
         }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('unassign-role.bad-status', role: "org-developer-#{org_id}", user_id: user_id, issuer: issuer, status: 'GRPC::Unavailable', code: anything, details: anything, metadata: anything)
+        expect(logger).to have_received(:error).with(
+          'unassign-role.bad-status',
+          role: "org-developer-#{org_id}",
+          user_id: user_id,
+          issuer: issuer,
+          status: 'GRPC::Unavailable',
+          code: anything,
+          details: anything,
+          metadata: anything)
       end
     end
 
@@ -228,8 +262,14 @@ module VCAP::CloudController::Perm
         allow(client).to receive(:create_role).and_raise(GRPC::Unavailable)
 
         expect { subject.create_space_role(role: 'developer', space_id: space_id) }.not_to raise_error
-
-        expect(logger).to have_received(:error).with('create-role.bad-status', status: 'GRPC::Unavailable', role: "space-developer-#{space_id}", code: anything, details: anything, metadata: anything)      end
+        expect(logger).to have_received(:error).with(
+          'create-role.bad-status',
+          role: "space-developer-#{space_id}",
+          status: 'GRPC::Unavailable',
+          code: anything,
+          details: anything,
+          metadata: anything)
+      end
     end
 
     describe '#delete_space_role' do
@@ -258,7 +298,13 @@ module VCAP::CloudController::Perm
 
         expect { subject.delete_space_role(role: 'developer', space_id: space_id) }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('delete-role.bad-status', status: 'GRPC::Unavailable', role: "space-developer-#{space_id}", code: anything, details: anything, metadata: anything)
+        expect(logger).to have_received(:error).with(
+          'delete-role.bad-status',
+          role: "space-developer-#{space_id}",
+          status: 'GRPC::Unavailable',
+          code: anything,
+          details: anything,
+          metadata: anything)
       end
     end
 
@@ -277,7 +323,11 @@ module VCAP::CloudController::Perm
           subject.assign_space_role(role: 'developer', space_id: space_id, user_id: user_id, issuer: issuer)
         }.not_to raise_error
 
-        expect(logger).to have_received(:debug).with('assign-role.assignment-already-exists', role: "space-developer-#{space_id}", user_id: user_id, issuer: issuer)
+        expect(logger).to have_received(:debug).with(
+          'assign-role.assignment-already-exists',
+          role: "space-developer-#{space_id}",
+          user_id: user_id,
+          issuer: issuer)
       end
 
       it 'does not fail if the role does not exist' do
@@ -287,7 +337,11 @@ module VCAP::CloudController::Perm
           subject.assign_space_role(role: 'developer', space_id: space_id, user_id: user_id, issuer: issuer)
         }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('assign-role.role-does-not-exist', role: "space-developer-#{space_id}", user_id: user_id, issuer: issuer)
+        expect(logger).to have_received(:error).with(
+          'assign-role.role-does-not-exist',
+          role: "space-developer-#{space_id}",
+          user_id: user_id,
+          issuer: issuer)
       end
 
       it 'does nothing when disabled' do
@@ -303,7 +357,15 @@ module VCAP::CloudController::Perm
           subject.assign_space_role(role: 'developer', space_id: space_id, user_id: user_id, issuer: issuer)
         }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('assign-role.bad-status', role: "space-developer-#{space_id}", user_id: user_id, issuer: issuer, status: 'GRPC::Unavailable', code: anything, details: anything, metadata: anything)
+        expect(logger).to have_received(:error).with(
+          'assign-role.bad-status',
+          role: "space-developer-#{space_id}",
+          user_id: user_id,
+          issuer: issuer,
+          status: 'GRPC::Unavailable',
+          code: anything,
+          details: anything,
+          metadata: anything)
       end
     end
 
@@ -322,7 +384,13 @@ module VCAP::CloudController::Perm
           subject.unassign_space_role(role: 'developer', space_id: space_id, user_id: user_id, issuer: issuer)
         }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('unassign-role.resource-not-found', role: "space-developer-#{space_id}", user_id: user_id, issuer: issuer, details: anything, metadata: anything)
+        expect(logger).to have_received(:error).with(
+          'unassign-role.resource-not-found',
+          role: "space-developer-#{space_id}",
+          user_id: user_id,
+          issuer: issuer,
+          details: anything,
+          metadata: anything)
       end
 
       it 'does nothing when disabled' do
@@ -338,7 +406,15 @@ module VCAP::CloudController::Perm
           subject.unassign_space_role(role: 'developer', space_id: space_id, user_id: user_id, issuer: issuer)
         }.not_to raise_error
 
-        expect(logger).to have_received(:error).with('unassign-role.bad-status', role: "space-developer-#{space_id}", user_id: user_id, issuer: issuer, status: 'GRPC::Unavailable', code: anything, details: anything, metadata: anything)
+        expect(logger).to have_received(:error).with(
+          'unassign-role.bad-status',
+          role: "space-developer-#{space_id}",
+          user_id: user_id,
+          issuer: issuer,
+          status: 'GRPC::Unavailable',
+          code: anything,
+          details: anything,
+          metadata: anything)
       end
     end
   end

--- a/spec/unit/lib/perm/client_spec.rb
+++ b/spec/unit/lib/perm/client_spec.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController::Perm
     subject(:subject) { Client.new(hostname: hostname, port: port, enabled: true, ca_cert_path: ca_cert_path, logger: logger) }
 
     before do
-      allow(CloudFoundry::Perm::V1::Client).to receive(:new).with(hostname: hostname, port: port, trusted_cas: trusted_cas).and_return(client)
+      allow(CloudFoundry::Perm::V1::Client).to receive(:new).with(hostname: hostname, port: port, trusted_cas: trusted_cas, timeout: anything).and_return(client)
 
       allow(logger).to receive(:info)
       allow(logger).to receive(:debug)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

We are now swallowing all GRPC errors and logging to the CC with debug and error logs.

* An explanation of the use cases your change solves

Perm should not cause a failure if it cannot be reached.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
