### PR TITLE
Allow unsharing service instance despite bindings in target space

### DIFF
--- a/app/actions/service_instance_unshare.rb
+++ b/app/actions/service_instance_unshare.rb
@@ -1,10 +1,22 @@
 module VCAP::CloudController
   class ServiceInstanceUnshare
     def unshare(service_instance, target_space, user_audit_info)
+      errors = delete_bindings_in_target_space!(service_instance, target_space, user_audit_info)
+      raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceUnshareFailed', errors) if errors.any?
+
       service_instance.remove_shared_space(target_space)
 
       Repositories::ServiceInstanceShareEventRepository.record_unshare_event(
         service_instance, target_space.guid, user_audit_info)
+    end
+
+    private
+
+    def delete_bindings_in_target_space!(service_instance, target_space, user_audit_info)
+      active_bindings = ServiceBinding.where(service_instance_guid: service_instance.guid)
+      bindings_in_target_space = active_bindings.all.select { |b| b.app.space_guid == target_space.guid }
+
+      ServiceBindingDelete.new(user_audit_info).delete(bindings_in_target_space)
     end
   end
 end

--- a/app/controllers/runtime/space_summaries_controller.rb
+++ b/app/controllers/runtime/space_summaries_controller.rb
@@ -51,7 +51,7 @@ module VCAP::CloudController
 
     def services_summary(space)
       shared_summary = space.service_instances_shared_from_other_spaces.map { |s| shared_service_instance_summary(s) }
-      source_summary = space.service_instances.map(&:as_summary_json)
+      source_summary = space.service_instances.map { |s| source_service_instance_summary(s) }
 
       shared_summary + source_summary
     end
@@ -62,6 +62,20 @@ module VCAP::CloudController
         'space_name' => service_instance.space.name,
         'organization_name' => service_instance.space.organization.name,
       })
+    end
+
+    def source_service_instance_summary(service_instance)
+      service_instance.as_summary_json.merge('shared_to' => shared_to_summary(service_instance))
+    end
+
+    def shared_to_summary(service_instance)
+      service_instance.shared_spaces.map do |s|
+        {
+          'space_guid' => s.guid,
+          'space_name' => s.name,
+          'organization_name' => s.organization.name
+        }
+      end
     end
   end
 end

--- a/app/controllers/runtime/space_summaries_controller.rb
+++ b/app/controllers/runtime/space_summaries_controller.rb
@@ -50,7 +50,18 @@ module VCAP::CloudController
     end
 
     def services_summary(space)
-      (space.service_instances + space.service_instances_shared_from_other_spaces).map(&:as_summary_json)
+      shared_summary = space.service_instances_shared_from_other_spaces.map { |s| shared_service_instance_summary(s) }
+      source_summary = space.service_instances.map(&:as_summary_json)
+
+      shared_summary + source_summary
+    end
+
+    def shared_service_instance_summary(service_instance)
+      service_instance.as_summary_json.merge('shared_from' => {
+        'space_guid' => service_instance.space.guid,
+        'space_name' => service_instance.space.name,
+        'organization_name' => service_instance.space.organization.name,
+      })
     end
   end
 end

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -43,8 +43,6 @@ class ServiceInstancesV3Controller < ApplicationController
       unprocessable!("Unable to unshare service instance from space #{space_guid}. Ensure the space exists and the service instance has been shared to this space.")
     end
 
-    delete_bindings_in_target_space!(service_instance, target_space)
-
     unshare = ServiceInstanceUnshare.new
     unshare.unshare(service_instance, target_space, user_audit_info)
 
@@ -52,15 +50,6 @@ class ServiceInstancesV3Controller < ApplicationController
   end
 
   private
