### PR TITLE
Emit an unshare event when purging a service instance

### DIFF
--- a/app/controllers/services/lifecycle/service_instance_purger.rb
+++ b/app/controllers/services/lifecycle/service_instance_purger.rb
@@ -24,6 +24,10 @@ module VCAP::CloudController
           @event_repository.record_service_key_event('delete', key, nil)
         end
 
+        service_instance.shared_spaces.each do |target_space|
+          Repositories::ServiceInstanceShareEventRepository.record_unshare_event(service_instance, target_space, @event_repository.user_audit_info)
+        end
+
         service_instance.destroy
         @event_repository.record_service_instance_event('delete', service_instance, nil)
       end

--- a/spec/unit/controllers/services/lifecycle/service_instance_purger_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_instance_purger_spec.rb
@@ -88,6 +88,24 @@ module VCAP::CloudController
           expect(service_key_2).not_to exist
         end
       end
+
+      context 'when the service instance has shared spaces' do
+        let(:target_space) { Space.make }
+
+        before do
+          service_instance.add_shared_space(target_space)
+        end
+
+        it 'records an unshare service event' do
+          purger.purge(service_instance)
+
+          events = Event.where(type: 'audit.service_instance.unshare').all
+          event_key_guid = events.collect(&:actee)
+
+          expect(events.length).to eq(1)
+          expect(event_key_guid).to match_array([service_instance.guid])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
cf-purge-service should record an unshare audit event [#154637473](https://www.pivotaltracker.com/story/show/154637473)

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)