### PR TITLE
Enable brokers to distinguish bindings that come from shared service instances

### DIFF
--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.10_spec.rb' => '27e81c4c540e39a4e4eac70c8efb14ba',
       'broker_api_v2.11_spec.rb' => '99e61dc50ceb635b09b3bd16901a4fa6',
       'broker_api_v2.12_spec.rb' => 'b9626f09abf20d9d1d0e71ef1ac0df70',
-      'broker_api_v2.13_spec.rb' => '877bfeabe26bead3c7c2e78287a0d623',
+      'broker_api_v2.13_spec.rb' => 'c0e45605138112adaa7c0eea5a65e3f7',
     }
   end
   let(:digester) { Digester.new(algorithm: Digest::MD5) }

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -39,6 +39,9 @@ module VCAP::CloudController::BrokerApiHelper
           bindable: true,
           requires: requires,
           plan_updateable: plan_updateable,
+          metadata: {
+            shareable: true
+          },
           plans: [
             {
               id: 'plan1-guid-here',
@@ -248,8 +251,8 @@ module VCAP::CloudController::BrokerApiHelper
         admin_headers)
   end
 
-  def create_app
-    process = VCAP::CloudController::ProcessModelFactory.make(space: @space)
+  def create_app(space=@space)
+    process = VCAP::CloudController::ProcessModelFactory.make(space: space)
     @app_guid = process.guid
   end
 
@@ -280,6 +283,12 @@ module VCAP::CloudController::BrokerApiHelper
     headers = opts[:user] ? admin_headers_for(opts[:user]) : admin_headers
     params = opts[:async] ? { async: true } : '{}'
     delete("/v2/service_bindings/#{@binding_id}", params, headers)
+  end
+
+  def share_service(service_instance_guid, space_guid, opts={})
+    headers = opts[:user] ? admin_headers_for(opts[:user]) : admin_headers
+    body = { data: [{ guid: space_guid }] }
+    post("/v3/service_instances/#{service_instance_guid}/relationships/shared_spaces", body.to_json, headers)
   end
 
   def create_service_key(opts={})

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -350,7 +350,10 @@ module VCAP::CloudController
             context: {
               platform: 'cloudfoundry',
               organization_guid: service_instance.organization.guid,
-              space_guid:        service_instance.space.guid
+              space_guid:        service_instance.space.guid,
+              bind_resource: {
+                space_guid: process.space.guid
+              }
             }
           }
 

--- a/spec/unit/controllers/services/service_keys_controller_spec.rb
+++ b/spec/unit/controllers/services/service_keys_controller_spec.rb
@@ -192,7 +192,10 @@ module VCAP::CloudController
             context: {
               platform: 'cloudfoundry',
               organization_guid: instance.organization.guid,
-              space_guid: instance.space.guid
+              space_guid: instance.space.guid,
+              bind_resource: {
+                space_guid: instance.space.guid
+              }
             }
           }.to_json
 

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -811,7 +811,10 @@ module VCAP::Services::ServiceBrokers::V2
             context:    {
               platform:          'cloudfoundry',
               organization_guid: key.service_instance.organization.guid,
-              space_guid:        key.service_instance.space.guid
+              space_guid:        key.service_instance.space_guid,
+              bind_resource: {
+                space_guid: key.service_instance.space_guid
+              }
             },
             bind_resource: {
               credential_client_id: cc_service_key_client_name,
@@ -950,7 +953,10 @@ module VCAP::Services::ServiceBrokers::V2
             context:       {
               platform:          'cloudfoundry',
               organization_guid: instance.organization.guid,
-              space_guid:        instance.space_guid
+              space_guid:        instance.space_guid,
+              bind_resource: {
+                space_guid: app.space_guid
+              }
             }
           )
       end


### PR DESCRIPTION
As a service broker author, I can see the GUID of the space the app belongs to when I create a binding for an app [#154392508](https://www.pivotaltracker.com/story/show/154392508)

## What

The service instance sharing feature allowed bindings of applications on shared service instances. Broker authors have requested the ability to give out different credentials based on if the binding occurred in a shared space. i.e. read-only.

This change adds `context.bind_resource.space_guid` in the platform bind service request to the broker. This represents the space_guid of the asset being bound to. Brokers can compare it to the `context.space_guid`, which represents the service instance's space, if they do not match then the binding occurred on a shared service_instance. 

Although service instance sharing is not supported for route services or service keys, the `context` field has also been expanded to include `bind_resource.space_guid` for these bindings. In these scenarios `bind_resource.space_guid` and `space_guid` will be the same. 

The OSBAPI [platform profiles documentation (draft)](https://github.com/mattmcneeney/servicebroker/blob/update-cloud-foundry-context-object/profile.md#cloud-foundry-context-object) will be updated to reflect this change.

#### Before
```
{
  "context": {
    "platform": "cloudfoundry",
    "organization_guid": "1113aa0-124e-4af2-1526-6bfacf61b111",
    "space_guid": "aaaa1234-da91-4f12-8ffa-b51d0336aaaa"
   },
  "service_id": "service-id-here",
  "plan_id": "plan-id-here",
  "bind_resource": {
    "app_guid": "app-guid-here"
  },
  "parameters": {
    "parameter1-name-here": 1,
    "parameter2-name-here": "parameter2-value-here"
  }
}

```

#### After
```
{
  "context": {
    "platform": "cloudfoundry",
    "organization_guid": "1113aa0-124e-4af2-1526-6bfacf61b111",
    "space_guid": "aaaa1234-da91-4f12-8ffa-b51d0336aaaa",
    "bind_resource": {
       "space_guid": "bbbb1234-da91-4f12-8ffa-b51d0336bbbb"
     }
  },
  "service_id": "service-id-here",
  "plan_id": "plan-id-here",
  "bind_resource": {
    "app_guid": "app-guid-here"
  },
  "parameters": {
    "parameter1-name-here": 1,
    "parameter2-name-here": "parameter2-value-here"
  }
}
```

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, SAPI team (@deniseyu / sam)