### PR TITLE
Wrap action errors in controller

### DIFF
--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -2,6 +2,9 @@ require 'repositories/service_instance_share_event_repository'
 
 module VCAP::CloudController
   class ServiceInstanceShare
+    class Error < ::StandardError
+    end
+
     def create(service_instance, target_spaces, user_audit_info)
       validate_supported_service_type!(service_instance)
       validate_service_instance_is_shareable!(service_instance)
@@ -21,6 +24,10 @@ module VCAP::CloudController
 
     private
 
+    def error!(message)
+      raise Error.new(message)
+    end
+
     def validate_target_spaces!(service_instance, target_spaces)
       validate_not_sharing_to_self!(service_instance, target_spaces)
       validate_plan_is_active!(service_instance)
@@ -34,42 +41,44 @@ module VCAP::CloudController
     def validate_plan_is_active!(service_instance)
       if !service_instance.service_plan.active?
         error_msg = "The service instance could not be shared as the #{service_instance.service_plan.name} plan is inactive."
-        raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', error_msg)
+        error!(error_msg)
       end
     end
 
     def validate_plan_visibility!(service_instance, space)
       unless service_instance.service_plan.visible_in_space?(space)
         error_msg = "Access to service #{service_instance.service.label} and plan #{service_instance.service_plan.name} is not enabled in #{space.organization.name}/#{space.name}"
-        raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', error_msg)
+        error!(error_msg)
       end
     end
 
     def validate_name_uniqueness!(service_instance, space)
       if space.service_instances.map(&:name).include?(service_instance.name)
-        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNameTaken', service_instance.name, space.name)
+        error_msg = "A service instance called #{service_instance.name} already exists in #{space.name}"
+        error!(error_msg)
       end
     end
 
     def validate_not_sharing_to_self!(service_instance, spaces)
       if spaces.include?(service_instance.space)
-        raise CloudController::Errors::ApiError.new_from_details('InvalidServiceInstanceSharingTargetSpace')
+        error!('Service instances cannot be shared into the space where they were created')
       end
     end
 
     def validate_supported_service_type!(service_instance)
       if service_instance.route_service?
-        raise CloudController::Errors::ApiError.new_from_details('RouteServiceInstanceSharingNotSupported')
+        error!('Route services cannot be shared')
       end
 
       unless service_instance.managed_instance?
-        raise CloudController::Errors::ApiError.new_from_details('UserProvidedServiceInstanceSharingNotSupported')
+        error!('User-provided services cannot be shared')
       end
     end
 
     def validate_service_instance_is_shareable!(service_instance)
       unless service_instance.shareable?
-        raise CloudController::Errors::ApiError.new_from_details('ServiceShareIsDisabled', service_instance.service.label)
+        error_msg = "The #{service_instance.service.label} service does not support service instance sharing."
+        error!(error_msg)
       end
     end
   end

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -160,6 +160,7 @@ module VCAP::CloudController
         return [HTTP::NO_CONTENT, nil]
       end
 
+      validate_shared_space_deleteable(service_instance)
       validate_access(:delete, service_instance)
 
       unless recursive_delete?
@@ -453,6 +454,12 @@ module VCAP::CloudController
     def validate_shared_space_updateable(service_instance)
       if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
         raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotUpdateableInTargetSpace')
+      end
+    end
+
+    def validate_shared_space_deleteable(service_instance)
+      if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
+        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotDeleteableInTargetSpace')
       end
     end
 

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -453,13 +453,13 @@ module VCAP::CloudController
 
     def validate_shared_space_updateable(service_instance)
       if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
-        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotUpdateableInTargetSpace')
+        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotUpdatableInTargetSpace')
       end
     end
 
     def validate_shared_space_deleteable(service_instance)
       if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
-        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotDeleteableInTargetSpace')
+        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotDeletableInTargetSpace')
       end
     end
 

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -119,6 +119,7 @@ module VCAP::CloudController
         raise CloudController::Errors::ApiError.new_from_details('UserProvidedServiceInstanceHandlerNeeded')
       end
 
