### PR TITLE
Use cf-perm 0.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'fog-openstack'
 gem 'cf-uaa-lib', '~> 3.13.0'
 gem 'vcap-concurrency', git: 'https://github.com/cloudfoundry/vcap-concurrency.git', ref: '2a5b0179'
 
-gem 'cf-perm', git: 'https://github.com/cloudfoundry-incubator/perm-rb.git', branch: 'master'
+gem 'cf-perm', '~> 0.0.5'
 gem 'scientist'
 
 group :db do
@@ -69,7 +69,7 @@ group :operations do
 end
 
 group :test do
-  gem 'cf-perm-test-helpers', git: 'https://github.com/cloudfoundry-incubator/perm-rb.git', branch: 'master'
+  gem 'cf-perm-test-helpers', '~> 0.0.2'
   gem 'codeclimate-test-reporter', require: false
   gem 'hashdiff'
   gem 'machinist', '~> 1.0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,4 @@
 GIT
-  remote: https://github.com/cloudfoundry-incubator/perm-rb.git
-  revision: cc623e9368b6eaf132f6559fb4903bdf281bdba0
-  branch: master
-  specs:
-    cf-perm (0.0.0)
-      grpc (~> 1.0)
-    cf-perm-test-helpers (0.0.1)
-      ruby-mysql (~> 2.9.14)
-      subprocess (~> 1)
-
-GIT
   remote: https://github.com/cloudfoundry/vcap-concurrency.git
   revision: 2a5b0179642cb3d3e7f912a6453ec5731979d115
   ref: 2a5b0179
@@ -92,6 +81,11 @@ GEM
     byebug (10.0.2)
     cf-copilot (0.0.3)
       grpc (~> 1.0)
+    cf-perm (0.0.5)
+      grpc (~> 1.0)
+    cf-perm-test-helpers (0.0.2)
+      ruby-mysql (~> 2.9.14)
+      subprocess (~> 1)
     cf-uaa-lib (3.13.0)
       httpclient (~> 2.8, >= 2.8.2.4)
       multi_json (~> 1.12.0, >= 1.12.1)
@@ -436,8 +430,8 @@ DEPENDENCIES
   bits_service_client
   byebug
   cf-copilot
-  cf-perm!
-  cf-perm-test-helpers!
+  cf-perm (~> 0.0.5)
+  cf-perm-test-helpers (~> 0.0.2)
   cf-uaa-lib (~> 3.13.0)
   clockwork
   cloudfront-signer

--- a/lib/cloud_controller/perm/permissions.rb
+++ b/lib/cloud_controller/perm/permissions.rb
@@ -26,17 +26,17 @@ module VCAP
 
         def can_read_from_org?(org_id)
           permissions = [
-            { permission_name: 'org.manager', resource_id: org_id },
-            { permission_name: 'org.auditor', resource_id: org_id },
-            { permission_name: 'org.user', resource_id: org_id },
-            { permission_name: 'org.billing_manager', resource_id: org_id },
+            { action: 'org.manager', resource: org_id },
+            { action: 'org.auditor', resource: org_id },
+            { action: 'org.user', resource: org_id },
+            { action: 'org.billing_manager', resource: org_id },
           ]
           can_read_globally? || has_any_permission?(permissions)
         end
 
         def can_write_to_org?(org_id)
           permissions = [
-            { permission_name: 'org.manager', resource_id: org_id },
+            { action: 'org.manager', resource: org_id },
           ]
 
           can_write_globally? || has_any_permission?(permissions)
@@ -44,10 +44,10 @@ module VCAP
 
         def can_read_from_space?(space_id, org_id)
           permissions = [
-            { permission_name: 'space.developer', resource_id: space_id },
-            { permission_name: 'space.manager', resource_id: space_id },
-            { permission_name: 'space.auditor', resource_id: space_id },
-            { permission_name: 'org.manager', resource_id: org_id },
+            { action: 'space.developer', resource: space_id },
+            { action: 'space.manager', resource: space_id },
+            { action: 'space.auditor', resource: space_id },
+            { action: 'org.manager', resource: org_id },
           ]
 
           can_read_globally? || has_any_permission?(permissions)
