### PR TITLE
Remove invalid event types from v2 event docs

### DIFF
--- a/docs/v2/events/list_app_create_events.html
+++ b/docs/v2/events/list_app_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.app.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.app.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_app_delete_events.html
+++ b/docs/v2/events/list_app_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.app.delete-request</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.app.delete-request</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_app_exited_events.html
+++ b/docs/v2/events/list_app_exited_events.html
@@ -226,7 +226,6 @@
               </td>
               <td>
                 <ul class="valid_values">
-                </ul>
               </td>
               <td>
                 <ul class="example_values">
@@ -292,89 +291,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>app.crash</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
                         <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_app_ssh_authorized_events.html
+++ b/docs/v2/events/list_app_ssh_authorized_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.app.ssh-authorized</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.app.ssh-authorized</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_app_ssh_unauthorized_events.html
+++ b/docs/v2/events/list_app_ssh_unauthorized_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.app.ssh-unauthorized</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.app.ssh-unauthorized</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_app_start_events.html
+++ b/docs/v2/events/list_app_start_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.app.start</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.app.start</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_app_stop_events.html
+++ b/docs/v2/events/list_app_stop_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.app.stop</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.app.stop</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_app_update_events.html
+++ b/docs/v2/events/list_app_update_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>app.crash</li>
                         <li>audit.app.update</li>
                   </ul>
                 </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
                 <td>
                   <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.app.update</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_route_create_events.html
+++ b/docs/v2/events/list_route_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.route.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.route.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_route_delete_events.html
+++ b/docs/v2/events/list_route_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.route.delete-request</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.route.delete-request</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_route_update_events.html
+++ b/docs/v2/events/list_route_update_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.route.update</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.route.update</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_binding_create_events.html
+++ b/docs/v2/events/list_service_binding_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_binding.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_binding.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_binding_delete_events.html
+++ b/docs/v2/events/list_service_binding_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_binding.delete</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_binding.delete</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_broker_create_events.html
+++ b/docs/v2/events/list_service_broker_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_broker.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_broker.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_broker_delete_events.html
+++ b/docs/v2/events/list_service_broker_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_broker.delete</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_broker.delete</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_broker_update_events.html
+++ b/docs/v2/events/list_service_broker_update_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_broker.update</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_broker.update</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_create_events.html
+++ b/docs/v2/events/list_service_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_dashboard_client_create_events.html
+++ b/docs/v2/events/list_service_dashboard_client_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_dashboard_client.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_dashboard_client.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_dashboard_client_delete_events.html
+++ b/docs/v2/events/list_service_dashboard_client_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_dashboard_client.delete</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_dashboard_client.delete</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_delete_events.html
+++ b/docs/v2/events/list_service_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service.delete</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service.delete</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_instance_bind_route_events.html
+++ b/docs/v2/events/list_service_instance_bind_route_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_instance.bind_route</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_instance.bind_route</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_instance_create_events.html
+++ b/docs/v2/events/list_service_instance_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_instance.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_instance.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_instance_delete_events.html
+++ b/docs/v2/events/list_service_instance_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_instance.delete</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_instance.delete</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_instance_unbind_route_events.html
+++ b/docs/v2/events/list_service_instance_unbind_route_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_instance.unbind_route</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_instance.unbind_route</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_instance_update_events.html
+++ b/docs/v2/events/list_service_instance_update_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_instance.update</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_instance.update</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_key_create_events.html
+++ b/docs/v2/events/list_service_key_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_key.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_key.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_key_delete_events.html
+++ b/docs/v2/events/list_service_key_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_key.delete</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_key.delete</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_plan_create_events.html
+++ b/docs/v2/events/list_service_plan_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_plan.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_plan.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_plan_delete_events.html
+++ b/docs/v2/events/list_service_plan_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_plan.delete</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_plan.delete</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_plan_update_events.html
+++ b/docs/v2/events/list_service_plan_update_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_plan.update</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_plan.update</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_plan_visibility_create_events.html
+++ b/docs/v2/events/list_service_plan_visibility_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_plan_visibility.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_plan_visibility.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_plan_visibility_delete_events.html
+++ b/docs/v2/events/list_service_plan_visibility_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_plan_visibility.delete</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_plan_visibility.delete</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_plan_visibility_update_events.html
+++ b/docs/v2/events/list_service_plan_visibility_update_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service_plan_visibility.update</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service_plan_visibility.update</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_service_update_events.html
+++ b/docs/v2/events/list_service_update_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.service.update</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.service.update</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_space_create_events.html
+++ b/docs/v2/events/list_space_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.space.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.space.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_space_delete_events.html
+++ b/docs/v2/events/list_space_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.space.delete-request</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.space.delete-request</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_space_update_events.html
+++ b/docs/v2/events/list_space_update_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.space.update</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.space.update</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_user_provided_service_instance_create_events.html
+++ b/docs/v2/events/list_user_provided_service_instance_create_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.user_provided_service_instance.create</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.user_provided_service_instance.create</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_user_provided_service_instance_delete_events.html
+++ b/docs/v2/events/list_user_provided_service_instance_delete_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.user_provided_service_instance.delete</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.user_provided_service_instance.delete</li>
                   </ul>
                 </td>
               </tr>

