### PR TITLE
Add ports to container_network_info

### DIFF
--- a/lib/cloud_controller/diego/protocol/container_network_info.rb
+++ b/lib/cloud_controller/diego/protocol/container_network_info.rb
@@ -15,6 +15,7 @@ module VCAP::CloudController
               'app_id' => app.guid,
               'space_id' => app.space.guid,
               'org_id' => app.organization.guid,
+              'ports' => app.processes.map { |p| Protocol::OpenProcessPorts.new(p).to_a }.flatten.sort.join(','),
             },
           }
         end

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -65,6 +65,7 @@ module VCAP::CloudController
           r
         end
 
+        let(:ports) { '' }
         let(:expected_network) do
           ::Diego::Bbs::Models::Network.new(
             properties: [
@@ -72,6 +73,7 @@ module VCAP::CloudController
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'app_id', value: app_model.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app_model.space.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app_model.organization.guid),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ports),
             ]
           )
         end
@@ -247,6 +249,8 @@ module VCAP::CloudController
               start_command:                command,
             )
           end
+
+          let(:ports) { '8080' }
 
           before do
             VCAP::CloudController::BuildpackLifecycleDataModel.make(

--- a/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
@@ -5,6 +5,12 @@ module VCAP::CloudController
     class Protocol
       RSpec.describe ContainerNetworkInfo do
         let(:app) { AppModel.make }
+        let!(:web_process) { ProcessModel.make(app: app, type: 'web') }
+        let!(:other_process) { ProcessModel.make(app: app, ports: [8765], type: 'meow') }
+        let!(:no_exposed_port_process) { ProcessModel.make(app: app, type: 'woof') }
+        let!(:docker_process) { ProcessModelFactory.make(app: app, type: 'docker', ports: [1111, 2222]) }
+        let(:ports_str) { '1111,2222,8080,8765' }
+
         subject(:container_info) { ContainerNetworkInfo.new(app) }
 
         describe '#to_h' do
@@ -15,6 +21,7 @@ module VCAP::CloudController
                 'app_id' => app.guid,
                 'space_id' => app.space.guid,
                 'org_id' => app.organization.guid,
+                'ports' => ports_str,
               },
             })
           end
@@ -29,6 +36,7 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'app_id', value: app.guid),
                   ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
                   ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
+                  ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ports_str),
                 ]
               )
             )

--- a/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
@@ -194,6 +194,7 @@ module VCAP::CloudController
                 'app_id' => process.guid,
                 'space_id' => process.space.guid,
                 'org_id' => process.organization.guid,
+                'ports' => '2222,3333'
               }
             },
             'volume_mounts' => an_instance_of(Array),

--- a/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
@@ -36,6 +36,7 @@ module VCAP::CloudController
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'app_id', value: app.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ''),
             ]
           )
         end
@@ -342,6 +343,7 @@ module VCAP::CloudController
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'app_id', value: app.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ''),
             ]
           )
         end


### PR DESCRIPTION
* A short explanation of the proposed change:

This adds `ports` (exposed app ports) to `container_network_info`.

* An explanation of the use cases your change solves

The container networking team uses this metadata for our policy system and we need to pass the exposed app ports to add policy for istio router on the overlay.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

/cc @ameowlia
