### PR TITLE
Fix typos in v3 service instance controller spec

### DIFF
--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -160,6 +160,7 @@ module VCAP::CloudController
         return [HTTP::NO_CONTENT, nil]
       end
 
+      validate_shared_space_deleteable(service_instance)
       validate_access(:delete, service_instance)
 
       unless recursive_delete?
@@ -453,6 +454,12 @@ module VCAP::CloudController
     def validate_shared_space_updateable(service_instance)
       if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
         raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotUpdateableInTargetSpace')
+      end
+    end
+
+    def validate_shared_space_deleteable(service_instance)
+      if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
+        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotDeleteableInTargetSpace')
       end
     end
 

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -119,6 +119,7 @@ module VCAP::CloudController
         raise CloudController::Errors::ApiError.new_from_details('UserProvidedServiceInstanceHandlerNeeded')
       end
 
+      validate_shared_space_updateable(service_instance)
       validate_access(:read_for_update, service_instance)
       validate_access(:update, projected_service_instance(service_instance))
 
@@ -446,6 +447,12 @@ module VCAP::CloudController
 
       if request_attrs['name'] != service_instance.name
         raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceCannotBeRenamed')
+      end
+    end
+
+    def validate_shared_space_updateable(service_instance)
+      if @access_context.can?(:read, service_instance) && @access_context.cannot?(:read, service_instance.space)
+        raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceNotUpdateableInTargetSpace')
       end
     end
 

--- a/spec/unit/access/service_instance_access_spec.rb
+++ b/spec/unit/access/service_instance_access_spec.rb
@@ -177,6 +177,10 @@ module VCAP::CloudController
         it 'returns false for purge' do
           expect(subject).not_to allow_op_on_object(:purge, service_instance)
         end
+
+        it 'does not allow the user to update the service' do
+          expect(subject).not_to allow_op_on_object(:update, service_instance)
+        end
       end
 
       context 'when the space of the service instance is not visible' do
@@ -202,6 +206,10 @@ module VCAP::CloudController
 
         it 'returns false for purge' do
           expect(subject).not_to allow_op_on_object(:purge, service_instance)
+        end
+
+        it 'does not allow the user to update the service' do
+          expect(subject).not_to allow_op_on_object(:update, service_instance)
         end
       end
     end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -4103,11 +4103,11 @@ module VCAP::CloudController
 
       describe 'permissions' do
         let(:user) { User.make }
-        let(:other_org) { Organization.make }
-        let(:other_space) { Space.make(organization: other_org) }
+        let(:target_org) { Organization.make }
+        let(:target_space) { Space.make(organization: target_org) }
 
         before do
-          instance.add_shared_space(other_space)
+          instance.add_shared_space(target_space)
         end
 
         context 'when the user is a member of the org/space this instance exists in' do
@@ -4134,7 +4134,7 @@ module VCAP::CloudController
 
               it "has a #{expected_status} http status code" do
                 get "/v2/service_instances/#{instance.guid}/shared_to"
-                expect(last_response.status).to eq(expected_status), "Expected #{expected_status}, got: #{last_response.status}, role: #{role}, response: #{last_response.body}"
+                expect(last_response.status).to eq(expected_status), "Expected #{expected_status}, got: #{last_response.status}, role: #{role}"
               end
             end
           end
@@ -4153,8 +4153,8 @@ module VCAP::CloudController
               before do
                 set_current_user_as_role(
                   role:   role,
-                  org:    other_org,
-                  space:  other_space,
+                  org:    target_org,
+                  space:  target_space,
                   user:   user,
                 )
               end

--- a/spec/unit/controllers/v3/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/v3/service_instances_controller_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
 
     context 'when the service instance does not exist' do
       it 'returns a 404' do
-        post :share_service_instance, service_instance_guid: 'nonexistant-service-instance-guid', body: req_body
+        post :share_service_instance, service_instance_guid: 'nonexistent-service-instance-guid', body: req_body
         expect(response.status).to eq 404
         expect(response.body).to include('Service instance not found')
       end
