### PR TITLE
ServiceInstanceDelete action should not know about whether we are in a multipart delete or not

### DIFF
--- a/app/actions/services/service_instance_delete.rb
+++ b/app/actions/services/service_instance_delete.rb
@@ -52,6 +52,7 @@ module VCAP::CloudController
 
         if attributes_to_update[:last_operation][:state] == 'succeeded'
           lock.unlock_and_destroy!
+          log_audit_event(service_instance)
         else
           lock.enqueue_unlock!(attributes_to_update, build_fetch_job(service_instance))
         end
@@ -86,6 +87,11 @@ module VCAP::CloudController
         @event_repository.user_audit_info,
         {},
       )
+    end
+
+    def log_audit_event(service_instance)
+      event_method = service_instance.managed_instance? ? :record_service_instance_event : :record_user_provided_service_instance_event
+      @event_repository.send(event_method, :delete, service_instance, {})
     end
   end
 end

--- a/app/actions/services/service_instance_delete.rb
+++ b/app/actions/services/service_instance_delete.rb
@@ -4,10 +4,9 @@ require 'actions/services/locks/deleter_lock'
 
 module VCAP::CloudController
   class ServiceInstanceDelete
-    def initialize(accepts_incomplete: false, event_repository:, multipart_delete: false)
+    def initialize(accepts_incomplete: false, event_repository:)
       @accepts_incomplete = accepts_incomplete
       @event_repository = event_repository
-      @multipart_delete = multipart_delete
     end
 
     def delete(service_instance_dataset)
@@ -20,11 +19,6 @@ module VCAP::CloudController
 
         if binding_errors.empty?
           instance_errors = delete_service_instance(service_instance)
-
-          if service_instance.operation_in_progress? && @multipart_delete && instance_errors.empty?
-            errors_accumulator.push CloudController::Errors::ApiError.new_from_details('AsyncServiceInstanceOperationInProgress', service_instance.name)
-          end
-
           errors_accumulator.concat instance_errors
         end
       end

--- a/app/controllers/services/lifecycle/service_instance_deprovisioner.rb
+++ b/app/controllers/services/lifecycle/service_instance_deprovisioner.rb
@@ -1,9 +1,7 @@
 module VCAP::CloudController
   class ServiceInstanceDeprovisioner
-    def initialize(services_event_repository, access_validator, logger)
+    def initialize(services_event_repository)
       @services_event_repository = services_event_repository
-      @access_validator = access_validator
-      @logger = logger
     end
 
     def deprovision_service_instance(service_instance, accepts_incomplete, async)
@@ -14,13 +12,10 @@ module VCAP::CloudController
 
       delete_job = build_delete_job(service_instance, delete_action)
 
-      enqueued_job = nil
-
       if async && !accepts_incomplete
-        enqueued_job = Jobs::Enqueuer.new(build_audit_job(service_instance, delete_job), queue: 'cc-generic').enqueue
+        enqueued_job = Jobs::Enqueuer.new(delete_job, queue: 'cc-generic').enqueue
       else
         delete_job.perform
-        log_audit_event(service_instance) unless service_instance.exists?
       end
 
       enqueued_job
@@ -30,16 +25,6 @@ module VCAP::CloudController
 
     def build_delete_job(service_instance, delete_action)
       Jobs::DeleteActionJob.new(VCAP::CloudController::ServiceInstance, service_instance.guid, delete_action)
-    end
-
-    def build_audit_job(service_instance, deletion_job)
-      event_method = service_instance.managed_instance? ? :record_service_instance_event : :record_user_provided_service_instance_event
-      Jobs::AuditEventJob.new(deletion_job, @services_event_repository, event_method, :delete, service_instance.class, service_instance.guid, {})
-    end
-
-    def log_audit_event(service_instance)
-      event_method = service_instance.managed_instance? ? :record_service_instance_event : :record_user_provided_service_instance_event
-      @services_event_repository.send(event_method, :delete, service_instance, {})
     end
   end
 end

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -173,7 +173,7 @@ module VCAP::CloudController
         association_not_empty! if has_associations
       end
 
