### PR TITLE
App Dev Sharers Cannot Delete Shared Service Instances

### DIFF
--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -464,7 +464,7 @@ module VCAP::CloudController
     end
 
     def service_is_shared!(name)
-      raise CloudController::Errors::ApiError.new_from_details('ServiceIsShared', name)
+      raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceDeletionSharesExists', name)
     end
 
     def space_change_not_allowed!

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -34,14 +34,13 @@ module VCAP::CloudController
     define_routes
 
     def self.translate_validation_exception(e, attributes)
-      space_and_name_errors = e.errors.on([:space_id, :name]).to_a
-      quota_errors = e.errors.on(:quota).to_a
-      service_plan_errors = e.errors.on(:service_plan).to_a
-      service_instance_errors = e.errors.on(:service_instance).to_a
+      quota_errors                 = e.errors.on(:quota).to_a
+      service_plan_errors          = e.errors.on(:service_plan).to_a
+      service_instance_errors      = e.errors.on(:service_instance).to_a
       service_instance_name_errors = e.errors.on(:name).to_a
       service_instance_tags_errors = e.errors.on(:tags).to_a
 
-      if space_and_name_errors.include?(:unique)
+      if service_instance_name_errors.include?(:unique)
         return CloudController::Errors::ApiError.new_from_details('ServiceInstanceNameTaken', attributes['name'])
       elsif quota_errors.include?(:service_instance_space_quota_exceeded)
         return CloudController::Errors::ApiError.new_from_details('ServiceInstanceSpaceQuotaExceeded')

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -161,12 +161,13 @@ module VCAP::CloudController
       validate_access(:delete, service_instance)
 
       unless recursive_delete?
+        service_is_shared!(service_instance.name) if has_shares?(service_instance)
+
         has_associations = has_routes?(service_instance) ||
           has_bindings?(service_instance) ||
           has_keys?(service_instance)
 
         association_not_empty! if has_associations
-        service_is_shared!     if has_shares?(service_instance)
       end
 
       deprovisioner = ServiceInstanceDeprovisioner.new(@services_event_repository, self, logger)
@@ -462,8 +463,8 @@ module VCAP::CloudController
       raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', associations, :service_instances)
     end
 
-    def service_is_shared!
-      raise CloudController::Errors::ApiError.new_from_details('ServiceIsShared')
+    def service_is_shared!(name)
+      raise CloudController::Errors::ApiError.new_from_details('ServiceIsShared', name)
     end
 
     def space_change_not_allowed!

--- a/app/controllers/services/user_provided_service_instances_controller.rb
+++ b/app/controllers/services/user_provided_service_instances_controller.rb
@@ -29,11 +29,11 @@ module VCAP::CloudController
     end
 
     def self.translate_validation_exception(e, attributes)
-      space_and_name_errors = e.errors.on([:space_id, :name])
+      name_errors = e.errors.on(:name)
       service_instance_errors = e.errors.on(:service_instance)
       service_instance_name_errors = e.errors.on(:name).to_a
 
-      if space_and_name_errors&.include?(:unique)
+      if name_errors&.include?(:unique)
         CloudController::Errors::ApiError.new_from_details('ServiceInstanceNameTaken', attributes['name'])
       elsif service_instance_errors&.include?(:space_mismatch)
         CloudController::Errors::ApiError.new_from_details('ServiceInstanceRouteBindingSpaceMismatch')

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -87,14 +87,27 @@ module VCAP::CloudController
       !user_provided_instance?
     end
 
+    def name_clashes
+      proc do |_, instance|
+        next if instance.space_id.nil? || instance.name.nil?
+
+        clashes_with_shared_instance_names =
+          ServiceInstance.select_all(ServiceInstance.table_name).
+          join(:service_instance_shares, target_space_guid: instance.space_guid).
+          where(name: instance.name)
+
+        clashes_with_instance_names =
+          ServiceInstance.select_all(ServiceInstance.table_name).
+          where(space_id: instance.space_id, name: instance.name)
+
+        clashes_with_shared_instance_names.union(clashes_with_instance_names)
+      end
+    end
+
     def validate
       validates_presence :name
       validates_presence :space
-      validates_unique [:space_id, :name], where: (proc do |_, obj, arr|
-                                                     vals = arr.map { |x| obj.send(x) }
-                                                     next if vals.any?(&:nil?)
-                                                     ServiceInstance.where(arr.zip(vals))
-                                                   end)
+      validates_unique :name, where: name_clashes
       validates_max_length 50, :name
       validates_max_length 10_000, :syslog_drain_url, allow_nil: true
     end

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -93,7 +93,7 @@ module VCAP::CloudController
 
         clashes_with_shared_instance_names =
           ServiceInstance.select_all(ServiceInstance.table_name).
