### PR TITLE
GET endpoint for service binding parameters

### DIFF
--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -25,6 +25,20 @@ module VCAP::CloudController
       object_renderer.render_json(self.class, obj, @opts)
     end
 
+    get '/v2/service_bindings/:guid/parameters', :parameters
+
+    def parameters(guid)
+      binding = find_guid(guid)
+      raise CloudController::Errors::ApiError.new_from_details('ServiceBindingNotFound', guid) unless binding.v2_app.present?
+
+      unless binding.service.bindings_retrievable
+        message = 'This service does not support fetching service binding parameters.'
+        raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', message)
+      end
+
+      [HTTP::OK, {}]
+    end
+
     post path, :create
 
     def create

--- a/app/models/services/service.rb
+++ b/app/models/services/service.rb
@@ -9,11 +9,13 @@ module VCAP::CloudController
 
     export_attributes :label, :provider, :url, :description, :long_description,
                       :version, :info_url, :active, :bindable,
-                      :unique_id, :extra, :tags, :requires, :documentation_url, :service_broker_guid, :plan_updateable
+                      :unique_id, :extra, :tags, :requires, :documentation_url,
+                      :service_broker_guid, :plan_updateable, :bindings_retrievable, :instances_retrievable
 
     import_attributes :label, :description, :long_description, :info_url,
                       :active, :bindable, :unique_id, :extra,
-                      :tags, :requires, :documentation_url, :plan_updateable
+                      :tags, :requires, :documentation_url, :plan_updateable,
+                      :bindings_retrievable, :instances_retrievable
 
     strip_attributes :label
 

--- a/db/migrations/20180115151922_add_instances_and_bindings_retrievable_to_services.rb
+++ b/db/migrations/20180115151922_add_instances_and_bindings_retrievable_to_services.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  change do
+    alter_table :services do
+      add_column :bindings_retrievable, :boolean, default: false, null: false
+      add_column :instances_retrievable, :boolean, default: false, null: false
+    end
+  end
+end

--- a/docs/v2/events/list_service_create_events.html
+++ b/docs/v2/events/list_service_create_events.html
@@ -524,7 +524,9 @@ Cookie: </pre>
           ],
           "documentation_url": null,
           "service_broker_guid": "3e0a6bd3-fb60-48cb-9929-18b4b95cbf7b",
-          "plan_updateable": false
+          "plan_updateable": false,
+          "instances_retrievable": false,
+          "bindings_retrievable": false,
         },
         "space_guid": "",
         "organization_guid": ""

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -815,6 +815,9 @@
       <li>
         <a href="service_bindings/retrieve_a_particular_service_binding.html">Retrieve a Particular Service Binding</a>
       </li>
+      <li>
+        <a href="service_bindings/retrieve_a_particular_service_binding_parameters.html">Retrieve a Particular Service Binding Parameters</a>
+      </li>
     </ul>
   </div>
   <div class="article">

