### PR TITLE
Add primary keys to tables missing them

### DIFF
--- a/db/migrations/20180220224558_add_missing_primary_keys.rb
+++ b/db/migrations/20180220224558_add_missing_primary_keys.rb
@@ -1,0 +1,43 @@
+Sequel.migration do
+  change do
+    alter_table :organizations_auditors do
+      add_primary_key :id, name: :organizations_auditors_pk
+    end
+
+    alter_table :organizations_billing_managers do
+      add_primary_key :id, name: :organizations_billing_managers_pk
+    end
+
+    alter_table :organizations_managers do
+      add_primary_key :id, name: :organizations_managers_pk
+    end
+
+    alter_table :organizations_private_domains do
+      add_primary_key :id, name: :organizations_private_domains_pk
+    end
+
+    alter_table :organizations_users do
+      add_primary_key :id, name: :organizations_users_pk
+    end
+
+    alter_table :security_groups_spaces do
+      add_primary_key :id, name: :security_groups_spaces_pk
+    end
+
+    alter_table :spaces_auditors do
+      add_primary_key :id, name: :spaces_auditors_pk
+    end
+
+    alter_table :spaces_developers do
+      add_primary_key :id, name: :spaces_developers_pk
+    end
+
+    alter_table :spaces_managers do
+      add_primary_key :id, name: :spaces_managers_pk
+    end
+
+    alter_table :staging_security_groups_spaces do
+      add_primary_key :id, name: :staging_security_groups_spaces_pk
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: Alvaro Perez-Shirley <aperezshirley@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: 
The mysql clustered database in cf-deployment has previously allowed tables without primary keys, although this is not recommended. This will be changed soon to enforce primary keys as the lack of primary keys can cause issues with the clustered database. 

* An explanation of the use cases your change solves
Using a clustered database with strict enforcement of primary keys enabled.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
