### PR TITLE
Send accepts_incomplete=true if cleaning a binding or instance

### DIFF
--- a/app/actions/services/database_error_service_resource_cleanup.rb
+++ b/app/actions/services/database_error_service_resource_cleanup.rb
@@ -1,12 +1,12 @@
 module VCAP::CloudController
-  class SynchronousOrphanMitigate
+  class DatabaseErrorServiceResourceCleanup
     def initialize(logger)
       @logger = logger
     end
 
     def attempt_deprovision_instance(service_instance)
       @logger.info "Attempting synchronous orphan mitigation for service instance #{service_instance.guid}"
-      client(service_instance).deprovision(service_instance)
+      client(service_instance).deprovision(service_instance, accepts_incomplete: true)
       @logger.info "Success deprovisioning orphaned service instance #{service_instance.guid}"
     rescue => e
       @logger.error "Unable to deprovision orphaned service instance #{service_instance.guid}: #{e}"
@@ -24,7 +24,7 @@ module VCAP::CloudController
     def attempt_unbind(service_binding)
       @logger.info "Attempting synchronous orphan mitigation for service binding #{service_binding.guid}"
       service_instance = service_binding.service_instance
-      client(service_instance).unbind(service_binding)
+      client(service_instance).unbind(service_binding, nil, true)
       @logger.info "Success unbinding orphaned service binding #{service_binding.guid}"
     rescue => e
       @logger.error "Unable to delete orphaned service binding #{service_binding.guid}: #{e}"

--- a/app/actions/services/service_key_create.rb
+++ b/app/actions/services/service_key_create.rb
@@ -1,4 +1,4 @@
-require 'actions/services/synchronous_orphan_mitigate'
+require 'actions/services/database_error_service_resource_cleanup'
 require 'actions/services/locks/lock_check'
 
 module VCAP::CloudController
@@ -25,8 +25,8 @@ module VCAP::CloudController
           service_key.save
         rescue => e
           @logger.error "Failed to save state of create for service key #{service_key.guid} with exception: #{e}"
-          orphan_mitigator = SynchronousOrphanMitigate.new(@logger)
-          orphan_mitigator.attempt_delete_key(service_key)
+          service_resource_cleanup = DatabaseErrorServiceResourceCleanup.new(@logger)
+          service_resource_cleanup.attempt_delete_key(service_key)
           raise
         end
       rescue => e

--- a/spec/unit/actions/service_binding_create_spec.rb
+++ b/spec/unit/actions/service_binding_create_spec.rb
@@ -338,8 +338,8 @@ module VCAP::CloudController
               }.to raise_error('failed').and not_change(ServiceBinding, :count)
             end
 
-            it 'should trigger orphan mitigation' do
-              expect_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_unbind)
+            it 'should attempt to unbind without using the database' do
+              expect_any_instance_of(DatabaseErrorServiceResourceCleanup).to receive(:attempt_unbind)
 
               expect {
                 service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)
@@ -358,8 +358,8 @@ module VCAP::CloudController
               }.to raise_error(ServiceBindingCreate::ServiceBrokerInvalidBindingsRetrievable)
             end
 
-            it 'should trigger orphan mitigation' do
-              expect_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_unbind)
+            it 'should attempt to unbind without using the database' do
+              expect_any_instance_of(DatabaseErrorServiceResourceCleanup).to receive(:attempt_unbind)
 
               begin
                 service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)
@@ -385,7 +385,7 @@ module VCAP::CloudController
           end
 
           it 'raises an error' do
-            expect_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_unbind)
+            expect_any_instance_of(DatabaseErrorServiceResourceCleanup).to receive(:attempt_unbind)
 
             expect {
               service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)
@@ -422,7 +422,7 @@ module VCAP::CloudController
           end
 
           it 'immediately attempts to unbind the service instance' do
-            expect_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_unbind)
+            expect_any_instance_of(DatabaseErrorServiceResourceCleanup).to receive(:attempt_unbind)
 
             expect {
               service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)

--- a/spec/unit/actions/services/database_error_service_resource_cleanup_spec.rb
+++ b/spec/unit/actions/services/database_error_service_resource_cleanup_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-RSpec.describe 'Synchronous orphan mitigation' do
+RSpec.describe 'DatabaseErrorServiceResourceCleanup' do
   let(:logger) { double }
   let(:client) { instance_double(VCAP::Services::ServiceBrokers::V2::Client) }
-  subject { VCAP::CloudController::SynchronousOrphanMitigate.new(logger) }
+  subject { VCAP::CloudController::DatabaseErrorServiceResourceCleanup.new(logger) }
 
   before do
     allow(logger).to receive(:info)
@@ -25,7 +25,7 @@ RSpec.describe 'Synchronous orphan mitigation' do
     it 'attempts to deprovision the service instance' do
       subject.attempt_deprovision_instance(service_instance)
 
-      expect(client).to have_received(:deprovision).with(service_instance)
+      expect(client).to have_received(:deprovision).with(service_instance, accepts_incomplete: true)
     end
 
     it 'logs that it is attempting to orphan mitigate' do
@@ -70,7 +70,7 @@ RSpec.describe 'Synchronous orphan mitigation' do
     it 'attempts to unbind the binding' do
       subject.attempt_unbind(service_binding)
 
