### PR TITLE
Perm/send permissions

### DIFF
--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -92,7 +92,9 @@ class ApplicationController < ActionController::Base
       perm_client,
       SecurityContext,
       configuration.get(:perm, :enabled),
-      configuration.get(:perm, :query_enabled))
+      configuration.get(:perm, :query_enabled),
+      configuration.get(:perm, :query_raise_on_mismatch)
+    )
   end
 
   private

--- a/lib/cloud_controller/perm/client.rb
+++ b/lib/cloud_controller/perm/client.rb
@@ -38,7 +38,9 @@ module VCAP::CloudController
       end
 
       def create_org_role(role:, org_id:)
-        create_role(org_role(role, org_id), [org_role_to_permission(role, org_id)])
+        create_role(org_role(role, org_id), [
+          org_role_to_permission(role, org_id)
+        ])
       end
 
       def delete_org_role(role:, org_id:)
@@ -54,7 +56,9 @@ module VCAP::CloudController
       end
 
       def create_space_role(role:, space_id:)
-        create_role(space_role(role, space_id), [space_role_to_permission(role, space_id)])
+        create_role(space_role(role, space_id), [
+          space_role_to_permission(role, space_id)
+        ])
       end
 
       def delete_space_role(role:, space_id:)

--- a/lib/cloud_controller/perm/permissions.rb
+++ b/lib/cloud_controller/perm/permissions.rb
@@ -28,7 +28,7 @@ module VCAP
           permissions = [
             { permission_name: 'org.manager', resource_id: org_id },
             { permission_name: 'org.auditor', resource_id: org_id },
-            { permission_name: 'org.member', resource_id: org_id },
+            { permission_name: 'org.user', resource_id: org_id },
             { permission_name: 'org.billing_manager', resource_id: org_id },
           ]
           can_read_globally? || has_any_permission?(permissions)

--- a/lib/cloud_controller/permissions/queryer.rb
+++ b/lib/cloud_controller/permissions/queryer.rb
@@ -1,7 +1,9 @@
 class VCAP::CloudController::Permissions::Queryer
   attr_reader :perm_permissions, :db_permissions
 
-  def self.build(perm_client, security_context, perm_enabled, query_enabled)
+  def self.build(perm_client, security_context, perm_enabled, query_enabled, query_raise_on_mismatch=false)
+    VCAP::CloudController::Science::Experiment.raise_on_mismatches = query_raise_on_mismatch
+
     db_permissions =
       VCAP::CloudController::Permissions.new(
         security_context.current_user

--- a/spec/support/fake_uaa_server.rb
+++ b/spec/support/fake_uaa_server.rb
@@ -32,11 +32,13 @@ class FakeUAAServer
 end
 
 class UAAIssuer < WEBrick::HTTPServlet::AbstractServlet
+  ISSUER = 'uaa_issuer'.freeze
+
   # rubocop:disable all
   def do_GET(_, response)
     # rubocop:enable all
     response.status          = 200
     response['Content-Type'] = 'application/json'
-    response.body            = { issuer: 'uaa_issuer' }.to_json
+    response.body            = { issuer: ISSUER }.to_json
   end
 end

--- a/spec/support/integration/http.rb
+++ b/spec/support/integration/http.rb
@@ -56,6 +56,13 @@ module IntegrationHttp
     response
   end
 
+  def make_patch_request(path, data='{}', headers={})
+    http = Net::HTTP.new('localhost', '8181')
+    response = http.patch(path, data, headers)
+    response.extend(JsonBody)
+    response
+  end
+
   def make_delete_request(path, headers={})
     http = Net::HTTP.new('localhost', '8181')
     response = http.delete(path, headers)

--- a/spec/unit/lib/perm/client_spec.rb
+++ b/spec/unit/lib/perm/client_spec.rb
@@ -31,10 +31,18 @@ module VCAP::CloudController::Perm
     end
 
     describe '#create_org_role' do
-      it 'creates the correct role' do
+      it 'creates the correct role and creates associated permission' do
         subject.create_org_role(role: 'developer', org_id: org_id)
 
-        expect(client).to have_received(:create_role).with(role_name: "org-developer-#{org_id}")
+        expect(client).to have_received(:create_role).with(
+          role_name: "org-developer-#{org_id}",
+          permissions: [
+            CloudFoundry::Perm::V1::Models::Permission.new(
+              name: 'org.developer',
+              resource_pattern: org_id.to_s
+            )
+          ]
+        )
       end
 
       it 'does not fail if the role already exists' do
@@ -289,7 +297,15 @@ module VCAP::CloudController::Perm
       it 'creates the correct role' do
         subject.create_space_role(role: 'developer', space_id: space_id)
 
-        expect(client).to have_received(:create_role).with(role_name: "space-developer-#{space_id}")
+        expect(client).to have_received(:create_role).with(
+          role_name: "space-developer-#{space_id}",
+          permissions: [
+            CloudFoundry::Perm::V1::Models::Permission.new(
+              name: 'space.developer',
+              resource_pattern: space_id.to_s
+            )
+          ]
+        )
       end
 
       it 'does not fail if the role already exists' do

--- a/spec/unit/lib/perm/permissions_spec.rb
+++ b/spec/unit/lib/perm/permissions_spec.rb
@@ -117,7 +117,7 @@ module VCAP::CloudController::Perm
         expected_permissions = [
           { permission_name: 'org.manager', resource_id: org_id },
           { permission_name: 'org.auditor', resource_id: org_id },
-          { permission_name: 'org.member', resource_id: org_id },
+          { permission_name: 'org.user', resource_id: org_id },
           { permission_name: 'org.billing_manager', resource_id: org_id },
         ]
 
@@ -368,7 +368,7 @@ module VCAP::CloudController::Perm
         expected_permissions = [
           { permission_name: 'org.manager', resource_id: 'some-org-id' },
           { permission_name: 'org.auditor', resource_id: 'some-org-id' },
-          { permission_name: 'org.member', resource_id: 'some-org-id' },
+          { permission_name: 'org.user', resource_id: 'some-org-id' },
           { permission_name: 'org.billing_manager', resource_id: 'some-org-id' },
         ]
 

--- a/spec/unit/lib/permissions/queryer_spec.rb
+++ b/spec/unit/lib/permissions/queryer_spec.rb
@@ -43,8 +43,9 @@ module VCAP::CloudController
 
         allow(VCAP::CloudController::Permissions).to receive(:new).and_return(db_permissions)
         allow(VCAP::CloudController::Perm::Permissions).to receive(:new).and_return(perm_permissions)
+        allow(VCAP::CloudController::Science::Experiment).to receive(:raise_on_mismatches=)
 
-        queryer = Permissions::Queryer.build(perm_client, security_context, true, true)
+        queryer = Permissions::Queryer.build(perm_client, security_context, true, true, true)
 
         expect(VCAP::CloudController::Permissions).to have_received(:new).with(current_user)
         expect(VCAP::CloudController::Perm::Permissions).to have_received(:new).with(
@@ -53,6 +54,7 @@ module VCAP::CloudController
           user_id: current_user_guid,
           issuer: issuer
         )
+        expect(VCAP::CloudController::Science::Experiment).to have_received(:raise_on_mismatches=).with(true)
 
         expect(queryer.db_permissions).to eq(db_permissions)
         expect(queryer.perm_permissions).to eq(perm_permissions)


### PR DESCRIPTION
This sends along the appropriately named permission when creating the roles, which should finish the circuit. Now querying for whether or not someone has permission via the /v3 api endpoints should be correct when using the database or when checking perm.