-
-  def delete_bindings_in_target_space!(service_instance, target_space)
-    active_bindings = ServiceBinding.where(service_instance_guid: service_instance.guid)
-    bindings_in_target_space = active_bindings.all.select { |b| b.app.space_guid == target_space.guid }
-
-    bindings_in_target_space.each do |binding|
-      ServiceBindingDelete.new(user_audit_info).single_delete_sync(binding)
-    end
-  end
 
   def check_spaces_are_writeable!(spaces)
     unwriteable_spaces = spaces.reject do |space|

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -54,6 +54,7 @@ module VCAP::CloudController
       super.merge(
         'last_operation' => last_operation.try(:to_hash),
         'dashboard_url' => dashboard_url,
+        'shared_from' => nil,
         'service_plan' => {
           'guid' => service_plan.guid,
           'name' => service_plan.name,

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -55,6 +55,7 @@ module VCAP::CloudController
         'last_operation' => last_operation.try(:to_hash),
         'dashboard_url' => dashboard_url,
         'shared_from' => nil,
+        'shared_to' => [],
         'service_plan' => {
           'guid' => service_plan.guid,
           'name' => service_plan.name,

--- a/docs/v2/spaces/get_space_summary.html
+++ b/docs/v2/spaces/get_space_summary.html
@@ -250,6 +250,11 @@ Cookie: </pre>
       "guid": "5cf08d8b-848c-4f27-bd92-8080fa021783",
       "name": "name-1385",
       "bound_app_count": 1,
+      "shared_from": {
+        "space_guid": "c4861ea6-fc27-4a20-ad21-461743ce8921",
+        "space_name": "source-space",
+        "organization_name": "source-org"
+      },
       "last_operation": {
         "type": "create",
         "state": "succeeded",

--- a/docs/v3/source/includes/experimental_resources/service_instances/_unshare_from_space.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_unshare_from_space.md.erb
@@ -18,7 +18,7 @@ Example Response
 HTTP/1.1 204 No Content
 ```
 
-This endpoint unshares the service instance with the specified space.
+This endpoint unshares the service instance with the specified space. This will automatically unbind any applications bound to this service instance in the specified space.
 
 #### Definition
 `DELETE /v3/service_instances/:guid/relationships/shared_spaces/:space_guid`

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -80,6 +80,21 @@ RSpec.describe 'Service Instances' do
     it 'unshares the service instance from the target space' do
       delete "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces/#{target_space.guid}", nil, user_header
       expect(last_response.status).to eq(204)
+
+      event = VCAP::CloudController::Event.last
+      expect(event.values).to include({
+        type:              'audit.service_instance.unshare',
+        actor:             user.guid,
+        actor_type:        'user',
+        actor_name:        user_email,
+        actor_username:    user_name,
+        actee:             service_instance.guid,
+        actee_type:        'service_instance',
+        actee_name:        service_instance.name,
+        space_guid:        service_instance.space.guid,
+        organization_guid: service_instance.space.organization.guid
+      })
+      expect(event.metadata['target_space_guid']).to eq(target_space.guid)
     end
   end
 end

--- a/spec/unit/controllers/runtime/space_summaries_controller_spec.rb
+++ b/spec/unit/controllers/runtime/space_summaries_controller_spec.rb
@@ -69,19 +69,7 @@ module VCAP::CloudController
 
         get "/v2/spaces/#{space.guid}/summary"
 
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response['services'].map { |service_json| service_json['guid'] }).to include(service_instance.guid)
-      end
-
-      it 'returns service summary for the space, including shared service instances' do
-        originating_space = Space.make
-        service_instance = ManagedServiceInstance.make(space: originating_space)
-        service_instance.add_shared_space(space)
-
-        get "/v2/spaces/#{space.guid}/summary"
-
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response['services'].map { |service_json| service_json['guid'] }).to include(service_instance.guid)
+        expect(decoded_response['services'].map { |service_json| service_json['guid'] }).to include(service_instance.guid)
       end
 
       it 'does not return private services from other spaces' do
@@ -95,6 +83,40 @@ module VCAP::CloudController
 
         parsed_response = MultiJson.load(last_response.body)
         expect(parsed_response['services'].map { |service_json| service_json['guid'] }).to_not include service_instance2.guid
+      end
+
+      it 'does not include sharing information for not-shared service instances' do
+        space = Space.make
+        ManagedServiceInstance.make(space: space)
+
+        get "/v2/spaces/#{space.guid}/summary"
+
+        expect(decoded_response['services'].first['shared_from']).to be_nil
+      end
+
+      context 'when a managed service has been shared into this space' do
+        let(:originating_space) { Space.make }
+        let(:service_instance) { ManagedServiceInstance.make(space: originating_space) }
+        let(:services_response) { decoded_response['services'] }
+
+        before do
+          service_instance.add_shared_space(space)
+
+          get "/v2/spaces/#{space.guid}/summary"
+        end
+
+        it 'includes the shared service instance' do
+          expect(services_response.map { |service_json| service_json['guid'] }).to include(service_instance.guid)
+        end
+
+        it 'includes sharing information' do
+          expect(services_response.first).to have_key('shared_from')
+          expect(services_response.first['shared_from']).to eq({
+            'space_guid' => originating_space.guid,
+            'space_name' => originating_space.name,
+            'organization_name' => originating_space.organization.name
+          })
+        end
       end
 
       context 'when an app is deleted concurrently' do

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -245,17 +245,18 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
     end
 
     context 'an application in the target space is bound to the service instance' do
+      let(:test_app) { VCAP::CloudController::AppModel.make(space: target_space, name: 'manatea') }
+
       before do
-        test_app = VCAP::CloudController::AppModel.make(space: target_space, name: 'manatea')
         VCAP::CloudController::ServiceBinding.make(service_instance: service_instance,
                                                    app: test_app,
                                                    credentials: { 'amelia' => 'apples' })
       end
 
-      it 'returns 422' do
+      it 'returns 204 and unbinds the app in the target space' do
         delete :unshare_service_instance, service_instance_guid: service_instance.guid, space_guid: target_space.guid
-        expect(response.status).to eq(422)
-        expect(response.body).to include("Unable to unshare service instance from space #{target_space.guid}. Ensure no bindings exist in the target space")
+        expect(response.status).to eq(204)
+        expect(test_app.service_bindings).to be_empty
       end
     end
 

--- a/spec/unit/models/runtime/space_spec.rb
+++ b/spec/unit/models/runtime/space_spec.rb
@@ -66,6 +66,7 @@ module VCAP::CloudController
       it { is_expected.to have_associated :default_users, class: User }
       it { is_expected.to have_associated :domains, class: SharedDomain }
       it { is_expected.to have_associated :space_quota_definition, associated_instance: ->(space) { SpaceQuotaDefinition.make(organization: space.organization) } }
+      it { is_expected.to have_associated :service_instances_shared_from_other_spaces, associated_instance: ->(space) { ManagedServiceInstance.make(space: Space.make) } }
 
       describe 'space_quota_definition' do
         subject(:space) { Space.make }
@@ -78,6 +79,23 @@ module VCAP::CloudController
 
         it 'allows nil' do
           expect { space.space_quota_definition = nil }.not_to raise_error
+        end
+      end
+
+      describe 'service_instances_shared_from_other_spaces' do
+        subject(:space) { Space.make }
+
+        it 'is empty by default' do
+          expect(space.service_instances_shared_from_other_spaces).to be_empty
+        end
+
+        it 'includes the services shared from other spaces' do
+          foreign_space = Space.make
+          foreign_service = ManagedServiceInstance.make(space: foreign_space)
+
+          space.add_service_instances_shared_from_other_space(foreign_service)
+
+          expect(space.service_instances_shared_from_other_spaces).to contain_exactly(foreign_service)
         end
       end
 

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1093,3 +1093,8 @@
   name: DropletUploadInvalid
   http_code: 400
   message: "The droplet upload is invalid: %s"
+
+390001:
+  name: ServiceInstanceUnshareFailed
+  http_code: 502
+  message: "Unshare of service instance failed because one or more bindings could not be deleted.\n\n%s"


### PR DESCRIPTION
As an app dev (sharer), I can unshare a service instance that I have shared which has bindings in another space. [#150801615](https://www.pivotaltracker.com/story/show/150801615)

**NOTE**: This PR builds on top of #957, which should be merged first. The actual changes on top of #957 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-service-instance-sharing-unshare-audit-test...cloudfoundry-incubator:pr-service-instance-sharing-unshare-despite-bindings).

## What

This PR enables app devs who have shared a service instance into a target space to unshare that instance, even if an app dev in the target space has bound an app to it. We expect the CLI to prompt a user before allow this operation, but at the API level it should be possible.

Changes:
* Remove previous validation preventing app devs (sharers) from unsharing bound services
* Delete bindings in target space when service is unshared
* Add error code for when unsharing fails
* Updated docs to reflect new behaviour

Feedback and comments appreciated!

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@jenspinney and @deniseyu)