### PR TITLE
Record a service instance delete event when space is deleted

### DIFF
--- a/app/actions/services/service_instance_delete.rb
+++ b/app/actions/services/service_instance_delete.rb
@@ -52,6 +52,7 @@ module VCAP::CloudController
 
         if attributes_to_update[:last_operation][:state] == 'succeeded'
           lock.unlock_and_destroy!
+          log_audit_event(service_instance)
         else
           lock.enqueue_unlock!(attributes_to_update, build_fetch_job(service_instance))
         end
@@ -86,6 +87,11 @@ module VCAP::CloudController
         @event_repository.user_audit_info,
         {},
       )
+    end
+
+    def log_audit_event(service_instance)
+      event_method = service_instance.managed_instance? ? :record_service_instance_event : :record_user_provided_service_instance_event
+      @event_repository.send(event_method, :delete, service_instance, {})
     end
   end
 end

--- a/app/controllers/services/lifecycle/service_instance_deprovisioner.rb
+++ b/app/controllers/services/lifecycle/service_instance_deprovisioner.rb
@@ -1,9 +1,7 @@
 module VCAP::CloudController
   class ServiceInstanceDeprovisioner
-    def initialize(services_event_repository, access_validator, logger)
+    def initialize(services_event_repository)
       @services_event_repository = services_event_repository
-      @access_validator = access_validator
-      @logger = logger
     end
 
     def deprovision_service_instance(service_instance, accepts_incomplete, async)
@@ -14,13 +12,10 @@ module VCAP::CloudController
 
       delete_job = build_delete_job(service_instance, delete_action)
 
-      enqueued_job = nil
-
       if async && !accepts_incomplete
-        enqueued_job = Jobs::Enqueuer.new(build_audit_job(service_instance, delete_job), queue: 'cc-generic').enqueue
+        enqueued_job = Jobs::Enqueuer.new(delete_job, queue: 'cc-generic').enqueue
       else
         delete_job.perform
-        log_audit_event(service_instance) unless service_instance.exists?
       end
 
       enqueued_job
@@ -30,16 +25,6 @@ module VCAP::CloudController
 
     def build_delete_job(service_instance, delete_action)
       Jobs::DeleteActionJob.new(VCAP::CloudController::ServiceInstance, service_instance.guid, delete_action)
-    end
-
-    def build_audit_job(service_instance, deletion_job)
-      event_method = service_instance.managed_instance? ? :record_service_instance_event : :record_user_provided_service_instance_event
-      Jobs::AuditEventJob.new(deletion_job, @services_event_repository, event_method, :delete, service_instance.class, service_instance.guid, {})
-    end
-
-    def log_audit_event(service_instance)
-      event_method = service_instance.managed_instance? ? :record_service_instance_event : :record_user_provided_service_instance_event
-      @services_event_repository.send(event_method, :delete, service_instance, {})
     end
   end
 end

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -173,7 +173,7 @@ module VCAP::CloudController
         association_not_empty! if has_associations
       end
 
-      deprovisioner = ServiceInstanceDeprovisioner.new(@services_event_repository, self, logger)
+      deprovisioner = ServiceInstanceDeprovisioner.new(@services_event_repository)
       delete_job = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
 
       if delete_job

