### PR TITLE
Return 502 if broker responds async to sync binding request

### DIFF
--- a/app/actions/service_binding_create.rb
+++ b/app/actions/service_binding_create.rb
@@ -9,6 +9,7 @@ module VCAP::CloudController
     class ServiceInstanceNotBindable < InvalidServiceBinding; end
     class ServiceBrokerInvalidSyslogDrainUrl < InvalidServiceBinding; end
     class ServiceBrokerInvalidBindingsRetrievable < InvalidServiceBinding; end
+    class ServiceBrokerRespondedAsyncWhenNotAllowed < InvalidServiceBinding; end
     class VolumeMountServiceDisabled < InvalidServiceBinding; end
     class SpaceMismatch < InvalidServiceBinding; end
 
@@ -42,6 +43,7 @@ module VCAP::CloudController
       begin
         if binding_result[:async]
           raise ServiceBrokerInvalidBindingsRetrievable.new unless binding.service.bindings_retrievable
+          raise ServiceBrokerRespondedAsyncWhenNotAllowed.new unless accepts_incomplete
 
           binding.save_with_new_operation({ type: 'create', state: 'in progress', broker_provided_operation: binding_result[:operation] })
           job = Jobs::Services::ServiceBindingStateFetch.new(binding.guid, @user_audit_info, message.audit_hash)

--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -71,6 +71,8 @@ module VCAP::CloudController
       raise CloudController::Errors::ApiError.new_from_details('VolumeMountServiceDisabled')
     rescue ServiceBindingCreate::ServiceBrokerInvalidBindingsRetrievable
       raise CloudController::Errors::ApiError.new_from_details('ServiceBindingInvalid', 'Could not create asynchronous binding when bindings_retrievable is false.')
+    rescue ServiceBindingCreate::ServiceBrokerRespondedAsyncWhenNotAllowed
+      raise CloudController::Errors::ApiError.new_from_details('ServiceBrokerRespondedAsyncWhenNotAllowed')
     rescue ServiceBindingCreate::InvalidServiceBinding => e
       raise CloudController::Errors::ApiError.new_from_details('ServiceBindingAppServiceTaken', e.message)
     end

--- a/spec/unit/actions/service_binding_create_spec.rb
+++ b/spec/unit/actions/service_binding_create_spec.rb
@@ -234,6 +234,21 @@ module VCAP::CloudController
           expect(client).to receive(:bind).with(instance_of(VCAP::CloudController::ServiceBinding), anything, false)
           service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)
         end
+
+        context 'and the broker responds asynchronously' do
+          before do
+            allow(client).to receive(:bind).and_return({ async: true, binding: {}, operation: '123' })
+          end
+
+          it 'raises an error' do
+            expect_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_unbind)
+
+            expect {
+              service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)
+            }.to raise_error(ServiceBindingCreate::ServiceBrokerRespondedAsyncWhenNotAllowed).
+              and not_change(ServiceBinding, :count)
+          end
+        end
       end
 
       describe 'orphan mitigation situations' do

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -868,6 +868,11 @@
   http_code: 400
   message: "User name and password fields in the broker URI are not supported"
 
+270017:
+  name: ServiceBrokerRespondedAsyncWhenNotAllowed
+  http_code: 502
+  message: "The service broker responded asynchronously to a request, but the accepts_incomplete query parameter was false or not given."
+
 290000:
   name: BuildpackNameStackTaken
   http_code: 422


### PR DESCRIPTION
## Summary of the Change

On the `POST /v2/service_bindings` endpoint there is a flag called `accepts_incomplete`. This flag is passed down to the broker. If `accepts_incomplete` is set to `true` the broker may respond to the service binding create request with 202, which indicates that the binding will be created asynchronously. If `accepts_incomplete` is set to `false` the broker must create the service binding synchronously. If the broker is unable to create binding synchronously it is supposed to return 422.

This change addresses spec incompliant brokers which return 202 despite `accepts_incomplete` being set to `false`. In this case now we will return 502 back to the user.
We also send unbind request to the broker.



## Associated Story
[#158106741: An operator, I can update the broker poll interval while an async binding job is enqueued](https://www.pivotaltracker.com/story/show/158106741)

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)


Thanks,
SAPI Team (@jenspinney  and @nmaslarski)