+      validate_shared_space_updateable(service_instance)
       validate_access(:read_for_update, service_instance)
       validate_access(:update, projected_service_instance(service_instance))
 
@@ -446,6 +447,12 @@ module VCAP::CloudController
 
       if request_attrs['name'] != service_instance.name
         raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceCannotBeRenamed')
+      end
+    end
+
+    def validate_shared_space_updateable(service_instance)
+      if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
+        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotUpdateableInTargetSpace')
       end
     end
 

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -44,6 +44,8 @@ class ServiceInstancesV3Controller < ApplicationController
 
     render status: :ok, json: Presenters::V3::ToManyRelationshipPresenter.new(
       "service_instances/#{service_instance.guid}", service_instance.shared_spaces, 'shared_spaces', build_related: false)
+  rescue VCAP::CloudController::ServiceInstanceShare::Error => e
+    unprocessable!(e.message)
   end
 
   def unshare_service_instance

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -65,6 +65,8 @@ class ServiceInstancesV3Controller < ApplicationController
     unshare.unshare(service_instance, target_space, user_audit_info)
 
     head :no_content
+  rescue VCAP::CloudController::ServiceInstanceUnshare::Error => e
+    raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceUnshareFailed', e.message)
   end
 
   def relationships_shared_spaces

--- a/spec/unit/access/service_instance_access_spec.rb
+++ b/spec/unit/access/service_instance_access_spec.rb
@@ -177,6 +177,10 @@ module VCAP::CloudController
         it 'returns false for purge' do
           expect(subject).not_to allow_op_on_object(:purge, service_instance)
         end
+
+        it 'does not allow the user to update the service' do
+          expect(subject).not_to allow_op_on_object(:update, service_instance)
+        end
       end
 
       context 'when the space of the service instance is not visible' do
@@ -202,6 +206,10 @@ module VCAP::CloudController
 
         it 'returns false for purge' do
           expect(subject).not_to allow_op_on_object(:purge, service_instance)
+        end
+
+        it 'does not allow the user to update the service' do
+          expect(subject).not_to allow_op_on_object(:update, service_instance)
         end
       end
     end

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -71,8 +71,7 @@ module VCAP::CloudController
         it 'does not share with any spaces' do
           expect {
             service_instance_share.create(service_instance, [target_space1, service_instance.space], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError,
-                           'Service instances cannot be shared into the space where they were created')
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'Service instances cannot be shared into the space where they were created')
 
           instance = ServiceInstance.find(guid: service_instance.guid)
 
@@ -84,8 +83,7 @@ module VCAP::CloudController
 
           expect {
             service_instance_share.create(service_instance, [target_space1, service_instance.space], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError,
-                           'Service instances cannot be shared into the space where they were created')
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'Service instances cannot be shared into the space where they were created')
         end
       end
 
@@ -97,7 +95,7 @@ module VCAP::CloudController
         it 'raises an api error' do
           expect {
             service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError, /The #{service_instance.service.label} service does not support service instance sharing./)
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, /The #{service_instance.service.label} service does not support service instance sharing./)
         end
       end
 
@@ -108,8 +106,7 @@ module VCAP::CloudController
         it 'raises an api error' do
           expect {
             service_instance_share.create(service_instance, [target_space1], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError,
-                           /A service instance called #{service_instance.name} already exists in #{target_space1.name}/)
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, /A service instance called #{service_instance.name} already exists in #{target_space1.name}/)
           expect(service_instance.shared_spaces).to be_empty
         end
       end
@@ -118,7 +115,7 @@ module VCAP::CloudController
         it 'raises an api error' do
           expect {
             service_instance_share.create(user_provided_service_instance, [target_space1, target_space2], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError, /User-provided services cannot be shared/)
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, /User-provided services cannot be shared/)
         end
       end
 
@@ -131,7 +128,7 @@ module VCAP::CloudController
           it 'raises an api error' do
             expect {
               service_instance_share.create(service_instance, [target_space1, target_space2], user_audit_info)
-            }.to raise_error(CloudController::Errors::ApiError, /Route services cannot be shared/)
+            }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, /Route services cannot be shared/)
           end
         end
 
@@ -143,7 +140,7 @@ module VCAP::CloudController
           it 'raises an api error' do
             expect {
               service_instance_share.create(user_provided_service_instance, [target_space1, target_space2], user_audit_info)
-            }.to raise_error(CloudController::Errors::ApiError, /Route services cannot be shared/)
+            }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, /Route services cannot be shared/)
           end
         end
       end
