### PR TITLE
Improve perm client latency and add custom timeout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 GIT
   remote: https://github.com/cloudfoundry-incubator/perm-rb.git
-  revision: 0d3830c7e7299e206c88da038d400c5ef0c5753a
+  revision: 7d762a5019f607468ac9a6c10360b2571373507f
   branch: master
   specs:
     cf-perm (0.0.0)
       grpc (~> 1.0)
     cf-perm-test-helpers (0.0.1)
+      ruby-mysql (~> 2.9.14)
       subprocess (~> 1)
 
 GIT
@@ -202,15 +203,15 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    grpc (1.6.2)
+    grpc (1.6.6)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
       googleauth (~> 0.5.1)
-    grpc (1.6.2-universal-darwin)
+    grpc (1.6.6-universal-darwin)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
       googleauth (~> 0.5.1)
-    grpc (1.6.2-x86_64-linux)
+    grpc (1.6.6-x86_64-linux)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
       googleauth (~> 0.5.1)
@@ -357,6 +358,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-debug-ide (0.6.1.beta4)
       rake (>= 0.8.1)
+    ruby-mysql (2.9.14)
     ruby-progressbar (1.9.0)
     ruby_parser (3.8.3)
       sexp_processor (~> 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/cloudfoundry-incubator/perm-rb.git
-  revision: 7d762a5019f607468ac9a6c10360b2571373507f
+  revision: 30d545dba0ee826f6f975542252d84f14097e864
   branch: master
   specs:
     cf-perm (0.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/cloudfoundry-incubator/perm-rb.git
-  revision: 30d545dba0ee826f6f975542252d84f14097e864
+  revision: 8ba367b05455e3b6009a2411408522a876a76224
   branch: master
   specs:
     cf-perm (0.0.0)

--- a/app/actions/perm_org_roles_delete.rb
+++ b/app/actions/perm_org_roles_delete.rb
@@ -5,6 +5,7 @@ module VCAP::CloudController
     end
 
     def delete(org)
+      @client = client.rehydrate
       OrganizationsController::ROLE_NAMES.each do |role|
         begin
           client.delete_org_role(role: role, org_id: org.guid)

--- a/app/actions/perm_space_roles_delete.rb
+++ b/app/actions/perm_space_roles_delete.rb
@@ -5,6 +5,7 @@ module VCAP::CloudController
     end
 
     def delete(space)
+      @client = client.rehydrate
       SpacesController::ROLE_NAMES.each do |role|
         begin
           client.delete_space_role(role: role, space_id: space.guid)

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -851,6 +851,9 @@ properties:
   perm.ca_certs:
     description: "An array of certificate authorities being used by Perm. Allows multiple in case of rotation."
     default: []
+  perm.timeout_in_milliseconds:
+    description: "Timeout for Perm requests in milliseconds."
+    default: 100
 
   credhub_api.hostname:
     description: "Hostname used to resolve the address of CredHub"

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -56,6 +56,7 @@ module VCAP::CloudController
         config[:rate_limiter][:general_limit] ||= 2000
         config[:rate_limiter][:reset_interval_in_minutes] ||= 60
         config[:perm] ||= { enabled: false }
+        config[:perm][:timeout_in_milliseconds] ||= 100
 
         unless config.key?(:users_can_select_backend)
           config[:users_can_select_backend] = true

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -299,6 +299,7 @@ module VCAP::CloudController
             enabled: bool,
             optional(:hostname) => String,
             optional(:port) => Integer,
+            optional(:timeout_in_milliseconds) => Integer,
             ca_cert_path: String,
           }
         }

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -434,12 +434,13 @@ module CloudController
       port = config.get(:perm, :port)
       enabled = config.get(:perm, :enabled)
       ca_cert_path = config.get(:perm, :ca_cert_path)
+      timeout = config.get(:perm, :timeout_in_milliseconds) / 1000.0
       trusted_cas = []
       if enabled
         trusted_cas << File.open(ca_cert_path).read
       end
 
-      VCAP::CloudController::Perm::Client.new(hostname: hostname, port: port, enabled: enabled, trusted_cas: trusted_cas, logger_name: 'perm.client')
+      VCAP::CloudController::Perm::Client.new(hostname: hostname, port: port, enabled: enabled, trusted_cas: trusted_cas, logger_name: 'perm.client', timeout: timeout)
     end
   end
 end

--- a/lib/cloud_controller/perm/client.rb
+++ b/lib/cloud_controller/perm/client.rb
@@ -135,8 +135,9 @@ module VCAP::CloudController
         end
       end
 
+      # Can't be cached because the Syslog logger doesn't deserialize correctly for delayed jobs :(
       def logger
-        @logger ||= Steno.logger(logger_name)
+        Steno.logger(logger_name)
       end
     end
   end

--- a/lib/cloud_controller/perm/client.rb
+++ b/lib/cloud_controller/perm/client.rb
@@ -3,12 +3,24 @@ require 'perm'
 module VCAP::CloudController
   module Perm
     class Client
-      def initialize(hostname:, port:, enabled:, trusted_cas:, logger_name:)
+      def initialize(hostname:, port:, enabled:, trusted_cas:, logger_name:, timeout:)
         @hostname = hostname
         @port = port
         @trusted_cas = trusted_cas
         @enabled = enabled
         @logger_name = logger_name
