### PR TITLE
Add service sharing to/from information in space summary

### DIFF
--- a/app/controllers/runtime/space_summaries_controller.rb
+++ b/app/controllers/runtime/space_summaries_controller.rb
@@ -51,7 +51,7 @@ module VCAP::CloudController
 
     def services_summary(space)
       shared_summary = space.service_instances_shared_from_other_spaces.map { |s| shared_service_instance_summary(s) }
-      source_summary = space.service_instances.map(&:as_summary_json)
+      source_summary = space.service_instances.map { |s| source_service_instance_summary(s) }
 
       shared_summary + source_summary
     end
@@ -62,6 +62,20 @@ module VCAP::CloudController
         'space_name' => service_instance.space.name,
         'organization_name' => service_instance.space.organization.name,
       })
+    end
+
+    def source_service_instance_summary(service_instance)
+      service_instance.as_summary_json.merge('shared_to' => shared_to_summary(service_instance))
+    end
+
+    def shared_to_summary(service_instance)
+      service_instance.shared_spaces.map do |s|
+        {
+          'space_guid' => s.guid,
+          'space_name' => s.name,
+          'organization_name' => s.organization.name
+        }
+      end
     end
   end
 end

--- a/app/controllers/runtime/space_summaries_controller.rb
+++ b/app/controllers/runtime/space_summaries_controller.rb
@@ -50,7 +50,18 @@ module VCAP::CloudController
     end
 
     def services_summary(space)