-          join(:service_instance_shares, target_space_guid: instance.space_guid).
+          join(:service_instance_shares, service_instance_guid: :guid, target_space_guid: instance.space_guid).
           where(name: instance.name)
 
         clashes_with_instance_names =

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe 'ServiceInstances' do
         expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted. ' \
           "Unsharing #{service_instance.name} will automatically delete any bindings " \
           'that have been made to applications in other spaces.'
-        expect(parsed_response['error_code']).to eq 'CF-ServiceIsShared'
+        expect(parsed_response['error_code']).to eq 'CF-ServiceInstanceDeletionSharesExists'
         expect(parsed_response['code']).to eq 390002
       end
     end

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -265,7 +265,9 @@ RSpec.describe 'ServiceInstances' do
         expect(last_response.status).to eq(400)
 
         parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted'
+        expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted. ' \
+          "Unsharing #{service_instance.name} will automatically delete any bindings " \
+          'that have been made to applications in other spaces'
         expect(parsed_response['error_code']).to eq 'CF-ServiceIsShared'
         expect(parsed_response['code']).to eq 10014
       end

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -267,9 +267,9 @@ RSpec.describe 'ServiceInstances' do
         parsed_response = MultiJson.load(last_response.body)
         expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted. ' \
           "Unsharing #{service_instance.name} will automatically delete any bindings " \
-          'that have been made to applications in other spaces'
+          'that have been made to applications in other spaces.'
         expect(parsed_response['error_code']).to eq 'CF-ServiceIsShared'
-        expect(parsed_response['code']).to eq 10014
+        expect(parsed_response['code']).to eq 390002
       end
     end
   end

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -244,4 +244,31 @@ RSpec.describe 'ServiceInstances' do
       )
     end
   end
+
+  describe 'DELETE /v2/service_instance/:guid' do
+    let(:originating_space) { VCAP::CloudController::Space.make }
+    let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: originating_space) }
+
+    context 'when the service instance has been shared' do
+      before do
+        allow(VCAP::Services::ServiceBrokers::V2::Client).to receive(:new) do |*args, **kwargs, &block|
+          FakeServiceBrokerV2Client.new(*args, **kwargs, &block)
+        end
+
+        set_current_user_as_admin
+        service_instance.add_shared_space(space)
+      end
+
+      it 'fails with an appropriate response' do
+        delete "v2/service_instances/#{service_instance.guid}", nil, admin_headers
+
+        expect(last_response.status).to eq(400)
+
+        parsed_response = MultiJson.load(last_response.body)
+        expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted'
+        expect(parsed_response['error_code']).to eq 'CF-ServiceIsShared'
+        expect(parsed_response['code']).to eq 10014
+      end
+    end
+  end
 end

--- a/spec/support/fakes/fake_service_broker_v2_client.rb
+++ b/spec/support/fakes/fake_service_broker_v2_client.rb
@@ -46,6 +46,16 @@ class FakeServiceBrokerV2Client
     }
   end
 
+  def deprovision(_instance, arbitrary_parameters: {}, accepts_incomplete: false)
+    {
+      last_operation: {
+        type:        'delete',
+        description: '',
+        state:       'succeeded'
+      }
+    }
+  end
+
   def bind(_binding, _arbitrary_parameters)
     {
       credentials: credentials,

--- a/spec/support/matchers/sequel_validations.rb
+++ b/spec/support/matchers/sequel_validations.rb
@@ -48,7 +48,7 @@ RSpec::Matchers.define :validate_uniqueness do |*attributes|
       duplicate_object[attr] = source_obj[attr]
     end
     unless duplicate_object.valid?
-      errors_key = attributes.length > 1 ? attributes : attributes.first
+      errors_key = options[:error_key] || (attributes.length > 1 ? attributes : attributes.first)
       errors = duplicate_object.errors.on(errors_key)
       expected_error = options[:message] || :unique
       errors && errors.include?(expected_error)

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2385,7 +2385,7 @@ module VCAP::CloudController
             expect(last_response.body).to include(
               'Service instances must be unshared before they can be deleted. ' \
               "Unsharing #{service_instance.name} will automatically delete any bindings " \
-              'that have been made to applications in other spaces')
+              'that have been made to applications in other spaces.')
           end
 
           context 'and there are bindings to the shared instance' do