@@ -55,7 +55,7 @@ module VCAP
 
         def can_see_secrets_in_space?(space_id, org_id)
           permissions = [
-            { permission_name: 'space.developer', resource_id: space_id },
+            { action: 'space.developer', resource: space_id },
           ]
 
           can_read_secrets_globally? || has_any_permission?(permissions)
@@ -63,7 +63,7 @@ module VCAP
 
         def can_write_to_space?(space_id)
           permissions = [
-            { permission_name: 'space.developer', resource_id: space_id },
+            { action: 'space.developer', resource: space_id },
           ]
 
           can_write_globally? || has_any_permission?(permissions)

--- a/lib/cloud_controller/science/experiment.rb
+++ b/lib/cloud_controller/science/experiment.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
       include Scientist::Experiment
 
       def initialize(name:, enabled:)
-        @name = name
+        @experiment_name = name
         @enabled = enabled
       end
 
@@ -37,10 +37,10 @@ module VCAP::CloudController
 
       private
 
-      attr_reader :name, :enabled
+      attr_reader :experiment_name, :enabled
 
       def logger
-        @logger ||= Steno.logger("science.#{name}")
+        @logger ||= Steno.logger("science.#{experiment_name}")
       end
 
       def observation_payload(observation)

--- a/spec/integration/perm_spec.rb
+++ b/spec/integration/perm_spec.rb
@@ -345,18 +345,18 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
         end
 
         it "assigns the specified user to the org #{role} role" do
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "org.#{role}", resource_id: org_id)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "org.#{role}", resource: org_id)
           expect(has_permission).to eq(false)
 
           put "/v2/organizations/#{org_id}/#{role}s/#{assignee.guid}"
           expect(last_response.status).to eq(201)
 
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "org.#{role}", resource_id: org_id)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "org.#{role}", resource: org_id)
           expect(has_permission).to eq(true)
         end
 
         it 'does nothing when the user is assigned to the role a second time' do
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "org.#{role}", resource_id: org_id)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "org.#{role}", resource: org_id)
           expect(has_permission).to eq(false)
 
           put "/v2/organizations/#{org_id}/#{role}s/#{assignee.guid}"
@@ -365,7 +365,7 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
           put "/v2/organizations/#{org_id}/#{role}s/#{assignee.guid}"
           expect(last_response.status).to eq(201)
 
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "org.#{role}", resource_id: org_id)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "org.#{role}", resource: org_id)
           expect(has_permission).to eq(true)
         end
       end
@@ -384,12 +384,12 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
         end
 
         it "removes the user from the org #{role} role" do
-          client.assign_role(role_name: role_name, actor_id: assignee.guid, issuer: issuer)
+          client.assign_role(role_name: role_name, actor_id: assignee.guid, namespace: issuer)
 
           delete "/v2/organizations/#{org.guid}/#{role}s", { 'username' => assignee.username }.to_json
           expect(last_response.status).to eq(204)
 
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "space.#{role}", resource_id: org.guid)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "space.#{role}", resource: org.guid)
           expect(has_permission).to eq(false)
         end
 
@@ -463,17 +463,17 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
       delete "/v2/organizations/#{org1_id}/users?recursive=true", { 'username' => assignee.username }.to_json
       expect(last_response.status).to eq(204)
 
-      has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: 'org.user', resource_id: org1_id)
+      has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: 'org.user', resource: org1_id)
       expect(has_permission).to eq(false)
 
-      has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: 'org.user', resource_id: org2_id)
+      has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: 'org.user', resource: org2_id)
       expect(has_permission).to eq(true)
 
       SPACE_ROLES.each do |role|
-        has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "space.#{role}", resource_id: org1_space_id)
+        has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "space.#{role}", resource: org1_space_id)
         expect(has_permission).to eq(false)
 
-        has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "space.#{role}", resource_id: org2_space_id)
+        has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "space.#{role}", resource: org2_space_id)
         expect(has_permission).to eq(true)
       end
     end