--- a/docs/v2/events/list_user_provided_service_instance_update_events.html
+++ b/docs/v2/events/list_user_provided_service_instance_update_events.html
@@ -292,89 +292,12 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="valid_values">
-                      <li>app.crash</li>
-                      <li>audit.app.copy-bits</li>
-                      <li>audit.app.create</li>
-                      <li>audit.app.delete-request</li>
-                      <li>audit.app.droplet.mapped</li>
-                      <li>audit.app.map-route</li>
-                      <li>audit.app.package.create</li>
-                      <li>audit.app.package.delete</li>
-                      <li>audit.app.package.download</li>
-                      <li>audit.app.package.upload</li>
-                      <li>audit.app.restage</li>
-                      <li>audit.app.ssh-authorized</li>
-                      <li>audit.app.ssh-unauthorized</li>
-                      <li>audit.app.start</li>
-                      <li>audit.app.stop</li>
-                      <li>audit.app.unmap-route</li>
-                      <li>audit.app.update</li>
-                      <li>audit.route.create</li>
-                      <li>audit.route.delete-request</li>
-                      <li>audit.route.update</li>
-                      <li>audit.service.create</li>
-                      <li>audit.service.delete</li>
-                      <li>audit.service.update</li>
-                      <li>audit.service_binding.create</li>
-                      <li>audit.service_binding.delete</li>
-                      <li>audit.service_broker.create</li>
-                      <li>audit.service_broker.delete</li>
-                      <li>audit.service_broker.update</li>
-                      <li>audit.service_dashboard_client.create</li>
-                      <li>audit.service_dashboard_client.delete</li>
-                      <li>audit.service_instance.bind_route</li>
-                      <li>audit.service_instance.create</li>
-                      <li>audit.service_instance.delete</li>
-                      <li>audit.service_instance.unbind_route</li>
-                      <li>audit.service_instance.update</li>
-                      <li>audit.service_key.create</li>
-                      <li>audit.service_key.delete</li>
-                      <li>audit.service_plan.create</li>
-                      <li>audit.service_plan.delete</li>
-                      <li>audit.service_plan.update</li>
-                      <li>audit.service_plan_visibility.create</li>
-                      <li>audit.service_plan_visibility.delete</li>
-                      <li>audit.service_plan_visibility.update</li>
-                      <li>audit.space.create</li>
-                      <li>audit.space.delete-request</li>
-                      <li>audit.space.update</li>
-                      <li>audit.user_provided_service_instance.create</li>
-                      <li>audit.user_provided_service_instance.delete</li>
-                      <li>audit.user_provided_service_instance.update</li>
+                        <li>audit.user_provided_service_instance.update</li>
                   </ul>
                 </td>
                 <td>
                   <ul class="example_values">
-                        <li>app.crash</li>
-                        <li>audit.app.update</li>
-                  </ul>
-                </td>
-              </tr>
-              <tr class="">
-                <td class="experimental">
-                    <span class="name">type</span>
-                </td>
-                <td>
-                  <span class="description">The type of the event.</span>
-                </td>
-                <td>
-                  <ul class="valid_values">
-                      <li>audit.app.droplet.create</li>
-                      <li>audit.app.droplet.delete</li>
-                      <li>audit.app.droplet.download</li>
-                      <li>audit.app.process.crash</li>
-                      <li>audit.app.process.create</li>
-                      <li>audit.app.process.delete</li>
-                      <li>audit.app.process.scale</li>
-                      <li>audit.app.process.terminate_instance</li>
-                      <li>audit.app.process.update</li>
-                      <li>audit.app.task.cancel</li>
-                      <li>audit.app.task.create</li>
-                  </ul>
-                </td>
-                <td>
-                  <ul class="example_values">
-                        <li>audit.app.process.crash</li>
+                        <li>audit.user_provided_service_instance.update</li>
                   </ul>
                 </td>
               </tr>


### PR DESCRIPTION
The existing v2 docs for events list every event type as a valid value in the response, despite the fact that the documentation is for a querying a specific event type.  This is confusing to doc consumers because they would never actually encounter that variety of event types when issuing the documented query. It also makes it awkward when adding a new event type, since the pattern is to add it to each of these 40 files, even though the new event has nothing to do with the other 40 events.

The "List all Events", "List events associated with an App since January 1, 2014", and "Retrieve a Particular Event" pages were left untouched.

Thanks,
@jenspinney and @Samze 


