### PR TITLE
Do not allow Service Broker registration with basic auth in the broker_url

### DIFF
--- a/app/actions/services/mixins/service_broker_registration_error_parser.rb
+++ b/app/actions/services/mixins/service_broker_registration_error_parser.rb
@@ -8,6 +8,8 @@ module VCAP::CloudController
         CloudController::Errors::ApiError.new_from_details('ServiceBrokerUrlInvalid', broker.broker_url)
       elsif errors.on(:broker_url) && errors.on(:broker_url).include?(:unique)
         CloudController::Errors::ApiError.new_from_details('ServiceBrokerUrlTaken', broker.broker_url)
+      elsif errors.on(:broker_url) && errors.on(:broker_url).include?(:basic_auth)
+        CloudController::Errors::ApiError.new_from_details('ServiceBrokerUrlBasicAuthNotSupported', broker.broker_url)
       elsif errors.on(:name) && errors.on(:name).include?(:unique)
         CloudController::Errors::ApiError.new_from_details('ServiceBrokerNameTaken', broker.name)
       elsif errors.on(:services)

--- a/app/models/services/service_broker.rb
+++ b/app/models/services/service_broker.rb
@@ -22,6 +22,7 @@ module VCAP::CloudController
       validates_unique :name
       validates_unique :broker_url
       validates_url :broker_url
+      validates_url_no_basic_auth
     end
 
     def client
@@ -34,6 +35,13 @@ module VCAP::CloudController
 
     def self.user_visibility_filter(user)
       { space: user.spaces_dataset }
+    end
+
+    private
+
+    def validates_url_no_basic_auth
+      errors.add(:broker_url, :basic_auth) if URI(broker_url).userinfo
+    rescue ArgumentError, URI::InvalidURIError
     end
   end
 end

--- a/spec/unit/controllers/services/service_brokers_controller_spec.rb
+++ b/spec/unit/controllers/services/service_brokers_controller_spec.rb
@@ -361,6 +361,18 @@ module VCAP::CloudController
           end
         end
 
+        context 'when the broker_url contains basic auth' do
+          before { body_hash[:broker_url] = 'http://basic:auth@cf-service-broker.example.com' }
+
+          it 'returns an error' do
+            stub_catalog
+            post '/v2/service_brokers', body
+
+            expect(last_response).to have_status_code(400)
+            expect(decoded_response.fetch('code')).to eq(270016)
+          end
+        end
+
         context 'when the broker name is taken' do
           before do
             ServiceBroker.make(name: body_hash[:name])

--- a/spec/unit/controllers/services/service_brokers_controller_spec.rb
+++ b/spec/unit/controllers/services/service_brokers_controller_spec.rb
@@ -930,6 +930,17 @@ module VCAP::CloudController
             end
           end
         end
+
+        context 'when the broker_url contains username and password' do
+          before { body_hash[:broker_url] = 'http://basic:auth@cf-service-broker.example.com' }
+
+          it 'returns an error' do
+            put "/v2/service_brokers/#{broker.guid}", body
+
+            expect(last_response).to have_status_code(400)
+            expect(decoded_response.fetch('code')).to eq(270016)
+          end
+        end
       end
     end
   end

--- a/spec/unit/models/services/service_broker_spec.rb
+++ b/spec/unit/models/services/service_broker_spec.rb
@@ -50,6 +50,9 @@ module VCAP::CloudController
 
         broker.broker_url = 'https://127.0.0.1/api'
         expect(broker).to be_valid
+
+        broker.broker_url = 'https://admin:password@127.0.0.1/api'
+        expect(broker).to_not be_valid
       end
     end
 

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -863,6 +863,11 @@
   http_code: 502
   message: "Service broker returned dashboard client configuration without a dashboard URL"
 
+270016:
+  name: ServiceBrokerUrlBasicAuthNotSupported
+  http_code: 400
+  message: "User name and password fields in the broker URI are not supported"
+
 290000:
   name: BuildpackNameStackTaken
   http_code: 422


### PR DESCRIPTION
## Story

Do not allow broker registration that contains basic auth credentials in the URL [#155659461](https://www.pivotaltracker.com/story/show/155659461)

## Why

At the moment when a Service broker returns an invalid response, CC error handling logs the full URL that was used to register the SB. If that URL contains basic auth username:password, then this will be visible to the user whose request was answered with invalid response regardless of who registered the broker.

## What

Adds a validation for basic auth in the URL for the `ServiceBroker` model, if basic auth is included in the `broker_url` field the object fails validation.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks, SAPI team