@@ -491,12 +491,12 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
         end
 
         it "removes the user from the org #{role} role" do
-          client.assign_role(role_name: role_name, actor_id: assignee.guid, issuer: issuer)
+          client.assign_role(role_name: role_name, actor_id: assignee.guid, namespace: issuer)
 
           delete "/v2/organizations/#{org.guid}/#{role}s/#{assignee.guid}"
           expect(last_response.status).to eq(204)
 
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "org.#{role}", resource_id: org.guid)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "org.#{role}", resource: org.guid)
           expect(has_permission).to eq(false)
         end
 
@@ -705,18 +705,18 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
     SPACE_ROLES.each do |role|
       describe "PUT /v2/spaces/:guid/#{role}s/:user_guid" do
         it "assigns the specified user to the space #{role} role" do
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "space.#{role}", resource_id: space_id)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "space.#{role}", resource: space_id)
           expect(has_permission).to eq(false)
 
           put "/v2/spaces/#{space_id}/#{role}s/#{assignee.guid}"
           expect(last_response.status).to eq(201)
 
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "space.#{role}", resource_id: space_id)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "space.#{role}", resource: space_id)
           expect(has_permission).to eq(true)
         end
 
         it 'does nothing when the user is assigned to the role a second time' do
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "space.#{role}", resource_id: space_id)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "space.#{role}", resource: space_id)
           expect(has_permission).to eq(false)
 
           put "/v2/spaces/#{space_id}/#{role}s/#{assignee.guid}"
@@ -725,7 +725,7 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
           put "/v2/spaces/#{space_id}/#{role}s/#{assignee.guid}"
           expect(last_response.status).to eq(201)
 
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "space.#{role}", resource_id: space_id)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "space.#{role}", resource: space_id)
           expect(has_permission).to eq(true)
         end
       end
@@ -749,12 +749,12 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
         end
 
         it "removes the user from the space #{role} role" do
-          client.assign_role(actor_id: assignee.guid, issuer: issuer, role_name: role_name)
+          client.assign_role(actor_id: assignee.guid, namespace: issuer, role_name: role_name)
 
           delete "/v2/spaces/#{space.guid}/#{role}s", { 'username' => assignee.username }.to_json
           expect(last_response.status).to eq(200)
 
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "space.#{role}", resource_id: space.guid)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "space.#{role}", resource: space.guid)
           expect(has_permission).to eq(false)
         end
       end
@@ -778,12 +778,12 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
         end
 
         it "removes the user from the space #{role} role" do
-          client.assign_role(actor_id: assignee.guid, issuer: issuer, role_name: role_name)
+          client.assign_role(actor_id: assignee.guid, namespace: issuer, role_name: role_name)
 
           delete "/v2/spaces/#{space.guid}/#{role}s/#{assignee.guid}"
           expect(last_response.status).to eq(204)
 
-          has_permission = client.has_permission?(actor_id: assignee.guid, issuer: issuer, permission_name: "space.#{role}", resource_id: space.guid)
+          has_permission = client.has_permission?(actor_id: assignee.guid, namespace: issuer, action: "space.#{role}", resource: space.guid)
           expect(has_permission).to eq(false)
         end
 

--- a/spec/unit/lib/perm/permissions_spec.rb
+++ b/spec/unit/lib/perm/permissions_spec.rb
@@ -115,10 +115,10 @@ module VCAP::CloudController::Perm
 
       it 'returns true when the user has any relevant permission' do
         expected_permissions = [
-          { permission_name: 'org.manager', resource_id: org_id },
-          { permission_name: 'org.auditor', resource_id: org_id },
-          { permission_name: 'org.user', resource_id: org_id },
-          { permission_name: 'org.billing_manager', resource_id: org_id },
+          { action: 'org.manager', resource: org_id },
+          { action: 'org.auditor', resource: org_id },
+          { action: 'org.user', resource: org_id },
+          { action: 'org.billing_manager', resource: org_id },
         ]
 
         allow(perm_client).to receive(:has_any_permission?).with(permissions: expected_permissions, user_id: user_id, issuer: issuer).and_return(true)
