### PR TITLE
Pass credentials to bits-service-client ResourcePool, bump major version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'railties'
 
 # Blobstore and Bits Service Dependencies
 gem 'azure-storage', '0.14.0.preview' # https://github.com/Azure/azure-storage-ruby/issues/122
-gem 'bits_service_client', '~> 2.1'
+gem 'bits_service_client', '~> 3.0'
 gem 'fog-aliyun'
 gem 'fog-aws'
 gem 'fog-azure-rm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     backports (3.6.8)
     beefcake (1.0.0)
     bit-struct (0.16)
-    bits_service_client (2.2.0)
+    bits_service_client (3.0.0)
       activesupport
       steno
     builder (3.2.3)
@@ -454,7 +454,7 @@ DEPENDENCIES
   allowy
   awesome_print
   azure-storage (= 0.14.0.preview)
-  bits_service_client (~> 2.1)
+  bits_service_client (~> 3.0)
   byebug
   cf-copilot
   cf-perm (~> 0.0.10)

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -316,7 +316,9 @@ module CloudController
         endpoint: bits_service_options[:private_endpoint],
         request_timeout_in_seconds: config.get(:request_timeout_in_seconds),
         ca_cert_path: bits_service_options[:ca_cert_path],
-        vcap_request_id: VCAP::Request.current_id
+        vcap_request_id: VCAP::Request.current_id,
+        username: bits_service_options[:username],
+        password: bits_service_options[:password]
       )
     end
 


### PR DESCRIPTION
* A short explanation of the proposed change:
    - Use the newest version of bits-service-client which requires to pass credentials to ResourcePool
    - https://www.pivotaltracker.com/story/show/158942220

* An explanation of the use cases your change solves
    The new version of bits-service-client makes it possible to get a signed `/app_stash/matches` URL from bits-service. This will help with https://www.pivotaltracker.com/story/show/158645204.
* Links to any other associated PRs
    - https://github.com/cloudfoundry-incubator/bits-service-client/commit/20b9fa0af10dc22c971c181defab086d1d464709
    - https://github.com/cloudfoundry-incubator/bits-service-client/commit/92f2660d4f3678422bdc4296a4133ecbde704e3a

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