@@ -156,7 +153,7 @@ module VCAP::CloudController
           error_msg = 'The service instance could not be shared as the service-plan-name plan is inactive.'
           expect {
             service_instance_share.create(service_instance, [target_space1], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError, error_msg)
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, error_msg)
         end
       end
 
@@ -173,7 +170,7 @@ module VCAP::CloudController
           error_msg = 'Access to service space-scoped-service and plan my-plan is not enabled in source-org/target-space'
           expect {
             service_instance_share.create(service_instance, [target_space1], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError, error_msg)
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, error_msg)
         end
       end
 
@@ -186,7 +183,7 @@ module VCAP::CloudController
             "enabled in #{target_space1.organization.name}/#{target_space1.name}"
           expect {
             service_instance_share.create(service_instance, [target_space1], user_audit_info)
-          }.to raise_error(CloudController::Errors::ApiError, error_msg)
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, error_msg)
         end
 
         context 'and when the source org has service plan access enabled but the target org has service plan access disabled' do
@@ -203,7 +200,7 @@ module VCAP::CloudController
               "enabled in #{target_space1.organization.name}/#{target_space1.name}"
             expect {
               service_instance_share.create(service_instance, [target_space1], user_audit_info)
-            }.to raise_error(CloudController::Errors::ApiError, error_msg)
+            }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, error_msg)
           end
         end
 

--- a/spec/unit/actions/service_instance_unshare_spec.rb
+++ b/spec/unit/actions/service_instance_unshare_spec.rb
@@ -58,7 +58,7 @@ module VCAP::CloudController
             err = StandardError.new('oops')
             allow(delete_binding_action).to receive(:delete).with([service_binding]).and_return([err])
 
-            expect { service_instance_unshare.unshare(service_instance, target_space, user_audit_info) }.to raise_error(CloudController::Errors::ApiError)
+            expect { service_instance_unshare.unshare(service_instance, target_space, user_audit_info) }.to raise_error(VCAP::CloudController::ServiceInstanceUnshare::Error)
             expect(service_instance.shared_spaces).to_not be_empty
           end
         end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -1761,7 +1761,7 @@ module VCAP::CloudController
               put "/v2/service_instances/#{service_instance.guid}", body
 
               expect(last_response).to have_status_code(422)
-              expect(decoded_response['code']).to eq(390008)
+              expect(decoded_response['code']).to eq(390003)
               expect(decoded_response['error_code']).to eq('CF-SharedServiceInstanceCannotBeRenamed')
             end
           end
@@ -1775,7 +1775,7 @@ module VCAP::CloudController
               put "/v2/service_instances/#{service_instance.guid}", body
 
               expect(last_response).to have_status_code 403
-              expect(last_response.body).to include 'SharedServiceInstanceNotUpdateableInTargetSpace'
+              expect(last_response.body).to include 'SharedServiceInstanceNotUpdatableInTargetSpace'
               expect(last_response.body).to include 'You cannot update service instances that have been shared with you'
             end
           end
@@ -1791,7 +1791,7 @@ module VCAP::CloudController
               put "/v2/service_instances/#{service_instance.guid}", body
 
               expect(last_response).to have_status_code 403
-              expect(last_response.body).to include 'SharedServiceInstanceNotUpdateableInTargetSpace'
+              expect(last_response.body).to include 'SharedServiceInstanceNotUpdatableInTargetSpace'
               expect(last_response.body).to include 'You cannot update service instances that have been shared with you'
             end
           end
@@ -2716,7 +2716,7 @@ module VCAP::CloudController
               delete "/v2/service_instances/#{service_instance.guid}"
 
               expect(last_response).to have_status_code 403
