### PR TITLE
When trying to share to multiple spaces, return better error message for each invalid space

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -76,18 +76,16 @@ class ServiceInstancesV3Controller < ApplicationController
   private
 
   def check_spaces_exist_and_are_writeable!(service_instance, request_guids, found_spaces)
-    unreadable_space_guids = request_guids - found_spaces.map(&:guid)
-
     unreadable_spaces = found_spaces.reject do |space|
       can_read_space?(space)
     end
 
-    unreadable_space_guids += unreadable_spaces.map(&:guid)
-
     unwriteable_spaces = found_spaces.reject do |space|
-      can_write?(space.guid)
+      can_write_space?(space) || unreadable_spaces.include?(space)
     end
 
+    unreadable_space_guids = request_guids - found_spaces.map(&:guid)
+    unreadable_space_guids += unreadable_spaces.map(&:guid)
     unwriteable_space_guids = unwriteable_spaces.map(&:guid)
 
     unless unreadable_space_guids.empty? && unwriteable_space_guids.empty?

--- a/spec/unit/controllers/v3/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instances_controller_spec.rb
@@ -339,6 +339,21 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
         expect(response.body).not_to include('Write permission is required in order to share a service instance with a space.')
       end
     end
+
+    context 'when the user does not have read access to the target space' do
+      before do
+        set_current_user_as_role(role: 'space_developer', org: source_space.organization, space: source_space, user: user)
+      end
+
+      it 'returns a 422' do
+        post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
+        expect(response.status).to eq 422
+        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['#{target_space.guid}']. ")
+        expect(response.body).to include('Ensure the spaces exist and that you have access to them.')
+        expect(response.body).not_to include('Write permission is required in order to share a service instance with a space.')
+      end
+    end
+
     context 'when multiple target spaces do not exist' do
       before do
         req_body[:data] = [

--- a/spec/unit/controllers/v3/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instances_controller_spec.rb
@@ -428,9 +428,10 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
       it 'returns a 422' do
         post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
         expect(response.status).to eq 422
-        expect(response.body).to include(
-          "Unable to share service instance #{service_instance.name} with spaces ['#{target_space.guid}', '#{target_space2.guid}']. "\
-          'Write permission is required in order to share a service instance with a space.')
+        expect(response.body).to include(target_space.guid)
+        expect(response.body).to include(target_space2.guid)
+        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ")
+        expect(response.body).to include('Write permission is required in order to share a service instance with a space.')
       end
     end
 


### PR DESCRIPTION
As a SpaceAuditor in the target space, when I POST /v3/service_instances/:guid/relationships/shared_spaces, the error message contains multiple errors if needed. [#153629300](https://www.pivotaltracker.com/story/show/153629300)

## What

Previously, when trying to share a service instance to multiple spaces, we would perform a bulk check on whether any of the specified spaces failed the read permissions validation. If it failed, we would return with a 422, listing all the non-readable spaces. If it succeeded, we would subsequently validate write permissions. If any space failed the write permissions check, we would return a 403 response code with no detailed error message. If someone tried to share into 50 spaces, and they had write permission on 49 of them, they would only see a 403 without knowing which space failed. This PR improves on this user experience.

We also now return 422 for validation failures on either read or write permissions for target spaces. 403s are used only for auth failures on the service instance itself.

This change consolidates the read and write permissions checks in order to return a single detailed error message explaining which validation each space failed on.

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@jenspinney and @deniseyu)