+        @timeout = timeout
+      end
+
+      # When this object is passed across the boundary to DelayedJob it is serialized in the database
+      # and then automatically rehydrated on the other side
+      # This does not work in our case because
+      # a) The gRPC connection is broken
+      # b) The logger's Syslog logger cannot be serialized
+      # Instead, provide a custom rehydrate method that returns a new object
+      # and do this when performing the DelayedJob
+      def rehydrate
+        Client.new(hostname: hostname, port: port, enabled: enabled, trusted_cas: trusted_cas, logger_name: logger_name, timeout: timeout)
       end
 
       def create_org_role(role:, org_id:)
@@ -59,10 +71,10 @@ module VCAP::CloudController
 
       private
 
-      attr_reader :hostname, :port, :enabled, :trusted_cas, :logger_name
+      attr_reader :hostname, :port, :enabled, :trusted_cas, :logger_name, :timeout
 
       def client
-        CloudFoundry::Perm::V1::Client.new(hostname: hostname, port: port, trusted_cas: trusted_cas, timeout: 0.1)
+        @client ||= CloudFoundry::Perm::V1::Client.new(hostname: hostname, port: port, trusted_cas: trusted_cas, timeout: timeout)
       end
 
       def org_role(role, org_id)
@@ -124,7 +136,7 @@ module VCAP::CloudController
       end
 
       def logger
-        Steno.logger(logger_name)
+        @logger ||= Steno.logger(logger_name)
       end
     end
   end

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -227,6 +227,7 @@ perm:
   hostname: perm.service.cf.internal
   port: 6283
   ca_cert_path: spec/fixtures/certs/perm_ca.crt
+  timeout_in_milliseconds: 1000
 
 credhub_api:
   internal_url: https://credhub.capi.me:8844

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe 'Perm', type: :integration, skip: ENV['CF_RUN_PERM_SPECS'] != 'tr
   let(:issuer) { 'https://auth.example.com/oauth/token' }
 
   if ENV['CF_RUN_PERM_SPECS'] == 'true'
-    before(:each) do
+    before(:all) do
       perm_server = CloudFoundry::PermTestHelpers::ServerRunner.new
       perm_server.start
     end
 
-    after(:each) do
+    after(:all) do
       perm_server.stop
     end
   end
@@ -38,7 +38,8 @@ RSpec.describe 'Perm', type: :integration, skip: ENV['CF_RUN_PERM_SPECS'] != 'tr
       enabled: true,
       hostname: perm_hostname,
       port: perm_port,
-      ca_cert_path: perm_server.tls_ca_path
+      ca_cert_path: perm_server.tls_ca_path,
+      timeout_in_milliseconds: 1000
     }
 
     allow_any_instance_of(VCAP::CloudController::UaaClient).to receive(:usernames_for_ids).with([assignee.guid]).and_return({ assignee.guid => assignee.username })
@@ -125,7 +126,7 @@ RSpec.describe 'Perm', type: :integration, skip: ENV['CF_RUN_PERM_SPECS'] != 'tr
 
             expect {
               client.get_role(role_name)
-            }.to raise_error GRPC::NotFound
+            }.to raise_error(GRPC::NotFound), "Expected that role #{role_name} was not found"
           end
         end
       end
@@ -231,10 +232,10 @@ RSpec.describe 'Perm', type: :integration, skip: ENV['CF_RUN_PERM_SPECS'] != 'tr
 
               expect {
                 client.get_role(org_role_name)
-              }.to raise_error GRPC::NotFound
+              }.to raise_error(GRPC::NotFound), "Expected that role #{org_role_name} was not found"
               expect {
                 client.get_role(space_role_name)
-              }.to raise_error GRPC::NotFound
+              }.to raise_error(GRPC::NotFound), "Expected that role #{space_role_name} was not found"
             end
           end
         end
@@ -488,7 +489,7 @@ RSpec.describe 'Perm', type: :integration, skip: ENV['CF_RUN_PERM_SPECS'] != 'tr
 
           expect {
             client.get_role(role_name)
-          }.to raise_error GRPC::NotFound
+          }.to raise_error(GRPC::NotFound), "Expected that role #{role_name} was not found"
         end
       end
 

--- a/spec/unit/lib/perm/client_spec.rb
+++ b/spec/unit/lib/perm/client_spec.rb
@@ -15,8 +15,8 @@ module VCAP::CloudController::Perm
 
     let(:logger) { instance_double(Steno::Logger) }
 
-    let(:disabled_subject) { Client.new(hostname: hostname, port: port, enabled: false, trusted_cas: [], logger_name: 'perm') }
-    subject(:subject) { Client.new(hostname: hostname, port: port, enabled: true, trusted_cas: trusted_cas, logger_name: 'perm') }
+    let(:disabled_subject) { Client.new(hostname: hostname, port: port, enabled: false, trusted_cas: [], logger_name: 'perm', timeout: 0.1) }
+    subject(:subject) { Client.new(hostname: hostname, port: port, enabled: true, trusted_cas: trusted_cas, logger_name: 'perm', timeout: 0.1) }
 
     before do
       allow(CloudFoundry::Perm::V1::Client).to receive(:new).with(hostname: hostname, port: port, trusted_cas: trusted_cas, timeout: anything).and_return(client)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

We had stopped caching the perm client since connections can't be (de)serialized. However, establishing a connection sometimes takes longer than we'd like to allot for a given request. We therefore started caching again and explicitly rehydrate the client in delayed jobs.

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite
