### PR TITLE
Increasing the default cc startup timeout for CORS integration tests

### DIFF
--- a/spec/support/integration/setup.rb
+++ b/spec/support/integration/setup.rb
@@ -1,7 +1,7 @@
 require 'English'
 
 module IntegrationSetup
-  CC_START_TIMEOUT = 20
+  CC_START_TIMEOUT = 60
   SLEEP_INTERVAL = 0.5
 
   def start_cc(opts={})


### PR DESCRIPTION
In the CORS integration test, the CC startup timeout was 20 seconds,
which we would often see fail on reasonable-enough dev workstations
(MacBook Pros). While running the parallel tests, the system can get under significant load and therefore might not finish doing the CC startup before the timeout.

We've bumped this up to 60 seconds, which seems to make the tests pass more reliably.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [n/a] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks,
SAPI Team (Luis and @jenspinney )
