### PR TITLE
Improve performance of service instances user_visibility_filter

### DIFF
--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -65,10 +65,10 @@ module VCAP::CloudController
     set_field_as_encrypted :credentials
 
     def self.user_visibility_filter(user)
-      visible_spaces = user.spaces_dataset.all.
-                       concat(user.audited_spaces_dataset.all).
-                       concat(user.managed_spaces_dataset.all).
-                       concat(managed_organizations_spaces_dataset(user.managed_organizations_dataset).all).uniq
+      visible_spaces = user.spaces_dataset.
+                       union(user.audited_spaces_dataset).
+                       union(user.managed_spaces_dataset).
+                       union(managed_organizations_spaces_dataset(user.managed_organizations_dataset)).all.uniq
 
       Sequel.or([
         [:space, visible_spaces],


### PR DESCRIPTION
In this PR we have made a change to a series of database calls, made by the service instance model. Rather than making 4 individual calls to the DB we instead construct a consolidated dataset of the user visibility information and make a single call to the DB. 

In testing, we noticed that the performance of http requests to the `/v2/spaces/:space_guid/service_instances` endpoint improved by around [1 second](https://www.pivotaltracker.com/story/show/156704514/comments/191974084)

The Sapi team will merge this when the commit has passed through CAPI CI

Thanks!

Sapi Team (CC: @nmaslarski)

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
