### PR TITLE
Support tags in user-provided services

### DIFF
--- a/app/controllers/services/user_provided_service_instances_controller.rb
+++ b/app/controllers/services/user_provided_service_instances_controller.rb
@@ -8,6 +8,7 @@ module VCAP::CloudController
       attribute :credentials, Hash, default: {}
       attribute :syslog_drain_url, String, default: ''
       attribute :route_service_url, String, default: ''
+      attribute :tags, [String], default: []
 
       to_one :space
       to_many :service_bindings
@@ -32,6 +33,7 @@ module VCAP::CloudController
       name_errors = e.errors.on(:name)
       service_instance_errors = e.errors.on(:service_instance)
       service_instance_name_errors = e.errors.on(:name).to_a
+      service_instance_tags_errors = e.errors.on(:tags).to_a
 
       if name_errors&.include?(:unique)
         CloudController::Errors::ApiError.new_from_details('ServiceInstanceNameTaken', attributes['name'])
@@ -45,6 +47,8 @@ module VCAP::CloudController
       elsif service_instance_errors&.include?(:route_service_url_invalid)
         raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceRouteServiceURLInvalid',
                                                       'route_service_url is invalid.')
+      elsif service_instance_tags_errors.include?(:too_long)
+        return CloudController::Errors::ApiError.new_from_details('ServiceInstanceTagsTooLong', attributes['name'])
       elsif service_instance_name_errors&.include?(:max_length)
         return CloudController::Errors::ApiError.new_from_details('ServiceInstanceNameTooLong')
       else

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -17,8 +17,6 @@ module VCAP::CloudController
 
     plugin :after_initialize
 
-    serialize_attributes :json, :tags
-
     add_association_dependencies service_instance_operation: :destroy
 
     def validation_policies
@@ -38,7 +36,6 @@ module VCAP::CloudController
       super
       validates_presence :service_plan
       validation_policies.map(&:validate)
-      validate_tags_length
     end
 
     def last_operation
@@ -119,10 +116,6 @@ module VCAP::CloudController
       service_plan.bindable?
     end
 
-    def tags
-      super || []
-    end
-
     def merged_tags
       (service.tags + tags).uniq
     end
@@ -183,12 +176,6 @@ module VCAP::CloudController
     def update_attributes(instance_attrs)
       set(instance_attrs)
       save_changes
-    end
-
-    def validate_tags_length
-      if tags.join('').length > 2048
-        @errors[:tags] = [:too_long]
-      end
     end
   end
 end

--- a/app/models/services/user_provided_service_instance.rb
+++ b/app/models/services/user_provided_service_instance.rb
@@ -1,16 +1,12 @@
 module VCAP::CloudController
   class UserProvidedServiceInstance < ServiceInstance
-    export_attributes :name, :credentials, :space_guid, :type, :syslog_drain_url, :route_service_url
-    import_attributes :name, :credentials, :space_guid, :syslog_drain_url, :route_service_url
+    export_attributes :name, :credentials, :space_guid, :type, :syslog_drain_url, :route_service_url, :tags
+    import_attributes :name, :credentials, :space_guid, :syslog_drain_url, :route_service_url, :tags
 
     # sad: can we declare this in parent class one day
     strip_attributes :name, :syslog_drain_url, :route_service_url
 
     add_association_dependencies service_bindings: :destroy
-
-    def tags
-      []
-    end
 
     def route_service?
       !(route_service_url.nil? || route_service_url.empty?)

--- a/docs/v2/events/list_user_provided_service_instance_create_events.html
+++ b/docs/v2/events/list_user_provided_service_instance_create_events.html
@@ -507,7 +507,8 @@ Cookie: </pre>
         "metadata": {
           "request": {
             "name": "name-1139",
-            "space_guid": "0908cd77-fdae-40b4-9d55-704ce974eabb"
+            "space_guid": "0908cd77-fdae-40b4-9d55-704ce974eabb",
+            "tags": ["accounting", "mongodb"]
           }
         },
         "space_guid": "0908cd77-fdae-40b4-9d55-704ce974eabb",

--- a/docs/v2/events/list_user_provided_service_instance_update_events.html
+++ b/docs/v2/events/list_user_provided_service_instance_update_events.html
@@ -506,7 +506,8 @@ Cookie: </pre>
         "timestamp": "2016-06-08T16:41:24Z",
         "metadata": {
           "request": {
-            "credentials": "[REDACTED]"
+            "credentials": "[REDACTED]",
+            "tags": ["acounting", "mongodb"]
           }
         },
         "space_guid": "15464998-bec6-401a-8a8d-e79d84e14850",

