### PR TITLE
Return a more helpful error when recipient space developers try to delete a shared service instance

### DIFF
--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -160,6 +160,7 @@ module VCAP::CloudController
         return [HTTP::NO_CONTENT, nil]
       end
 
+      validate_shared_space_deleteable(service_instance)
       validate_access(:delete, service_instance)
 
       unless recursive_delete?
@@ -453,6 +454,12 @@ module VCAP::CloudController
     def validate_shared_space_updateable(service_instance)
       if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
         raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotUpdateableInTargetSpace')
+      end
+    end
+
+    def validate_shared_space_deleteable(service_instance)
+      if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
+        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotDeleteableInTargetSpace')
       end
     end
 

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -119,6 +119,7 @@ module VCAP::CloudController
         raise CloudController::Errors::ApiError.new_from_details('UserProvidedServiceInstanceHandlerNeeded')
       end
 
+      validate_shared_space_updateable(service_instance)
       validate_access(:read_for_update, service_instance)
       validate_access(:update, projected_service_instance(service_instance))
 
@@ -446,6 +447,12 @@ module VCAP::CloudController
 
       if request_attrs['name'] != service_instance.name
         raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceCannotBeRenamed')
+      end
+    end
+
+    def validate_shared_space_updateable(service_instance)
+      if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
+        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotUpdateableInTargetSpace')
       end
     end
 

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -76,18 +76,16 @@ class ServiceInstancesV3Controller < ApplicationController
   private
 
   def check_spaces_exist_and_are_writeable!(service_instance, request_guids, found_spaces)
-    unreadable_space_guids = request_guids - found_spaces.map(&:guid)
-
     unreadable_spaces = found_spaces.reject do |space|
       can_read_space?(space)
     end
 
-    unreadable_space_guids += unreadable_spaces.map(&:guid)
-
     unwriteable_spaces = found_spaces.reject do |space|
-      can_write?(space.guid)
+      can_write_space?(space) || unreadable_spaces.include?(space)
     end
 
+    unreadable_space_guids = request_guids - found_spaces.map(&:guid)
+    unreadable_space_guids += unreadable_spaces.map(&:guid)
     unwriteable_space_guids = unwriteable_spaces.map(&:guid)
 
     unless unreadable_space_guids.empty? && unwriteable_space_guids.empty?

--- a/spec/unit/access/service_instance_access_spec.rb
+++ b/spec/unit/access/service_instance_access_spec.rb
@@ -177,6 +177,10 @@ module VCAP::CloudController
         it 'returns false for purge' do
           expect(subject).not_to allow_op_on_object(:purge, service_instance)
         end
+
+        it 'does not allow the user to update the service' do
+          expect(subject).not_to allow_op_on_object(:update, service_instance)
+        end
       end
 
       context 'when the space of the service instance is not visible' do
@@ -202,6 +206,10 @@ module VCAP::CloudController
 
         it 'returns false for purge' do
           expect(subject).not_to allow_op_on_object(:purge, service_instance)
+        end
+
+        it 'does not allow the user to update the service' do
+          expect(subject).not_to allow_op_on_object(:update, service_instance)
         end
       end
     end

--- a/spec/unit/controllers/v3/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instances_controller_spec.rb
@@ -339,6 +339,21 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
         expect(response.body).not_to include('Write permission is required in order to share a service instance with a space.')
       end
     end
+
+    context 'when the user does not have read access to the target space' do
+      before do
+        set_current_user_as_role(role: 'space_developer', org: source_space.organization, space: source_space, user: user)
+      end
+
+      it 'returns a 422' do
+        post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
+        expect(response.status).to eq 422
+        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['#{target_space.guid}']. ")
+        expect(response.body).to include('Ensure the spaces exist and that you have access to them.')
+        expect(response.body).not_to include('Write permission is required in order to share a service instance with a space.')
+      end
+    end
+
     context 'when multiple target spaces do not exist' do
       before do
         req_body[:data] = [

--- a/spec/unit/controllers/v3/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instances_controller_spec.rb
@@ -428,9 +428,10 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
       it 'returns a 422' do
         post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
         expect(response.status).to eq 422
-        expect(response.body).to include(
-          "Unable to share service instance #{service_instance.name} with spaces ['#{target_space.guid}', '#{target_space2.guid}']. "\
-          'Write permission is required in order to share a service instance with a space.')
+        expect(response.body).to include(target_space.guid)
+        expect(response.body).to include(target_space2.guid)
+        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ")
+        expect(response.body).to include('Write permission is required in order to share a service instance with a space.')
       end
     end
 

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1148,3 +1148,8 @@
   name: SharedServiceInstanceNotUpdateableInTargetSpace
   http_code: 403
   message: 'You cannot update service instances that have been shared with you'
+
+390010:
+  name: SharedServiceInstanceNotDeleteableInTargetSpace
+  http_code: 403
+  message: 'You cannot delete service instances that have been shared with you'

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1143,3 +1143,8 @@
   name: SharedServiceInstanceCannotBeRenamed
   http_code: 422
   message: 'Service instances that have been shared cannot be renamed'
+
+390009:
+  name: SharedServiceInstanceNotUpdateableInTargetSpace
+  http_code: 403
+  message: 'You cannot update service instances that have been shared with you'


### PR DESCRIPTION
**NOTE**: This PR builds on top of #1040, which should be merged first. The actual changes on top of #1040 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/cloudfoundry-incubator:pr-service-instance-sharing-update-error...cloudfoundry-incubator:pr-service-instance-sharing-delete-error).

As an app dev (receiver), I see a relevant error message when I try to delete a service instance that has been shared with me [#152552021](https://www.pivotaltracker.com/story/show/152552021)


## What

When a service instance is shared, only developers in the source space have authorisation to delete the service instance. Anyone else (space auditors, developers in target space, etc) will see a 403 Not Authorized when they attempt to run cf delete-service.

In this PR we return a more helpful error message in the case when a space developer in a shared-to space attempts to run cf delete-service, still with a 403 status code. Errors for other types of users remain unchanged.

## PR

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)


Thanks, sapi (alex, @deniseyu)
