### PR TITLE
Adds warning if params are present for a bind to a user-provided service

### DIFF
--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -56,6 +56,7 @@ module VCAP::CloudController
 
       creator = ServiceBindingCreate.new(UserAuditInfo.from_context(SecurityContext))
       service_binding = creator.create(app, service_instance, message, volume_services_enabled?)
+      warn_if_user_provided_service_has_parameters!(service_instance)
 
       [HTTP::CREATED,
        { 'Location' => "#{self.class.path}/#{service_binding.guid}" },
@@ -115,6 +116,12 @@ module VCAP::CloudController
 
     def volume_services_enabled?
       @config.get(:volume_services_enabled)
+    end
+
+    def warn_if_user_provided_service_has_parameters!(service_instance)
+      if service_instance.user_provided_instance? && @request_attrs['parameters']
+        add_warning('Configuration parameters are ignored for bindings to user-provided service instances.')
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Previous to this PR, if a user requested a service binding to a user-provided service instance and gave configuration parameters along with the request, we would just silently ignore the configuration parameters.

This change simply adds a warning that the parameters they provided have been ignored.

Story: [As a dev, I see a warning when providing configuration params when creating a service binding for a user-provided service instance](https://www.pivotaltracker.com/story/show/154667172)

## The Checklist
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks,
SAPI Team
