### PR TITLE
Stop memoizing client and logger

### DIFF
--- a/lib/cloud_controller/perm/client.rb
+++ b/lib/cloud_controller/perm/client.rb
@@ -62,7 +62,7 @@ module VCAP::CloudController
       attr_reader :hostname, :port, :enabled, :trusted_cas, :logger_name
 
       def client
-        @client ||= CloudFoundry::Perm::V1::Client.new(hostname: hostname, port: port, trusted_cas: trusted_cas, timeout: 0.1)
+        CloudFoundry::Perm::V1::Client.new(hostname: hostname, port: port, trusted_cas: trusted_cas, timeout: 0.1)
       end
 
       def org_role(role, org_id)
@@ -124,7 +124,7 @@ module VCAP::CloudController
       end
 
       def logger
-        @logger ||= Steno.logger(logger_name)
+        Steno.logger(logger_name)
       end
     end
   end


### PR DESCRIPTION
This broke async deletion due to the serialization of the logger. Also,
the client connection was sometimes closed unexpectedly.

Signed-off-by: Chris Hendrix <chendrix@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
