### PR TITLE
Implement DB encryption key rotation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .idea
+.vscode
 .yardoc
 .byebug_history
 \#*\#

--- a/app/models/runtime/environment_variable_group.rb
+++ b/app/models/runtime/environment_variable_group.rb
@@ -3,7 +3,7 @@ module VCAP::CloudController
     import_attributes :environment_json
     export_attributes :name, :environment_json
 
-    encrypt :environment_json, salt: :salt
+    set_field_as_encrypted :environment_json, salt: :salt
 
     def self.running
       find_by_name(:running)

--- a/app/models/runtime/environment_variable_group.rb
+++ b/app/models/runtime/environment_variable_group.rb
@@ -3,7 +3,7 @@ module VCAP::CloudController
     import_attributes :environment_json
     export_attributes :name, :environment_json
 
-    set_field_as_encrypted :environment_json, salt: :salt
+    set_field_as_encrypted :environment_json
 
     def self.running
       find_by_name(:running)

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -16,10 +16,10 @@ module VCAP::CloudController
       right_primary_key: :app_guid, right_key: :guid,
       conditions: { type: ProcessTypes::WEB }
 
-    encrypt :credentials, salt: :salt
+    set_field_as_encrypted :credentials, salt: :salt
     serializes_via_json :credentials
 
-    encrypt :volume_mounts, salt: :volume_mounts_salt
+    set_field_as_encrypted :volume_mounts, salt: :volume_mounts_salt
     serializes_via_json :volume_mounts
 
     import_attributes :app_guid, :service_instance_guid, :credentials, :syslog_drain_url

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -16,7 +16,7 @@ module VCAP::CloudController
       right_primary_key: :app_guid, right_key: :guid,
       conditions: { type: ProcessTypes::WEB }
 
-    set_field_as_encrypted :credentials, salt: :salt
+    set_field_as_encrypted :credentials
     serializes_via_json :credentials
 
     set_field_as_encrypted :volume_mounts, salt: :volume_mounts_salt

--- a/app/models/services/service_broker.rb
+++ b/app/models/services/service_broker.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
 
     many_to_many :service_plans, join_table: :services, right_key: :id, right_primary_key: :service_id
 
-    encrypt :auth_password, salt: :salt
+    set_field_as_encrypted :auth_password, salt: :salt
 
     def validate
       validates_presence :name

--- a/app/models/services/service_broker.rb
+++ b/app/models/services/service_broker.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
 
     many_to_many :service_plans, join_table: :services, right_key: :id, right_primary_key: :service_id
 
-    set_field_as_encrypted :auth_password, salt: :salt
+    set_field_as_encrypted :auth_password
 
     def validate
       validates_presence :name

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -60,7 +60,7 @@ module VCAP::CloudController
 
     delegate :organization, to: :space
 
