### PR TITLE
Raise binding operation in progress error on service instance update

### DIFF
--- a/app/actions/services/locks/lock_check.rb
+++ b/app/actions/services/locks/lock_check.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
 
     def raise_if_binding_locked(service_binding)
       if service_binding.operation_in_progress?
-        raise CloudController::Errors::ApiError.new_from_details('AsyncServiceBindingOperationInProgress', service_binding.name)
+        raise CloudController::Errors::ApiError.new_from_details('AsyncServiceBindingOperationInProgress')
       end
     end
   end

--- a/app/actions/services/locks/updater_lock.rb
+++ b/app/actions/services/locks/updater_lock.rb
@@ -19,6 +19,10 @@ module VCAP::CloudController
 
         raise_if_instance_locked(service_instance)
 
+        service_instance.service_bindings.each do |binding|
+          raise_if_binding_locked(binding)
+        end
+
         service_instance.save_with_new_operation({}, { type: @type, state: 'in progress' })
         @needs_unlock = true
       end

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -391,7 +391,7 @@
 90008:
   name: AsyncServiceBindingOperationInProgress
   http_code: 409
-  message: "An operation for the service binding is in progress."
+  message: "A service binding operation is in progress."
 
 100001:
   name: AppInvalid


### PR DESCRIPTION
## Summary
If a CC client tries to update a service instance while a service binding operation is in progress, the CC now raises an error.

## Details
For now we raise a general error that does not include information about a particular binding. In v3 we can return multiple errors with more specific information about which binding has an operation in progress.

Prior to this change, the service broker could receive update requests while a binding operation was in progress. This change protects the broker from this scenario, which puts it in alignment with how CC is defensive for concurrent broker operations.

From a CC client's point of view, this could technically be viewed as a breaking change, but a very minimal one and it is easy to work around. The user just needs to wait for the service binding operation to complete before updating the service instance.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thanks,
The SAPI Team