### PR TITLE
rename tld from sd-local to apps.internal

### DIFF
--- a/lib/cloud_controller/diego/protocol/routing_info.rb
+++ b/lib/cloud_controller/diego/protocol/routing_info.rb
@@ -39,7 +39,7 @@ module VCAP::CloudController
           route_info = {}
           route_info['http_routes'] = http_info unless http_info.blank?
           route_info['tcp_routes'] = tcp_info unless tcp_info.blank?
-          route_info['internal_routes'] = [{ 'hostname' => "#{process.guid}.sd-local" }]
+          route_info['internal_routes'] = [{ 'hostname' => "#{process.guid}.apps.internal" }]
           route_info
         rescue RoutingApi::RoutingApiDisabled
           raise CloudController::Errors::ApiError.new_from_details('RoutingApiDisabled')

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -530,7 +530,7 @@ module VCAP::CloudController
                 ],
                 'internal_routes' => [
                   {
-                    'hostname' => 'app-guid.sd-local',
+                    'hostname' => 'app-guid.apps.internal',
                   }
                 ]
               }
@@ -579,7 +579,7 @@ module VCAP::CloudController
                     key:   'internal-router',
                     value: [
                       {
-                        'hostname' => 'app-guid.sd-local',
+                        'hostname' => 'app-guid.apps.internal',
                       }
                     ].to_json
                   )
@@ -608,7 +608,7 @@ module VCAP::CloudController
                   ],
                   'internal_routes' => [
                     {
-                      'hostname' => 'app-guid.sd-local',
+                      'hostname' => 'app-guid.apps.internal',
                     }
                   ]
                 }
@@ -644,7 +644,7 @@ module VCAP::CloudController
                       key: 'internal-router',
                       value: [
                         {
-                          'hostname' => 'app-guid.sd-local',
+                          'hostname' => 'app-guid.apps.internal',
                         }
                       ].to_json
                     )
@@ -674,7 +674,7 @@ module VCAP::CloudController
                   ],
                   'internal_routes' => [
                     {
-                      'hostname' => 'app-guid.sd-local',
+                      'hostname' => 'app-guid.apps.internal',
                     }
                   ]
                 }
@@ -712,7 +712,7 @@ module VCAP::CloudController
                       key: 'internal-router',
                       value: [
                         {
-                          'hostname' => 'app-guid.sd-local',
+                          'hostname' => 'app-guid.apps.internal',
                         }
                       ].to_json
                     )
@@ -1221,7 +1221,7 @@ module VCAP::CloudController
               ],
               'internal_routes' => [
                 {
-                  'hostname' => 'app-guid.sd-local',
+                  'hostname' => 'app-guid.apps.internal',
                 }
               ]
             }
@@ -1270,7 +1270,7 @@ module VCAP::CloudController
                   key:   'internal-router',
                   value: [
                     {
-                      'hostname' => 'app-guid.sd-local',
+                      'hostname' => 'app-guid.apps.internal',
                     }
                   ].to_json
                 )
@@ -1299,7 +1299,7 @@ module VCAP::CloudController
                 ],
                 'internal_routes' => [
                   {
-                    'hostname' => 'app-guid.sd-local',
+                    'hostname' => 'app-guid.apps.internal',
                   }
                 ]
               }
@@ -1335,7 +1335,7 @@ module VCAP::CloudController
                     key:   'internal-router',
                     value: [
                       {
-                        'hostname' => 'app-guid.sd-local',
+                        'hostname' => 'app-guid.apps.internal',
                       }
                     ].to_json
                   )
@@ -1364,7 +1364,7 @@ module VCAP::CloudController
                 ],
                 'internal_routes' => [
                   {
-                    'hostname' => 'app-guid.sd-local',
+                    'hostname' => 'app-guid.apps.internal',
                   }
                 ]
               }
@@ -1402,7 +1402,7 @@ module VCAP::CloudController
                     key:   'internal-router',
                     value: [
                       {
-                        'hostname' => 'app-guid.sd-local',
+                        'hostname' => 'app-guid.apps.internal',
                       }
                     ].to_json
                   )

--- a/spec/unit/lib/cloud_controller/diego/protocol/routing_info_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/routing_info_spec.rb
@@ -269,7 +269,7 @@ module VCAP::CloudController
           context 'internal routes' do
             it 'returns the internal route hostname' do
               expected_routes = [
-                { 'hostname' => process.guid + '.sd-local' },
+                { 'hostname' => process.guid + '.apps.internal' },
               ]
 
               expect(ri.keys).to match_array ['internal_routes']

--- a/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
@@ -183,7 +183,7 @@ module VCAP::CloudController
                 }
               ],
               'internal_routes' => [
-                { 'hostname' => "#{process.guid}.sd-local" }
+                { 'hostname' => "#{process.guid}.apps.internal" }
               ]
             },
             'egress_rules' => ['running_egress_rule'],


### PR DESCRIPTION
[#152251321]

Signed-off-by: Joachim Valdez <valdezj@us.ibm.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Change tld for internal routes.

* An explanation of the use cases your change solves
Our PM wants the name change.

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
