### PR TITLE
Prevent service instance sharers from attempting to share with themselves

### DIFF
--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -1,18 +1,16 @@
 module VCAP::CloudController
   class ServiceInstanceAccess < BaseAccess
     def create?(service_instance, params=nil)
-      return false unless service_instance.space
       return true if admin_user?
       FeatureFlag.raise_unless_enabled!(:service_instance_creation)
       return false if service_instance.in_suspended_org?
-      service_instance.space.has_developer?(context.user) && allowed?(service_instance)
+      service_instance.space && service_instance.space.has_developer?(context.user) && allowed?(service_instance)
     end
 
     def read_for_update?(service_instance, params=nil)
-      return false unless service_instance.space
       return true if admin_user?
       return false if service_instance.in_suspended_org?
-      service_instance.space.has_developer?(context.user)
+      service_instance.space && service_instance.space.has_developer?(context.user)
     end
 
     def update?(service_instance, params=nil)
@@ -20,16 +18,14 @@ module VCAP::CloudController
     end
 
     def delete?(service_instance)
-      return false unless service_instance.space
       return true if admin_user?
       return false if service_instance.in_suspended_org?
-      service_instance.space.has_developer?(context.user)
+      service_instance.space && service_instance.space.has_developer?(context.user)
     end
 
     def manage_permissions?(service_instance)
-      return false unless service_instance.space
       return true if admin_user?
-      service_instance.space.has_developer?(context.user)
+      service_instance.space && service_instance.space.has_developer?(context.user)
     end
 
     def manage_permissions_with_token?(service_instance)
@@ -45,9 +41,8 @@ module VCAP::CloudController
     end
 
     def read_env?(service_instance)
-      return false unless service_instance.space
       return true if admin_user? || admin_read_only_user?
-      service_instance.space.has_developer?(context.user)
+      service_instance.space && service_instance.space.has_developer?(context.user)
     end
 
     def read_env_with_token?(service_instance)
@@ -68,8 +63,7 @@ module VCAP::CloudController
     end
 
     def purge?(service_instance)
-      return false unless service_instance.space
-      admin_user? || (service_instance.space.has_developer?(context.user) && service_instance.service_broker.private?)
+      admin_user? || (service_instance.space && service_instance.space.has_developer?(context.user) && service_instance.service_broker.private?)
     end
 
     def purge_with_token?(instance)

--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
     end
 
     def read_permissions?(service_instance)
-      read?(service_instance)
+      admin_user? || admin_read_only_user? || object_is_visible_to_user?(service_instance, context.user)
     end
 
     def read_permissions_with_token?(service_instance)

--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -4,13 +4,13 @@ module VCAP::CloudController
       return true if admin_user?
       FeatureFlag.raise_unless_enabled!(:service_instance_creation)
       return false if service_instance.in_suspended_org?
-      service_instance.space && service_instance.space.has_developer?(context.user) && allowed?(service_instance)
+      service_instance.space&.has_developer?(context.user) && allowed?(service_instance)
     end
 
     def read_for_update?(service_instance, params=nil)
       return true if admin_user?
       return false if service_instance.in_suspended_org?
-      service_instance.space && service_instance.space.has_developer?(context.user)
+      service_instance.space&.has_developer?(context.user)
     end
 
     def update?(service_instance, params=nil)
@@ -20,12 +20,12 @@ module VCAP::CloudController
     def delete?(service_instance)
       return true if admin_user?
       return false if service_instance.in_suspended_org?
-      service_instance.space && service_instance.space.has_developer?(context.user)
+      service_instance.space&.has_developer?(context.user)
     end
 
     def manage_permissions?(service_instance)
       return true if admin_user?
-      service_instance.space && service_instance.space.has_developer?(context.user)
+      service_instance.space&.has_developer?(context.user)
     end
 
     def manage_permissions_with_token?(service_instance)
@@ -42,7 +42,7 @@ module VCAP::CloudController
 
     def read_env?(service_instance)
       return true if admin_user? || admin_read_only_user?
-      service_instance.space && service_instance.space.has_developer?(context.user)
+      service_instance.space&.has_developer?(context.user)
     end
 
     def read_env_with_token?(service_instance)
@@ -63,7 +63,7 @@ module VCAP::CloudController
     end
 
     def purge?(service_instance)
-      admin_user? || (service_instance.space && service_instance.space.has_developer?(context.user) && service_instance.service_broker.private?)
+      admin_user? || (service_instance.space&.has_developer?(context.user) && service_instance.service_broker.private?)
     end
 
     def purge_with_token?(instance)

--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -37,9 +37,7 @@ module VCAP::CloudController
     end
 
     def read_permissions?(service_instance)
-      return false unless service_instance.space
-      return true if admin_user? || admin_read_only_user?
-      service_instance.space.has_member?(context.user) || service_instance.space.organization.managers.include?(context.user)
+      read?(service_instance)
     end
 
     def read_permissions_with_token?(service_instance)

--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -1,6 +1,7 @@
 module VCAP::CloudController
   class ServiceInstanceAccess < BaseAccess
     def create?(service_instance, params=nil)
+      return false unless service_instance.space
       return true if admin_user?
       FeatureFlag.raise_unless_enabled!(:service_instance_creation)
       return false if service_instance.in_suspended_org?
@@ -8,6 +9,7 @@ module VCAP::CloudController
     end
 
     def read_for_update?(service_instance, params=nil)
+      return false unless service_instance.space
       return true if admin_user?
       return false if service_instance.in_suspended_org?
       service_instance.space.has_developer?(context.user)
@@ -18,12 +20,14 @@ module VCAP::CloudController
     end
 
     def delete?(service_instance)
+      return false unless service_instance.space
       return true if admin_user?
       return false if service_instance.in_suspended_org?
       service_instance.space.has_developer?(context.user)
     end
 
     def manage_permissions?(service_instance)
+      return false unless service_instance.space
       return true if admin_user?
       service_instance.space.has_developer?(context.user)
     end
@@ -33,6 +37,7 @@ module VCAP::CloudController
     end
 
     def read_permissions?(service_instance)
+      return false unless service_instance.space
       return true if admin_user? || admin_read_only_user?
       service_instance.space.has_member?(context.user) || service_instance.space.organization.managers.include?(context.user)
     end
@@ -42,6 +47,7 @@ module VCAP::CloudController
     end
 
     def read_env?(service_instance)
+      return false unless service_instance.space
       return true if admin_user? || admin_read_only_user?
       service_instance.space.has_developer?(context.user)
     end
@@ -64,6 +70,7 @@ module VCAP::CloudController
     end
 
     def purge?(service_instance)
+      return false unless service_instance.space
       admin_user? || (service_instance.space.has_developer?(context.user) && service_instance.service_broker.private?)
     end
 

--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -3,6 +3,12 @@ require 'repositories/service_instance_share_event_repository'
 module VCAP::CloudController
   class ServiceInstanceShare
     def create(service_instance, target_spaces, user_audit_info)
+      if service_instance.managed_instance?
+        unless service_instance.shareable?
+          raise CloudController::Errors::ApiError.new_from_details('ServiceShareIsDisabled', service_instance.service.label)
+        end
+      end
+
       ServiceInstance.db.transaction do
         target_spaces.each do |space|
           service_instance.add_shared_space(space)
@@ -10,7 +16,8 @@ module VCAP::CloudController
       end
 
       Repositories::ServiceInstanceShareEventRepository.record_share_event(
-        service_instance, target_spaces.map(&:guid), user_audit_info)
+        service_instance, target_spaces.map(&:guid), user_audit_info
+      )
       service_instance
     end
   end

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -34,14 +34,13 @@ module VCAP::CloudController
     define_routes
 
     def self.translate_validation_exception(e, attributes)
-      space_and_name_errors        = e.errors.on([:space_id, :name]).to_a
       quota_errors                 = e.errors.on(:quota).to_a
       service_plan_errors          = e.errors.on(:service_plan).to_a
       service_instance_errors      = e.errors.on(:service_instance).to_a
       service_instance_name_errors = e.errors.on(:name).to_a
       service_instance_tags_errors = e.errors.on(:tags).to_a
 
-      if space_and_name_errors.include?(:unique)
+      if service_instance_name_errors.include?(:unique)
         return CloudController::Errors::ApiError.new_from_details('ServiceInstanceNameTaken', attributes['name'])
       elsif quota_errors.include?(:service_instance_space_quota_exceeded)
         return CloudController::Errors::ApiError.new_from_details('ServiceInstanceSpaceQuotaExceeded')

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -467,7 +467,7 @@ module VCAP::CloudController
     end
 
     def service_is_shared!(name)
-      raise CloudController::Errors::ApiError.new_from_details('ServiceIsShared', name)
+      raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceDeletionSharesExists', name)
     end
 
     def space_change_not_allowed!

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -159,11 +159,15 @@ module VCAP::CloudController
       end
 
       validate_access(:delete, service_instance)
-      has_assocations = has_routes?(service_instance) ||
-        has_bindings?(service_instance) ||
-        has_keys?(service_instance)
 
-      association_not_empty! if has_assocations && !recursive_delete?
+      unless recursive_delete?
+        has_associations = has_routes?(service_instance) ||
+          has_bindings?(service_instance) ||
+          has_keys?(service_instance)
+
+        association_not_empty! if has_associations
+        service_is_shared!     if has_shares?(service_instance)
+      end
 
       deprovisioner = ServiceInstanceDeprovisioner.new(@services_event_repository, self, logger)
       delete_job    = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
@@ -461,6 +465,10 @@ module VCAP::CloudController
       raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', associations, :service_instances)
     end
 
+    def service_is_shared!
+      raise CloudController::Errors::ApiError.new_from_details('ServiceIsShared')
+    end
+
     def space_change_not_allowed!
       raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceSpaceChangeNotAllowed')
     end
@@ -491,6 +499,10 @@ module VCAP::CloudController
 
     def has_keys?(service_instance)
       !service_instance.service_keys.empty?
+    end
+
+    def has_shares?(service_instance)
+      !service_instance.shared_spaces.empty?
     end
 
     def space_change_requested?(requested_space_guid, current_space)

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -161,12 +161,13 @@ module VCAP::CloudController
       validate_access(:delete, service_instance)
 
       unless recursive_delete?
+        service_is_shared!(service_instance.name) if has_shares?(service_instance)
+
         has_associations = has_routes?(service_instance) ||
           has_bindings?(service_instance) ||
           has_keys?(service_instance)
 
         association_not_empty! if has_associations
-        service_is_shared!     if has_shares?(service_instance)
       end
 
       deprovisioner = ServiceInstanceDeprovisioner.new(@services_event_repository, self, logger)
@@ -465,8 +466,8 @@ module VCAP::CloudController
       raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', associations, :service_instances)
     end
 
-    def service_is_shared!
-      raise CloudController::Errors::ApiError.new_from_details('ServiceIsShared')
+    def service_is_shared!(name)
+      raise CloudController::Errors::ApiError.new_from_details('ServiceIsShared', name)
     end
 
     def space_change_not_allowed!

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -5,6 +5,7 @@ require 'actions/services/service_instance_update'
 require 'controllers/services/lifecycle/service_instance_deprovisioner'
 require 'controllers/services/lifecycle/service_instance_purger'
 require 'fetchers/service_instance_fetcher'
+require 'fetchers/service_binding_list_fetcher'
 require 'presenters/v2/service_instance_shared_to_presenter'
 require 'presenters/v2/service_instance_shared_from_presenter'
 
@@ -232,7 +233,7 @@ module VCAP::CloudController
       associated_controller = VCAP::CloudController::SpacesController
       associated_path = "#{self.class.url_for_guid(guid)}/shared_to"
 