--- a/docs/v2/user_provided_service_instances/associate_route_with_the_user_provided_service_instance.html
+++ b/docs/v2/user_provided_service_instances/associate_route_with_the_user_provided_service_instance.html
@@ -113,6 +113,7 @@ Cookie: </pre>
     "type": "user_provided_service_instance",
     "syslog_drain_url": "https://foo.com/url-93",
     "route_service_url": "https://foo.com/url-92",
+    "tags": ["accounting", "mongodb"],
     "space_url": "/v2/spaces/91b53184-6430-4891-8d4b-fabbe96a84f6",
     "service_bindings_url": "/v2/user_provided_service_instances/5badd282-6e07-4fc6-a8c4-78be99040774/service_bindings",
     "routes_url": "/v2/user_provided_service_instances/5badd282-6e07-4fc6-a8c4-78be99040774/routes"

--- a/docs/v2/user_provided_service_instances/creating_a_user_provided_service_instance.html
+++ b/docs/v2/user_provided_service_instances/creating_a_user_provided_service_instance.html
@@ -186,6 +186,27 @@
                 </ul>
               </td>
             </tr>
+            <tr class=" ">
+              <td class=" ">
+                <span class="name">tags</span>
+              </td>
+              <td>
+                <span class="description">A list of tags for the service instance. Max characters: 2048</span>
+              </td>
+              <td>
+                <span class="default">[]</span>
+              </td>
+              <td>
+                <ul class="valid_values">
+                </ul>
+              </td>
+              <td>
+                <ul class="example_values">
+                      <li>[&quot;db&quot;]</li>
+                      <li>[&quot;accounting&quot;, &quot;mongodb&quot;]</li>
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
 
@@ -196,7 +217,8 @@
     "somekey": "somevalue"
   },
   "syslog_drain_url": "syslog://example.com",
-  "route_service_url": "https://logger.example.com"
+  "route_service_url": "https://logger.example.com",
+  "tags": ["accounting", "mongodb"]
 }</pre>
 
       <h4>Headers</h4>
@@ -213,7 +235,8 @@ Cookie: </pre>
     &quot;somekey&quot;: &quot;somevalue&quot;
   },
   &quot;syslog_drain_url&quot;: &quot;syslog://example.com&quot;,
-  &quot;route_service_url&quot;: &quot;https://logger.example.com&quot;
+  &quot;route_service_url&quot;: &quot;https://logger.example.com&quot;,
+  "tags": ["accounting", "mongodb"]
 }&#39; -X POST \
 	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTE5MyIsImVtYWlsIjoiZW1haWwtMTQ4QHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg4OTN9.3e7tZmyp9P6Ca_KFYwIg_6e4zO6k96Avm0y6ghyV7LU&quot; \
 	-H &quot;Host: example.org&quot; \
@@ -243,6 +266,7 @@ Cookie: </pre>
     "type": "user_provided_service_instance",
     "syslog_drain_url": "syslog://example.com",
     "route_service_url": "https://logger.example.com",
+    "tags": ["accounting", "mongodb"],
     "space_url": "/v2/spaces/d5d30998-48ea-4499-9d10-80a8af005aca",
     "service_bindings_url": "/v2/user_provided_service_instances/d7facf53-dbff-470c-a032-9ea9b8be12f1/service_bindings",
     "routes_url": "/v2/user_provided_service_instances/d7facf53-dbff-470c-a032-9ea9b8be12f1/routes"

--- a/docs/v2/user_provided_service_instances/list_all_user_provided_service_instances.html
+++ b/docs/v2/user_provided_service_instances/list_all_user_provided_service_instances.html
@@ -261,6 +261,7 @@ Cookie: </pre>
         "type": "user_provided_service_instance",
         "syslog_drain_url": "https://foo.com/url-103",
         "route_service_url": null,
+        "tags": ["accounting", "mongodb"],
         "space_url": "/v2/spaces/87d14ac2-f396-460e-a523-dc1d77aba35a",
         "service_bindings_url": "/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee/service_bindings",
         "routes_url": "/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee/routes"

--- a/docs/v2/user_provided_service_instances/retrieve_a_particular_user_provided_service_instance.html
+++ b/docs/v2/user_provided_service_instances/retrieve_a_particular_user_provided_service_instance.html
@@ -111,6 +111,7 @@ Cookie: </pre>
     "type": "user_provided_service_instance",
     "syslog_drain_url": "https://foo.com/url-104",
     "route_service_url": null,
