### PR TITLE
Rename upgrade_service_instance to update_service_instance in broker computability tests

### DIFF
--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.12_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.12_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Service Broker API integration' do
     context 'service update request' do
       before do
         provision_service
-        upgrade_service_instance(200)
+        update_service_instance(200)
       end
 
       it 'receives a context object' do

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe 'Service Broker API integration' do
         let(:user) { VCAP::CloudController::User.make }
         before do
           provision_service(user: user)
-          upgrade_service_instance(200, user: user)
+          update_service_instance(200, user: user)
         end
 
         it 'receives the user_id in the X-Broker-API-Originating-Identity header' do
@@ -450,7 +450,7 @@ RSpec.describe 'Service Broker API integration' do
 
         before do
           provision_service(user: user_a)
-          upgrade_service_instance(200, user: user_b)
+          update_service_instance(200, user: user_b)
           deprovision_service(user: user_c)
         end
 

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.4_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.4_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Service Broker API integration' do
           provision_service
           expect(VCAP::CloudController::ServiceInstance.find(guid: @service_instance_guid).service_plan_guid).to eq @plan_guid
 
-          upgrade_service_instance(200)
+          update_service_instance(200)
           expect(last_response.status).to eq 201
           expect(VCAP::CloudController::ServiceInstance.find(guid: @service_instance_guid).service_plan_guid).to eq @large_plan_guid
         end
@@ -61,7 +61,7 @@ RSpec.describe 'Service Broker API integration' do
         it 'returns 502 to the client' do
           provision_service
 
-          upgrade_service_instance(422)
+          update_service_instance(422)
           expect(last_response.status).to eq 502
         end
       end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.5_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.5_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Service Broker API integration' do
 
       it 'sends params to broker for service instance update' do
         provision_service
-        upgrade_service_instance(200, parameters: parameters)
+        update_service_instance(200, parameters: parameters)
         expected_body = hash_including({ 'parameters' => parameters })
 
         expect(

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.6_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.6_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Service Broker API integration' do
         end
 
         it 'sends service_id for service instance update' do
-          upgrade_service_instance(200)
+          update_service_instance(200)
           expected_body = hash_including({ 'service_id' => service_id })
 
           expect(

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.1_spec.rb' => 'd0559352542dda5cbd3f010cbdc622f2',
       'broker_api_v2.2_spec.rb' => '4fc472fc502b50aa7451b3e376823fe0',
       'broker_api_v2.3_spec.rb' => 'b226a2bcd068ba6db28dd4ea26a94cdb',
-      'broker_api_v2.4_spec.rb' => '17ddf45ce44d07f8912f3a8031ae8016',
-      'broker_api_v2.5_spec.rb' => 'a1c55e4193072955fa600197e07ac64a',
-      'broker_api_v2.6_spec.rb' => '4c55e7de2295685022e580e49c2e8d5c',
+      'broker_api_v2.4_spec.rb' => '229f05a3f6fab68163418794bd9bfab2',
+      'broker_api_v2.5_spec.rb' => 'efc346680280b2f7bb8c5d2443fed810',
+      'broker_api_v2.6_spec.rb' => 'a1608878f601819c90b44be5f317ec44',
       'broker_api_v2.7_spec.rb' => '6ac3a8f83f3bc2492715b42a8fecb2a0',
       'broker_api_v2.8_spec.rb' => '2b1b662b4874f5bac4481de7cf15b363',
       'broker_api_v2.9_spec.rb' => 'c297d302b57dd5b1aba9c92f0c9c4c4f',
       'broker_api_v2.10_spec.rb' => '27e81c4c540e39a4e4eac70c8efb14ba',
       'broker_api_v2.11_spec.rb' => '99e61dc50ceb635b09b3bd16901a4fa6',
-      'broker_api_v2.12_spec.rb' => 'b9626f09abf20d9d1d0e71ef1ac0df70',
-      'broker_api_v2.13_spec.rb' => '877bfeabe26bead3c7c2e78287a0d623',
+      'broker_api_v2.12_spec.rb' => '45db41892336b8bf8748fd5ae484bc29',
+      'broker_api_v2.13_spec.rb' => '06b4683ffd7f69d800c3b9097bc9cd73',
     }
   end
   let(:digester) { Digester.new(algorithm: Digest::MD5) }

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -235,7 +235,7 @@ module VCAP::CloudController::BrokerApiHelper
     @service_instance_guid = response['metadata']['guid']
   end
 
-  def upgrade_service_instance(return_code, opts={})
+  def update_service_instance(return_code, opts={})
     stub_request(:patch, %r{broker-url/v2/service_instances/[[:alnum:]-]+}).to_return(status: return_code, body: '{}')
 
     body = {


### PR DESCRIPTION
## Story
Rename upgrade_service_instance to update_service_instance in tests [#157938803](https://www.pivotaltracker.com/story/show/157938803)

## Why
In the broker API compatibility tests, we've used the term "upgrade" instead of "update" in a helper method. We should rename this to "update" to avoid confusion in these tests.

## What
Rename upgrade_service_instance to update_service_instance in broker computability tests

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks, SAPI team
@nmaslarski

