### PR TITLE
Listing all service bindings for unknown service instance returns 500 instead of 404

### DIFF
--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -159,7 +159,7 @@ module VCAP::CloudController
       async = convert_flag_to_bool(params['async'])
       purge = convert_flag_to_bool(params['purge'])
 
-      service_instance = find_guid(guid, ServiceInstance)
+      service_instance = find_service_instance(guid)
 
       if purge
         validate_access(:purge, service_instance)
@@ -229,7 +229,7 @@ module VCAP::CloudController
 
     get '/v2/service_instances/:guid/shared_from', :shared_from_information
     def shared_from_information(guid)
-      service_instance = find_guid_and_validate_access(:read, guid, ManagedServiceInstance)
+      service_instance = find_guid_and_validate_access(:read, guid, ServiceInstance)
 
       return HTTP::NO_CONTENT unless service_instance.shared?
 
@@ -424,7 +424,7 @@ module VCAP::CloudController
     end
 
     def find_service_instance(guid)
-      find_guid(guid, ManagedServiceInstance)
+      find_guid(guid, ServiceInstance)
     end
 
     def validate_service_instance_access(service_instance)

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -4025,6 +4025,14 @@ module VCAP::CloudController
       let(:space) { Space.make(organization: org) }
       let(:instance) { ManagedServiceInstance.make(space: space) }
 
+      context 'when the service instance does not exist' do
+        it 'returns a 404' do
+          set_current_user_as_admin
+          get '/v2/service_instances/fake-guid/shared_from'
+          expect(last_response.status).to eql(404)
+        end
+      end
+
       context 'when the service instance is not shared' do
         it 'returns no content' do
           set_current_user_as_admin
@@ -4139,6 +4147,14 @@ module VCAP::CloudController
         get "/v2/service_instances/#{instance.guid}/shared_to"
         expect(last_response.status).to eql(200)
         expect(JSON.parse(last_response.body)['resources']).to eq([])
+      end
+
+      context 'when the service instance does not exist' do
+        it 'returns a 404' do
+          set_current_user_as_admin
+          get '/v2/service_instances/fake-guid/shared_to'
+          expect(last_response.status).to eql(404)
+        end
       end
 
       context 'when the service instance is shared into multiple spaces' do
@@ -4815,6 +4831,18 @@ module VCAP::CloudController
       end
     end
 
+    describe 'GET /v2/service_instances/:service_instance_guid/service_bindings' do
+      let(:space) { service_instance.space }
+      let(:developer) { make_developer_for_space(space) }
+
+      context 'when the service instance does not exist' do
+        it 'returns a 404' do
+          set_current_user_as_admin
+          get '/v2/service_instances/fake-guid/service_bindings'
+          expect(last_response.status).to eql(404)
+        end
+      end
+    end
     describe 'Validation messages' do
       let(:paid_quota) { QuotaDefinition.make(total_services: 1) }
       let(:free_quota_with_no_services) do

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -318,6 +318,11 @@
   http_code: 502
   message: "Deletion of service instance %s failed because one or more associated resources could not be deleted.\n\n%s"
 
+60028:
+  name: ManagedServiceInstanceNotFound
+  http_code: 404
+  message: "The service instance could not be found: %s"
+
 70001:
   name: RuntimeInvalid
   http_code: 400


### PR DESCRIPTION
This fixes a bug that was returning 500s instead of
404s when the ManagedServiceInstance related model was not found.

The resources that were affected were:

* shared_to
* shared_from
* service_instances/:not-found-guid/service_bindings
* service_instances/:not-found_guid/service_keys
* service_instances/:not-found_guid/routes

Reasons for this change are summarised here, but a more detailed explanation can be found in [the story](https://www.pivotaltracker.com/story/show/158914498). 

Sometimes, when attempting to load a `Service Instance` model we do so by loading the`ManagedServiceInstance` model. If the Service Instance was not found we produce an error key based on the model name. We used that error key to lookup the error massage from the `errors/v2.yml`. In that `errors/v2.yml` it is not possible to lookup by `ManagedServiceInstance`. If you try to do so a `KeyError` exception is raised and is returned to the CLI as an `UnknownError`.


Sapi team will merge this when CAPI ci is green

Thanks! 

Sapi Team (CC: @lurraca @williammartin )

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