-              expect(last_response.body).to include 'SharedServiceInstanceNotDeleteableInTargetSpace'
+              expect(last_response.body).to include 'SharedServiceInstanceNotDeletableInTargetSpace'
               expect(last_response.body).to include 'You cannot delete service instances that have been shared with you'
             end
           end
@@ -2732,7 +2732,7 @@ module VCAP::CloudController
               delete "/v2/service_instances/#{service_instance.guid}"
 
               expect(last_response).to have_status_code 403
-              expect(last_response.body).to include 'SharedServiceInstanceNotDeleteableInTargetSpace'
+              expect(last_response.body).to include 'SharedServiceInstanceNotDeletableInTargetSpace'
               expect(last_response.body).to include 'You cannot delete service instances that have been shared with you'
             end
           end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -4103,11 +4103,11 @@ module VCAP::CloudController
 
       describe 'permissions' do
         let(:user) { User.make }
-        let(:other_org) { Organization.make }
-        let(:other_space) { Space.make(organization: other_org) }
+        let(:target_org) { Organization.make }
+        let(:target_space) { Space.make(organization: target_org) }
 
         before do
-          instance.add_shared_space(other_space)
+          instance.add_shared_space(target_space)
         end
 
         context 'when the user is a member of the org/space this instance exists in' do
@@ -4134,7 +4134,7 @@ module VCAP::CloudController
 
               it "has a #{expected_status} http status code" do
                 get "/v2/service_instances/#{instance.guid}/shared_to"
-                expect(last_response.status).to eq(expected_status), "Expected #{expected_status}, got: #{last_response.status}, role: #{role}, response: #{last_response.body}"
+                expect(last_response.status).to eq(expected_status), "Expected #{expected_status}, got: #{last_response.status}, role: #{role}"
               end
             end
           end
@@ -4153,8 +4153,8 @@ module VCAP::CloudController
               before do
                 set_current_user_as_role(
                   role:   role,
-                  org:    other_org,
-                  space:  other_space,
+                  org:    target_org,
+                  space:  target_space,
                   user:   user,
                 )
               end

--- a/spec/unit/controllers/v3/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instances_controller_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
 
     context 'when the service instance does not exist' do
       it 'returns a 404' do
-        post :share_service_instance, service_instance_guid: 'nonexistant-service-instance-guid', body: req_body
+        post :share_service_instance, service_instance_guid: 'nonexistent-service-instance-guid', body: req_body
         expect(response.status).to eq 404
         expect(response.body).to include('Service instance not found')
       end
@@ -328,13 +328,13 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
 
     context 'when the target space does not exist' do
       before do
-        req_body[:data] = [{ guid: 'nonexistant-space-guid' }]
+        req_body[:data] = [{ guid: 'nonexistent-space-guid' }]
       end
 
       it 'returns a 422' do
         post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
         expect(response.status).to eq 422
-        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['nonexistant-space-guid']. ")
+        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['nonexistent-space-guid']. ")
         expect(response.body).to include('Ensure the spaces exist and that you have access to them.')
         expect(response.body).not_to include('Write permission is required in order to share a service instance with a space.')
       end
@@ -357,8 +357,8 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
     context 'when multiple target spaces do not exist' do
       before do
         req_body[:data] = [
-          { guid: 'nonexistant-space-guid' },
-          { guid: 'nonexistant-space-guid2' },
+          { guid: 'nonexistent-space-guid' },
+          { guid: 'nonexistent-space-guid2' },
           { guid: target_space.guid }
         ]
       end
@@ -366,7 +366,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
       it 'does not share to any of the valid target spaces and returns a 422' do
         post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
         expect(response.status).to eq 422
-        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['nonexistant-space-guid', 'nonexistant-space-guid2']. ")
+        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['nonexistent-space-guid', 'nonexistent-space-guid2']. ")
         expect(response.body).to include('Ensure the spaces exist and that you have access to them.')
         expect(response.body).not_to include('Write permission is required in order to share a service instance with a space.')
       end