@@ -328,13 +328,13 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
 
     context 'when the target space does not exist' do
       before do
-        req_body[:data] = [{ guid: 'nonexistant-space-guid' }]
+        req_body[:data] = [{ guid: 'nonexistent-space-guid' }]
       end
 
       it 'returns a 422' do
         post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
         expect(response.status).to eq 422
-        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['nonexistant-space-guid']. ")
+        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['nonexistent-space-guid']. ")
         expect(response.body).to include('Ensure the spaces exist and that you have access to them.')
         expect(response.body).not_to include('Write permission is required in order to share a service instance with a space.')
       end
@@ -357,8 +357,8 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
     context 'when multiple target spaces do not exist' do
       before do
         req_body[:data] = [
-          { guid: 'nonexistant-space-guid' },
-          { guid: 'nonexistant-space-guid2' },
+          { guid: 'nonexistent-space-guid' },
+          { guid: 'nonexistent-space-guid2' },
           { guid: target_space.guid }
         ]
       end
@@ -366,7 +366,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
       it 'does not share to any of the valid target spaces and returns a 422' do
         post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
         expect(response.status).to eq 422
-        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['nonexistant-space-guid', 'nonexistant-space-guid2']. ")
+        expect(response.body).to include("Unable to share service instance #{service_instance.name} with spaces ['nonexistent-space-guid', 'nonexistent-space-guid2']. ")
         expect(response.body).to include('Ensure the spaces exist and that you have access to them.')
         expect(response.body).not_to include('Write permission is required in order to share a service instance with a space.')
       end
@@ -393,7 +393,7 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
         set_current_user_as_role(role: 'space_auditor', org: target_space.organization, space: target_space, user: user)
 
         req_body[:data] = [
-          { guid: 'nonexistant-space-guid' },
+          { guid: 'nonexistent-space-guid' },
           { guid: target_space.guid }
         ]
       end
@@ -402,14 +402,14 @@ RSpec.describe ServiceInstancesV3Controller, type: :controller do
         post :share_service_instance, service_instance_guid: service_instance.guid, body: req_body
         expect(response.status).to eq 422
         expect(response.body).to include(
-          "Unable to share service instance #{service_instance.name} with spaces ['nonexistant-space-guid']. Ensure the spaces exist and that you have access to them.\\n" \
+          "Unable to share service instance #{service_instance.name} with spaces ['nonexistent-space-guid']. Ensure the spaces exist and that you have access to them.\\n" \
           "Unable to share service instance #{service_instance.name} with spaces ['#{target_space.guid}']. "\
           'Write permission is required in order to share a service instance with a space.'
         )
       end
     end
 
-    context 'when the user is a SpaceAuditor in mulitple target spaces' do
+    context 'when the user is a SpaceAuditor in multiple target spaces' do
       let(:req_body) do
         {
           data: [

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1148,3 +1148,8 @@
   name: SharedServiceInstanceNotUpdateableInTargetSpace
   http_code: 403
   message: 'You cannot update service instances that have been shared with you'
+
+390010:
+  name: SharedServiceInstanceNotDeleteableInTargetSpace
+  http_code: 403
+  message: 'You cannot delete service instances that have been shared with you'

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1143,3 +1143,8 @@
   name: SharedServiceInstanceCannotBeRenamed
   http_code: 422
   message: 'Service instances that have been shared cannot be renamed'
+
+390009:
+  name: SharedServiceInstanceNotUpdateableInTargetSpace
+  http_code: 403
+  message: 'You cannot update service instances that have been shared with you'


### PR DESCRIPTION
This PR addresses feedback left by @ericpromislow on PR #1037. The actual comment can be found [here](https://github.com/cloudfoundry/cloud_controller_ng/pull/1037#issuecomment-355157108)

Several typos have been fixed in the v3 service instance controller spec. 

**NOTE**: This PR builds on top of #1048, which should be merged first. The actual changes on top of #1048 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-service-instance-sharing-fix-test-variables...cloudfoundry-incubator:pr-service-instance-sharing-controller-typos)

## PR

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)


Thanks, sapi (alex, @deniseyu)
