### PR TITLE
Bump bits-service-client to 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'railties'
 
 # Blobstore and Bits Service Dependencies
 gem 'azure-storage', '0.14.0.preview' # https://github.com/Azure/azure-storage-ruby/issues/122
-gem 'bits_service_client'
+gem 'bits_service_client', '~> 2.1'
 gem 'fog-aws'
 gem 'fog-azure-rm'
 gem 'fog-google'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     backports (3.6.8)
     beefcake (1.0.0)
     bit-struct (0.16)
-    bits_service_client (0.3.2)
+    bits_service_client (2.1.0)
       activesupport
       steno
     builder (3.2.3)
@@ -448,7 +448,7 @@ DEPENDENCIES
   allowy
   awesome_print
   azure-storage (= 0.14.0.preview)
-  bits_service_client
+  bits_service_client (~> 2.1)
   byebug
   cf-copilot
   cf-perm (~> 0.0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     backports (3.6.8)
     beefcake (1.0.0)
     bit-struct (0.16)
-    bits_service_client (2.1.0)
+    bits_service_client (2.2.0)
       activesupport
       steno
     builder (3.2.3)

--- a/lib/cloud_controller/packager/bits_service_packer.rb
+++ b/lib/cloud_controller/packager/bits_service_packer.rb
@@ -3,9 +3,14 @@ require 'cloud_controller/dependency_locator'
 module CloudController
   module Packager
     class BitsServicePacker
-      def send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
-        fingerprints_from_upload = upload_missing_entries(uploaded_files_path)
-        generate_package(cached_files_fingerprints | fingerprints_from_upload, 'package.zip', blobstore_key)
+      def send_package_to_blobstore(blobstore_key, uploaded_package_zip, cached_files_fingerprints)
+        bundle_response = resource_pool.bundles(cached_files_fingerprints.to_json, uploaded_package_zip)
+        package = create_temp_file_with_content(bundle_response.body)
+        package_blobstore.cp_to_blobstore(package.path, blobstore_key)
+        {
+          sha1: Digester.new.digest_file(package),
+          sha256: Digester.new(algorithm: Digest::SHA256).digest_file(package),
+        }
       rescue => e
         raise CloudController::Errors::ApiError.new_from_details('BitsServiceError', e.message) if e.is_a?(BitsService::Errors::Error)
         raise
@@ -13,27 +18,8 @@ module CloudController
 
       private
 
-      def upload_missing_entries(zip_of_files_not_in_blobstore_path)
-        if zip_of_files_not_in_blobstore_path.to_s != ''
-          entries_response = resource_pool.upload_entries(zip_of_files_not_in_blobstore_path)
-          JSON.parse(entries_response.body)
-        else
-          []
-        end
-      end
-
-      def generate_package(fingerprints, package_filename, blobstore_key)
-        bundle_response = resource_pool.bundles(fingerprints.to_json)
-        package         = create_temp_file_with_content(package_filename, bundle_response.body)
-        package_blobstore.cp_to_blobstore(package.path, blobstore_key)
-        {
-          sha1: Digester.new.digest_file(package),
-          sha256: Digester.new(algorithm: Digest::SHA256).digest_file(package),
-        }
-      end
-
-      def create_temp_file_with_content(filename, content)
-        package = Tempfile.new(filename).binmode
+      def create_temp_file_with_content(content)
+        package = Tempfile.new('package.zip').binmode
         package.write(content)
         package.close
         package


### PR DESCRIPTION
- This change bumps the bits-service-client first to 2.1.0, which uses bits-service 2.4.0's new multipart `/app_stash/bundles` endpoint. bits-service-client 2.1.0 is incompatible with previous versions. That change also required a change in the Cloud Controller itself to use the new methods. (Note: bits-service has *no* incompatible changes, only the client)
- Afterwards, it bumps bits-service-client to 2.2.0 which uses the new `async=true` query parameter when building URLs for package upload.

Related tracker stories:
- https://www.pivotaltracker.com/story/show/157623171
- https://www.pivotaltracker.com/story/show/157623194
- https://www.pivotaltracker.com/story/show/153779415
- https://www.pivotaltracker.com/story/show/157623317

Checks:
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)
* [x] I have viewed, signed, and submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