@@ -393,7 +393,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
         set_current_user_as_role(role: 'space_auditor', org: target_space.organization, space: target_space, user: user)
 
         req_body[:data] = [
-          { guid: 'nonexistant-space-guid' },
+          { guid: 'nonexistent-space-guid' },
           { guid: target_space.guid }
         ]
       end
@@ -402,14 +402,14 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
         post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
         expect(response.status).to eq 422
         expect(response.body).to include(
-          "Unable to share service instance #{service_instance.name} with spaces ['nonexistant-space-guid']. Ensure the spaces exist and that you have access to them.\\n" \
+          "Unable to share service instance #{service_instance.name} with spaces ['nonexistent-space-guid']. Ensure the spaces exist and that you have access to them.\\n" \
           "Unable to share service instance #{service_instance.name} with spaces ['#{target_space.guid}']. "\
           'Write permission is required in order to share a service instance with a space.'
         )
       end
     end
 
-    context 'when the user is a SpaceAuditor in mulitple target spaces' do
+    context 'when the user is a SpaceAuditor in multiple target spaces' do
       let(:req_body) do
         {
           data: [

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1148,3 +1148,8 @@
   name: SharedServiceInstanceNotUpdateableInTargetSpace
   http_code: 403
   message: 'You cannot update service instances that have been shared with you'
+
+390010:
+  name: SharedServiceInstanceNotDeleteableInTargetSpace
+  http_code: 403
+  message: 'You cannot delete service instances that have been shared with you'

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1143,3 +1143,8 @@
   name: SharedServiceInstanceCannotBeRenamed
   http_code: 422
   message: 'Service instances that have been shared cannot be renamed'
+
+390009:
+  name: SharedServiceInstanceNotUpdateableInTargetSpace
+  http_code: 403
+  message: 'You cannot update service instances that have been shared with you'

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1115,41 +1115,16 @@
   message: "Service instances must be unshared before they can be deleted. Unsharing %s will automatically delete any bindings that have been made to applications in other spaces."
 
 390003:
-  name: ServiceShareIsDisabled
-  http_code: 422
-  message: "The %s service does not support service instance sharing."
-
-390004:
-  name: UserProvidedServiceInstanceSharingNotSupported
-  http_code: 422
-  message: "User-provided services cannot be shared"
-
-390005:
-  name: RouteServiceInstanceSharingNotSupported
-  http_code: 422
-  message: "Route services cannot be shared"
-
-390006:
-  name: SharedServiceInstanceNameTaken
-  http_code: 422
-  message: "A service instance called %s already exists in %s"
-
-390007:
-  name: InvalidServiceInstanceSharingTargetSpace
-  http_code: 422
-  message: 'Service instances cannot be shared into the space where they were created'
-
-390008:
   name: SharedServiceInstanceCannotBeRenamed
   http_code: 422
   message: 'Service instances that have been shared cannot be renamed'
 
-390009:
-  name: SharedServiceInstanceNotUpdateableInTargetSpace
+390004:
+  name: SharedServiceInstanceNotUpdatableInTargetSpace
   http_code: 403
   message: 'You cannot update service instances that have been shared with you'
 
-390010:
-  name: SharedServiceInstanceNotDeleteableInTargetSpace
+390005:
+  name: SharedServiceInstanceNotDeletableInTargetSpace
   http_code: 403
   message: 'You cannot delete service instances that have been shared with you'


### PR DESCRIPTION
This PR addresses some feedback from @Gerg that was made on PR #1006, specifically the comments [here](https://github.com/cloudfoundry/cloud_controller_ng/pull/1006#discussion_r156518084)

**NOTE**: This PR builds on top of #1048, which should be merged first. The actual changes on top of #1048 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-service-instance-sharing-fix-test-variables...cloudfoundry-incubator:pr-service-instance-sharing-api-errors-in-sharing-action).

## What
A pattern that we have been using for our actions is to raise a custom error class with a message and then wrap them all as unprocessable at the controller layer:

This Pr adopts a pattern in the service instance share action that raises a custom error class with a message, and then wraps these errors as unprocessable in the controller layer. 

As a result of this refactor we have reduced the number of `CloudController::Errors::ApiError` errors.

## PR

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