--- a/docs/v2/service_bindings/retrieve_a_particular_service_binding_parameters.html
+++ b/docs/v2/service_bindings/retrieve_a_particular_service_binding_parameters.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Service Bindings API</title>
+  <meta charset="utf-8">
+  <link id="bootstrapcss" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" />
+  <script>
+    if( "file:" == document.location.protocol ) {
+      var csslink = document.getElementById("bootstrapcss");
+      csslink.href = "http://" + csslink.href.replace(/.*\/\//, "");
+    }
+  </script>
+  <style>
+    p {
+      padding: 15px;
+      font-size: 130%;
+    }
+
+    pre {
+      white-space: pre;
+    }
+
+    td.required .name:after {
+      float: right;
+      content: " required";
+      font-weight: normal;
+      color: #F08080;
+    }
+
+    td.experimental:after {
+      float: right;
+      content: " experimental";
+      font-weight: normal;
+      color: #FFA500;
+      padding: 2px;
+    }
+
+    tr.deprecated td:first-child:before {
+      content: "deprecated: ";
+      font-weight: bold;
+      color: gray;
+    }
+
+    tr.deprecated span, tr.deprecated ul {
+      text-decoration: line-through;
+      color: gray;
+    }
+
+    tr.readonly .name:after {
+      float: right;
+      content: " read-only";
+      font-weight: normal;
+    }
+
+    tr.readonly {
+      color: grey;
+    }
+
+    table ul {
+      padding-left: 1.2em;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>Service Bindings API</h1>
+
+  <div class="article">
+    <h2>Retrieve a Particular Service Binding Parameters</h2>
+    <h3>GET /v2/service_bindings/:guid/parameters</h3>
+
+      <h3>Request</h3>
+      <h4>Route</h4>
+      <pre class="request route highlight">GET /v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters</pre>
+
+
+
+
+
+      <h4>Headers</h4>
+      <pre class="request headers">Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTQzMCIsImVtYWlsIjoiZW1haWwtMjkyQHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg5MDN9.0MsVZ0mRjX1JYkb_CfI1sjMRuP0vy5IgtdK90ktWtGg
+Host: example.org
+Cookie: </pre>
+
+        <h4>cURL</h4>
+        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters&quot; -X GET \
+	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTQzMCIsImVtYWlsIjoiZW1haWwtMjkyQHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg5MDN9.0MsVZ0mRjX1JYkb_CfI1sjMRuP0vy5IgtdK90ktWtGg&quot; \
+	-H &quot;Host: example.org&quot; \
+	-H &quot;Cookie: &quot;</pre>
+
+        <h3>Response</h3>
+
+        <h4>Status</h4>
+        <pre class="response status">200 OK</pre>
+
+          <h4>Body</h4>
+
+          <pre class="response body">{}</pre>
+
+        <h4>Headers</h4>
+        <pre class="response headers">Content-Type: application/json;charset=utf-8
+X-VCAP-Request-ID: 5f0b6b5a-990a-4798-bb6a-f7bdfd2ff0d2
+Content-Length: 0
+X-Content-Type-Options: nosniff</pre>
+
+  </div>
+</div>
+</body>
+</html>

--- a/docs/v2/services/list_all_services.html
+++ b/docs/v2/services/list_all_services.html
@@ -588,6 +588,44 @@
                 </ul>
               </td>
             </tr>
+            <tr class=" ">
+              <td class=" ">
+                <span class="name">instances_retrievable</span>
+              </td>
+              <td>
+                <span class="description">A boolean describing that the service may support fetching configuration parameters for service instances</span>
+              </td>
+              <td>
+                <span class="default">false</span>
+              </td>
+              <td>
+                <ul class="valid_values">
+                </ul>
+              </td>
+              <td>
+                <ul class="example_values">
+                </ul>
+              </td>
+            </tr>
+            <tr class=" ">
+              <td class=" ">
+                <span class="name">bindings_retrievable</span>
+              </td>
+              <td>
+                <span class="description">A boolean describing that the service may support fetching configuration parameters for service bindings</span>
+              </td>
+              <td>
+                <span class="default">false</span>
+              </td>
+              <td>
+                <ul class="valid_values">
+                </ul>
+              </td>
+              <td>
+                <ul class="example_values">
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
 
@@ -644,6 +682,8 @@ Cookie: </pre>
         "documentation_url": null,
         "service_broker_guid": "34b94a65-3cd3-4655-8c07-e2bd94ae21c5",
         "plan_updateable": false,
+        "instances_retrievable": false,
+        "bindings_retrievable": false,
         "service_plans_url": "/v2/services/1993218f-096d-4216-bf9d-e0f250332dc6/service_plans"
       }
     }

--- a/docs/v2/services/retrieve_a_particular_service.html
+++ b/docs/v2/services/retrieve_a_particular_service.html
@@ -444,6 +444,44 @@
                 </ul>
               </td>
             </tr>
+            <tr class=" ">
+              <td class=" ">
+                <span class="name">instances_retrievable</span>
+              </td>
+              <td>
+                <span class="description">A boolean describing that the service may support fetching configuration parameters for service instances</span>
+              </td>
+              <td>
+                <span class="default">false</span>
+              </td>
+              <td>
+                <ul class="valid_values">
+                </ul>
+              </td>
+              <td>
+                <ul class="example_values">
+                </ul>
+              </td>
+            </tr>
+            <tr class=" ">
+              <td class=" ">
+                <span class="name">bindings_retrievable</span>
+              </td>
+              <td>
+                <span class="description">A boolean describing that the service may support fetching configuration parameters for service bindings</span>
+              </td>
+              <td>
+                <span class="default">false</span>
+              </td>
+              <td>
+                <ul class="valid_values">
+                </ul>
+              </td>
+              <td>
+                <ul class="example_values">
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
 