-      expect(client).to have_received(:unbind).with(service_binding)
+      expect(client).to have_received(:unbind).with(service_binding, nil, true)
     end
 
     it 'logs that it is attempting to orphan mitigate' do

--- a/spec/unit/actions/services/service_instance_create_spec.rb
+++ b/spec/unit/actions/services/service_instance_create_spec.rb
@@ -91,18 +91,18 @@ module VCAP::CloudController
       end
 
       context 'when the instance fails to save to the db' do
-        let(:mock_orphan_mitigator) { double(:mock_orphan_mitigator, attempt_deprovision_instance: nil) }
+        let(:mock_service_resource_cleanup) { double(:mock_service_resource_cleanup, attempt_deprovision_instance: nil) }
         before do
-          allow(SynchronousOrphanMitigate).to receive(:new).and_return(mock_orphan_mitigator)
+          allow(DatabaseErrorServiceResourceCleanup).to receive(:new).and_return(mock_service_resource_cleanup)
           allow_any_instance_of(ManagedServiceInstance).to receive(:save).and_raise
           allow(logger).to receive(:error)
         end
 
-        it 'attempts synchronous orphan mitigation' do
+        it 'attempts to deprovision the instance without using the database' do
           expect {
             create_action.create(request_attrs, false)
           }.to raise_error(RuntimeError)
-          expect(mock_orphan_mitigator).to have_received(:attempt_deprovision_instance)
+          expect(mock_service_resource_cleanup).to have_received(:attempt_deprovision_instance)
         end
 
         it 'logs that it was unable to save' do

--- a/spec/unit/actions/services/service_key_create_spec.rb
+++ b/spec/unit/actions/services/service_key_create_spec.rb
@@ -59,12 +59,12 @@ module VCAP::CloudController
         end
 
         it 'immediately attempts to unbind the service instance' do
-          expect_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_delete_key)
+          expect_any_instance_of(DatabaseErrorServiceResourceCleanup).to receive(:attempt_delete_key)
           subject.create(service_instance, key_attrs, {})
         end
 
         it 'logs that the unbind failed' do
-          allow_any_instance_of(SynchronousOrphanMitigate).to receive(:attempt_delete_key)
+          allow_any_instance_of(DatabaseErrorServiceResourceCleanup).to receive(:attempt_delete_key)
           subject.create(service_instance, key_attrs, {})
           expect(logger).to have_received(:error).with /Failed to save/
         end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::ServiceInstancesController, :services do
     let(:service_broker_url_regex) { %r{http://example.com/v2/service_instances/(.*)} }
-    let(:mock_orphan_mitigator) { double(:mock_orphan_mitigator, attempt_deprovision_instance: nil) }
     let(:logger) { double(:logger) }
 
     describe 'Query Parameters' do
@@ -542,7 +541,6 @@ module VCAP::CloudController
               stub_request(:put, service_broker_url_regex).
                 with(headers: { 'Accept' => 'application/json' }, basic_auth: basic_auth(service_broker: service_broker)).
                 to_return(status: 422, body: { error: 'AsyncRequired' }.to_json, headers: { 'Content-Type' => 'application/json' })
-              allow(SynchronousOrphanMitigate).to receive(:new).and_return(mock_orphan_mitigator)
               allow(logger).to receive(:error)
             end
 
@@ -759,7 +757,6 @@ module VCAP::CloudController
             )
           end
           let(:response_code) { 409 }
-          let(:mock_orphan_mitigator) { double(:mock_orphan_mitigator, attempt_deprovision_instance: nil) }
           let(:body) do
             {
               dashboard_url: 'http://example-dashboard.com/9189kdfsk0vfnku',
@@ -767,7 +764,6 @@ module VCAP::CloudController
           end
 
           before do
-            allow(SynchronousOrphanMitigate).to receive(:new).and_return(mock_orphan_mitigator)
             allow(logger).to receive(:error)
           end
 
@@ -969,7 +965,6 @@ module VCAP::CloudController
             end
 
             before do
-              allow(SynchronousOrphanMitigate).to receive(:new).and_return(mock_orphan_mitigator)
               allow(logger).to receive(:error)
             end
 
@@ -992,7 +987,6 @@ module VCAP::CloudController
               let(:delete_request_status) { 202 }
 
               before do
-                allow(SynchronousOrphanMitigate).to receive(:new).and_return(mock_orphan_mitigator)
                 allow(logger).to receive(:error)
               end
 


### PR DESCRIPTION
* If the operation to save the instance or binding to the database
failed for any reason, we now send `accepts_incomplete=true` when
issuing the request to the broker to clean up that resource. This allows
brokers who are async-only to delete resources that are orphaned because
of a DB connection problem.

* We also renamed `SynchronousOrphanMitigate` to
`DatabaseErrorServiceResourceCleanup` to add clarity around exactly when
this action should be used and separate it from "orphan mitigation" as
defined by the OSBAPI spec.

* We also removed unneeded mocks in the
service_instances_controller_spec.

Tracker Story: https://www.pivotaltracker.com/story/show/158818208

Thanks,
Services API

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