+    "tags": ["accounting", "mongodb"],
     "space_url": "/v2/spaces/22236d1a-d9c7-44b7-bdad-2bb079a6c4a1",
     "service_bindings_url": "/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87/service_bindings",
     "routes_url": "/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87/routes"

--- a/docs/v2/user_provided_service_instances/updating_a_user_provided_service_instance.html
+++ b/docs/v2/user_provided_service_instances/updating_a_user_provided_service_instance.html
@@ -167,13 +167,35 @@
                 </ul>
               </td>
             </tr>
+            <tr class=" ">
+              <td class=" ">
+                <span class="name">tags</span>
+              </td>
+              <td>
+                <span class="description">A list of tags for the service instance. NOTE: Updating the tags will overwrite any old tags. Max characters: 2048</span>
+              </td>
+              <td>
+                <span class="default"></span>
+              </td>
+              <td>
+                <ul class="valid_values">
+                </ul>
+              </td>
+              <td>
+                <ul class="example_values">
+                      <li>[&quot;db&quot;]</li>
+                      <li>[&quot;accounting&quot;, &quot;mongodb&quot;]</li>
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
 
         <pre class="request body">{
   "credentials": {
     "somekey": "somenewvalue"
-  }
+  },
+  "tags": ["new-tag"]
 }</pre>
 
       <h4>Headers</h4>
@@ -186,7 +208,8 @@ Cookie: </pre>
         <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/user_provided_service_instances/1af1629e-0c47-4b09-bedd-5174b9862b23&quot; -d &#39;{
   &quot;credentials&quot;: {
     &quot;somekey&quot;: &quot;somenewvalue&quot;
-  }
+  },
+  "tags": ["new-tag"]
 }&#39; -X PUT \
 	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTE5MCIsImVtYWlsIjoiZW1haWwtMTQ1QHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg4OTN9.fu_vRQ0QoFrVrMUO8Z-TQPrnT2JwFPWklSgSZ5PYKeM&quot; \
 	-H &quot;Host: example.org&quot; \
@@ -216,6 +239,7 @@ Cookie: </pre>
     "type": "user_provided_service_instance",
     "syslog_drain_url": "https://foo.com/url-102",
     "route_service_url": null,
+    "tags": ["new-tag"],
     "space_url": "/v2/spaces/884c5c61-fbb8-4c89-91d2-a7a5ab27b004",
     "service_bindings_url": "/v2/user_provided_service_instances/1af1629e-0c47-4b09-bedd-5174b9862b23/service_bindings",
     "routes_url": "/v2/user_provided_service_instances/1af1629e-0c47-4b09-bedd-5174b9862b23/routes"

--- a/spec/support/fakes/fake_service_broker_v2_client.rb
+++ b/spec/support/fakes/fake_service_broker_v2_client.rb
@@ -56,6 +56,16 @@ class FakeServiceBrokerV2Client
     }
   end
 
+  def update(_instance, _plan, accepts_incomplete: false, arbitrary_parameters: nil, previous_values: {})
+    [{
+      last_operation: {
+        type:        'update',
+        description: '',
+        state:       'succeeded'
+      },
+    }, nil]
+  end
+
   def bind(_binding, _arbitrary_parameters)
     {
       credentials: credentials,

--- a/spec/unit/presenters/system_environment/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/system_environment/service_instance_presenter_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe ServiceInstancePresenter do
     end
 
     context 'for a provided service instance' do
-      let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make }
+      let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make(tags: ['wonderful', 'the-best']) }
 
       specify do
         expect(subject[:label]).to eq('user-provided')
         expect(subject[:name]).to eq(service_instance.name)
-        expect(subject[:tags]).to eq([])
+        expect(subject[:tags]).to eq(['wonderful', 'the-best'])
       end
     end
   end


### PR DESCRIPTION
* A short explanation of the proposed change:
  * POST /v2/user_provided_services now supports tags, just like managed
service instances
  * PUT /v2/user_provided_services/:guid now also supports tags, and will
overwrite all tags if specified (just like managed service instances)
  * Backfilled some request specs for POST and PUT to both managed and
user-provided service instances.

https://www.pivotaltracker.com/story/show/155062901
[finishes #155062901]

Signed-off-by: Nikolay Maslarski <nikolay.maslarski@sap.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