-      create_paginated_collection_renderer.render_json(
+      create_paginated_collection_renderer(service_instance).render_json(
         associated_controller,
         service_instance.shared_spaces_dataset,
         associated_path,
@@ -346,15 +347,20 @@ module VCAP::CloudController
     private
 
     class ServiceInstanceSharedToSerializer
+      def initialize(service_instance)
+        @service_instance = service_instance
+      end
+
       def serialize(controller, space, opts, orphans=nil)
-        CloudController::Presenters::V2::ServiceInstanceSharedToPresenter.new.to_hash(space)
+        bound_app_count = ServiceBindingListFetcher.fetch_service_instance_bindings_in_space(@service_instance.guid, space.guid).count
+        CloudController::Presenters::V2::ServiceInstanceSharedToPresenter.new.to_hash(space, bound_app_count)
       end
     end
 
-    def create_paginated_collection_renderer
+    def create_paginated_collection_renderer(service_instance)
       VCAP::CloudController::RestController::PaginatedCollectionRenderer.new(
         VCAP::CloudController::RestController::SecureEagerLoader.new,
-        ServiceInstanceSharedToSerializer.new,
+        ServiceInstanceSharedToSerializer.new(service_instance),
         {
           max_results_per_page: config.get(:renderer, :max_results_per_page),
           default_results_per_page: config.get(:renderer, :default_results_per_page),

--- a/app/controllers/services/user_provided_service_instances_controller.rb
+++ b/app/controllers/services/user_provided_service_instances_controller.rb
@@ -29,11 +29,11 @@ module VCAP::CloudController
     end
 
     def self.translate_validation_exception(e, attributes)
-      space_and_name_errors = e.errors.on([:space_id, :name])
+      name_errors = e.errors.on(:name)
       service_instance_errors = e.errors.on(:service_instance)
       service_instance_name_errors = e.errors.on(:name).to_a
 
-      if space_and_name_errors&.include?(:unique)
+      if name_errors&.include?(:unique)
         CloudController::Errors::ApiError.new_from_details('ServiceInstanceNameTaken', attributes['name'])
       elsif service_instance_errors&.include?(:space_mismatch)
         CloudController::Errors::ApiError.new_from_details('ServiceInstanceRouteBindingSpaceMismatch')

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -30,7 +30,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
     service_instance = ServiceInstance.first(guid: params[:service_instance_guid])
 
-    resource_not_found!(:service_instance) unless service_instance && can_read_space?(service_instance.space)
+    resource_not_found!(:service_instance) unless service_instance && can_read_service_instance?(service_instance)
     unauthorized! unless can_write_space?(service_instance.space)
 
     message = VCAP::CloudController::ToManyRelationshipMessage.create_from_http_request(params[:body])
@@ -52,7 +52,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
     service_instance = ServiceInstance.first(guid: params[:service_instance_guid])
 
-    resource_not_found!(:service_instance) unless service_instance && can_read_space?(service_instance.space)
+    resource_not_found!(:service_instance) unless service_instance && can_read_service_instance?(service_instance)
     unauthorized! unless can_write_space?(service_instance.space)
 
     space_guid = params[:space_guid]
@@ -93,8 +93,16 @@ class ServiceInstancesV3Controller < ApplicationController
     end
   end
 
+  def can_read_service_instance?(service_instance)
+    readable_spaces = service_instance.shared_spaces + [service_instance.space]
+
+    readable_spaces.any? do |space|
+      can_read?(space.guid, space.organization_guid)
+    end
+  end
+
   def can_read_space?(space)
-    can_read?(space.guid, space.organization_guid)
+    can_read?(space.guid, space.organization.guid)
   end
 
   def can_write_space?(space)

--- a/app/fetchers/service_binding_list_fetcher.rb
+++ b/app/fetchers/service_binding_list_fetcher.rb
@@ -16,6 +16,13 @@ module VCAP::CloudController
       filter(dataset)
     end
 
+    def self.fetch_service_instance_bindings_in_space(service_instance_guid, space_guid)
+      ServiceBinding.select_all(ServiceBinding.table_name).
+        join(:apps, guid: :app_guid).
+        where(apps__space_guid: space_guid).
+        where(service_bindings__service_instance_guid: service_instance_guid)
+    end
+
     private
 
     def filter(dataset)

--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -1,0 +1,25 @@
+module VCAP::CloudController
+  class ServiceInstanceListFetcher
+    def fetch(message:, space_guids:)
+      dataset = ServiceInstance.select_all(ServiceInstance.table_name).
+                join(Space.table_name, id: :space_id, guid: space_guids)
+
+      filter(dataset, message)
+    end
+
+    def fetch_all(message:)
+      dataset = ServiceInstance.dataset
+      filter(dataset, message)
+    end
+
+    private
+
+    def filter(dataset, message)
+      if message.requested?(:names)
+        dataset = dataset.where(service_instances__name: message.names)
+      end
+
+      dataset
+    end
+  end
+end

--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -1,8 +1,13 @@
 module VCAP::CloudController
   class ServiceInstanceListFetcher
     def fetch(message:, space_guids:)
-      dataset = ServiceInstance.select_all(ServiceInstance.table_name).
-                join(Space.table_name, id: :space_id, guid: space_guids)
+      source_space_instance_dataset = ServiceInstance.select_all(ServiceInstance.table_name).
+                                      join(Space.table_name, id: :space_id, guid: space_guids)
+
+      shared_instance_dataset = ServiceInstance.select_all(ServiceInstance.table_name).
+                                join(:service_instance_shares, service_instance_guid: :guid, target_space_guid: space_guids)
+
+      dataset = source_space_instance_dataset.union(shared_instance_dataset, alias: :service_instances)
 
       filter(dataset, message)
     end

--- a/app/messages/service_instances/service_instances_list_message.rb
+++ b/app/messages/service_instances/service_instances_list_message.rb
@@ -1,0 +1,32 @@
+require 'messages/list_message'
+
+module VCAP::CloudController
+  class ServiceInstancesListMessage < ListMessage
+    ALLOWED_KEYS = [:page, :per_page, :order_by, :names].freeze
+
+    attr_accessor(*ALLOWED_KEYS)
+
+    validates_with NoAdditionalParamsValidator
+    validates :names, array: true, allow_nil: true
+
+    def initialize(params={})
+      super(params.symbolize_keys)
+    end
+
+    def self.from_params(params)
+      opts = params.dup
+      to_array! opts, 'names'
+      new(opts.symbolize_keys)
+    end
+
+    def valid_order_by_values
+      super << :name
+    end
+
+    private
+
+    def allowed_keys
+      ALLOWED_KEYS
+    end
+  end
+end

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -103,6 +103,10 @@ module VCAP::CloudController
       service.route_service?
     end
 
+    def shareable?
+      service.shareable?
+    end
+
     def volume_service?
       service.volume_service?
     end

--- a/app/models/services/service.rb
+++ b/app/models/services/service.rb
@@ -129,6 +129,14 @@ module VCAP::CloudController
       requires.include?('route_forwarding')
     end
 
+    def shareable?
+      return false if extra.nil?
+      metadata = JSON.parse(extra)
+      metadata && metadata['shareable']
+    rescue JSON::ParserError
+      return false
+    end
+
     def volume_service?
       requires.include?('volume_mount')
     end

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -138,7 +138,7 @@ module VCAP::CloudController
     alias_method_chain :credentials, 'serialization'
 
     def in_suspended_org?
-      space && space.in_suspended_org?
+      space&.in_suspended_org?
     end
 
     def after_create

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -69,6 +69,9 @@ module VCAP::CloudController
         [:space, user.audited_spaces_dataset],
         [:space, user.managed_spaces_dataset],
         [:shared_spaces, user.spaces_dataset],
+        [:shared_spaces, user.managed_spaces_dataset],
+        [:shared_spaces, user.audited_spaces_dataset],
+        [:shared_spaces, managed_organizations_spaces_dataset(user.managed_organizations_dataset)],
       ])
     end
 

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -175,6 +175,10 @@ module VCAP::CloudController
       false
     end
 
+    def shared?
+      shared_spaces.any?
+    end
+
     def self.managed_organizations_spaces_dataset(managed_organizations_dataset)
       VCAP::CloudController::Space.dataset.filter({ organization_id: managed_organizations_dataset.select(:organization_id) })
     end

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -184,6 +184,10 @@ module VCAP::CloudController
       false
     end
 
+    def shareable?
+      false
+    end
+
     def volume_service?
       false
     end

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -68,6 +68,7 @@ module VCAP::CloudController
         [:space, user.spaces_dataset],
         [:space, user.audited_spaces_dataset],
         [:space, user.managed_spaces_dataset],
+        [:shared_spaces, user.spaces_dataset],
       ])
     end
 

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -87,14 +87,27 @@ module VCAP::CloudController
       !user_provided_instance?
     end
 
+    def name_clashes
+      proc do |_, instance|
+        next if instance.space_id.nil? || instance.name.nil?
+
+        clashes_with_shared_instance_names =
+          ServiceInstance.select_all(ServiceInstance.table_name).
+          join(:service_instance_shares, target_space_guid: instance.space_guid).
+          where(name: instance.name)
+
+        clashes_with_instance_names =
+          ServiceInstance.select_all(ServiceInstance.table_name).
+          where(space_id: instance.space_id, name: instance.name)
+
+        clashes_with_shared_instance_names.union(clashes_with_instance_names)
+      end
+    end
+
     def validate
       validates_presence :name
       validates_presence :space
-      validates_unique [:space_id, :name], where: (proc do |_, obj, arr|
-                                                     vals = arr.map { |x| obj.send(x) }
-                                                     next if vals.any?(&:nil?)
-                                                     ServiceInstance.where(arr.zip(vals))
-                                                   end)
+      validates_unique :name, where: name_clashes
       validates_max_length 50, :name
       validates_max_length 10_000, :syslog_drain_url, allow_nil: true
     end

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -93,7 +93,7 @@ module VCAP::CloudController
 
         clashes_with_shared_instance_names =
           ServiceInstance.select_all(ServiceInstance.table_name).
-          join(:service_instance_shares, target_space_guid: instance.space_guid).
+          join(:service_instance_shares, service_instance_guid: :guid, target_space_guid: instance.space_guid).
           where(name: instance.name)
 
         clashes_with_instance_names =

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -135,7 +135,7 @@ module VCAP::CloudController
     alias_method_chain :credentials, 'serialization'
 
     def in_suspended_org?
-      space.in_suspended_org?
+      space && space.in_suspended_org?
     end
 
     def after_create

--- a/app/presenters/v2/service_instance_presenter.rb
+++ b/app/presenters/v2/service_instance_presenter.rb
@@ -29,6 +29,7 @@ module CloudController
             obj_hash['service_guid'] = service_plan.service.guid
             rel_hash['service_url'] = "/v2/services/#{service_plan.service.guid}"
             rel_hash['shared_from_url'] = "/v2/service_instances/#{obj.guid}/shared_from"
+            rel_hash['shared_to_url'] = "/v2/service_instances/#{obj.guid}/shared_to"
           end
 
           obj_hash.merge!(rel_hash)

--- a/app/presenters/v2/service_instance_presenter.rb
+++ b/app/presenters/v2/service_instance_presenter.rb
@@ -28,6 +28,7 @@ module CloudController
             obj_hash['service_plan_guid'] = service_plan.guid
             obj_hash['service_guid'] = service_plan.service.guid
             rel_hash['service_url'] = "/v2/services/#{service_plan.service.guid}"
+            rel_hash['shared_from_url'] = "/v2/service_instances/#{obj.guid}/shared_from"
           end
 
           obj_hash.merge!(rel_hash)

--- a/app/presenters/v2/service_instance_shared_from_presenter.rb
+++ b/app/presenters/v2/service_instance_shared_from_presenter.rb
@@ -1,0 +1,14 @@
+module CloudController
+  module Presenters
+    module V2
+      class ServiceInstanceSharedFromPresenter
+        def to_hash(space)
+          {
+            'space_name' => space.name,
+            'organization_name' => space.organization.name
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/v2/service_instance_shared_to_presenter.rb
+++ b/app/presenters/v2/service_instance_shared_to_presenter.rb
@@ -4,8 +4,8 @@ module CloudController
   module Presenters
     module V2
       class ServiceInstanceSharedToPresenter < ServiceInstanceSharedFromPresenter
-        def to_hash(space)
-          super(space)
+        def to_hash(space, bound_app_count)
+          super(space).merge({ 'bound_app_count' => bound_app_count })
         end
       end
     end

--- a/app/presenters/v2/service_instance_shared_to_presenter.rb
+++ b/app/presenters/v2/service_instance_shared_to_presenter.rb
@@ -1,0 +1,13 @@
+require 'presenters/v2/service_instance_shared_from_presenter'
+
+module CloudController
+  module Presenters
+    module V2
+      class ServiceInstanceSharedToPresenter < ServiceInstanceSharedFromPresenter
+        def to_hash(space)
+          super(space)
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/v3/paginated_list_presenter.rb
+++ b/app/presenters/v3/paginated_list_presenter.rb
@@ -6,6 +6,7 @@ require 'presenters/v3/pagination_presenter'
 require 'presenters/v3/process_presenter'
 require 'presenters/v3/route_mapping_presenter'
 require 'presenters/v3/service_binding_presenter'
+require 'presenters/v3/service_instance_presenter'
 require 'presenters/v3/task_presenter'
 require 'presenters/v3/organization_presenter'
 require 'presenters/v3/space_presenter'
@@ -24,7 +25,8 @@ module VCAP::CloudController
           'PackageModel'          => VCAP::CloudController::Presenters::V3::PackagePresenter,
           'RouteMappingModel'     => VCAP::CloudController::Presenters::V3::RouteMappingPresenter,
           'ServiceBinding'        => VCAP::CloudController::Presenters::V3::ServiceBindingPresenter,
-          'TaskModel'             => VCAP::CloudController::Presenters::V3::TaskPresenter,
+          'ManagedServiceInstance' => VCAP::CloudController::Presenters::V3::ServiceInstancePresenter,
+          'TaskModel' => VCAP::CloudController::Presenters::V3::TaskPresenter,
         }.freeze
 
         def initialize(dataset:, path:, message: nil, show_secrets: false)

--- a/app/presenters/v3/service_instance_presenter.rb
+++ b/app/presenters/v3/service_instance_presenter.rb
@@ -1,0 +1,24 @@
+require 'presenters/v3/base_presenter'
+
+module VCAP::CloudController
+  module Presenters
+    module V3
+      class ServiceInstancePresenter < BasePresenter
+        def to_hash
+          {
+            guid:       service_instance.guid,
+            created_at: service_instance.created_at,
+            updated_at: service_instance.updated_at,
+            name:      service_instance.name
+          }
+        end
+
+        private
+
+        def service_instance
+          @resource
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
   get '/apps/:app_guid/tasks', to: 'tasks#index'
 
   # service_instances
+  get '/service_instances', to: 'service_instances_v3#index'
   post '/service_instances/:service_instance_guid/relationships/shared_spaces', to: 'service_instances_v3#share_service_instance'
   delete '/service_instances/:service_instance_guid/relationships/shared_spaces/:space_guid', to: 'service_instances_v3#unshare_service_instance'
 end

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -876,6 +876,9 @@
         <a href="service_instances/retrieving_permissions_on_a_service_instance.html">Retrieving permissions on a Service Instance</a>
       </li>
       <li>
+        <a href="service_instances/retrieve_info_where_service_instance_is_shared_from.html">Retrieve Information Regarding Where a Service Instance is Shared From (Experimental)</a>
+      </li>
+      <li>
         <a href="service_instances/unbinding_a_service_instance_from_a_route.html">Unbinding a service instance from a route</a>
       </li>
       <li>

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -879,6 +879,9 @@
         <a href="service_instances/retrieve_info_where_service_instance_is_shared_from.html">Retrieve Information Regarding Where a Service Instance is Shared From (Experimental)</a>
       </li>
       <li>
+        <a href="service_instances/retrieve_info_where_service_instance_is_shared_to.html">Retrieve Information Regarding Where a Service Instance is Shared To (Experimental)</a>
+      </li>
+      <li>
         <a href="service_instances/unbinding_a_service_instance_from_a_route.html">Unbinding a service instance from a route</a>
       </li>
       <li>

--- a/docs/v2/service_instances/binding_a_service_instance_to_a_route.html
+++ b/docs/v2/service_instances/binding_a_service_instance_to_a_route.html
@@ -165,7 +165,8 @@ Cookie: </pre>
     "service_bindings_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/service_bindings",
     "service_keys_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/service_keys",
     "routes_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/routes",