@@ -151,7 +151,7 @@ module VCAP::CloudController::Perm
 
       it 'returns true when the user has any relevant permission' do
         expected_permissions = [
-          { permission_name: 'org.manager', resource_id: org_id },
+          { action: 'org.manager', resource: org_id },
         ]
 
         allow(perm_client).to receive(:has_any_permission?).with(permissions: expected_permissions, user_id: user_id, issuer: issuer).and_return(true)
@@ -202,10 +202,10 @@ module VCAP::CloudController::Perm
 
       it 'returns true when the user has any relevant permission' do
         expected_permissions = [
-          { permission_name: 'space.developer', resource_id: space_id },
-          { permission_name: 'space.manager', resource_id: space_id },
-          { permission_name: 'space.auditor', resource_id: space_id },
-          { permission_name: 'org.manager', resource_id: org_id },
+          { action: 'space.developer', resource: space_id },
+          { action: 'space.manager', resource: space_id },
+          { action: 'space.auditor', resource: space_id },
+          { action: 'org.manager', resource: org_id },
         ]
 
         allow(perm_client).to receive(:has_any_permission?).with(permissions: expected_permissions, user_id: user_id, issuer: issuer).and_return(true)
@@ -247,7 +247,7 @@ module VCAP::CloudController::Perm
 
       it 'returns true when the user has any relevant permission' do
         expected_permissions = [
-          { permission_name: 'space.developer', resource_id: space_id }
+          { action: 'space.developer', resource: space_id }
         ]
 
         allow(perm_client).to receive(:has_any_permission?).with(permissions: expected_permissions, user_id: user_id, issuer: issuer).and_return(true)
@@ -280,7 +280,7 @@ module VCAP::CloudController::Perm
 
       it 'returns true when the user has any relevant permission' do
         expected_permissions = [
-          { permission_name: 'space.developer', resource_id: space_id }
+          { action: 'space.developer', resource: space_id }
         ]
 
         allow(perm_client).to receive(:has_any_permission?).with(permissions: expected_permissions, user_id: user_id, issuer: issuer).and_return(true)
@@ -343,10 +343,10 @@ module VCAP::CloudController::Perm
         has_permission = permissions.can_read_from_isolation_segment?(isolation_segment)
 
         expected_permissions = [
-          { permission_name: 'space.developer', resource_id: 'some-space-id' },
-          { permission_name: 'space.manager', resource_id: 'some-space-id' },
-          { permission_name: 'space.auditor', resource_id: 'some-space-id' },
-          { permission_name: 'org.manager', resource_id: 'some-org-id' },
+          { action: 'space.developer', resource: 'some-space-id' },
+          { action: 'space.manager', resource: 'some-space-id' },
+          { action: 'space.auditor', resource: 'some-space-id' },
+          { action: 'org.manager', resource: 'some-org-id' },
         ]
 
         expect(has_permission).to equal(true)
@@ -366,10 +366,10 @@ module VCAP::CloudController::Perm
         has_permission = permissions.can_read_from_isolation_segment?(isolation_segment)
 
         expected_permissions = [
-          { permission_name: 'org.manager', resource_id: 'some-org-id' },
-          { permission_name: 'org.auditor', resource_id: 'some-org-id' },
-          { permission_name: 'org.user', resource_id: 'some-org-id' },
-          { permission_name: 'org.billing_manager', resource_id: 'some-org-id' },
+          { action: 'org.manager', resource: 'some-org-id' },
+          { action: 'org.auditor', resource: 'some-org-id' },
+          { action: 'org.user', resource: 'some-org-id' },
+          { action: 'org.billing_manager', resource: 'some-org-id' },
         ]
 
         expect(has_permission).to equal(true)


### PR DESCRIPTION
The latest version of cf-perm includes a number of breaking changes,
which the Perm wrapper now accommodates. Some names in CAPI have also
been changed to reflect the new Perm names (e.g., `permission_name` ->
`action`).

cf-perm and cf-perm-test-helpers are also now hosted on rubygems.

[#157059792]

Signed-off-by: Isobel Redelmeier <iredelmeier@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
