### PR TITLE
Move service_instance_state_fetch module require

### DIFF
--- a/app/actions/services/service_instance_create.rb
+++ b/app/actions/services/service_instance_create.rb
@@ -1,4 +1,5 @@
 require 'actions/services/synchronous_orphan_mitigate'
+require 'jobs/services/service_instance_state_fetch'
 
 module VCAP::CloudController
   class ServiceInstanceCreate

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -1,5 +1,3 @@
-require 'jobs/services/service_instance_state_fetch'
-
 module VCAP::Services::ServiceBrokers::V2
   class Client
     CATALOG_PATH = '/v2/catalog'.freeze


### PR DESCRIPTION
It seems that the service broker client requires a module that it doesn't use and the service_instance_create action use that module, but doesn't require it. However the whole thing works, due to the order the modules are loaded.

Rearrange the order of the requires to be semantically correct.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thank you,
SAPI Team