-    "shared_from_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_from"
+    "shared_from_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_from",
+    "shared_to_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_to"
   }
 }</pre>
 

--- a/docs/v2/service_instances/binding_a_service_instance_to_a_route.html
+++ b/docs/v2/service_instances/binding_a_service_instance_to_a_route.html
@@ -164,7 +164,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/4cfefd27-3eb7-4f55-806e-1db649038ad2",
     "service_bindings_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/service_bindings",
     "service_keys_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/service_keys",
-    "routes_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/routes"
+    "routes_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/routes",
+    "shared_from_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_instances/creating_a_service_instance.html
+++ b/docs/v2/service_instances/creating_a_service_instance.html
@@ -575,6 +575,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_to_url</span>
+                </td>
+                <td>
+                  <span class="description">Information about where the service instance instance has been shared to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -625,7 +641,8 @@ Cookie: </pre>
     "service_bindings_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/service_bindings",
     "service_keys_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/service_keys",
     "routes_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/routes",
-    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
   }
 }</pre>
 

--- a/docs/v2/service_instances/creating_a_service_instance.html
+++ b/docs/v2/service_instances/creating_a_service_instance.html
@@ -559,6 +559,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -608,7 +624,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/fe173a83-df28-4891-8d91-46334e04600d",
     "service_bindings_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/service_bindings",
     "service_keys_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/service_keys",
-    "routes_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/routes"
+    "routes_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_instances/delete_a_service_instance.html
+++ b/docs/v2/service_instances/delete_a_service_instance.html
@@ -479,6 +479,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_to_url</span>
+                </td>
+                <td>
+                  <span class="description">Information about where the service instance instance has been shared to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -529,7 +545,8 @@ Cookie: </pre>
     "service_bindings_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/service_bindings",
     "service_keys_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/service_keys",
     "routes_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/routes",
-    "shared_from_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_from"
+    "shared_from_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_from",
+    "shared_to_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_to"
   }
 }</pre>
 

--- a/docs/v2/service_instances/delete_a_service_instance.html
+++ b/docs/v2/service_instances/delete_a_service_instance.html
@@ -463,6 +463,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -512,7 +528,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/8ea19d29-2e20-469e-8b91-917a6410e2f2",
     "service_bindings_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/service_bindings",
     "service_keys_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/service_keys",
-    "routes_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/routes"
+    "routes_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/routes",
+    "shared_from_url": "/v2/service_instances/6da8d173-b409-4094-949f-3c1cc8a68503/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_instances/list_all_service_instances.html
+++ b/docs/v2/service_instances/list_all_service_instances.html
@@ -530,6 +530,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_to_url</span>
+                </td>
+                <td>
+                  <span class="description">Information about where the service instance instance has been shared to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -588,7 +604,8 @@ Cookie: </pre>
         "service_bindings_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/service_bindings",
         "service_keys_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/service_keys",
         "routes_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/routes",
-        "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
+        "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+        "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
       }
     }
   ]

--- a/docs/v2/service_instances/list_all_service_instances.html
+++ b/docs/v2/service_instances/list_all_service_instances.html
@@ -514,6 +514,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -571,7 +587,8 @@ Cookie: </pre>
         "service_plan_url": "/v2/service_plans/05a372c6-6dc2-4f7f-8f65-a90ebe5fa6e2",
         "service_bindings_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/service_bindings",
         "service_keys_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/service_keys",
-        "routes_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/routes"
+        "routes_url": "/v2/service_instances/215b97be-ec77-4224-9c38-c4f2d86b56c1/routes",
+        "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
       }
     }
   ]

--- a/docs/v2/service_instances/retrieve_a_particular_service_instance.html
+++ b/docs/v2/service_instances/retrieve_a_particular_service_instance.html
@@ -386,6 +386,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_to_url</span>
+                </td>
+                <td>
+                  <span class="description">Information about where the service instance instance has been shared to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -438,7 +454,8 @@ Cookie: </pre>
     "service_bindings_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/service_bindings",
     "service_keys_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/service_keys",
     "routes_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/routes",
-    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
   }
 }</pre>
 

--- a/docs/v2/service_instances/retrieve_a_particular_service_instance.html
+++ b/docs/v2/service_instances/retrieve_a_particular_service_instance.html
@@ -370,6 +370,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -421,7 +437,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1",
     "service_bindings_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/service_bindings",
     "service_keys_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/service_keys",
-    "routes_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/routes"
+    "routes_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_from.html
+++ b/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_from.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Service Instances API</title>
+  <meta charset="utf-8">
+  <link id="bootstrapcss" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" />
+  <script>
+    if( "file:" == document.location.protocol ) {
+      var csslink = document.getElementById("bootstrapcss");
+      csslink.href = "http://" + csslink.href.replace(/.*\/\//, "");
+    }
+  </script>
+  <style>
+    p {
+      padding: 15px;
+      font-size: 130%;
+    }
+
+    pre {
+      white-space: pre;
+    }
+
+    td.required .name:after {
+      float: right;
+      content: " required";
+      font-weight: normal;
+      color: #F08080;
+    }
+
+    td.experimental:after {
+      float: right;
+      content: " experimental";
+      font-weight: normal;
+      color: #FFA500;
+      padding: 2px;
+    }
+
+    tr.deprecated td:first-child:before {
+      content: "deprecated: ";
+      font-weight: bold;
+      color: gray;
+    }
+
+    tr.deprecated span, tr.deprecated ul {
+      text-decoration: line-through;
+      color: gray;
+    }
+
+    tr.readonly .name:after {
+      float: right;
+      content: " read-only";
+      font-weight: normal;
+    }
+
+    tr.readonly {
+      color: grey;
+    }
+
+    table ul {
+      padding-left: 1.2em;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>Service Instances API</h1>
+
+  <div class="article">
+    <h2>Retrieve Information Regarding Where a Service Instance is Shared From (Experimental)</h2>
+    <h3>GET /v2/service_instances/:guid/shared_from</h3>
+
+      <h3>Request</h3>
+      <h4>Route</h4>
+      <pre class="request route highlight">GET /v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from</pre>
+
+      <h4>Headers</h4>
+      <pre class="request headers">Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTE1MCIsImVtYWlsIjoiZW1haWwtMTA1QHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg4ODl9.eyvSz10WWSQt0pFotoQI2Lm5XdH22-50O_R8rxy7n4k
+Host: example.org
+Cookie: </pre>
+
+        <h4>cURL</h4>
+        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from&quot; -X GET \
+	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTE1MCIsImVtYWlsIjoiZW1haWwtMTA1QHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg4ODl9.eyvSz10WWSQt0pFotoQI2Lm5XdH22-50O_R8rxy7n4k&quot; \
+	-H &quot;Host: example.org&quot; \
+	-H &quot;Cookie: &quot;</pre>
+
+        <h3>Response</h3>
+
+        <h4>Status</h4>
+        <pre class="response status">200 OK</pre>
+
+          <h4>Body</h4>
+          <table class="response-fields table table-striped table-bordered table-condensed">
+            <thead>
+            <tr>
+              <th>Name</th>
+              <th>Description</th>
+              <th>Valid Values</th>
+              <th>Example Values</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr class="">
+                <td>
+                    <span class="name">space_name</span>
+                </td>
+                <td>
+                  <span class="description">The space name that this service instance belongs to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
+                    <span class="name">organization_name</span>
+                </td>
+                <td>
+                  <span class="description">The organization name that this service instance belongs to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <pre class="response body">{
+    "space_name": "space-name",
+    "organization_name": "org-name"
+}
+</pre>
+
+        <h4>Headers</h4>
+        <pre class="response headers">Content-Type: application/json;charset=utf-8
+X-VCAP-Request-ID: febb14ab-a7bc-492d-b017-3db59d83967d
+Content-Length: 253
+X-Content-Type-Options: nosniff</pre>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_to.html
+++ b/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_to.html
@@ -194,6 +194,22 @@ Cookie: </pre>
                   </ul>
                 </td>
               </tr>
+              <tr class="">
+                <td>
+                    <span class="name">bound_app_count</span>
+                </td>
+                <td>
+                  <span class="description">The number of applications bound to the service instance in the space.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
             </tbody>
           </table>
 
@@ -205,11 +221,13 @@ Cookie: </pre>
    "resources": [
       {
           "space_name": "target-space-1",
-          "organization_name": "org-name"
+          "organization_name": "org-name",
+          "bound_app_count": 3
       },
       {
           "space_name": "target-space-2",
-          "organization_name": "org-name"
+          "organization_name": "org-name",
+          "bound_app_count": 0
       }
    ]
 }</pre>

--- a/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_to.html
+++ b/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_to.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Service Instances API</title>
+  <meta charset="utf-8">
+  <link id="bootstrapcss" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" />
+  <script>
+    if( "file:" == document.location.protocol ) {
+      var csslink = document.getElementById("bootstrapcss");
+      csslink.href = "http://" + csslink.href.replace(/.*\/\//, "");
+    }
+  </script>
+  <style>
+    p {
+      padding: 15px;
+      font-size: 130%;
+    }
+
+    pre {
+      white-space: pre;
+    }
+
+    td.required .name:after {
+      float: right;
+      content: " required";
+      font-weight: normal;
+      color: #F08080;
+    }
+
+    td.experimental:after {
+      float: right;
+      content: " experimental";
+      font-weight: normal;
+      color: #FFA500;
+      padding: 2px;
+    }
+
+    tr.deprecated td:first-child:before {
+      content: "deprecated: ";
+      font-weight: bold;
+      color: gray;
+    }
+
+    tr.deprecated span, tr.deprecated ul {
+      text-decoration: line-through;
+      color: gray;
+    }
+
+    tr.readonly .name:after {
+      float: right;
+      content: " read-only";
+      font-weight: normal;
+    }
+
+    tr.readonly {
+      color: grey;
+    }
+
+    table ul {
+      padding-left: 1.2em;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>Service Instances API</h1>
+
+  <div class="article">
+    <h2>Retrieve Information Regarding Where a Service Instance is Shared To (Experimental)</h2>
+    <h3>GET /v2/service_instances/:guid/shared_to</h3>
+
+      <h3>Request</h3>
+      <h4>Route</h4>
+      <pre class="request route highlight">GET /v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to</pre>
+
+      <h4>Parameters</h4>
+      <table class="parameters table table-striped table-bordered table-condensed">
+        <thead>
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+          <th>Valid Values</th>
+          <th>Example Values</th>
+        </tr>
+        </thead>
+        <tbody>
+          <tr class="">
+            <td class=" ">
+                <span class="name">page</span>
+            </td>
+            <td>
+                <span class="description">Page of results to fetch</span>
+            </td>
+            <td>
+              <ul class="valid_values">
+              </ul>
+            </td>
+            <td>
+              <ul class="example_values">
+              </ul>
+            </td>
+          </tr>
+          <tr class="">
+            <td class=" ">
+                <span class="name">results-per-page</span>
+            </td>
+            <td>
+                <span class="description">Number of results per page</span>
+            </td>
+            <td>
+              <ul class="valid_values">
+              </ul>
+            </td>
+            <td>
+              <ul class="example_values">
+              </ul>
+            </td>
+          </tr>
+          <tr class="">
+            <td class=" ">
+                <span class="name">order-direction</span>
+            </td>
+            <td>
+                <span class="description">Order of the results: asc (default) or desc</span>
+            </td>
+            <td>
+              <ul class="valid_values">
+              </ul>
+            </td>
+            <td>
+              <ul class="example_values">
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h4>Headers</h4>
+      <pre class="request headers">Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTE1MCIsImVtYWlsIjoiZW1haWwtMTA1QHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg4ODl9.eyvSz10WWSQt0pFotoQI2Lm5XdH22-50O_R8rxy7n4k
+Host: example.org
+Cookie: </pre>
+
+        <h4>cURL</h4>
+        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to&quot; -X GET \
+	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTE1MCIsImVtYWlsIjoiZW1haWwtMTA1QHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg4ODl9.eyvSz10WWSQt0pFotoQI2Lm5XdH22-50O_R8rxy7n4k&quot; \
+	-H &quot;Host: example.org&quot; \
+	-H &quot;Cookie: &quot;</pre>
+
+        <h3>Response</h3>
+
+        <h4>Status</h4>
+        <pre class="response status">200 OK</pre>
+
+          <h4>Body</h4>
+          <table class="response-fields table table-striped table-bordered table-condensed">
+            <thead>
+            <tr>
+              <th>Name</th>
+              <th>Description</th>
+              <th>Valid Values</th>
+              <th>Example Values</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr class="">
+                <td>
+                    <span class="name">space_name</span>
+                </td>
+                <td>
+                  <span class="description">The name of the space being shared to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
+                    <span class="name">organization_name</span>
+                </td>
+                <td>
+                  <span class="description">The name of the organization of the space the service instance has been shared to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <pre class="response body">{
+   "total_results": 2,
+   "total_pages": 1,
+   "prev_url": null,
+   "next_url": null,
+   "resources": [
+      {
+          "space_name": "target-space-1",
+          "organization_name": "org-name"
+      },
+      {
+          "space_name": "target-space-2",
+          "organization_name": "org-name"
+      }
+   ]
+}</pre>
+
+        <h4>Headers</h4>
+        <pre class="response headers">Content-Type: application/json;charset=utf-8
+X-VCAP-Request-ID: febb14ab-a7bc-492d-b017-3db59d83967d
+Content-Length: 378
+X-Content-Type-Options: nosniff</pre>
+
+  </div>
+</div>
+</body>
+</html>

--- a/docs/v2/service_instances/update_a_service_instance.html
+++ b/docs/v2/service_instances/update_a_service_instance.html
@@ -517,6 +517,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_to_url</span>
+                </td>
+                <td>
+                  <span class="description">Information about where the service instance instance has been shared to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -566,7 +582,8 @@ Cookie: </pre>
     "service_bindings_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/service_bindings",
     "service_keys_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/service_keys",
     "routes_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/routes",
-    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from",
+    "shared_to_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to"
   }
 }</pre>
 

--- a/docs/v2/service_instances/update_a_service_instance.html
+++ b/docs/v2/service_instances/update_a_service_instance.html
@@ -501,6 +501,22 @@ Cookie: </pre>
               </tr>
               <tr class="">
                 <td>
+                    <span class="name">shared_from_url</span>
+                </td>
+                <td>
+                  <span class="description">Source information for a shared service instance. Users of a shared service instance can find out its space and org information.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">tags</span>
                 </td>
                 <td>
@@ -549,7 +565,8 @@ Cookie: </pre>
     "service_plan_url": "/v2/service_plans/4ec73bf4-9f3a-44c7-bbac-61ee9cb5a511",
     "service_bindings_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/service_bindings",
     "service_keys_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/service_keys",
-    "routes_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/routes"
+    "routes_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/routes",
+    "shared_from_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from"
   }
 }</pre>
 