-      deprovisioner = ServiceInstanceDeprovisioner.new(@services_event_repository, self, logger)
+      deprovisioner = ServiceInstanceDeprovisioner.new(@services_event_repository)
       delete_job = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
 
       if delete_job

--- a/spec/unit/actions/services/service_instance_delete_spec.rb
+++ b/spec/unit/actions/services/service_instance_delete_spec.rb
@@ -14,7 +14,6 @@ module VCAP::CloudController
 
       let!(:service_binding_1) { ServiceBinding.make(service_instance: managed_service_instance) }
       let!(:service_binding_2) { ServiceBinding.make(service_instance: managed_service_instance) }
-
       let!(:service_binding_3) { ServiceBinding.make(service_instance: user_provided_service_instance) }
       let!(:service_binding_4) { ServiceBinding.make(service_instance: user_provided_service_instance) }
 
@@ -22,6 +21,8 @@ module VCAP::CloudController
       let!(:route_2) { Route.make(space: route_service_instance.space) }
       let!(:route_binding_1) { RouteBinding.make(route: route_1, service_instance: route_service_instance) }
       let!(:route_binding_2) { RouteBinding.make(route: route_2, service_instance: route_service_instance) }
+
+      let!(:service_key) { ServiceKey.make(service_instance: managed_service_instance) }
 
       let!(:service_instance_dataset) { ServiceInstance.dataset }
       let(:user) { User.make }
@@ -36,6 +37,7 @@ module VCAP::CloudController
         stub_unbind(service_binding_2)
         stub_unbind(route_binding_1)
         stub_unbind(route_binding_2)
+        stub_unbind(service_key)
       end
 
       it 'deletes all the service_instances and logs events' do
@@ -64,6 +66,12 @@ module VCAP::CloudController
         expect(errors).to be_empty
 
         expect(user_provided_instance.exists?).to be_falsey
+      end
+
+      it 'deletes service keys associated with the service instance' do
+        expect {
+          service_instance_delete.delete(service_instance_dataset)
+        }.to change { ServiceKey.count }.by(-1)
       end
 
       it 'deletes the last operation for each managed service instance' do

--- a/spec/unit/actions/services/service_instance_delete_spec.rb
+++ b/spec/unit/actions/services/service_instance_delete_spec.rb
@@ -94,13 +94,11 @@ module VCAP::CloudController
 
       context 'when accepts_incomplete is true' do
         let(:service_instance) { ManagedServiceInstance.make }
-        let(:multipart_delete) { false }
 
         subject(:service_instance_delete) do
           ServiceInstanceDelete.new(
             accepts_incomplete: true,
             event_repository: event_repository,
-            multipart_delete: multipart_delete,
           )
         end
 
@@ -141,17 +139,6 @@ module VCAP::CloudController
 
             poll_interval = VCAP::CloudController::Config.config.get(:broker_client_default_async_poll_interval_seconds).seconds
             expect(job.run_at).to be < Time.now.utc + poll_interval
-          end
-        end
-
-        context 'and the caller wants to treat accepts_incomplete deprovisioning as a failure during a multipart deletion' do
-          let(:multipart_delete) { true }
-
-          it 'should return an error if there is an operation in progress' do
-            result = service_instance_delete.delete([service_instance])
-
-            expect(result.length).to be(1)
-            expect(result.first.message).to include("An operation for service instance #{service_instance.name} is in progress.")
           end
         end
       end

--- a/spec/unit/actions/services/service_instance_delete_spec.rb
+++ b/spec/unit/actions/services/service_instance_delete_spec.rb
@@ -8,42 +8,48 @@ module VCAP::CloudController
     subject(:service_instance_delete) { ServiceInstanceDelete.new(event_repository: event_repository) }
 
     describe '#delete' do
-      let!(:service_instance_1) { ManagedServiceInstance.make(:routing) }
-      let!(:service_instance_2) { ManagedServiceInstance.make(:routing) }
+      let!(:route_service_instance) { ManagedServiceInstance.make(:routing) }
+      let!(:managed_service_instance) { ManagedServiceInstance.make }
+      let!(:user_provided_service_instance) { UserProvidedServiceInstance.make }
 
