### PR TITLE
Validate that Service is Shareable Before Sharing Service Instances

### DIFF
--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -3,6 +3,12 @@ require 'repositories/service_instance_share_event_repository'
 module VCAP::CloudController
   class ServiceInstanceShare
     def create(service_instance, target_spaces, user_audit_info)
+      if service_instance.managed_instance?
+        unless service_instance.shareable?
+          raise CloudController::Errors::ApiError.new_from_details('ServiceShareIsDisabled', service_instance.service.label)
+        end
+      end
+
       ServiceInstance.db.transaction do
         target_spaces.each do |space|
           service_instance.add_shared_space(space)
@@ -10,7 +16,8 @@ module VCAP::CloudController
       end
 
       Repositories::ServiceInstanceShareEventRepository.record_share_event(
-        service_instance, target_spaces.map(&:guid), user_audit_info)
+        service_instance, target_spaces.map(&:guid), user_audit_info
+      )
       service_instance
     end
   end

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -103,6 +103,10 @@ module VCAP::CloudController
       service.route_service?
     end
 
+    def shareable?
+      service.shareable?
+    end
+
     def volume_service?
       service.volume_service?
     end

--- a/app/models/services/service.rb
+++ b/app/models/services/service.rb
@@ -129,6 +129,14 @@ module VCAP::CloudController
       requires.include?('route_forwarding')
     end
 
+    def shareable?
+      return false if extra.nil?
+      metadata = JSON.parse(extra)
+      metadata && metadata['shareable']
+    rescue JSON::ParserError
+      return false
+    end
+
     def volume_service?
       requires.include?('volume_mount')
     end

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -184,6 +184,10 @@ module VCAP::CloudController
       false
     end
 
+    def shareable?
+      false
+    end
+
     def volume_service?
       false
     end

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -205,6 +205,7 @@ module VCAP::CloudController
     active            { true }
     service_broker    { ServiceBroker.make }
     description       { Sham.description } # remove hack
