### PR TITLE
GET endpoint for service binding parameters

### DIFF
--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -25,6 +25,20 @@ module VCAP::CloudController
       object_renderer.render_json(self.class, obj, @opts)
     end
 
+    get '/v2/service_bindings/:guid/parameters', :parameters
+
+    def parameters(guid)
+      binding = find_guid(guid)
+      raise CloudController::Errors::ApiError.new_from_details('ServiceBindingNotFound', guid) unless binding.v2_app.present?
+
+      unless binding.service.bindings_retrievable
+        message = 'This service does not support fetching service binding parameters.'
+        raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', message)
+      end
+
+      [HTTP::OK, {}]
+    end
+
     post path, :create
 
     def create

--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
       binding = find_guid(guid)
       raise CloudController::Errors::ApiError.new_from_details('ServiceBindingNotFound', guid) unless binding.v2_app.present?
 
-      unless binding.service.bindings_retrievable
+      unless binding.service_instance.managed_instance? && binding.service.bindings_retrievable
         message = 'This service does not support fetching service binding parameters.'
         raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', message)
       end

--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -28,7 +28,7 @@ module VCAP::CloudController
     get '/v2/service_bindings/:guid/parameters', :parameters
 
     def parameters(guid)
-      binding = find_guid(guid)
+      binding = find_guid_and_validate_access(:read, guid)
       raise CloudController::Errors::ApiError.new_from_details('ServiceBindingNotFound', guid) unless binding.v2_app.present?
 
       unless binding.service_instance.managed_instance? && binding.service.bindings_retrievable

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -815,6 +815,9 @@
       <li>
         <a href="service_bindings/retrieve_a_particular_service_binding.html">Retrieve a Particular Service Binding</a>
       </li>
+      <li>
+        <a href="service_bindings/retrieve_a_particular_service_binding_parameters_experimental.html">Retrieve a Particular Service Binding Parameters (Experimental)</a>
+      </li>
     </ul>
   </div>
   <div class="article">

--- a/docs/v2/service_bindings/retrieve_a_particular_service_binding_parameters_experimental.html
+++ b/docs/v2/service_bindings/retrieve_a_particular_service_binding_parameters_experimental.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Service Bindings API</title>
+  <meta charset="utf-8">
+  <link id="bootstrapcss" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" />
+  <script>
+    if( "file:" == document.location.protocol ) {
+      var csslink = document.getElementById("bootstrapcss");
+      csslink.href = "http://" + csslink.href.replace(/.*\/\//, "");
+    }
+  </script>
+  <style>
+    p {
+      padding: 15px;
+      font-size: 130%;
+    }
+
+    pre {
+      white-space: pre;
+    }
+
+    td.required .name:after {
+      float: right;
+      content: " required";
+      font-weight: normal;
+      color: #F08080;
+    }
+
+    td.experimental:after {
+      float: right;
+      content: " experimental";
+      font-weight: normal;
+      color: #FFA500;
+      padding: 2px;
+    }
+
+    tr.deprecated td:first-child:before {
+      content: "deprecated: ";
+      font-weight: bold;
+      color: gray;
+    }
+
+    tr.deprecated span, tr.deprecated ul {
+      text-decoration: line-through;
+      color: gray;
+    }
+
+    tr.readonly .name:after {
+      float: right;
+      content: " read-only";
+      font-weight: normal;
+    }
+
+    tr.readonly {
+      color: grey;
+    }
+
+    table ul {
+      padding-left: 1.2em;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>Service Bindings API</h1>
+
+  <div class="article">
+    <h2>Retrieve a Particular Service Binding Parameters (Experimental)</h2>
+    <h3>GET /v2/service_bindings/:guid/parameters</h3>
+
+      <h3>Request</h3>
+      <h4>Route</h4>
+      <pre class="request route highlight">GET /v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters</pre>
+
+
+
+
+
+      <h4>Headers</h4>
+      <pre class="request headers">Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTQzMCIsImVtYWlsIjoiZW1haWwtMjkyQHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg5MDN9.0MsVZ0mRjX1JYkb_CfI1sjMRuP0vy5IgtdK90ktWtGg
+Host: example.org
+Cookie: </pre>
+
+        <h4>cURL</h4>
+        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters&quot; -X GET \
+	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTQzMCIsImVtYWlsIjoiZW1haWwtMjkyQHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg5MDN9.0MsVZ0mRjX1JYkb_CfI1sjMRuP0vy5IgtdK90ktWtGg&quot; \
+	-H &quot;Host: example.org&quot; \
+	-H &quot;Cookie: &quot;</pre>
+
+        <h3>Response</h3>
+
+        <h4>Status</h4>
+        <pre class="response status">200 OK</pre>
+
+          <h4>Body</h4>
+
+          <pre class="response body">{}</pre>
+
+        <h4>Headers</h4>
+        <pre class="response headers">Content-Type: application/json;charset=utf-8
+X-VCAP-Request-ID: 5f0b6b5a-990a-4798-bb6a-f7bdfd2ff0d2
+Content-Length: 0
+X-Content-Type-Options: nosniff</pre>
+
+  </div>
+</div>
+</body>
+</html>

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1055,6 +1055,20 @@ module VCAP::CloudController
         end
       end
 
+      context 'when the binding is for a user provided service' do
+        let(:process) { ProcessModelFactory.make(space: space) }
+        let(:user_provided_service_instance) { UserProvidedServiceInstance.make(space: space) }
+
+        it 'returns a 422' do
+          set_current_user(developer)
+          binding = ServiceBinding.make(service_instance: user_provided_service_instance, app: process.app)
+
+          get "/v2/service_bindings/#{binding.guid}/parameters"
+          expect(last_response.status).to eql(422)
+          expect(last_response.body).to include('This service does not support fetching service binding parameters.')
+        end
+      end
+
       context 'when the binding guid is invalid' do
         it 'returns a 404' do
           set_current_user(developer)

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1019,5 +1019,61 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe 'GET', '/v2/service_bindings/:guid/parameters' do
+      let(:space) { Space.make }
+      let(:developer) { make_developer_for_space(space) }
+
+      context 'when the service binding is valid' do
+        let(:service_plan) { ServicePlan.make(service: service) }
+        let(:managed_service_instance) { ManagedServiceInstance.make(space: space, service_plan: service_plan) }
+        let(:process) { ProcessModelFactory.make(space: space) }
+
+        context 'when the service has bindings_retrievable is set to false' do
+          let(:service) { Service.make(bindings_retrievable: false) }
+
+          it 'returns a 422' do
+            set_current_user(developer)
+            binding = ServiceBinding.make(service_instance: managed_service_instance, app: process.app)
+
+            get "/v2/service_bindings/#{binding.guid}/parameters"
+            expect(last_response.status).to eql(422)
+            expect(last_response.body).to include('This service does not support fetching service binding parameters.')
+          end
+        end
+
+        context 'bindings_retrievable is set to true' do
+          let(:service) { Service.make(bindings_retrievable: true) }
+
+          it 'returns a 200' do
+            set_current_user(developer)
+            binding = ServiceBinding.make(service_instance: managed_service_instance, app: process.app)
+
+            get "/v2/service_bindings/#{binding.guid}/parameters"
+            expect(last_response.status).to eql(200)
+          end
+        end
+      end
+
+      context 'when the binding guid is invalid' do
+        it 'returns a 404' do
+          set_current_user(developer)
+          get '/v2/service_bindings/some-bogus-guid/parameters'
+          expect(last_response.status).to eql(404)
+          expect(last_response.body).to include('The service binding could not be found: some-bogus-guid')
+        end
+      end
+
+      context 'when the requested binding is a service key' do
+        let(:service_key) { ServiceKey.make }
+
+        it 'returns a 404' do
+          set_current_user(developer)
+          get "/v2/service_bindings/#{service_key.guid}/parameters"
+          expect(last_response.status).to eql(404)
+          expect(last_response.body).to include("The service binding could not be found: #{service_key.guid}")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
**NOTE**: This PR builds on top of #1062, which should be merged first. The actual changes on top of #1062 can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-retrievable-service-instances-and-bindings...cloudfoundry-incubator:pr-fetching-service-binding-parameters).

- As a developer, I can call an endpoint to fetch service binding parameters for a broker that does not support this [#153738945](https://www.pivotaltracker.com/story/show/153738945)

- Fetching the parameters of a service bound to a user provided service results in a 500 [#154556208](https://www.pivotaltracker.com/story/show/154556208)

## What

This PR begins implementing the `GET` endpoints for retrieving services bindings and instances. This PR contains only the endpoint to `GET` service binding parameters; service instance parameters will be implemented as [a separate story](https://www.pivotaltracker.com/story/show/153739004).

422 responses are returned if a broker has not set `bindings_retrievable`, set it to false or is bound to a user provided service. 404 is returned if the service binding guid is invalid or if the guid belongs to a service key. The 200 case, when a service broker has `bindings_retrievable: true` returns an empty response for now but will be updated later.

## Changes

* Add `/v2/service_bindings/:guid/parameters` endpoint
* Add corresponding API docs

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, sapi (@nmaslarski and @Samze)