### PR TITLE
Restore PR: service instance sharing prevent sharing if will cause name clash

### DIFF
--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -3,19 +3,17 @@ require 'repositories/service_instance_share_event_repository'
 module VCAP::CloudController
   class ServiceInstanceShare
     def create(service_instance, target_spaces, user_audit_info)
-      if service_instance.route_service?
-        raise CloudController::Errors::ApiError.new_from_details('RouteServiceInstanceSharingNotSupported')
-      end
-      unless service_instance.managed_instance?
-        raise CloudController::Errors::ApiError.new_from_details('UserProvidedServiceInstanceSharingNotSupported')
-      end
-
-      unless service_instance.shareable?
-        raise CloudController::Errors::ApiError.new_from_details('ServiceShareIsDisabled', service_instance.service.label)
-      end
+      supported_service_type?(service_instance)
+      service_instance_shareable?(service_instance)
 
       if target_spaces.include?(service_instance.space)
         raise CloudController::Errors::ApiError.new_from_details('InvalidServiceInstanceSharingTargetSpace')
+      end
+
+      target_spaces.each do |space|
+        if space.service_instances.map(&:name).include?(service_instance.name)
+          raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNameTaken', service_instance.name, space.name)
+        end
       end
 
       ServiceInstance.db.transaction do
@@ -28,6 +26,24 @@ module VCAP::CloudController
         service_instance, target_spaces.map(&:guid), user_audit_info
       )
       service_instance
+    end
+
+    private
+
+    def supported_service_type?(service_instance)
+      if service_instance.route_service?
+        raise CloudController::Errors::ApiError.new_from_details('RouteServiceInstanceSharingNotSupported')
+      end
+
+      unless service_instance.managed_instance?
+        raise CloudController::Errors::ApiError.new_from_details('UserProvidedServiceInstanceSharingNotSupported')
+      end
+    end
+
+    def service_instance_shareable?(service_instance)
+      unless service_instance.shareable?
+        raise CloudController::Errors::ApiError.new_from_details('ServiceShareIsDisabled', service_instance.service.label)
+      end
     end
   end
 end

--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -14,6 +14,10 @@ module VCAP::CloudController
         raise CloudController::Errors::ApiError.new_from_details('ServiceShareIsDisabled', service_instance.service.label)
       end
 
+      if target_spaces.include?(service_instance.space)
+        raise CloudController::Errors::ApiError.new_from_details('InvalidServiceInstanceSharingTargetSpace')
+      end
+
       ServiceInstance.db.transaction do
         target_spaces.each do |space|
           service_instance.add_shared_space(space)

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -101,6 +101,19 @@ module VCAP::CloudController
         end
       end
 
+      context 'when a service instance already exists in the target space with the same name as the service being shared' do
+        let(:service_instance) { ManagedServiceInstance.make(name: 'banana') }
+        let!(:target_space_service_instance) { ManagedServiceInstance.make(name: 'banana', space: target_space1) }
+
+        it 'raises an api error' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          }.to raise_error(CloudController::Errors::ApiError,
+                           /A service instance called #{service_instance.name} already exists in #{target_space1.name}/)
+          expect(service_instance.shared_spaces).to be_empty
+        end
+      end
+
       context 'when the service is user-provided' do
         it 'raises an api error' do
           expect {

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -67,6 +67,28 @@ module VCAP::CloudController
         end
       end
 
+      context 'when source space is included in list of target spaces' do
+        it 'does not share with any spaces' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1, service_instance.space], user_audit_info)
+          }.to raise_error(CloudController::Errors::ApiError,
+                           'Service instances cannot be shared into the space where they were created')
+
+          instance = ServiceInstance.find(guid: service_instance.guid)
+
+          expect(instance.shared_spaces.length).to eq 0
+        end
+
+        it 'does not audit any share events' do
+          expect(Repositories::ServiceInstanceShareEventRepository).to_not receive(:record_share_event)
+
+          expect {
+            service_instance_share.create(service_instance, [target_space1, service_instance.space], user_audit_info)
+          }.to raise_error(CloudController::Errors::ApiError,
+                           'Service instances cannot be shared into the space where they were created')
+        end
+      end
+
       context 'when the service does is not shareable' do
         before do
           allow(service_instance).to receive(:shareable?).and_return(false)

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1128,3 +1128,7 @@
   name: RouteServiceInstanceSharingNotSupported
   http_code: 400
   message: "Route services cannot be shared"
+390007:
+  name: InvalidServiceInstanceSharingTargetSpace
+  http_code: 422
+  message: 'Service instances cannot be shared into the space where they were created'

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1128,6 +1128,12 @@
   name: RouteServiceInstanceSharingNotSupported
   http_code: 400
   message: "Route services cannot be shared"
+
+390006:
+  name: SharedServiceInstanceNameTaken
+  http_code: 400
+  message: "A service instance called %s already exists in %s"
+
 390007:
   name: InvalidServiceInstanceSharingTargetSpace
   http_code: 422


### PR DESCRIPTION
This PR is a resubmission of a PR that was accidentally merged. See comments here #994 .

**NOTE**: This PR builds on top of #1001 , which should be merged first. The actual changes on top of #1001 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/cloudfoundry-incubator:restore-pr-service-instance-sharing-no-renaming-to-shared-instance-name...cloudfoundry-incubator:restore-pr-service-instance-sharing-prevent-sharing-if-will-cause-name-clash).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
