### PR TITLE
Add tests for updating/deleting shared service instances

### DIFF
--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -3,6 +3,12 @@ require 'repositories/service_instance_share_event_repository'
 module VCAP::CloudController
   class ServiceInstanceShare
     def create(service_instance, target_spaces, user_audit_info)
+      if service_instance.managed_instance?
+        unless service_instance.shareable?
+          raise CloudController::Errors::ApiError.new_from_details('ServiceShareIsDisabled', service_instance.service.label)
+        end
+      end
+
       ServiceInstance.db.transaction do
         target_spaces.each do |space|
           service_instance.add_shared_space(space)
@@ -10,7 +16,8 @@ module VCAP::CloudController
       end
 
       Repositories::ServiceInstanceShareEventRepository.record_share_event(
-        service_instance, target_spaces.map(&:guid), user_audit_info)
+        service_instance, target_spaces.map(&:guid), user_audit_info
+      )
       service_instance
     end
   end

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -103,6 +103,10 @@ module VCAP::CloudController
       service.route_service?
     end
 
+    def shareable?
+      service.shareable?
+    end
+
     def volume_service?
       service.volume_service?
     end

--- a/app/models/services/service.rb
+++ b/app/models/services/service.rb
@@ -129,6 +129,14 @@ module VCAP::CloudController
       requires.include?('route_forwarding')
     end
 
+    def shareable?
+      return false if extra.nil?
+      metadata = JSON.parse(extra)
+      metadata && metadata['shareable']
+    rescue JSON::ParserError
+      return false
+    end
+
     def volume_service?
       requires.include?('volume_mount')
     end

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -184,6 +184,10 @@ module VCAP::CloudController
       false
     end
 
+    def shareable?
+      false
+    end
+
     def volume_service?
       false
     end

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -205,6 +205,7 @@ module VCAP::CloudController
     active            { true }
     service_broker    { ServiceBroker.make }
     description       { Sham.description } # remove hack
+    extra             { '{"shareable": true}' }
   end
 
   Service.blueprint(:routing) do

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -74,7 +74,7 @@ module VCAP::CloudController
         it 'raises an api error' do
           expect {
             service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError, /Service #{service_instance.service.label} has not enabled service instance sharing/)
+          }.to raise_error(CloudController::Errors::ApiError, /The #{service_instance.service.label} service does not support service instance sharing./)
         end
       end
     end

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -29,6 +29,54 @@ module VCAP::CloudController
         expect(Repositories::ServiceInstanceShareEventRepository).to have_received(:record_share_event).with(
           service_instance, [target_space1.guid, target_space2.guid], user_audit_info)
       end
+
+      context 'when a share already exists' do
+        before do
+          service_instance.add_shared_space(target_space1)
+        end
+
+        it 'is idempotent' do
+          shared_instance = service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          expect(shared_instance.shared_spaces.length).to eq 1
+        end
+      end
+
+      context 'when sharing one space from the list of spaces fails' do
+        before do
+          allow(service_instance).to receive(:add_shared_space).with(target_space1).and_call_original
+          allow(service_instance).to receive(:add_shared_space).with(target_space2).and_raise('db failure')
+        end
+
+        it 'does not share with any spaces' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
+          }.to raise_error('db failure')
+
+          instance = ServiceInstance.find(guid: service_instance.guid)
+
+          expect(instance.shared_spaces.length).to eq 0
+        end
+
+        it 'does not audit any share events' do
+          expect(Repositories::ServiceInstanceShareEventRepository).to_not receive(:record_share_event)
+
+          expect {
+            service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
+          }.to raise_error('db failure')
+        end
+      end
+
+      context 'when the service does is not shareable' do
+        before do
+          allow(service_instance).to receive(:shareable?).and_return(false)
+        end
+
+        it 'raises an api error' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
+          }.to raise_error(CloudController::Errors::ApiError, /Service #{service_instance.service.label} has not enabled service instance sharing/)
+        end
+      end
     end
   end
 end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -1540,6 +1540,43 @@ module VCAP::CloudController
           end
         end
 
+        context 'when the service instance is shared' do
+          let(:service_instance) { ManagedServiceInstance.make }
+          let(:shared_to_space) { Space.make }
+          let(:body) do
+            {
+              tags: []
+            }.to_json
+          end
+
+          before do
+            service_instance.add_shared_space(shared_to_space)
+          end
+
+          context 'and a developer in the originating space tries to update the instance' do
+            it 'updates successfully' do
+              put "/v2/service_instances/#{service_instance.guid}", body
+              expect(last_response).to have_status_code 201
+            end
+          end
+
+          context 'and a developer in the shared to space tries to update the instance' do
+            let(:shared_to_user) { make_developer_for_space(shared_to_space) }
+
+            before do
+              set_current_user(shared_to_user)
+            end
+
+            it 'should give the user an error' do
+              put "/v2/service_instances/#{service_instance.guid}", body
+
+              expect(last_response).to have_status_code 403
+              expect(last_response.body).to include 'CF-NotAuthorized'
+              expect(last_response.body).to include 'You are not authorized to perform the requested action'
+            end
+          end
+        end
+
         describe 'error cases' do
           context 'when the service instance does not exist' do
             it 'returns a ServiceInstanceNotFound error' do
@@ -2374,11 +2411,11 @@ module VCAP::CloudController
 
           context 'as a SpaceDeveloper in target space' do
             let(:target_space) { Space.make }
-            let(:tommy) { make_developer_for_space(target_space) }
+            let(:target_space_dev) { make_developer_for_space(target_space) }
 
             before do
               service_instance.add_shared_space(target_space)
-              set_current_user(tommy, email: 'tommy@example.com')
+              set_current_user(target_space_dev)
             end
 
             it 'should give the user an error' do

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2321,32 +2321,7 @@ module VCAP::CloudController
             service_instance.add_shared_space(space)
           end
 
-          it 'does not delete the associated shares' do
-            delete "/v2/service_instances/#{service_instance.guid}"
-
-            expect(ServiceInstance.find(guid: service_instance.guid)).to be
-            expect(ServiceInstance.find(guid: service_instance.guid).shared_spaces.length).to eq(1)
-          end
-
-          it 'should give the user an error' do
-            delete "/v2/service_instances/#{service_instance.guid}"
-
-            expect(last_response).to have_status_code 400
-            expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
-            expect(last_response.body).to include(
-              'Service instances must be unshared before they can be deleted. ' \
-              "Unsharing #{service_instance.name} will automatically delete any bindings " \
-              'that have been made to applications in other spaces.')
-          end
-
-          context 'and there are bindings to the shared instance' do
-            before do
-              ServiceBinding.make(
-                app: AppModel.make(space: space),
-                service_instance: service_instance
-              )
-            end
-
+          context 'as a SpaceDeveloper in source and target space' do
             it 'should give the user an error' do
               delete "/v2/service_instances/#{service_instance.guid}"
 
@@ -2357,16 +2332,61 @@ module VCAP::CloudController
                 "Unsharing #{service_instance.name} will automatically delete any bindings " \
                 'that have been made to applications in other spaces.')
             end
