### PR TITLE
Extend cp_to_blobstore with resources param, bump bits-service-client to 3.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     backports (3.11.3)
     beefcake (1.0.0)
     bit-struct (0.16)
-    bits_service_client (3.1.0)
+    bits_service_client (3.2.0)
       activesupport
       steno
     builder (3.2.3)

--- a/lib/cloud_controller/packager/bits_service_packer.rb
+++ b/lib/cloud_controller/packager/bits_service_packer.rb
@@ -4,34 +4,11 @@ module CloudController
   module Packager
     class BitsServicePacker
       def send_package_to_blobstore(blobstore_key, uploaded_package_zip, cached_files_fingerprints)
-        bundle_response = resource_pool.bundles(cached_files_fingerprints.to_json, uploaded_package_zip)
-        package = create_temp_file_with_content(bundle_response.body)
-        package_blobstore.cp_to_blobstore(package.path, blobstore_key)
-        {
-          sha1: Digester.new.digest_file(package),
-          sha256: Digester.new(algorithm: Digest::SHA256).digest_file(package),
-        }
+        CloudController::DependencyLocator.instance.package_blobstore.
+          cp_to_blobstore(uploaded_package_zip, blobstore_key, resources: cached_files_fingerprints)
       rescue => e
         raise CloudController::Errors::ApiError.new_from_details('BitsServiceError', e.message) if e.is_a?(BitsService::Errors::Error)
         raise
-      end
-
-      private
-
-      def create_temp_file_with_content(content)
-        package = Tempfile.new('package.zip')
-        package.binmode
-        package.write(content)
-        package.close
-        package
-      end
-
-      def resource_pool
-        CloudController::DependencyLocator.instance.bits_service_resource_pool
-      end
-
-      def package_blobstore
-        CloudController::DependencyLocator.instance.package_blobstore
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/packager/bits_service_packer_spec.rb
+++ b/spec/unit/lib/cloud_controller/packager/bits_service_packer_spec.rb
@@ -10,123 +10,37 @@ module CloudController::Packager
     let(:cached_files_fingerprints) { [{ 'sha1' => 'abcde', 'fn' => 'lib.rb' }] }
 
     let(:package_blobstore) { double(:package_blobstore) }
-    let(:receipt) { [{ 'sha1' => '12345', 'fn' => 'app.rb' }] }
-    let(:package_file) { Tempfile.new('package') }
-    let(:resource_pool) { double(BitsService::ResourcePool) }
 
     before do
-      allow_any_instance_of(CloudController::DependencyLocator).to receive(:bits_service_resource_pool).
-        and_return(resource_pool)
       allow_any_instance_of(CloudController::DependencyLocator).to receive(:package_blobstore).
         and_return(package_blobstore)
-      allow(resource_pool).to receive(:upload_entries).
-        and_return(double(:response, code: 201, body: receipt.to_json))
-      allow(resource_pool).to receive(:bundles).
-        and_return(double(:response, code: 200, body: 'contents'))
       allow(package_blobstore).to receive(:cp_to_blobstore)
-      allow(Tempfile).to receive(:new).and_return(package_file)
     end
 
     describe '#send_package_to_blobstore' do
-      it 'uses the resource_pool to upload the zip file and pass cached fingerprints' do
-        expect(resource_pool).to receive(:bundles).
-          with(cached_files_fingerprints.to_json, uploaded_files_path)
-        packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
-      end
-
       it 'uploads the package to the bits service' do
-        expect(package_blobstore).to receive(:cp_to_blobstore) do |package_path, guid|
-          expect(File.read(package_path)).to eq('contents')
-          expect(guid).to eq(blobstore_key)
-        end.and_return(double(Net::HTTPCreated))
+        expect(package_blobstore).to receive(:cp_to_blobstore).
+          with(uploaded_files_path, blobstore_key, resources: cached_files_fingerprints)
         packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
       end
 
       it 'returns the uploaded file hash' do
+        expect(package_blobstore).to receive(:cp_to_blobstore).
+          with(uploaded_files_path, blobstore_key, resources: cached_files_fingerprints).
+          and_return({ sha1: 'abc', sha256: 'def' })
         result_hash = packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
-        expect(result_hash).to eq({
-          sha1:   Digester.new.digest_file(package_file),
-          sha256: Digester.new(algorithm: Digest::SHA256).digest_file(package_file),
-        })
-      end
-
-      shared_examples 'a packaging failure' do
-        let(:expected_exception) { ::CloudController::Errors::ApiError }
-
-        it 'raises the exception' do
-          expect {
-            packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
-          }.to raise_error(expected_exception)
-        end
-      end
-
-      context 'when no new bits are being uploaded' do
-        let(:uploaded_files_path) { nil }
-
-        it 'does not upload new entries to the bits service' do
-          expect(resource_pool).to_not receive(:upload_entries)
-          packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
-        end
-
-        it 'downloads a bundle with the original fingerprints' do
-          expect(resource_pool).to receive(:bundles).with(cached_files_fingerprints.to_json, uploaded_files_path)
-          packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
-        end
-
-        it 'uploads the package to the bits service' do
-          expect(package_blobstore).to receive(:cp_to_blobstore) do |package_path, guid|
-            expect(File.read(package_path)).to eq('contents')
-            expect(guid).to eq(blobstore_key)
-          end
-          packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
-        end
-
-        it 'returns the correct package hash in the app' do
-          result_hash = packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
-          expect(result_hash).to eq({
-            sha1:   Digester.new.digest_file(package_file),
-            sha256: Digester.new(algorithm: Digest::SHA256).digest_file(package_file),
-          })
-        end
-      end
-
-      context 'when `bundles` fails' do
-        before do
-          allow(resource_pool).to receive(:bundles).
-            and_raise(BitsService::Errors::UnexpectedResponseCode)
-        end
-
-        it_behaves_like 'a packaging failure'
-      end
-
-      context 'when writing the package to a temp file fails' do
-        let(:expected_exception) { StandardError.new('some error') }
-
-        before do
-          allow(Tempfile).to receive(:new).
-            and_raise(expected_exception)
-        end
-
-        it_behaves_like 'a packaging failure'
+        expect(result_hash).to eq({ sha1: 'abc', sha256: 'def' })
       end
 
       context 'when uploading the package to the bits service fails' do
         let(:expected_exception) { StandardError.new('some error') }
 
-        before do
+        it 'raises the exception' do
           allow(package_blobstore).to receive(:cp_to_blobstore).and_raise(expected_exception)
+          expect {
+            packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
+          }.to raise_error(expected_exception)
         end
-
-        it_behaves_like 'a packaging failure'
-      end
-
-      context 'when the bits service has an internal error on bundles' do
-        before do
-          allow(resource_pool).to receive(:bundles).
-            and_raise(BitsService::Errors::UnexpectedResponseCode)
-        end
-
-        it_behaves_like 'a packaging failure'
       end
     end
   end


### PR DESCRIPTION
This is the same as https://github.com/cloudfoundry/cloud_controller_ng/pull/1184 (which was merged by @selzoc, but then reverted upon my request), but this time with [Bits-Service-Client **3.2.0**](https://github.com/cloudfoundry-incubator/bits-service-client/releases/tag/v3.2.0). This version of Bits-Service-Client fixes the issues with the previous version.

[#158942266]

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)
* [x] I have viewed, signed, and submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
