### PR TITLE
Package-upload-URL in package-links points to Bits-Service when it is enabled

### DIFF
--- a/app/presenters/v3/package_presenter.rb
+++ b/app/presenters/v3/package_presenter.rb
@@ -53,11 +53,11 @@ module VCAP::CloudController
           upload_link   = nil
           download_link = nil
           if package.type == 'bits'
-            if VCAP::CloudController::Config.config.get(:bits_service, :enabled)
-              upload_link   = { href: bits_service_client.blob(package.guid).public_upload_url, method: 'PUT' }
-            else
-              upload_link   = { href: url_builder.build_url(path: "/v3/packages/#{package.guid}/upload"), method: 'POST' }
-            end
+            upload_link = if VCAP::CloudController::Config.config.get(:bits_service, :enabled)
+                            { href: bits_service_client.blob(package.guid).public_upload_url, method: 'PUT' }
+                          else
+                            { href: url_builder.build_url(path: "/v3/packages/#{package.guid}/upload"), method: 'POST' }
+                          end
 
             download_link = { href: url_builder.build_url(path: "/v3/packages/#{package.guid}/download"), method: 'GET' }
           end

--- a/app/presenters/v3/package_presenter.rb
+++ b/app/presenters/v3/package_presenter.rb
@@ -53,7 +53,12 @@ module VCAP::CloudController
           upload_link   = nil
           download_link = nil
           if package.type == 'bits'
-            upload_link   = { href: url_builder.build_url(path: "/v3/packages/#{package.guid}/upload"), method: 'POST' }
+            if VCAP::CloudController::Config.config.get(:bits_service, :enabled)
+              upload_link   = { href: bits_service_client.blob(package.guid).public_upload_url, method: 'PUT' }
+            else
+              upload_link   = { href: url_builder.build_url(path: "/v3/packages/#{package.guid}/upload"), method: 'POST' }
+            end
+
             download_link = { href: url_builder.build_url(path: "/v3/packages/#{package.guid}/download"), method: 'GET' }
           end
 
@@ -65,6 +70,10 @@ module VCAP::CloudController
           }
 
           links.delete_if { |_, v| v.nil? }
+        end
+
+        def bits_service_client
+          CloudController::DependencyLocator.instance.package_blobstore
         end
       end
     end


### PR DESCRIPTION
Related tracker stories:
- CAPI: [#153779343 ](https://www.pivotaltracker.com/story/show/153779343)
- Bits-Service: [#153774125](https://www.pivotaltracker.com/story/show/153774125)

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