@@ -2404,7 +2404,7 @@ module VCAP::CloudController
               expect(last_response.body).to include(
                 'Service instances must be unshared before they can be deleted. ' \
                 "Unsharing #{service_instance.name} will automatically delete any bindings " \
-                'that have been made to applications in other spaces')
+                'that have been made to applications in other spaces.')
             end
           end
 

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2381,7 +2381,7 @@ module VCAP::CloudController
             delete "/v2/service_instances/#{service_instance.guid}"
 
             expect(last_response).to have_status_code 400
-            expect(last_response.body).to include 'ServiceIsShared'
+            expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
             expect(last_response.body).to include(
               'Service instances must be unshared before they can be deleted. ' \
               "Unsharing #{service_instance.name} will automatically delete any bindings " \
@@ -2400,7 +2400,7 @@ module VCAP::CloudController
               delete "/v2/service_instances/#{service_instance.guid}"
 
               expect(last_response).to have_status_code 400
-              expect(last_response.body).to include 'ServiceIsShared'
+              expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
               expect(last_response.body).to include(
                 'Service instances must be unshared before they can be deleted. ' \
                 "Unsharing #{service_instance.name} will automatically delete any bindings " \

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -885,6 +885,32 @@ module VCAP::CloudController
             expect(last_response.status).to eq(400)
             expect(decoded_response['code']).to eq(60002)
           end
+
+          it 'does not allow a managed service instance with same name as a shared service instance' do
+            source_space = Space.make(organization: space.organization)
+            source_space.add_developer(developer)
+            service_instance = create_managed_service_instance(accepts_incomplete: 'false', space: source_space)
+            expect(last_response.status).to eq(201)
+
+            service_instance.add_shared_space(space)
+
+            create_managed_service_instance
+            expect(last_response.status).to eq(400)
+            expect(decoded_response['code']).to eq(60002)
+          end
+
+          it 'does not allow a user provided service instance with same name as a shared service instance' do
+            source_space = Space.make(organization: space.organization)
+            source_space.add_developer(developer)
+            service_instance = create_managed_service_instance(accepts_incomplete: 'false', space: source_space)
+            expect(last_response.status).to eq(201)
+
+            service_instance.add_shared_space(space)
+
+            create_user_provided_service_instance
+            expect(last_response.status).to eq(400)
+            expect(decoded_response['code']).to eq(60002)
+          end
         end
 
         context 'when the service_plan does not exist' do
@@ -4003,7 +4029,6 @@ module VCAP::CloudController
       let(:errors) { instance_double(Sequel::Model::Errors) }
       let(:attributes) { {} }
 
-      let(:space_and_name_errors) { nil }
       let(:quota_errors) { nil }
       let(:service_plan_errors) { nil }
       let(:service_instance_name_errors) { nil }
@@ -4013,7 +4038,6 @@ module VCAP::CloudController
 
       before do
         allow(e).to receive(:errors).and_return(errors)
-        allow(errors).to receive(:on).with([:space_id, :name]).and_return(space_and_name_errors)
         allow(errors).to receive(:on).with(:quota).and_return(quota_errors)
         allow(errors).to receive(:on).with(:service_plan).and_return(service_plan_errors)
         allow(errors).to receive(:on).with(:name).and_return(service_instance_name_errors)
@@ -4028,7 +4052,6 @@ module VCAP::CloudController
       end
 
       context "when errors are included but aren't supported validation exceptions" do
-        let(:space_and_name_errors) { [:stuff] }
         let(:quota_errors) { [:stuff] }
         let(:service_plan_errors) { [:stuff] }
         let(:service_instance_name_errors) { [:stuff] }
@@ -4042,7 +4065,7 @@ module VCAP::CloudController
 
       context 'when there is a service instance name taken error' do
         let(:attributes) { { 'name' => 'test name' } }
-        let(:space_and_name_errors) { [:unique] }
+        let(:service_instance_name_errors) { [:unique] }
 
         it 'returns a ServiceInstanceNameTaken error' do
           expect(VCAP::CloudController::ServiceInstancesController.translate_validation_exception(e, attributes).name).to eq('ServiceInstanceNameTaken')
@@ -4111,10 +4134,11 @@ module VCAP::CloudController
       arbitrary_params = user_opts.delete(:parameters)
       accepts_incomplete = user_opts.delete(:accepts_incomplete) { |_| 'true' }
       tags = user_opts.delete(:tags)
+      service_instance_space = user_opts.delete(:space) || space
 
       body = {
         name: 'foo',
-        space_guid: space.guid,
+        space_guid: service_instance_space.guid,
         service_plan_guid: plan.guid,
       }
       body[:parameters] = arbitrary_params if arbitrary_params

--- a/spec/unit/models/services/managed_service_instance_spec.rb
+++ b/spec/unit/models/services/managed_service_instance_spec.rb
@@ -32,7 +32,7 @@ module VCAP::CloudController
       it { is_expected.to validate_presence :name }
       it { is_expected.to validate_presence :service_plan }
       it { is_expected.to validate_presence :space }
-      it { is_expected.to validate_uniqueness [:space_id, :name] }
+      it { is_expected.to validate_uniqueness :space_id, :name, { error_key: :name } }
       it { is_expected.to strip_whitespace :name }
       let(:max_tags) { ['a' * 1024, 'b' * 1024] }
 

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -85,7 +85,7 @@ module VCAP::CloudController
             expect {
               service_instance_foo.set(name: 'bar')
               service_instance_foo.save_changes
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
         end
       end
@@ -97,13 +97,13 @@ module VCAP::CloudController
           it 'raises an exception when creating another UserProvidedServiceInstance' do
             expect {
               UserProvidedServiceInstance.create(service_instance_attrs)
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
 
           it 'raises an exception when creating a ManagedServiceInstance' do
             expect {
               ManagedServiceInstance.create(service_instance_attrs)
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
         end
 
@@ -116,13 +116,37 @@ module VCAP::CloudController
           it 'raises an exception when creating another ManagedServiceInstance' do
             expect {
               ManagedServiceInstance.create(service_instance_attrs)
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
 
           it 'raises an exception when creating a UserProvidedServiceInstance' do
             expect {
               UserProvidedServiceInstance.create(service_instance_attrs)
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
+          end
+        end
+
+        describe 'when a ManagedServiceInstance has been shared' do
+          let(:space) { Space.make }
+          let(:originating_space) { Space.make }
+          let(:service_instance) {
+            ManagedServiceInstance.make(name: 'shared-service', space: originating_space)
+          }
+
+          before do
+            service_instance.add_shared_space(space)
+          end
+
+          it 'raises an exception when creating another ManagedServiceInstance' do
+            expect {
+              ManagedServiceInstance.make(name: 'shared-service', space: space)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
+          end
+
+          it 'raises an exception when creating another UserProvidedServiceInstance' do
+            expect {
+              UserProvidedServiceInstance.make(name: 'shared-service', space: space)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
         end
       end

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -88,11 +88,6 @@
   http_code: 429
   message: "Rate Limit Exceeded"
 
-10014:
-  name: ServiceIsShared
-  http_code: 400
-  message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces"
-
 20001:
   name: UserInvalid
   http_code: 400
@@ -1113,3 +1108,8 @@
   name: ServiceInstanceUnshareFailed
   http_code: 502
   message: "Unshare of service instance failed because one or more bindings could not be deleted.\n\n%s"
+
+390002:
+  name: ServiceIsShared
+  http_code: 400
+  message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces."

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1110,6 +1110,6 @@
   message: "Unshare of service instance failed because one or more bindings could not be deleted.\n\n%s"
 
 390002:
-  name: ServiceIsShared
+  name: ServiceInstanceDeletionSharesExists
   http_code: 400
   message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces."

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -91,7 +91,7 @@
 10014:
   name: ServiceIsShared
   http_code: 400
-  message: "Service instances must be unshared before they can be deleted"
+  message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces"
 
 20001:
   name: UserInvalid

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -88,6 +88,11 @@
   http_code: 429
   message: "Rate Limit Exceeded"
 
+10014:
+  name: ServiceIsShared
+  http_code: 400
+  message: "Service instances must be unshared before they can be deleted"
+
 20001:
   name: UserInvalid
   http_code: 400


### PR DESCRIPTION
As an app dev (sharer), I cannot delete a service instance that I have shared which does not have bindings in another space [#152470931](https://www.pivotaltracker.com/story/show/152470931)
As an app dev (sharer), I cannot delete a service instance that I have shared which has bindings in another space[#151710830](https://www.pivotaltracker.com/story/show/151710830)

**NOTE**: This PR builds on top of #980, which should be merged first. The actual changes on top of #980 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-service-instance-sharing-name-collisions...cloudfoundry-incubator:pr-service-instance-sharing-deleting-shared-instances).

## What

This PR disables the deletion of service instances that have been shared to other spaces. This is similar validation to service instances that have bindings or have service keys. Users should unshare the service before issuing a delete. Note that if the service instance is deleted with the recursive query parameter then this validation is skipped.

Changes:
* Added to the validation in the service_instance_controller
* Added new user error message

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@jenspinney and @Samze)