### PR TITLE
As a dev, I do not see a warning when I do not provide configuration params when creating a service binding for a user-provided service instance

### DIFF
--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -125,7 +125,7 @@ module VCAP::CloudController
     end
 
     def warn_if_user_provided_service_has_parameters!(service_instance)
-      if service_instance.user_provided_instance? && @request_attrs['parameters']
+      if service_instance.user_provided_instance? && @request_attrs['parameters'] && @request_attrs['parameters'].any?
         add_warning('Configuration parameters are ignored for bindings to user-provided service instances.')
       end
     end


### PR DESCRIPTION
[#158250648](https://www.pivotaltracker.com/story/show/158250648)

When binding to a user provided service instance, we warn the user if
they include custom parameters to the bind request, since these values are
ignored. However, we have previously been only checking for the
existance of the `parameters` key in the request, not whether that key
has any real value. The CF CLI always includes the `parameters` key in
bind requests and leaves the constants empty if the user didn't provide
parameters. Thus, users were seeing warnings even if they hadn't
provided parameters. This commit fixes that.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
