### PR TITLE
Continue polling on 410 from last_operation endpoint

### DIFF
--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -277,7 +277,7 @@ module VCAP::Services::ServiceBrokers::V2
       if instance.last_operation.type == 'delete'
         'succeeded'
       else
-        'failed'
+        'in progress'
       end
     end
 

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -2156,7 +2156,7 @@ module VCAP::CloudController
               end
 
               service_instance.reload
-              expect(service_instance.last_operation.state).to eq('failed')
+              expect(service_instance.last_operation.state).to eq('in progress')
             end
           end
 

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -442,11 +442,11 @@ module VCAP::Services::ServiceBrokers::V2
             instance.save_with_new_operation({}, { type: 'update' })
           end
 
-          it 'returns attributes to indicate the service instance operation failed' do
+          it 'returns attributes to indicate the service instance operation is in progress' do
             attrs = client.fetch_service_instance_last_operation(instance)
             expect(attrs).to include(
               last_operation: {
-                state: 'failed'
+                state: 'in progress'
               }
             )
           end

--- a/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
@@ -984,7 +984,7 @@ module VCAP::Services
         test_case(:fetch_service_binding_last_operation, 422, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
         test_case(:fetch_service_binding_last_operation, 422, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
         test_case(:fetch_service_binding_last_operation, 422, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_common_error_cases(:fetch_state)
+        test_common_error_cases(:fetch_service_binding_last_operation)
         # rubocop:enable Metrics/LineLength
       end
     end


### PR DESCRIPTION
What:
When creating an asynchronous service instance the CC is polling the service broker's `last_operation` endpoint to know the state of the instance. Response on this endpoint with status code 410 was treated as a failure - the instance is marked as failed and the polling job is interrupted.

With this change it is no longer treated as failure, but as invalid. and the CC will continue polling.

Why:
As per OSBAPI spec, CC was not complaint, since treated last_operation
410 responses as failures, instead of invalid. (failures are not
re-queued)

Best,
SAPI Team

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
