### PR TITLE
Add missing fields to shared service docs examples

### DIFF
--- a/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_from.html
+++ b/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_from.html
@@ -102,6 +102,22 @@ Cookie: </pre>
             <tbody>
               <tr class="">
                 <td>
+                    <span class="name">space_guid</span>
+                </td>
+                <td>
+                  <span class="description">The space guid that this service instance belongs to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">space_name</span>
                 </td>
                 <td>
@@ -136,6 +152,7 @@ Cookie: </pre>
           </table>
 
           <pre class="response body">{
+    "space_guid": "dbce7e1e-32ce-446a-9061-bd748778077b",
     "space_name": "space-name",
     "organization_name": "org-name"
 }
@@ -144,7 +161,7 @@ Cookie: </pre>
         <h4>Headers</h4>
         <pre class="response headers">Content-Type: application/json;charset=utf-8
 X-VCAP-Request-ID: febb14ab-a7bc-492d-b017-3db59d83967d
-Content-Length: 253
+Content-Length: 120
 X-Content-Type-Options: nosniff</pre>
   </div>
 </div>

--- a/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_to.html
+++ b/docs/v2/service_instances/retrieve_info_where_service_instance_is_shared_to.html
@@ -164,6 +164,22 @@ Cookie: </pre>
             <tbody>
               <tr class="">
                 <td>
+                    <span class="name">space_guid</span>
+                </td>
+                <td>
+                  <span class="description">The guid of the space being shared to.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                  </ul>
+                </td>
+              </tr>
+              <tr class="">
+                <td>
                     <span class="name">space_name</span>
                 </td>
                 <td>
@@ -220,11 +236,13 @@ Cookie: </pre>
    "next_url": null,
    "resources": [
       {
+          "space_guid": "2cf74cc4-a0a8-4b43-a01a-4207a356347d",
           "space_name": "target-space-1",
           "organization_name": "org-name",
           "bound_app_count": 3
       },
       {
+          "space_guid": "880ad078-1cef-4dd3-9902-ba59767bdc63",
           "space_name": "target-space-2",
           "organization_name": "org-name",
           "bound_app_count": 0
@@ -235,7 +253,7 @@ Cookie: </pre>
         <h4>Headers</h4>
         <pre class="response headers">Content-Type: application/json;charset=utf-8
 X-VCAP-Request-ID: febb14ab-a7bc-492d-b017-3db59d83967d
-Content-Length: 378
+Content-Length: 525
 X-Content-Type-Options: nosniff</pre>
 
   </div>

--- a/docs/v2/spaces/get_space_summary.html
+++ b/docs/v2/spaces/get_space_summary.html
@@ -255,6 +255,7 @@ Cookie: </pre>
         "space_name": "source-space",
         "organization_name": "source-org"
       },
+      "shared_to": [],
       "last_operation": {
         "type": "create",
         "state": "succeeded",


### PR DESCRIPTION
This PR adds documentation for fields related to service instance sharing in v2. In particular the fields that were added are:
1. "space_guid" that a service instance originates from.
2. "space_guid" for where the service instance is shared to.

Sapi team will merge this when Capi CI is green. 

Thanks! Sapi Team

(cc: @williammartin @georgi-lozev )


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
