### PR TITLE
Add v3 service_instances to v3 root

### DIFF
--- a/app/controllers/v3/root_controller.rb
+++ b/app/controllers/v3/root_controller.rb
@@ -32,6 +32,10 @@ class RootController < ActionController::Base
           },
           droplets: {
             href: build_api_uri(path: '/droplets')
+          },
+          service_instances: {
+            href: build_api_uri(path: '/service_instances'),
+            experimental: true,
           }
         }
       }, pretty: true)

--- a/spec/unit/controllers/v3/root_controller_spec.rb
+++ b/spec/unit/controllers/v3/root_controller_spec.rb
@@ -71,5 +71,13 @@ RSpec.describe RootController, type: :controller do
       expected_uri = "#{TestConfig.config[:external_protocol]}://#{TestConfig.config[:external_domain]}/v3/droplets"
       expect(hash['links']['droplets']['href']).to eq(expected_uri)
     end
+
+    it 'returns a link to service instances' do
+      get :v3_root
+      hash = MultiJson.load(response.body)
+      expected_uri = "#{TestConfig.config[:external_protocol]}://#{TestConfig.config[:external_domain]}/v3/service_instances"
+      expect(hash['links']['service_instances']['href']).to eq(expected_uri)
+      expect(hash['links']['service_instances']['experimental']).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
As an API client I can discover the /v3/service_instances resource [#152726367](https://www.pivotaltracker.com/story/show/152726367)

## What

This PR adds the new service_instances resource to `/v3`. This is important for the CF CLI as it discovers resource urls automatically. To distinguish this experimental resource from the others, a temporary experimental field has been included.

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi