### PR TITLE
Remove duplicate errors when deleting service instance bindings

### DIFF
--- a/spec/acceptance/async_bindings_spec.rb
+++ b/spec/acceptance/async_bindings_spec.rb
@@ -242,6 +242,42 @@ module VCAP::CloudController
           end
         end
       end
+
+      context 'when DELETE /v2/service_instances/:guid is called and when an async binding operation is in progress' do
+        let(:process) { ProcessModelFactory.make }
+        let(:service_binding) { ServiceBinding.make(app: process.app, service_instance: ManagedServiceInstance.make(space: process.space)) }
+        let!(:service_binding_operation) { ServiceBindingOperation.make(state: 'in progress', type: operation_type, service_binding_id: service_binding.id) }
+
+        context 'when the binding operation is create' do
+          let(:operation_type) { 'create' }
+
+          it 'returns an operation in progress error' do
+            delete("/v2/service_instances/#{service_binding.service_instance.guid}?accepts_incomplete=true&recursive=true", {}, admin_headers)
+            expect(last_response).to have_status_code(502)
+
+            expect(a_request(:delete, deprovision_url(service_binding.service_instance))).not_to have_been_made
+
+            parsed_response = JSON.parse(last_response.body)
+            expect(parsed_response['error_code']).to eq('CF-ServiceInstanceRecursiveDeleteFailed')
+            expect(parsed_response['description']).to match(/An operation for the service binding .* is in progress./)
+          end
+        end
+
+        context 'when the binding operation is delete' do
+          let(:operation_type) { 'delete' }
+
+          it 'returns an operation in progress error' do
+            delete("/v2/service_instances/#{service_binding.service_instance.guid}?accepts_incomplete=true&recursive=true", {}, admin_headers)
+            expect(last_response).to have_status_code(502)
+
+            expect(a_request(:delete, deprovision_url(service_binding.service_instance))).not_to have_been_made
+
+            parsed_response = JSON.parse(last_response.body)
+            expect(parsed_response['error_code']).to eq('CF-ServiceInstanceRecursiveDeleteFailed')
+            expect(parsed_response['description']).to match(/An operation for the service binding .* is in progress./)
+          end
+        end
+      end
     end
 
     context 'when the broker returns 410 on last_operation during binding creation' do


### PR DESCRIPTION
We use to propagate duplicate error massages for bindings that have
operation in progress. The duplication was caused from the fact that the
binding delete action was raising in case of operation in progress and
the instance delete action was relying also on the operation to
determine if the broker has responded asynchronously to the undbind
request.
We come up with a couple of approaches to solve this problem, however
we were not quite happy with none.
We decided to go with the approach to filter the duplicate errors
coming from the binding delete aciton since it results in the
most valuable end user massage and the least amount of components changed.

Best,
@williammartin and @nmaslarski, 
on behalf of SAPI team

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
