### PR TITLE
Include service_binding_parameters_url in the service_binding resource

### DIFF
--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -39,7 +39,7 @@ module VCAP::CloudController
       client = VCAP::Services::ServiceClientProvider.provide(instance: binding.service_instance)
       resp = client.fetch_service_binding(binding)
 
-      [HTTP::OK, {}, resp['parameters'].to_json]
+      [HTTP::OK, {}, resp.fetch('parameters', {}).to_json]
     end
 
     post path, :create

--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -25,6 +25,20 @@ module VCAP::CloudController
       object_renderer.render_json(self.class, obj, @opts)
     end
 
+    get '/v2/service_bindings/:guid/parameters', :parameters
+
+    def parameters(guid)
+      binding = find_guid(guid)
+      raise CloudController::Errors::ApiError.new_from_details('ServiceBindingNotFound', guid) unless binding.v2_app.present?
+
+      unless binding.service.bindings_retrievable
+        message = 'This service does not support fetching service binding parameters.'
+        raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', message)
+      end
+
+      [HTTP::OK, {}]
+    end
+
     post path, :create
 
     def create

--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -36,7 +36,10 @@ module VCAP::CloudController
         raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', message)
       end
 
-      [HTTP::OK, {}]
+      client = VCAP::Services::ServiceClientProvider.provide(instance: binding.service_instance)
+      resp = client.fetch_service_binding(binding)
+
+      [HTTP::OK, {}, resp['parameters'].to_json]
     end
 
     post path, :create

--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
       binding = find_guid(guid)
       raise CloudController::Errors::ApiError.new_from_details('ServiceBindingNotFound', guid) unless binding.v2_app.present?
 
-      unless binding.service.bindings_retrievable
+      unless binding.service_instance.managed_instance? && binding.service.bindings_retrievable
         message = 'This service does not support fetching service binding parameters.'
         raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', message)
       end

--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -28,7 +28,7 @@ module VCAP::CloudController
     get '/v2/service_bindings/:guid/parameters', :parameters
 
     def parameters(guid)
-      binding = find_guid(guid)
+      binding = find_guid_and_validate_access(:read, guid)
       raise CloudController::Errors::ApiError.new_from_details('ServiceBindingNotFound', guid) unless binding.v2_app.present?
 
       unless binding.service_instance.managed_instance? && binding.service.bindings_retrievable

--- a/app/presenters/v2/service_binding_presenter.rb
+++ b/app/presenters/v2/service_binding_presenter.rb
@@ -7,6 +7,9 @@ module CloudController
         present_for_class 'VCAP::CloudController::ServiceBinding'
 
         def entity_hash(controller, service_binding, opts, depth, parents, orphans=nil)
+          rel_hash = RelationsPresenter.new.to_hash(controller, service_binding, opts, depth, parents, orphans)
+          rel_hash['service_binding_parameters_url'] = "/v2/service_bindings/#{service_binding.guid}/parameters"
+
           {
             'app_guid'              => service_binding.app_guid,
             'service_instance_guid' => service_binding.service_instance_guid,
@@ -17,7 +20,7 @@ module CloudController
             'syslog_drain_url'      => service_binding.syslog_drain_url,
             'volume_mounts'         => ::ServiceBindingPresenter.censor_volume_mounts(service_binding.volume_mounts),
             'name'                  => service_binding.name,
-          }.merge!(RelationsPresenter.new.to_hash(controller, service_binding, opts, depth, parents, orphans))
+          }.merge!(rel_hash)
         end
 
         private

--- a/docs/v2/apps/list_all_service_bindings_for_the_app.html
+++ b/docs/v2/apps/list_all_service_bindings_for_the_app.html
@@ -285,7 +285,8 @@ Cookie: </pre>
 
         ],
         "app_url": "/v2/apps/2a3820bb-febd-4c90-ab66-80faa4362142",
-        "service_instance_url": "/v2/service_instances/92f0f510-dbb1-4c04-aa7c-28a8dc0797b4"
+        "service_instance_url": "/v2/service_instances/92f0f510-dbb1-4c04-aa7c-28a8dc0797b4",
+        "service_binding_parameters_url": "/v2/service_bindings/0b6e8fe9-b173-4845-a7aa-e093f1081c94/parameters"
       }
     }
   ]

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -815,6 +815,9 @@
       <li>
         <a href="service_bindings/retrieve_a_particular_service_binding.html">Retrieve a Particular Service Binding</a>
       </li>
+      <li>
+        <a href="service_bindings/retrieve_a_particular_service_binding_parameters_experimental.html">Retrieve a Particular Service Binding Parameters (Experimental)</a>
+      </li>
     </ul>
   </div>
   <div class="article">

--- a/docs/v2/service_bindings/create_a_service_binding.html
+++ b/docs/v2/service_bindings/create_a_service_binding.html
@@ -245,7 +245,8 @@ Cookie: </pre>
 
     ],
     "app_url": "/v2/apps/081d55a0-1bfa-4e51-8d08-273f764988db",
