### PR TITLE
Record an audit event for service instance/bind delete even if the user doesn't exist

### DIFF
--- a/app/jobs/services/service_binding_state_fetch.rb
+++ b/app/jobs/services/service_binding_state_fetch.rb
@@ -59,11 +59,7 @@ module VCAP::CloudController
         end
 
         def record_event(binding, request_attrs)
-          user = User.find(guid: @user_audit_info.user_guid)
-
-          if user
-            Repositories::ServiceBindingEventRepository.record_create(binding, @user_audit_info, request_attrs)
-          end
+          Repositories::ServiceBindingEventRepository.record_create(binding, @user_audit_info, request_attrs)
         end
 
         def enqueue_again

--- a/app/jobs/services/service_instance_state_fetch.rb
+++ b/app/jobs/services/service_instance_state_fetch.rb
@@ -43,10 +43,7 @@ module VCAP::CloudController
         end
 
         def repository
-          user = User.find(guid: @user_audit_info.user_guid)
-          if user
-            Repositories::ServiceEventRepository.new(@user_audit_info)
-          end
+          Repositories::ServiceEventRepository.new(@user_audit_info)
         end
 
         def update_with_attributes(attrs_to_update, service_instance)
@@ -78,10 +75,8 @@ module VCAP::CloudController
         end
 
         def record_event(service_instance, request_attrs)
-          services_event_repository = repository
-          return unless services_event_repository
           type = service_instance.last_operation.type
-          services_event_repository.record_service_instance_event(type, service_instance, request_attrs)
+          repository.record_service_instance_event(type, service_instance, request_attrs)
         end
 
         def apply_proposed_changes(service_instance)

--- a/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
@@ -283,13 +283,16 @@ module VCAP::CloudController
             end
 
             context 'when the user has gone away' do
-              it 'should not create an audit event' do
+              it 'should create an audit event' do
                 allow(client).to receive(:fetch_service_binding).with(service_binding).and_return(binding_response)
                 user.destroy
 
                 run_job(job)
 
-                expect(Event.find(type: 'audit.service_binding.create')).to be_nil
+                event = Event.find(type: 'audit.service_binding.create')
+                expect(event).to be
+                expect(event.actee).to eq(service_binding.guid)
+                expect(event.metadata['request']).to have_key('some_attr')
               end
             end
           end

--- a/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
@@ -198,12 +198,15 @@ module VCAP::CloudController
             end
 
             context 'when the user has gone away' do
-              it 'should not create an audit event' do
+              it 'should create an audit event' do
                 user.destroy
 
                 run_job(job)
 
-                expect(Event.find(type: 'audit.service_instance.create')).to be_nil
+                event = Event.find(type: 'audit.service_instance.create')
+                expect(event).to be
+                expect(event.actee).to eq(service_instance.guid)
+                expect(event.metadata['request']).to have_key('dummy_data')
               end
             end
           end


### PR DESCRIPTION
Prior to this PR, if a user requested an operation that was asynchronously completed by a service broker, and that user got deleted between the time they requested the operation and the time the operation completed, we wouldn't log an audit event at all for the completed operation. 

Associated tracker story is [#157559523: We should log an audit event for async operations even if user is deleted](https://www.pivotaltracker.com/story/show/157559523)

Thanks,
SAPI Team (Jen and @Samze)

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)