### PR TITLE
Do not allow fetching service binding parameters while async operation is in progress

### DIFF
--- a/app/actions/services/service_binding_read.rb
+++ b/app/actions/services/service_binding_read.rb
@@ -1,5 +1,6 @@
 module VCAP::CloudController
   class ServiceBindingRead
+    include VCAP::CloudController::LockCheck
     class NotSupportedError < StandardError
     end
 
@@ -7,6 +8,8 @@ module VCAP::CloudController
       unless service_binding.service_instance.managed_instance? && service_binding.service.bindings_retrievable
         raise NotSupportedError.new
       end
+
+      raise_if_binding_locked(service_binding)
 
       client = VCAP::Services::ServiceClientProvider.provide(instance: service_binding.service_instance)
       response = client.fetch_service_binding(service_binding)

--- a/app/models/services/route_binding.rb
+++ b/app/models/services/route_binding.rb
@@ -33,6 +33,10 @@ module VCAP::CloudController
       { route: route.uri }
     end
 
+    def operation_in_progress?
+      false
+    end
+
     private
 
     def validate_routing_service

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -75,5 +75,9 @@ module VCAP::CloudController
     def logger
       @logger ||= Steno.logger('cc.models.service_key')
     end
+
+    def operation_in_progress?
+      false
+    end
   end
 end

--- a/spec/unit/actions/services/service_binding_read_spec.rb
+++ b/spec/unit/actions/services/service_binding_read_spec.rb
@@ -37,6 +37,17 @@ module VCAP::CloudController
             action = ServiceBindingRead.new
             expect(action.fetch_parameters(service_binding)).to eql({})
           end
+
+          it 'should raise "AsyncServiceBindingOperationInProgress"' do
+            service_binding.service_binding_operation = ServiceBindingOperation.make(state: 'in progress')
+            service
+
+            action = ServiceBindingRead.new
+            expect { action.fetch_parameters(service_binding) }.to raise_error do |error|
+              expect(error).to be_a(CloudController::Errors::ApiError)
+              expect(error.name).to eql('AsyncServiceBindingOperationInProgress')
+            end
+          end
         end
 
         context 'when the broker has bindings_retrievable disabled' do

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1320,6 +1320,21 @@ module VCAP::CloudController
             end
           end
 
+          context 'when the service binding has an operation in progress' do
+            let(:last_operation) { ServiceBindingOperation.make(state: 'in progress') }
+
+            before do
+              binding.service_binding_operation = last_operation
+              binding.save
+            end
+
+            it 'should show an error message for get parameter operation' do
+              get "/v2/service_bindings/#{binding.guid}/parameters"
+              expect(last_response).to have_status_code 409
+              expect(last_response.body).to match 'AsyncServiceBindingOperationInProgress'
+            end
+          end
+
           context 'user permissions' do
             let(:user) { User.make }
             let(:body) { {}.to_json }


### PR DESCRIPTION
## Summary of the Change
If a user tries to fetch a service binding parameters while an asynchronous operation for that binding is in progress we return an error.

## Associated Story
[#158073118: As a developer, I see an error if I try to fetch service binding parameters whilst an asynchronous binding is in progress](https://www.pivotaltracker.com/story/show/158073118)


* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks,
SAPI Team (Georgi and @nmaslarski)