-    "service_instance_url": "/v2/user_provided_service_instances/a0029c76-7017-4a74-94b0-54a04ad94b80"
+    "service_instance_url": "/v2/user_provided_service_instances/a0029c76-7017-4a74-94b0-54a04ad94b80",
+    "service_binding_parameters_url": "/v2/service_bindings/4e690cd4-66ef-4052-a23d-0d748316f18c/parameters"
   }
 }</pre>
 

--- a/docs/v2/service_bindings/list_all_service_bindings.html
+++ b/docs/v2/service_bindings/list_all_service_bindings.html
@@ -269,7 +269,8 @@ Cookie: </pre>
 
         ],
         "app_url": "/v2/apps/b26e7e98-f002-41a8-a663-1b60f808a92a",
-        "service_instance_url": "/v2/service_instances/bde206e0-1ee8-48ad-b794-44c857633d50"
+        "service_instance_url": "/v2/service_instances/bde206e0-1ee8-48ad-b794-44c857633d50",
+        "service_binding_parameters_url": "/v2/service_bindings/aa599bb3-4811-405a-bbe3-a68c7c55afc8/parameters"
       }
     }
   ]

--- a/docs/v2/service_bindings/retrieve_a_particular_service_binding.html
+++ b/docs/v2/service_bindings/retrieve_a_particular_service_binding.html
@@ -119,7 +119,8 @@ Cookie: </pre>
 
     ],
     "app_url": "/v2/apps/784bca1b-c4d9-4d99-9961-9f413620031a",
-    "service_instance_url": "/v2/service_instances/ada8700c-dd02-467c-937b-32ce498302f6"
+    "service_instance_url": "/v2/service_instances/ada8700c-dd02-467c-937b-32ce498302f6",
+    "service_binding_parameters_url": "/v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters"
   }
 }</pre>
 

--- a/docs/v2/service_bindings/retrieve_a_particular_service_binding_parameters_experimental.html
+++ b/docs/v2/service_bindings/retrieve_a_particular_service_binding_parameters_experimental.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Service Bindings API</title>
+  <meta charset="utf-8">
+  <link id="bootstrapcss" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" />
+  <script>
+    if( "file:" == document.location.protocol ) {
+      var csslink = document.getElementById("bootstrapcss");
+      csslink.href = "http://" + csslink.href.replace(/.*\/\//, "");
+    }
+  </script>
+  <style>
+    p {
+      padding: 15px;
+      font-size: 130%;
+    }
+
+    pre {
+      white-space: pre;
+    }
+
+    td.required .name:after {
+      float: right;
+      content: " required";
+      font-weight: normal;
+      color: #F08080;
+    }
+
+    td.experimental:after {
+      float: right;
+      content: " experimental";
+      font-weight: normal;
+      color: #FFA500;
+      padding: 2px;
+    }
+
+    tr.deprecated td:first-child:before {
+      content: "deprecated: ";
+      font-weight: bold;
+      color: gray;
+    }
+
+    tr.deprecated span, tr.deprecated ul {
+      text-decoration: line-through;
+      color: gray;
+    }
+
+    tr.readonly .name:after {
+      float: right;
+      content: " read-only";
+      font-weight: normal;
+    }
+
+    tr.readonly {
+      color: grey;
+    }
+
+    table ul {
+      padding-left: 1.2em;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>Service Bindings API</h1>
+
+  <div class="article">
+    <h2>Retrieve a Particular Service Binding Parameters (Experimental)</h2>
+    <h3>GET /v2/service_bindings/:guid/parameters</h3>
+
+      <h3>Request</h3>
+      <h4>Route</h4>
+      <pre class="request route highlight">GET /v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters</pre>
+
+
+
+
+
+      <h4>Headers</h4>
+      <pre class="request headers">Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTQzMCIsImVtYWlsIjoiZW1haWwtMjkyQHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg5MDN9.0MsVZ0mRjX1JYkb_CfI1sjMRuP0vy5IgtdK90ktWtGg
+Host: example.org
+Cookie: </pre>
+
+        <h4>cURL</h4>
+        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters&quot; -X GET \
+	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTQzMCIsImVtYWlsIjoiZW1haWwtMjkyQHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg5MDN9.0MsVZ0mRjX1JYkb_CfI1sjMRuP0vy5IgtdK90ktWtGg&quot; \
+	-H &quot;Host: example.org&quot; \
+	-H &quot;Cookie: &quot;</pre>
+
+        <h3>Response</h3>
+
+        <h4>Status</h4>
+        <pre class="response status">200 OK</pre>
+
+          <h4>Body</h4>
+
+          <pre class="response body">{}</pre>
+
+        <h4>Headers</h4>
+        <pre class="response headers">Content-Type: application/json;charset=utf-8
+X-VCAP-Request-ID: 5f0b6b5a-990a-4798-bb6a-f7bdfd2ff0d2
+Content-Length: 0
+X-Content-Type-Options: nosniff</pre>
+
+  </div>
+</div>
+</body>
+</html>

--- a/docs/v2/service_instances/list_all_service_bindings_for_the_service_instance.html
+++ b/docs/v2/service_instances/list_all_service_bindings_for_the_service_instance.html
@@ -269,7 +269,8 @@ Cookie: </pre>
 
         ],
         "app_url": "/v2/apps/31809eda-4bdd-44fc-b804-eefe662b3a98",
-        "service_instance_url": "/v2/service_instances/92d707ce-c06c-421a-a1d2-ed1e750af650"
+        "service_instance_url": "/v2/service_instances/92d707ce-c06c-421a-a1d2-ed1e750af650",
+        "service_binding_parameters_url": "/v2/service_bindings/83a87158-92b2-46ea-be66-9dad6b2cb116/parameters"
       }
     }
   ]

