### PR TITLE
Include space_guids in shared_to and shared_from v2 endpoints

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -6,7 +6,7 @@ require 'presenters/v3/to_many_relationship_presenter'
 require 'presenters/v3/paginated_list_presenter'
 require 'actions/service_instance_share'
 require 'actions/service_instance_unshare'
-require 'fetchers/service_instance_list_fetcher'
+require 'fetchers/managed_service_instance_list_fetcher'
 
 class ServiceInstancesV3Controller < ApplicationController
   def index
@@ -14,9 +14,9 @@ class ServiceInstancesV3Controller < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     dataset = if can_read_globally?
-                ServiceInstanceListFetcher.new.fetch_all(message: message)
+                ManagedServiceInstanceListFetcher.new.fetch_all(message: message)
               else
-                ServiceInstanceListFetcher.new.fetch(message: message, readable_space_guids: readable_space_guids)
+                ManagedServiceInstanceListFetcher.new.fetch(message: message, readable_space_guids: readable_space_guids)
               end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -16,7 +16,7 @@ class ServiceInstancesV3Controller < ApplicationController
     dataset = if can_read_globally?
                 ServiceInstanceListFetcher.new.fetch_all(message: message)
               else
-                ServiceInstanceListFetcher.new.fetch(message: message, space_guids: readable_space_guids)
+                ServiceInstanceListFetcher.new.fetch(message: message, readable_space_guids: readable_space_guids)
               end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(

--- a/app/fetchers/managed_service_instance_list_fetcher.rb
+++ b/app/fetchers/managed_service_instance_list_fetcher.rb
@@ -1,10 +1,10 @@
 module VCAP::CloudController
-  class ServiceInstanceListFetcher
+  class ManagedServiceInstanceListFetcher
     def fetch(message:, readable_space_guids:)
-      source_space_instance_dataset = ServiceInstance.select_all(ServiceInstance.table_name).
+      source_space_instance_dataset = ManagedServiceInstance.select_all(ServiceInstance.table_name).
                                       join(Space.table_name, id: :space_id, guid: readable_space_guids)
 
-      shared_instance_dataset = ServiceInstance.select_all(ServiceInstance.table_name).
+      shared_instance_dataset = ManagedServiceInstance.select_all(ServiceInstance.table_name).
                                 join(:service_instance_shares, service_instance_guid: :guid, target_space_guid: readable_space_guids)
 
       dataset = source_space_instance_dataset.union(shared_instance_dataset, alias: :service_instances)
@@ -13,7 +13,7 @@ module VCAP::CloudController
     end
 
     def fetch_all(message:)
-      dataset = ServiceInstance.dataset
+      dataset = ManagedServiceInstance.dataset
       filter(dataset, message)
     end
 

--- a/app/messages/service_instances/service_instances_list_message.rb
+++ b/app/messages/service_instances/service_instances_list_message.rb
@@ -2,12 +2,13 @@ require 'messages/list_message'
 
 module VCAP::CloudController
   class ServiceInstancesListMessage < ListMessage
-    ALLOWED_KEYS = [:page, :per_page, :order_by, :names].freeze
+    ALLOWED_KEYS = [:page, :per_page, :order_by, :names, :space_guids].freeze
 
     attr_accessor(*ALLOWED_KEYS)
 
     validates_with NoAdditionalParamsValidator
     validates :names, array: true, allow_nil: true
+    validates :space_guids, array: true, allow_nil: true
 
     def initialize(params={})
       super(params.symbolize_keys)
@@ -16,6 +17,7 @@ module VCAP::CloudController
     def self.from_params(params)
       opts = params.dup
       to_array! opts, 'names'
+      to_array! opts, 'space_guids'
       new(opts.symbolize_keys)
     end
 

--- a/app/presenters/v2/service_instance_shared_from_presenter.rb
+++ b/app/presenters/v2/service_instance_shared_from_presenter.rb
@@ -4,6 +4,7 @@ module CloudController
       class ServiceInstanceSharedFromPresenter
         def to_hash(space)
           {
+            'space_guid' => space.guid,
             'space_name' => space.name,
             'organization_name' => space.organization.name
           }

--- a/app/presenters/v3/service_instance_presenter.rb
+++ b/app/presenters/v3/service_instance_presenter.rb
@@ -9,11 +9,27 @@ module VCAP::CloudController
             guid:       service_instance.guid,
             created_at: service_instance.created_at,
             updated_at: service_instance.updated_at,
-            name:      service_instance.name
+            name:      service_instance.name,
+            relationships: {
+              space: {
+                data: {
+                  guid: service_instance.space.guid
+                }
+              }
+            },
+            links: {
+              space: {
+                href: url_builder.build_url(path: "/v3/spaces/#{service_instance.space.guid}")
+              }
+            }
           }
         end
 
         private
