### PR TITLE
Add cell_id field to metadata of app crashed events

### DIFF
--- a/app/repositories/app_event_repository.rb
+++ b/app/repositories/app_event_repository.rb
@@ -16,7 +16,7 @@ module VCAP::CloudController
         Loggregator.emit(app.guid, "App instance exited with guid #{app.guid} payload: #{droplet_exited_payload}")
 
         actor    = { name: app.name, guid: app.guid, type: 'app' }
-        metadata = droplet_exited_payload.slice('instance', 'index', 'exit_status', 'exit_description', 'reason')
+        metadata = droplet_exited_payload.slice('instance', 'index', 'cell_id', 'exit_status', 'exit_description', 'reason')
         create_app_audit_event('app.crash', app, app.space, actor, metadata)
       end
 

--- a/spec/unit/repositories/app_event_repository_spec.rb
+++ b/spec/unit/repositories/app_event_repository_spec.rb
@@ -191,6 +191,7 @@ module VCAP::CloudController
           {
             'instance' => 'abc',
             'index' => '2',
+            'cell_id' => 'some-cell',
             'exit_status' => '1',
             'exit_description' => 'shut down',
             'reason' => 'evacuation',
@@ -209,6 +210,7 @@ module VCAP::CloudController
           expect(event.actee_name).to eq(exiting_process.name)
           expect(event.metadata['unknown_key']).to eq(nil)
           expect(event.metadata['instance']).to eq('abc')
+          expect(event.metadata['cell_id']).to eq('some-cell')
           expect(event.metadata['index']).to eq('2')
           expect(event.metadata['exit_status']).to eq('1')
           expect(event.metadata['exit_description']).to eq('shut down')

--- a/spec/unit/repositories/process_event_repository_spec.rb
+++ b/spec/unit/repositories/process_event_repository_spec.rb
@@ -222,6 +222,7 @@ module VCAP::CloudController
           {
             'instance' => Sham.guid,
             'index' => 3,
+            'cell_id' => 'some-cell',
             'exit_status' => 137,
             'exit_description' => 'description',
             'reason' => 'CRASHED'


### PR DESCRIPTION
[#155871993]

Signed-off-by: Edwin Xie <exie@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

As a CF app developer, I expect to see the Diego cell ID in the app crash event metadata so that I can more easily report the cell on which an app instance crashed

* An explanation of the use cases your change solves

see this story in Diego's backlog: https://www.pivotaltracker.com/story/show/155871993

* [ x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [ x] I have viewed, signed, and submitted the Contributor License Agreement

* [x ] I have made this pull request to the `master` branch

* [x ] I have run all the unit tests using `bundle exec rake`

* [ x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