--- a/docs/v2/user_provided_service_instances/list_all_service_bindings_for_the_user_provided_service_instance.html
+++ b/docs/v2/user_provided_service_instances/list_all_service_bindings_for_the_user_provided_service_instance.html
@@ -302,7 +302,8 @@ Cookie: </pre>
 
         ],
         "app_url": "/v2/apps/8891667a-382e-4919-b001-187ea05672cb",
-        "service_instance_url": "/v2/user_provided_service_instances/db54cd2a-3664-4e07-81eb-fe00dacdaedf"
+        "service_instance_url": "/v2/user_provided_service_instances/db54cd2a-3664-4e07-81eb-fe00dacdaedf",
+        "service_binding_parameters_url": "/v2/service_bindings/5e1f6d4e-97b6-44dc-af9b-d6a8def8a68f/parameters"
       }
     }
   ]

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -230,6 +230,12 @@ module VCAP::Services::ServiceBrokers::V2
       return attributes, e
     end
 
+    def fetch_service_binding(service_binding)
+      path = service_binding_resource_path(service_binding.guid, service_binding.service_instance.guid)
+      response = @http_client.get(path)
+      @response_parser.parse_fetch_service_binding(path, response)
+    end
+
     private
 
     def context_hash(service_instance)

--- a/lib/services/service_brokers/v2/response_parser.rb
+++ b/lib/services/service_brokers/v2/response_parser.rb
@@ -188,7 +188,9 @@ module VCAP::Services
         def parse_fetch_service_binding(path, response)
           unvalidated_response = UnvalidatedResponse.new(:get, @url, path, response)
 
-          validator = JsonObjectValidator.new(@logger, SuccessValidator.new)
+          validator = JsonObjectValidator.new(@logger,
+            BindParametersValidator.new(SuccessValidator.new))
+
           validator.validate(unvalidated_response.to_hash)
         end
 
@@ -493,6 +495,24 @@ module VCAP::Services
             when 500..599
               raise Errors::ServiceBrokerBadResponse.new(uri.to_s, method, response)
             end
+            @validator.validate(method: method, uri: uri, code: code, response: response)
+          end
+        end
+
+        class BindParametersValidator
+          def initialize(validator)
+            @validator = validator
+          end
+
+          def validate(method:, uri:, code:, response:)
+            parsed_response = MultiJson.load(response.body)
+            parameters = parsed_response['parameters']
+
+            if parameters && !parameters.is_a?(Hash)
+              raise Errors::ServiceBrokerResponseMalformed. new(uri, method, response,
+                'The service broker response contained a parameters field that was not a JSON object.')
+            end
+
             @validator.validate(method: method, uri: uri, code: code, response: response)
           end
         end

--- a/lib/services/service_brokers/v2/response_parser.rb
+++ b/lib/services/service_brokers/v2/response_parser.rb
@@ -185,6 +185,13 @@ module VCAP::Services
           validator.validate(unvalidated_response.to_hash)
         end
 
