### PR TITLE
Call binmode in a separate statement

### DIFF
--- a/lib/cloud_controller/packager/bits_service_packer.rb
+++ b/lib/cloud_controller/packager/bits_service_packer.rb
@@ -19,7 +19,8 @@ module CloudController
       private
 
       def create_temp_file_with_content(content)
-        package = Tempfile.new('package.zip').binmode
+        package = Tempfile.new('package.zip')
+        package.binmode
         package.write(content)
         package.close
         package


### PR DESCRIPTION

* A short explanation of the proposed change:

    Fix Tempfile usage when using bits-service-client.

* An explanation of the use cases your change solves

    While Tempfile's binmode method, according to its implementation (https://ruby-doc.org/core-2.4.0/IO.html#method-i-binmode), returns the Tempfile object, it seems that garbage collection does not consider this a proper reference (note that the documentation also does not state that it is returning the Tempfile object). Hence, whenever garbage collection kicks in, it collects the package reference and with it, deletes the temporary file, which causes a failure further down the line when trying to work with the temp file. That's what we've seen in RelInt's Hermione env. The fact we haven't seen this anywhere else is probably because GC is undeterministic and simply wasn't executed in this specific case. Bottom line is, we used the Tempfile API wrong.

    [#157250835]

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