+
+        def url_builder
+          VCAP::CloudController::Presenters::ApiUrlBuilder.new
+        end
 
         def service_instance
           @resource

--- a/docs/v3/source/includes/api_resources/_service_instances.erb
+++ b/docs/v3/source/includes/api_resources/_service_instances.erb
@@ -35,10 +35,22 @@
   },
   "resources": [
     {
-      "guid": "d4c91047-7b29-4fda-b7f9-04033e5c9c9f",
-      "created_at": "2017-02-02T00:14:30Z",
-      "updated_at": "2017-02-02T00:14:30Z",
-      "name": "my_service_instance"
+      "guid": "85ccdcad-d725-4109-bca4-fd6ba062b5c8",
+      "created_at": "2017-11-17T13:54:21Z",
+      "updated_at": "2017-11-17T13:54:21Z",
+      "name": "my_service_instance",
+      "relationships": {
+        "space": {
+          "data": {
+            "guid": "ae0031f9-dd49-461c-a945-df40e77c39cb"
+          }
+        }
+      },
+      "links": {
+        "space": {
+          "href": "https://api.example.org/v3/spaces/ae0031f9-dd49-461c-a945-df40e77c39cb"
+        }
+      }
     }
   ]
 }

--- a/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_list.md.erb
@@ -32,5 +32,6 @@ This includes access granted by service instance sharing.
 Name | Type | Description
 ---- | ---- | ------------
 **names** | _list of strings_ | Comma-delimited list of service instance names to filter by.
+**space_guids** | _list of strings_ | Comma-delimited list of space guids to filter by.
 **page** | _integer_ | Page to display. Valid values are integers >= 1.
 **per_page** | _integer_ | Number of results per page. <br>Valid values are 1 through 5000.

--- a/docs/v3/source/includes/experimental_resources/service_instances/_object.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_instances/_object.md.erb
@@ -1,0 +1,10 @@
+### The service_instance object
+
+Name | Type | Description
+---- | ---- | -----------
+**name** | _string_ | Name of the service instance.
+**guid** | _uuid_ | Unique identifier for the service instance.
+**created_at** | _datetime_ | The time with zone when the object was created.
+**updated_at** | _datetime_ | The time with zone when the object was last updated.
+**space** | [_to-one relationship_](#to-one-relationships) | The space the service instance is contained in.
+**links** | [_links object_](#links) | Links to related resources.

--- a/docs/v3/source/index.md
+++ b/docs/v3/source/index.md
@@ -137,6 +137,7 @@ includes:
   - experimental_resources/service_bindings/delete
   - experimental_resources/service_bindings/list
   - experimental_resources/service_instances/header
+  - experimental_resources/service_instances/object
   - experimental_resources/service_instances/list
   - experimental_resources/service_instances/share_to_space
   - experimental_resources/service_instances/unshare_from_space

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -280,28 +280,6 @@ RSpec.describe 'Service Instances' do
       })
       expect(event.metadata['target_space_guids']).to eq([target_space.guid])
     end
-
-    context 'when the service offering has shareable false' do
-      before do
-        service_instance1.service.extra = { shareable: false }.to_json
-        service_instance1.service.save
-      end
-
-      it 'fails to share' do
-        share_request = {
-          'data' => [
-            { 'guid' => target_space.guid }
-          ]
-        }
-
-        post "/v3/service_instances/#{service_instance1.guid}/relationships/shared_spaces", share_request.to_json, admin_header
-
-        expect(last_response.status).to eq(400)
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response['errors'].first['code']).to eq(390003)
-        expect(parsed_response['errors'].first['title']).to eq('CF-ServiceShareIsDisabled')
-      end
-    end
   end
 
   describe 'DELETE /v3/service_instances/:guid/relationships/shared_spaces/:space-guid' do

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -166,6 +166,7 @@ RSpec.describe 'ServiceInstances' do
 
       parsed_response = MultiJson.load(last_response.body)
       expect(parsed_response).to be_a_response_like({
+        'space_guid' => space.guid,
         'space_name' => space.name,
         'organization_name' => space.organization.name
       })
