### PR TITLE
fixed YAMLConfig name spacing for Perm tests

### DIFF
--- a/spec/integration/v3_perm_spec.rb
+++ b/spec/integration/v3_perm_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Perm', type: :integration, skip: skip_perm_tests, perm: skip_per
 
       client = CloudFoundry::Perm::V1::Client.new(hostname: perm_hostname, port: perm_port, trusted_cas: ca_certs)
 
-      config = YAMLConfig.safe_load_file('config/cloud_controller.yml')
+      config = VCAP::CloudController::YAMLConfig.safe_load_file('config/cloud_controller.yml')
       config[:perm] = perm_config
       config_file = Tempfile.new('perm_config')
       config_file.write(config.to_json)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Fixed name spacing of a reference to a Ruby library so that Perm tests will run.

* An explanation of the use cases your change solves
The tests will otherwise not run because the library cannot be loaded.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [] I have run all the unit tests using `bundle exec rake`
The changed spec file passes.

* [] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
This spec file change should not impact CATs.
