### PR TITLE
Bump bits_service_client version to 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     backports (3.6.8)
     beefcake (1.0.0)
     bit-struct (0.16)
-    bits_service_client (0.2.1)
+    bits_service_client (0.3.0)
       activesupport
       steno
     builder (3.2.3)

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -49,7 +49,7 @@ templates:
   db_ca.crt.erb: config/certs/db_ca.crt
   credhub_ca.crt.erb: config/certs/credhub_ca.crt
   perm_ca.crt.erb: config/certs/perm_ca.crt
-
+  bits_service_ca.crt.erb: config/certs/bits_service_ca.crt
 
 packages:
   - capi_utils
@@ -746,6 +746,9 @@ properties:
     default: ""
   cc.bits_service.password:
     description: "Password for the bits-service"
+    default: ""
+  cc.bits_service.ca_cert:
+    description: "The ca cert to use when communicating with bits-service endpoints"
     default: ""
 
   cc.rate_limiter.enabled:

--- a/bosh/jobs/cloud_controller_ng/templates/bits_service_ca.crt.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/bits_service_ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p('cc.bits_service.ca_cert') %>

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -338,6 +338,9 @@ bits_service:
   private_endpoint: <%= p("cc.bits_service.private_endpoint") %>
   username: <%= p("cc.bits_service.username") %>
   password: <%= p("cc.bits_service.password") %>
+  <% if p("cc.bits_service.ca_cert") != "" && p("cc.bits_service.ca_cert") != nil %>
+  ca_cert_path: /var/vcap/jobs/cloud_controller_ng/config/certs/bits_service_ca.crt
+  <% end %>
 
 rate_limiter:
   enabled: <%= p("cc.rate_limiter.enabled") %>

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -30,7 +30,8 @@ templates:
   mutual_tls.key.erb: config/certs/mutual_tls.key
   uaa_ca.crt.erb: config/certs/uaa_ca.crt
   db_ca.crt.erb: config/certs/db_ca.crt
-
+  bits_service_ca.crt.erb: config/certs/bits_service_ca.crt
+  
 packages:
   - capi_utils
   - cloud_controller_ng
@@ -439,6 +440,9 @@ properties:
     default: ""
   cc.bits_service.password:
     description: "Password for the bits-service"
+    default: ""
+  cc.bits_service.ca_cert:
+    description: "The ca cert to use when communicating with bits-service endpoints"
     default: ""
 
   cc.diego.bbs.url:

--- a/bosh/jobs/cloud_controller_worker/templates/bits_service_ca.crt.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/bits_service_ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p('cc.bits_service.ca_cert') %>

--- a/bosh/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -1,6 +1,6 @@
 <%
   require 'uri'
-  
+
   def discover_external_ip
     networks = spec.networks.marshal_dump
     network = networks.values.detect(&:default) || networks.values.first
@@ -206,6 +206,9 @@ bits_service:
   private_endpoint: <%= p("cc.bits_service.private_endpoint") %>
   username: <%= p("cc.bits_service.username") %>
   password: <%= p("cc.bits_service.password") %>
+  <% if p("cc.bits_service.ca_cert") != "" && p("cc.bits_service.ca_cert") != nil %>
+  ca_cert_path: /var/vcap/jobs/cloud_controller_worker/config/certs/bits_service_ca.crt
+  <% end %>
 
 diego:
   temporary_local_staging: <%= p("cc.diego.temporary_local_staging") %>

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -325,6 +325,7 @@ module CloudController
       BitsService::ResourcePool.new(
         endpoint: bits_service_options[:private_endpoint],
         request_timeout_in_seconds: config.get(:request_timeout_in_seconds),
+        ca_cert_path: bits_service_options[:ca_cert_path]
       )
     end
 


### PR DESCRIPTION
This version supports https, hence ca_cert properties were added to the bosh jobs to make use of it.

bits-service versions starting from 1.0.0-dev.645 only support https.

A new ops file was introduced in https://github.com/cloudfoundry/cf-deployment/pull/299 which can be used to use the new bits-service version. To do so, please add `-o operations/experimental/enable-bits-service-https.yml` when generating the deployment manifest.

-----------------
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
