### PR TITLE
As an auditor, I see an event when a service instance is unshared

### DIFF
--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -1,6 +1,6 @@
 module VCAP::CloudController
   class ServiceInstanceShare
-    def create(service_instance, target_spaces, user_audit_info, target_space_guids)
+    def create(service_instance, target_spaces, user_audit_info)
       ServiceInstance.db.transaction do
         target_spaces.each do |space|
           service_instance.add_shared_space(space)
@@ -8,7 +8,7 @@ module VCAP::CloudController
       end
 
       Repositories::ServiceInstanceShareEventRepository.record_share_event(
-        service_instance, user_audit_info, target_space_guids)
+        service_instance, target_spaces.map(&:guid), user_audit_info)
       service_instance
     end
   end

--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -1,3 +1,5 @@
+require 'repositories/service_instance_share_event_repository'
+
 module VCAP::CloudController
   class ServiceInstanceShare
     def create(service_instance, target_spaces, user_audit_info)

--- a/app/actions/service_instance_unshare.rb
+++ b/app/actions/service_instance_unshare.rb
@@ -1,7 +1,10 @@
 module VCAP::CloudController
   class ServiceInstanceUnshare
-    def unshare(service_instance, target_space)
+    def unshare(service_instance, target_space, user_audit_info)
       service_instance.remove_shared_space(target_space)
+
+      Repositories::ServiceInstanceShareEventRepository.record_unshare_event(
+        service_instance, target_space.guid, user_audit_info)
     end
   end
 end

--- a/app/actions/service_instance_unshare.rb
+++ b/app/actions/service_instance_unshare.rb
@@ -1,0 +1,7 @@
+module VCAP::CloudController
+  class ServiceInstanceUnshare
+    def unshare(service_instance, target_space)
+      service_instance.remove_shared_space(target_space)
+    end
+  end
+end

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -23,7 +23,7 @@ class ServiceInstancesV3Controller < ApplicationController
     check_spaces_are_writeable!(spaces)
 
     share = ServiceInstanceShare.new
-    share.create(service_instance, spaces, user_audit_info, message.guids)
+    share.create(service_instance, spaces, user_audit_info)
 
     render status: :ok, json: Presenters::V3::ToManyRelationshipPresenter.new(
       "service_instances/#{service_instance.guid}", service_instance.shared_spaces, 'shared_spaces')

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -4,6 +4,7 @@ require 'repositories/service_instance_share_event_repository'
 require 'presenters/v3/relationship_presenter'
 require 'presenters/v3/to_many_relationship_presenter'
 require 'actions/service_instance_share'
+require 'actions/service_instance_unshare'
 
 class ServiceInstancesV3Controller < ApplicationController
   def share_service_instance
@@ -47,7 +48,8 @@ class ServiceInstancesV3Controller < ApplicationController
       unprocessable!("Unable to unshare service instance from space #{space_guid}. Ensure no bindings exist in the target space")
     end
 
-    service_instance.remove_shared_space(target_space)
+    unshare = ServiceInstanceUnshare.new
+    unshare.unshare(service_instance, target_space)
 
     head :no_content
   end

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -40,11 +40,11 @@ class ServiceInstancesV3Controller < ApplicationController
     target_space = Space.first(guid: space_guid)
 
     unless target_space && service_instance.shared_spaces.include?(target_space)
-      unprocessable!("Unable to unshare service instance from space #{space_guid}. Ensure the spaces exist and it has been shared.")
+      unprocessable!("Unable to unshare service instance from space #{space_guid}. Ensure the space exists and the service instance has been shared to this space.")
     end
 
     if bound_apps_in_target_space?(service_instance, target_space)
-      unprocessable!('Service instance still bound to apps in target space!')
+      unprocessable!("Unable to unshare service instance from space #{space_guid}. Ensure no bindings exist in the target space")
     end
 
     service_instance.remove_shared_space(target_space)

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -1,5 +1,4 @@
 require 'messages/to_many_relationship_message'
