### PR TITLE
Add /v2/service_instances/:guid/shared_from

### DIFF
--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -1,18 +1,16 @@
 module VCAP::CloudController
   class ServiceInstanceAccess < BaseAccess
     def create?(service_instance, params=nil)
-      return false unless service_instance.space
       return true if admin_user?
       FeatureFlag.raise_unless_enabled!(:service_instance_creation)
       return false if service_instance.in_suspended_org?
-      service_instance.space.has_developer?(context.user) && allowed?(service_instance)
+      service_instance.space && service_instance.space.has_developer?(context.user) && allowed?(service_instance)
     end
 
     def read_for_update?(service_instance, params=nil)
-      return false unless service_instance.space
       return true if admin_user?
       return false if service_instance.in_suspended_org?
-      service_instance.space.has_developer?(context.user)
+      service_instance.space && service_instance.space.has_developer?(context.user)
     end
 
     def update?(service_instance, params=nil)
@@ -20,16 +18,14 @@ module VCAP::CloudController
     end
 
     def delete?(service_instance)
-      return false unless service_instance.space
       return true if admin_user?
       return false if service_instance.in_suspended_org?
-      service_instance.space.has_developer?(context.user)
+      service_instance.space && service_instance.space.has_developer?(context.user)
     end
 
     def manage_permissions?(service_instance)
-      return false unless service_instance.space
       return true if admin_user?
-      service_instance.space.has_developer?(context.user)
+      service_instance.space && service_instance.space.has_developer?(context.user)
     end
 
     def manage_permissions_with_token?(service_instance)
@@ -45,9 +41,8 @@ module VCAP::CloudController
     end
 
     def read_env?(service_instance)
-      return false unless service_instance.space
       return true if admin_user? || admin_read_only_user?
-      service_instance.space.has_developer?(context.user)
+      service_instance.space && service_instance.space.has_developer?(context.user)
     end
 
     def read_env_with_token?(service_instance)
@@ -68,8 +63,7 @@ module VCAP::CloudController
     end
 
     def purge?(service_instance)
-      return false unless service_instance.space
-      admin_user? || (service_instance.space.has_developer?(context.user) && service_instance.service_broker.private?)
+      admin_user? || (service_instance.space && service_instance.space.has_developer?(context.user) && service_instance.service_broker.private?)
     end
 
     def purge_with_token?(instance)

--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
     end
 
     def read_permissions?(service_instance)
-      read?(service_instance)
+      admin_user? || admin_read_only_user? || object_is_visible_to_user?(service_instance, context.user)
     end
 
     def read_permissions_with_token?(service_instance)

--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -4,13 +4,13 @@ module VCAP::CloudController
       return true if admin_user?
       FeatureFlag.raise_unless_enabled!(:service_instance_creation)
       return false if service_instance.in_suspended_org?
-      service_instance.space && service_instance.space.has_developer?(context.user) && allowed?(service_instance)
+      service_instance.space&.has_developer?(context.user) && allowed?(service_instance)
     end
 
     def read_for_update?(service_instance, params=nil)
       return true if admin_user?
       return false if service_instance.in_suspended_org?
-      service_instance.space && service_instance.space.has_developer?(context.user)
+      service_instance.space&.has_developer?(context.user)
     end
 
     def update?(service_instance, params=nil)
@@ -20,12 +20,12 @@ module VCAP::CloudController
     def delete?(service_instance)
       return true if admin_user?
       return false if service_instance.in_suspended_org?
-      service_instance.space && service_instance.space.has_developer?(context.user)
+      service_instance.space&.has_developer?(context.user)
     end
 
     def manage_permissions?(service_instance)
       return true if admin_user?
-      service_instance.space && service_instance.space.has_developer?(context.user)
+      service_instance.space&.has_developer?(context.user)
     end
 
     def manage_permissions_with_token?(service_instance)
@@ -42,7 +42,7 @@ module VCAP::CloudController
 
     def read_env?(service_instance)
       return true if admin_user? || admin_read_only_user?
-      service_instance.space && service_instance.space.has_developer?(context.user)
+      service_instance.space&.has_developer?(context.user)
     end
 
     def read_env_with_token?(service_instance)
@@ -63,7 +63,7 @@ module VCAP::CloudController
     end
 
     def purge?(service_instance)
-      admin_user? || (service_instance.space && service_instance.space.has_developer?(context.user) && service_instance.service_broker.private?)
+      admin_user? || (service_instance.space&.has_developer?(context.user) && service_instance.service_broker.private?)
     end
 
     def purge_with_token?(instance)

--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -37,9 +37,7 @@ module VCAP::CloudController
     end
 
     def read_permissions?(service_instance)
-      return false unless service_instance.space
-      return true if admin_user? || admin_read_only_user?
-      service_instance.space.has_member?(context.user) || service_instance.space.organization.managers.include?(context.user)
+      read?(service_instance)
     end
 
     def read_permissions_with_token?(service_instance)

--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -1,6 +1,7 @@
 module VCAP::CloudController
   class ServiceInstanceAccess < BaseAccess
     def create?(service_instance, params=nil)
+      return false unless service_instance.space
       return true if admin_user?
       FeatureFlag.raise_unless_enabled!(:service_instance_creation)
       return false if service_instance.in_suspended_org?
@@ -8,6 +9,7 @@ module VCAP::CloudController
     end
 
     def read_for_update?(service_instance, params=nil)
+      return false unless service_instance.space
       return true if admin_user?
       return false if service_instance.in_suspended_org?
       service_instance.space.has_developer?(context.user)
@@ -18,12 +20,14 @@ module VCAP::CloudController
     end
 
     def delete?(service_instance)
+      return false unless service_instance.space
       return true if admin_user?
       return false if service_instance.in_suspended_org?
       service_instance.space.has_developer?(context.user)
     end
 
     def manage_permissions?(service_instance)
+      return false unless service_instance.space
       return true if admin_user?
       service_instance.space.has_developer?(context.user)
     end
@@ -33,6 +37,7 @@ module VCAP::CloudController
     end
 
     def read_permissions?(service_instance)
+      return false unless service_instance.space
       return true if admin_user? || admin_read_only_user?
       service_instance.space.has_member?(context.user) || service_instance.space.organization.managers.include?(context.user)
     end
@@ -42,6 +47,7 @@ module VCAP::CloudController
     end
 
     def read_env?(service_instance)
+      return false unless service_instance.space
       return true if admin_user? || admin_read_only_user?
       service_instance.space.has_developer?(context.user)
     end
@@ -64,6 +70,7 @@ module VCAP::CloudController
     end
 
     def purge?(service_instance)
+      return false unless service_instance.space
       admin_user? || (service_instance.space.has_developer?(context.user) && service_instance.service_broker.private?)
     end
 