--- a/docs/v2/service_plans/list_all_service_instances_for_the_service_plan.html
+++ b/docs/v2/service_plans/list_all_service_instances_for_the_service_plan.html
@@ -303,7 +303,8 @@ Cookie: </pre>
         "service_plan_url": "/v2/service_plans/85615ea0-9d23-4de8-aabd-89bffcce39d5",
         "service_bindings_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/service_bindings",
         "service_keys_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/service_keys",
-        "routes_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/routes"
+        "routes_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/routes",
+        "shared_from_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from"
       }
     }
   ]

--- a/docs/v2/service_plans/list_all_service_instances_for_the_service_plan.html
+++ b/docs/v2/service_plans/list_all_service_instances_for_the_service_plan.html
@@ -304,7 +304,8 @@ Cookie: </pre>
         "service_bindings_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/service_bindings",
         "service_keys_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/service_keys",
         "routes_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/routes",
-        "shared_from_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from"
+        "shared_from_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from",
+        "shared_to_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_to"
       }
     }
   ]

--- a/docs/v2/spaces/list_all_service_instances_for_the_space.html
+++ b/docs/v2/spaces/list_all_service_instances_for_the_space.html
@@ -303,7 +303,8 @@ Cookie: </pre>
         "service_bindings_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_bindings",
         "service_keys_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_keys",
         "routes_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/routes",
-        "shared_from_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from"
+        "shared_from_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from",
+        "shared_to_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_to"
       }
     }
   ]

--- a/docs/v2/spaces/list_all_service_instances_for_the_space.html
+++ b/docs/v2/spaces/list_all_service_instances_for_the_space.html
@@ -302,7 +302,8 @@ Cookie: </pre>
         "service_plan_url": "/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab",
         "service_bindings_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_bindings",
         "service_keys_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_keys",
-        "routes_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/routes"
+        "routes_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/routes",
+        "shared_from_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/shared_from"
       }
     }
   ]

--- a/docs/v3/source/includes/api_resources/_service_instances.erb
+++ b/docs/v3/source/includes/api_resources/_service_instances.erb
@@ -18,3 +18,28 @@
   }
 }
 <% end %>
+
+<% content_for :paginated_list_of_service_instances do %>
+{
+  "pagination": {
+    "total_results": 1,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "d4c91047-7b29-4fda-b7f9-04033e5c9c9f",
+      "created_at": "2017-02-02T00:14:30Z",
+      "updated_at": "2017-02-02T00:14:30Z",
+      "name": "my_service_instance"
+    }
+  ]
+}
+<% end %>

--- a/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
@@ -20,7 +20,7 @@ Content-Type: application/json
 
 <%= yield_content :paginated_list_of_service_instances, '/v3/service_instances' %>
 ```
-This endpoint retrieves the service instances the user has access to.
+This endpoint retrieves the service instances the user has access to. This includes access granted by service instance sharing.
 
 #### Definition
 `GET /v3/service_instances`

--- a/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
@@ -20,7 +20,9 @@ Content-Type: application/json
 
 <%= yield_content :paginated_list_of_service_instances, '/v3/service_instances' %>
 ```
-This endpoint retrieves the service instances the user has access to. This includes access granted by service instance sharing.
+This endpoint retrieves the service instances the user has access to. At the moment, this endpoint only returns managed service instances. This may change in the future.
+
+This includes access granted by service instance sharing.
 
 #### Definition
 `GET /v3/service_instances`

