### PR TITLE
Restrict service and service plan descriptions to 10000 characters

### DIFF
--- a/db/migrations/20180710115626_change_broker_catalog_descriptions_to_type_text.rb
+++ b/db/migrations/20180710115626_change_broker_catalog_descriptions_to_type_text.rb
@@ -1,0 +1,20 @@
+Sequel.migration do
+  up do
+    # In this PR https://github.com/cloudfoundry/cloud_controller_ng/pull/1193
+    # we are performing an API level validation on the length of description
+    # fields in the service broker catalog. However we do not want to break
+    # older brokers that may have long descriptions. Here we are disabling
+    # rubocop from checking the string size.
+    alter_table :services do
+      # rubocop:disable Migration/IncludeStringSize
+      set_column_type :description, String, text: true
+      # rubocop:enable Migration/IncludeStringSize
+    end
+
+    alter_table :service_plans do
+      # rubocop:disable Migration/IncludeStringSize
+      set_column_type :description, String, text: true
+      # rubocop:enable Migration/IncludeStringSize
+    end
+  end
+end

--- a/lib/services/service_brokers/v2/catalog_plan.rb
+++ b/lib/services/service_brokers/v2/catalog_plan.rb
@@ -44,7 +44,7 @@ module VCAP::Services::ServiceBrokers::V2
     def validate!
       validate_string!(:broker_provided_id, broker_provided_id, required: true)
       validate_string!(:name, name, required: true)
-      validate_string!(:description, description, required: true)
+      validate_description!(:description, description, required: true)
       validate_hash!(:metadata, metadata) if metadata
       validate_bool!(:free, free) if free
       validate_bool!(:bindable, bindable) if bindable

--- a/lib/services/service_brokers/v2/catalog_service.rb
+++ b/lib/services/service_brokers/v2/catalog_service.rb
@@ -58,7 +58,7 @@ module VCAP::Services::ServiceBrokers::V2
     def validate_service
       validate_string!(:broker_provided_id, broker_provided_id, required: true)
       validate_string!(:name, name, required: true)
-      validate_string!(:description, description, required: true)
+      validate_description!(:description, description, required: true)
       validate_bool!(:bindable, bindable, required: true)
       validate_bool!(:plan_updateable, plan_updateable, required: true)
       validate_bool!(:bindings_retrievable, bindings_retrievable, required: false)

--- a/lib/services/service_brokers/v2/catalog_validation_helper.rb
+++ b/lib/services/service_brokers/v2/catalog_validation_helper.rb
@@ -1,5 +1,13 @@
 module VCAP::Services::ServiceBrokers::V2
   module CatalogValidationHelper
+    def validate_description!(name, input, opts={})
+      validate_string!(name, input, opts)
+
+      if input.respond_to?(:length) && input.length > 10_000
+        errors.add("#{human_readable_attr_name(name)} may not have more than 10000 characters")
+      end
+    end
+
     def validate_string!(name, input, opts={})
       if !input.is_a?(String) && !input.nil?
         errors.add("#{human_readable_attr_name(name)} must be a string, but has value #{input.inspect}")

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Service Broker' do
             {
               id: 12345,
               name: 'service-1',
-              description: 'A service, duh!',
+              description: 'A' * 10_001,
               bindable: true,
               bindings_retrievable: 'not-a-bool',
               instances_retrievable: 'not-a-bool',
@@ -125,7 +125,7 @@ RSpec.describe 'Service Broker' do
                 {
                   id: 'plan-1',
                   name: 'small',
-                  description: 'A small shared database with 100mb storage quota and 10 connections',
+                  description: 'B' * 10_001,
                   schemas: {
                     service_instance: {
                       create: {
@@ -205,9 +205,11 @@ RSpec.describe 'Service Broker' do
           "Service dashboard_client id must be unique\n" \
           "Service service-1\n" \
           "  Service id must be a string, but has value 12345\n" \
+          "  Service description may not have more than 10000 characters\n" \
           "  Service \"bindings_retrievable\" field must be a boolean, but has value \"not-a-bool\"\n" \
           "  Service \"instances_retrievable\" field must be a boolean, but has value \"not-a-bool\"\n" \
           "  Plan small\n" \
+          "    Plan description may not have more than 10000 characters\n" \
           "    Schemas\n" \
           '      Schema service_instance.create.parameters is not valid. Must conform to JSON Schema Draft 04 (experimental support for later versions): '\
           "The property '#/properties' of type boolean did not match the following type: object in schema "\

--- a/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
@@ -86,6 +86,20 @@ module VCAP::Services::ServiceBrokers::V2
         expect(plan.errors.messages).to include 'Plan description is required'
       end
 
+      it 'validates that @description is less than 10_001 characters' do
+        plan_attrs['description'] = 'A' * 10_001
+
+        expect(plan).to_not be_valid
+        expect(plan.errors.messages).to include 'Plan description may not have more than 10000 characters'
+      end
+
+      it 'is valid if @description is 10_000 characters' do
+        plan_attrs['description'] = 'A' * 10_000
+
+        expect(plan).to be_valid
+        expect(plan.errors.messages).to be_empty
+      end
+
       it 'validates that @metadata is a hash' do
         plan_attrs['metadata'] = ['list', 'of', 'strings']
 

--- a/spec/unit/lib/services/service_brokers/v2/catalog_service_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_service_spec.rb
@@ -92,6 +92,22 @@ module VCAP::Services::ServiceBrokers::V2
         expect(service.errors.messages).to include 'Service description must be a string, but has value 123'
       end
 
+      it 'validates that @description is less than 10_001 characters' do
+        attrs = build_valid_service_attrs(description: 'A' * 10_001)
+        service = CatalogService.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
+        expect(service).to_not be_valid
+
+        expect(service.errors.messages).to include 'Service description may not have more than 10000 characters'
+      end
+
+      it 'is valid if @description is 10_000 characters' do
+        attrs = build_valid_service_attrs(description: 'A' * 10_000)
+        service = CatalogService.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
+        expect(service).to be_valid
+
+        expect(service.errors.messages).to be_empty
+      end
+
       it 'validates that @description is present' do
         attrs = build_valid_service_attrs
         attrs['description'] = nil


### PR DESCRIPTION
Previously, there was a database-imposed limit of 255 characters on description fields on MySQL only.

For MySQL users, this will be an increase in the possible length of the description field. For Postgres users, this will be a decrease (i.e., a new restriction).

This is, therefore, a breaking change for anyone who is using Postgres and has a description field in their broker catalog of larger than 10_000 characters. If such a broker exists, they will get an error the next time they update the service broker. They can fix this by reducing the size of the description to 10_000 characters or less.

Thanks, Services API Team (@ablease an @lurraca)

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)