@@ -199,6 +200,7 @@ RSpec.describe 'ServiceInstances' do
 
         parsed_response = MultiJson.load(last_response.body)
         expect(parsed_response).to be_a_response_like({
+          'space_guid' => space.guid,
           'space_name' => space.name,
           'organization_name' => space.organization.name
         })
@@ -230,11 +232,13 @@ RSpec.describe 'ServiceInstances' do
           'next_url' => nil,
           'resources' => [
             {
+              'space_guid' => space1.guid,
               'space_name' => space1.name,
               'organization_name' => space1.organization.name,
               'bound_app_count' => 0
             },
             {
+              'space_guid' => space2.guid,
               'space_name' => space2.name,
               'organization_name' => space2.organization.name,
               'bound_app_count' => 0

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe 'ServiceInstances' do
       it 'fails with an appropriate response' do
         delete "v2/service_instances/#{service_instance.guid}", nil, admin_headers
 
-        expect(last_response.status).to eq(400)
+        expect(last_response.status).to eq(422)
 
         parsed_response = MultiJson.load(last_response.body)
         expect(parsed_response['description']).to eq 'Service instances must be unshared before they can be deleted. ' \

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3848,9 +3848,11 @@ module VCAP::CloudController
           get "/v2/service_instances/#{instance.guid}/shared_from"
           expect(last_response.status).to eql(200), last_response.body
           parsed_response = JSON.parse(last_response.body)
+
+          expect(parsed_response.keys).to match_array(['space_name', 'space_guid', 'organization_name'])
           expect(parsed_response['space_name']).to eq(space.name)
+          expect(parsed_response['space_guid']).to eq(space.guid)
           expect(parsed_response['organization_name']).to eq(space.organization.name)
-          expect(parsed_response.keys).to match_array(['space_name', 'organization_name'])
         end
 
         describe 'permissions' do
@@ -3961,11 +3963,14 @@ module VCAP::CloudController
           space1_resource = resources.find { |resource| resource['space_name'] == space1.name }
           space2_resource = resources.find { |resource| resource['space_name'] == space2.name }
 
-          expect(space1_resource.keys).to match_array(['space_name', 'organization_name', 'bound_app_count'])
-          expect(space2_resource.keys).to match_array(['space_name', 'organization_name', 'bound_app_count'])
+          expect(space1_resource.keys).to match_array(['space_name', 'space_guid', 'organization_name', 'bound_app_count'])
+          expect(space2_resource.keys).to match_array(['space_name', 'space_guid', 'organization_name', 'bound_app_count'])
 
           expect(space1_resource.fetch('space_name')).to eq(space1.name)
           expect(space2_resource.fetch('space_name')).to eq(space2.name)
+
+          expect(space1_resource.fetch('space_guid')).to eq(space1.guid)
+          expect(space2_resource.fetch('space_guid')).to eq(space2.guid)
 
           expect(space1_resource.fetch('organization_name')).to eq(space1.organization.name)
           expect(space2_resource.fetch('organization_name')).to eq(space2.organization.name)

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2574,7 +2574,7 @@ module VCAP::CloudController
             it 'should give the user an error' do
               delete "/v2/service_instances/#{service_instance.guid}"
 
-              expect(last_response).to have_status_code 400
+              expect(last_response).to have_status_code 422
               expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
               expect(last_response.body).to include(
                 'Service instances must be unshared before they can be deleted. ' \
@@ -2600,7 +2600,7 @@ module VCAP::CloudController
               it 'should give the user an error' do
                 delete "/v2/service_instances/#{service_instance.guid}"
 
-                expect(last_response).to have_status_code 400
+                expect(last_response).to have_status_code 422
                 expect(last_response.body).to include 'ServiceInstanceDeletionSharesExists'
                 expect(last_response.body).to include(
                   'Service instances must be unshared before they can be deleted. ' \

--- a/spec/unit/messages/service_instances_list_message_spec.rb
+++ b/spec/unit/messages/service_instances_list_message_spec.rb
@@ -9,7 +9,8 @@ module VCAP::CloudController
           'page'      => 1,
           'per_page'  => 5,
           'order_by'  => 'name',
-          'names' => 'rabbitmq, redis,mysql'
+          'names' => 'rabbitmq, redis,mysql',
+          'space_guids' => 'space-1, space-2, space-3',
         }
       end
 
@@ -21,6 +22,7 @@ module VCAP::CloudController
         expect(message.per_page).to eq(5)
         expect(message.order_by).to eq('name')
         expect(message.names).to match_array(['mysql', 'rabbitmq', 'redis'])
+        expect(message.space_guids).to match_array(['space-1', 'space-2', 'space-3'])
       end
 
       it 'converts requested keys to symbols' do
@@ -30,6 +32,7 @@ module VCAP::CloudController
         expect(message.requested?(:per_page)).to be_truthy
         expect(message.requested?(:order_by)).to be_truthy
         expect(message.requested?(:names)).to be_truthy
+        expect(message.requested?(:space_guids)).to be_truthy
       end
     end
 
@@ -39,7 +42,8 @@ module VCAP::CloudController
             page: 1,
             per_page: 5,
             order_by: 'created_at',
-            names: ['rabbitmq', 'redis']
+            names: ['rabbitmq', 'redis'],
+            space_guids: ['space-1', 'space-2'],
           })
         expect(message).to be_valid
       end
@@ -54,6 +58,24 @@ module VCAP::CloudController
 
         expect(message).not_to be_valid
         expect(message.errors[:base]).to include("Unknown query parameter(s): 'foobar'")
+      end
+    end
+
+    describe 'validations' do
+      context 'names' do
+        it 'validates names is an array' do
+          message = ServiceInstancesListMessage.new names: 'tricked you, not an array'
+          expect(message).to be_invalid
+          expect(message.errors[:names]).to include('must be an array')
+        end
+      end
+
+      context 'space guids' do
+        it 'validates app_guids is an array' do
+          message = ServiceInstancesListMessage.new space_guids: 'tricked you, not an array'
+          expect(message).to be_invalid
+          expect(message.errors[:space_guids]).to include('must be an array')
+        end
       end
     end
   end

--- a/spec/unit/presenters/v2/service_instance_shared_from_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_shared_from_presenter_spec.rb
@@ -8,6 +8,7 @@ module CloudController::Presenters::V2
         presenter = ServiceInstanceSharedFromPresenter.new
         expect(presenter.to_hash(space)).to eq(
           {
+            'space_guid' => space.guid,
             'space_name' => space.name,
             'organization_name' => space.organization.name,
           }

--- a/spec/unit/presenters/v2/service_instance_shared_to_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_shared_to_presenter_spec.rb
@@ -8,6 +8,7 @@ module CloudController::Presenters::V2
         presenter = ServiceInstanceSharedToPresenter.new
         expect(presenter.to_hash(space, 42)).to eq(
           {
+            'space_guid' => space.guid,
             'space_name' => space.name,
             'organization_name' => space.organization.name,
             'bound_app_count' => 42

--- a/spec/unit/presenters/v3/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_instance_presenter_spec.rb
@@ -14,6 +14,11 @@ module VCAP::CloudController::Presenters::V3
         expect(result[:created_at]).to eq(service_instance.created_at)
         expect(result[:updated_at]).to eq(service_instance.updated_at)
         expect(result[:name]).to eq('denise-db')
+        expect(result[:relationships][:space][:data][:guid]).to equal(service_instance.space.guid)
+      end
+
+      it 'has a links hash with a space url' do
+        expect(result[:links][:space][:href]).to eq "#{link_prefix}/v3/spaces/#{service_instance.space.guid}"
       end
     end
   end

--- a/spec/unit/queries/service_instance_list_fetcher_spec.rb
+++ b/spec/unit/queries/service_instance_list_fetcher_spec.rb
@@ -44,6 +44,21 @@ module VCAP::CloudController
             expect(results).not_to include(service_instance_1)
           end
         end
+
+        context 'by all query params' do
+          let!(:service_instance_4) { ManagedServiceInstance.make(name: 'couchdb', space: service_instance_3.space) }
+          let(:filters) {
+            {
+              space_guids: ['space-3'],
+              names: ['couchdb'],
+            }
+          }
+
+          it 'only returns matching service instances' do
+            results = fetcher.fetch_all(message: message).all
+            expect(results).to match_array([service_instance_4])
+          end
+        end
       end
     end
 
@@ -78,6 +93,20 @@ module VCAP::CloudController
             results = fetcher.fetch_all(message: message).all
             expect(results).to match_array([service_instance_1, service_instance_2])
             expect(results).not_to include(service_instance_3)
+          end
+        end
+
+        context 'by all query params' do
+          let(:filters) {
+            {
+              space_guids: ['space-1'],
+              names: ['rabbitmq'],
+            }
+          }
+
+          it 'only returns matching service instances' do
+            results = fetcher.fetch_all(message: message).all
+            expect(results).to match_array([service_instance_1])
           end
         end
 

--- a/spec/unit/queries/service_instance_list_fetcher_spec.rb
+++ b/spec/unit/queries/service_instance_list_fetcher_spec.rb
@@ -9,8 +9,9 @@ module VCAP::CloudController
     let(:fetcher) { ServiceInstanceListFetcher.new }
 
     describe '#fetch_all' do
-      let!(:service_instance_1) { ManagedServiceInstance.make(name: 'rabbitmq') }
-      let!(:service_instance_2) { ManagedServiceInstance.make(name: 'redis') }
+      let!(:service_instance_1) { ManagedServiceInstance.make(name: 'rabbitmq', space: Space.make(guid: 'space-1')) }
+      let!(:service_instance_2) { ManagedServiceInstance.make(name: 'redis', space: Space.make(guid: 'space-2')) }
+      let!(:service_instance_3) { ManagedServiceInstance.make(name: 'mysql', space: Space.make(guid: 'space-3')) }
 
       it 'returns a Sequel::Dataset' do
         results = fetcher.fetch_all(message: message)
@@ -19,18 +20,28 @@ module VCAP::CloudController
 
       it 'includes all the V3 Service Instances' do
         results = fetcher.fetch_all(message: message).all
-        expect(results.length).to eq 2
-        expect(results).to include(service_instance_1, service_instance_2)
+        expect(results.length).to eq 3
+        expect(results).to include(service_instance_1, service_instance_2, service_instance_3)
       end
 
       context 'filter' do
         context 'by service instance name' do
-          let(:filters) { { names: ['rabbitmq'] } }
+          let(:filters) { { names: ['rabbitmq', 'redis'] } }
 
           it 'only returns matching service instances' do
             results = fetcher.fetch_all(message: message).all
-            expect(results).to match_array([service_instance_1])
-            expect(results).not_to include(service_instance_2)
+            expect(results).to match_array([service_instance_1, service_instance_2])
+            expect(results).not_to include(service_instance_3)
+          end
+        end
+
+        context 'by space guid' do
+          let(:filters) { { space_guids: ['space-2', 'space-3'] } }
+
+          it 'only returns matching service instances' do
+            results = fetcher.fetch_all(message: message).all
+            expect(results).to match_array([service_instance_2, service_instance_3])
+            expect(results).not_to include(service_instance_1)
           end
         end
       end
@@ -41,11 +52,11 @@ module VCAP::CloudController
       let!(:service_instance_2) { ManagedServiceInstance.make(name: 'redis', space: space_1) }
       let!(:service_instance_3) { ManagedServiceInstance.make(name: 'mysql', space: space_2) }
 
-      let(:space_1) { Space.make }
-      let(:space_2) { Space.make }
+      let(:space_1) { Space.make(guid: 'space-1') }
+      let(:space_2) { Space.make(guid: 'space-2') }
 
       it 'returns all of the service instances in the specified space' do
-        results = fetcher.fetch(message: message, space_guids: [space_1.guid]).all
+        results = fetcher.fetch(message: message, readable_space_guids: [space_1.guid]).all
 
         expect(results).to match_array([service_instance_1, service_instance_2])
       end
@@ -55,8 +66,18 @@ module VCAP::CloudController
           let(:filters) { { names: ['rabbitmq'] } }
 
           it 'only returns matching service instances' do
-            results = fetcher.fetch(message: message, space_guids: [space_1.guid]).all
+            results = fetcher.fetch(message: message, readable_space_guids: [space_1.guid]).all
             expect(results).to match_array([service_instance_1])
+          end
+        end
+
+        context 'by space guid' do
+          let(:filters) { { space_guids: ['space-1'] } }
+
+          it 'only returns matching service instances' do
+            results = fetcher.fetch_all(message: message).all
+            expect(results).to match_array([service_instance_1, service_instance_2])
+            expect(results).not_to include(service_instance_3)
           end
         end
 
@@ -64,7 +85,16 @@ module VCAP::CloudController
           let(:filters) { { names: ['made-up-name'] } }
 
           it 'returns no matching service instances' do
-            results = fetcher.fetch(message: message, space_guids: [space_1.guid]).all
+            results = fetcher.fetch(message: message, readable_space_guids: [space_1.guid]).all
+            expect(results).to be_empty
+          end
+        end
+
+        context 'by non-existent space guid' do
+          let(:filters) { { space_guids: ['made-up-name'] } }
+
+          it 'returns no matching service instances' do
+            results = fetcher.fetch(message: message, readable_space_guids: [space_1.guid]).all
             expect(results).to be_empty
           end
         end
@@ -79,7 +109,7 @@ module VCAP::CloudController
         end
 
         it 'returns all of the service instances shared into the specified space' do
-          results = fetcher.fetch(message: message, space_guids: [shared_to_space.guid]).all
+          results = fetcher.fetch(message: message, readable_space_guids: [shared_to_space.guid]).all
           expect(results).to match_array([service_instance_1, service_instance_2])
         end
       end
@@ -94,7 +124,7 @@ module VCAP::CloudController
         end
 
         it 'returns all of the service instances shared into the specified space' do
-          results = fetcher.fetch(message: message, space_guids: [shared_to_space.guid]).all
+          results = fetcher.fetch(message: message, readable_space_guids: [shared_to_space.guid]).all
           expect(results).to match_array([service_instance_1, service_instance_2, service_instance_4])
         end
       end

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1111,27 +1111,27 @@
 
 390002:
   name: ServiceInstanceDeletionSharesExists
-  http_code: 400
+  http_code: 422
   message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces."
 
 390003:
   name: ServiceShareIsDisabled
-  http_code: 400
+  http_code: 422
   message: "The %s service does not support service instance sharing."
 
 390004:
   name: UserProvidedServiceInstanceSharingNotSupported
-  http_code: 400
+  http_code: 422
   message: "User-provided services cannot be shared"
 
 390005:
   name: RouteServiceInstanceSharingNotSupported
-  http_code: 400
+  http_code: 422
   message: "Route services cannot be shared"
 
 390006:
   name: SharedServiceInstanceNameTaken
-  http_code: 400
+  http_code: 422
   message: "A service instance called %s already exists in %s"
 
 390007:


### PR DESCRIPTION
As an app dev, I can discover the guids of spaces to/from which a service instance has been shared. [#153253258](https://www.pivotaltracker.com/story/show/153253258)

## What

We previously created two endpoints for information related to shared service instances. `/v2/service_instances/:guid/shared_to` is used by developers in a service instance's source space to discover where the instance is shared to, and `/v2/service_instances/:guid/shared_from` is used by developers in the receiving space to discover the instance's source space. This is required because the users may not have read permissions to those spaces ordinarily.

This change adds `space_guids` to these responses. This was previously omitted because we preferred to disclose the minimum amount of information to users who didn't previously have read permissions to other spaces. After integrating with the CLI, `space_guid` is now required information for users in the source space to unshare a shared service instance.

**NOTE**: This PR builds on top of #1014, which should be merged first. The actual changes on top of #1014 can be viewed in [here](https://github.com/cloudfoundry/cloud_controller_ng/commit/6991644844be40224a9133699a98747ac4570e19).

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@Samze and @deniseyu)