### PR TITLE
Update BPM to 0.2.0

### DIFF
--- a/bosh/jobs/cloud_controller_clock/templates/bpm.yml.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/bpm.yml.erb
@@ -1,13 +1,13 @@
 ---
 processes:
-  cloud_controller_clock:
-    executable: /var/vcap/jobs/cloud_controller_clock/bin/cloud_controller_clock
-    limits:
-      memory: <%= p("cc.thresholds.api.restart_if_above_mb") %>M
-    env:
-      BUNDLE_GEMFILE: /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile
-      CLOUD_CONTROLLER_NG_CONFIG: /var/vcap/jobs/cloud_controller_clock/config/cloud_controller_ng.yml
-      C_INCLUDE_PATH: /var/vcap/packages/libpq/include
-      LANG: en_US.UTF-8
-      LIBRARY_PATH: /var/vcap/packages/libpq/lib
-      NEWRELIC_ENABLE: false
+- name: cloud_controller_clock
+  executable: /var/vcap/jobs/cloud_controller_clock/bin/cloud_controller_clock
+  limits:
+    memory: <%= p("cc.thresholds.api.restart_if_above_mb") %>M
+  env:
+    BUNDLE_GEMFILE: /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile
+    CLOUD_CONTROLLER_NG_CONFIG: /var/vcap/jobs/cloud_controller_clock/config/cloud_controller_ng.yml
+    C_INCLUDE_PATH: /var/vcap/packages/libpq/include
+    LANG: en_US.UTF-8
+    LIBRARY_PATH: /var/vcap/packages/libpq/lib
+    NEWRELIC_ENABLE: false

--- a/bosh/jobs/cloud_controller_clock/templates/bpm.yml.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/bpm.yml.erb
@@ -5,9 +5,9 @@ processes:
     limits:
       memory: <%= p("cc.thresholds.api.restart_if_above_mb") %>M
     env:
-      - BUNDLE_GEMFILE=/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile
-      - CLOUD_CONTROLLER_NG_CONFIG=/var/vcap/jobs/cloud_controller_clock/config/cloud_controller_ng.yml
-      - C_INCLUDE_PATH=/var/vcap/packages/libpq/include
-      - LANG=en_US.UTF-8
-      - LIBRARY_PATH=/var/vcap/packages/libpq/lib
-      - NEWRELIC_ENABLE=false
+      BUNDLE_GEMFILE: /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile
+      CLOUD_CONTROLLER_NG_CONFIG: /var/vcap/jobs/cloud_controller_clock/config/cloud_controller_ng.yml
+      C_INCLUDE_PATH: /var/vcap/packages/libpq/include
+      LANG: en_US.UTF-8
+      LIBRARY_PATH: /var/vcap/packages/libpq/lib
+      NEWRELIC_ENABLE: false

--- a/bosh/jobs/cloud_controller_ng/templates/bpm.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/bpm.yml.erb
@@ -1,6 +1,7 @@
 <%=
 
 cloud_controller_ng_config = {
+  "name" => "cloud_controller_ng",
   "executable" => "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng",
   "limits" => {"memory" => "#{p("cc.thresholds.api.restart_if_above_mb")}M"},
   "env" => {
@@ -37,24 +38,27 @@ if properties.env
 end
 
 nginx_config = {
+  "name" => "nginx",
   "executable" => "/var/vcap/packages/nginx/sbin/nginx",
   "args" => ["-c", "/var/vcap/jobs/cloud_controller_ng/config/nginx.conf"],
 }
 
 nginx_newrelic_plugin_config = {
+  "name" => "nginx_newrelic_plugin",
   "executable" => "/var/vcap/jobs/cloud_controller_ng/bin/nginx_newrelic_plugin",
 }
 
 config = {
-  "processes" => {
-    "cloud_controller_ng" => cloud_controller_ng_config,
-    "nginx" => nginx_config,
-    "nginx_newrelic_plugin" => nginx_newrelic_plugin_config,
-  }
+  "processes" => [
+    cloud_controller_ng_config,
+    nginx_config,
+    nginx_newrelic_plugin_config,
+  ]
 }
 
 (1..(p("cc.jobs.local.number_of_workers"))).each do |index|
   local_worker_config = {
+    "name" => "local_worker_#{index}",
     "executable" => "/var/vcap/jobs/cloud_controller_ng/bin/local_worker",
     "limits" => {"memory" => "#{p("cc.thresholds.api.restart_if_above_mb")}M"},
     "env" => {
@@ -74,7 +78,7 @@ config = {
    local_worker_config["env"]["NEWRELIC_ENABLE"] = true
   end
 
-  config["processes"]["local_worker_#{index}"] = local_worker_config
+  config["processes"] << local_worker_config
 end
 
 YAML.dump(config)

--- a/bosh/jobs/cloud_controller_ng/templates/bpm.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/bpm.yml.erb
@@ -4,6 +4,7 @@ cloud_controller_ng_config = {
   "name" => "cloud_controller_ng",
   "executable" => "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng",
   "limits" => {"memory" => "#{p("cc.thresholds.api.restart_if_above_mb")}M"},
+  "ephemeral_disk" => true,
   "env" => {
     "BUNDLE_GEMFILE" => "/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
     "CLOUD_CONTROLLER_NG_CONFIG" => "/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml",
@@ -41,6 +42,7 @@ nginx_config = {
   "name" => "nginx",
   "executable" => "/var/vcap/packages/nginx/sbin/nginx",
   "args" => ["-c", "/var/vcap/jobs/cloud_controller_ng/config/nginx.conf"],
+  "ephemeral_disk" => true,
 }
 
 nginx_newrelic_plugin_config = {
@@ -61,6 +63,7 @@ config = {
     "name" => "local_worker_#{index}",
     "executable" => "/var/vcap/jobs/cloud_controller_ng/bin/local_worker",
     "limits" => {"memory" => "#{p("cc.thresholds.api.restart_if_above_mb")}M"},
+    "ephemeral_disk" => true,
     "env" => {
       "BUNDLE_GEMFILE" => "/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
       "CLOUD_CONTROLLER_NG_CONFIG" => "/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml",

--- a/bosh/jobs/cloud_controller_ng/templates/bpm.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/bpm.yml.erb
@@ -3,36 +3,36 @@
 cloud_controller_ng_config = {
   "executable" => "/var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng",
   "limits" => {"memory" => "#{p("cc.thresholds.api.restart_if_above_mb")}M"},
-  "env" => [
-    "BUNDLE_GEMFILE=/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
-    "CLOUD_CONTROLLER_NG_CONFIG=/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml",
-    "C_INCLUDE_PATH=/var/vcap/packages/libpq/include",
-    "DYNO=#{spec.job.name}-#{spec.index}",
-    "HOME=/home/vcap",
-    "LANG=en_US.UTF-8",
-    "LIBRARY_PATH=/var/vcap/packages/libpq/lib",
-    "NEW_RELIC_ENV=#{p("cc.newrelic.environment_name")}",
-    "NRCONFIG=/var/vcap/jobs/cloud_controller_ng/config/newrelic.yml",
-    "RAILS_ENV=production",
-  ]
+  "env" => {
+    "BUNDLE_GEMFILE" => "/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
+    "CLOUD_CONTROLLER_NG_CONFIG" => "/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml",
+    "C_INCLUDE_PATH" => "/var/vcap/packages/libpq/include",
+    "DYNO" => "#{spec.job.name}-#{spec.index}",
+    "HOME" => "/home/vcap",
+    "LANG" => "en_US.UTF-8",
+    "LIBRARY_PATH" => "/var/vcap/packages/libpq/lib",
+    "NEW_RELIC_ENV" => "#{p("cc.newrelic.environment_name")}",
+    "NRCONFIG" => "/var/vcap/jobs/cloud_controller_ng/config/newrelic.yml",
+    "RAILS_ENV" => "production",
+  }
 }
 
 if !!properties.cc.newrelic.license_key || p("cc.development_mode")
-    cloud_controller_ng_config["env"] << "NEWRELIC_ENABLE=true"
+    cloud_controller_ng_config["env"]["NEWRELIC_ENABLE"] = true
 end
 
 if properties.env
     if properties.env.http_proxy
-        cloud_controller_ng_config["env"] << "HTTP_PROXY=#{properties.env.http_proxy}"
-        cloud_controller_ng_config["env"] << "http_proxy=#{properties.env.http_proxy}"
+        cloud_controller_ng_config["env"]["HTTP_PROXY"] = "#{properties.env.http_proxy}"
+        cloud_controller_ng_config["env"]["http_proxy"] = "#{properties.env.http_proxy}"
     end
     if properties.env.https_proxy
-        cloud_controller_ng_config["env"] << "HTTPS_PROXY=#{properties.env.https_proxy}"
-        cloud_controller_ng_config["env"] << "https_proxy=#{properties.env.https_proxy}"
+        cloud_controller_ng_config["env"]["HTTPS_PROXY"] = "#{properties.env.https_proxy}"
+        cloud_controller_ng_config["env"]["https_proxy"] = "#{properties.env.https_proxy}"
     end
     if properties.env.no_proxy
-        cloud_controller_ng_config["env"] << "NO_PROXY=#{properties.env.no_proxy}"
-        cloud_controller_ng_config["env"] << "no_proxy=#{properties.env.no_proxy}"
+        cloud_controller_ng_config["env"]["NO_PROXY"] = "#{properties.env.no_proxy}"
+        cloud_controller_ng_config["env"]["no_proxy"] = "#{properties.env.no_proxy}"
     end
 end
 
@@ -57,21 +57,21 @@ config = {
   local_worker_config = {
     "executable" => "/var/vcap/jobs/cloud_controller_ng/bin/local_worker",
     "limits" => {"memory" => "#{p("cc.thresholds.api.restart_if_above_mb")}M"},
-    "env" => [
-      "BUNDLE_GEMFILE=/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
-      "CLOUD_CONTROLLER_NG_CONFIG=/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml",
-      "C_INCLUDE_PATH=/var/vcap/packages/libpq/include",
-      "LANG=en_US.UTF-8",
-      "LIBRARY_PATH=/var/vcap/packages/libpq/lib",
-      "NEW_RELIC_ENV=#{p("cc.newrelic.environment_name")}",
-      "NEW_RELIC_DISPATCHER=delayed_job",
-      "NRCONFIG=/var/vcap/jobs/cloud_controller_ng/config/newrelic.yml",
-      "INDEX=#{index}"
-    ]
+    "env" => {
+      "BUNDLE_GEMFILE" => "/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
+      "CLOUD_CONTROLLER_NG_CONFIG" => "/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml",
+      "C_INCLUDE_PATH" => "/var/vcap/packages/libpq/include",
+      "LANG" => "en_US.UTF-8",
+      "LIBRARY_PATH" => "/var/vcap/packages/libpq/lib",
+      "NEW_RELIC_ENV" => "#{p("cc.newrelic.environment_name")}",
+      "NEW_RELIC_DISPATCHER" => "delayed_job",
+      "NRCONFIG" => "/var/vcap/jobs/cloud_controller_ng/config/newrelic.yml",
+      "INDEX" => index
+    }
   }
 
   if !!properties.cc.newrelic.license_key
-   local_worker_config["env"] << "NEWRELIC_ENABLE=true"
+   local_worker_config["env"]["NEWRELIC_ENABLE"] = true
   end
 
   config["processes"]["local_worker_#{index}"] = local_worker_config

--- a/bosh/jobs/cloud_controller_worker/templates/bpm.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/bpm.yml.erb
@@ -1,9 +1,10 @@
 <%=
 
-config = { "processes" => {} }
+config = { "processes" => [] }
 
 (1..(p("cc.jobs.generic.number_of_workers"))).each do |index|
   worker_config = {
+    "name" => "worker_#{index}",
     "executable" => "/var/vcap/jobs/cloud_controller_worker/bin/cloud_controller_worker",
     "limits" => {"memory" => "#{p("cc.thresholds.worker.restart_if_above_mb")}M"},
     "env" => {
@@ -23,7 +24,7 @@ config = { "processes" => {} }
    worker_config["env"]["NEWRELIC_ENABLE"] = true
   end
 
-  config["processes"]["worker_#{index}"] = worker_config
+  config["processes"] << worker_config
 end
 
 YAML.dump(config)

--- a/bosh/jobs/cloud_controller_worker/templates/bpm.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/bpm.yml.erb
@@ -6,21 +6,21 @@ config = { "processes" => {} }
   worker_config = {
     "executable" => "/var/vcap/jobs/cloud_controller_worker/bin/cloud_controller_worker",
     "limits" => {"memory" => "#{p("cc.thresholds.worker.restart_if_above_mb")}M"},
-    "env" => [
-      "BUNDLE_GEMFILE=/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
-      "CLOUD_CONTROLLER_NG_CONFIG=/var/vcap/jobs/cloud_controller_worker/config/cloud_controller_ng.yml",
-      "C_INCLUDE_PATH=/var/vcap/packages/libpq/include",
-      "LANG=en_US.UTF-8",
-      "LIBRARY_PATH=/var/vcap/packages/libpq/lib",
-      "NEW_RELIC_ENV=#{p("cc.newrelic.environment_name")}_background",
-      "NEW_RELIC_DISPATCHER=delayed_job",
-      "NRCONFIG=/var/vcap/jobs/cloud_controller_worker/config/newrelic.yml",
-      "INDEX=#{index}"
-    ]
+    "env" => {
+      "BUNDLE_GEMFILE" => "/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
+      "CLOUD_CONTROLLER_NG_CONFIG" => "/var/vcap/jobs/cloud_controller_worker/config/cloud_controller_ng.yml",
+      "C_INCLUDE_PATH" => "/var/vcap/packages/libpq/include",
+      "LANG" => "en_US.UTF-8",
+      "LIBRARY_PATH" => "/var/vcap/packages/libpq/lib",
+      "NEW_RELIC_ENV" => "#{p("cc.newrelic.environment_name")}_background",
+      "NEW_RELIC_DISPATCHER" => "delayed_job",
+      "NRCONFIG" => "/var/vcap/jobs/cloud_controller_worker/config/newrelic.yml",
+      "INDEX" => index
+    }
   }
 
   if !!properties.cc.newrelic.license_key
-   worker_config["env"] << "NEWRELIC_ENABLE=true"
+   worker_config["env"]["NEWRELIC_ENABLE"] = true
   end
 
   config["processes"]["worker_#{index}"] = worker_config


### PR DESCRIPTION
*Note*: This PR should **NOT** be merged until BPM version `0.2.0` is on [release-candidate of cf-deployment](https://github.com/cloudfoundry/cf-deployment/blob/release-candidate/operations/experimental/enable-bpm.yml#L8)

This change set entails all the configuration changes necessary to migrate from BPM v0.1.0 to v0.2.0.

Configuration changes include:
- [Environment variables as a hash](https://www.pivotaltracker.com/story/show/151345092)
- [Processes as an array](https://www.pivotaltracker.com/story/show/151451341)
- [Volumes are read only by default](https://www.pivotaltracker.com/story/show/151408169)
- [Rename Volumes to AdditionalVolumes](https://www.pivotaltracker.com/story/show/151531845)
- [Opting into persistent volumes being mounted](https://www.pivotaltracker.com/story/show/151531925)
- [Opting into ephemeral volumes being mounted](https://www.pivotaltracker.com/story/show/151532030)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