+        def parse_fetch_service_binding(path, response)
+          unvalidated_response = UnvalidatedResponse.new(:get, @url, path, response)
+
+          validator = JsonObjectValidator.new(@logger, SuccessValidator.new)
+          validator.validate(unvalidated_response.to_hash)
+        end
+
         class UnvalidatedResponse
           attr_reader :code, :uri
 

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.14_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.14_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Service Broker API integration' do
 
             get("/v2/service_bindings/#{@binding_id}/parameters",
               {}.to_json,
-              headers_for(user))
+              headers_for(user, scopes: %w(cloud_controller.admin)))
 
             expect(
               a_request(:get, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).with do |req|

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.14_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.14_spec.rb
@@ -11,19 +11,6 @@ RSpec.describe 'Service Broker API integration' do
     end
 
     describe 'fetching service binding configuration parameters' do
-      context 'when the brokers catalog does not set bindings_retrievable' do
-        let(:catalog) { default_catalog }
-
-        it 'defaults to false' do
-          get("/v2/services/#{@service_guid}",
-              {}.to_json,
-              json_headers(admin_headers))
-          parsed_body = MultiJson.load(last_response.body)
-
-          expect(parsed_body['entity']['bindings_retrievable']).to eq false
-        end
-      end
-
       context 'when the brokers catalog has bindings_retrievable set to true' do
         let(:catalog) do
           catalog = default_catalog
@@ -31,7 +18,7 @@ RSpec.describe 'Service Broker API integration' do
           catalog
         end
 
-        it 'returns true' do
+        it 'is set to true on the service resource' do
           get("/v2/services/#{@service_guid}",
               {}.to_json,
               json_headers(admin_headers))
@@ -82,7 +69,20 @@ RSpec.describe 'Service Broker API integration' do
           catalog
         end
 
-        it 'shows the service as bindings_retrievable false' do
+        it 'is set to false on the service resource' do
+          get("/v2/services/#{@service_guid}",
+              {}.to_json,
+              json_headers(admin_headers))
+          parsed_body = MultiJson.load(last_response.body)
+
+          expect(parsed_body['entity']['bindings_retrievable']).to eq false
+        end
+      end
+
+      context 'when the brokers catalog does not set bindings_retrievable' do
+        let(:catalog) { default_catalog }
+
+        it 'defaults to false on the service resource' do
           get("/v2/services/#{@service_guid}",
               {}.to_json,
               json_headers(admin_headers))
@@ -94,19 +94,6 @@ RSpec.describe 'Service Broker API integration' do
     end
 
     describe 'fetching service instance configuration parameters' do
-      context 'when the brokers catalog does not set instances_retrievable' do
-        let(:catalog) { default_catalog }
-
-        it 'defaults to false' do
-          get("/v2/services/#{@service_guid}",
-              {}.to_json,
-              json_headers(admin_headers))
-          parsed_body = MultiJson.load(last_response.body)
-
-          expect(parsed_body['entity']['instances_retrievable']).to eq false
-        end
-      end
-
       context 'when the brokers catalog has instances_retrievable set to true' do
         let(:catalog) do
           catalog = default_catalog
@@ -132,6 +119,19 @@ RSpec.describe 'Service Broker API integration' do
         end
 
         it 'shows the service as instances_retrievable false' do
+          get("/v2/services/#{@service_guid}",
+              {}.to_json,
+              json_headers(admin_headers))
+          parsed_body = MultiJson.load(last_response.body)
+
+          expect(parsed_body['entity']['instances_retrievable']).to eq false
+        end
+      end
+
+      context 'when the brokers catalog does not set instances_retrievable' do
+        let(:catalog) { default_catalog }
+
+        it 'defaults to false' do
           get("/v2/services/#{@service_guid}",
               {}.to_json,
               json_headers(admin_headers))

--- a/spec/request/v2/apps_spec.rb
+++ b/spec/request/v2/apps_spec.rb
@@ -239,7 +239,8 @@ RSpec.describe 'Apps' do
                       'syslog_drain_url'      => nil,
                       'volume_mounts'         => [],
                       'app_url'               => "/v2/apps/#{process.guid}",
-                      'service_instance_url'  => "/v2/service_instances/#{service_binding.service_instance.guid}"
+                      'service_instance_url'  => "/v2/service_instances/#{service_binding.service_instance.guid}",
+                      'service_binding_parameters_url' => "/v2/service_bindings/#{service_binding.guid}/parameters"
                     }
                   }
                 ],
@@ -1237,7 +1238,8 @@ RSpec.describe 'Apps' do
                 'syslog_drain_url'      => nil,
                 'volume_mounts'         => [],
                 'app_url'               => "/v2/apps/#{process.guid}",
-                'service_instance_url'  => "/v2/service_instances/#{service_instance.guid}"
+                'service_instance_url'  => "/v2/service_instances/#{service_instance.guid}",
+                'service_binding_parameters_url' => "/v2/service_bindings/#{service_binding.guid}/parameters"
               }
             }
           ]

--- a/spec/request/v2/service_bindings_spec.rb
+++ b/spec/request/v2/service_bindings_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe 'ServiceBindings' do
                 'syslog_drain_url' => nil,
                 'volume_mounts' => [],
                 'app_url' => "/v2/apps/#{process1.guid}",
-                'service_instance_url' => "/v2/service_instances/#{service_instance.guid}"
+                'service_instance_url' => "/v2/service_instances/#{service_instance.guid}",
+                'service_binding_parameters_url' => "/v2/service_bindings/#{service_binding1.guid}/parameters"
               }
             },
             {
@@ -72,7 +73,8 @@ RSpec.describe 'ServiceBindings' do
                 'syslog_drain_url' => nil,
                 'volume_mounts' => [],
                 'app_url' => "/v2/apps/#{process2.guid}",
-                'service_instance_url' => "/v2/service_instances/#{service_instance.guid}"
+                'service_instance_url' => "/v2/service_instances/#{service_instance.guid}",
+                'service_binding_parameters_url' => "/v2/service_bindings/#{service_binding2.guid}/parameters"
               }
             }
           ]
@@ -173,6 +175,7 @@ RSpec.describe 'ServiceBindings' do
                       'route_mappings_url' => "/v2/apps/#{process1.guid}/route_mappings"
                     }
                   },