-require 'repositories/service_instance_share_event_repository'
 
 require 'presenters/v3/relationship_presenter'
 require 'presenters/v3/to_many_relationship_presenter'

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -49,7 +49,7 @@ class ServiceInstancesV3Controller < ApplicationController
     end
 
     unshare = ServiceInstanceUnshare.new
-    unshare.unshare(service_instance, target_space)
+    unshare.unshare(service_instance, target_space, user_audit_info)
 
     head :no_content
   end

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -44,12 +44,13 @@ module VCAP::CloudController
 
     def validate_space_match
       return unless service_instance && app
+      return if service_instance.space == app.space
 
       if FeatureFlag.enabled?(:service_instance_sharing)
         if service_instance.shared_spaces.exclude?(app.space)
           errors.add(:service_instance, :space_mismatch)
         end
-      elsif service_instance.space != app.space
+      else
         errors.add(:service_instance, :space_mismatch)
       end
     end

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -45,7 +45,11 @@ module VCAP::CloudController
     def validate_space_match
       return unless service_instance && app
 
-      unless service_instance.space == app.space
+      if FeatureFlag.enabled?(:service_instance_sharing)
+        if service_instance.shared_spaces.exclude?(app.space)
+          errors.add(:service_instance, :space_mismatch)
+        end
+      elsif service_instance.space != app.space
         errors.add(:service_instance, :space_mismatch)
       end
     end
@@ -69,7 +73,7 @@ module VCAP::CloudController
     end
 
     def space
-      service_instance.space
+      app.space
     end
 
     def after_initialize

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -46,11 +46,7 @@ module VCAP::CloudController
       return unless service_instance && app
       return if service_instance.space == app.space
 
-      if FeatureFlag.enabled?(:service_instance_sharing)
-        if service_instance.shared_spaces.exclude?(app.space)
-          errors.add(:service_instance, :space_mismatch)
-        end
-      else
+      if !FeatureFlag.enabled?(:service_instance_sharing) || service_instance.shared_spaces.exclude?(app.space)
         errors.add(:service_instance, :space_mismatch)
       end
     end

--- a/app/repositories/service_instance_share_event_repository.rb
+++ b/app/repositories/service_instance_share_event_repository.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   module Repositories
     class ServiceInstanceShareEventRepository
       class << self
-        def record_share_event(service_instance, user_audit_info, target_space_guids)
+        def record_share_event(service_instance, target_space_guids, user_audit_info)
           Event.create(
             type:              'audit.service_instance.share',
             actor:             user_audit_info.user_guid,

--- a/app/repositories/service_instance_share_event_repository.rb
+++ b/app/repositories/service_instance_share_event_repository.rb
@@ -20,6 +20,25 @@ module VCAP::CloudController
             organization_guid: service_instance.space.organization.guid,
           )
         end
+
+        def record_unshare_event(service_instance, target_space_guid, user_audit_info)
+          Event.create(
+            type:              'audit.service_instance.unshare',
+            actor:             user_audit_info.user_guid,
+            actor_type:        'user',
+            actor_name:        user_audit_info.user_email,
+            actor_username:    user_audit_info.user_name,
+            actee:             service_instance.guid,
+            actee_type:        'service_instance',
+            actee_name:        service_instance.name,
+            timestamp:         Sequel::CURRENT_TIMESTAMP,
+            metadata:          {
+              target_space_guid: target_space_guid
+            },
+            space_guid:        service_instance.space.guid,
+            organization_guid: service_instance.space.organization.guid,
+          )
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,4 +119,5 @@ Rails.application.routes.draw do
 
   # service_instances
   post '/service_instances/:service_instance_guid/relationships/shared_spaces', to: 'service_instances_v3#share_service_instance'
+  delete '/service_instances/:service_instance_guid/relationships/shared_spaces/:space_guid', to: 'service_instances_v3#unshare_service_instance'
 end

