### PR TITLE
Refactor some compound conditionals on services

### DIFF
--- a/app/actions/services/service_binding_read.rb
+++ b/app/actions/services/service_binding_read.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
     end
 
     def fetch_parameters(service_binding)
-      unless service_binding.service_instance.managed_instance? && service_binding.service.bindings_retrievable
+      unless binding_retrievable?(service_binding)
         raise NotSupportedError.new
       end
 
@@ -14,6 +14,12 @@ module VCAP::CloudController
       client = VCAP::Services::ServiceClientProvider.provide(instance: service_binding.service_instance)
       response = client.fetch_service_binding(service_binding)
       response.fetch(:parameters, {})
+    end
+
+    private
+
+    def binding_retrievable?(service_binding)
+      service_binding.service_instance.managed_instance? && service_binding.service.bindings_retrievable
     end
   end
 end

--- a/app/controllers/services/service_bindings_controller.rb
+++ b/app/controllers/services/service_bindings_controller.rb
@@ -132,7 +132,7 @@ module VCAP::CloudController
     end
 
     def status_from_operation_state(last_operation)
-      if last_operation && last_operation.state == 'in progress'
+      if last_operation&.state == 'in progress'
         HTTP::ACCEPTED
       else
         HTTP::CREATED

--- a/app/models/services/service_plan_visibility.rb
+++ b/app/models/services/service_plan_visibility.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
     private
 
     def validate_plan_is_not_private
-      if service_plan && service_plan.broker_private?
+      if service_plan&.broker_private?
         errors.add(:service_plan, 'is from a private broker')
       end
     end


### PR DESCRIPTION
Very small refactor of some compound conditionals in /services. 

* Moving compound conditional into named method, with a higher level concept name

* Using the safe navigator instead of nil or false check.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