-      let!(:service_binding_1) { ServiceBinding.make(service_instance: service_instance_1) }
-      let!(:service_binding_2) { ServiceBinding.make(service_instance: service_instance_2) }
+      let!(:service_binding_1) { ServiceBinding.make(service_instance: managed_service_instance) }
+      let!(:service_binding_2) { ServiceBinding.make(service_instance: managed_service_instance) }
 
-      let!(:route_1) { Route.make(space: service_instance_1.space) }
-      let!(:route_2) { Route.make(space: service_instance_2.space) }
-      let!(:route_binding_1) { RouteBinding.make(route: route_1, service_instance: service_instance_1) }
-      let!(:route_binding_2) { RouteBinding.make(route: route_2, service_instance: service_instance_2) }
+      let!(:service_binding_3) { ServiceBinding.make(service_instance: user_provided_service_instance) }
+      let!(:service_binding_4) { ServiceBinding.make(service_instance: user_provided_service_instance) }
+
+      let!(:route_1) { Route.make(space: route_service_instance.space) }
+      let!(:route_2) { Route.make(space: route_service_instance.space) }
+      let!(:route_binding_1) { RouteBinding.make(route: route_1, service_instance: route_service_instance) }
+      let!(:route_binding_2) { RouteBinding.make(route: route_2, service_instance: route_service_instance) }
 
       let!(:service_instance_dataset) { ServiceInstance.dataset }
       let(:user) { User.make }
       let(:user_email) { 'user@example.com' }
 
       before do
-        [service_instance_1, service_instance_2].each do |service_instance|
+        [route_service_instance, managed_service_instance].each do |service_instance|
           stub_deprovision(service_instance)
-          stub_unbind(service_instance.service_bindings.first)
         end
 
+        stub_unbind(service_binding_1)
+        stub_unbind(service_binding_2)
         stub_unbind(route_binding_1)
         stub_unbind(route_binding_2)
       end
 
       it 'deletes all the service_instances and logs events' do
-        expect(event_repository).to receive(:record_service_instance_event).with(:delete, kind_of(ServiceInstance), {}).twice
+        expect(event_repository).to receive(:record_service_instance_event).with(:delete, instance_of(ManagedServiceInstance), {}).twice
+        expect(event_repository).to receive(:record_user_provided_service_instance_event).with(:delete, instance_of(UserProvidedServiceInstance), {}).once
         expect {
           service_instance_delete.delete(service_instance_dataset)
-        }.to change { ServiceInstance.count }.by(-2)
+        }.to change { ServiceInstance.count }.by(-3)
       end
 
       it 'deletes all the bindings for all the service instance' do
         expect {
           service_instance_delete.delete(service_instance_dataset)
-        }.to change { ServiceBinding.count }.by(-2)
+        }.to change { ServiceBinding.count }.by(-4)
       end
 
       it 'deletes all the route bindings for all the service instance' do
@@ -62,19 +68,19 @@ module VCAP::CloudController
 
       it 'deletes the last operation for each managed service instance' do
         instance_operation_1 = ServiceInstanceOperation.make(state: 'succeeded')
-        service_instance_1.service_instance_operation = instance_operation_1
-        service_instance_1.save
+        route_service_instance.service_instance_operation = instance_operation_1
+        route_service_instance.save
 
         errors = service_instance_delete.delete(service_instance_dataset)
         expect(errors).to be_empty
 
-        expect(service_instance_1.exists?).to be_falsey
+        expect(route_service_instance.exists?).to be_falsey
         expect(instance_operation_1.exists?).to be_falsey
       end
 
       it 'defaults accepts_incomplete to false' do
-        service_instance_delete.delete([service_instance_1])
-        broker_url = deprovision_url(service_instance_1)
+        service_instance_delete.delete([route_service_instance])
+        broker_url = deprovision_url(route_service_instance)
         expect(a_request(:delete, broker_url)).to have_been_made
       end
 
@@ -151,26 +157,26 @@ module VCAP::CloudController
         end
 
         it 'should leave the service instance unchanged' do
-          original_attrs = service_instance_1.as_json
+          original_attrs = managed_service_instance.as_json
           expect {
             Timeout.timeout(0.5.second) do
               service_instance_delete.delete(service_instance_dataset)
             end
           }.to raise_error(Timeout::Error)
 