--- a/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
@@ -1,0 +1,34 @@
+### List service instances
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/service_instances" \
+  -X GET \
+  -H "Authorization: bearer [token]"
+```
+
+```
+Example Response
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+<%= yield_content :paginated_list_of_service_instances, '/v3/service_instances' %>
+```
+This endpoint retrieves the service instances the user has access to.
+
+#### Definition
+`GET /v3/service_instances`
+
+#### Query Parameters
+
+Name | Type | Description
+---- | ---- | ------------
+**name** | _list of strings_ | Comma-delimited list of service instance names to filter by.
+**page** | _integer_ | Page to display. Valid values are integers >= 1.
+**per_page** | _integer_ | Number of results per page. <br>Valid values are 1 through 5000.

--- a/docs/v3/source/index.md
+++ b/docs/v3/source/index.md
@@ -137,6 +137,7 @@ includes:
   - experimental_resources/service_bindings/delete
   - experimental_resources/service_bindings/list
   - experimental_resources/service_instances/header
+  - experimental_resources/service_instances/list
   - experimental_resources/service_instances/share_to_space
   - experimental_resources/service_instances/unshare_from_space
 search: true

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -2,11 +2,89 @@ require 'spec_helper'
 
 RSpec.describe 'Service Instances' do
   let(:user_email) { 'user@email.example.com' }
-  let(:user_name) { 'sharer_username' }
+  let(:user_name) { 'username' }
   let(:user) { VCAP::CloudController::User.make }
+  let(:user_header) { headers_for(user) }
   let(:admin_header) { admin_headers_for(user, email: user_email, user_name: user_name) }
+  let(:space) { VCAP::CloudController::Space.make }
   let(:target_space) { VCAP::CloudController::Space.make }
-  let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make }
+  let!(:service_instance1) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'rabbitmq') }
+  let!(:service_instance2) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'redis') }
+  let!(:service_instance3) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'mysql') }
+
+  describe 'GET /v3/service_instances' do
+    it 'returns a paginated list of service instances the user has access to' do
+      set_current_user_as_role(role: 'space_developer', org: space.organization, space: space, user: user)
+      get '/v3/service_instances?per_page=2&order_by=name', nil, user_header
+      expect(last_response.status).to eq(200)
+
+      parsed_response = MultiJson.load(last_response.body)
+      expect(parsed_response).to be_a_response_like(
+        {
+          'pagination' => {
+            'total_results' => 3,
+            'total_pages' => 2,
+            'first' => {
+              'href' => "#{link_prefix}/v3/service_instances?order_by=name&page=1&per_page=2"
+            },
+            'last' => {
+              'href' => "#{link_prefix}/v3/service_instances?order_by=name&page=2&per_page=2"
+            },
+            'next' => {
+              'href' => "#{link_prefix}/v3/service_instances?order_by=name&page=2&per_page=2"
+            },
+            'previous' => nil
+          },
+          'resources' => [
+            {
+              'guid' => service_instance3.guid,
+              'name' => 'mysql',
+              'created_at' => iso8601,
+              'updated_at' => iso8601,
+            },
+            {
+              'guid' => service_instance1.guid,
+              'name' => 'rabbitmq',
+              'created_at' => iso8601,
+              'updated_at' => iso8601,
+            }
+          ]
+        }
+      )
+    end
+
+    it 'returns a paginated list of service instances filtered by name' do
+      set_current_user_as_role(role: 'space_developer', org: space.organization, space: space, user: user)
+      get '/v3/service_instances?per_page=2&names=redis', nil, user_header
+      expect(last_response.status).to eq(200)
+
+      parsed_response = MultiJson.load(last_response.body)
+      expect(parsed_response).to be_a_response_like(
+        {
+          'pagination' => {
+            'total_results' => 1,
+            'total_pages' => 1,
+            'first' => {
+              'href' => "#{link_prefix}/v3/service_instances?names=redis&page=1&per_page=2"
+            },
+            'last' => {
+              'href' => "#{link_prefix}/v3/service_instances?names=redis&page=1&per_page=2"
+            },
+            'next' => nil,
+            'previous' => nil
+          },
+          'resources' => [
+            {
+              'guid' => service_instance2.guid,
+              'name' => 'redis',
+              'created_at' => iso8601,
+              'updated_at' => iso8601,
+            }
+          ]
+        }
+      )
+    end
+  end
 
   describe 'POST /v3/service_instances/:guid/relationships/shared_spaces' do
     before do
@@ -20,7 +98,7 @@ RSpec.describe 'Service Instances' do
         ]
       }
 
-      post "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces", share_request.to_json, admin_header
+      post "/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces", share_request.to_json, admin_header
 
       parsed_response = MultiJson.load(last_response.body)
       expect(last_response.status).to eq(200)
@@ -30,8 +108,8 @@ RSpec.describe 'Service Instances' do
           { 'guid' => target_space.guid }
         ],
         'links' => {
-          'self' => { 'href' => "#{link_prefix}/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces" },
-          'related' => { 'href' => "#{link_prefix}/v3/service_instances/#{service_instance.guid}/shared_spaces" },
+          'self' => { 'href' => "#{link_prefix}/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces" },
+          'related' => { 'href' => "#{link_prefix}/v3/service_instances/#{service_instance1.guid}/shared_spaces" },
         }
       }
 
@@ -44,11 +122,11 @@ RSpec.describe 'Service Instances' do
         actor_type:        'user',
         actor_name:        user_email,
         actor_username:    user_name,
-        actee:             service_instance.guid,
+        actee:             service_instance1.guid,
         actee_type:        'service_instance',
-        actee_name:        service_instance.name,
-        space_guid:        service_instance.space.guid,
-        organization_guid: service_instance.space.organization.guid
+        actee_name:        service_instance1.name,
+        space_guid:        space.guid,
+        organization_guid: space.organization.guid
       })
       expect(event.metadata['target_space_guids']).to eq([target_space.guid])
     end
@@ -68,12 +146,12 @@ RSpec.describe 'Service Instances' do
         ]
       }
 
-      post "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces", share_request.to_json, admin_header
+      post "/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces", share_request.to_json, admin_header
       expect(last_response.status).to eq(200)
     end
 
     it 'unshares the service instance from the target space' do
-      delete "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces/#{target_space.guid}", nil, admin_header
+      delete "/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces/#{target_space.guid}", nil, admin_header
       expect(last_response.status).to eq(204)
 
       event = VCAP::CloudController::Event.last
@@ -83,23 +161,23 @@ RSpec.describe 'Service Instances' do
         actor_type:        'user',
         actor_name:        user_email,
         actor_username:    user_name,
-        actee:             service_instance.guid,
+        actee:             service_instance1.guid,
         actee_type:        'service_instance',
-        actee_name:        service_instance.name,
-        space_guid:        service_instance.space.guid,
-        organization_guid: service_instance.space.organization.guid
+        actee_name:        service_instance1.name,
+        space_guid:        space.guid,
+        organization_guid: space.organization.guid
       })
       expect(event.metadata['target_space_guid']).to eq(target_space.guid)
     end
 
     it 'deletes associated bindings in target space when service instance is unshared' do
       process = VCAP::CloudController::ProcessModelFactory.make(diego: false, space: target_space)
-      service_binding = VCAP::CloudController::ServiceBinding.make(service_instance: service_instance, app: process.app, credentials: { secret: 'key' })
+      service_binding = VCAP::CloudController::ServiceBinding.make(service_instance: service_instance1, app: process.app, credentials: { secret: 'key' })
 
       get "/v2/service_bindings/#{service_binding.guid}", nil, admin_header
       expect(last_response.status).to eq(200)
 
-      delete "/v3/service_instances/#{service_instance.guid}/relationships/shared_spaces/#{target_space.guid}", nil, admin_header
+      delete "/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces/#{target_space.guid}", nil, admin_header
       expect(last_response.status).to eq(204)
 
       get "/v2/service_bindings/#{service_binding.guid}", nil, admin_header

--- a/spec/request/v2/service_bindings_spec.rb
+++ b/spec/request/v2/service_bindings_spec.rb
@@ -197,7 +197,8 @@ RSpec.describe 'ServiceBindings' do
                       'service_plan_url' => "/v2/service_plans/#{service_instance.service_plan.guid}",
                       'service_bindings_url' => "/v2/service_instances/#{service_instance.guid}/service_bindings",
                       'service_keys_url' => "/v2/service_instances/#{service_instance.guid}/service_keys",
-                      'routes_url' => "/v2/service_instances/#{service_instance.guid}/routes"
+                      'routes_url' => "/v2/service_instances/#{service_instance.guid}/routes",
+                      'shared_from_url' => "/v2/service_instances/#{service_instance.guid}/shared_from"
                     }
                   }
                 }

--- a/spec/request/v2/service_bindings_spec.rb
+++ b/spec/request/v2/service_bindings_spec.rb
@@ -198,7 +198,8 @@ RSpec.describe 'ServiceBindings' do
                       'service_bindings_url' => "/v2/service_instances/#{service_instance.guid}/service_bindings",
                       'service_keys_url' => "/v2/service_instances/#{service_instance.guid}/service_keys",
                       'routes_url' => "/v2/service_instances/#{service_instance.guid}/routes",
-                      'shared_from_url' => "/v2/service_instances/#{service_instance.guid}/shared_from"
+                      'shared_from_url' => "/v2/service_instances/#{service_instance.guid}/shared_from",
+                      'shared_to_url' => "/v2/service_instances/#{service_instance.guid}/shared_to",
                     }
                   }
                 }

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe 'ServiceInstances' do
         expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted. ' \
           "Unsharing #{service_instance.name} will automatically delete any bindings " \
           'that have been made to applications in other spaces.'
-        expect(parsed_response['error_code']).to eq 'CF-ServiceIsShared'
+        expect(parsed_response['error_code']).to eq 'CF-ServiceInstanceDeletionSharesExists'
         expect(parsed_response['code']).to eq 390002
       end
     end

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe 'ServiceInstances' do
                 'service_bindings_url' => "/v2/service_instances/#{service_instance.guid}/service_bindings",
                 'service_keys_url'     => "/v2/service_instances/#{service_instance.guid}/service_keys",
                 'routes_url'           => "/v2/service_instances/#{service_instance.guid}/routes",
-                'shared_from_url'      => "/v2/service_instances/#{service_instance.guid}/shared_from"
+                'shared_from_url'      => "/v2/service_instances/#{service_instance.guid}/shared_from",
+                'shared_to_url'        => "/v2/service_instances/#{service_instance.guid}/shared_to",
               }
             }
           )
@@ -98,7 +99,8 @@ RSpec.describe 'ServiceInstances' do
                 'service_bindings_url' => "/v2/service_instances/#{service_instance.guid}/service_bindings",
                 'service_keys_url'     => "/v2/service_instances/#{service_instance.guid}/service_keys",
                 'routes_url'           => "/v2/service_instances/#{service_instance.guid}/routes",
-                'shared_from_url'      => "/v2/service_instances/#{service_instance.guid}/shared_from"
+                'shared_from_url'      => "/v2/service_instances/#{service_instance.guid}/shared_from",
+                'shared_to_url'        => "/v2/service_instances/#{service_instance.guid}/shared_to",
               }
             }
           )
@@ -140,7 +142,8 @@ RSpec.describe 'ServiceInstances' do
                 'service_bindings_url' => "/v2/service_instances/#{service_instance.guid}/service_bindings",
                 'service_keys_url'     => "/v2/service_instances/#{service_instance.guid}/service_keys",
                 'routes_url'           => "/v2/service_instances/#{service_instance.guid}/routes",
-                'shared_from_url'      => "/v2/service_instances/#{service_instance.guid}/shared_from"
+                'shared_from_url'      => "/v2/service_instances/#{service_instance.guid}/shared_from",
+                'shared_to_url'        => "/v2/service_instances/#{service_instance.guid}/shared_to",
               }
             }
           )
@@ -200,6 +203,43 @@ RSpec.describe 'ServiceInstances' do
           'organization_name' => space.organization.name
         })
       end
+    end
+  end
+
+  describe 'GET /v2/service_instances/:service_instance_guid/shared_to' do
+    let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
+    let(:space1) { VCAP::CloudController::Space.make }
+    let(:space2) { VCAP::CloudController::Space.make }
+
+    before do
+      service_instance.add_shared_space(space1)
+      service_instance.add_shared_space(space2)
+    end
+
+    it 'returns data about the source space and org' do
+      get "v2/service_instances/#{service_instance.guid}/shared_to", nil, admin_headers
+
+      expect(last_response.status).to eq(200)
+
+      parsed_response = MultiJson.load(last_response.body)
+      expect(parsed_response).to be_a_response_like(
+        {
+          'total_results' => 2,
+          'total_pages' => 1,
+          'prev_url' => nil,
+          'next_url' => nil,
+          'resources' => [
+            {
+              'space_name' => space1.name,
+              'organization_name' => space1.organization.name
+            },
+            {
+              'space_name' => space2.name,
+              'organization_name' => space2.organization.name
+            }
+          ]
+        }
+      )
     end
   end
 end

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -265,7 +265,9 @@ RSpec.describe 'ServiceInstances' do
         expect(last_response.status).to eq(400)
 
         parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted'
+        expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted. ' \
+          "Unsharing #{service_instance.name} will automatically delete any bindings " \
+          'that have been made to applications in other spaces'
         expect(parsed_response['error_code']).to eq 'CF-ServiceIsShared'
         expect(parsed_response['code']).to eq 10014
       end

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe 'ServiceInstances' do
       service_instance.add_shared_space(space2)
     end
 
-    it 'returns data about the source space and org' do
+    it 'returns data about the source space, org, and bound_app_count' do
       get "v2/service_instances/#{service_instance.guid}/shared_to", nil, admin_headers
 
       expect(last_response.status).to eq(200)
@@ -231,11 +231,13 @@ RSpec.describe 'ServiceInstances' do
           'resources' => [
             {
               'space_name' => space1.name,
-              'organization_name' => space1.organization.name
+              'organization_name' => space1.organization.name,
+              'bound_app_count' => 0
             },
             {
               'space_name' => space2.name,
-              'organization_name' => space2.organization.name
+              'organization_name' => space2.organization.name,
+              'bound_app_count' => 0
             }
           ]
         }

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -267,9 +267,9 @@ RSpec.describe 'ServiceInstances' do
         parsed_response = MultiJson.load(last_response.body)
         expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted. ' \
           "Unsharing #{service_instance.name} will automatically delete any bindings " \
-          'that have been made to applications in other spaces'
+          'that have been made to applications in other spaces.'
         expect(parsed_response['error_code']).to eq 'CF-ServiceIsShared'
-        expect(parsed_response['code']).to eq 10014
+        expect(parsed_response['code']).to eq 390002
       end
     end
   end

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -244,4 +244,31 @@ RSpec.describe 'ServiceInstances' do
       )
     end
   end
+
+  describe 'DELETE /v2/service_instance/:guid' do
+    let(:originating_space) { VCAP::CloudController::Space.make }
+    let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: originating_space) }
+
+    context 'when the service instance has been shared' do
+      before do
+        allow(VCAP::Services::ServiceBrokers::V2::Client).to receive(:new) do |*args, **kwargs, &block|
+          FakeServiceBrokerV2Client.new(*args, **kwargs, &block)
+        end
+
+        set_current_user_as_admin
+        service_instance.add_shared_space(space)
+      end
+
+      it 'fails with an appropriate response' do
+        delete "v2/service_instances/#{service_instance.guid}", nil, admin_headers
+
+        expect(last_response.status).to eq(400)
+
+        parsed_response = MultiJson.load(last_response.body)
+        expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted'
+        expect(parsed_response['error_code']).to eq 'CF-ServiceIsShared'
+        expect(parsed_response['code']).to eq 10014
+      end
+    end
+  end
 end

--- a/spec/request/v2/spaces_spec.rb
+++ b/spec/request/v2/spaces_spec.rb
@@ -219,7 +219,8 @@ RSpec.describe 'Spaces' do
             'service_keys_url' => "/v2/service_instances/#{shared_service_instance.guid}/service_keys",
             'routes_url' => "/v2/service_instances/#{shared_service_instance.guid}/routes",
             'service_url' => "/v2/services/#{shared_service_instance.service_plan.service_guid}",
-            'shared_from_url' => "/v2/service_instances/#{shared_service_instance.guid}/shared_from"
+            'shared_from_url' => "/v2/service_instances/#{shared_service_instance.guid}/shared_from",
+            'shared_to_url' => "/v2/service_instances/#{shared_service_instance.guid}/shared_to",
           }
         }]
       })

--- a/spec/request/v2/spaces_spec.rb
+++ b/spec/request/v2/spaces_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Spaces' do
         space.add_developer(user)
       end
 
-      it 'lists the isolation segment for SpaceDvelopers' do
+      it 'lists the isolation segment for SpaceDevelopers' do
         get "/v2/spaces/#{space.guid}", {}, headers_for(user)
 
         expect(last_response.status).to eq(200)
@@ -167,6 +167,62 @@ RSpec.describe 'Spaces' do
           }
         })
       end
+    end
+  end
+
+  describe 'GET /v2/spaces/:guid/service_instances' do
+    let(:originating_space) { VCAP::CloudController::Space.make }
+    let(:shared_service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: originating_space) }
+    let(:space) { VCAP::CloudController::Space.make }
+
+    before do
+      originating_space.organization.add_user(user)
+      originating_space.add_developer(user)
+      space.organization.add_user(user)
+      space.add_developer(user)
+
+      shared_service_instance.add_shared_space(space)
+    end
+
+    it 'shows the shared service instances associated with the space' do
+      get "/v2/spaces/#{space.guid}/service_instances", {}, headers_for(user)
+
+      expect(last_response.status).to eq(200)
+      parsed_response = MultiJson.load(last_response.body)
+
+      expect(parsed_response).to be_a_response_like({
+        'total_results' => 1,
+        'total_pages'   => 1,
+        'prev_url'      => nil,
+        'next_url'      => nil,
+        'resources'     => [{
+          'metadata' => {
+            'guid' => shared_service_instance.guid,
+            'url' => "/v2/service_instances/#{shared_service_instance.guid}",
+            'created_at' => iso8601,
+            'updated_at' => iso8601,
+          },
+          'entity' => {
+            'name' => shared_service_instance.name,
+            'credentials' => shared_service_instance.credentials,
+            'service_plan_guid' => shared_service_instance.service_plan_guid,
+            'space_guid' => originating_space.guid,
+            'gateway_data' => nil,
+            'dashboard_url' => nil,
+            'type' => 'managed_service_instance',
+            'last_operation' => nil,
+            'tags' => [],
+            'service_guid' => shared_service_instance.service_plan.service_guid,
+            'space_url' => "/v2/spaces/#{originating_space.guid}",
+            'service_plan_url' => "/v2/service_plans/#{shared_service_instance.service_plan_guid}",
+            'service_bindings_url' => "/v2/service_instances/#{shared_service_instance.guid}/service_bindings",
+            'service_keys_url' => "/v2/service_instances/#{shared_service_instance.guid}/service_keys",
+            'routes_url' => "/v2/service_instances/#{shared_service_instance.guid}/routes",
+            'service_url' => "/v2/services/#{shared_service_instance.service_plan.service_guid}",
+            'shared_from_url' => "/v2/service_instances/#{shared_service_instance.guid}/shared_from"
+          }
+        }]
+      })
     end
   end
 

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -205,6 +205,7 @@ module VCAP::CloudController
     active            { true }
     service_broker    { ServiceBroker.make }
     description       { Sham.description } # remove hack
+    extra             { '{"shareable": true}' }
   end
 
   Service.blueprint(:routing) do

--- a/spec/support/fakes/fake_service_broker_v2_client.rb
+++ b/spec/support/fakes/fake_service_broker_v2_client.rb
@@ -46,6 +46,16 @@ class FakeServiceBrokerV2Client
     }
   end
 
+  def deprovision(_instance, arbitrary_parameters: {}, accepts_incomplete: false)
+    {
+      last_operation: {
+        type:        'delete',
+        description: '',
+        state:       'succeeded'
+      }
+    }
+  end
+
   def bind(_binding, _arbitrary_parameters)
     {
       credentials: credentials,

--- a/spec/support/matchers/sequel_validations.rb
+++ b/spec/support/matchers/sequel_validations.rb
@@ -48,7 +48,7 @@ RSpec::Matchers.define :validate_uniqueness do |*attributes|
       duplicate_object[attr] = source_obj[attr]
     end
     unless duplicate_object.valid?
-      errors_key = attributes.length > 1 ? attributes : attributes.first
+      errors_key = options[:error_key] || (attributes.length > 1 ? attributes : attributes.first)
       errors = duplicate_object.errors.on(errors_key)
       expected_error = options[:message] || :unique
       errors && errors.include?(expected_error)

--- a/spec/unit/access/service_instance_access_spec.rb
+++ b/spec/unit/access/service_instance_access_spec.rb
@@ -149,6 +149,63 @@ module VCAP::CloudController
       end
     end
 
+    context 'space developer in a space that the service instance has been shared into' do
+      before do
+        org.add_user(user)
+        target_space = VCAP::CloudController::Space.make(organization: org)
+        target_space.add_developer(user)
+        service_instance.add_shared_space(target_space)
+      end
+
+      context 'when the space of the service instance is visible' do
+        it_behaves_like :read_only_access do
+          let(:object) { service_instance }
+        end
+
+        it 'does NOT allow the user to have manage permissions of the service instance' do
+          expect(subject).to_not allow_op_on_object(:manage_permissions, service_instance)
+        end
+
+        it 'allows the user to have read permissions of the service instance' do
+          expect(subject).to allow_op_on_object(:read_permissions, service_instance)
+        end
+
+        it 'does NOT allow the user to read default credentials of the service instance' do
+          expect(subject).not_to allow_op_on_object(:read_env, service_instance)
+        end
+
+        it 'returns false for purge' do
+          expect(subject).not_to allow_op_on_object(:purge, service_instance)
+        end
+      end
+
+      context 'when the space of the service instance is not visible' do
+        before do
+          service_instance.space = nil
+        end
+
+        it_behaves_like :read_only_access do
+          let(:object) { service_instance }
+        end
+
+        it 'does NOT allow the user to have manage permissions of the service instance' do
+          expect(subject).to_not allow_op_on_object(:manage_permissions, service_instance)
+        end
+
+        it 'allows the user to have read permissions of the service instance' do
+          expect(subject).to allow_op_on_object(:read_permissions, service_instance)
+        end
+
+        it 'does NOT allow the user to read default credentials of the service instance' do
+          expect(subject).not_to allow_op_on_object(:read_env, service_instance)
+        end
+
+        it 'returns false for purge' do
+          expect(subject).not_to allow_op_on_object(:purge, service_instance)
+        end
+      end
+    end
+
     context 'organization manager (defensive)' do
       before { org.add_manager(user) }
 

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -74,7 +74,7 @@ module VCAP::CloudController
         it 'raises an api error' do
           expect {
             service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError, /Service #{service_instance.service.label} has not enabled service instance sharing/)
+          }.to raise_error(CloudController::Errors::ApiError, /The #{service_instance.service.label} service does not support service instance sharing./)
         end
       end
     end

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -29,6 +29,54 @@ module VCAP::CloudController
         expect(Repositories::ServiceInstanceShareEventRepository).to have_received(:record_share_event).with(
           service_instance, [target_space1.guid, target_space2.guid], user_audit_info)
       end
+
+      context 'when a share already exists' do
+        before do
+          service_instance.add_shared_space(target_space1)
+        end
+
+        it 'is idempotent' do
+          shared_instance = service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          expect(shared_instance.shared_spaces.length).to eq 1
+        end
+      end
+
+      context 'when sharing one space from the list of spaces fails' do
+        before do
+          allow(service_instance).to receive(:add_shared_space).with(target_space1).and_call_original
+          allow(service_instance).to receive(:add_shared_space).with(target_space2).and_raise('db failure')
+        end
+
+        it 'does not share with any spaces' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
+          }.to raise_error('db failure')
+
+          instance = ServiceInstance.find(guid: service_instance.guid)
+
+          expect(instance.shared_spaces.length).to eq 0
+        end
+
+        it 'does not audit any share events' do
+          expect(Repositories::ServiceInstanceShareEventRepository).to_not receive(:record_share_event)
+
+          expect {
+            service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
+          }.to raise_error('db failure')
+        end
+      end
+
+      context 'when the service does is not shareable' do
+        before do
+          allow(service_instance).to receive(:shareable?).and_return(false)
+        end
+
+        it 'raises an api error' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
+          }.to raise_error(CloudController::Errors::ApiError, /Service #{service_instance.service.label} has not enabled service instance sharing/)
+        end
+      end
     end
   end
 end

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -223,6 +223,14 @@ module VCAP::CloudController
 
       before { set_current_user(developer) }
 
+      it 'returns the shared from url' do
+        space_instance = ManagedServiceInstance.make(space: space)
+
+        get "/v2/spaces/#{space.guid}/service_instances"
+        service_instance_response = decoded_response.fetch('resources').first
+        expect(service_instance_response.fetch('entity').fetch('shared_from_url')).to eq("/v2/service_instances/#{space_instance.guid}/shared_from")
+      end
+
       context 'when filtering results' do
         it 'returns only matching results' do
           user_provided_service_instance_1 = UserProvidedServiceInstance.make(space: space, name: 'provided service 1')

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3404,7 +3404,7 @@ module VCAP::CloudController
             'org_manager'         => { manage: false, read: true },
             'admin'               => { manage: true, read: true },
             'admin_read_only'     => { manage: false, read: true },
-            'global_auditor'      => { manage: false, read: true },
+            'global_auditor'      => { manage: false, read: false },
           }.each do |role, expected_return_values|
             context "as an #{role}" do
               before do

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3932,6 +3932,16 @@ module VCAP::CloudController
         it 'returns the forbidden code for auditors' do
           verify_forbidden auditor
         end
+
+        context 'when user is a developer in space to which the instance was shared' do
+          before do
+            instance.add_shared_space(space)
+          end
+
+          it 'returns the forbidden code' do
+            verify_forbidden developer
+          end
+        end
       end
 
       context 'when the user is a member of the space this instance exists in' do

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2385,7 +2385,7 @@ module VCAP::CloudController
             expect(last_response.body).to include(
               'Service instances must be unshared before they can be deleted. ' \
               "Unsharing #{service_instance.name} will automatically delete any bindings " \
-              'that have been made to applications in other spaces')
+              'that have been made to applications in other spaces.')
           end
 
           context 'and there are bindings to the shared instance' do
@@ -2404,7 +2404,7 @@ module VCAP::CloudController
               expect(last_response.body).to include(
                 'Service instances must be unshared before they can be deleted. ' \
                 "Unsharing #{service_instance.name} will automatically delete any bindings " \
-                'that have been made to applications in other spaces')
+                'that have been made to applications in other spaces.')
             end
           end
 

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3404,7 +3404,7 @@ module VCAP::CloudController
             'org_manager'         => { manage: false, read: true },
             'admin'               => { manage: true, read: true },
             'admin_read_only'     => { manage: false, read: true },
-            'global_auditor'      => { manage: false, read: false },
+            'global_auditor'      => { manage: false, read: true },
           }.each do |role, expected_return_values|
             context "as an #{role}" do
               before do

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2381,7 +2381,7 @@ module VCAP::CloudController
             delete "/v2/service_instances/#{service_instance.guid}"
 
             expect(last_response).to have_status_code 400
-            expect(last_response.body).to include 'ServiceIsShared'
+            expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
             expect(last_response.body).to include(
               'Service instances must be unshared before they can be deleted. ' \
               "Unsharing #{service_instance.name} will automatically delete any bindings " \
@@ -2400,7 +2400,7 @@ module VCAP::CloudController
               delete "/v2/service_instances/#{service_instance.guid}"
 
               expect(last_response).to have_status_code 400
-              expect(last_response.body).to include 'ServiceIsShared'
+              expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
               expect(last_response.body).to include(
                 'Service instances must be unshared before they can be deleted. ' \
                 "Unsharing #{service_instance.name} will automatically delete any bindings " \

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -885,6 +885,32 @@ module VCAP::CloudController
             expect(last_response.status).to eq(400)
             expect(decoded_response['code']).to eq(60002)
           end
+
+          it 'does not allow a managed service instance with same name as a shared service instance' do
+            source_space = Space.make(organization: space.organization)
+            source_space.add_developer(developer)
+            service_instance = create_managed_service_instance(accepts_incomplete: 'false', space: source_space)
+            expect(last_response.status).to eq(201)
+
+            service_instance.add_shared_space(space)
+
+            create_managed_service_instance
+            expect(last_response.status).to eq(400)
+            expect(decoded_response['code']).to eq(60002)
+          end
+
+          it 'does not allow a user provided service instance with same name as a shared service instance' do
+            source_space = Space.make(organization: space.organization)
+            source_space.add_developer(developer)
+            service_instance = create_managed_service_instance(accepts_incomplete: 'false', space: source_space)
+            expect(last_response.status).to eq(201)
+
+            service_instance.add_shared_space(space)
+
+            create_user_provided_service_instance
+            expect(last_response.status).to eq(400)
+            expect(decoded_response['code']).to eq(60002)
+          end
         end
 
         context 'when the service_plan does not exist' do
@@ -4003,7 +4029,6 @@ module VCAP::CloudController
       let(:errors) { instance_double(Sequel::Model::Errors) }
       let(:attributes) { {} }
 
-      let(:space_and_name_errors) { nil }
       let(:quota_errors) { nil }
       let(:service_plan_errors) { nil }
       let(:service_instance_name_errors) { nil }
@@ -4013,7 +4038,6 @@ module VCAP::CloudController
 
       before do
         allow(e).to receive(:errors).and_return(errors)
-        allow(errors).to receive(:on).with([:space_id, :name]).and_return(space_and_name_errors)
         allow(errors).to receive(:on).with(:quota).and_return(quota_errors)
         allow(errors).to receive(:on).with(:service_plan).and_return(service_plan_errors)
         allow(errors).to receive(:on).with(:name).and_return(service_instance_name_errors)
@@ -4028,7 +4052,6 @@ module VCAP::CloudController
       end
 
       context "when errors are included but aren't supported validation exceptions" do
-        let(:space_and_name_errors) { [:stuff] }
         let(:quota_errors) { [:stuff] }
         let(:service_plan_errors) { [:stuff] }
         let(:service_instance_name_errors) { [:stuff] }
@@ -4042,7 +4065,7 @@ module VCAP::CloudController
 
       context 'when there is a service instance name taken error' do
         let(:attributes) { { 'name' => 'test name' } }
-        let(:space_and_name_errors) { [:unique] }
+        let(:service_instance_name_errors) { [:unique] }
 
         it 'returns a ServiceInstanceNameTaken error' do
           expect(VCAP::CloudController::ServiceInstancesController.translate_validation_exception(e, attributes).name).to eq('ServiceInstanceNameTaken')
@@ -4111,10 +4134,11 @@ module VCAP::CloudController
       arbitrary_params = user_opts.delete(:parameters)
       accepts_incomplete = user_opts.delete(:accepts_incomplete) { |_| 'true' }
       tags = user_opts.delete(:tags)
+      service_instance_space = user_opts.delete(:space) || space
 
       body = {
         name: 'foo',
-        space_guid: space.guid,
+        space_guid: service_instance_space.guid,
         service_plan_guid: plan.guid,
       }
       body[:parameters] = arbitrary_params if arbitrary_params

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2370,32 +2370,7 @@ module VCAP::CloudController
             service_instance.add_shared_space(space)
           end
 
-          it 'does not delete the associated shares' do
-            delete "/v2/service_instances/#{service_instance.guid}"
-
-            expect(ServiceInstance.find(guid: service_instance.guid)).to be
-            expect(ServiceInstance.find(guid: service_instance.guid).shared_spaces.length).to eq(1)
-          end
-
-          it 'should give the user an error' do
-            delete "/v2/service_instances/#{service_instance.guid}"
-
-            expect(last_response).to have_status_code 400
-            expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
-            expect(last_response.body).to include(
-              'Service instances must be unshared before they can be deleted. ' \
-              "Unsharing #{service_instance.name} will automatically delete any bindings " \
-              'that have been made to applications in other spaces.')
-          end
-
-          context 'and there are bindings to the shared instance' do
-            before do
-              ServiceBinding.make(
-                app: AppModel.make(space: space),
-                service_instance: service_instance
-              )
-            end
-
+          context 'as a SpaceDeveloper in source and target space' do
             it 'should give the user an error' do
               delete "/v2/service_instances/#{service_instance.guid}"
 
@@ -2406,16 +2381,61 @@ module VCAP::CloudController
                 "Unsharing #{service_instance.name} will automatically delete any bindings " \
                 'that have been made to applications in other spaces.')
             end
+
+            it 'associated shares are not deleted' do
+              delete "/v2/service_instances/#{service_instance.guid}"
+
+              expect(ServiceInstance.find(guid: service_instance.guid)).to be
+              expect(ServiceInstance.find(guid: service_instance.guid).shared_spaces.length).to eq(1)
+            end
+
+            context 'and there are bindings to the shared instance' do
+              before do
+                ServiceBinding.make(
+                  app: AppModel.make(space: space),
+                  service_instance: service_instance
+                )
+              end
+
+              it 'should give the user an error' do
+                delete "/v2/service_instances/#{service_instance.guid}"
+
+                expect(last_response).to have_status_code 400
+                expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
+                expect(last_response.body).to include(
+                  'Service instances must be unshared before they can be deleted. ' \
+                  "Unsharing #{service_instance.name} will automatically delete any bindings " \
+                  'that have been made to applications in other spaces.')
+              end
+            end
+
+            context 'and recursive=true' do
+              it 'deletes the associated shares' do
+                expect {
+                  delete "/v2/service_instances/#{service_instance.guid}?recursive=true"
+                }.to change(ServiceInstance.join(:service_instance_shares, service_instance_guid: :service_instances__guid), :count).by(-1)
+
+                expect(last_response.status).to eq(204)
+                expect(ServiceInstance.find(guid: service_instance.guid)).to be_nil
+              end
+            end
           end
 
-          context 'and recursive=true' do
-            it 'deletes the associated shares' do
-              expect {
-                delete "/v2/service_instances/#{service_instance.guid}?recursive=true"
-              }.to change(ServiceInstance.join(:service_instance_shares, service_instance_guid: :service_instances__guid), :count).by(-1)
+          context 'as a SpaceDeveloper in target space' do
+            let(:target_space) { Space.make }
+            let(:tommy) { make_developer_for_space(target_space) }
 
-              expect(last_response.status).to eq(204)
-              expect(ServiceInstance.find(guid: service_instance.guid)).to be_nil
+            before do
+              service_instance.add_shared_space(target_space)
+              set_current_user(tommy, email: 'tommy@example.com')
+            end
+
+            it 'should give the user an error' do
+              delete "/v2/service_instances/#{service_instance.guid}"
+
+              expect(last_response).to have_status_code 403
+              expect(last_response.body).to include 'CF-NotAuthorized'
+              expect(last_response.body).to include 'You are not authorized to perform the requested action'
             end
           end
         end

--- a/spec/unit/controllers/services/service_keys_controller_spec.rb
+++ b/spec/unit/controllers/services/service_keys_controller_spec.rb
@@ -387,6 +387,30 @@ module VCAP::CloudController
             expect(a_request(:put, url_regex).with(body: hash_including(expected_body))).to have_been_made
           end
         end
+
+        context 'when the service instance has been shared' do
+          let(:other_space) { Space.make }
+
+          before do
+            instance.add_shared_space(other_space)
+          end
+
+          context 'when the user is a space developer in the service instance space' do
+            it 'returns successfully' do
+              post '/v2/service_keys', req
+              expect(last_response).to have_status_code(201)
+            end
+          end
+
+          context 'when the user does not have access to the service instance space' do
+            let(:developer) { make_developer_for_space(other_space) }
+
+            it 'returns a 403' do
+              post '/v2/service_keys', req
+              expect(last_response).to have_status_code(403)
+            end
+          end
+        end
       end
 
       context 'for a user-provided service instance' do

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -217,6 +217,23 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
       end
     end
 
+    context 'when the source space is contained in the list of target spaces' do
+      before do
+        req_body[:data] = [
+          { guid: service_instance.space.guid },
+          { guid: target_space.guid }
+        ]
+      end
+
+      it 'does not share into any spaces and returns an error message' do
+        post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
+
+        expect(response.status).to eq 422
+        expect(response.body).to include('Service instances cannot be shared into the space where they were created')
+        expect(service_instance.shared_spaces).to be_empty
+      end
+    end
+
     context 'when the request is malformed' do
       let(:req_body) {
         {

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
     it 'shares the service instance to multiple target spaces' do
       action = instance_double(VCAP::CloudController::ServiceInstanceShare)
       allow(VCAP::CloudController::ServiceInstanceShare).to receive(:new).and_return(action)
-      expect(action).to receive(:create).with(service_instance, [target_space, target_space2], an_instance_of(VCAP::CloudController::UserAuditInfo))
+      expect(action).to receive(:create).with(service_instance, a_collection_containing_exactly(target_space, target_space2), an_instance_of(VCAP::CloudController::UserAuditInfo))
 
       req_body[:data] << { guid: target_space2.guid }
 

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -2,6 +2,49 @@ require 'rails_helper'
 
 RSpec.describe ServiceInstancesV3Controller, type: :controller do
   let(:user) { set_current_user(VCAP::CloudController::User.make) }
+  let(:space) { VCAP::CloudController::Space.make }
+  let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'awesome service') }
+
+  describe '#index' do
+    describe 'permissions by role' do
+      role_to_expected_http_response = {
+        'admin'               => true,
+        'admin_read_only'     => true,
+        'global_auditor'      => true,
+        'org_manager'         => true,
+        'org_auditor'         => false,
+        'org_billing_manager' => false,
+        'space_manager'       => true,
+        'space_auditor'       => true,
+        'space_developer'     => true,
+      }.freeze
+
+      role_to_expected_http_response.each do |role, can_see_service_instance|
+        context "as an #{role}" do
+          it "#{can_see_service_instance ? 'can' : 'cannot'} see the service instance" do
+            set_current_user_as_role(role: role, org: space.organization, space: space, user: user)
+
+            expected_service_instance_names = can_see_service_instance ? ['awesome service'] : []
+
+            get :index
+            expect(response.status).to eq(200), response.body
+            expect(parsed_body['resources'].map { |h| h['name'] }).to match_array(expected_service_instance_names)
+          end
+        end
+      end
+    end
+
+    context 'when a non-supported value is specified' do
+      it 'a bad query parameter error is returned' do
+        set_current_user_as_admin
+        get :index, { order_by: 'banana' }
+
+        expect(response.status).to eq(400)
+        expect(response.body).to include 'BadQueryParameter'
+        expect(response.body).to include("Order by can only be: 'created_at', 'updated_at', 'name'")
+      end
+    end
+  end
 
   describe '#share_service_instance' do
     let(:service_instance) { VCAP::CloudController::ServiceInstance.make }

--- a/spec/unit/controllers/v3/service_instance_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instance_controller_spec.rb
@@ -3,9 +3,44 @@ require 'rails_helper'
 RSpec.describe ServiceInstancesV3Controller, type: :controller do
   let(:user) { set_current_user(VCAP::CloudController::User.make) }
   let(:space) { VCAP::CloudController::Space.make }
-  let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'awesome service') }
+  let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
 
   describe '#index' do
+    context 'when there are multiple service instances' do
+      let!(:service_instance2) { VCAP::CloudController::ManagedServiceInstance.make }
+      let!(:service_instance3) { VCAP::CloudController::ManagedServiceInstance.make }
+
+      context 'as an admin' do
+        before do
+          set_current_user_as_admin
+        end
+
+        it 'returns all service instances' do
+          get :index
+          expect(response.status).to eq(200), response.body
+          expect(parsed_body['resources'].length).to eq 3
+
+          response_names = parsed_body['resources'].map { |resource| resource['name'] }
+          expect(response_names).to include(service_instance.name, service_instance2.name, service_instance3.name)
+        end
+      end
+
+      context 'as a user who only has limited access' do
+        before do
+          set_current_user_as_role(role: 'space_developer', org: space.organization, space: space, user: user)
+        end
+
+        it 'returns a subset of service instances' do
+          get :index
+          expect(response.status).to eq(200), response.body
+          expect(parsed_body['resources'].length).to eq 1
+
+          response_names = parsed_body['resources'].map { |resource| resource['name'] }
+          expect(response_names).to include(service_instance.name)
+        end
+      end
+    end
+
     describe 'permissions by role' do
       role_to_expected_http_response = {
         'admin'               => true,
@@ -24,7 +59,36 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
           it "#{can_see_service_instance ? 'can' : 'cannot'} see the service instance" do
             set_current_user_as_role(role: role, org: space.organization, space: space, user: user)
 
-            expected_service_instance_names = can_see_service_instance ? ['awesome service'] : []
+            expected_service_instance_names = can_see_service_instance ? [service_instance.name] : []
+
+            get :index
+            expect(response.status).to eq(200), response.body
+            expect(parsed_body['resources'].map { |h| h['name'] }).to match_array(expected_service_instance_names)
+          end
+        end
+      end
+    end
+
+    describe 'permissions by role for shared services' do
+      let(:target_space) { VCAP::CloudController::Space.make }
+      before do
+        service_instance.add_shared_space(target_space)
+      end
+      role_to_expected_http_response = {
+        'org_manager'         => true,
+        'org_auditor'         => false,
+        'org_billing_manager' => false,
+        'space_manager'       => true,
+        'space_auditor'       => true,
+        'space_developer'     => true,
+      }.freeze
+
+      role_to_expected_http_response.each do |role, can_see_service_instance|
+        context "as an #{role}" do
+          it "#{can_see_service_instance ? 'can' : 'cannot'} see the service instance" do
+            set_current_user_as_role(role: role, org: target_space.organization, space: target_space, user: user)
+
+            expected_service_instance_names = can_see_service_instance ? [service_instance.name] : []
 
             get :index
             expect(response.status).to eq(200), response.body

--- a/spec/unit/messages/service_instances_list_message_spec.rb
+++ b/spec/unit/messages/service_instances_list_message_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'messages/service_instances/service_instances_list_message'
+
+module VCAP::CloudController
+  RSpec.describe ServiceInstancesListMessage do
+    describe '.from_params' do
+      let(:params) do
+        {
+          'page'      => 1,
+          'per_page'  => 5,
+          'order_by'  => 'name',
+          'names' => 'rabbitmq, redis,mysql'
+        }
+      end
+
+      it 'returns the correct ServiceInstancesListMessage' do
+        message = ServiceInstancesListMessage.from_params(params)
+
+        expect(message).to be_a(ServiceInstancesListMessage)
+        expect(message.page).to eq(1)
+        expect(message.per_page).to eq(5)
+        expect(message.order_by).to eq('name')
+        expect(message.names).to match_array(['mysql', 'rabbitmq', 'redis'])
+      end
+
+      it 'converts requested keys to symbols' do
+        message = ServiceInstancesListMessage.from_params(params)
+
+        expect(message.requested?(:page)).to be_truthy
+        expect(message.requested?(:per_page)).to be_truthy
+        expect(message.requested?(:order_by)).to be_truthy
+        expect(message.requested?(:names)).to be_truthy
+      end
+    end
+
+    describe 'fields' do
+      it 'accepts a set of fields' do
+        message = ServiceInstancesListMessage.new({
+            page: 1,
+            per_page: 5,
+            order_by: 'created_at',
+            names: ['rabbitmq', 'redis']
+          })
+        expect(message).to be_valid
+      end
+
+      it 'accepts an empty set' do
+        message = ServiceInstancesListMessage.new
+        expect(message).to be_valid
+      end
+
+      it 'does not accept a field not in this set' do
+        message = ServiceInstancesListMessage.new({ foobar: 'pants' })
+
+        expect(message).not_to be_valid
+        expect(message.errors[:base]).to include("Unknown query parameter(s): 'foobar'")
+      end
+    end
+  end
+end

--- a/spec/unit/models/services/managed_service_instance_spec.rb
+++ b/spec/unit/models/services/managed_service_instance_spec.rb
@@ -258,6 +258,32 @@ module VCAP::CloudController
       end
     end
 
+    describe '#shareable?' do
+      let(:service) { Service.make }
+      let(:service_instance) { ManagedServiceInstance.make }
+
+      before do
+        allow(service).to receive(:shareable?).and_return(is_shareable)
+        allow(service_instance).to receive(:service).and_return(service)
+      end
+
+      context 'when the service instance is not a shareable' do
+        let(:is_shareable) { false }
+
+        it 'returns false' do
+          expect(service_instance).to_not be_shareable
+        end
+      end
+
+      context 'when the service instance is shareable' do
+        let(:is_shareable) { true }
+
+        it 'returns true' do
+          expect(service_instance).to be_shareable
+        end
+      end
+    end
+
     describe '#as_summary_json' do
       let(:service) { Service.make(label: 'YourSQL', guid: '9876XZ') }
       let(:service_plan) { ServicePlan.make(name: 'Gold Plan', guid: '12763abc', service: service) }

--- a/spec/unit/models/services/managed_service_instance_spec.rb
+++ b/spec/unit/models/services/managed_service_instance_spec.rb
@@ -32,7 +32,7 @@ module VCAP::CloudController
       it { is_expected.to validate_presence :name }
       it { is_expected.to validate_presence :service_plan }
       it { is_expected.to validate_presence :space }
-      it { is_expected.to validate_uniqueness [:space_id, :name] }
+      it { is_expected.to validate_uniqueness :space_id, :name, { error_key: :name } }
       it { is_expected.to strip_whitespace :name }
       let(:max_tags) { ['a' * 1024, 'b' * 1024] }
 

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -432,5 +432,23 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe '#shared?' do
+      context 'when the service instance has shared spaces' do
+        before do
+          service_instance.add_shared_space(Space.make)
+        end
+
+        it 'returns true' do
+          expect(service_instance.shared?).to be true
+        end
+      end
+
+      context 'when the service instance does not have shared spaces' do
+        it 'returns false' do
+          expect(service_instance.shared?).to be false
+        end
+      end
+    end
   end
 end

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -326,5 +326,48 @@ module VCAP::CloudController
         expect(service_instance.to_hash(opts)['credentials']).to eq({ redacted_message: '[PRIVATE DATA HIDDEN]' })
       end
     end
+
+    describe '#user_visibility_filter' do
+      let(:developer)     { make_developer_for_space(service_instance.space) }
+      let(:auditor)       { make_auditor_for_space(service_instance.space) }
+      let(:user)          { make_user_for_space(service_instance.space) }
+      let(:org_manager)   { make_manager_for_org(service_instance.space.organization) }
+      let(:space_manager) { make_manager_for_space(service_instance.space) }
+
+      context 'when a user is an org manager where the instance was created' do
+        it 'the service instance is visible' do
+          filter = ServiceInstance.user_visibility_filter(org_manager)
+          expect(ServiceInstance.filter(filter).all.length).to eq(1)
+        end
+      end
+
+      context 'when a user is a space developer in the space the instance was created' do
+        it 'the service instance is visible' do
+          filter = ServiceInstance.user_visibility_filter(developer)
+          expect(ServiceInstance.filter(filter).all.length).to eq(1)
+        end
+      end
+
+      context 'when a user is a space auditor in the space the instance was created' do
+        it 'the service instance is visible' do
+          filter = ServiceInstance.user_visibility_filter(auditor)
+          expect(ServiceInstance.filter(filter).all.length).to eq(1)
+        end
+      end
+
+      context 'when a user is a space manager in the space the instance was created' do
+        it 'the service instance is visible' do
+          filter = ServiceInstance.user_visibility_filter(space_manager)
+          expect(ServiceInstance.filter(filter).all.length).to eq(1)
+        end
+      end
+
+      context 'when a user does not have access to the originating space' do
+        it 'the service instance is not visible' do
+          filter = ServiceInstance.user_visibility_filter(user)
+          expect(ServiceInstance.filter(filter).all.length).to eq(0)
+        end
+      end
+    end
   end
 end

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -85,7 +85,7 @@ module VCAP::CloudController
             expect {
               service_instance_foo.set(name: 'bar')
               service_instance_foo.save_changes
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
         end
       end
@@ -97,13 +97,13 @@ module VCAP::CloudController
           it 'raises an exception when creating another UserProvidedServiceInstance' do
             expect {
               UserProvidedServiceInstance.create(service_instance_attrs)
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
 
           it 'raises an exception when creating a ManagedServiceInstance' do
             expect {
               ManagedServiceInstance.create(service_instance_attrs)
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
         end
 
@@ -116,13 +116,37 @@ module VCAP::CloudController
           it 'raises an exception when creating another ManagedServiceInstance' do
             expect {
               ManagedServiceInstance.create(service_instance_attrs)
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
 
           it 'raises an exception when creating a UserProvidedServiceInstance' do
             expect {
               UserProvidedServiceInstance.create(service_instance_attrs)
-            }.to raise_error(Sequel::ValidationFailed, /space_id and name unique/)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
+          end
+        end
+
+        describe 'when a ManagedServiceInstance has been shared' do
+          let(:space) { Space.make }
+          let(:originating_space) { Space.make }
+          let(:service_instance) {
+            ManagedServiceInstance.make(name: 'shared-service', space: originating_space)
+          }
+
+          before do
+            service_instance.add_shared_space(space)
+          end
+
+          it 'raises an exception when creating another ManagedServiceInstance' do
+            expect {
+              ManagedServiceInstance.make(name: 'shared-service', space: space)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
+          end
+
+          it 'raises an exception when creating another UserProvidedServiceInstance' do
+            expect {
+              UserProvidedServiceInstance.make(name: 'shared-service', space: space)
+            }.to raise_error(Sequel::ValidationFailed, /name unique/)
           end
         end
       end

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -368,6 +368,30 @@ module VCAP::CloudController
           expect(ServiceInstance.filter(filter).all.length).to eq(0)
         end
       end
+
+      context 'when the service instance is shared' do
+        let(:target_space)     { VCAP::CloudController::Space.make }
+        let(:target_space_dev) { make_developer_for_space(target_space) }
+        let(:target_space_auditor) { make_auditor_for_space(target_space) }
+
+        before do
+          service_instance.add_shared_space(target_space)
+        end
+
+        context 'when a user is a space developer in the target space' do
+          it 'the service instance is visible' do
+            filter = ServiceInstance.user_visibility_filter(target_space_dev)
+            expect(ServiceInstance.filter(filter).all.length).to eq(1)
+          end
+        end
+
+        context 'when a user is a space auditor in the target space' do
+          it 'the service instance is not visible' do
+            filter = ServiceInstance.user_visibility_filter(target_space_auditor)
+            expect(ServiceInstance.filter(filter).all.length).to eq(0)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -289,6 +289,12 @@ module VCAP::CloudController
       it { is_expected.to be_bindable }
     end
 
+    describe '#shareable?' do
+      it 'returns false' do
+        expect(service_instance.shareable?).to be_falsey
+      end
+    end
+
     describe '#as_summary_json' do
       it 'contains name, guid, and binding count' do
         instance = VCAP::CloudController::ServiceInstance.make(

--- a/spec/unit/models/services/service_spec.rb
+++ b/spec/unit/models/services/service_spec.rb
@@ -397,6 +397,48 @@ module VCAP::CloudController
       end
     end
 
+    describe '#shareable?' do
+      context 'when the service metadata include shareable true' do
+        let(:service) { Service.make(extra: '{"shareable":true}') }
+
+        it 'returns true' do
+          expect(service).to be_shareable
+        end
+      end
+
+      context 'when the service metadata include shareable false' do
+        let(:service) { Service.make(extra: '{"shareable":false}') }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+
+      context 'when the service does not include the shareable field in metadata' do
+        let(:service) { Service.make(extra: '{"other-key": "value"}') }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+
+      context 'when the service metadata is nil' do
+        let(:service) { Service.make(extra: nil) }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+
+      context 'when extra contains malformed json' do
+        let(:service) { Service.make(extra: '{"not-json"}') }
+
+        it 'returns false' do
+          expect(service).to_not be_shareable
+        end
+      end
+    end
+
     describe '#client' do
       let(:service) { Service.make(service_broker: ServiceBroker.make) }
 

--- a/spec/unit/presenters/v2/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_presenter_spec.rb
@@ -35,6 +35,7 @@ module CloudController::Presenters::V2
               'relationship_url'  => 'http://relationship.example.com',
               'service_url'       => "/v2/services/#{service_plan.service.guid}",
               'shared_from_url'   => "/v2/service_instances/#{service_instance.guid}/shared_from",
+              'shared_to_url'     => "/v2/service_instances/#{service_instance.guid}/shared_to",
             }
           )
         end

--- a/spec/unit/presenters/v2/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_presenter_spec.rb
@@ -11,35 +11,48 @@ module CloudController::Presenters::V2
     let(:relations_hash) { { 'relationship_url' => 'http://relationship.example.com' } }
     subject { ServiceInstancePresenter.new }
 
-    describe '#entity_hash' do
-      before do
-        set_current_user_as_admin
+    before do
+      set_current_user_as_admin
+      allow(RelationsPresenter).to receive(:new).and_return(relations_presenter)
+    end
+
+    describe 'ManagedServiceInstance' do
+      describe '#entity_hash' do
+        let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make }
+        let(:service_plan) { VCAP::CloudController::ServicePlan.make }
+
+        before do
+          service_instance.service_plan_id = service_plan.id
+          service_instance.save
+        end
+
+        it 'returns the service instance entity' do
+          expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)).to eq(
+            {
+              'name'              => service_instance.name,
+              'service_plan_guid' => service_plan.guid,
+              'service_guid'      => service_plan.service.guid,
+              'relationship_url'  => 'http://relationship.example.com',
+              'service_url'       => "/v2/services/#{service_plan.service.guid}",
+              'shared_from_url'   => "/v2/service_instances/#{service_instance.guid}/shared_from",
+            }
+          )
+        end
       end
+    end
 
-      let(:service_instance) do
-        VCAP::CloudController::ServiceInstance.make(
-          name: 'things',
-        )
-      end
-      let(:service_plan) { VCAP::CloudController::ServicePlan.make }
+    describe 'UserProvidedServiceInstance' do
+      describe '#entity_hash' do
+        let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make }
 
-      before do
-        service_instance.service_plan_id = service_plan.id
-        service_instance.save
-
-        allow(RelationsPresenter).to receive(:new).and_return(relations_presenter)
-      end
-
-      it 'returns the service instance entity' do
-        expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)).to eq(
-          {
-            'name'              => service_instance.name,
-            'service_plan_guid' => service_plan.guid,
-            'service_guid'      => service_plan.service.guid,
-            'relationship_url'  => 'http://relationship.example.com',
-            'service_url'       => "/v2/services/#{service_plan.service.guid}"
-          }
-        )
+        it 'returns the service instance entity' do
+          expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)).to eq(
+            {
+              'name'              => service_instance.name,
+              'relationship_url'  => 'http://relationship.example.com',
+            }
+          )
+        end
       end
     end
   end

--- a/spec/unit/presenters/v2/service_instance_shared_from_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_shared_from_presenter_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module CloudController::Presenters::V2
+  RSpec.describe ServiceInstanceSharedFromPresenter do
+    describe '#to_hash' do
+      it 'returns the space and org name' do
+        space = VCAP::CloudController::Space.make
+        presenter = ServiceInstanceSharedFromPresenter.new
+        expect(presenter.to_hash(space)).to eq(
+          {
+            'space_name' => space.name,
+            'organization_name' => space.organization.name,
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/presenters/v2/service_instance_shared_to_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_shared_to_presenter_spec.rb
@@ -3,13 +3,14 @@ require 'spec_helper'
 module CloudController::Presenters::V2
   RSpec.describe ServiceInstanceSharedToPresenter do
     describe '#to_hash' do
-      it 'returns the space and org name' do
+      it 'returns the space name, org name, and bound app count' do
         space = VCAP::CloudController::Space.make
         presenter = ServiceInstanceSharedToPresenter.new
-        expect(presenter.to_hash(space)).to eq(
+        expect(presenter.to_hash(space, 42)).to eq(
           {
             'space_name' => space.name,
             'organization_name' => space.organization.name,
+            'bound_app_count' => 42
           }
         )
       end

--- a/spec/unit/presenters/v2/service_instance_shared_to_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_shared_to_presenter_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module CloudController::Presenters::V2
+  RSpec.describe ServiceInstanceSharedToPresenter do
+    describe '#to_hash' do
+      it 'returns the space and org name' do
+        space = VCAP::CloudController::Space.make
+        presenter = ServiceInstanceSharedToPresenter.new
+        expect(presenter.to_hash(space)).to eq(
+          {
+            'space_name' => space.name,
+            'organization_name' => space.organization.name,
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/presenters/v3/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_instance_presenter_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'presenters/v3/service_instance_presenter'
+
+module VCAP::CloudController::Presenters::V3
+  RSpec.describe ServiceInstancePresenter do
+    let(:presenter) { ServiceInstancePresenter.new(service_instance) }
+    let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(name: 'denise-db') }
+
+    describe '#to_hash' do
+      let(:result) { presenter.to_hash }
+
+      it 'presents the model as a hash' do
+        expect(result[:guid]).to eq(service_instance.guid)
+        expect(result[:created_at]).to eq(service_instance.created_at)
+        expect(result[:updated_at]).to eq(service_instance.updated_at)
+        expect(result[:name]).to eq('denise-db')
+      end
+    end
+  end
+end

--- a/spec/unit/queries/service_binding_list_fetcher_spec.rb
+++ b/spec/unit/queries/service_binding_list_fetcher_spec.rb
@@ -90,5 +90,53 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe '#fetch_service_instance_bindings_in_space' do
+      let(:space) { Space.make }
+      let(:service_instance) { ServiceInstance.make(space: space) }
+
+      it 'returns a Sequel::Dataset' do
+        results = ServiceBindingListFetcher.fetch_service_instance_bindings_in_space(service_instance.guid, space.guid)
+        expect(results).to be_a(Sequel::Dataset)
+      end
+
+      context 'when there are no bindings' do
+        it 'returns an empty dataset' do
+          results = ServiceBindingListFetcher.fetch_service_instance_bindings_in_space(service_instance.guid, space.guid)
+          expect(results.count).to eql(0)
+        end
+      end
+
+      context 'when a binding exists in a space' do
+        let!(:service_binding) { ServiceBinding.make(app: AppModel.make(space: space), service_instance: service_instance) }
+        let!(:other_service_binding) { ServiceBinding.make }
+
+        it 'returns the binding for the correct space' do
+          results = ServiceBindingListFetcher.fetch_service_instance_bindings_in_space(service_instance.guid, space.guid)
+          expect(results.count).to eql(1)
+        end
+      end
+
+      context 'when multiple bindings exist in a space' do
+        let!(:service_binding1) { ServiceBinding.make(app: AppModel.make(space: space), service_instance: service_instance) }
+        let!(:service_binding2) { ServiceBinding.make(app: AppModel.make(space: space), service_instance: service_instance) }
+        let!(:other_service_binding) { ServiceBinding.make }
+
+        it 'returns the bindings for the correct space' do
+          results = ServiceBindingListFetcher.fetch_service_instance_bindings_in_space(service_instance.guid, space.guid)
+          expect(results.count).to eql(2)
+        end
+      end
+
+      context 'when multiple service instances exist' do
+        let!(:service_binding) { ServiceBinding.make(app: AppModel.make(space: space), service_instance: service_instance) }
+        let!(:other_service_binding) { ServiceBinding.make(service_instance: ServiceInstance.make(space: space)) }
+
+        it 'returns the binding for the correct service instance' do
+          results = ServiceBindingListFetcher.fetch_service_instance_bindings_in_space(service_instance.guid, space.guid)
+          expect(results.count).to eql(1)
+        end
+      end
+    end
   end
 end

--- a/spec/unit/queries/service_instance_list_fetcher_spec.rb
+++ b/spec/unit/queries/service_instance_list_fetcher_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'fetchers/service_instance_list_fetcher'
+require 'messages/service_instances/service_instances_list_message'
+
+module VCAP::CloudController
+  RSpec.describe ServiceInstanceListFetcher do
+    let(:filters) { {} }
+    let(:message) { ServiceInstancesListMessage.new(filters) }
+    let(:fetcher) { ServiceInstanceListFetcher.new }
+
+    describe '#fetch_all' do
+      let!(:service_instance_1) { ManagedServiceInstance.make(name: 'rabbitmq') }
+      let!(:service_instance_2) { ManagedServiceInstance.make(name: 'redis') }
+
+      it 'returns a Sequel::Dataset' do
+        results = fetcher.fetch_all(message: message)
+        expect(results).to be_a(Sequel::Dataset)
+      end
+
+      it 'includes all the V3 Service Instances' do
+        results = fetcher.fetch_all(message: message).all
+        expect(results.length).to eq 2
+        expect(results).to include(service_instance_1, service_instance_2)
+      end
+
+      context 'filter' do
+        context 'by service instance name' do
+          let(:filters) { { names: ['rabbitmq'] } }
+
+          it 'only returns matching service instances' do
+            results = fetcher.fetch_all(message: message).all
+            expect(results).to match_array([service_instance_1])
+            expect(results).not_to include(service_instance_2)
+          end
+        end
+      end
+    end
+
+    describe '#fetch' do
+      let!(:service_instance_1) { ManagedServiceInstance.make(name: 'rabbitmq', space: space_1) }
+      let!(:service_instance_2) { ManagedServiceInstance.make(name: 'redis', space: space_1) }
+      let!(:service_instance_3) { ManagedServiceInstance.make(name: 'mysql', space: space_2) }
+
+      let(:space_1) { Space.make }
+      let(:space_2) { Space.make }
+
+      it 'returns all of the service instances in the specified space' do
+        results = fetcher.fetch(message: message, space_guids: [space_1.guid]).all
+
+        expect(results).to match_array([service_instance_1, service_instance_2])
+      end
+
+      context 'filter' do
+        context 'by service instance name' do
+          let(:filters) { { names: ['rabbitmq', 'redis'] } }
+
+          it 'only returns matching service instances' do
+            results = fetcher.fetch(message: message, space_guids: [space_1.guid]).all
+            expect(results).to match_array([service_instance_1, service_instance_2])
+          end
+        end
+
+        context 'by non-existent service instance name' do
+          let(:filters) { { names: ['made-up-name'] } }
+
+          it 'returns no matching service instances' do
+            results = fetcher.fetch(message: message, space_guids: [space_1.guid]).all
+            expect(results).to be_empty
+          end
+        end
+      end
+    end
+  end
+end

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -88,11 +88,6 @@
   http_code: 429
   message: "Rate Limit Exceeded"
 
-10014:
-  name: ServiceIsShared
-  http_code: 400
-  message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces"
-
 20001:
   name: UserInvalid
   http_code: 400
@@ -1113,3 +1108,8 @@
   name: ServiceInstanceUnshareFailed
   http_code: 502
   message: "Unshare of service instance failed because one or more bindings could not be deleted.\n\n%s"
+
+390002:
+  name: ServiceIsShared
+  http_code: 400
+  message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces."

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1117,4 +1117,4 @@
 390003:
   name: ServiceShareIsDisabled
   http_code: 400
-  message: "Service %s has not enabled service instance sharing."
+  message: "The %s service does not support service instance sharing."

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1110,6 +1110,6 @@
   message: "Unshare of service instance failed because one or more bindings could not be deleted.\n\n%s"
 
 390002:
-  name: ServiceIsShared
+  name: ServiceInstanceDeletionSharesExists
   http_code: 400
   message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces."

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -91,7 +91,7 @@
 10014:
   name: ServiceIsShared
   http_code: 400
-  message: "Service instances must be unshared before they can be deleted"
+  message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces"
 
 20001:
   name: UserInvalid

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -88,6 +88,11 @@
   http_code: 429
   message: "Rate Limit Exceeded"
 
+10014:
+  name: ServiceIsShared
+  http_code: 400
+  message: "Service instances must be unshared before they can be deleted"
+
 20001:
   name: UserInvalid
   http_code: 400

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1113,3 +1113,8 @@
   name: ServiceInstanceDeletionSharesExists
   http_code: 400
   message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces."
+
+390003:
+  name: ServiceShareIsDisabled
+  http_code: 400
+  message: "Service %s has not enabled service instance sharing."


### PR DESCRIPTION
As an app dev (sharer), I cannot share service instances with myself. [#152109683](https://www.pivotaltracker.com/story/show/152109683)

**NOTE**: This PR builds on top of #987, which should be merged first. The actual changes on top of #987 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-service-instance-sharing-add-tests-service-keys...cloudfoundry-incubator:pr-service-instance-sharing-no-sharing-to-self).

## What

This PR closes a loophole in the validation logic when a service instance share is created. If the service instance's own space GUID is in the body of the request to the sharing service instances endpoint, a 422 will be returned and no service instance shares will be recorded (or audited). This approach is consistent with the pattern of failing a request if any GUIDs in the body of the request do not correspond to valid spaces that the user can read.

Changes:
* Raise 422 when source space is included in list of target spaces

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi