### PR TITLE
Enable brokers to distinguish bindings that come from shared service instances

### DIFF
--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -87,7 +87,9 @@ module VCAP::CloudController
     end
 
     def required_parameters
-      { app_guid: app_guid }
+      { app_guid: app_guid,
+        space_guid: space.guid
+      }
     end
   end
 end

--- a/spec/unit/models/services/service_binding_spec.rb
+++ b/spec/unit/models/services/service_binding_spec.rb
@@ -353,7 +353,8 @@ module VCAP::CloudController
 
       it 'returns the required params' do
         expect(service_binding.required_parameters).to eq(
-          app_guid: app.guid
+          app_guid: app.guid,
+          space_guid: app.space.guid
         )
       end
     end


### PR DESCRIPTION
As a service broker author, I can see the GUID of the space the app belongs to when I create a binding for an app [#154588944](https://www.pivotaltracker.com/story/show/154588944)

## What

The service instance sharing feature allowed bindings of applications on shared service instances. Broker authors have requested the ability to give out different credentials based on if the binding occurred in a shared space. i.e. read-only.

This change adds `bind_resource.space_guid` in the platform bind service request to the broker. This represents the `space_guid` of the asset being bound to. Brokers can compare it to the `context.space_guid`, which represents the service instance's space. If they do not match then the binding occurred on a shared `service_instance`. 

This change only affects binding requests for managed service instances, not service keys or user-provided service instances.

The OSBAPI [platform profiles documentation (draft)](https://github.com/mattmcneeney/servicebroker/blob/update-cloud-foundry-context-object/profile.md#cloud-foundry-context-object) will be updated to reflect this change.

#### Before
```
{
  "context": {
    "platform": "cloudfoundry",
    "organization_guid": "1113aa0-124e-4af2-1526-6bfacf61b111",
    "space_guid": "aaaa1234-da91-4f12-8ffa-b51d0336aaaa"
   },
  "service_id": "service-id-here",
  "plan_id": "plan-id-here",
  "bind_resource": {
    "app_guid": "app-guid-here"
  },
  "parameters": {
    "parameter1-name-here": 1,
    "parameter2-name-here": "parameter2-value-here"
  }
}

```

#### After
```
{
  "context": {
    "platform": "cloudfoundry",
    "organization_guid": "1113aa0-124e-4af2-1526-6bfacf61b111",
    "space_guid": "aaaa1234-da91-4f12-8ffa-b51d0336aaaa"
  },
  "service_id": "service-id-here",
  "plan_id": "plan-id-here",
  "bind_resource": {
    "app_guid": "app-guid-here",
    "space_guid": "space-guid-here"
  },
  "parameters": {
    "parameter1-name-here": 1,
    "parameter2-name-here": "parameter2-value-here"
  }
}
```

## PR 

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `master` branch
* [X] I have run all the unit tests using `bundle exec rake`
* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) on bosh lite

Thanks, SAPI team (@deniseyu / @nmaslarski )