+
+            it 'associated shares are not deleted' do
+              delete "/v2/service_instances/#{service_instance.guid}"
+
+              expect(ServiceInstance.find(guid: service_instance.guid)).to be
+              expect(ServiceInstance.find(guid: service_instance.guid).shared_spaces.length).to eq(1)
+            end
+
+            context 'and there are bindings to the shared instance' do
+              before do
+                ServiceBinding.make(
+                  app: AppModel.make(space: space),
+                  service_instance: service_instance
+                )
+              end
+
+              it 'should give the user an error' do
+                delete "/v2/service_instances/#{service_instance.guid}"
+
+                expect(last_response).to have_status_code 400
+                expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
+                expect(last_response.body).to include(
+                  'Service instances must be unshared before they can be deleted. ' \
+                  "Unsharing #{service_instance.name} will automatically delete any bindings " \
+                  'that have been made to applications in other spaces.')
+              end
+            end
+
+            context 'and recursive=true' do
+              it 'deletes the associated shares' do
+                expect {
+                  delete "/v2/service_instances/#{service_instance.guid}?recursive=true"
+                }.to change(ServiceInstance.join(:service_instance_shares, service_instance_guid: :service_instances__guid), :count).by(-1)
+
+                expect(last_response.status).to eq(204)
+                expect(ServiceInstance.find(guid: service_instance.guid)).to be_nil
+              end
+            end
           end
 
-          context 'and recursive=true' do
-            it 'deletes the associated shares' do
-              expect {
-                delete "/v2/service_instances/#{service_instance.guid}?recursive=true"
-              }.to change(ServiceInstance.join(:service_instance_shares, service_instance_guid: :service_instances__guid), :count).by(-1)
+          context 'as a SpaceDeveloper in target space' do
+            let(:target_space) { Space.make }
+            let(:tommy) { make_developer_for_space(target_space) }
 