--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -1,0 +1,25 @@
+module VCAP::CloudController
+  class ServiceInstanceListFetcher
+    def fetch(message:, space_guids:)
+      dataset = ServiceInstance.select_all(ServiceInstance.table_name).
+                join(Space.table_name, id: :space_id, guid: space_guids)
+
+      filter(dataset, message)
+    end
+
+    def fetch_all(message:)
+      dataset = ServiceInstance.dataset
+      filter(dataset, message)
+    end
+
+    private
+
+    def filter(dataset, message)
+      if message.requested?(:names)
+        dataset = dataset.where(service_instances__name: message.names)
+      end
+
+      dataset
+    end
+  end
+end

--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -1,8 +1,13 @@
 module VCAP::CloudController
   class ServiceInstanceListFetcher
     def fetch(message:, space_guids:)
-      dataset = ServiceInstance.select_all(ServiceInstance.table_name).
-                join(Space.table_name, id: :space_id, guid: space_guids)
+      source_space_instance_dataset = ServiceInstance.select_all(ServiceInstance.table_name).
+                                      join(Space.table_name, id: :space_id, guid: space_guids)
+
+      shared_instance_dataset = ServiceInstance.select_all(ServiceInstance.table_name).
+                                join(:service_instance_shares, service_instance_guid: :guid, target_space_guid: space_guids)
+
+      dataset = source_space_instance_dataset.union(shared_instance_dataset, alias: :service_instances)
 
       filter(dataset, message)
     end

--- a/app/messages/service_instances/service_instances_list_message.rb
+++ b/app/messages/service_instances/service_instances_list_message.rb
@@ -1,0 +1,32 @@
+require 'messages/list_message'
+
+module VCAP::CloudController
+  class ServiceInstancesListMessage < ListMessage
+    ALLOWED_KEYS = [:page, :per_page, :order_by, :names].freeze
+
+    attr_accessor(*ALLOWED_KEYS)
+
+    validates_with NoAdditionalParamsValidator
+    validates :names, array: true, allow_nil: true
+
+    def initialize(params={})
+      super(params.symbolize_keys)
+    end
+
+    def self.from_params(params)
+      opts = params.dup
+      to_array! opts, 'names'
+      new(opts.symbolize_keys)
+    end
+
+    def valid_order_by_values
+      super << :name
+    end
+
+    private
+
+    def allowed_keys
+      ALLOWED_KEYS
+    end
+  end
+end

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -138,7 +138,7 @@ module VCAP::CloudController
     alias_method_chain :credentials, 'serialization'
 
     def in_suspended_org?
-      space && space.in_suspended_org?
+      space&.in_suspended_org?
     end
 
     def after_create

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -69,6 +69,9 @@ module VCAP::CloudController
         [:space, user.audited_spaces_dataset],
         [:space, user.managed_spaces_dataset],
         [:shared_spaces, user.spaces_dataset],
+        [:shared_spaces, user.managed_spaces_dataset],
+        [:shared_spaces, user.audited_spaces_dataset],
+        [:shared_spaces, managed_organizations_spaces_dataset(user.managed_organizations_dataset)],
       ])
     end
 

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -175,6 +175,10 @@ module VCAP::CloudController
       false
     end
 
+    def shared?
+      shared_spaces.any?
+    end
+
     def self.managed_organizations_spaces_dataset(managed_organizations_dataset)
       VCAP::CloudController::Space.dataset.filter({ organization_id: managed_organizations_dataset.select(:organization_id) })
     end

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -68,6 +68,7 @@ module VCAP::CloudController
         [:space, user.spaces_dataset],
         [:space, user.audited_spaces_dataset],
         [:space, user.managed_spaces_dataset],
+        [:shared_spaces, user.spaces_dataset],
       ])
     end
 

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -135,7 +135,7 @@ module VCAP::CloudController
     alias_method_chain :credentials, 'serialization'
 
     def in_suspended_org?
-      space.in_suspended_org?
+      space && space.in_suspended_org?
     end
 
     def after_create

--- a/app/presenters/v2/service_instance_presenter.rb
+++ b/app/presenters/v2/service_instance_presenter.rb
@@ -28,6 +28,7 @@ module CloudController
             obj_hash['service_plan_guid'] = service_plan.guid
             obj_hash['service_guid'] = service_plan.service.guid
             rel_hash['service_url'] = "/v2/services/#{service_plan.service.guid}"
+            rel_hash['shared_from_url'] = "/v2/service_instances/#{obj.guid}/shared_from"
           end
 
           obj_hash.merge!(rel_hash)

--- a/app/presenters/v2/service_instance_shared_from_presenter.rb
+++ b/app/presenters/v2/service_instance_shared_from_presenter.rb
@@ -1,0 +1,14 @@
+module CloudController
+  module Presenters
+    module V2
+      class ServiceInstanceSharedFromPresenter
+        def to_hash(space)
+          {
+            'space_name' => space.name,
+            'organization_name' => space.organization.name
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/v3/paginated_list_presenter.rb
+++ b/app/presenters/v3/paginated_list_presenter.rb
@@ -6,6 +6,7 @@ require 'presenters/v3/pagination_presenter'
 require 'presenters/v3/process_presenter'
 require 'presenters/v3/route_mapping_presenter'
 require 'presenters/v3/service_binding_presenter'
+require 'presenters/v3/service_instance_presenter'
 require 'presenters/v3/task_presenter'
 require 'presenters/v3/organization_presenter'
 require 'presenters/v3/space_presenter'
@@ -24,7 +25,8 @@ module VCAP::CloudController
           'PackageModel'          => VCAP::CloudController::Presenters::V3::PackagePresenter,
           'RouteMappingModel'     => VCAP::CloudController::Presenters::V3::RouteMappingPresenter,
           'ServiceBinding'        => VCAP::CloudController::Presenters::V3::ServiceBindingPresenter,
-          'TaskModel'             => VCAP::CloudController::Presenters::V3::TaskPresenter,
+          'ManagedServiceInstance' => VCAP::CloudController::Presenters::V3::ServiceInstancePresenter,
+          'TaskModel' => VCAP::CloudController::Presenters::V3::TaskPresenter,
         }.freeze
 
         def initialize(dataset:, path:, message: nil, show_secrets: false)

--- a/app/presenters/v3/service_instance_presenter.rb
+++ b/app/presenters/v3/service_instance_presenter.rb
@@ -1,0 +1,24 @@
+require 'presenters/v3/base_presenter'
+
+module VCAP::CloudController
+  module Presenters
+    module V3
+      class ServiceInstancePresenter < BasePresenter
+        def to_hash
+          {
+            guid:       service_instance.guid,
+            created_at: service_instance.created_at,
+            updated_at: service_instance.updated_at,
+            name:      service_instance.name
+          }
+        end
+
+        private
+
+        def service_instance
+          @resource
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
   get '/apps/:app_guid/tasks', to: 'tasks#index'
 
   # service_instances