@@ -494,6 +532,8 @@ Cookie: </pre>
     "documentation_url": null,
     "service_broker_guid": "0e7250aa-364f-42c2-8fd2-808b0224376f",
     "plan_updateable": false,
+    "instances_retrievable": false,
+    "bindings_retrievable": false,
     "service_plans_url": "/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5/service_plans"
   }
 }</pre>

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -40,6 +40,8 @@ module VCAP::Services::ServiceBrokers
           active:      catalog_service.plans_present?,
           requires:    catalog_service.requires,
           plan_updateable: catalog_service.plan_updateable,
+          bindings_retrievable: catalog_service.bindings_retrievable,
+          instances_retrievable: catalog_service.instances_retrievable,
         )
 
         @services_event_repository.with_service_event(obj) do

--- a/lib/services/service_brokers/v2/catalog_service.rb
+++ b/lib/services/service_brokers/v2/catalog_service.rb
@@ -5,7 +5,8 @@ module VCAP::Services::ServiceBrokers::V2
     SUPPORTED_REQUIRES_VALUES = ['syslog_drain', 'route_forwarding', 'volume_mount'].freeze
 
     attr_reader :service_broker, :broker_provided_id, :metadata, :name,
-      :description, :bindable, :tags, :plans, :requires, :dashboard_client, :errors, :plan_updateable
+      :description, :bindable, :tags, :plans, :requires, :dashboard_client,
+      :errors, :plan_updateable, :bindings_retrievable, :instances_retrievable
 
     def initialize(service_broker, attrs)
       @service_broker     = service_broker
@@ -21,6 +22,8 @@ module VCAP::Services::ServiceBrokers::V2
       @plan_updateable    = attrs['plan_updateable'] || false
       @errors             = VCAP::Services::ValidationErrors.new
       @plans              = []
+      @bindings_retrievable = attrs.fetch('bindings_retrievable', false)
+      @instances_retrievable = attrs.fetch('instances_retrievable', false)
 
       build_plans
     end
@@ -58,6 +61,8 @@ module VCAP::Services::ServiceBrokers::V2
       validate_string!(:description, description, required: true)
       validate_bool!(:bindable, bindable, required: true)
       validate_bool!(:plan_updateable, plan_updateable, required: true)
+      validate_bool!(:bindings_retrievable, bindings_retrievable, required: false)
+      validate_bool!(:instances_retrievable, instances_retrievable, required: false)
 
       validate_tags!(:tags, tags)
       validate_array_of_strings!(:requires, requires)
@@ -168,7 +173,9 @@ module VCAP::Services::ServiceBrokers::V2
         dashboard_client: 'Service dashboard client attributes',
         dashboard_client_id: 'Service dashboard client id',
         dashboard_client_secret: 'Service dashboard client secret',
-        dashboard_client_redirect_uri: 'Service dashboard client redirect_uri'
+        dashboard_client_redirect_uri: 'Service dashboard client redirect_uri',
+        bindings_retrievable: 'Service "bindings_retrievable" field',
+        instances_retrievable: 'Service "instances_retrievable" field',
       }.fetch(name) { raise NotImplementedError }
     end
   end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.14_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.14_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+RSpec.describe 'Service Broker API integration' do
