### PR TITLE
Deprecate DELETE /v2/apps/:guid/service_bindings/:guid'

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -333,6 +333,7 @@ module VCAP::CloudController
       [HTTP::NO_CONTENT]
     end
 
+    deprecated_endpoint '/v2/apps/:app_guid/service_bindings/:service_binding_guid'
     delete '/v2/apps/:app_guid/service_bindings/:service_binding_guid', :remove_service_binding
 
     def remove_service_binding(app_guid, service_binding_guid)

--- a/docs/v2/apps/remove_service_binding_from_the_app_(deprecated).html
+++ b/docs/v2/apps/remove_service_binding_from_the_app_(deprecated).html
@@ -66,7 +66,7 @@
   <h1>Apps API</h1>
 
   <div class="article">
-    <h2>Remove Service Binding from the App</h2>
+    <h2>Remove Service Binding from the App (deprecated)</h2>
     <h3>DELETE /v2/apps/:guid/service_bindings/:service_binding_guid</h3>
 
       <h3>Request</h3>
@@ -144,7 +144,9 @@ Cookie: </pre>
 
         <h4>Headers</h4>
         <pre class="response headers">X-VCAP-Request-ID: d78246be-bd92-408d-be42-adf9c01dc695
-X-Content-Type-Options: nosniff</pre>
+X-Content-Type-Options: nosniff
+X-Cf-Warnings: Endpoint+deprecated
+        </pre>
 
   </div>
 </div>

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -108,7 +108,7 @@
         <a href="apps/remove_route_from_the_app.html">Remove Route from the App</a>
       </li>
       <li>
-        <a href="apps/remove_service_binding_from_the_app.html">Remove Service Binding from the App</a>
+        <a href="apps/remove_service_binding_from_the_app_(deprecated).html">Remove Service Binding from the App (deprecated)</a>
       </li>
       <li>
         <a href="apps/restage_an_app.html">Restage an App</a>

--- a/spec/unit/controllers/runtime/apps_controller_spec.rb
+++ b/spec/unit/controllers/runtime/apps_controller_spec.rb
@@ -2294,6 +2294,11 @@ module VCAP::CloudController
         expect(process.reload.service_bindings).to be_empty
       end
 
+      it 'has the deprecated warning header' do
+        delete "/v2/apps/not-found/service_bindings/#{service_binding.guid}"
+        expect(last_response).to be_a_deprecated_response
+      end
+
       context 'when the app does not exist' do
         it 'returns 404' do
           delete "/v2/apps/not-found/service_bindings/#{service_binding.guid}"


### PR DESCRIPTION
## Story

As a developer, I can see that the DELETE /v2/apps/:guid/service_bindings/:service_binding_guid endpoint is deprecated in the docs [#157197079](https://www.pivotaltracker.com/story/show/157197079)

## Why
The API already allows deletion of bindings via
/v2/service_binding/:guid. Having two ways to delete the binding
just means we have to maintain both. There isn't even any advantage for
a client to delete via the app resource since they have to know the guid of the binding anyway.

## What
Deprecate the obsolete endpoint in the documentation and add "Deprecated endpoint"
warning in the header

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks, SAPI team
@nmaslarski && @ablease 