+                  'service_binding_parameters_url' => "/v2/service_bindings/#{service_binding1.guid}/parameters",
                   'service_instance_url' => "/v2/service_instances/#{service_instance.guid}",
                   'service_instance' => {
                     'metadata' => {
@@ -263,7 +266,8 @@ RSpec.describe 'ServiceBindings' do
             'syslog_drain_url' => nil,
             'volume_mounts' => [],
             'app_url' => "/v2/apps/#{process1.guid}",
-            'service_instance_url' => "/v2/service_instances/#{service_instance.guid}"
+            'service_instance_url' => "/v2/service_instances/#{service_instance.guid}",
+            'service_binding_parameters_url' => "/v2/service_bindings/#{service_binding1.guid}/parameters"
           }
         }
       )
@@ -324,7 +328,8 @@ RSpec.describe 'ServiceBindings' do
             'syslog_drain_url' => 'syslog://mydrain.example.com',
             'volume_mounts' => [{ 'container_dir' => 'mount' }],
             'app_url' => "/v2/apps/#{process.guid}",
-            'service_instance_url' => "/v2/service_instances/#{service_instance.guid}"
+            'service_instance_url' => "/v2/service_instances/#{service_instance.guid}",
+            'service_binding_parameters_url' => "/v2/service_bindings/#{service_binding.guid}/parameters"
           }
         }
       )

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1046,11 +1046,22 @@ module VCAP::CloudController
           let(:service) { Service.make(bindings_retrievable: true) }
           let(:binding) { ServiceBinding.make(service_instance: managed_service_instance, app: process.app) }
 
-          it 'returns a 200' do
-            set_current_user(developer)
+          context 'when the broker has nested binding parameters' do
+            let(:broker) { service.service_broker }
 