+    extra             { '{"shareable": true}' }
   end
 
   Service.blueprint(:routing) do

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -74,7 +74,7 @@ module VCAP::CloudController
         it 'raises an api error' do
           expect {
             service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError, /Service #{service_instance.service.label} has not enabled service instance sharing/)
+          }.to raise_error(CloudController::Errors::ApiError, /The #{service_instance.service.label} service does not support service instance sharing./)
         end
       end
     end

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -29,6 +29,54 @@ module VCAP::CloudController
         expect(Repositories::ServiceInstanceShareEventRepository).to have_received(:record_share_event).with(
           service_instance, [target_space1.guid, target_space2.guid], user_audit_info)
       end
+
+      context 'when a share already exists' do
+        before do
+          service_instance.add_shared_space(target_space1)
+        end
+
+        it 'is idempotent' do
+          shared_instance = service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          expect(shared_instance.shared_spaces.length).to eq 1
+        end
+      end
+
+      context 'when sharing one space from the list of spaces fails' do
+        before do
+          allow(service_instance).to receive(:add_shared_space).with(target_space1).and_call_original
+          allow(service_instance).to receive(:add_shared_space).with(target_space2).and_raise('db failure')
+        end
+
+        it 'does not share with any spaces' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
+          }.to raise_error('db failure')
+
+          instance = ServiceInstance.find(guid: service_instance.guid)
+
+          expect(instance.shared_spaces.length).to eq 0
+        end
+
+        it 'does not audit any share events' do
+          expect(Repositories::ServiceInstanceShareEventRepository).to_not receive(:record_share_event)
+
+          expect {
+            service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
+          }.to raise_error('db failure')
+        end
+      end
+
+      context 'when the service does is not shareable' do
+        before do
+          allow(service_instance).to receive(:shareable?).and_return(false)
+        end
+
+        it 'raises an api error' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
+          }.to raise_error(CloudController::Errors::ApiError, /Service #{service_instance.service.label} has not enabled service instance sharing/)
+        end
+      end
     end
   end
 end

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
     it 'shares the service instance to multiple target spaces' do
       action = instance_double(VCAP::CloudController::ServiceInstanceShare)
       allow(VCAP::CloudController::ServiceInstanceShare).to receive(:new).and_return(action)
-      expect(action).to receive(:create).with(service_instance, [target_space, target_space2], an_instance_of(VCAP::CloudController::UserAuditInfo))
+      expect(action).to receive(:create).with(service_instance, a_collection_containing_exactly(target_space, target_space2), an_instance_of(VCAP::CloudController::UserAuditInfo))
 
       req_body[:data] << { guid: target_space2.guid }
 

--- a/spec/unit/models/services/managed_service_instance_spec.rb
+++ b/spec/unit/models/services/managed_service_instance_spec.rb
@@ -206,6 +206,32 @@ module VCAP::CloudController
       end
     end
 
+    describe '#shareable?' do
+      let(:service) { Service.make }
+      let(:service_instance) { ManagedServiceInstance.make }
+
+      before do
+        allow(service).to receive(:shareable?).and_return(is_shareable)
+        allow(service_instance).to receive(:service).and_return(service)
+      end
+
+      context 'when the service instance is not a shareable' do
+        let(:is_shareable) { false }
+
+        it 'returns false' do
+          expect(service_instance).to_not be_shareable
+        end
+      end
+
+      context 'when the service instance is shareable' do
+        let(:is_shareable) { true }
+
+        it 'returns true' do
+          expect(service_instance).to be_shareable
+        end
+      end
+    end
+
     describe '#as_summary_json' do
       let(:service) { Service.make(label: 'YourSQL', guid: '9876XZ') }
       let(:service_plan) { ServicePlan.make(name: 'Gold Plan', guid: '12763abc', service: service) }

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -289,6 +289,12 @@ module VCAP::CloudController
       it { is_expected.to be_bindable }
     end
 
+    describe '#shareable?' do
+      it 'returns false' do
+        expect(service_instance.shareable?).to be_falsey
+      end
+    end
+
     describe '#as_summary_json' do
       it 'contains name, guid, and binding count' do
         instance = VCAP::CloudController::ServiceInstance.make(

--- a/spec/unit/models/services/service_spec.rb
+++ b/spec/unit/models/services/service_spec.rb
@@ -397,6 +397,48 @@ module VCAP::CloudController
       end
     end
 
+    describe '#shareable?' do
+      context 'when the service metadata include shareable true' do
+        let(:service) { Service.make(extra: '{"shareable":true}') }
+
+        it 'returns true' do
+          expect(service).to be_shareable
+        end
+      end
+
+      context 'when the service metadata include shareable false' do
+        let(:service) { Service.make(extra: '{"shareable":false}') }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+
+      context 'when the service does not include the shareable field in metadata' do
+        let(:service) { Service.make(extra: '{"other-key": "value"}') }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+
+      context 'when the service metadata is nil' do
+        let(:service) { Service.make(extra: nil) }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+
+      context 'when extra contains malformed json' do
+        let(:service) { Service.make(extra: '{"not-json"}') }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+    end
+
     describe '#client' do
       let(:service) { Service.make(service_broker: ServiceBroker.make) }
 

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1117,4 +1117,4 @@
 390003:
   name: ServiceShareIsDisabled
   http_code: 400
-  message: "Service %s has not enabled service instance sharing."
+  message: "The %s service does not support service instance sharing."

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1113,3 +1113,8 @@
   name: ServiceInstanceDeletionSharesExists
   http_code: 400
   message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces."
+
+390003:
+  name: ServiceShareIsDisabled
+  http_code: 400
+  message: "Service %s has not enabled service instance sharing."


### PR DESCRIPTION
As an app dev (sharer), if I try to share a service instance into a space when the service has not specified `shareable: true` the share fails. [#151909779](https://www.pivotaltracker.com/story/show/151909779)

**NOTE**: This PR builds on top of #981, which should be merged first. The actual changes on top of #981 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-service-instance-sharing-deleting-shared-instances...cloudfoundry-incubator:pr-service-instance-sharing-broker-service-shareable).

## What
This PR adds validation that the service instance attempting to be shared originates from a service which has the `shareable: true` metadata specified. The absense of this field results in service instances not being shareable.

## Notes
* As a side-effect of this, user provided service instances are not shareable, which is the desired behavior for now. Sharing user provided service instances is explicitly out of scope for the initial release of service instance sharing.

* The `shareable: true` metadata of the service is not documented in the api docs, since the service broker docs are a more appropriate place. The work in progress for these doc additions are [here](https://docs.google.com/document/d/1F59E63d0L47pNTa1h_XyiKnw1zz2g5rbAz1P4L1qZ4E/) and will be merged into the official docs later.

Changes:
* Added new validation.
* Added new error message for when this validation fails.

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@jenspinney and @Samze)