### PR TITLE
CC should continue polling last_operation on 410 from the broker in case of binding create

### DIFF
--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -167,7 +167,7 @@ module VCAP::Services::ServiceBrokers::V2
       path = service_binding_last_operation_path(service_binding)
       response = @http_client.get(path)
       parsed_response = @response_parser.parse_fetch_service_binding_last_operation(path, response)
-      last_operation_hash = parsed_response.delete('last_operation') || {}
+      last_operation_hash = parsed_response['last_operation'] || {}
 
       {}.tap do |result|
         result[:last_operation] = {}

--- a/spec/acceptance/async_bindings_spec.rb
+++ b/spec/acceptance/async_bindings_spec.rb
@@ -106,7 +106,7 @@ module VCAP::CloudController
         stub_async_binding_last_operation(body: {}, return_code: 410)
       end
 
-      it 'should continue polling' do
+      it 'should continue polling in a new background job' do
         async_bind_service(status: 202)
 
         expect(last_response).to have_status_code(202)

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController::BrokerApiHelper
         body: catalog.to_json)
   end
 
-  def default_catalog(plan_updateable: false, requires: [], plan_schemas: {})
+  def default_catalog(plan_updateable: false, requires: [], plan_schemas: {}, bindings_retrievable: false)
     {
       services: [
         {
@@ -39,6 +39,7 @@ module VCAP::CloudController::BrokerApiHelper
           bindable: true,
           requires: requires,
           plan_updateable: plan_updateable,
+          bindings_retrievable: bindings_retrievable,
           plans: [
             {
               id: 'plan1-guid-here',
@@ -193,11 +194,7 @@ module VCAP::CloudController::BrokerApiHelper
         body: fetch_body.to_json)
   end
 
-  def stub_async_binding_last_operation(state: 'succeeded', operation_data: nil, return_code: 200)
-    fetch_body = {
-      state: state
-    }
-
+  def stub_async_binding_last_operation(body: { state: 'succeeded' }, operation_data: nil, return_code: 200)
     url = "http://#{stubbed_broker_host}/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+/last_operation"
     if !operation_data.nil?
       url += "\\?operation=#{operation_data}"
@@ -208,7 +205,7 @@ module VCAP::CloudController::BrokerApiHelper
       with(basic_auth: [stubbed_broker_username, stubbed_broker_password]).
       to_return(
         status: return_code,
-        body: fetch_body.to_json)
+        body: body.to_json)
   end
 
   def provision_service(opts={})

--- a/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
@@ -435,6 +435,11 @@ module VCAP::CloudController
                 event = Event.find(type: 'audit.service_binding.delete')
                 expect(event).to be_nil
               end
+
+              it 'should enqueue another fetch job' do
+                expect(Delayed::Job.count).to eq 1
+                expect(Delayed::Job.first).to be_a_fully_wrapped_job_of(ServiceBindingStateFetch)
+              end
             end
 
             context 'when the last_operation state is failed' do


### PR DESCRIPTION
As per the OSBPAI spec

```
410 Gone	

Appropriate only for asynchronous delete operations. The Platform MUST consider this response a success and forget about the resource. The expected response body is {}. Returning this while the Platform is polling for create or update operations SHOULD be interpreted as an invalid response and the Platform SHOULD continue polling.
```

CC isn't compliant with that part of the spec and when the operation is create and the service broker returns 410 it stops polling.

The PR fixes this behaviour and aligns it with the spec.
For more details https://www.pivotaltracker.com/story/show/158939993

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

BR,
SAPI Team