### PR TITLE
Add OSBAPI supported version to /v2/info

### DIFF
--- a/app/controllers/runtime/info_controller.rb
+++ b/app/controllers/runtime/info_controller.rb
@@ -14,11 +14,12 @@ module VCAP::CloudController
         token_endpoint: config.get(:uaa, :url),
         min_cli_version: @config.get(:info, :min_cli_version),
         min_recommended_cli_version: @config.get(:info, :min_recommended_cli_version),
-        api_version: VCAP::CloudController::Constants::API_VERSION,
         app_ssh_endpoint: @config.get(:info, :app_ssh_endpoint),
         app_ssh_host_key_fingerprint: @config.get(:info, :app_ssh_host_key_fingerprint),
         app_ssh_oauth_client: @config.get(:info, :app_ssh_oauth_client),
         doppler_logging_endpoint: @config.get(:doppler, :url),
+        api_version: VCAP::CloudController::Constants::API_VERSION,
+        osbapi_version: VCAP::CloudController::Constants::OSBAPI_VERSION,
       }
 
       if @config.get(:bits_service, :enabled)

--- a/spec/unit/controllers/runtime/info_controller_spec.rb
+++ b/spec/unit/controllers/runtime/info_controller_spec.rb
@@ -27,10 +27,11 @@ module VCAP::CloudController
         expect(hash['description']).to eq(TestConfig.config[:info][:description])
         expect(hash['authorization_endpoint']).to eq(TestConfig.config[:login][:url])
         expect(hash['token_endpoint']).to eq(TestConfig.config[:uaa][:url])
-        expect(hash['api_version']).to eq(VCAP::CloudController::Constants::API_VERSION)
         expect(hash['app_ssh_endpoint']).to eq(TestConfig.config[:info][:app_ssh_endpoint])
         expect(hash['app_ssh_host_key_fingerprint']).to eq(TestConfig.config[:info][:app_ssh_host_key_fingerprint])
         expect(hash['app_ssh_oauth_client']).to eq(TestConfig.config[:info][:app_ssh_oauth_client])
+        expect(hash['api_version']).to eq(VCAP::CloudController::Constants::API_VERSION)
+        expect(hash['osbapi_version']).to eq(VCAP::CloudController::Constants::OSBAPI_VERSION)
       end
 
       it 'includes bits_endpoint when bits service is enabled' do


### PR DESCRIPTION
Tracker Story: https://www.pivotaltracker.com/story/show/160233225

SAPI Team


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
