### PR TITLE
Revert "Users cannot share into a space where an existing service instance name would clash"

### DIFF
--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -3,17 +3,19 @@ require 'repositories/service_instance_share_event_repository'
 module VCAP::CloudController
   class ServiceInstanceShare
     def create(service_instance, target_spaces, user_audit_info)
-      supported_service_type?(service_instance)
-      service_instance_shareable?(service_instance)
+      if service_instance.route_service?
+        raise CloudController::Errors::ApiError.new_from_details('RouteServiceInstanceSharingNotSupported')
+      end
+      unless service_instance.managed_instance?
+        raise CloudController::Errors::ApiError.new_from_details('UserProvidedServiceInstanceSharingNotSupported')
+      end
+
+      unless service_instance.shareable?
+        raise CloudController::Errors::ApiError.new_from_details('ServiceShareIsDisabled', service_instance.service.label)
+      end
 
       if target_spaces.include?(service_instance.space)
         raise CloudController::Errors::ApiError.new_from_details('InvalidServiceInstanceSharingTargetSpace')
-      end
-
-      target_spaces.each do |space|
-        if space.service_instances.map(&:name).include?(service_instance.name)
-          raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNameTaken', service_instance.name, space.name)
-        end
       end
 
       ServiceInstance.db.transaction do
@@ -26,24 +28,6 @@ module VCAP::CloudController
         service_instance, target_spaces.map(&:guid), user_audit_info
       )
       service_instance
-    end
-
-    private
-
-    def supported_service_type?(service_instance)
-      if service_instance.route_service?
-        raise CloudController::Errors::ApiError.new_from_details('RouteServiceInstanceSharingNotSupported')
-      end
-
-      unless service_instance.managed_instance?
-        raise CloudController::Errors::ApiError.new_from_details('UserProvidedServiceInstanceSharingNotSupported')
-      end
-    end
-
-    def service_instance_shareable?(service_instance)
-      unless service_instance.shareable?
-        raise CloudController::Errors::ApiError.new_from_details('ServiceShareIsDisabled', service_instance.service.label)
-      end
     end
   end
 end

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -101,19 +101,6 @@ module VCAP::CloudController
         end
       end
 
-      context 'when a service instance already exists in the target space with the same name as the service being shared' do
-        let(:service_instance) { ManagedServiceInstance.make(name: 'banana') }
-        let!(:target_space_service_instance) { ManagedServiceInstance.make(name: 'banana', space: target_space1) }
-
-        it 'raises an api error' do
-          expect {
-            service_instance_share.create(service_instance, [target_space1], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError,
-                           /A service instance called #{service_instance.name} already exists in #{target_space1.name}/)
-          expect(service_instance.shared_spaces).to be_empty
-        end
-      end
-
       context 'when the service is user-provided' do
         it 'raises an api error' do
           expect {

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1128,12 +1128,6 @@
   name: RouteServiceInstanceSharingNotSupported
   http_code: 400
   message: "Route services cannot be shared"
-
-390006:
-  name: SharedServiceInstanceNameTaken
-  http_code: 400
-  message: "A service instance called %s already exists in %s"
-
 390007:
   name: InvalidServiceInstanceSharingTargetSpace
   http_code: 422


### PR DESCRIPTION
Reverts cloudfoundry/cloud_controller_ng#994

We accidentally merged this PR before reviewing and going through acceptance.
[#152853525]