### PR TITLE
As an admin, I can disable access to the marketplace using a feature flag

### DIFF
--- a/app/controllers/services/service_plans_controller.rb
+++ b/app/controllers/services/service_plans_controller.rb
@@ -20,6 +20,8 @@ module VCAP::CloudController
 
     def enumerate
       if SecurityContext.missing_token?
+        raise CloudController::Errors::NotAuthenticated if VCAP::CloudController::FeatureFlag.enabled?(:hide_marketplace_from_unauthenticated_users)
+
         single_filter = @opts[:q][0] if @opts[:q]
         service_guid = single_filter.split(':')[1] if single_filter && single_filter.start_with?('service_guid')
 

--- a/app/controllers/services/services_controller.rb
+++ b/app/controllers/services/services_controller.rb
@@ -28,6 +28,8 @@ module VCAP::CloudController
     allow_unauthenticated_access only: :enumerate
     def enumerate
       if SecurityContext.missing_token?
+        raise CloudController::Errors::NotAuthenticated if VCAP::CloudController::FeatureFlag.enabled?(:hide_marketplace_from_unauthenticated_users)
+
         @opts.delete(:inline_relations_depth)
       elsif SecurityContext.invalid_token?
         raise CloudController::Errors::InvalidAuthToken

--- a/app/models/runtime/feature_flag.rb
+++ b/app/models/runtime/feature_flag.rb
@@ -20,6 +20,7 @@ module VCAP::CloudController
       space_scoped_private_broker_creation: true,
       space_developer_env_var_visibility: true,
       service_instance_sharing: false,