+  describe 'v2.14' do
+    include VCAP::CloudController::BrokerApiHelper
+
+    before do
+      setup_cc
+      setup_broker(catalog)
+      @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+    end
+
+    describe 'fetching service binding configuration parameters' do
+      context 'when the brokers catalog does not set bindings_retrievable' do
+        let(:catalog) { default_catalog }
+
+        it 'defaults to false' do
+          get("/v2/services/#{@service_guid}",
+              {}.to_json,
+              json_headers(admin_headers))
+          parsed_body = MultiJson.load(last_response.body)
+
+          expect(parsed_body['entity']['bindings_retrievable']).to eq false
+        end
+      end
+
+      context 'when the brokers catalog has bindings_retrievable set to true' do
+        let(:catalog) do
+          catalog = default_catalog
+          catalog[:services].first[:bindings_retrievable] = true
+          catalog
+        end
+
+        it 'returns true' do
+          get("/v2/services/#{@service_guid}",
+              {}.to_json,
+              json_headers(admin_headers))
+          parsed_body = MultiJson.load(last_response.body)
+
+          expect(parsed_body['entity']['bindings_retrievable']).to eq true
+        end
+      end
+
+      context 'when the brokers catalog has bindings_retrievable set to false' do
+        let(:catalog) do
+          catalog = default_catalog
+          catalog[:services].first[:bindings_retrievable] = false
+          catalog
+        end
+
+        it 'shows the service as bindings_retrievable false' do
+          get("/v2/services/#{@service_guid}",
+              {}.to_json,
+              json_headers(admin_headers))
+          parsed_body = MultiJson.load(last_response.body)
+
+          expect(parsed_body['entity']['bindings_retrievable']).to eq false
+        end
+      end
+    end
+
+    describe 'fetching service instance configuration parameters' do
+      context 'when the brokers catalog does not set instances_retrievable' do
+        let(:catalog) { default_catalog }
+
+        it 'defaults to false' do
+          get("/v2/services/#{@service_guid}",
+              {}.to_json,
+              json_headers(admin_headers))
+          parsed_body = MultiJson.load(last_response.body)
+
+          expect(parsed_body['entity']['instances_retrievable']).to eq false
+        end
+      end
+
+      context 'when the brokers catalog has instances_retrievable set to true' do
+        let(:catalog) do
+          catalog = default_catalog
+          catalog[:services].first[:instances_retrievable] = true
+          catalog
+        end
+
+        it 'returns true' do
+          get("/v2/services/#{@service_guid}",
+              {}.to_json,
+              json_headers(admin_headers))
+          parsed_body = MultiJson.load(last_response.body)
+
+          expect(parsed_body['entity']['instances_retrievable']).to eq true
+        end
+      end
+
+      context 'when the brokers catalog has instances_retrievable set to false' do
+        let(:catalog) do
+          catalog = default_catalog
+          catalog[:services].first[:instances_retrievable] = false
+          catalog
+        end
+
+        it 'shows the service as instances_retrievable false' do
+          get("/v2/services/#{@service_guid}",
+              {}.to_json,
+              json_headers(admin_headers))
+          parsed_body = MultiJson.load(last_response.body)
+
+          expect(parsed_body['entity']['instances_retrievable']).to eq false
+        end
+      end
+    end
+  end
+end

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'vcap/digester'
 
 RSpec.describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = '8d08df242e77b29ef0374b7557031985fcdfba43'.freeze
+  API_FOLDER_CHECKSUM = '3655fc8ee4b47c9bbf4773e5743b65b52fa04305'.freeze
 
   it 'tells the developer if the API specs change' do
     api_folder = File.expand_path('..', __FILE__)

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -768,6 +768,8 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         bindable:        true,
         service_broker:  test_broker,
         plan_updateable: false,
+        bindings_retrievable: true,
+        instances_retrievable: true,
         active:          true,
       )
       service_event_repository.with_service_event(new_service) do
@@ -801,6 +803,8 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
           'active'              => new_service.active,
           'requires'            => new_service.requires,
           'plan_updateable'     => new_service.plan_updateable,
+          'bindings_retrievable'   => new_service.bindings_retrievable,
+          'instances_retrievable'  => new_service.instances_retrievable,
         }
       }
     end

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -99,6 +99,8 @@ module VCAP::CloudController::BrokerApiHelper
 
     get('/v2/services?inline-relations-depth=1', '{}', admin_headers)
     response = JSON.parse(last_response.body)
+    @service_guid = response['resources'].first['metadata']['guid']
+
     service_plans = response['resources'].first['entity']['service_plans']
     @plan_guid = service_plans.find { |plan| plan['entity']['name'] == 'small' }['metadata']['guid']
 

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -69,6 +69,8 @@ module VCAP::Services::ServiceBrokers
             'tags'        => ['mysql', 'relational'],
             'requires'    => ['ultimate', 'power'],
             'plan_updateable' => true,