--- a/docs/v2/events/list_all_events.html
+++ b/docs/v2/events/list_all_events.html
@@ -390,6 +390,7 @@ Cookie: </pre>
                       <li>audit.app.task.cancel</li>
                       <li>audit.app.task.create</li>
                       <li>audit.service_instance.share</li>
+                      <li>audit.service_instance.unshare</li>
                   </ul>
                 </td>
                 <td>

--- a/docs/v2/events/list_events_associated_with_an_app_since_january_1,_2014.html
+++ b/docs/v2/events/list_events_associated_with_an_app_since_january_1,_2014.html
@@ -341,6 +341,7 @@ Cookie: </pre>
                       <li>audit.app.task.cancel</li>
                       <li>audit.app.task.create</li>
                       <li>audit.service_instance.share</li>
+                      <li>audit.service_instance.unshare</li>
                   </ul>
                 </td>
                 <td>

--- a/docs/v2/events/retrieve_a_particular_event.html
+++ b/docs/v2/events/retrieve_a_particular_event.html
@@ -208,6 +208,7 @@ Cookie: </pre>
                       <li>audit.app.task.cancel</li>
                       <li>audit.app.task.create</li>
                       <li>audit.service_instance.share</li>
+                      <li>audit.service_instance.unshare</li>
                   </ul>
                 </td>
                 <td>

