### PR TITLE
Allow devs to set custom DB connection info and still run units in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,28 @@ keep it up to date, documenting the purpose of the various types of tests.
 By default `rspec` will randomly pick between postgres and mysql.
 
 It will try to connect to those databases with the following connection string:
-postgres: postgres://postgres@localhost:5432/cc_test
-mysql: mysql2://root:password@localhost:3306/cc_test
 
+* postgres: `postgres://postgres@localhost:5432/cc_test`
+* mysql: `mysql2://root:password@localhost:3306/cc_test`
+
+To specify a custom username, password, host, or port for either database type, you can override the default
+connection string prefix (the part before the `cc_test` database name) by setting the `MYSQL_CONNECTION_PREFIX`
+and/or `POSTGRES_CONNECTION_PREFIX` variables. Alternatively, to override the full connection string, including 
+the database name, you can set the `DB_CONNECTION_STRING` environment variable.  This will restrict you to only 
+running tests in serial, however.
+
+For example, to run unit tests in parallel with a custom mysql username and password, you could execute:
 ```
-rake db:create
+MYSQL_CONNECTION_PREFIX=mysql2://custom_user:custom_password@localhost:3306 bundle exec rake
 ```
-will create the above database when the `DB` environment variable is set to postgres or mysql.
-You should run this before running rake in order to ensure that the `cc_test` database exists.
 
-You can specify the full connection string via the `DB_CONNECTION_STRING`
-environment variable. Examples:
+The following are examples of completely fully overriding the database connection string:
 
-    DB_CONNECTION_STRING="postgres://postgres@localhost:5432/cc_test" rake
-    DB_CONNECTION_STRING="mysql2://root:password@localhost:3306/cc_test" rake
+    DB_CONNECTION_STRING="postgres://postgres@localhost:5432/cc_test" DB=postgres rake spec:serial
+    DB_CONNECTION_STRING="mysql2://root:password@localhost:3306/cc_test" DB=mysql rake spec:serial
 
 If you are running the integration specs (which are included in the full rake),
-and you are specifying DB_CONNECTION_STRING, you will also
+and you are specifying `DB_CONNECTION_STRING`, you will also
 need to have a second test database with `_integration_cc` as the name suffix.
 
 For example, if you are using:
@@ -85,6 +90,13 @@ You will also need a database called:
 
     `cc_test_integration_cc`
 
+The command
+```
+rake db:create
+```
+will create the above database when the `DB` environment variable is set to postgres or mysql.
+You should run this before running rake in order to ensure that the `cc_test` database exists.
+
 #### Running tests on a single file
 
 The development team typically will run the specs to a single file as (e.g.)
@@ -94,6 +106,14 @@ The development team typically will run the specs to a single file as (e.g.)
 #### Running all the unit tests
 
     bundle exec rake spec
+
+Note that this will run all tests in parallel by default. If you are setting a custom `DB_CONNECTION_STRING`,
+you will need to run the tests in serial instead:
+
+    bundle exec rake spec:serial
+
+To be able to run the unit tests in parallel and still use custom connection strings, use the
+`MYSQL_CONNECTION_PREFIX` and `POSTGRES_CONNECTION_PREFIX` environment variables described above.
 
 #### Running static analysis
 

--- a/spec/support/bootstrap/db_config.rb
+++ b/spec/support/bootstrap/db_config.rb
@@ -51,9 +51,9 @@ class DbConfig
 
   def default_connection_prefix(db_type)
     default_connection_prefixes = {
-      'mysql' => 'mysql2://root:password@localhost:3306',
+      'mysql' => ENV['MYSQL_CONNECTION_PREFIX'] || 'mysql2://root:password@localhost:3306',
       'mysql_travis' => 'mysql2://root@localhost:3306',
-      'postgres' => 'postgres://postgres@localhost:5432'
+      'postgres' => ENV['POSTGRES_CONNECTION_PREFIX'] || 'postgres://postgres@localhost:5432'
     }
 
     db_type = 'mysql_travis' if ENV['TRAVIS'] == 'true' && db_type == 'mysql'


### PR DESCRIPTION
Previous to this PR, a developer working on cloud controller needed to have a root user in mysql with a password of `password` in order to run the unit tests in parallel.

A user wishing to use a different username and password for the unit test database could do so with `DB_CONNECTION_STRING`, but this would not allow the developer to run the units in parallel, which is the default `rake` behavior.

This change adds two new environment variables (`MYSQL_CONNECTION_PREFIX` and `POSTGRES_CONNECTION_PREFIX`) that a developer may set to override the default connection string prefix for mysql and postgres. Using these connection prefixes will still create and use databases called `cc_test` (serial) or `cc_test_<n>` (parallel).

Example usage:

    MYSQL_CONNECTION_PREFIX=mysql2://custom_user:custom_pass@localhost:3306 POSTGRES_CONNECTION_PREFIX=postgres://custom_user@localhost:5432 bundle exec rake

**Note**: You (capi team) may want to consider removing the mysql-travis db type and just using the MYSQL_CONNECTION_PREFIX for your travis CI runs.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [n/a] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks,
SAPI Team (Jen and @lurraca)