+            'bindings_retrievable' => true,
+            'instances_retrievable' => true,
             'plans' => [
               {
                 'id'          => plan_id,
@@ -123,6 +125,8 @@ module VCAP::Services::ServiceBrokers
         expect(JSON.parse(service.extra)).to eq({ 'foo' => 'bar' })
         expect(service.requires).to eq(['ultimate', 'power'])
         expect(service.plan_updateable).to eq true
+        expect(service.bindings_retrievable).to eq true
+        expect(service.instances_retrievable).to eq true
       end
 
       it 'records an audit event for each service and plan' do
@@ -157,6 +161,8 @@ module VCAP::Services::ServiceBrokers
           'active' => service.active,
           'requires' => service.requires,
           'plan_updateable' => service.plan_updateable,
+          'bindings_retrievable' => service.bindings_retrievable,
+          'instances_retrievable' => service.instances_retrievable,
         })
 
         event = VCAP::CloudController::Event.first(type: 'audit.service_plan.create')

--- a/spec/unit/lib/services/service_brokers/v2/catalog_service_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_service_spec.rb
@@ -235,6 +235,22 @@ module VCAP::Services::ServiceBrokers::V2
         expect(service.errors.messages).to include "Plan names must be unique within a service. Service #{service.name} already has a plan named same-name"
       end
 
+      it 'validates that @bindings_retrievable is a boolean' do
+        attrs = build_valid_service_attrs(bindings_retrievable: 'foo')
+        service = CatalogService.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
+        expect(service).not_to be_valid
+
+        expect(service.errors.messages).to include 'Service "bindings_retrievable" field must be a boolean, but has value "foo"'
+      end
+
+      it 'validates that @instances_retrievable is a boolean' do
+        attrs = build_valid_service_attrs(instances_retrievable: 'foo')
+        service = CatalogService.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
+        expect(service).not_to be_valid
+
+        expect(service.errors.messages).to include 'Service "instances_retrievable" field must be a boolean, but has value "foo"'
+      end
+
       context 'when there are multiple duplicate plan names' do
         it 'validates that the plan names are all unique' do
           plans = [

--- a/spec/unit/models/services/service_spec.rb
+++ b/spec/unit/models/services/service_spec.rb
@@ -37,10 +37,10 @@ module VCAP::CloudController
 
     describe 'Serialization' do
       it { is_expected.to export_attributes :label, :provider, :url, :description, :long_description, :version, :info_url, :active, :bindable,
-                                    :unique_id, :extra, :tags, :requires, :documentation_url, :service_broker_guid, :plan_updateable
+                                    :unique_id, :extra, :tags, :requires, :documentation_url, :service_broker_guid, :plan_updateable, :bindings_retrievable, :instances_retrievable
       }
       it { is_expected.to import_attributes :label, :description, :long_description, :info_url,
-                                    :active, :bindable, :unique_id, :extra, :tags, :requires, :documentation_url, :plan_updateable
+                                    :active, :bindable, :unique_id, :extra, :tags, :requires, :documentation_url, :plan_updateable, :bindings_retrievable, :instances_retrievable
       }
     end
 


### PR DESCRIPTION
**NOTE**: This PR builds on top of #1062, which should be merged first. The actual changes on top of #1062 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-retrievable-service-instances-and-bindings...cloudfoundry-incubator:pr-get-service-binding-parameters).

## What

This PR begins implementing the `GET` endpoints for retrieving services bindings and instances. This PR contains only the endpoint to `GET` service binding parameters; service instance parameters will be implemented as [a separate story](https://www.pivotaltracker.com/story/show/153739004).

422 responses are returned if a broker has not set `bindings_retrievable` or set it to false. 404 is returned if the service binding guid is invalid or if the guid belongs to a service key. The 200 case, when a service broker has `bindings_retrievable: true` returns an empty response for now but will be updated later.

## Changes

* Add `/v2/service_bindings/:guid/parameters` endpoint
* Add corresponding API docs

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@ablease and @deniseyu)