-      (space.service_instances + space.service_instances_shared_from_other_spaces).map(&:as_summary_json)
+      shared_summary = space.service_instances_shared_from_other_spaces.map { |s| shared_service_instance_summary(s) }
+      source_summary = space.service_instances.map(&:as_summary_json)
+
+      shared_summary + source_summary
+    end
+
+    def shared_service_instance_summary(service_instance)
+      service_instance.as_summary_json.merge('shared_from' => {
+        'space_guid' => service_instance.space.guid,
+        'space_name' => service_instance.space.name,
+        'organization_name' => service_instance.space.organization.name,
+      })
     end
   end
 end

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -54,6 +54,7 @@ module VCAP::CloudController
       super.merge(
         'last_operation' => last_operation.try(:to_hash),
         'dashboard_url' => dashboard_url,
+        'shared_from' => nil,
         'service_plan' => {
           'guid' => service_plan.guid,
           'name' => service_plan.name,

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -55,6 +55,7 @@ module VCAP::CloudController
         'last_operation' => last_operation.try(:to_hash),
         'dashboard_url' => dashboard_url,
         'shared_from' => nil,
+        'shared_to' => [],
         'service_plan' => {
           'guid' => service_plan.guid,
           'name' => service_plan.name,

--- a/docs/v2/spaces/get_space_summary.html
+++ b/docs/v2/spaces/get_space_summary.html
@@ -250,6 +250,11 @@ Cookie: </pre>
       "guid": "5cf08d8b-848c-4f27-bd92-8080fa021783",
       "name": "name-1385",
       "bound_app_count": 1,
+      "shared_from": {
+        "space_guid": "c4861ea6-fc27-4a20-ad21-461743ce8921",
+        "space_name": "source-space",
+        "organization_name": "source-org"
+      },
       "last_operation": {
         "type": "create",
         "state": "succeeded",

--- a/spec/unit/controllers/runtime/space_summaries_controller_spec.rb
+++ b/spec/unit/controllers/runtime/space_summaries_controller_spec.rb
@@ -69,19 +69,7 @@ module VCAP::CloudController
 
         get "/v2/spaces/#{space.guid}/summary"
 
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response['services'].map { |service_json| service_json['guid'] }).to include(service_instance.guid)
-      end
-
-      it 'returns service summary for the space, including shared service instances' do
-        originating_space = Space.make
-        service_instance = ManagedServiceInstance.make(space: originating_space)
-        service_instance.add_shared_space(space)
-
-        get "/v2/spaces/#{space.guid}/summary"
-
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response['services'].map { |service_json| service_json['guid'] }).to include(service_instance.guid)
+        expect(decoded_response['services'].map { |service_json| service_json['guid'] }).to include(service_instance.guid)
       end
 
       it 'does not return private services from other spaces' do
@@ -95,6 +83,40 @@ module VCAP::CloudController
 
         parsed_response = MultiJson.load(last_response.body)
         expect(parsed_response['services'].map { |service_json| service_json['guid'] }).to_not include service_instance2.guid
+      end
+
+      it 'does not include sharing information for not-shared service instances' do
+        space = Space.make
+        ManagedServiceInstance.make(space: space)
+
+        get "/v2/spaces/#{space.guid}/summary"
+
+        expect(decoded_response['services'].first['shared_from']).to be_nil
+      end
+
+      context 'when a managed service has been shared into this space' do
+        let(:originating_space) { Space.make }
+        let(:service_instance) { ManagedServiceInstance.make(space: originating_space) }
+        let(:services_response) { decoded_response['services'] }
+
+        before do
+          service_instance.add_shared_space(space)
+
+          get "/v2/spaces/#{space.guid}/summary"
+        end
+
+        it 'includes the shared service instance' do
+          expect(services_response.map { |service_json| service_json['guid'] }).to include(service_instance.guid)
+        end
+
+        it 'includes sharing information' do
+          expect(services_response.first).to have_key('shared_from')
+          expect(services_response.first['shared_from']).to eq({
+            'space_guid' => originating_space.guid,
+            'space_name' => originating_space.name,
+            'organization_name' => originating_space.organization.name
+          })
+        end
       end
 
       context 'when an app is deleted concurrently' do

--- a/spec/unit/models/runtime/space_spec.rb
+++ b/spec/unit/models/runtime/space_spec.rb
@@ -66,6 +66,7 @@ module VCAP::CloudController
       it { is_expected.to have_associated :default_users, class: User }
       it { is_expected.to have_associated :domains, class: SharedDomain }
       it { is_expected.to have_associated :space_quota_definition, associated_instance: ->(space) { SpaceQuotaDefinition.make(organization: space.organization) } }
+      it { is_expected.to have_associated :service_instances_shared_from_other_spaces, associated_instance: ->(space) { ManagedServiceInstance.make(space: Space.make) } }
 
       describe 'space_quota_definition' do
         subject(:space) { Space.make }
@@ -78,6 +79,23 @@ module VCAP::CloudController
 
         it 'allows nil' do
           expect { space.space_quota_definition = nil }.not_to raise_error
+        end
+      end
+
+      describe 'service_instances_shared_from_other_spaces' do
+        subject(:space) { Space.make }
+
+        it 'is empty by default' do
+          expect(space.service_instances_shared_from_other_spaces).to be_empty
+        end
+
+        it 'includes the services shared from other spaces' do
+          foreign_space = Space.make
+          foreign_service = ManagedServiceInstance.make(space: foreign_space)
+
+          space.add_service_instances_shared_from_other_space(foreign_service)
+
+          expect(space.service_instances_shared_from_other_spaces).to contain_exactly(foreign_service)
         end
       end
 


### PR DESCRIPTION
As an app dev (sharer), I can see shared service instances in the space summary. [#151988848](https://www.pivotaltracker.com/story/show/151988848)

As an app dev (receiver), I can see shared service instances in the space summary. [#151988915](https://www.pivotaltracker.com/story/show/151988915)

## What

This PR adds two fields to the space summary, `shared_to` and `shared_from`. The `shared_from` field provides information on where the service instance was created (if not in the space being summarized), and the `shared_to` field provides information on which spaces the service instance has been shared to if the service instance was created in this space. 

If the service instance originated from the space being summarized, `shared_from` will be null. Similarly, if the service instance has not been shared into any other spaces, `shared_to` will be an empty array.

Changes:
* Added `shared_to` and `shared_from` fields in the service instance list inside the `/v2/space/:guid/summary` endpoint response.

Feedback and comments appreciated!

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@deniseyu and @jenspinney )