--- a/spec/unit/controllers/services/lifecycle/service_instance_deprovisioner_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_instance_deprovisioner_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  RSpec.describe ServiceInstanceDeprovisioner do
+    describe '#deprovision_service_instance' do
+      let(:event_repository) { Repositories::ServiceEventRepository.new(UserAuditInfo.new(user_guid: User.make.guid, user_email: 'email')) }
+      let(:deprovisioner) { ServiceInstanceDeprovisioner.new(event_repository) }
+      let(:service_instance) { ManagedServiceInstance.make }
+      let(:fake_job) { instance_double(Jobs::DeleteActionJob) }
+      let(:some_boolean) { false }
+
+      before do
+        allow(Jobs::DeleteActionJob).to receive(:new).and_return(fake_job)
+        allow(fake_job).to receive(:perform)
+      end
+
+      context 'when accepts_incomplete is true' do
+        it 'creates a service instance delete action' do
+          accepts_incomplete = true
+
+          expect(ServiceInstanceDelete).to receive(:new).
+            with({ accepts_incomplete: true, event_repository: event_repository }).once
+
+          deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, some_boolean)
+        end
+      end
+
+      context 'when accepts_incomplete is false' do
+        it 'creates a service instance delete action' do
+          accepts_incomplete = false
+
+          expect(ServiceInstanceDelete).to receive(:new).
+            with({ accepts_incomplete: false, event_repository: event_repository }).once
+
+          deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, some_boolean)
+        end
+      end
+
+      it 'creates a delete action job' do
+        expect(Jobs::DeleteActionJob).to receive(:new).
+          with(ServiceInstance, service_instance.guid, instance_of(ServiceInstanceDelete)).once
+
+        deprovisioner.deprovision_service_instance(service_instance, some_boolean, some_boolean)
+      end
+
+      context 'when async is false' do
+        let(:async) { false }
+
+        context 'and accepts_incomplete is true' do
+          let(:accepts_incomplete) { true }
+
+          it 'executes the job immediately' do
+            expect(fake_job).to receive(:perform).once
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'does not enqueue the job' do
+            expect(Jobs::Enqueuer).not_to receive(:new)
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'returns nil' do
+            result = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and accepts_incomplete is false' do
+          let(:accepts_incomplete) { false }
+
+          it 'executes the job immediately' do
+            expect(fake_job).to receive(:perform).once
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'does not enqueue the job' do
+            expect(Jobs::Enqueuer).not_to receive(:new)
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'returns nil' do
+            result = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+            expect(result).to be_nil
+          end
+        end
+      end
+
+      context 'when async is true' do
+        let(:async) { true }
+
+        context 'and accepts_incomplete is false' do
+          let(:accepts_incomplete) { false }
+
+          it 'enqueues a job' do
+            fake_enqueuer = instance_double(Jobs::Enqueuer)
+            expect(Jobs::Enqueuer).to receive(:new).with(duck_type(:perform), { queue: 'cc-generic' }).and_return(fake_enqueuer)
+            expect(fake_enqueuer).to receive(:enqueue).once
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'returns the enqueued job' do
+            result = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+            expect(result).to be_instance_of Delayed::Job
+          end
+        end
+
+        context 'and accepts_incomplete is true' do
+          let(:accepts_incomplete) { true }
+
+          it 'executes the job immediately' do
+            expect(fake_job).to receive(:perform).once
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'does not enqueue a job' do
+            expect(Jobs::Enqueuer).not_to receive(:new)
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'returns nil' do
+            result = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+            expect(result).to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fixes #974. With this change, audit events are correctly created when a service instance is deleted via its parent space deletion and the deprovision call to the broker is completed synchronously.

Tracker story (SAPI backlog): https://www.pivotaltracker.com/story/show/152631677
Tracker story (CAPI backlog): https://www.pivotaltracker.com/story/show/152542410

## Details
In investigating this bug, we familiarized ourselves with all the possible code paths that ultimately end up with a service instance being deleted. There are 3 different "choices" in the service deletion flow, resulting in 6 possible combinations. The 3 choices are:  
1. The service instance can be either deleted directly (via a `DELETE` request to `/v2/service_instances/:guid`, or deleted indirectly by deleting the parent space or org.
1. If a service instance is deleted directly, the request to CC can provide `async=true` or `async=false` as a query parameter. This determines whether the **cloud controller** responds synchronously or asynchronously. An async query here means the delete job get placed on the delayed jobs queue.
1. The **service broker** itself can choose whether to respond synchronously or asynchronously to the service instance deprovision request. An async response here means the broker responds to the CC with a 202, and the CC polls the broker and updates its db when the broker operation is finished.

So, the 6 combinations are:

| Deletion | CC response to CC client | broker response to CC |
| --- | --- | --- |
| Direct | sync | sync |
| Direct | async | sync |
| Direct | sync | async |
| Direct | async | async |
| Parent | sync | sync |
| Parent | sync | async |

Previous to this PR, the event logging for service instance deletion was scattered throughout each of these specific code paths. There was one bit of code responsible for logging the event when it was a direct deletion and the cc request was synchronous, another bit of code responsible for logging when it was a direct deletion and the cc request was async, and another bit of code responsible for logging whenever the broker response was async. If you draw these combinations out, you'll see it misses one of the 6 possible combinations: deletion of the parent when the broker responds synchronously.

This change not only fixes that gap, but also simplifies this logic significantly.  Now there are just two places where this event is logged: one place whenever the broker is synchronous and another whenever the broker is asynchronous. We've tested this change against all six combinations. 

In the course of doing this work, we found that the service_instance_deprovisioner had no tests, so we added a test file for that and backfilled all the tests there. By TDDing this file, we were able to delete some dead code from it.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks,
SAPI team (Jen and @deniseyu)