-    encrypt :credentials, salt: :salt
+    set_field_as_encrypted :credentials, salt: :salt
 
     def self.user_visibility_filter(user)
       Sequel.or([

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -60,7 +60,7 @@ module VCAP::CloudController
 
     delegate :organization, to: :space
 
-    set_field_as_encrypted :credentials, salt: :salt
+    set_field_as_encrypted :credentials
 
     def self.user_visibility_filter(user)
       Sequel.or([

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
 
     plugin :after_initialize
 
-    encrypt :credentials, salt: :salt
+    set_field_as_encrypted :credentials, salt: :salt
 
     def to_hash(opts={})
       access_context = VCAP::CloudController::Security::AccessContext.new

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
 
     plugin :after_initialize
 
-    set_field_as_encrypted :credentials, salt: :salt
+    set_field_as_encrypted :credentials
 
     def to_hash(opts={})
       access_context = VCAP::CloudController::Security::AccessContext.new

--- a/app/models/v3/persistence/app_model.rb
+++ b/app/models/v3/persistence/app_model.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
                 key: :app_guid,
                 primary_key: :guid
 
-    encrypt :environment_variables, salt: :salt, column: :encrypted_environment_variables
+    set_field_as_encrypted :environment_variables, salt: :salt, column: :encrypted_environment_variables
     serializes_via_json :environment_variables
 
     add_association_dependencies buildpack_lifecycle_data: :destroy

--- a/app/models/v3/persistence/app_model.rb
+++ b/app/models/v3/persistence/app_model.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
                 key: :app_guid,
                 primary_key: :guid
 
-    set_field_as_encrypted :environment_variables, salt: :salt, column: :encrypted_environment_variables
+    set_field_as_encrypted :environment_variables, column: :encrypted_environment_variables
     serializes_via_json :environment_variables
 
     add_association_dependencies buildpack_lifecycle_data: :destroy

--- a/app/models/v3/persistence/buildpack_lifecycle_buildpack_model.rb
+++ b/app/models/v3/persistence/buildpack_lifecycle_buildpack_model.rb
@@ -2,7 +2,7 @@ require 'utils/uri_utils'
 
 module VCAP::CloudController
   class BuildpackLifecycleBuildpackModel < Sequel::Model(:buildpack_lifecycle_buildpacks)
-    encrypt :buildpack_url, salt: :encrypted_buildpack_url_salt, column: :encrypted_buildpack_url
+    set_field_as_encrypted :buildpack_url, salt: :encrypted_buildpack_url_salt, column: :encrypted_buildpack_url
 
     many_to_one :buildpack_lifecycle_data,
       class: 'VCAP::CloudController::BuildpackLifecycleDataModel',

--- a/app/models/v3/persistence/buildpack_lifecycle_data_model.rb
+++ b/app/models/v3/persistence/buildpack_lifecycle_data_model.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
   class BuildpackLifecycleDataModel < Sequel::Model(:buildpack_lifecycle_data)
     LIFECYCLE_TYPE = Lifecycles::BUILDPACK
 
-    encrypt :buildpack_url, salt: :encrypted_buildpack_url_salt, column: :encrypted_buildpack_url
+    set_field_as_encrypted :buildpack_url, salt: :encrypted_buildpack_url_salt, column: :encrypted_buildpack_url
 
     many_to_one :droplet,
       class: '::VCAP::CloudController::DropletModel',

--- a/app/models/v3/persistence/droplet_model.rb
+++ b/app/models/v3/persistence/droplet_model.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
 
     add_association_dependencies buildpack_lifecycle_data: :destroy
 
-    encrypt :docker_receipt_password, salt: :docker_receipt_password_salt, column: :encrypted_docker_receipt_password
+    set_field_as_encrypted :docker_receipt_password, salt: :docker_receipt_password_salt, column: :encrypted_docker_receipt_password
     serializes_via_json :process_types
 
     def error

--- a/app/models/v3/persistence/package_model.rb
+++ b/app/models/v3/persistence/package_model.rb
@@ -22,7 +22,7 @@ module VCAP::CloudController
                                 key: :package_guid, primary_key: :guid,
                                 order: [Sequel.desc(:created_at), Sequel.desc(:id)], limit: 1
 
-    encrypt :docker_password, salt: :docker_password_salt, column: :encrypted_docker_password
+    set_field_as_encrypted :docker_password, salt: :docker_password_salt, column: :encrypted_docker_password
 
     def validate
       validates_max_length 1_000, :docker_password, message: 'can be up to 1,000 characters', allow_nil: true

--- a/app/models/v3/persistence/task_model.rb
+++ b/app/models/v3/persistence/task_model.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
     one_through_one :space, join_table: AppModel.table_name,
                             left_key: :guid, left_primary_key: :app_guid,
                             right_key: :space_guid, right_primary_key: :guid
-    encrypt :environment_variables, salt: :salt, column: :encrypted_environment_variables
+    set_field_as_encrypted :environment_variables, salt: :salt, column: :encrypted_environment_variables
     serializes_via_json :environment_variables
 
     def after_create

--- a/app/models/v3/persistence/task_model.rb
+++ b/app/models/v3/persistence/task_model.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
     one_through_one :space, join_table: AppModel.table_name,
                             left_key: :guid, left_primary_key: :app_guid,
                             right_key: :space_guid, right_primary_key: :guid
-    set_field_as_encrypted :environment_variables, salt: :salt, column: :encrypted_environment_variables
+    set_field_as_encrypted :environment_variables, column: :encrypted_environment_variables
     serializes_via_json :environment_variables
 
     def after_create

--- a/bosh/jobs/cloud_controller_clock/spec
+++ b/bosh/jobs/cloud_controller_clock/spec
@@ -363,6 +363,14 @@ properties:
     default: ""
     description: "key for encrypting sensitive values in the CC database"
 
+  cc.database_encryption_keys.keys:
+    default: {}
+    description: "label-key pairs for encrypting sensitive values in the CC database"
+
+  cc.database_encryption_keys.current_key_label:
+    default: ""
+    description: "current key label for encrypting values in the CC database"
+
   cc.default_app_memory:
     default: 1024
     description: "How much memory given to an app if not specified"

--- a/bosh/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
+++ b/bosh/jobs/cloud_controller_clock/templates/cloud_controller_ng.yml.erb
@@ -223,6 +223,12 @@ buildpacks:
 
 db_encryption_key: <%= p("cc.db_encryption_key") %>
 
+<% if_p("cc.database_encryption_keys") do %>
+database_encryption_keys:
+  keys: <%= p("cc.database_encryption_keys.keys") %>
+  current_key_label: <%= p("cc.database_encryption_keys.current_key_label").inspect %>
+<% end %>
+
 <% if_p("uaa.clients.cc_service_broker_client.secret") do %>
 uaa_client_name: "cc_service_broker_client"
 uaa_client_secret: <%= p("uaa.clients.cc_service_broker_client.secret") %>

--- a/bosh/jobs/cloud_controller_ng/spec
+++ b/bosh/jobs/cloud_controller_ng/spec
@@ -510,6 +510,14 @@ properties:
     default: ""
     description: "key for encrypting sensitive values in the CC database"
 
+  cc.database_encryption_keys.keys:
+    default: {}
+    description: "label-key pairs for encrypting sensitive values in the CC database"
+
+  cc.database_encryption_keys.current_key_label:
+    default: ""
+    description: "current key label for encrypting values in the CC database"
+
   cc.default_app_memory:
     default: 1024
     description: "How much memory given to an app if not specified"

--- a/bosh/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
+++ b/bosh/jobs/cloud_controller_ng/templates/cloud_controller_ng.yml.erb
@@ -283,6 +283,12 @@ buildpacks:
 
 db_encryption_key: <%= p("cc.db_encryption_key") %>
 
+<% if_p("cc.database_encryption_keys") do %>
+database_encryption_keys:
+  keys: <%= p("cc.database_encryption_keys.keys") %>
+  current_key_label: <%= p("cc.database_encryption_keys.current_key_label").inspect %>
+<% end %>
+
 disable_custom_buildpacks: <%= p("cc.disable_custom_buildpacks") %>
 
 broker_client_timeout_seconds: <%= p("cc.broker_client_timeout_seconds") %>

--- a/bosh/jobs/cloud_controller_worker/spec
+++ b/bosh/jobs/cloud_controller_worker/spec
@@ -313,6 +313,14 @@ properties:
     default: ""
     description: "key for encrypting sensitive values in the CC database"
 
+  cc.database_encryption_keys.keys:
+    default: {}
+    description: "label-key pairs for encrypting sensitive values in the CC database"
+
+  cc.database_encryption_keys.current_key_label:
+    default: ""
+    description: "current key label for encrypting values in the CC database"
+
   cc.default_app_memory:
     default: 1024
     description: "How much memory given to an app if not specified"

--- a/bosh/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
+++ b/bosh/jobs/cloud_controller_worker/templates/cloud_controller_ng.yml.erb
@@ -181,6 +181,12 @@ buildpacks:
 
 db_encryption_key: <%= p("cc.db_encryption_key") %>
 
+<% if_p("cc.database_encryption_keys") do %>
+database_encryption_keys:
+  keys: <%= p("cc.database_encryption_keys.keys") %>
+  current_key_label: <%= p("cc.database_encryption_keys.current_key_label").inspect %>
+<% end %>
+
 broker_client_timeout_seconds: <%= p("cc.broker_client_timeout_seconds") %>
 broker_client_default_async_poll_interval_seconds: <%= p('cc.broker_client_default_async_poll_interval_seconds') %>
 broker_client_max_async_poll_duration_minutes: <%= p('cc.broker_client_max_async_poll_duration_minutes') %>

--- a/db/migrations/20170830183100_add_encryption_key_label_column_to_tables_with_encrypted_columns.rb
+++ b/db/migrations/20170830183100_add_encryption_key_label_column_to_tables_with_encrypted_columns.rb
@@ -1,0 +1,32 @@
+Sequel.migration do
+  up do
+    tables_to_alter = %w(
+      env_groups
+      service_brokers
+      service_bindings
+      service_instances
+      service_keys
+      apps
+      buildpack_lifecycle_buildpacks
+      buildpack_lifecycle_data
+      droplets
+      packages
+      tasks
+    )
+    tables_to_alter.each do |table|
+      alter_table(table.to_sym) do
+        add_column :encryption_key_label, String, size: 255
+      end
+    end
+  end
+
+  down do
+    if supports_table_listing?
+      tables.each do |table|
+        alter_table(table) do
+          drop_column :encryption_key_label
+        end
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -118,6 +118,11 @@ module VCAP::CloudController
     def configure_components
       Encryptor.db_encryption_key = get(:db_encryption_key)
 
+      if get(:database_encryption_keys)
+        Encryptor.database_encryption_keys = get(:database_encryption_keys)[:keys]
+        Encryptor.current_encryption_key_label = get(:database_encryption_keys)[:current_key_label]
+      end
+
       dependency_locator = CloudController::DependencyLocator.instance
       dependency_locator.config = self
 

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -157,6 +157,11 @@ module VCAP::CloudController
 
           db_encryption_key: String,
 
+          optional(:database_encryption_keys) => {
+              keys: Hash,
+              current_key_label: String
+          },
+
           disable_custom_buildpacks: bool,
           broker_client_timeout_seconds: Integer,
           broker_client_default_async_poll_interval_seconds: Integer,

--- a/lib/cloud_controller/config_schemas/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/clock_schema.rb
@@ -101,6 +101,11 @@ module VCAP::CloudController
 
           db_encryption_key: String,
 
+          optional(:database_encryption_keys) => {
+              keys: Hash,
+              current_key_label: String
+          },
+
           optional(:uaa_client_name) => String,
           optional(:uaa_client_secret) => String,
           optional(:uaa_client_scope) => String,

--- a/lib/cloud_controller/config_schemas/migrate_schema.rb
+++ b/lib/cloud_controller/config_schemas/migrate_schema.rb
@@ -16,6 +16,11 @@ module VCAP::CloudController
 
           db_encryption_key: String,
 
+          optional(:database_encryption_keys) => {
+              keys: Hash,
+              current_key_label: String
+          },
+
           logging: {
             level: String, # debug, info, etc.
             file: String, # Log file to use

--- a/lib/cloud_controller/config_schemas/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/worker_schema.rb
@@ -87,6 +87,11 @@ module VCAP::CloudController
 
           db_encryption_key: String,
 
+          optional(:database_encryption_keys) => {
+              keys: Hash,
+              current_key_label: String
+          },
+
           optional(:broker_client_timeout_seconds) => Integer,
           optional(:broker_client_default_async_poll_interval_seconds) => Integer,
           broker_client_max_async_poll_duration_minutes: Integer,

--- a/lib/cloud_controller/encryptor.rb
+++ b/lib/cloud_controller/encryptor.rb
@@ -1,35 +1,67 @@
 require 'securerandom'
+require 'openssl'
 require 'openssl/cipher'
+require 'openssl/digest'
+
+# require 'openssl/ossl'
 require 'base64'
 
 module VCAP::CloudController::Encryptor
   class << self
-    ALGORITHM = 'AES-128-CBC'.freeze
+    ALGORITHM = 'AES-256-CBC'.freeze
 
     def generate_salt
-      SecureRandom.hex(4).to_s
+      SecureRandom.hex(8).to_s
     end
 
+    # takes no label, looks up in global config
     def encrypt(input, salt)
       return nil unless input
-      Base64.strict_encode64(run_cipher(make_cipher.encrypt, input, salt))
+
+      label = current_encryption_key_label
+      key = key_to_use(label)
+
+      Base64.strict_encode64(run_cipher(make_cipher.encrypt, input, salt, key))
     end
 
-    def decrypt(encrypted_input, salt)
+    # this takes a label
+    def decrypt(encrypted_input, salt, label=nil)
       return nil unless encrypted_input
-      run_cipher(make_cipher.decrypt, Base64.decode64(encrypted_input), salt)
+
+      key = key_to_use(label)
+
+      run_cipher(make_cipher.decrypt, Base64.decode64(encrypted_input), salt, key)
     end
 
-    attr_accessor :db_encryption_key
+    attr_writer :db_encryption_key
+    attr_writer :database_encryption_keys
+    attr_accessor :current_encryption_key_label
 
     private
+
+    attr_reader :db_encryption_key
+    attr_reader :database_encryption_keys
+
+    def key_to_use(label)
+      if database_encryption_keys.nil? || !database_encryption_keys.key?(label)
+        return db_encryption_key
+      end
+
+      database_encryption_keys[label]
+    end
 
     def make_cipher
       OpenSSL::Cipher.new(ALGORITHM)
     end
 
-    def run_cipher(cipher, input, salt)
-      cipher.pkcs5_keyivgen(db_encryption_key, salt)
+    def run_cipher(cipher, input, salt, key)
+      if salt.length.eql?(8)
+        # Backwards compatibility
+        cipher.pkcs5_keyivgen(key, salt)
+      else
+        cipher.key = OpenSSL::PKCS5.pbkdf2_hmac(key, salt, 2048, 32, OpenSSL::Digest::SHA256.new)
+        cipher.iv = salt
+      end
       cipher.update(input).tap { |result| result << cipher.final }
     end
   end
@@ -38,15 +70,28 @@ module VCAP::CloudController::Encryptor
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def encrypt(field_name, options={})
+      attr_accessor :encrypted_fields
+
+      def set_field_as_encrypted(field_name, options={})
         field_name = field_name.to_sym
         salt_name = (options[:salt] || "#{field_name}_salt").to_sym
         generate_salt_name = "generate_#{salt_name}".to_sym
         storage_column = options[:column]
 
+        field_entry = { field_name: field_name, salt_name: salt_name }
+
+        # Store the list of encrypted fields for use during key rotation
+        if self.encrypted_fields.nil?
+          self.encrypted_fields = [field_entry]
+        else
+          self.encrypted_fields.append(field_entry)
+        end
+
         unless columns.include?(salt_name)
           raise "Salt field `#{salt_name}` does not exist"
         end
+
+        raise 'Field "encryption_key_label" does not exist' unless columns.include?(:encryption_key_label)
 
         define_method generate_salt_name do
           return unless send(salt_name).blank?
@@ -64,25 +109,39 @@ module VCAP::CloudController::Encryptor
         end
 
         define_method "#{field_name}_with_encryption" do
-          VCAP::CloudController::Encryptor.decrypt send("#{field_name}_without_encryption"), send(salt_name)
+          VCAP::CloudController::Encryptor.decrypt send("#{field_name}_without_encryption"), send(salt_name), self.encryption_key_label
         end
         alias_method_chain field_name, 'encryption'
 
         define_method "#{field_name}_with_encryption=" do |value|
           send generate_salt_name
 
-          encrypted_value =
-            if value.blank?
-              nil
-            else
-              VCAP::CloudController::Encryptor.encrypt(value, send(salt_name))
+          if value.blank?
+            send "#{field_name}_without_encryption=", nil
+          elsif !VCAP::CloudController::Encryptor.current_encryption_key_label.nil? && self.encryption_key_label != VCAP::CloudController::Encryptor.current_encryption_key_label
+            send(:db).transaction do
+              e_fields = self.class.encrypted_fields
+              if !e_fields.nil?
+                self.class.encrypted_fields.each do |field|
+                  if !field[:field_name].eql?(field_name)
+                    send "#{field[:field_name]}_without_encryption=", VCAP::CloudController::Encryptor.encrypt(send(field[:field_name]), send(field[:salt_name]))
+                  else
+                    send "#{field_name}_without_encryption=", VCAP::CloudController::Encryptor.encrypt(value, send(salt_name))
+                  end
+                end
+              end
+              self.encryption_key_label = VCAP::CloudController::Encryptor.current_encryption_key_label
             end
-
-          send "#{field_name}_without_encryption=", encrypted_value
+          else
+            # will use the current key label to encrypt
+            encrypted_value = VCAP::CloudController::Encryptor.encrypt(value, send(salt_name))
+            send "#{field_name}_without_encryption=", encrypted_value
+          end
         end
         alias_method_chain "#{field_name}=", 'encryption'
       end
-      private :encrypt
+
+      private :set_field_as_encrypted
     end
   end
 end

--- a/lib/cloud_controller/encryptor.rb
+++ b/lib/cloud_controller/encryptor.rb
@@ -6,142 +6,122 @@ require 'openssl/digest'
 # require 'openssl/ossl'
 require 'base64'
 
-module VCAP::CloudController::Encryptor
-  class << self
-    ALGORITHM = 'AES-256-CBC'.freeze
+module VCAP::CloudController
+  module Encryptor
+    class << self
+      ALGORITHM = 'AES-256-CBC'.freeze
 
-    def generate_salt
-      SecureRandom.hex(8).to_s
-    end
-
-    # takes no label, looks up in global config
-    def encrypt(input, salt)
-      return nil unless input
-
-      label = current_encryption_key_label
-      key = key_to_use(label)
-
-      Base64.strict_encode64(run_cipher(make_cipher.encrypt, input, salt, key))
-    end
-
-    # this takes a label
-    def decrypt(encrypted_input, salt, label=nil)
-      return nil unless encrypted_input
-
-      key = key_to_use(label)
-
-      run_cipher(make_cipher.decrypt, Base64.decode64(encrypted_input), salt, key)
-    end
-
-    attr_writer :db_encryption_key
-    attr_writer :database_encryption_keys
-    attr_accessor :current_encryption_key_label
-
-    private
-
-    attr_reader :db_encryption_key
-    attr_reader :database_encryption_keys
-
-    def key_to_use(label)
-      if database_encryption_keys.nil? || !database_encryption_keys.key?(label)
-        return db_encryption_key
+      def generate_salt
+        SecureRandom.hex(8).to_s
       end
 
-      database_encryption_keys[label]
-    end
+      def encrypt(input, salt)
+        return unless input
 
-    def make_cipher
-      OpenSSL::Cipher.new(ALGORITHM)
-    end
+        label = current_encryption_key_label
+        key = key_to_use(label)
 
-    def run_cipher(cipher, input, salt, key)
-      if salt.length.eql?(8)
-        # Backwards compatibility
-        cipher.pkcs5_keyivgen(key, salt)
-      else
-        cipher.key = OpenSSL::PKCS5.pbkdf2_hmac(key, salt, 2048, 32, OpenSSL::Digest::SHA256.new)
-        cipher.iv = salt
+        Base64.strict_encode64(run_cipher(make_cipher.encrypt, input, salt, key))
       end
-      cipher.update(input).tap { |result| result << cipher.final }
-    end
-  end
 
-  module FieldEncryptor
-    extend ActiveSupport::Concern
+      def decrypt(encrypted_input, salt, label=nil)
+        return unless encrypted_input
 
-    module ClassMethods
-      attr_accessor :encrypted_fields
+        key = key_to_use(label)
 
-      def set_field_as_encrypted(field_name, options={})
-        field_name = field_name.to_sym
-        salt_name = (options[:salt] || "#{field_name}_salt").to_sym
-        generate_salt_name = "generate_#{salt_name}".to_sym
-        storage_column = options[:column]
+        run_cipher(make_cipher.decrypt, Base64.decode64(encrypted_input), salt, key)
+      end
 
-        field_entry = { field_name: field_name, salt_name: salt_name }
+      attr_writer :db_encryption_key
+      attr_writer :database_encryption_keys
+      attr_accessor :current_encryption_key_label
 
-        # Store the list of encrypted fields for use during key rotation
-        if self.encrypted_fields.nil?
-          self.encrypted_fields = [field_entry]
+      private
+
+      attr_reader :db_encryption_key
+      attr_reader :database_encryption_keys
+
+      def key_to_use(label)
+        if database_encryption_keys.nil? || !database_encryption_keys.key?(label)
+          return db_encryption_key
+        end
+
+        database_encryption_keys[label]
+      end
+
+      def make_cipher
+        OpenSSL::Cipher.new(ALGORITHM)
+      end
+
+      def run_cipher(cipher, input, salt, key)
+        if salt.length.eql?(8)
+          # Backwards compatibility
+          cipher.pkcs5_keyivgen(key, salt)
         else
-          self.encrypted_fields.append(field_entry)
+          cipher.key = OpenSSL::PKCS5.pbkdf2_hmac(key, salt, 2048, 32, OpenSSL::Digest::SHA256.new)
+          cipher.iv = salt
         end
+        cipher.update(input).tap { |result| result << cipher.final }
+      end
+    end
 
-        unless columns.include?(salt_name)
-          raise "Salt field `#{salt_name}` does not exist"
-        end
+    module FieldEncryptor
+      extend ActiveSupport::Concern
 
-        raise 'Field "encryption_key_label" does not exist' unless columns.include?(:encryption_key_label)
+      module ClassMethods
+        attr_accessor :encrypted_fields
 
-        define_method generate_salt_name do
-          return unless send(salt_name).blank?
-          send "#{salt_name}=", VCAP::CloudController::Encryptor.generate_salt
-        end
+        def set_field_as_encrypted(field_name, options={})
+          field_name = field_name.to_sym
+          salt_name = (options[:salt] || 'salt').to_sym
+          generate_salt_name = "generate_#{salt_name}".to_sym
+          storage_column = options[:column]
+          raise "Salt field `#{salt_name}` does not exist" unless columns.include?(salt_name)
+          raise 'Field "encryption_key_label" does not exist' unless columns.include?(:encryption_key_label)
 
-        if storage_column
-          define_method field_name do
-            send storage_column
+          self.encrypted_fields ||= []
+          encrypted_fields << { field_name: field_name, salt_name: salt_name }
+
+          define_method generate_salt_name do
+            return if send(salt_name).present?
+            send("#{salt_name}=", Encryptor.generate_salt)
           end
 
-          define_method "#{field_name}=" do |value|
-            send "#{storage_column}=", value
+          if storage_column
+            alias_method field_name, storage_column
+            alias_method "#{field_name}=", "#{storage_column}="
           end
-        end
 
-        define_method "#{field_name}_with_encryption" do
-          VCAP::CloudController::Encryptor.decrypt send("#{field_name}_without_encryption"), send(salt_name), self.encryption_key_label
-        end
-        alias_method_chain field_name, 'encryption'
+          define_method "#{field_name}_with_encryption" do
+            Encryptor.decrypt(send("#{field_name}_without_encryption"), send(salt_name), encryption_key_label)
+          end
+          alias_method_chain field_name, 'encryption'
 
-        define_method "#{field_name}_with_encryption=" do |value|
-          send generate_salt_name
-
-          if value.blank?
-            send "#{field_name}_without_encryption=", nil
-          elsif !VCAP::CloudController::Encryptor.current_encryption_key_label.nil? && self.encryption_key_label != VCAP::CloudController::Encryptor.current_encryption_key_label
-            send(:db).transaction do
-              e_fields = self.class.encrypted_fields
-              if !e_fields.nil?
-                self.class.encrypted_fields.each do |field|
-                  if !field[:field_name].eql?(field_name)
-                    send "#{field[:field_name]}_without_encryption=", VCAP::CloudController::Encryptor.encrypt(send(field[:field_name]), send(field[:salt_name]))
-                  else
-                    send "#{field_name}_without_encryption=", VCAP::CloudController::Encryptor.encrypt(value, send(salt_name))
-                  end
-                end
-              end
-              self.encryption_key_label = VCAP::CloudController::Encryptor.current_encryption_key_label
+          define_method "#{field_name}_with_encryption=" do |value|
+            send(generate_salt_name)
+            db.transaction do
+              update_encryption_key
+              encrypted_value = Encryptor.encrypt(value.presence, send(salt_name))
+              send("#{field_name}_without_encryption=", encrypted_value)
             end
-          else
-            # will use the current key label to encrypt
-            encrypted_value = VCAP::CloudController::Encryptor.encrypt(value, send(salt_name))
-            send "#{field_name}_without_encryption=", encrypted_value
           end
+          alias_method_chain "#{field_name}=", 'encryption'
         end
-        alias_method_chain "#{field_name}=", 'encryption'
+
+        private :set_field_as_encrypted
       end
 
-      private :set_field_as_encrypted
+      def update_encryption_key
+        return if Encryptor.current_encryption_key_label.nil?
+        return if encryption_key_label == Encryptor.current_encryption_key_label
+
+        db.transaction do
+          (self.class.encrypted_fields || []).each do |field|
+            send("#{field[:field_name]}_without_encryption=", Encryptor.encrypt(send(field[:field_name]), send(field[:salt_name])))
+          end
+          self.encryption_key_label = Encryptor.current_encryption_key_label
+        end
+      end
     end
   end
 end

--- a/lib/cloud_controller/encryptor.rb
+++ b/lib/cloud_controller/encryptor.rb
@@ -9,7 +9,7 @@ require 'base64'
 module VCAP::CloudController
   module Encryptor
     class << self
-      ALGORITHM = 'AES-256-CBC'.freeze
+      ALGORITHM = 'AES-128-CBC'.freeze
 
       def generate_salt
         SecureRandom.hex(8).to_s
@@ -56,7 +56,7 @@ module VCAP::CloudController
         if deprecated_short_salt?(salt)
           cipher.pkcs5_keyivgen(key, salt)
         else
-          cipher.key = OpenSSL::PKCS5.pbkdf2_hmac(key, salt, 2048, 32, OpenSSL::Digest::SHA256.new)
+          cipher.key = OpenSSL::PKCS5.pbkdf2_hmac(key, salt, 2048, 16, OpenSSL::Digest::SHA256.new)
           cipher.iv = salt
         end
         cipher.update(input) << cipher.final

--- a/spec/support/shared_examples/models/encrypted_attribute.rb
+++ b/spec/support/shared_examples/models/encrypted_attribute.rb
@@ -64,8 +64,8 @@ module VCAP::CloudController
       expect(value_with_original_salt).not_to eql(last_row[storage_column])
     end
 
-    it 'must have a salt of length 8' do
-      expect(model.reload.send(attr_salt).length).to eq 8
+    it 'must have a salt of length 16' do
+      expect(model.reload.send(attr_salt).length).to eq 16
     end
   end
 end

--- a/spec/unit/lib/cloud_controller/config_spec.rb
+++ b/spec/unit/lib/cloud_controller/config_spec.rb
@@ -4,50 +4,50 @@ module VCAP::CloudController
   RSpec.describe Config do
     let(:test_config_hash) {
       {
-        packages: {
-          fog_connection: {},
-          fog_aws_storage_options: {
-            encryption: 'AES256'
+          packages: {
+              fog_connection: {},
+              fog_aws_storage_options: {
+                  encryption: 'AES256'
+              },
+              app_package_directory_key: 'app_key',
           },
-          app_package_directory_key: 'app_key',
-        },
-        droplets: {
-          fog_connection: {},
-          droplet_directory_key: 'droplet_key',
-        },
-        buildpacks: {
-          fog_connection: {},
-          buildpack_directory_key: 'bp_key',
-        },
-        resource_pool: {
-          minimum_size: 9001,
-          maximum_size: 0,
-          fog_connection: {},
-          resource_directory_key: 'resource_key',
-        },
-        bulk_api: {},
-        external_domain: 'host',
-        external_port: 1234,
-        staging: {
-          auth: {
-            user: 'user',
-            password: 'password',
+          droplets: {
+              fog_connection: {},
+              droplet_directory_key: 'droplet_key',
           },
-        },
-        bits_service: { enabled: false },
-        reserved_private_domains: File.join(Paths::FIXTURES, 'config/reserved_private_domains.dat'),
-        diego: {},
-        stacks_file: 'path/to/stacks/file',
-        db_encryption_key: '123-456',
-        install_buildpacks: [
-          {
-            name: 'some-buildpack',
-          }
-        ]
+          buildpacks: {
+              fog_connection: {},
+              buildpack_directory_key: 'bp_key',
+          },
+          resource_pool: {
+              minimum_size: 9001,
+              maximum_size: 0,
+              fog_connection: {},
+              resource_directory_key: 'resource_key',
+          },
+          bulk_api: {},
+          external_domain: 'host',
+          external_port: 1234,
+          staging: {
+              auth: {
+                  user: 'user',
+                  password: 'password',
+              },
+          },
+          bits_service: { enabled: false },
+          reserved_private_domains: File.join(Paths::FIXTURES, 'config/reserved_private_domains.dat'),
+          diego: {},
+          stacks_file: 'path/to/stacks/file',
+          db_encryption_key: '123-456',
+          install_buildpacks: [
+            {
+                name: 'some-buildpack',
+            }
+          ]
       }
     }
 
-    describe '.load_from_file' do
+    describe '#load_from_file' do
       it 'raises if the file does not exist' do
         expect {
           Config.load_from_file('nonexistent.yml', context: :worker)
@@ -92,6 +92,10 @@ module VCAP::CloudController
 
           let(:config) do
             Config.load_from_file(cc_config_file, context: :worker).config_hash
+          end
+
+          it 'does not set a default for database_encryption_keys' do
+            expect(config[:database_encryption_keys]).to be_nil
           end
 
           it 'sets default stacks_file' do
@@ -164,6 +168,14 @@ module VCAP::CloudController
               config['maximum_app_disk_in_mb'] = 3072
               config['broker_client_default_async_poll_interval_seconds'] = 42
               config['broker_client_timeout_seconds'] = 70
+              config['database_encryption_keys'] = {
+                  keys: {
+                      'foo' => 'bar',
+                      'current' => 'yomama',
+                      'head' => 'banging'
+                  },
+                  current_key_label: 'foo'
+              }
 
               file = Tempfile.new('cc_config.yml')
               file.write(YAML.dump(config))
@@ -173,6 +185,10 @@ module VCAP::CloudController
 
             let(:config) do
               Config.load_from_file(cc_config_file.path, context: :worker).config_hash
+            end
+
+            it 'preserves the current_encryption_key_label value from the file' do
+              expect(config[:database_encryption_keys][:current_key_label]).to eq('foo')
             end
 
             it 'preserves the stacks_file value from the file' do
@@ -326,41 +342,41 @@ module VCAP::CloudController
 
       let(:test_config_hash) {
         {
-          packages: {
-            fog_connection: {},
-            fog_aws_storage_options: {
-              encryption: 'AES256'
+            packages: {
+                fog_connection: {},
+                fog_aws_storage_options: {
+                    encryption: 'AES256'
+                },
+                app_package_directory_key: 'app_key',
             },
-            app_package_directory_key: 'app_key',
-          },
-          droplets: {
-            fog_connection: {},
-            droplet_directory_key: 'droplet_key',
-          },
-          buildpacks: {
-            fog_connection: {},
-            buildpack_directory_key: 'bp_key',
-          },
-          resource_pool: {
-            minimum_size: 9001,
-            maximum_size: 0,
-            fog_connection: {},
-            resource_directory_key: 'resource_key',
-          },
-          bulk_api: {},
-          external_host: 'host',
-          external_port: 1234,
-          staging: {
-            auth: {
-              user: 'user',
-              password: 'password',
+            droplets: {
+                fog_connection: {},
+                droplet_directory_key: 'droplet_key',
             },
-          },
-          bits_service: { enabled: false },
-          reserved_private_domains: File.join(Paths::FIXTURES, 'config/reserved_private_domains.dat'),
-          diego: {},
-          stacks_file: 'path/to/stacks/file',
-          db_encryption_key: '123-456'
+            buildpacks: {
+                fog_connection: {},
+                buildpack_directory_key: 'bp_key',
+            },
+            resource_pool: {
+                minimum_size: 9001,
+                maximum_size: 0,
+                fog_connection: {},
+                resource_directory_key: 'resource_key',
+            },
+            bulk_api: {},
+            external_host: 'host',
+            external_port: 1234,
+            staging: {
+                auth: {
+                    user: 'user',
+                    password: 'password',
+                },
+            },
+            bits_service: { enabled: false },
+            reserved_private_domains: File.join(Paths::FIXTURES, 'config/reserved_private_domains.dat'),
+            diego: {},
+            stacks_file: 'path/to/stacks/file',
+            db_encryption_key: '123-456'
         }
       }
 
@@ -377,8 +393,8 @@ module VCAP::CloudController
       end
 
       it 'sets up the db encryption key' do
+        expect(Encryptor).to receive(:db_encryption_key=).with('123-456')
         config_instance.configure_components
-        expect(Encryptor.db_encryption_key).to eq('123-456')
       end
 
       it 'sets up the resource pool instance' do
@@ -425,6 +441,37 @@ module VCAP::CloudController
         end
       end
 
+      context 'when database encryption keys are used' do
+        let(:keys) do
+          {
+              keys: {
+                  'current' => 'abc-123',
+                  'previous' => 'def-456',
+                  'old' => 'ghi-789'
+              },
+              current_key_label: 'current'
+          }
+        end
+
+        let(:config_instance) do
+          Config.new(test_config_hash.merge(database_encryption_keys: keys))
+        end
+
+        before do
+          allow(Encryptor).to receive(:current_encryption_key_label=)
+        end
+
+        it 'sets up the current encryption key label' do
+          expect(Encryptor).to receive(:current_encryption_key_label=).with(keys[:current_key_label])
+          config_instance.configure_components
+        end
+
+        it 'sets up the database encryption keys' do
+          expect(Encryptor).to receive(:database_encryption_keys=).with(keys[:keys])
+          config_instance.configure_components
+        end
+      end
+
       context 'when newrelic is enabled' do
         let(:config_instance) do
           Config.new(test_config_hash.merge(newrelic_enabled: true))
@@ -461,12 +508,12 @@ module VCAP::CloudController
 
       it 'returns a hash for nested properties' do
         expect(config_instance.get(:packages)).to eq({
-          fog_connection: {},
-          fog_aws_storage_options: {
-            encryption: 'AES256'
-          },
-          app_package_directory_key: 'app_key',
-        })
+                                                         fog_connection: {},
+                                                         fog_aws_storage_options: {
+                                                             encryption: 'AES256'
+                                                         },
+                                                         app_package_directory_key: 'app_key',
+                                                     })
         expect(config_instance.get(:packages, :fog_aws_storage_options)).to eq(encryption: 'AES256')
       end
 

--- a/spec/unit/lib/cloud_controller/encryptor_spec.rb
+++ b/spec/unit/lib/cloud_controller/encryptor_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     describe 'generating some salt' do
       it 'returns a short, random string' do
-        expect(salt.length).to eql(8)
+        expect(salt.length).to eql(16)
         expect(salt).not_to eql(Encryptor.generate_salt)
       end
     end
@@ -37,13 +37,123 @@ module VCAP::CloudController
         expect(Encryptor.encrypt(nil, salt)).to be_nil
       end
 
-      describe 'decrypting the string' do
-        it 'returns the original string' do
-          expect(Encryptor.decrypt(encrypted_string, salt)).to eq(input)
+      context 'when database_encryption_keys has been set' do
+        let(:salt) { 'FFFFFFFFFFFFFFFF' }
+        let(:encrypted_death_string) { 'NHQ+mjls1UHJBqpO0KWjTA==' }
+        let(:encrypted_legacy_string) { '1XJDJYNqWOKokyVx0WHZ/g==' }
+
+        before(:each) do
+          Encryptor.db_encryption_key = 'legacy-crypto-key'
+          Encryptor.database_encryption_keys = {
+              'foo' => 'fooencryptionkey',
+              'death' => 'headbangingdeathmetalkey'
+          }
         end
 
-        it 'returns nil if the encrypted string is nil' do
-          expect(Encryptor.decrypt(nil, salt)).to be_nil
+        context 'when the label is found in the hash' do
+          it 'will encrypt using the value corresponding to the label' do
+            allow(Encryptor).to receive(:current_encryption_key_label) { 'death' }
+            expect(Encryptor.encrypt(input, salt)).to eql(encrypted_death_string)
+          end
+        end
+
+        context 'when the label is not found in the hash' do
+          it 'will encrypt using current db_encryption_key when the label is not nil' do
+            allow(Encryptor).to receive(:current_encryption_key_label) { 'Inigo Montoya' }
+            expect(Encryptor.encrypt(input, salt)).to eql(encrypted_legacy_string)
+          end
+
+          it 'will encrypt using current db_encryption_key when the label is nil' do
+            allow(Encryptor).to receive(:current_encryption_key_label) { nil }
+            expect(Encryptor.encrypt(input, salt)).to eql(encrypted_legacy_string)
+          end
+        end
+      end
+
+      context 'when database_encryption_keys has not been set' do
+        let(:salt) { 'FFFFFFFFFFFFFFFF' }
+        let(:encrypted_legacy_string) { '1XJDJYNqWOKokyVx0WHZ/g==' }
+
+        before(:each) do
+          Encryptor.db_encryption_key = 'legacy-crypto-key'
+          Encryptor.database_encryption_keys = nil
+          allow(Encryptor).to receive(:current_encryption_key_label) { 'foo' }
+        end
+
+        it 'will encrypt using db_encryption_key' do
+          expect(Encryptor.encrypt(input, salt)).to eql(encrypted_legacy_string)
+        end
+      end
+    end
+
+    describe '#decrypt' do
+      let(:unencrypted_string) { 'some-string' }
+
+      before(:each) do
+        Encryptor.db_encryption_key = 'legacy-crypto-key'
+      end
+
+      it 'returns the original string' do
+        encrypted_string = Encryptor.encrypt(unencrypted_string, salt)
+        expect(Encryptor.decrypt(encrypted_string, salt)).to eq(unencrypted_string)
+      end
+
+      it 'returns nil if the encrypted string is nil' do
+        expect(Encryptor.decrypt(nil, salt)).to be_nil
+      end
+
+      context 'when database_encryption_keys is configured' do
+        before(:each) do
+          allow(Encryptor).to receive(:current_encryption_key_label) { 'foo' }
+          Encryptor.database_encryption_keys = {
+              'foo' => 'fooencryptionkey',
+              'death' => 'headbangingdeathmetalkey'
+          }
+        end
+
+        context 'when no encryption key label is passed' do
+          before(:each) do
+            allow(Encryptor).to receive(:current_encryption_key_label) { nil }
+          end
+
+          it 'decrypts using #db_encryption_key' do
+            encrypted_string = Encryptor.encrypt(unencrypted_string, salt)
+            expect(Encryptor).to receive(:db_encryption_key).and_call_original.at_least(:once)
+            expect(Encryptor.decrypt(encrypted_string, salt)).to eq(unencrypted_string)
+          end
+        end
+
+        context 'when encryption was done using a labelled key' do
+          context 'when no key label is passed for decryption' do
+            it 'fails to decrypt' do
+              encrypted_string = Encryptor.encrypt(unencrypted_string, salt)
+              expect { Encryptor.decrypt(encrypted_string, salt) }.to raise_error(/bad decrypt/)
+            end
+          end
+
+          context 'when the wrong label is passed for decryption' do
+            before(:each) do
+              allow(Encryptor).to receive(:current_encryption_key_label) { 'foo' }
+            end
+            it 'fails to decrypt' do
+              encrypted_string = Encryptor.encrypt(unencrypted_string, salt)
+              expect { Encryptor.decrypt(encrypted_string, salt, 'death') }.to raise_error(/bad decrypt/)
+            end
+          end
+
+          it 'decrypts using the key specified by the passed label' do
+            encrypted_string = Encryptor.encrypt(unencrypted_string, salt)
+            expect(Encryptor.decrypt(encrypted_string, salt, 'foo')).to eq(unencrypted_string)
+          end
+        end
+      end
+
+      context 'when the salt is only 8 bytes (legacy mode)' do
+        let(:salt) { SecureRandom.hex(4).to_s }
+
+        it 'decrypts correctly' do
+          encrypted_string = Encryptor.encrypt(unencrypted_string, salt)
+          expect(Encryptor.decrypt(encrypted_string, salt)).to eq(unencrypted_string)
         end
       end
     end
@@ -56,19 +166,24 @@ module VCAP::CloudController
       end
     end
 
+    let(:db) { double(Sequel::Database) }
+
     before do
       allow(klass).to receive(:columns) { columns }
+      allow(db).to receive(:transaction) do |&block|
+        block.call
+      end
       klass.send :attr_accessor, *columns # emulate Sequel super methods
     end
 
-    describe '#encrypt' do
+    describe '#set_field_as_encrypted' do
       context 'model does not have the salt column' do
-        let(:columns) { [:id, :name, :size] }
+        let(:columns) { [:id, :name, :size, :encryption_key_label] }
 
         context 'default name' do
           it 'raises an error' do
             expect {
-              klass.send :encrypt, :name
+              klass.send :set_field_as_encrypted, :name
             }.to raise_error(RuntimeError, /name_salt/)
           end
         end
@@ -76,52 +191,62 @@ module VCAP::CloudController
         context 'explicit name' do
           it 'raises an error' do
             expect {
-              klass.send :encrypt, :name, salt: :foobar
+              klass.send :set_field_as_encrypted, :name, salt: :foobar
             }.to raise_error(RuntimeError, /foobar/)
           end
         end
       end
 
       context 'model has the salt column' do
-        context 'default name' do
-          let(:columns) { [:id, :name, :size, :name_salt] }
+        let(:columns) { [:id, :name, :size, :name_salt, :encryption_key_label] }
 
-          it 'does not raise an error' do
-            expect {
-              klass.send :encrypt, :name
-            }.to_not raise_error
-          end
+        it 'does not raise an error' do
+          expect {
+            klass.send :set_field_as_encrypted, :name
+          }.to_not raise_error
+        end
 
-          it 'creates a salt generation method' do
-            klass.send :encrypt, :name
-            expect(klass.instance_methods).to include(:generate_name_salt)
-          end
+        it 'creates a salt generation method' do
+          klass.send :set_field_as_encrypted, :name
+          expect(klass.instance_methods).to include(:generate_name_salt)
         end
 
         context 'explicit name' do
-          let(:columns) { [:id, :name, :size, :foobar] }
+          let(:columns) { [:id, :name, :size, :foobar, :encryption_key_label] }
 
           it 'does not raise an error' do
             expect {
-              klass.send :encrypt, :name, salt: :foobar
+              klass.send :set_field_as_encrypted, :name, salt: :foobar
             }.to_not raise_error
           end
 
           it 'creates a salt generation method' do
-            klass.send :encrypt, :name, salt: :foobar
+            klass.send :set_field_as_encrypted, :name, salt: :foobar
             expect(klass.instance_methods).to include(:generate_foobar)
           end
+        end
+      end
+
+      context 'model does not have the "encryption_key_label" column' do
+        let(:columns) { [:id, :name, :name_salt, :size] }
+
+        it 'raises an error' do
+          expect {
+            klass.send :set_field_as_encrypted, :name
+          }.to raise_error(RuntimeError, /encryption_key_label/)
         end
       end
     end
 
     describe 'field-specific methods' do
-      let(:columns) { [:sekret, :sekret_salt] }
+      let(:columns) { [:sekret, :sekret_salt, :encryption_key_label] }
       let(:klass2) { Class.new klass }
       let(:subject) { klass2.new }
       let(:encryption_args) { {} }
+      let(:default_key) { 'somerandomkey' }
 
       before do
+        allow(subject).to receive(:db) { db }
         klass.class_eval do
           def underlying_sekret=(value)
             @sekret = value
@@ -131,7 +256,9 @@ module VCAP::CloudController
             @sekret
           end
         end
-        klass2.send :encrypt, :sekret, encryption_args
+        klass2.send :set_field_as_encrypted, :sekret, encryption_args
+
+        Encryptor.db_encryption_key = default_key
       end
 
       describe 'salt generation method' do
@@ -159,39 +286,114 @@ module VCAP::CloudController
         it 'decrypts by passing the salt and the underlying value to Encryptor' do
           subject.sekret_salt = 'asdf'
           subject.underlying_sekret = 'underlying'
-          expect(Encryptor).to receive(:decrypt).with('underlying', 'asdf') { 'unencrypted' }
+          expect(Encryptor).to receive(:decrypt).with('underlying', 'asdf', nil) { 'unencrypted' }
           expect(subject.sekret).to eq 'unencrypted'
         end
       end
 
       describe 'encryption' do
         it 'calls the salt generation method' do
-          expect(subject).to receive(:generate_sekret_salt)
+          expect(subject).to receive(:generate_sekret_salt).and_call_original
           subject.sekret = 'foobar'
         end
 
         context 'blank value' do
+          before do
+          end
+
           it 'stores a default nil value without trying to encrypt' do
             expect(Encryptor).to_not receive(:encrypt)
             [nil, ''].each do |blank_value|
-              subject.sekret = blank_value
-              expect(subject.underlying_sekret).to eq nil
+              subject.underlying_sekret = 'notanilvalue'
+              expect {
+                subject.sekret = blank_value
+              }.to change(subject, :underlying_sekret).to(nil)
             end
           end
         end
 
         context 'non-blank value' do
+          let(:salt) { Encryptor.generate_salt }
+          let(:unencrypted_string) { 'unencrypted' }
+
+          before do
+            Encryptor.database_encryption_keys = {
+                'foo' => 'fooencryptionkey',
+                'bar' => 'headbangingdeathmetalkey'
+            }
+          end
+
           it 'encrypts by passing the value and salt to Encryptor' do
-            subject.sekret_salt = 'asdf'
-            expect(Encryptor).to receive(:encrypt).with('unencrypted', 'asdf') { 'encrypted' }
-            subject.sekret = 'unencrypted'
+            subject.sekret_salt = salt
+            expect(Encryptor).to receive(:encrypt).with('unencrypted', salt) { 'encrypted' }
+            subject.sekret = unencrypted_string
             expect(subject.underlying_sekret).to eq 'encrypted'
+          end
+
+          it 'encrypts using the default db_encryption_key' do
+            subject.sekret_salt = salt
+            subject.sekret = unencrypted_string
+            expect(Encryptor.decrypt(subject.underlying_sekret, subject.sekret_salt)).to eq(unencrypted_string)
+          end
+
+          context 'model has a value for encryption_key_label' do
+            let(:columns) { [:sekret, :sekret_salt, :encryption_key_label] }
+
+            before do
+              allow(Encryptor).to receive(:current_encryption_key_label) { 'foo' }
+              subject.sekret_salt = salt
+              subject.encryption_key_label = 'foo'
+              subject.sekret = unencrypted_string
+              expect(subject.sekret).to eq(unencrypted_string)
+            end
+
+            it 'encrypts using the key corresponding to the label' do
+              subject.sekret_salt = salt
+              expect(Encryptor).to receive(:encrypt).with(unencrypted_string, salt).and_call_original
+              subject.sekret = unencrypted_string
+              expect(Encryptor.decrypt(subject.underlying_sekret, salt, 'foo')).to eq(unencrypted_string)
+            end
+
+            context 'and the key has been rotated' do
+              it 'updates encryption_key_label in the record when encrypting' do
+                allow(Encryptor).to receive(:current_encryption_key_label) { 'bar' }
+                subject.sekret = 'nu'
+                expect(subject.sekret).to eq('nu')
+                expect(subject.encryption_key_label).to eq(Encryptor.current_encryption_key_label)
+              end
+
+              context 'and the model has another encrypted field' do
+                let(:columns) { [:sekret, :sekret_salt, :sekret2, :sekret2_salt, :encryption_key_label] }
+                let(:unencrypted_string2) { 'announce presence with authority' }
+
+                before do
+                  klass.class_eval do
+                    def underlying_sekret2=(value)
+                      @sekret2 = value
+                    end
+
+                    def underlying_sekret2
+                      @sekret2
+                    end
+                  end
+                  klass2.send :set_field_as_encrypted, :sekret2, encryption_args
+                  subject.sekret2_salt = Encryptor.generate_salt
+                  subject.sekret2 = unencrypted_string2
+                end
+
+                it 'reencrypts that field with the new key' do
+                  allow(Encryptor).to receive(:current_encryption_key_label) { 'bar' }
+                  subject.sekret = 'nu'
+                  expect(Encryptor.decrypt(subject.underlying_sekret2, subject.sekret2_salt, 'bar')).to eq(unencrypted_string2)
+                end
+              end
+            end
           end
         end
       end
 
       describe 'alternative storage column is specified' do
-        let(:columns) { [:sekret, :sekret_salt, :encrypted_sekret] }
+        let(:columns) { [:sekret, :sekret_salt, :encrypted_sekret, :encryption_key_label] }
         let(:encryption_args) { { column: :encrypted_sekret } }
 
         it 'stores the encrypted value in that column' do

--- a/spec/unit/lib/cloud_controller/encryptor_spec.rb
+++ b/spec/unit/lib/cloud_controller/encryptor_spec.rb
@@ -39,8 +39,8 @@ module VCAP::CloudController
 
       context 'when database_encryption_keys has been set' do
         let(:salt) { 'FFFFFFFFFFFFFFFF' }
-        let(:encrypted_death_string) { 'NHQ+mjls1UHJBqpO0KWjTA==' }
-        let(:encrypted_legacy_string) { '1XJDJYNqWOKokyVx0WHZ/g==' }
+        let(:encrypted_death_string) { 'UsFVj9hjohvzOwlJQ4tqHA==' }
+        let(:encrypted_legacy_string) { 'a6FHdu9k3+CCSjvzIX+i7w==' }
 
         before(:each) do
           Encryptor.db_encryption_key = 'legacy-crypto-key'
@@ -72,7 +72,7 @@ module VCAP::CloudController
 
       context 'when database_encryption_keys has not been set' do
         let(:salt) { 'FFFFFFFFFFFFFFFF' }
-        let(:encrypted_legacy_string) { '1XJDJYNqWOKokyVx0WHZ/g==' }
+        let(:encrypted_legacy_string) { 'a6FHdu9k3+CCSjvzIX+i7w==' }
 
         before(:each) do
           Encryptor.db_encryption_key = 'legacy-crypto-key'


### PR DESCRIPTION
Implement DB encryption key rotation.  Includes reviewer-requested changes and keeps the 128 bit algo (as opposed to moving to 256).