+      hide_marketplace_from_unauthenticated_users: false,
     }.freeze
 
     ADMIN_SKIPPABLE = [

--- a/spec/api/documentation/feature_flags_api_spec.rb
+++ b/spec/api/documentation/feature_flags_api_spec.rb
@@ -19,7 +19,7 @@ RSpec.resource 'Feature Flags', type: [:api, :legacy_api] do
       client.get '/v2/config/feature_flags', {}, headers
 
       expect(status).to eq(200)
-      expect(parsed_response.length).to eq(14)
+      expect(parsed_response.length).to eq(15)
       expect(parsed_response).to include(
         {
           'name'          => 'user_org_creation',
@@ -117,6 +117,13 @@ RSpec.resource 'Feature Flags', type: [:api, :legacy_api] do
           'enabled'       => false,
           'error_message' => nil,
           'url'           => '/v2/config/feature_flags/service_instance_sharing'
+        })
+      expect(parsed_response).to include(
+        {
+          'name'          => 'hide_marketplace_from_unauthenticated_users',
+          'enabled'       => false,
+          'error_message' => nil,
+          'url'           => '/v2/config/feature_flags/hide_marketplace_from_unauthenticated_users'
         })
     end
   end

--- a/spec/unit/controllers/services/service_plans_controller_spec.rb
+++ b/spec/unit/controllers/services/service_plans_controller_spec.rb
@@ -162,7 +162,7 @@ module VCAP::CloudController
 
         get "/v2/service_plans/#{service_plan.guid}"
 
-        expect(last_response.status).to eq 200
+        expect(last_response).to have_status_code 200
 
         metadata = decoded_response.fetch('metadata')
         expect(metadata['guid']).to eq service_plan.guid
@@ -176,7 +176,7 @@ module VCAP::CloudController
 
         get "/v2/service_plans/#{service_plan.guid}"
 
-        expect(last_response.status).to eq 200
+        expect(last_response).to have_status_code 200
 
         schemas = decoded_response.fetch('entity')['schemas']
 
@@ -202,7 +202,7 @@ module VCAP::CloudController
 
           get "/v2/service_plans/#{service_plan.guid}"
 
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_status_code 200
 
           bindable = decoded_response.fetch('entity')['bindable']
           expect(bindable).to_not be_nil
@@ -219,7 +219,7 @@ module VCAP::CloudController
 
         it 'returns the plan' do
           get "/v2/service_plans/#{service_plan.guid}"
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_status_code 200
 
           metadata = decoded_response.fetch('metadata')
           expect(metadata['guid']).to eq service_plan.guid
@@ -233,7 +233,7 @@ module VCAP::CloudController
 
           it 'returns a 403' do
             get "/v2/service_plans/#{inactive_plan.guid}"
-            expect(last_response.status).to eq 403
+            expect(last_response).to have_status_code 403
           end
 
           context 'and the user has a service instance associated with that plan' do
@@ -255,7 +255,7 @@ module VCAP::CloudController
 
               set_current_user(user)
               get "/v2/service_plans/#{service_plan.guid}"
-              expect(last_response.status).to eq(200), "Expected response to be 200: #{last_response.body}"
+              expect(last_response).to have_status_code(200), "Expected response to be 200: #{last_response.body}"
 
               entity = decoded_response.fetch('entity')
               expect(entity['public']).to be_falsey
@@ -277,7 +277,7 @@ module VCAP::CloudController
 
               set_current_user(user)
               get "/v2/service_plans/#{service_plan.guid}"
-              expect(last_response.status).to eq 200
+              expect(last_response).to have_status_code 200
 
               expect(decoded_response.fetch('entity')['public']).to be_falsey
 
@@ -321,7 +321,7 @@ module VCAP::CloudController
 
             set_current_user(user)
             get '/v2/service_plans'
-            expect(last_response.status).to eq 200
+            expect(last_response).to have_status_code 200
 
             returned_plan_guids = decoded_response.fetch('resources').map do |res|
               res['metadata']['guid']
@@ -346,7 +346,7 @@ module VCAP::CloudController
 
             set_current_user(user)
             get '/v2/service_plans'
-            expect(last_response.status).to eq 200
+            expect(last_response).to have_status_code 200
 
             returned_plan_guids = decoded_response.fetch('resources').map do |res|
               res['metadata']['guid']
@@ -367,7 +367,7 @@ module VCAP::CloudController
 
         it 'displays all service plans' do
           get '/v2/service_plans'
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_status_code 200
 
           plans = ServicePlan.all
           expected_plan_guids = plans.map(&:guid)
@@ -389,7 +389,7 @@ module VCAP::CloudController
         it 'can query by service plan guid' do
           service = @services[:public][0].service
           get "/v2/service_plans?q=service_guid:#{service.guid}"
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_status_code 200
 
           expected_plan_guids = service.service_plans.map(&:guid)
           expected_service_guids = [service.guid]
@@ -410,7 +410,7 @@ module VCAP::CloudController
         it 'can query by service broker guid using ":"' do
           service = @services[:public][0].service
           get "/v2/service_plans?q=service_broker_guid:#{service.service_broker.guid}"
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_status_code 200
 
           expected_plan_guids = service.service_plans.map(&:guid)
           expected_service_guids = [service.guid]
@@ -431,7 +431,7 @@ module VCAP::CloudController
         it 'can query by service broker guid using "IN"' do
           service = @services[:public][0].service
           get "/v2/service_plans?q=service_broker_guid%20IN%20#{service.service_broker.guid}"
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_status_code 200
 
           expected_plan_guids = service.service_plans.map(&:guid)
           expected_service_guids = [service.guid]
@@ -478,7 +478,7 @@ module VCAP::CloudController
 
         it 'returns plans that are public and active' do
           get '/v2/service_plans'
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_status_code 200
 
           public_and_active_plans = ServicePlan.where(active: true, public: true).all
           expected_plan_guids = public_and_active_plans.map(&:guid)
@@ -520,7 +520,7 @@ module VCAP::CloudController
         it 'raises an InvalidAuthToken error' do
           set_current_user(developer, token: :invalid_token)
           get '/v2/service_plans'
-          expect(last_response.status).to eq 401
+          expect(last_response).to have_status_code 401
           expect(decoded_response.fetch('error_code')).to eq 'CF-InvalidAuthToken'
         end
 
@@ -532,7 +532,7 @@ module VCAP::CloudController
           it 'continues to raise an InvalidAuthToken error' do
             set_current_user(developer, token: :invalid_token)
             get '/v2/service_plans'
-            expect(last_response.status).to eq 401
+            expect(last_response).to have_status_code 401
             expect(decoded_response.fetch('error_code')).to eq 'CF-InvalidAuthToken'
           end
         end
@@ -548,7 +548,7 @@ module VCAP::CloudController
           set_current_user_as_admin
           put "/v2/service_plans/#{service_plan.guid}", payload
 
-          expect(last_response.status).to eq(201)
+          expect(last_response).to have_status_code(201)
           service_plan.reload
           expect(service_plan.name).to eq('old-name')
           expect(service_plan.public).to eq(false)
@@ -563,7 +563,7 @@ module VCAP::CloudController
         set_current_user_as_admin
         ManagedServiceInstance.make(service_plan: service_plan)
         delete "/v2/service_plans/#{service_plan.guid}?recursive=true"
-        expect(last_response.status).to eq(400)
+        expect(last_response).to have_status_code(400)
 
         expect(decoded_response.fetch('code')).to eq(10006)
         expect(decoded_response.fetch('description')).to eq('Please delete the service_instances associations for your service_plans.')

--- a/spec/unit/controllers/services/services_controller_spec.rb
+++ b/spec/unit/controllers/services/services_controller_spec.rb
@@ -122,12 +122,12 @@ module VCAP::CloudController
 
       it 'allows querying by service_guid' do
         get "/v2/services/#{service.guid}/service_plans?q=service_guid:#{service.guid}"
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_status_code(200)
       end
 
       it 'allows querying by service_instance_guid' do
         get "/v2/services/#{service.guid}/service_plans?q=service_instance_guid:some-guid"
-        expect(last_response.status).to eq(200)
+        expect(last_response).to have_status_code(200)
       end
     end
 
@@ -203,7 +203,7 @@ module VCAP::CloudController
 
       it 'returns plans visible to the user' do
         get '/v2/services'
-        expect(last_response.status).to eq 200
+        expect(last_response).to have_status_code 200
         expect(decoded_guids).to eq(visible_services.map(&:guid))
       end
 
@@ -216,7 +216,7 @@ module VCAP::CloudController
           space.add_developer(user)
 
           get '/v2/services'
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_status_code 200
 
           expect(decoded_guids).to include(service.guid)
         end
@@ -229,7 +229,7 @@ module VCAP::CloudController
 
         it 'a user can view public and active services' do
           get '/v2/services'
-          expect(last_response.status).to eq 200
+          expect(last_response).to have_status_code 200
         end
       end
 
@@ -239,7 +239,7 @@ module VCAP::CloudController
             set_current_user(User.make, token: :invalid_token)
             get '/v2/services'
 
-            expect(last_response.status).to eq 401
+            expect(last_response).to have_status_code 401
             expect(decoded_response.fetch('error_code')).to eq 'CF-InvalidAuthToken'
           end
         end
@@ -252,7 +252,7 @@ module VCAP::CloudController
             set_current_user(User.make, token: :invalid_token)
             get '/v2/services'
 
-            expect(last_response.status).to eq 401
+            expect(last_response).to have_status_code 401
             expect(decoded_response.fetch('error_code')).to eq 'CF-InvalidAuthToken'
           end
         end
@@ -264,7 +264,7 @@ module VCAP::CloudController
             set_current_user(nil)
             get '/v2/services'
 
-            expect(last_response.status).to eq 200
+            expect(last_response).to have_status_code 200
             expect(decoded_guids).to eq([public_and_active.guid])
           end
         end
@@ -277,7 +277,7 @@ module VCAP::CloudController
           it 'they cannot view public and active services' do
             set_current_user(nil)
             get '/v2/services'
-            expect(last_response.status).to eq 401
+            expect(last_response).to have_status_code 401
             expect(decoded_response.fetch('error_code')).to eq 'CF-NotAuthenticated'
           end
         end
@@ -319,7 +319,7 @@ module VCAP::CloudController
 
         it 'creates a service delete event' do
           delete "/v2/services/#{service.guid}?purge=true"
-          expect(last_response.status).to eq(204)
+          expect(last_response).to have_status_code(204)
 
           event = Event.order(:id).last
           expect(event.type).to eq('audit.service.delete')
@@ -342,11 +342,11 @@ module VCAP::CloudController
         it 'requires admin headers' do
           set_current_user(nil)
           delete "/v2/services/#{service.guid}"
-          expect(last_response.status).to eq 401
+          expect(last_response).to have_status_code 401
 
           set_current_user(User.make)
           delete "/v2/services/#{service.guid}"
-          expect(last_response.status).to eq 403
+          expect(last_response).to have_status_code 403
         end
 
         it 'deletes the service and its dependent models' do

--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -7,7 +7,8 @@ module VCAP::CloudController
        :app_scaling, :route_creation, :service_instance_creation,
        :diego_docker, :set_roles_by_username, :unset_roles_by_username,
        :task_creation, :env_var_visibility, :space_scoped_private_broker_creation,
-       :space_developer_env_var_visibility, :service_instance_sharing]
+       :space_developer_env_var_visibility, :service_instance_sharing,
+       :hide_marketplace_from_unauthenticated_users]
     end
     let(:feature_flag) { FeatureFlag.make }
 


### PR DESCRIPTION
Today, the `/v2/services` and `/v2/service_plans` endpoints are exposed to users who are not authenticated. We have heard feedback from users who don't want unauthenticated users to be able to view these endpoints. 

This change implements a feature flag (`hide_marketplace_from_unauthenticated_users`), which when enabled, makes these endpoints not visibile to users who are not authenticated. This feature flag is not enabled by default, meaning there is no behaviour change for existing users, unless they flip this flag. 

Associated story in SAPI teams backlog https://www.pivotaltracker.com/story/show/160093242

Thanks!

Alex + @jenspinney 


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
