### PR TITLE
Support Multipart messages with CRLF in message parts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'thin'
 gem 'unf'
 gem 'vcap_common', '~> 4.0.4'
 gem 'yajl-ruby'
+gem 'multipart-parser'
 
 gem 'fog-aws'
 gem 'fog-azure-rm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,7 @@ GEM
       ms_rest (~> 0.6.3)
     msgpack (1.1.0)
     multi_json (1.12.2)
+    multipart-parser (0.1.1)
     multipart-post (2.0.0)
     mustache (0.99.8)
     mysql2 (0.4.8)
@@ -477,6 +478,7 @@ DEPENDENCIES
   membrane (~> 1.0)
   mime-types (~> 2.6.2)
   multi_json
+  multipart-parser
   mysql2 (= 0.4.8)
   net-ssh
   netaddr

--- a/lib/traffic_controller/errors.rb
+++ b/lib/traffic_controller/errors.rb
@@ -10,4 +10,7 @@ module TrafficController
 
   class DecodeError < Error
   end
+
+  class ParseError < Error
+  end
 end

--- a/spec/traffic_controller/client_spec.rb
+++ b/spec/traffic_controller/client_spec.rb
@@ -118,21 +118,21 @@ module TrafficController
         ].join('')
       end
       let(:boundary) { 'boundary-guid' }
-      let(:first_part) { 'part one data' }
+      let(:first_part) { "part one\r\n data" }
       let(:second_part) { 'part two data' }
 
       it 'can return the first part' do
-        expect(parser.next_part).to eq('part one data')
+        expect(parser.next_part).to eq("part one\r\n data")
       end
 
       it 'can read more than one part' do
-        expect(parser.next_part).to eq('part one data')
+        expect(parser.next_part).to eq("part one\r\n data")
         expect(parser.next_part).to eq('part two data')
       end
 
       context 'when there are no parts left' do
         it 'returns nil' do
-          expect(parser.next_part).to eq('part one data')
+          expect(parser.next_part).to eq("part one\r\n data")
           expect(parser.next_part).to eq('part two data')
           expect(parser.next_part).to be_nil
         end


### PR DESCRIPTION
Previously, the MultipartParser would split a message part on CRLF. This meant
that if a message part contained a CRLF (which is valid), the parser would
fail to parse correctly.

This commit resolves the issue and supports CRLF in message parts.

What exposed this issue was that Loggregator recently made changes in v100 that applied more tags to envelopes. The protobuf encoding does some checking on the number of tags in an envelopes, does some bit shifting and inserts that data into the envelope. Because of the extra tags `\r` (13) was inserted to the envelope right before a `\n` that is inserted at the beginning of the tags segment of the encoded envelope. This caused the multipart parsing to break in the trafficcontroller multipart parser.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
