### PR TITLE
Remove unused exceptions from ServiceBindingDelete

### DIFF
--- a/app/actions/service_binding_delete.rb
+++ b/app/actions/service_binding_delete.rb
@@ -2,9 +2,6 @@ require 'actions/services/locks/lock_check'
 
 module VCAP::CloudController
   class ServiceBindingDelete
-    class FailedToDelete < StandardError; end
-    class OperationInProgress < FailedToDelete; end
-
     include VCAP::CloudController::LockCheck
 
     def initialize(user_audit_info)

--- a/app/controllers/v3/service_bindings_controller.rb
+++ b/app/controllers/v3/service_bindings_controller.rb
@@ -64,8 +64,6 @@ class ServiceBindingsController < ApplicationController
     ServiceBindingDelete.new(user_audit_info).single_delete_sync(binding)
 
     head :no_content
-  rescue ServiceBindingDelete::FailedToDelete => e
-    unprocessable!(e.message)
   end
 
   private


### PR DESCRIPTION
These exceptions are no longer raised. Unless there is some ruby/cc magic here we are not getting.

[This](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/commit/36cd615f8a717105d3faeca57933e0fc258074be) commit introduced OperationInProgress and removed the raising of FailedToDelete. This was subsequently refactored to use a general [lock check](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/blob/cbe87ee1c0c5f0926a717bcd1f11be81d5b7e879/app/actions/services/locks/lock_check.rb).

This is not high priority.

Thanks,
Sam

* [ x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x ] I have viewed, signed, and submitted the Contributor License Agreement

* [x ] I have made this pull request to the `master` branch

* [x ] I have run all the unit tests using `bundle exec rake`

* [x ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