+  get '/service_instances', to: 'service_instances_v3#index'
   post '/service_instances/:service_instance_guid/relationships/shared_spaces', to: 'service_instances_v3#share_service_instance'
   delete '/service_instances/:service_instance_guid/relationships/shared_spaces/:space_guid', to: 'service_instances_v3#unshare_service_instance'
 end

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -876,6 +876,9 @@
         <a href="service_instances/retrieving_permissions_on_a_service_instance.html">Retrieving permissions on a Service Instance</a>
       </li>
       <li>
+        <a href="service_instances/retrieve_info_where_service_instance_is_shared_from.html">Retrieve Information Regarding Where a Service Instance is Shared From (Experimental)</a>
+      </li>
+      <li>
         <a href="service_instances/unbinding_a_service_instance_from_a_route.html">Unbinding a service instance from a route</a>
       </li>
       <li>

--- a/docs/v2/service_instances/binding_a_service_instance_to_a_route.html
+++ b/docs/v2/service_instances/binding_a_service_instance_to_a_route.html
@@ -164,7 +164,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/4cfefd27-3eb7-4f55-806e-1db649038ad2",
     "service_bindings_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/service_bindings",
     "service_keys_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/service_keys",
-    "routes_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/routes"
+    "routes_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/routes",
+    "shared_from_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_instances/creating_a_service_instance.html
+++ b/docs/v2/service_instances/creating_a_service_instance.html
@@ -559,6 +559,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -608,7 +624,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/fe173a83-df28-4891-8d91-46334e04600d",
     "service_bindings_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/service_bindings",
     "service_keys_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/service_keys",
-    "routes_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/routes"
+    "routes_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_instances/delete_a_service_instance.html
+++ b/docs/v2/service_instances/delete_a_service_instance.html
@@ -463,6 +463,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -512,7 +528,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/8ea19d29-2e20-469e-8b91-917a6410e2f2",
     "service_bindings_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/service_bindings",
     "service_keys_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/service_keys",
-    "routes_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/routes"
+    "routes_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/routes",
+    "shared_from_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_instances/list_all_service_instances.html
+++ b/docs/v2/service_instances/list_all_service_instances.html
@@ -514,6 +514,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -571,7 +587,8 @@ Cookie: </pre>
         "service_plan_url": "/v2/service_plans/05a372c6-6dc2-4f7f-8f65-a90ebe5fa6e2",
         "service_bindings_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/service_bindings",
         "service_keys_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/service_keys",
-        "routes_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/routes"
+        "routes_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/routes",
+        "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
       }
     }
   ]

--- a/docs/v2/service_instances/retrieve_a_particular_service_instance.html
+++ b/docs/v2/service_instances/retrieve_a_particular_service_instance.html
@@ -370,6 +370,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -421,7 +437,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1",
     "service_bindings_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/service_bindings",
     "service_keys_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/service_keys",
-    "routes_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/routes"
+    "routes_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_from.html
+++ b/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_from.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Service Instances API</title>
+  <meta charset="utf-8">
+  <link id="bootstrapcss" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" />
+  <script>
+    if( "file:" == document.location.protocol ) {
+      var csslink = document.getElementById("bootstrapcss");
+      csslink.href = "http://" + csslink.href.replace(/.*\/\//, "");
+    }
+  </script>
+  <style>
+    p {
+      padding: 15px;
+      font-size: 130%;
+    }
+
+    pre {
+      white-space: pre;
+    }
+
+    td.required .name:after {
+      float: right;
+      content: " required";
+      font-weight: normal;
+      color: #F08080;
+    }
+
+    td.experimental:after {
+      float: right;
+      content: " experimental";
+      font-weight: normal;
+      color: #FFA500;
+      padding: 2px;
+    }
+
+    tr.deprecated td:first-child:before {
+      content: "deprecated: ";
+      font-weight: bold;
+      color: gray;
+    }
+
+    tr.deprecated span, tr.deprecated ul {
+      text-decoration: line-through;
+      color: gray;
+    }
+
+    tr.readonly .name:after {
+      float: right;
+      content: " read-only";
+      font-weight: normal;
+    }
+
+    tr.readonly {
+      color: grey;
+    }
+
+    table ul {
+      padding-left: 1.2em;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>Service Instances API</h1>
+
+  <div class="article">
+    <h2>Retrieve Information Regarding Where a Service Instance is Shared From (Experimental)</h2>
+    <h3>GET /v2/service_instances/:guid/shared_from</h3>
+
+      <h3>Request</h3>
+      <h4>Route</h4>
+      <pre class="request route highlight">GET /v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from</pre>
+
+      <h4>Headers</h4>
+      <pre class="request headers">Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTE1MCIsImVtYWlsIjoiZW1haWwtMTA1QHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg4ODl9.eyvSz10WWSQt0pFotoQI2Lm5XdH22-50O_R8rxy7n4k
+Host: example.org
+Cookie: </pre>
+
+        <h4>cURL</h4>
+        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from&quot; -X GET \
+	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTE1MCIsImVtYWlsIjoiZW1haWwtMTA1QHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg4ODl9.eyvSz10WWSQt0pFotoQI2Lm5XdH22-50O_R8rxy7n4k&quot; \
+	-H &quot;Host: example.org&quot; \
+	-H &quot;Cookie: &quot;</pre>
+
+        <h3>Response</h3>
+
+        <h4>Status</h4>
+        <pre class="response status">200 OK</pre>
+
+          <h4>Body</h4>
+          <table class="response-fields table table-striped table-bordered table-condensed">
+            <thead>
+            <tr>
+              <th>Name</th>
+              <th>Description</th>
+              <th>Valid Values</th>
+              <th>Example Values</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr class="">
+                <td>
+                    <span class="name">space_name</span>
+                </td>
+                <td>
+                  <span class="description">The space name that this service instance belongs to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
+                    <span class="name">organization_name</span>
+                </td>
+                <td>
+                  <span class="description">The organization name that this service instance belongs to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <pre class="response body">{
+    "space_name": "space-name",
+    "organization_name": "org-name"
+}
+</pre>
+
+        <h4>Headers</h4>
+        <pre class="response headers">Content-Type: application/json;charset=utf-8
+X-VCAP-Request-ID: febb14ab-a7bc-492d-b017-3db59d83967d
+Content-Length: 253
+X-Content-Type-Options: nosniff</pre>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/v2/service_instances/update_a_service_instance.html
+++ b/docs/v2/service_instances/update_a_service_instance.html
@@ -501,6 +501,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -549,7 +565,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/4ec73bf4-9f3a-44c7-bbac-61ee9cb5a511",
     "service_bindings_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/service_bindings",
     "service_keys_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/service_keys",
-    "routes_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/routes"
+    "routes_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_plans/list_all_service_instances_for_the_service_plan.html
+++ b/docs/v2/service_plans/list_all_service_instances_for_the_service_plan.html
@@ -303,7 +303,8 @@ Cookie: </pre>
         "service_plan_url": "/v2/service_plans/85615ea0-9d23-4de8-aabd-89bffcce39d5",
         "service_bindings_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/service_bindings",
         "service_keys_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/service_keys",
-        "routes_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/routes"
+        "routes_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/routes",
+        "shared_from_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from"
       }
     }
   ]