-              expect(last_response.status).to eq(204)
-              expect(ServiceInstance.find(guid: service_instance.guid)).to be_nil
+            before do
+              service_instance.add_shared_space(target_space)
+              set_current_user(tommy, email: 'tommy@example.com')
+            end
+
+            it 'should give the user an error' do
+              delete "/v2/service_instances/#{service_instance.guid}"
+
+              expect(last_response).to have_status_code 403
+              expect(last_response.body).to include 'CF-NotAuthorized'
+              expect(last_response.body).to include 'You are not authorized to perform the requested action'
             end
           end
         end

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
     it 'shares the service instance to multiple target spaces' do
       action = instance_double(VCAP::CloudController::ServiceInstanceShare)
       allow(VCAP::CloudController::ServiceInstanceShare).to receive(:new).and_return(action)
-      expect(action).to receive(:create).with(service_instance, [target_space, target_space2], an_instance_of(VCAP::CloudController::UserAuditInfo))
+      expect(action).to receive(:create).with(service_instance, a_collection_containing_exactly(target_space, target_space2), an_instance_of(VCAP::CloudController::UserAuditInfo))
 
       req_body[:data] << { guid: target_space2.guid }
 

--- a/spec/unit/models/services/managed_service_instance_spec.rb
+++ b/spec/unit/models/services/managed_service_instance_spec.rb
@@ -206,6 +206,32 @@ module VCAP::CloudController
       end
     end
 
+    describe '#shareable?' do
+      let(:service) { Service.make }
+      let(:service_instance) { ManagedServiceInstance.make }
+
+      before do
+        allow(service).to receive(:shareable?).and_return(is_shareable)
+        allow(service_instance).to receive(:service).and_return(service)
+      end
+
+      context 'when the service instance is not a shareable' do
+        let(:is_shareable) { false }
+
+        it 'returns false' do
+          expect(service_instance).to_not be_shareable
+        end
+      end
+
+      context 'when the service instance is shareable' do
+        let(:is_shareable) { true }
+
+        it 'returns true' do
+          expect(service_instance).to be_shareable
+        end
+      end
+    end
+
     describe '#as_summary_json' do
       let(:service) { Service.make(label: 'YourSQL', guid: '9876XZ') }
       let(:service_plan) { ServicePlan.make(name: 'Gold Plan', guid: '12763abc', service: service) }

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -289,6 +289,12 @@ module VCAP::CloudController
       it { is_expected.to be_bindable }
     end
 
+    describe '#shareable?' do
+      it 'returns false' do
+        expect(service_instance.shareable?).to be_falsey
+      end
+    end
+
     describe '#as_summary_json' do
       it 'contains name, guid, and binding count' do
         instance = VCAP::CloudController::ServiceInstance.make(

--- a/spec/unit/models/services/service_spec.rb
+++ b/spec/unit/models/services/service_spec.rb
@@ -397,6 +397,48 @@ module VCAP::CloudController
       end
     end
 
+    describe '#shareable?' do
+      context 'when the service metadata include shareable true' do
+        let(:service) { Service.make(extra: '{"shareable":true}') }
+
+        it 'returns true' do
+          expect(service).to be_shareable
+        end
+      end
+
+      context 'when the service metadata include shareable false' do
+        let(:service) { Service.make(extra: '{"shareable":false}') }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+
+      context 'when the service does not include the shareable field in metadata' do
+        let(:service) { Service.make(extra: '{"other-key": "value"}') }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+
+      context 'when the service metadata is nil' do
+        let(:service) { Service.make(extra: nil) }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+
+      context 'when extra contains malformed json' do
+        let(:service) { Service.make(extra: '{"not-json"}') }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+    end
+
     describe '#client' do
       let(:service) { Service.make(service_broker: ServiceBroker.make) }
 

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1117,4 +1117,4 @@
 390003:
   name: ServiceShareIsDisabled
   http_code: 400
-  message: "Service %s has not enabled service instance sharing."
+  message: "The %s service does not support service instance sharing."

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1113,3 +1113,8 @@
   name: ServiceInstanceDeletionSharesExists
   http_code: 400
   message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces."
+
+390003:
+  name: ServiceShareIsDisabled
+  http_code: 400
+  message: "Service %s has not enabled service instance sharing."


### PR DESCRIPTION
As an app dev (receiver), I cannot update a service instance that has been shared with me [#150973390](https://www.pivotaltracker.com/story/show/150973390)
As an app dev (receiver), I cannot delete a service instance that has been shared with me[#150973376](https://www.pivotaltracker.com/story/show/150973376)

**NOTE**: This PR builds on top of #982 which should be merged first. The actual changes on top of #982 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-service-instance-sharing-broker-service-shareable...cloudfoundry-incubator:pr-service-instance-sharing-test-instance-access).

## What

This PR adds additional test to ensure that only users who have write access to the space in which the service instance was created are able to update/delete it.

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@jenspinney and @samze)