### PR TITLE
Emit metrics / events for monitoring service brokers

### DIFF
--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -5,17 +5,28 @@ module VCAP::CloudController
     class RequestMetrics
       def initialize(statsd=Statsd.new)
         @statsd = statsd
+        @collect_metrics_for_routes = ['service_instances', 'service_bindings', 'service_keys']
       end
 
       def start_request
         @statsd.increment 'cc.requests.outstanding'
       end
 
-      def complete_request(status)
+      def complete_request(path, method, status)
         @statsd.batch do |batch|
           batch.decrement 'cc.requests.outstanding'
           batch.increment 'cc.requests.completed'
           batch.increment "cc.http_status.#{status.to_s[0]}XX"
+
+          pos = path.index('/', 1)
+          if !pos.nil?
+            path_without_version = path[pos + 1..-1]
+            @collect_metrics_for_routes.each do |route|
+              if path_without_version.start_with?(route)
+                batch.increment "cc.requests.#{route}.#{method.downcase}.http_status.#{status.to_s[0]}XX"
+              end
+            end
+          end
         end
       end
     end

--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -19,14 +19,12 @@ module VCAP::CloudController
           batch.increment "cc.http_status.#{status.to_s[0]}XX"
 
           pos = path.index('/', 1)
-          if !pos.nil?
-            path_without_version = path[pos + 1..-1]
-            @collect_metrics_for_routes.each do |route|
-              if path_without_version.start_with?(route)
-                batch.increment "cc.requests.#{route}.#{method.downcase}.http_status.#{status.to_s[0]}XX"
-              end
-            end
-          end
+          next if pos.nil?
+
+          path_without_version = path[pos + 1..-1]
+          @collect_metrics_for_routes.
+            select { |route| path_without_version.start_with? route }.
+            each { |route| batch.increment "cc.requests.#{route}.#{method.downcase}.http_status.#{status.to_s[0]}XX" }
         end
       end
     end

--- a/middleware/request_metrics.rb
+++ b/middleware/request_metrics.rb
@@ -11,7 +11,7 @@ module CloudFoundry
 
         status, headers, body = @app.call(env)
 
-        @request_metrics.complete_request(status)
+        @request_metrics.complete_request(env['PATH_INFO'], env['REQUEST_METHOD'], status)
 
         [status, headers, body]
       end

--- a/spec/unit/middleware/request_metrics_spec.rb
+++ b/spec/unit/middleware/request_metrics_spec.rb
@@ -5,18 +5,19 @@ module CloudFoundry
   module Middleware
     RSpec.describe RequestMetrics do
       let(:middleware) { RequestMetrics.new(app, request_metrics) }
+      let(:env) { { 'PATH_INFO' => '/v2/some-path', 'REQUEST_METHOD' => 'GET' } }
       let(:app) { double(:app, call: [200, {}, 'a body']) }
       let(:request_metrics) { instance_double(VCAP::CloudController::Metrics::RequestMetrics, start_request: nil, complete_request: nil) }
 
       describe 'handling the request' do
         it 'calls start request on request metrics before the request' do
-          middleware.call({})
+          middleware.call(env)
           expect(request_metrics).to have_received(:start_request)
         end
 
         it 'calls complete request on request metrics after the request' do
-          middleware.call({})
-          expect(request_metrics).to have_received(:complete_request).with(200)
+          middleware.call(env)
+          expect(request_metrics).to have_received(:complete_request).with('/v2/some-path', 'GET', 200)
         end
       end
     end


### PR DESCRIPTION
## A short explanation of the proposed change

Emit extra http status code metrics for certain API endpoints, namely service broker-related endpoints. HTTP requests with the following prefixes will send extra metrics:

/[version]/service_instances
/[version]/service_bindings
/[version]/service_keys

The emitted metric name is:

cc.requests.#{route}.#{method.downcase}.http_status.#{status.to_s[0]}XX

E.g. cc.requests.service_bindings.put.http_status.5XX

## An explanation of the use cases our change solves

Monitoring of service brokers to ensure operations are not failing, such as binding for example.

The current metrics only cover things internal to Cloud Foundry. These metrics provide the opportunity to monitor external components the platform relies on.

## Links to any other associated PRs

Associated issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/929

---

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