--- a/docs/v3/source/includes/experimental_resources/service_instances/_unshare_from_space.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_unshare_from_space.md.erb
@@ -1,0 +1,30 @@
+### Unshare a service instance from another space
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/service_instances/[guid]/relationships/shared_spaces/[space_guid]" \
+  -X DELETE \
+  -H "Authorization: bearer [token]"
+```
+
+```
+Example Response
+```
+
+```http
+HTTP/1.1 204 No Content
+```
+
+This endpoint unshares the service instance with the specified space.
+
+#### Definition
+`DELETE /v3/service_instances/:guid/relationships/shared_spaces/:space_guid`
+
+#### Permitted Roles
+ |
+--- | ---
+Space Developer|
+Admin|

--- a/docs/v3/source/index.md
+++ b/docs/v3/source/index.md
@@ -136,5 +136,6 @@ includes:
   - experimental_resources/service_bindings/list
   - experimental_resources/service_instances/header
   - experimental_resources/service_instances/share_to_space
+  - experimental_resources/service_instances/unshare_from_space
 search: true
 ---

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -66,9 +66,7 @@ RSpec.describe 'Service Instances' do
 
     before do
       VCAP::CloudController::FeatureFlag.make(name: 'service_instance_sharing', enabled: true, error_message: nil)
-    end
 
-    it 'unshares the service instance from the target space' do
       share_request = {
         'data' => [
           { 'guid' => target_space.guid }
@@ -77,8 +75,10 @@ RSpec.describe 'Service Instances' do
 
       post "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces", share_request.to_json, user_header
       expect(last_response.status).to eq(200)
+    end
 
-      delete "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces/#{target_space.guid}", user_header
+    it 'unshares the service instance from the target space' do
+      delete "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces/#{target_space.guid}", nil, user_header
       expect(last_response.status).to eq(204)
     end
   end

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -54,4 +54,32 @@ RSpec.describe 'Service Instances' do
       expect(event.metadata['target_space_guids']).to eq([target_space.guid])
     end
   end
+
+  describe 'DELETE /v3/service_instances/:guid/relationships/shared_spaces/:space-guid' do
+    let(:user_email) { 'user@email.example.com' }
+    let(:user_name) { 'sharer_username' }
+    let(:user) { VCAP::CloudController::User.make }
+    let(:user_header) { admin_headers_for(user, email: user_email, user_name: user_name) }
+
+    let(:target_space) { VCAP::CloudController::Space.make }
+    let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make }
+
+    before do
+      VCAP::CloudController::FeatureFlag.make(name: 'service_instance_sharing', enabled: true, error_message: nil)
+    end
+
+    it 'unshares the service instance from the target space' do
+      share_request = {
+        'data' => [
+          { 'guid' => target_space.guid }
+        ]
+      }
+
+      post "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces", share_request.to_json, user_header
+      expect(last_response.status).to eq(200)
+
+      delete "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces/#{target_space.guid}", user_header
+      expect(last_response.status).to eq(204)
+    end
+  end
 end

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -6,13 +6,12 @@ module VCAP::CloudController
     let(:service_instance_share) { ServiceInstanceShare.new }
     let(:service_instance) { ManagedServiceInstance.make }
     let(:user_audit_info) { UserAuditInfo.new(user_guid: 'user-guid-1', user_email: 'user@email.com') }
-    let(:target_space_guids) { ['space-guid'] }
     let(:target_space1) { Space.make }
     let(:target_space2) { Space.make }
 
     describe '#create' do
       it 'creates share' do
-        shared_instance = service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info, target_space_guids)
+        shared_instance = service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
 
         expect(shared_instance.shared_spaces.length).to eq 2
 
@@ -26,9 +25,9 @@ module VCAP::CloudController
       it 'records a share event' do
         allow(Repositories::ServiceInstanceShareEventRepository).to receive(:record_share_event)
 
-        service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info, target_space_guids)
+        service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
         expect(Repositories::ServiceInstanceShareEventRepository).to have_received(:record_share_event).with(
-          service_instance, user_audit_info, target_space_guids)
+          service_instance, [target_space1.guid, target_space2.guid], user_audit_info)
       end
     end
   end

--- a/spec/unit/actions/service_instance_unshare_spec.rb
+++ b/spec/unit/actions/service_instance_unshare_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
-require 'actions/service_instance_share'
+require 'actions/service_instance_unshare'
 
 module VCAP::CloudController
   RSpec.describe ServiceInstanceUnshare do
     let(:service_instance_unshare) { ServiceInstanceUnshare.new }
     let(:service_instance) { ManagedServiceInstance.make }
+    let(:user_audit_info) { UserAuditInfo.new(user_guid: 'user-guid-1', user_email: 'user@email.com') }
     let(:target_space) { Space.make }
 
     before do
@@ -14,8 +15,16 @@ module VCAP::CloudController
 
     describe '#unshare' do
       it 'removes the share' do
-        service_instance_unshare.unshare(service_instance, target_space)
+        service_instance_unshare.unshare(service_instance, target_space, user_audit_info)
         expect(service_instance.shared_spaces).to be_empty
+      end
+
+      it 'records an unshare event' do
+        allow(Repositories::ServiceInstanceShareEventRepository).to receive(:record_unshare_event)
+
+        service_instance_unshare.unshare(service_instance, target_space, user_audit_info)
+        expect(Repositories::ServiceInstanceShareEventRepository).to have_received(:record_unshare_event).with(
+          service_instance, target_space.guid, user_audit_info)
       end
     end
   end

--- a/spec/unit/actions/service_instance_unshare_spec.rb
+++ b/spec/unit/actions/service_instance_unshare_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'actions/service_instance_share'
+
+module VCAP::CloudController
+  RSpec.describe ServiceInstanceUnshare do
+    let(:service_instance_unshare) { ServiceInstanceUnshare.new }
+    let(:service_instance) { ManagedServiceInstance.make }
+    let(:target_space) { Space.make }
+
+    before do
+      service_instance.add_shared_space(target_space)
+      expect(service_instance.shared_spaces).not_to be_empty
+    end
+
+    describe '#unshare' do
+      it 'removes the share' do
+        service_instance_unshare.unshare(service_instance, target_space)
+        expect(service_instance.shared_spaces).to be_empty
+      end
+    end
+  end
+end

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -236,8 +236,11 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
 
     context 'target space does not exist' do
       it 'returns 422' do
-        delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: 'foo'
+        delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: 'non-existent-target-space-guid'
         expect(response.status).to eq(422)
+        error_message = 'Unable to unshare service instance from space non-existent-target-space-guid. '\
+          'Ensure the space exists and the service instance has been shared to this space.'
+        expect(response.body).to include(error_message)
       end
     end
 
@@ -252,6 +255,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
       it 'returns 422' do
         delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
         expect(response.status).to eq(422)
+        expect(response.body).to include("Unable to unshare service instance from space #{target_space.guid}. Ensure no bindings exist in the target space")
       end
     end
 
@@ -288,6 +292,9 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
       it 'returns 422' do
         delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space2.guid
         expect(response.status).to eq(422)
+        error_message = "Unable to unshare service instance from space #{target_space2.guid}. "\
+          'Ensure the space exists and the service instance has been shared to this space.'
+        expect(response.body).to include(error_message)
       end
     end
 

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -200,6 +200,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
     let(:service_instance) { VCAP::CloudController::ServiceInstance.make }
     let(:target_space) { VCAP::CloudController::Space.make }
     let(:source_space) { service_instance.space }
+    let(:service_instance_sharing_enabled) { true }
 
     let(:req_body) do
       {
@@ -210,80 +211,113 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
     end
 
     before do
+      feature_flag = VCAP::CloudController::FeatureFlag.make(name: 'service_instance_sharing', enabled: true, error_message: nil)
       set_current_user_as_admin
+
+      post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
+      expect(response.status).to eq 200
+
+      feature_flag.enabled = service_instance_sharing_enabled
+      feature_flag.save
     end
 
-    context 'when feature flag is enabled' do
+    it 'unshares the service instance from the target space' do
+      delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
+      expect(response.status).to eq 204
+      expect(service_instance.shared_spaces).to be_empty
+    end
+
+    context 'service instance does not exist' do
+      it 'returns with 404' do
+        delete :unshare_service_instance, service_instance_guid: 'not a service instance guid', space_guid: target_space.guid
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'target space does not exist' do
+      it 'returns 422' do
+        delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: 'foo'
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context 'an application in the target space is bound to the service instance' do
       before do
-        VCAP::CloudController::FeatureFlag.make(name: 'service_instance_sharing', enabled: true, error_message: nil)
-        post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
+        test_app = VCAP::CloudController::AppModel.make(space: target_space, name: 'manatea')
+        VCAP::CloudController::ServiceBinding.make(service_instance: service_instance,
+                                                   app: test_app,
+                                                   credentials: { 'amelia' => 'apples' })
+      end
+
+      it 'returns 422' do
+        delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
+        expect(response.status).to eq(422)
+      end
+    end
+
+    describe 'permissions by role' do
+      role_to_expected_http_response = {
+        'admin'               => 204,
+        'space_developer'     => 204,
+        'admin_read_only'     => 403,
+        'global_auditor'      => 403,
+        'space_manager'       => 403,
+        'space_auditor'       => 403,
+        'org_manager'         => 403,
+        'org_auditor'         => 404,
+        'org_billing_manager' => 404,
+      }.freeze
+
+      role_to_expected_http_response.each do |role, expected_return_value|
+        context "when the user is a #{role} in the source space" do
+          it "returns #{expected_return_value}" do
+            set_current_user_as_role(role: role, org: source_space.organization, space: source_space, user: user)
+
+            delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
+
+            expect(response.status).to eq(expected_return_value),
+              "Expected #{expected_return_value}, but got #{response.status}. Response: #{response.body}"
+          end
+        end
+      end
+    end
+
+    context 'when trying to unshare a service instance that has not been shared' do
+      let(:target_space2) { VCAP::CloudController::Space.make }
+
+      it 'returns 422' do
+        delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space2.guid
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context 'when there are multiple shares' do
+      let(:target_space2) { VCAP::CloudController::Space.make }
+
+      let(:req_body2) do
+        {
+          data: [
+            { guid: target_space2.guid }
+          ]
+        }
+      end
+
+      before do
+        post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body2
         expect(response.status).to eq 200
       end
 
-      it 'unshares the service instance from the target space' do
+      it 'only deletes the requested share' do
         delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
-        expect(response.status).to eq 204
-      end
-
-      context 'unsharing will fail if' do
-        it 'service instance does not exist' do
-          delete :unshare_service_instance, service_instance_guid: 'not a service instance guid', space_guid: target_space.guid
-          expect(response.status).to eq(404)
-        end
-
-        it 'service instance is in source space that user cannot read' do
-          # User is SpaceDeveloper but not in source space
-          set_current_user_as_role(role: 'space_developer', org: target_space.organization, space: target_space, user: user)
-
-          delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
-          expect(response.status).to eq(404)
-        end
-
-        it 'service instance is in source space that user cannot write' do
-          # User is SpaceAuditor in source space
-          set_current_user_as_role(role: 'space_auditor', org: source_space.organization, space: source_space, user: user)
-
-          delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
-          expect(response.status).to eq(403)
-        end
-
-        it 'target space does not exist' do
-          delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: 'foo'
-          expect(response.status).to eq(422)
-        end
-
-        it 'user is a SpaceDeveloper in source space but has no role in target space' do
-          set_current_user_as_role(role: 'space_developer', org: source_space.organization, space: source_space, user: user)
-
-          delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
-          expect(response.status).to eq(422)
-        end
-
-        it 'user is a SpaceDeveloper in source space but only SpaceAuditor in target space' do
-          set_current_user_as_role(role: 'space_developer', org: source_space.organization, space: source_space, user: user)
-          set_current_user_as_role(role: 'space_auditor', org: target_space.organization, space: target_space, user: user)
-
-          delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
-          expect(response.status).to eq(403)
-        end
-
-        it 'an application in the target space is bound to the service instance' do
-          test_app = VCAP::CloudController::AppModel.make(space: target_space, name: 'manatea')
-          VCAP::CloudController::ServiceBinding.make(service_instance: service_instance,
-                                                     app: test_app,
-                                                     credentials: { 'amelia' => 'apples' }
-          )
-
-          delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
-          expect(response.status).to eq(422)
-        end
+        expect(response.status).to eq(204)
+        expect(service_instance.shared_spaces).to contain_exactly(target_space2)
       end
     end
 
-    context 'when feature flag is disabled (by default)' do
-      it 'cannot unshare if the feature flag is disabled' do
-        VCAP::CloudController::FeatureFlag.make(name: 'service_instance_sharing', enabled: false, error_message: nil)
+    context 'when feature flag is disabled' do
+      let(:service_instance_sharing_enabled) { false }
 
+      it 'returns 403' do
         delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
         expect(response.status).to eq(403)
         expect(response.body).to include('FeatureDisabled')

--- a/spec/unit/models/services/service_binding_spec.rb
+++ b/spec/unit/models/services/service_binding_spec.rb
@@ -97,7 +97,7 @@ module VCAP::CloudController
                 service_instance.add_shared_space(app.space)
               end
 
-              it 'it is valid' do
+              it 'is valid' do
                 expect(ServiceBinding.make(service_instance: service_instance, app: app)).to be_valid
               end
             end
@@ -118,13 +118,14 @@ module VCAP::CloudController
             before do
               VCAP::CloudController::FeatureFlag.create(name: :service_instance_sharing, enabled: true)
             end
-            it 'it is valid' do
+
+            it 'is valid' do
               expect(ServiceBinding.make(service_instance: service_instance, app: app)).to be_valid
             end
           end
 
           context 'when the service_instance_sharing feature flag is not enabled' do
-            it 'it is valid' do
+            it 'is valid' do
               expect(ServiceBinding.make(service_instance: service_instance, app: app)).to be_valid
             end
           end

--- a/spec/unit/models/services/service_binding_spec.rb
+++ b/spec/unit/models/services/service_binding_spec.rb
@@ -83,6 +83,29 @@ module VCAP::CloudController
           expect { ServiceBinding.make(service_instance: service_instance, app: app)
           }.to raise_error(Sequel::ValidationFailed, /service_instance space_mismatch/)
         end
+
+        context 'when the service_instance_sharing feature flag is enabled' do
+          before do
+            VCAP::CloudController::FeatureFlag.create(name: :service_instance_sharing, enabled: true)
+          end
+
+          context 'when the service instance has not been shared into the app space' do
+            it 'is not valid' do
+              expect { ServiceBinding.make(service_instance: service_instance, app: app)
+              }.to raise_error(Sequel::ValidationFailed, /service_instance space_mismatch/)
+            end
+          end
+
+          context 'when the service instance has been shared into the app space' do
+            before do
+              service_instance.add_shared_space(app.space)
+            end
+
+            it 'it is valid' do
+              expect(ServiceBinding.make(service_instance: service_instance, app: app)).to be_valid
+            end
+          end
+        end
       end
     end
 

--- a/spec/unit/repositories/service_instance_share_event_repository_spec.rb
+++ b/spec/unit/repositories/service_instance_share_event_repository_spec.rb
@@ -28,6 +28,24 @@ module VCAP
             expect(event.organization_guid).to eq(service_instance.space.organization.guid)
           end
         end
+
+        describe '#record_unshare_event' do
+          it 'records the event correctly' do
+            event = ServiceInstanceShareEventRepository.record_unshare_event(service_instance, target_space_guids[0], user_audit_info)
+
+            expect(event.type).to eq('audit.service_instance.unshare')
+            expect(event.actor).to eq(user_guid)
+            expect(event.actor_type).to eq('user')
+            expect(event.actor_name).to eq(user_email)
+            expect(event.actor_username).to eq(user_name)
+            expect(event.actee).to eq(service_instance.guid)
+            expect(event.actee_type).to eq('service_instance')
+            expect(event.actee_name).to eq(service_instance.name)
+            expect(event.metadata[:target_space_guid]).to eq('space-guid')
+            expect(event.space_guid).to eq(service_instance.space.guid)
+            expect(event.organization_guid).to eq(service_instance.space.organization.guid)
+          end
+        end
       end
     end
   end

--- a/spec/unit/repositories/service_instance_share_event_repository_spec.rb
+++ b/spec/unit/repositories/service_instance_share_event_repository_spec.rb
@@ -11,9 +11,9 @@ module VCAP
         let(:user_audit_info) { UserAuditInfo.new(user_guid: user_guid, user_name: user_name, user_email: user_email) }
         let(:target_space_guids) { ['space-guid', 'another-guid'] }
 
-        describe '#record_share_create' do
+        describe '#record_share_event' do
           it 'records the event correctly' do
-            event = ServiceInstanceShareEventRepository.record_share_event(service_instance, user_audit_info, target_space_guids)
+            event = ServiceInstanceShareEventRepository.record_share_event(service_instance, target_space_guids, user_audit_info)
 
             expect(event.type).to eq('audit.service_instance.share')
             expect(event.actor).to eq(user_guid)


### PR DESCRIPTION
This PR adds an `audit.service_instance.unshare` event when a service instance is unshared . [#150801613](https://www.pivotaltracker.com/story/show/150801613)

**NOTE**: This PR builds on top of #948, which should be merged first. The actual changes on top of #948 can be viewed in [this DIFF](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-service-instance-sharing-unshare...cloudfoundry-incubator:pr-service-instance-sharing-unshare-event).

## What

This PR adds an event of type `audit.service_instance.unshare` when a shared service instance is unshared.

Changes:
* Unshare service instance implementation moved from the controller into its own action.
* Event creation function added and called by the new action.

Notes:
* We intentionally did not add the new event type to each individual event doc listing, since we think PR #938 is a better approach going forward (i.e., not maintaining a list of event types on every individual event doc page).

Feedback and comments appreciated!

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@jenspinney and @ablease)