--- a/docs/v2/spaces/list_all_service_instances_for_the_space.html
+++ b/docs/v2/spaces/list_all_service_instances_for_the_space.html
@@ -302,7 +302,8 @@ Cookie: </pre>
         "service_plan_url": "/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab",
         "service_bindings_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_bindings",
         "service_keys_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_keys",
-        "routes_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/routes"
+        "routes_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/routes",
+        "shared_from_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from"
       }
     }
   ]

--- a/docs/v3/source/includes/api_resources/_service_instances.erb
+++ b/docs/v3/source/includes/api_resources/_service_instances.erb
@@ -18,3 +18,28 @@
   }
 }
 <% end %>
+
+<% content_for :paginated_list_of_service_instances do %>
+{
+  "pagination": {
+    "total_results": 1,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "d4c91047-7b29-4fda-b7f9-04033e5c9c9f",
+      "created_at": "2017-02-02T00:14:30Z",
+      "updated_at": "2017-02-02T00:14:30Z",
+      "name": "my_service_instance"
+    }
+  ]
+}
+<% end %>

--- a/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
@@ -20,7 +20,7 @@ Content-Type: application/json
 
 <%= yield_content :paginated_list_of_service_instances, '/v3/service_instances' %>
 ```
-This endpoint retrieves the service instances the user has access to.
+This endpoint retrieves the service instances the user has access to. This includes access granted by service instance sharing.
 
 #### Definition
 `GET /v3/service_instances`

--- a/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
@@ -20,7 +20,9 @@ Content-Type: application/json
 
 <%= yield_content :paginated_list_of_service_instances, '/v3/service_instances' %>
 ```
-This endpoint retrieves the service instances the user has access to. This includes access granted by service instance sharing.
+This endpoint retrieves the service instances the user has access to. At the moment, this endpoint only returns managed service instances. This may change in the future.
+
+This includes access granted by service instance sharing.
 
 #### Definition
 `GET /v3/service_instances`