-            get "/v2/service_bindings/#{binding.guid}/parameters"
-            expect(last_response.status).to eql(200)
+            before do
+              stub_request(:get, %r{#{broker_url(broker)}/v2/service_instances/#{guid_pattern}/service_bindings/#{guid_pattern}}).
+                with(basic_auth: basic_auth(service_broker: broker)).
+                to_return(status: 200, body: { 'parameters' => { 'foo' => { 'bar' => true } } }.to_json)
+
+              set_current_user(developer)
+            end
+
+            it 'returns a 200 and the parameters' do
+              get "/v2/service_bindings/#{binding.guid}/parameters"
+              expect(last_response.status).to eql(200)
+              expect(last_response.body).to eql({ 'foo' => { 'bar' => true } }.to_json)
+            end
           end
 
           context 'user permissions' do

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1119,6 +1119,7 @@ module VCAP::CloudController
 
           context 'user permissions' do
             let(:user) { User.make }
+            let(:body) { {}.to_json }
 
             {
               'admin'               => 200,

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1055,6 +1055,20 @@ module VCAP::CloudController
         end
       end
 
+      context 'when the binding is for a user provided service' do
+        let(:process) { ProcessModelFactory.make(space: space) }
+        let(:user_provided_service_instance) { UserProvidedServiceInstance.make(space: space) }
+
+        it 'returns a 422' do
+          set_current_user(developer)
+          binding = ServiceBinding.make(service_instance: user_provided_service_instance, app: process.app)
+
+          get "/v2/service_bindings/#{binding.guid}/parameters"
+          expect(last_response.status).to eql(422)
+          expect(last_response.body).to include('This service does not support fetching service binding parameters.')
+        end
+      end
+
       context 'when the binding guid is invalid' do
         it 'returns a 404' do
           set_current_user(developer)

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1019,5 +1019,61 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe 'GET', '/v2/service_bindings/:guid/parameters' do
+      let(:space) { Space.make }
+      let(:developer) { make_developer_for_space(space) }
+
+      context 'when the service binding is valid' do
+        let(:service_plan) { ServicePlan.make(service: service) }
+        let(:managed_service_instance) { ManagedServiceInstance.make(space: space, service_plan: service_plan) }
+        let(:process) { ProcessModelFactory.make(space: space) }
+
+        context 'when the service has bindings_retrievable is set to false' do
+          let(:service) { Service.make(bindings_retrievable: false) }
+
+          it 'returns a 422' do
+            set_current_user(developer)
+            binding = ServiceBinding.make(service_instance: managed_service_instance, app: process.app)
+
+            get "/v2/service_bindings/#{binding.guid}/parameters"
+            expect(last_response.status).to eql(422)
+            expect(last_response.body).to include('This service does not support fetching service binding parameters.')
+          end
+        end
+
+        context 'bindings_retrievable is set to true' do
+          let(:service) { Service.make(bindings_retrievable: true) }
+
+          it 'returns a 200' do
+            set_current_user(developer)
+            binding = ServiceBinding.make(service_instance: managed_service_instance, app: process.app)
+
+            get "/v2/service_bindings/#{binding.guid}/parameters"
+            expect(last_response.status).to eql(200)
+          end
+        end
+      end
+
+      context 'when the binding guid is invalid' do
+        it 'returns a 404' do
+          set_current_user(developer)
+          get '/v2/service_bindings/some-bogus-guid/parameters'
+          expect(last_response.status).to eql(404)
+          expect(last_response.body).to include('The service binding could not be found: some-bogus-guid')
+        end
+      end
+
+      context 'when the requested binding is a service key' do
+        let(:service_key) { ServiceKey.make }
+
+        it 'returns a 404' do
+          set_current_user(developer)
+          get "/v2/service_bindings/#{service_key.guid}/parameters"
+          expect(last_response.status).to eql(404)
+          expect(last_response.body).to include("The service binding could not be found: #{service_key.guid}")
+        end
+      end
+    end
   end
 end

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1029,7 +1029,7 @@ module VCAP::CloudController
         let(:managed_service_instance) { ManagedServiceInstance.make(space: space, service_plan: service_plan) }
         let(:process) { ProcessModelFactory.make(space: space) }
 
-        context 'when the service has bindings_retrievable is set to false' do
+        context 'when the service has bindings_retrievable set to false' do
           let(:service) { Service.make(bindings_retrievable: false) }
 
           it 'returns a 422' do
@@ -1042,25 +1042,78 @@ module VCAP::CloudController
           end
         end
 
-        context 'bindings_retrievable is set to true' do
+        context 'when the service has bindings_retrievable set to true' do
           let(:service) { Service.make(bindings_retrievable: true) }
+          let(:broker) { service.service_broker }
           let(:binding) { ServiceBinding.make(service_instance: managed_service_instance, app: process.app) }
+          let(:body) {}
+
+          before do
+            stub_request(:get, %r{#{broker_url(broker)}/v2/service_instances/#{guid_pattern}/service_bindings/#{guid_pattern}}).
+              with(basic_auth: basic_auth(service_broker: broker)).
+              to_return(status: 200, body: body)
+            set_current_user(developer)
+          end
 
           context 'when the broker has nested binding parameters' do
-            let(:broker) { service.service_broker }
+            let(:body) { { 'parameters' => { 'foo' => { 'bar' => true } } }.to_json }
 
-            before do
-              stub_request(:get, %r{#{broker_url(broker)}/v2/service_instances/#{guid_pattern}/service_bindings/#{guid_pattern}}).
-                with(basic_auth: basic_auth(service_broker: broker)).
-                to_return(status: 200, body: { 'parameters' => { 'foo' => { 'bar' => true } } }.to_json)
-
-              set_current_user(developer)
-            end
-
-            it 'returns a 200 and the parameters' do
+            it 'returns the parameters' do
               get "/v2/service_bindings/#{binding.guid}/parameters"
               expect(last_response.status).to eql(200)
               expect(last_response.body).to eql({ 'foo' => { 'bar' => true } }.to_json)
+            end
+          end
+
+          context 'when the broker returns empty object' do
+            let(:body) { {}.to_json }
+
+            it 'returns an empty object' do
+              get "/v2/service_bindings/#{binding.guid}/parameters"
+              expect(last_response.status).to eql(200)
+              expect(last_response.body).to eql({}.to_json)
+            end
+          end
+
+          context 'when the brokers response is missing a parameters key but contains other keys' do
+            let(:body) { { 'credentials' => 'value' }.to_json }
+
+            it 'returns an empty object' do
+              get "/v2/service_bindings/#{binding.guid}/parameters"
+              expect(last_response.status).to eql(200)
+              expect(last_response.body).to eql({}.to_json)
+            end
+          end
+
+          context 'when the broker returns multiple keys' do
+            let(:body) { { 'credentials' => 'value', 'parameters' => { 'foo' => 'bar' } }.to_json }
+
+            it 'returns only the parameters' do
+              get "/v2/service_bindings/#{binding.guid}/parameters"
+              expect(last_response.status).to eql(200)
+              expect(last_response.body).to eql({ 'foo' => 'bar' }.to_json)
+            end
+          end
+
+          context 'when the broker returns invalid json' do
+            let(:body) { '{]' }
+
+            it 'returns 502' do
+              get "/v2/service_bindings/#{binding.guid}/parameters"
+              expect(last_response.status).to eql(502)
+              hash_body = JSON.parse(last_response.body)
+              expect(hash_body['error_code']).to eq('CF-ServiceBrokerResponseMalformed')
+            end
+          end
+
+          context 'when the broker parameters is not a JSON object' do
+            let(:body) { { 'parameters' => true }.to_json }
+
+            it 'returns 502' do
+              get "/v2/service_bindings/#{binding.guid}/parameters"
+              expect(last_response.status).to eql(502)
+              hash_body = JSON.parse(last_response.body)
+              expect(hash_body['error_code']).to eq('CF-ServiceBrokerResponseMalformed')
             end
           end
 

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1032,12 +1032,12 @@ module VCAP::CloudController
         context 'when the service has bindings_retrievable set to false' do
           let(:service) { Service.make(bindings_retrievable: false) }
 
-          it 'returns a 422' do
+          it 'returns a 400' do
             set_current_user(developer)
             binding = ServiceBinding.make(service_instance: managed_service_instance, app: process.app)
 
             get "/v2/service_bindings/#{binding.guid}/parameters"
-            expect(last_response.status).to eql(422)
+            expect(last_response.status).to eql(400)
             expect(last_response.body).to include('This service does not support fetching service binding parameters.')
           end
         end
@@ -1157,12 +1157,12 @@ module VCAP::CloudController
         let(:process) { ProcessModelFactory.make(space: space) }
         let(:user_provided_service_instance) { UserProvidedServiceInstance.make(space: space) }
 
-        it 'returns a 422' do
+        it 'returns a 400' do
           set_current_user(developer)
           binding = ServiceBinding.make(service_instance: user_provided_service_instance, app: process.app)
 
           get "/v2/service_bindings/#{binding.guid}/parameters"
-          expect(last_response.status).to eql(422)
+          expect(last_response.status).to eql(400)
           expect(last_response.body).to include('This service does not support fetching service binding parameters.')
         end
       end

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -1380,6 +1380,35 @@ module VCAP::Services::ServiceBrokers::V2
       end
     end
 
+    describe 'fetch_service_binding' do
+      let(:instance) { VCAP::CloudController::ManagedServiceInstance.make }
+      let(:app) { VCAP::CloudController::AppModel.make(space: instance.space) }
+      let(:binding) do
+        VCAP::CloudController::ServiceBinding.new(
+          service_instance: instance,
+          app:              app,
+          type:             'app'
+        )
+      end
+
+      let(:broker_response) { HttpResponse.new(code: 200, body: { foo: 'bar' }.to_json) }
+
+      before do
+        allow(http_client).to receive(:get).and_return(broker_response)
+      end
+
+      it 'makes a get request with the correct path' do
+        client.fetch_service_binding(binding)
+        expect(http_client).to have_received(:get).
+          with("/v2/service_instances/#{binding.service_instance.guid}/service_bindings/#{binding.guid}")
+      end
+
+      it 'returns the broker response' do
+        response = client.fetch_service_binding(binding)
+        expect(response).to eq({ 'foo' => 'bar' })
+      end
+    end
+
     def unwrap_delayed_job(job)
       job.payload_object.handler.handler.handler
     end

--- a/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
@@ -27,6 +27,9 @@ module VCAP::Services
           when :fetch_catalog
             method = :parse_catalog
             path = '/v2/catalog'
+          when :fetch_service_binding
+            method = :parse_fetch_service_binding
+            path = '/v2/service_instances/GUID/service_bindings/BINDING_GUID'
           end
 
           [method, path]
@@ -650,6 +653,11 @@ module VCAP::Services
         test_case(:update, 422, broker_partial_json,                                            error: Errors::ServiceBrokerRequestRejected)
         test_case(:update, 422, { error: 'AsyncRequired' }.to_json,                             error: Errors::AsyncRequired)
         test_common_error_cases(:update)
+
+        test_case(:fetch_service_binding, 200, { foo: 'bar' }.to_json, result: { 'foo' => 'bar' })
+        test_case(:fetch_service_binding, 200, broker_malformed_json, error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_malformed_json, binding_uri))
+        test_case(:fetch_service_binding, 200, broker_partial_json, error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
+        test_case(:fetch_service_binding, 200, broker_empty_json, result: {})
         # rubocop:enable Metrics/LineLength
       end
     end

--- a/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
@@ -303,7 +303,7 @@ module VCAP::Services
           'Please contact the service provider.'
         end
 
-        def self.invalid_operation_error(uri, message)
+        def self.malformed_repsonse_error(uri, message)
           "The service broker returned an invalid response for the request to #{uri}: #{message}"
         end
 
@@ -441,8 +441,8 @@ module VCAP::Services
         test_case(:provision, 202, broker_non_empty_json,                                       result: client_result_with_state('in progress'))
         test_case(:provision, 202, with_dashboard_url.to_json,                                  result: client_result_with_state('in progress').merge(with_dashboard_url))
         test_case(:provision, 202, with_operation.to_json,                                      result: client_result_with_state('in progress').merge(with_operation))
-        test_case(:provision, 202, with_non_string_operation.to_json,                           error: Errors::ServiceBrokerResponseMalformed, description: invalid_operation_error(instance_uri, 'The service broker response contained an operation field that was not a string.'))
-        test_case(:provision, 202, with_long_operation.to_json,                                 error: Errors::ServiceBrokerResponseMalformed, description: invalid_operation_error(instance_uri, 'The service broker response contained an operation field exceeding 10k characters.'))
+        test_case(:provision, 202, with_non_string_operation.to_json,                           error: Errors::ServiceBrokerResponseMalformed, description: malformed_repsonse_error(instance_uri, 'The service broker response contained an operation field that was not a string.'))
+        test_case(:provision, 202, with_long_operation.to_json,                                 error: Errors::ServiceBrokerResponseMalformed, description: malformed_repsonse_error(instance_uri, 'The service broker response contained an operation field exceeding 10k characters.'))
         test_pass_through(:provision, 202, with_dashboard_url,                                  expected_state: 'in progress')
         test_case(:provision, 204, broker_partial_json,                                         error: Errors::ServiceBrokerBadResponse)
         test_case(:provision, 204, broker_malformed_json,                                       error: Errors::ServiceBrokerBadResponse)
@@ -586,8 +586,8 @@ module VCAP::Services
         test_case(:deprovision, 202, broker_empty_json,                                         result: client_result_with_state('in progress'))
         test_case(:deprovision, 202, broker_non_empty_json,                                     result: client_result_with_state('in progress'))
         test_case(:deprovision, 202, with_operation.to_json,                                    result: client_result_with_state('in progress').merge(with_operation))
-        test_case(:deprovision, 202, with_non_string_operation.to_json,                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_operation_error(instance_uri, 'The service broker response contained an operation field that was not a string.'))
-        test_case(:deprovision, 202, with_long_operation.to_json,                               error: Errors::ServiceBrokerResponseMalformed, description: invalid_operation_error(instance_uri, 'The service broker response contained an operation field exceeding 10k characters.'))
+        test_case(:deprovision, 202, with_non_string_operation.to_json,                         error: Errors::ServiceBrokerResponseMalformed, description: malformed_repsonse_error(instance_uri, 'The service broker response contained an operation field that was not a string.'))
+        test_case(:deprovision, 202, with_long_operation.to_json,                               error: Errors::ServiceBrokerResponseMalformed, description: malformed_repsonse_error(instance_uri, 'The service broker response contained an operation field exceeding 10k characters.'))
         test_pass_through(:deprovision, 202,                                                    expected_state: 'in progress')
         test_case(:deprovision, 204, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
         test_case(:deprovision, 204, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
@@ -639,8 +639,8 @@ module VCAP::Services
         test_case(:update, 202, broker_empty_json,                                              result: client_result_with_state('in progress'))
         test_case(:update, 202, broker_non_empty_json,                                          result: client_result_with_state('in progress'))
         test_case(:update, 202, with_operation.to_json,                                         result: client_result_with_state('in progress').merge(with_operation))
-        test_case(:update, 202, with_non_string_operation.to_json,                              error: Errors::ServiceBrokerResponseMalformed, description: invalid_operation_error(instance_uri, 'The service broker response contained an operation field that was not a string.'))
-        test_case(:update, 202, with_long_operation.to_json,                                    error: Errors::ServiceBrokerResponseMalformed, description: invalid_operation_error(instance_uri, 'The service broker response contained an operation field exceeding 10k characters.'))
+        test_case(:update, 202, with_non_string_operation.to_json,                              error: Errors::ServiceBrokerResponseMalformed, description: malformed_repsonse_error(instance_uri, 'The service broker response contained an operation field that was not a string.'))
+        test_case(:update, 202, with_long_operation.to_json,                                    error: Errors::ServiceBrokerResponseMalformed, description: malformed_repsonse_error(instance_uri, 'The service broker response contained an operation field exceeding 10k characters.'))
         test_pass_through(:update, 202,                                                         expected_state: 'in progress')
         test_case(:update, 204, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse)
         test_case(:update, 204, broker_malformed_json,                                          error: Errors::ServiceBrokerBadResponse)
@@ -658,6 +658,7 @@ module VCAP::Services
         test_case(:fetch_service_binding, 200, broker_malformed_json, error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_malformed_json, binding_uri))
         test_case(:fetch_service_binding, 200, broker_partial_json, error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
         test_case(:fetch_service_binding, 200, broker_empty_json, result: {})
+        test_case(:fetch_service_binding, 200, { parameters: true }.to_json, error: Errors::ServiceBrokerResponseMalformed, description: malformed_repsonse_error(binding_uri, 'The service broker response contained a parameters field that was not a JSON object.'))
         # rubocop:enable Metrics/LineLength
       end
     end

--- a/spec/unit/presenters/v2/service_binding_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_binding_presenter_spec.rb
@@ -41,7 +41,8 @@ module CloudController::Presenters::V2
             'syslog_drain_url'      => 'syslog://drain.example.com',
             'volume_mounts'         => [{ 'container_dir' => 'mount' }],
             'relationship_url'      => 'http://relationship.example.com',
-            'name'                  => nil
+            'name'                  => nil,
+            'service_binding_parameters_url' => "/v2/service_bindings/#{service_binding.guid}/parameters"
           }
         )
       end

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -373,6 +373,11 @@
   http_code: 502
   message: "The service is attempting to stream logs from your application, but is not registered as a logging service. Please contact the service provider."
 
+90007:
+  name: ServiceFetchBindingParametersNotSupported
+  http_code: 400
+  message: "This service does not support fetching service binding parameters."
+
 100001:
   name: AppInvalid
   http_code: 400


### PR DESCRIPTION
**NOTE**: This PR builds on top of #1073, which should be merged first. The actual changes on top of #1073  can be viewed in [this diff](https://github.com/cloudfoundry-incubator/cloud_controller_ng_sapi/compare/pr-fetch-binding-params-from-unsupported-broker...cloudfoundry-incubator:pr-discover-service-binding-parameters-url).

[#153738714](https://www.pivotaltracker.com/story/show/153738714) As a developer, I can discover the service_binding_parameters_url for a service binding

## What

We include the `service_binding_parameters_url` field as part of the service binding presenter. We've also updated the documentation accordingly.

## PR
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks Sapiteam, (@georgi-lozev + @ablease)