### PR TITLE
Update how to run tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,10 @@ Follow these steps to make a contribution to any of our open source repositories
 1. Check out `master` of cloud_controller 
 1. Create a feature branch (`git checkout -b better_cloud_controller`)
 1. Make changes on your branch
-1. [Run tests](https://github.com/cloudfoundry/cloud_controller_ng#testing)
-1. [Run static analysis](https://github.com/cloudfoundry/cloud_controller_ng#static-analysis)
-1. If you are deploying to bosh, checkout `develop` of capi-release and `develop` of cf-release
+1. [Run unit tests](https://github.com/cloudfoundry/cloud_controller_ng#unit-tests)
+1. [Run static analysis](https://github.com/cloudfoundry/cloud_controller_ng#running-static-analysis)
+1. If you are deploying to bosh, checkout `develop` of [capi-release](https://github.com/cloudfoundry/capi-release)
+1. [Run CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
 1. Push to your fork (`git push origin better_cloud_controller`) and submit a pull request
 
 We favor pull requests with very small, single commits with a single purpose.

--- a/spec/README.md
+++ b/spec/README.md
@@ -4,7 +4,7 @@
 
 ### [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests/)
 
-These tests run against a full Cloud Foundry deployment. They should be used to test integrations between CC an other Cloud Foundry components. Because they are comparatively more expensive to run than other types of testing, they are typically not used for behavior that is only relevant to the CC.
+These tests run against a full Cloud Foundry deployment. They should be used to test integrations between CC and other Cloud Foundry components. Because they are comparatively more expensive to run than other types of testing, they are typically not used for behavior that is only relevant to the CC.
 
 ### [Sync Integration Tests](https://github.com/cloudfoundry/sync-integration-tests)
 


### PR DESCRIPTION
The links about running unit tests and static analysis in the CONTRIBUTING.md are broken. This PR is to fix it.
Also added the how to run CATs.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

No need to run unit tests and CATs since the code changes are only for docs.