--- a/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
@@ -1,0 +1,34 @@
+### List service instances
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/service_instances" \
+  -X GET \
+  -H "Authorization: bearer [token]"
+```
+
+```
+Example Response
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+<%= yield_content :paginated_list_of_service_instances, '/v3/service_instances' %>
+```
+This endpoint retrieves the service instances the user has access to.
+
+#### Definition
+`GET /v3/service_instances`
+
+#### Query Parameters
+
+Name | Type | Description
+---- | ---- | ------------
+**name** | _list of strings_ | Comma-delimited list of service instance names to filter by.
+**page** | _integer_ | Page to display. Valid values are integers >= 1.
+**per_page** | _integer_ | Number of results per page. <br>Valid values are 1 through 5000.

--- a/docs/v3/source/index.md
+++ b/docs/v3/source/index.md
@@ -137,6 +137,7 @@ includes:
   - experimental_resources/service_bindings/delete
   - experimental_resources/service_bindings/list
   - experimental_resources/service_instances/header
+  - experimental_resources/service_instances/list
   - experimental_resources/service_instances/share_to_space
   - experimental_resources/service_instances/unshare_from_space
 search: true

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -2,11 +2,89 @@ require 'spec_helper'
 
 RSpec.describe 'Service Instances' do
   let(:user_email) { 'user@email.example.com' }
-  let(:user_name) { 'sharer_username' }
+  let(:user_name) { 'username' }
   let(:user) { VCAP::CloudController::User.make }
+  let(:user_header) { headers_for(user) }
   let(:admin_header) { admin_headers_for(user, email: user_email, user_name: user_name) }
+  let(:space) { VCAP::CloudController::Space.make }
   let(:target_space) { VCAP::CloudController::Space.make }
-  let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make }
+  let!(:service_instance1) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'rabbitmq') }
+  let!(:service_instance2) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'redis') }
+  let!(:service_instance3) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'mysql') }
+
+  describe 'GET /v3/service_instances' do
+    it 'returns a paginated list of service instances the user has access to' do
+      set_current_user_as_role(role: 'space_developer', org: space.organization, space: space, user: user)
+      get '/v3/service_instances?per_page=2&order_by=name', nil, user_header
+      expect(last_response.status).to eq(200)
+
+      parsed_response = MultiJson.load(last_response.body)
+      expect(parsed_response).to be_a_response_like(
+        {
+          'pagination' => {
+            'total_results' => 3,
+            'total_pages' => 2,
+            'first' => {
+              'href' => "#{link_prefix}/v3/service_instances?order_by=name&page=1&per_page=2"
+            },
+            'last' => {
+              'href' => "#{link_prefix}/v3/service_instances?order_by=name&page=2&per_page=2"
+            },
+            'next' => {
+              'href' => "#{link_prefix}/v3/service_instances?order_by=name&page=2&per_page=2"
+            },
+            'previous' => nil
+          },
+          'resources' => [
+            {
+              'guid' => service_instance3.guid,
+              'name' => 'mysql',
+              'created_at' => iso8601,
+              'updated_at' => iso8601,
+            },
+            {
+              'guid' => service_instance1.guid,
+              'name' => 'rabbitmq',
+              'created_at' => iso8601,
+              'updated_at' => iso8601,
+            }
+          ]
+        }
+      )
+    end
+
+    it 'returns a paginated list of service instances filtered by name' do
+      set_current_user_as_role(role: 'space_developer', org: space.organization, space: space, user: user)
+      get '/v3/service_instances?per_page=2&names=redis', nil, user_header
+      expect(last_response.status).to eq(200)
+
+      parsed_response = MultiJson.load(last_response.body)
+      expect(parsed_response).to be_a_response_like(
+        {
+          'pagination' => {
+            'total_results' => 1,
+            'total_pages' => 1,
+            'first' => {
+              'href' => "#{link_prefix}/v3/service_instances?names=redis&page=1&per_page=2"
+            },
+            'last' => {
+              'href' => "#{link_prefix}/v3/service_instances?names=redis&page=1&per_page=2"
+            },
+            'next' => nil,
+            'previous' => nil
+          },
+          'resources' => [
+            {
+              'guid' => service_instance2.guid,
+              'name' => 'redis',
+              'created_at' => iso8601,
+              'updated_at' => iso8601,
+            }
+          ]
+        }
+      )
+    end
+  end
 
   describe 'POST /v3/service_instances/:guid/relationships/shared_spaces' do
     before do
@@ -20,7 +98,7 @@ RSpec.describe 'Service Instances' do
         ]
       }
 
-      post "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces", share_request.to_json, admin_header
+      post "/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces", share_request.to_json, admin_header
 
       parsed_response = MultiJson.load(last_response.body)
       expect(last_response.status).to eq(200)
@@ -30,8 +108,8 @@ RSpec.describe 'Service Instances' do
           { 'guid' => target_space.guid }
         ],
         'links' => {
-          'self' => { 'href' => "#{link_prefix}/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces" },
-          'related' => { 'href' => "#{link_prefix}/v3/service_instances/#{service_instance.guid}/shared_spaces" },
+          'self' => { 'href' => "#{link_prefix}/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces" },
+          'related' => { 'href' => "#{link_prefix}/v3/service_instances/#{service_instance1.guid}/shared_spaces" },
         }
       }
 
@@ -44,11 +122,11 @@ RSpec.describe 'Service Instances' do
         actor_type:        'user',
         actor_name:        user_email,
         actor_username:    user_name,
-        actee:             service_instance.guid,
+        actee:             service_instance1.guid,
         actee_type:        'service_instance',
-        actee_name:        service_instance.name,
-        space_guid:        service_instance.space.guid,
-        organization_guid: service_instance.space.organization.guid
+        actee_name:        service_instance1.name,
+        space_guid:        space.guid,
+        organization_guid: space.organization.guid
       })
       expect(event.metadata['target_space_guids']).to eq([target_space.guid])
     end
@@ -68,12 +146,12 @@ RSpec.describe 'Service Instances' do
         ]
       }
 
-      post "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces", share_request.to_json, admin_header
+      post "/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces", share_request.to_json, admin_header
       expect(last_response.status).to eq(200)
     end
 
     it 'unshares the service instance from the target space' do
-      delete "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces/#{target_space.guid}", nil, admin_header
+      delete "/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces/#{target_space.guid}", nil, admin_header
       expect(last_response.status).to eq(204)
 
       event = VCAP::CloudController::Event.last
@@ -83,23 +161,23 @@ RSpec.describe 'Service Instances' do
         actor_type:        'user',
         actor_name:        user_email,
         actor_username:    user_name,
-        actee:             service_instance.guid,
+        actee:             service_instance1.guid,
         actee_type:        'service_instance',
-        actee_name:        service_instance.name,
-        space_guid:        service_instance.space.guid,
-        organization_guid: service_instance.space.organization.guid
+        actee_name:        service_instance1.name,
+        space_guid:        space.guid,
+        organization_guid: space.organization.guid
       })
       expect(event.metadata['target_space_guid']).to eq(target_space.guid)
     end
 
     it 'deletes associated bindings in target space when service instance is unshared' do
       process = VCAP::CloudController::ProcessModelFactory.make(diego: false, space: target_space)
-      service_binding = VCAP::CloudController::ServiceBinding.make(service_instance: service_instance, app: process.app, credentials: { secret: 'key' })
+      service_binding = VCAP::CloudController::ServiceBinding.make(service_instance: service_instance1, app: process.app, credentials: { secret: 'key' })
 
       get "/v2/service_bindings/#{service_binding.guid}", nil, admin_header
       expect(last_response.status).to eq(200)
 
-      delete "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces/#{target_space.guid}", nil, admin_header
+      delete "/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces/#{target_space.guid}", nil, admin_header
       expect(last_response.status).to eq(204)
 
       get "/v2/service_bindings/#{service_binding.guid}", nil, admin_header

--- a/spec/request/v2/service_bindings_spec.rb
+++ b/spec/request/v2/service_bindings_spec.rb
@@ -197,7 +197,8 @@ RSpec.describe 'ServiceBindings' do
                       'service_plan_url' => "/v2/service_plans/#{service_instance.service_plan.guid}",
                       'service_bindings_url' => "/v2/service_instances/#{service_instance.guid}/service_bindings",
                       'service_keys_url' => "/v2/service_instances/#{service_instance.guid}/service_keys",
-                      'routes_url' => "/v2/service_instances/#{service_instance.guid}/routes"
+                      'routes_url' => "/v2/service_instances/#{service_instance.guid}/routes",
+                      'shared_from_url' => "/v2/service_instances/#{service_instance.guid}/shared_from"
                     }
                   }
                 }

--- a/spec/request/v2/spaces_spec.rb
+++ b/spec/request/v2/spaces_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Spaces' do
         space.add_developer(user)
       end
 
-      it 'lists the isolation segment for SpaceDvelopers' do
+      it 'lists the isolation segment for SpaceDevelopers' do
         get "/v2/spaces/#{space.guid}", {}, headers_for(user)
 
         expect(last_response.status).to eq(200)
@@ -167,6 +167,62 @@ RSpec.describe 'Spaces' do
           }
         })
       end
+    end
+  end
+
+  describe 'GET /v2/spaces/:guid/service_instances' do
+    let(:originating_space) { VCAP::CloudController::Space.make }
+    let(:shared_service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: originating_space) }
+    let(:space) { VCAP::CloudController::Space.make }
+
+    before do
+      originating_space.organization.add_user(user)
+      originating_space.add_developer(user)
+      space.organization.add_user(user)
+      space.add_developer(user)
+
+      shared_service_instance.add_shared_space(space)
+    end
+
+    it 'shows the shared service instances associated with the space' do
+      get "/v2/spaces/#{space.guid}/service_instances", {}, headers_for(user)
+
+      expect(last_response.status).to eq(200)
+      parsed_response = MultiJson.load(last_response.body)
+
+      expect(parsed_response).to be_a_response_like({
+        'total_results' => 1,
+        'total_pages'   => 1,
+        'prev_url'      => nil,
+        'next_url'      => nil,
+        'resources'     => [{
+          'metadata' => {
+            'guid' => shared_service_instance.guid,
+            'url' => "/v2/service_instances/#{shared_service_instance.guid}",
+            'created_at' => iso8601,
+            'updated_at' => iso8601,
+          },
+          'entity' => {
+            'name' => shared_service_instance.name,
+            'credentials' => shared_service_instance.credentials,
+            'service_plan_guid' => shared_service_instance.service_plan_guid,
+            'space_guid' => originating_space.guid,
+            'gateway_data' => nil,
+            'dashboard_url' => nil,
+            'type' => 'managed_service_instance',
+            'last_operation' => nil,
+            'tags' => [],
+            'service_guid' => shared_service_instance.service_plan.service_guid,
+            'space_url' => "/v2/spaces/#{originating_space.guid}",
+            'service_plan_url' => "/v2/service_plans/#{shared_service_instance.service_plan_guid}",
+            'service_bindings_url' => "/v2/service_instances/#{shared_service_instance.guid}/service_bindings",
+            'service_keys_url' => "/v2/service_instances/#{shared_service_instance.guid}/service_keys",
+            'routes_url' => "/v2/service_instances/#{shared_service_instance.guid}/routes",
+            'service_url' => "/v2/services/#{shared_service_instance.service_plan.service_guid}",
+            'shared_from_url' => "/v2/service_instances/#{shared_service_instance.guid}/shared_from"
+          }
+        }]
+      })
     end
   end
 

--- a/spec/unit/access/service_instance_access_spec.rb
+++ b/spec/unit/access/service_instance_access_spec.rb
@@ -149,6 +149,63 @@ module VCAP::CloudController
       end
     end
 
+    context 'space developer in a space that the service instance has been shared into' do
+      before do
+        org.add_user(user)
+        target_space = VCAP::CloudController::Space.make(organization: org)
+        target_space.add_developer(user)
+        service_instance.add_shared_space(target_space)
+      end
+
+      context 'when the space of the service instance is visible' do
+        it_behaves_like :read_only_access do
+          let(:object) { service_instance }
+        end
+
+        it 'does NOT allow the user to have manage permissions of the service instance' do
+          expect(subject).to_not allow_op_on_object(:manage_permissions, service_instance)
+        end
+
+        it 'allows the user to have read permissions of the service instance' do
+          expect(subject).to allow_op_on_object(:read_permissions, service_instance)
+        end
+
+        it 'does NOT allow the user to read default credentials of the service instance' do
+          expect(subject).not_to allow_op_on_object(:read_env, service_instance)
+        end
+
+        it 'returns false for purge' do
+          expect(subject).not_to allow_op_on_object(:purge, service_instance)
+        end
+      end
+
+      context 'when the space of the service instance is not visible' do
+        before do
+          service_instance.space = nil
+        end
+
+        it_behaves_like :read_only_access do
+          let(:object) { service_instance }
+        end
+
+        it 'does NOT allow the user to have manage permissions of the service instance' do
+          expect(subject).to_not allow_op_on_object(:manage_permissions, service_instance)
+        end
+
+        it 'allows the user to have read permissions of the service instance' do
+          expect(subject).to allow_op_on_object(:read_permissions, service_instance)
+        end
+
+        it 'does NOT allow the user to read default credentials of the service instance' do
+          expect(subject).not_to allow_op_on_object(:read_env, service_instance)
+        end
+
+        it 'returns false for purge' do
+          expect(subject).not_to allow_op_on_object(:purge, service_instance)
+        end
+      end
+    end
+
     context 'organization manager (defensive)' do
       before { org.add_manager(user) }
 

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -223,6 +223,14 @@ module VCAP::CloudController
 
       before { set_current_user(developer) }
 
+      it 'returns the shared from url' do
+        space_instance = ManagedServiceInstance.make(space: space)
+
+        get "/v2/spaces/#{space.guid}/service_instances"
+        service_instance_response = decoded_response.fetch('resources').first
+        expect(service_instance_response.fetch('entity').fetch('shared_from_url')).to eq("/v2/service_instances/#{space_instance.guid}/shared_from")
+      end
+
       context 'when filtering results' do
         it 'returns only matching results' do
           user_provided_service_instance_1 = UserProvidedServiceInstance.make(space: space, name: 'provided service 1')

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3404,7 +3404,7 @@ module VCAP::CloudController
             'org_manager'         => { manage: false, read: true },
             'admin'               => { manage: true, read: true },
             'admin_read_only'     => { manage: false, read: true },
-            'global_auditor'      => { manage: false, read: true },
+            'global_auditor'      => { manage: false, read: false },
           }.each do |role, expected_return_values|
             context "as an #{role}" do
               before do

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3404,7 +3404,7 @@ module VCAP::CloudController
             'org_manager'         => { manage: false, read: true },
             'admin'               => { manage: true, read: true },
             'admin_read_only'     => { manage: false, read: true },
-            'global_auditor'      => { manage: false, read: false },
+            'global_auditor'      => { manage: false, read: true },
           }.each do |role, expected_return_values|
             context "as an #{role}" do
               before do

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -2,6 +2,49 @@ require 'rails_helper'
 
 RSpec.describe ServiceInstancesV3Controller, type: :controller do
   let(:user) { set_current_user(VCAP::CloudController::User.make) }
+  let(:space) { VCAP::CloudController::Space.make }
+  let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'awesome service') }
+
+  describe '#index' do
+    describe 'permissions by role' do
+      role_to_expected_http_response = {
+        'admin'               => true,
+        'admin_read_only'     => true,
+        'global_auditor'      => true,
+        'org_manager'         => true,
+        'org_auditor'         => false,
+        'org_billing_manager' => false,
+        'space_manager'       => true,
+        'space_auditor'       => true,
+        'space_developer'     => true,
+      }.freeze
+
+      role_to_expected_http_response.each do |role, can_see_service_instance|
+        context "as an #{role}" do
+          it "#{can_see_service_instance ? 'can' : 'cannot'} see the service instance" do
+            set_current_user_as_role(role: role, org: space.organization, space: space, user: user)
+
+            expected_service_instance_names = can_see_service_instance ? ['awesome service'] : []
+
+            get :index
+            expect(response.status).to eq(200), response.body
+            expect(parsed_body['resources'].map { |h| h['name'] }).to match_array(expected_service_instance_names)
+          end
+        end
+      end
+    end
+
+    context 'when a non-supported value is specified' do
+      it 'a bad query parameter error is returned' do
+        set_current_user_as_admin
+        get :index, { order_by: 'banana' }
+
+        expect(response.status).to eq(400)
+        expect(response.body).to include 'BadQueryParameter'
+        expect(response.body).to include("Order by can only be: 'created_at', 'updated_at', 'name'")
+      end
+    end
+  end
 
   describe '#share_service_instance' do
     let(:service_instance) { VCAP::CloudController::ServiceInstance.make }

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -3,9 +3,44 @@ require 'rails_helper'
 RSpec.describe ServiceInstancesV3Controller, type: :controller do
   let(:user) { set_current_user(VCAP::CloudController::User.make) }
   let(:space) { VCAP::CloudController::Space.make }
-  let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'awesome service') }
+  let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
 
   describe '#index' do
+    context 'when there are multiple service instances' do
+      let!(:service_instance2) { VCAP::CloudController::ManagedServiceInstance.make }
+      let!(:service_instance3) { VCAP::CloudController::ManagedServiceInstance.make }
+
+      context 'as an admin' do
+        before do
+          set_current_user_as_admin
+        end
+
+        it 'returns all service instances' do
+          get :index
+          expect(response.status).to eq(200), response.body
+          expect(parsed_body['resources'].length).to eq 3
+
+          response_names = parsed_body['resources'].map { |resource| resource['name'] }
+          expect(response_names).to include(service_instance.name, service_instance2.name, service_instance3.name)
+        end
+      end
+
+      context 'as a user who only has limited access' do
+        before do
+          set_current_user_as_role(role: 'space_developer', org: space.organization, space: space, user: user)
+        end
+
+        it 'returns a subset of service instances' do
+          get :index
+          expect(response.status).to eq(200), response.body
+          expect(parsed_body['resources'].length).to eq 1
+
+          response_names = parsed_body['resources'].map { |resource| resource['name'] }
+          expect(response_names).to include(service_instance.name)
+        end
+      end
+    end
+
     describe 'permissions by role' do
       role_to_expected_http_response = {
         'admin'               => true,
@@ -24,7 +59,36 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
           it "#{can_see_service_instance ? 'can' : 'cannot'} see the service instance" do
             set_current_user_as_role(role: role, org: space.organization, space: space, user: user)
 
-            expected_service_instance_names = can_see_service_instance ? ['awesome service'] : []
+            expected_service_instance_names = can_see_service_instance ? [service_instance.name] : []
+
+            get :index
+            expect(response.status).to eq(200), response.body
+            expect(parsed_body['resources'].map { |h| h['name'] }).to match_array(expected_service_instance_names)
+          end
+        end
+      end
+    end
+
+    describe 'permissions by role for shared services' do
+      let(:target_space) { VCAP::CloudController::Space.make }
+      before do
+        service_instance.add_shared_space(target_space)
+      end
+      role_to_expected_http_response = {
+        'org_manager'         => true,
+        'org_auditor'         => false,
+        'org_billing_manager' => false,
+        'space_manager'       => true,
+        'space_auditor'       => true,
+        'space_developer'     => true,
+      }.freeze
+
+      role_to_expected_http_response.each do |role, can_see_service_instance|
+        context "as an #{role}" do
+          it "#{can_see_service_instance ? 'can' : 'cannot'} see the service instance" do
+            set_current_user_as_role(role: role, org: target_space.organization, space: target_space, user: user)
+
+            expected_service_instance_names = can_see_service_instance ? [service_instance.name] : []
 
             get :index
             expect(response.status).to eq(200), response.body

--- a/spec/unit/messages/service_instances_list_message_spec.rb
+++ b/spec/unit/messages/service_instances_list_message_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'messages/service_instances/service_instances_list_message'
+
+module VCAP::CloudController
+  RSpec.describe ServiceInstancesListMessage do
+    describe '.from_params' do
+      let(:params) do
+        {
+          'page'      => 1,
+          'per_page'  => 5,
+          'order_by'  => 'name',
+          'names' => 'rabbitmq, redis,mysql'
+        }
+      end
+
+      it 'returns the correct ServiceInstancesListMessage' do
+        message = ServiceInstancesListMessage.from_params(params)
+
+        expect(message).to be_a(ServiceInstancesListMessage)
+        expect(message.page).to eq(1)
+        expect(message.per_page).to eq(5)
+        expect(message.order_by).to eq('name')
+        expect(message.names).to match_array(['mysql', 'rabbitmq', 'redis'])
+      end
+
+      it 'converts requested keys to symbols' do
+        message = ServiceInstancesListMessage.from_params(params)
+
+        expect(message.requested?(:page)).to be_truthy
+        expect(message.requested?(:per_page)).to be_truthy
+        expect(message.requested?(:order_by)).to be_truthy
+        expect(message.requested?(:names)).to be_truthy
+      end
+    end
+
+    describe 'fields' do
+      it 'accepts a set of fields' do
+        message = ServiceInstancesListMessage.new({
+            page: 1,
+            per_page: 5,
+            order_by: 'created_at',
+            names: ['rabbitmq', 'redis']
+          })
+        expect(message).to be_valid
+      end
+
+      it 'accepts an empty set' do
+        message = ServiceInstancesListMessage.new
+        expect(message).to be_valid
+      end
+
+      it 'does not accept a field not in this set' do
+        message = ServiceInstancesListMessage.new({ foobar: 'pants' })
+
+        expect(message).not_to be_valid
+        expect(message.errors[:base]).to include("Unknown query parameter(s): 'foobar'")
+      end
+    end
+  end
+end

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -432,5 +432,23 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe '#shared?' do
+      context 'when the service instance has shared spaces' do
+        before do
+          service_instance.add_shared_space(Space.make)
+        end
+
+        it 'returns true' do
+          expect(service_instance.shared?).to be true
+        end
+      end
+
+      context 'when the service instance does not have shared spaces' do
+        it 'returns false' do
+          expect(service_instance.shared?).to be false
+        end
+      end
+    end
   end
 end

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -326,5 +326,48 @@ module VCAP::CloudController
         expect(service_instance.to_hash(opts)['credentials']).to eq({ redacted_message: '[PRIVATE DATA HIDDEN]' })
       end
     end
+
+    describe '#user_visibility_filter' do
+      let(:developer)     { make_developer_for_space(service_instance.space) }
+      let(:auditor)       { make_auditor_for_space(service_instance.space) }
+      let(:user)          { make_user_for_space(service_instance.space) }
+      let(:org_manager)   { make_manager_for_org(service_instance.space.organization) }
+      let(:space_manager) { make_manager_for_space(service_instance.space) }
+
+      context 'when a user is an org manager where the instance was created' do
+        it 'the service instance is visible' do
+          filter = ServiceInstance.user_visibility_filter(org_manager)
+          expect(ServiceInstance.filter(filter).all.length).to eq(1)
+        end
+      end
+
+      context 'when a user is a space developer in the space the instance was created' do
+        it 'the service instance is visible' do
+          filter = ServiceInstance.user_visibility_filter(developer)
+          expect(ServiceInstance.filter(filter).all.length).to eq(1)
+        end
+      end
+
+      context 'when a user is a space auditor in the space the instance was created' do
+        it 'the service instance is visible' do
+          filter = ServiceInstance.user_visibility_filter(auditor)
+          expect(ServiceInstance.filter(filter).all.length).to eq(1)
+        end
+      end
+
+      context 'when a user is a space manager in the space the instance was created' do
+        it 'the service instance is visible' do
+          filter = ServiceInstance.user_visibility_filter(space_manager)
+          expect(ServiceInstance.filter(filter).all.length).to eq(1)
+        end
+      end
+
+      context 'when a user does not have access to the originating space' do
+        it 'the service instance is not visible' do
+          filter = ServiceInstance.user_visibility_filter(user)
+          expect(ServiceInstance.filter(filter).all.length).to eq(0)
+        end
+      end
+    end
   end
 end

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -368,6 +368,30 @@ module VCAP::CloudController
           expect(ServiceInstance.filter(filter).all.length).to eq(0)
         end
       end
+
+      context 'when the service instance is shared' do
+        let(:target_space)     { VCAP::CloudController::Space.make }
+        let(:target_space_dev) { make_developer_for_space(target_space) }
+        let(:target_space_auditor) { make_auditor_for_space(target_space) }
+
+        before do
+          service_instance.add_shared_space(target_space)
+        end
+
+        context 'when a user is a space developer in the target space' do
+          it 'the service instance is visible' do
+            filter = ServiceInstance.user_visibility_filter(target_space_dev)
+            expect(ServiceInstance.filter(filter).all.length).to eq(1)
+          end
+        end
+
+        context 'when a user is a space auditor in the target space' do
+          it 'the service instance is not visible' do
+            filter = ServiceInstance.user_visibility_filter(target_space_auditor)
+            expect(ServiceInstance.filter(filter).all.length).to eq(0)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/unit/presenters/v2/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_presenter_spec.rb
@@ -11,35 +11,48 @@ module CloudController::Presenters::V2
     let(:relations_hash) { { 'relationship_url' => 'http://relationship.example.com' } }
     subject { ServiceInstancePresenter.new }
 
-    describe '#entity_hash' do
-      before do
-        set_current_user_as_admin
+    before do
+      set_current_user_as_admin
+      allow(RelationsPresenter).to receive(:new).and_return(relations_presenter)
+    end
+
+    describe 'ManagedServiceInstance' do
+      describe '#entity_hash' do
+        let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make }
+        let(:service_plan) { VCAP::CloudController::ServicePlan.make }
+
+        before do
+          service_instance.service_plan_id = service_plan.id
+          service_instance.save
+        end
+
+        it 'returns the service instance entity' do
+          expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)).to eq(
+            {
+              'name'              => service_instance.name,
+              'service_plan_guid' => service_plan.guid,
+              'service_guid'      => service_plan.service.guid,
+              'relationship_url'  => 'http://relationship.example.com',
+              'service_url'       => "/v2/services/#{service_plan.service.guid}",
+              'shared_from_url'   => "/v2/service_instances/#{service_instance.guid}/shared_from",
+            }
+          )
+        end
       end
+    end
 
-      let(:service_instance) do
-        VCAP::CloudController::ServiceInstance.make(
-          name: 'things',
-        )
-      end
-      let(:service_plan) { VCAP::CloudController::ServicePlan.make }
+    describe 'UserProvidedServiceInstance' do
+      describe '#entity_hash' do
+        let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make }
 
-      before do
-        service_instance.service_plan_id = service_plan.id
-        service_instance.save
-
-        allow(RelationsPresenter).to receive(:new).and_return(relations_presenter)
-      end
-
-      it 'returns the service instance entity' do
-        expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)).to eq(
-          {
-            'name'              => service_instance.name,
-            'service_plan_guid' => service_plan.guid,
-            'service_guid'      => service_plan.service.guid,
-            'relationship_url'  => 'http://relationship.example.com',
-            'service_url'       => "/v2/services/#{service_plan.service.guid}"
-          }
-        )
+        it 'returns the service instance entity' do
+          expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)).to eq(
+            {
+              'name'              => service_instance.name,
+              'relationship_url'  => 'http://relationship.example.com',
+            }
+          )
+        end
       end
     end
   end

--- a/spec/unit/presenters/v2/service_instance_shared_from_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_shared_from_presenter_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module CloudController::Presenters::V2
+  RSpec.describe ServiceInstanceSharedFromPresenter do
+    describe '#to_hash' do
+      it 'returns the space and org name' do
+        space = VCAP::CloudController::Space.make
+        presenter = ServiceInstanceSharedFromPresenter.new
+        expect(presenter.to_hash(space)).to eq(
+          {
+            'space_name' => space.name,
+            'organization_name' => space.organization.name,
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/presenters/v3/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_instance_presenter_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'presenters/v3/service_instance_presenter'
+
+module VCAP::CloudController::Presenters::V3
+  RSpec.describe ServiceInstancePresenter do
+    let(:presenter) { ServiceInstancePresenter.new(service_instance) }
+    let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(name: 'denise-db') }
+
+    describe '#to_hash' do
+      let(:result) { presenter.to_hash }
+
+      it 'presents the model as a hash' do
+        expect(result[:guid]).to eq(service_instance.guid)
+        expect(result[:created_at]).to eq(service_instance.created_at)
+        expect(result[:updated_at]).to eq(service_instance.updated_at)
+        expect(result[:name]).to eq('denise-db')
+      end
+    end
+  end
+end

--- a/spec/unit/queries/service_instance_list_fetcher_spec.rb
+++ b/spec/unit/queries/service_instance_list_fetcher_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'fetchers/service_instance_list_fetcher'
+require 'messages/service_instances/service_instances_list_message'
+
+module VCAP::CloudController
+  RSpec.describe ServiceInstanceListFetcher do
+    let(:filters) { {} }
+    let(:message) { ServiceInstancesListMessage.new(filters) }
+    let(:fetcher) { ServiceInstanceListFetcher.new }
+
+    describe '#fetch_all' do
+      let!(:service_instance_1) { ManagedServiceInstance.make(name: 'rabbitmq') }
+      let!(:service_instance_2) { ManagedServiceInstance.make(name: 'redis') }
+
+      it 'returns a Sequel::Dataset' do
+        results = fetcher.fetch_all(message: message)
+        expect(results).to be_a(Sequel::Dataset)
+      end
+
+      it 'includes all the V3 Service Instances' do
+        results = fetcher.fetch_all(message: message).all
+        expect(results.length).to eq 2
+        expect(results).to include(service_instance_1, service_instance_2)
+      end
+
+      context 'filter' do
+        context 'by service instance name' do
+          let(:filters) { { names: ['rabbitmq'] } }
+
+          it 'only returns matching service instances' do
+            results = fetcher.fetch_all(message: message).all
+            expect(results).to match_array([service_instance_1])
+            expect(results).not_to include(service_instance_2)
+          end
+        end
+      end
+    end
+
+    describe '#fetch' do
+      let!(:service_instance_1) { ManagedServiceInstance.make(name: 'rabbitmq', space: space_1) }
+      let!(:service_instance_2) { ManagedServiceInstance.make(name: 'redis', space: space_1) }
+      let!(:service_instance_3) { ManagedServiceInstance.make(name: 'mysql', space: space_2) }
+
+      let(:space_1) { Space.make }
+      let(:space_2) { Space.make }
+
+      it 'returns all of the service instances in the specified space' do
+        results = fetcher.fetch(message: message, space_guids: [space_1.guid]).all
+
+        expect(results).to match_array([service_instance_1, service_instance_2])
+      end
+
+      context 'filter' do
+        context 'by service instance name' do
+          let(:filters) { { names: ['rabbitmq', 'redis'] } }
+
+          it 'only returns matching service instances' do
+            results = fetcher.fetch(message: message, space_guids: [space_1.guid]).all
+            expect(results).to match_array([service_instance_1, service_instance_2])
+          end
+        end
+
+        context 'by non-existent service instance name' do
+          let(:filters) { { names: ['made-up-name'] } }
+
+          it 'returns no matching service instances' do
+            results = fetcher.fetch(message: message, space_guids: [space_1.guid]).all
+            expect(results).to be_empty
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As an app dev (receiver), I can see sharing information regarding service instances that have been shared with me (shared_from). [#150973038](https://www.pivotaltracker.com/story/show/150973038)

**NOTE**: This PR builds on top of #972, which should be merged first. The actual changes on top of #972 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-service-instance-sharing-v3-service-instances...cloudfoundry-incubator:pr-service-instance-sharing-shared-from-url).

## What

This PR adds `/v2/service_instances/:guid/shared_from`. This is required by the CLI in order to display the originating space and org of a shared service instance when a user would otherwise not have permission to view those names.

Changes:
* All service_instance response bodies have shared_from_url
* /v2/service_instances/:guid/shared_from endpoint returns space name and org name of service
instance, if that service instance has been shared
* If not shared, this endpoint returns 204 No Content

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@jenspinney and @deniseyu)