### PR TITLE
Fix schema section in audit.service_plan.create event docs

### DIFF
--- a/docs/v2/events/list_service_plan_create_events.html
+++ b/docs/v2/events/list_service_plan_create_events.html
@@ -512,17 +512,11 @@ Cookie: </pre>
           "extra": null,
           "unique_id": "guid",
           "public": true,
-          "active": true,
           "bindable": true,
-          "schemas": {
-            "service_instance": {
-              "create": {},
-              "update": {}
-            },
-            "service_binding": {
-              "create": {}
-            }
-          }
+          "active": true,
+          "create_instance_schema": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"additionalProperties\":false,\"type\":\"object\",\"properties\":{\"lang\":{\"type\":\"string\",\"default\":\"de-DE\"}}}",
+          "update_instance_schema": null,
+          "create_binding_schema": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"account\":{\"type\":\"string\"}},\"required\":[\"account\"]}"
         },
         "space_guid": "",
         "organization_guid": ""


### PR DESCRIPTION
In the documentation page for "List Service Plan Create Events", the schemas section of the example response is incorrect. This PR fixes it to match what the CC would actually respond with, including some sample simple schemas.

Story link: [#153557902](https://www.pivotaltracker.com/story/show/153557902)

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [n/a] I have run all the unit tests using `bundle exec rake`

* [n/a] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)