-          service_instance_1.reload
+          managed_service_instance.reload
 
           expect(a_request(:delete, unbind_url(service_binding_1))).
             to have_been_made.times(1)
 
-          expect(service_instance_1.as_json).to eq(original_attrs)
+          expect(managed_service_instance.as_json).to eq(original_attrs)
           expect(service_binding_1.exists?).to be_truthy
         end
       end
 
       context 'when deprovisioning a service instance times out' do
         before do
-          stub_deprovision(service_instance_1, body: lambda { |r|
+          stub_deprovision(route_service_instance, body: lambda { |r|
             sleep 10
             raise 'Should time out'
           })
@@ -183,18 +189,18 @@ module VCAP::CloudController
             end
           }.to raise_error(Timeout::Error)
 
-          service_instance_1.reload
+          route_service_instance.reload
 
-          expect(a_request(:delete, deprovision_url(service_instance_1))).
+          expect(a_request(:delete, deprovision_url(route_service_instance))).
             to have_been_made.times(1)
-          expect(service_instance_1.last_operation.type).to eq('delete')
-          expect(service_instance_1.last_operation.state).to eq('failed')
+          expect(route_service_instance.last_operation.type).to eq('delete')
+          expect(route_service_instance.last_operation.state).to eq('failed')
         end
       end
 
       context 'when a service instance has an operation in progress' do
         before do
-          service_instance_1.service_instance_operation = ServiceInstanceOperation.make(state: 'in progress')
+          route_service_instance.service_instance_operation = ServiceInstanceOperation.make(state: 'in progress')
         end
 
         it 'returns an operation in progress error for route and service bindings' do
@@ -206,7 +212,7 @@ module VCAP::CloudController
 
         it 'still exists and is in an `in progress` state' do
           service_instance_delete.delete(service_instance_dataset)
-          expect(service_instance_1.last_operation.reload.state).to eq 'in progress'
+          expect(route_service_instance.last_operation.reload.state).to eq 'in progress'
         end
       end
 
@@ -214,13 +220,13 @@ module VCAP::CloudController
         let(:error_status_code) { 500 }
 
         before do
-          stub_deprovision(service_instance_2, status: error_status_code)
+          stub_deprovision(managed_service_instance, status: error_status_code)
         end
 
         it 'does not rollback previous deletions of service instances' do
-          expect(ServiceInstance.count).to eq 2
-          service_instance_delete.delete(service_instance_dataset)
-          expect(ServiceInstance.count).to eq 1
+          expect {
+            service_instance_delete.delete(service_instance_dataset)
+          }.to change { ServiceInstance.count }.by(-2)
         end
 
         it 'returns errors it has captured' do
@@ -231,11 +237,11 @@ module VCAP::CloudController
 
         it 'fails the last operation of the service instance' do
           service_instance_delete.delete(service_instance_dataset)
-          expect(service_instance_2.last_operation.state).to eq('failed')
+          expect(managed_service_instance.last_operation.state).to eq('failed')
         end
 
         it 'only records one delete audit event' do
-          expect(event_repository).to receive(:record_service_instance_event).with(:delete, service_instance_1, {}).once
+          expect(event_repository).to receive(:record_service_instance_event).with(:delete, route_service_instance, {}).once
           service_instance_delete.delete(service_instance_dataset)
         end
       end
@@ -246,9 +252,9 @@ module VCAP::CloudController
         end
 
         it 'does not rollback previous deletions of service instances' do
-          expect(ServiceInstance.count).to eq 2
-          service_instance_delete.delete(service_instance_dataset)
-          expect(ServiceInstance.count).to eq 1
+          expect {
+            service_instance_delete.delete(service_instance_dataset)
+          }.to change { ServiceInstance.count }.by(-2)
         end
 
         it 'propagates service unbind errors' do
@@ -259,25 +265,25 @@ module VCAP::CloudController
 
         it 'does not attempt to delete that service instance' do
           service_instance_delete.delete(service_instance_dataset)
-          expect(service_instance_1.exists?).to be_falsey
-          expect(service_instance_2.exists?).to be_truthy
+          expect(route_service_instance.exists?).to be_truthy
+          expect(managed_service_instance.exists?).to be_falsey
 
-          broker_url_1 = deprovision_url(service_instance_1, accepts_incomplete: nil)
-          broker_url_2 = deprovision_url(service_instance_2, accepts_incomplete: nil)
-          expect(a_request(:delete, broker_url_1)).to have_been_made
-          expect(a_request(:delete, broker_url_2)).not_to have_been_made
+          broker_url_1 = deprovision_url(route_service_instance, accepts_incomplete: nil)
+          broker_url_2 = deprovision_url(managed_service_instance, accepts_incomplete: nil)
+          expect(a_request(:delete, broker_url_1)).not_to have_been_made
+          expect(a_request(:delete, broker_url_2)).to have_been_made
         end
       end
 
       context 'when the broker returns an error for unbinding' do
         before do
-          stub_unbind(service_instance_2.service_bindings.first, status: 500)
+          stub_unbind(managed_service_instance.service_bindings.first, status: 500)
         end
 
         it 'does not rollback previous deletions of service instances' do
-          expect(ServiceInstance.count).to eq 2
-          service_instance_delete.delete(service_instance_dataset)
-          expect(ServiceInstance.count).to eq 1
+          expect {
+            service_instance_delete.delete(service_instance_dataset)
+          }.to change { ServiceInstance.count }.by(-2)
         end
 
         it 'propagates service unbind errors' do
@@ -288,11 +294,11 @@ module VCAP::CloudController
 
         it 'does not attempt to delete that service instance' do
           service_instance_delete.delete(service_instance_dataset)
-          expect(service_instance_1.exists?).to be_falsey
-          expect(service_instance_2.exists?).to be_truthy
+          expect(route_service_instance.exists?).to be_falsey
+          expect(managed_service_instance.exists?).to be_truthy
 
-          broker_url_1 = deprovision_url(service_instance_1, accepts_incomplete: nil)
-          broker_url_2 = deprovision_url(service_instance_2, accepts_incomplete: nil)
+          broker_url_1 = deprovision_url(route_service_instance, accepts_incomplete: nil)
+          broker_url_2 = deprovision_url(managed_service_instance, accepts_incomplete: nil)
           expect(a_request(:delete, broker_url_1)).to have_been_made
           expect(a_request(:delete, broker_url_2)).not_to have_been_made
         end
@@ -300,17 +306,17 @@ module VCAP::CloudController
 
       context 'when deletion from the database fails for a service instance' do
         before do
-          allow(service_instance_2).to receive(:destroy).and_raise('BOOM')
+          allow(managed_service_instance).to receive(:destroy).and_raise('BOOM')
         end
 
         it 'does not rollback previous deletions of service instances' do
-          expect(ServiceInstance.count).to eq 2
-          service_instance_delete.delete([service_instance_1, service_instance_2])
-          expect(ServiceInstance.count).to eq 1
+          expect {
+            service_instance_delete.delete([route_service_instance, managed_service_instance])
+          }.to change { ServiceInstance.count }.by(-1)
         end
 
         it 'returns errors it has captured' do
-          errors = service_instance_delete.delete([service_instance_1, service_instance_2])
+          errors = service_instance_delete.delete([route_service_instance, managed_service_instance])
           expect(errors.count).to eq(1)
           expect(errors[0].message).to eq 'BOOM'
         end
@@ -318,10 +324,11 @@ module VCAP::CloudController
 
       context 'when deleting already deleted service instance' do
         it 'does not throw errors as element is missing anyway' do
+          expect(ServiceInstance.count).to eq 3
+          service_instance_delete.delete([route_service_instance])
           expect(ServiceInstance.count).to eq 2
-          service_instance_delete.delete([service_instance_1])
-          errors = service_instance_delete.delete([service_instance_1])
-          expect(ServiceInstance.count).to eq 1
+          errors = service_instance_delete.delete([route_service_instance])
+          expect(ServiceInstance.count).to eq 2
 
           expect(errors.count).to eq(0)
         end

--- a/spec/unit/controllers/services/lifecycle/service_instance_deprovisioner_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_instance_deprovisioner_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  RSpec.describe ServiceInstanceDeprovisioner do
+    describe '#deprovision_service_instance' do
+      let(:event_repository) { Repositories::ServiceEventRepository.new(UserAuditInfo.new(user_guid: User.make.guid, user_email: 'email')) }
+      let(:deprovisioner) { ServiceInstanceDeprovisioner.new(event_repository) }
+      let(:service_instance) { ManagedServiceInstance.make }
+      let(:fake_job) { instance_double(Jobs::DeleteActionJob) }
+      let(:some_boolean) { false }
+
+      before do
+        allow(Jobs::DeleteActionJob).to receive(:new).and_return(fake_job)
+        allow(fake_job).to receive(:perform)
+      end
+
+      context 'when accepts_incomplete is true' do
+        it 'creates a service instance delete action' do
+          accepts_incomplete = true
+
+          expect(ServiceInstanceDelete).to receive(:new).
+            with({ accepts_incomplete: true, event_repository: event_repository }).once
+
+          deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, some_boolean)
+        end
+      end
+
+      context 'when accepts_incomplete is false' do
+        it 'creates a service instance delete action' do
+          accepts_incomplete = false
+
+          expect(ServiceInstanceDelete).to receive(:new).
+            with({ accepts_incomplete: false, event_repository: event_repository }).once
+
+          deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, some_boolean)
+        end
+      end
+
+      it 'creates a delete action job' do
+        expect(Jobs::DeleteActionJob).to receive(:new).
+          with(ServiceInstance, service_instance.guid, instance_of(ServiceInstanceDelete)).once
+
+        deprovisioner.deprovision_service_instance(service_instance, some_boolean, some_boolean)
+      end
+
+      context 'when async is false' do
+        let(:async) { false }
+
+        context 'and accepts_incomplete is true' do
+          let(:accepts_incomplete) { true }
+
+          it 'executes the job immediately' do
+            expect(fake_job).to receive(:perform).once
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'does not enqueue the job' do
+            expect(Jobs::Enqueuer).not_to receive(:new)
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'returns nil' do
+            result = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and accepts_incomplete is false' do
+          let(:accepts_incomplete) { false }
+
+          it 'executes the job immediately' do
+            expect(fake_job).to receive(:perform).once
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'does not enqueue the job' do
+            expect(Jobs::Enqueuer).not_to receive(:new)
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'returns nil' do
+            result = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+            expect(result).to be_nil
+          end
+        end
+      end
+
+      context 'when async is true' do
+        let(:async) { true }
+
+        context 'and accepts_incomplete is false' do
+          let(:accepts_incomplete) { false }
+
+          it 'enqueues a job' do
+            fake_enqueuer = instance_double(Jobs::Enqueuer)
+            expect(Jobs::Enqueuer).to receive(:new).with(duck_type(:perform), { queue: 'cc-generic' }).and_return(fake_enqueuer)
+            expect(fake_enqueuer).to receive(:enqueue).once
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'returns the enqueued job' do
+            result = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+            expect(result).to be_instance_of Delayed::Job
+          end
+        end
+
+        context 'and accepts_incomplete is true' do
+          let(:accepts_incomplete) { true }
+
+          it 'executes the job immediately' do
+            expect(fake_job).to receive(:perform).once
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'does not enqueue a job' do
+            expect(Jobs::Enqueuer).not_to receive(:new)
+
+            deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+          end
+
+          it 'returns nil' do
+            result = deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
+            expect(result).to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
ServiceInstanceDelete action should not know about whether we are in a multipart delete or not.
 [#154243915](https://www.pivotaltracker.com/story/show/154243915)

**NOTE**: This PR builds on top of #1059, which should be merged first. The actual changes on top of #1059 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-clean-up-service-instance-delete-test...cloudfoundry-incubator:refactor-service-instance-delete).

## What

This PR includes a refactor to the Service Instance Delete action. Specifically we have pulled out the concern around multipart_delete. Multipart delete for service instances is only ever used when a space is deleted. Therefore it makes more sense for multipart delete to be reasoned about, in the space delete action, rather than the service instance delete action which is reused in various places. 

There are no other behavioural or functional code changes. 
## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@ablease  and @deniseyu)