### PR TITLE
Refactor broker client to always use keyword args

### DIFF
--- a/app/actions/service_binding_create.rb
+++ b/app/actions/service_binding_create.rb
@@ -68,7 +68,7 @@ module VCAP::CloudController
     private
 
     def request_binding_from_broker(client, service_binding, parameters, accepts_incomplete)
-      client.bind(service_binding, parameters, accepts_incomplete)
+      client.bind(service_binding, arbitrary_parameters: parameters, accepts_incomplete: accepts_incomplete)
     end
 
     def cleanup_binding_without_db(binding)

--- a/app/controllers/services/lifecycle/service_instance_binding_manager.rb
+++ b/app/controllers/services/lifecycle/service_instance_binding_manager.rb
@@ -82,7 +82,7 @@ module VCAP::CloudController
       service_instance = binding_obj.service_instance
       raise_if_instance_locked(service_instance)
       client = VCAP::Services::ServiceClientProvider.provide(instance: service_instance)
-      broker_response = client.bind(binding_obj, arbitrary_parameters)
+      broker_response = client.bind(binding_obj, arbitrary_parameters: arbitrary_parameters)
       broker_response[:binding]
     end
 

--- a/lib/services/service_brokers/user_provided/client.rb
+++ b/lib/services/service_brokers/user_provided/client.rb
@@ -2,7 +2,7 @@ module VCAP::Services
   class ServiceBrokers::UserProvided::Client
     def provision(_); end
 
-    def bind(binding, _arbitrary_parameters, _accepts_incomplete=nil)
+    def bind(binding, arbitrary_parameters: nil, accepts_incomplete: nil)
       if binding.class.name.demodulize == 'RouteBinding'
         {
           async: false,

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -110,7 +110,7 @@ module VCAP::Services::ServiceBrokers::V2
       raise e
     end
 
-    def bind(binding, arbitrary_parameters, accepts_incomplete=false)
+    def bind(binding, arbitrary_parameters: {}, accepts_incomplete: false)
       path              = service_binding_resource_path(binding.guid, binding.service_instance.guid, accepts_incomplete: accepts_incomplete)
       body              = {
         service_id:    binding.service.broker_provided_id,

--- a/spec/unit/actions/service_binding_create_spec.rb
+++ b/spec/unit/actions/service_binding_create_spec.rb
@@ -282,7 +282,7 @@ module VCAP::CloudController
         let(:accepts_incomplete) { true }
 
         it 'passes the accepts_incomplete parameter to the broker client' do
-          expect(client).to receive(:bind).with(instance_of(VCAP::CloudController::ServiceBinding), anything, true)
+          expect(client).to receive(:bind).with(instance_of(VCAP::CloudController::ServiceBinding), arbitrary_parameters: anything, accepts_incomplete: true)
           service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)
         end
 
@@ -375,7 +375,7 @@ module VCAP::CloudController
         let(:accepts_incomplete) { false }
 
         it 'passes the accepts_incomplete parameter to the broker client' do
-          expect(client).to receive(:bind).with(instance_of(VCAP::CloudController::ServiceBinding), anything, false)
+          expect(client).to receive(:bind).with(instance_of(VCAP::CloudController::ServiceBinding), arbitrary_parameters: anything, accepts_incomplete: false)
           service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)
         end
 

--- a/spec/unit/controllers/services/lifecycle/service_instance_binding_manager_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_instance_binding_manager_spec.rb
@@ -90,7 +90,7 @@ module VCAP::CloudController
 
         it 'tells the broker client to bind the route and the service instance' do
           expect_any_instance_of(VCAP::Services::ServiceBrokers::V2::Client).
-            to receive(:bind).with(anything, arbitrary_parameters).
+            to receive(:bind).with(anything, arbitrary_parameters: arbitrary_parameters).
             and_return({ async: false, binding: {} })
 
           manager.create_route_service_instance_binding(route.guid, service_instance.guid, arbitrary_parameters, route_services_enabled)

--- a/spec/unit/lib/services/service_brokers/user_provided/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/user_provided/client_spec.rb
@@ -14,7 +14,6 @@ module VCAP::Services
 
     describe '#bind' do
       let(:instance) { VCAP::CloudController::UserProvidedServiceInstance.make }
-      let(:unsupported_arbitrary_parameters) { {} }
 
       context 'when binding to an app' do
         let(:binding) do
@@ -22,7 +21,7 @@ module VCAP::Services
         end
 
         it 'sets relevant attributes of the instance' do
-          attributes = client.bind(binding, unsupported_arbitrary_parameters)
+          attributes = client.bind(binding)
           # save to the database to ensure attributes match tables
           binding.set(attributes[:binding])
           binding.save
@@ -34,7 +33,7 @@ module VCAP::Services
         context 'when binding to a service with a route_service_url' do
           let(:instance) { VCAP::CloudController::UserProvidedServiceInstance.make(:routing) }
           it 'sets relevant attributes of the instance' do
-            attributes = client.bind(binding, unsupported_arbitrary_parameters)
+            attributes = client.bind(binding)
             # save to the database to ensure attributes match tables
             binding.set(attributes[:binding])
             binding.save
@@ -55,7 +54,7 @@ module VCAP::Services
         end
 
         it 'sets relevant attributes of the instance' do
-          attributes = client.bind(binding, unsupported_arbitrary_parameters)
+          attributes = client.bind(binding)
           # save to the database to ensure attributes match tables
           binding.set(attributes[:binding])
           binding.save

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -957,14 +957,14 @@ module VCAP::Services::ServiceBrokers::V2
       end
 
       it 'makes a put request with correct path' do
-        client.bind(binding, arbitrary_parameters)
+        client.bind(binding)
 
         expect(http_client).to have_received(:put).
           with("/v2/service_instances/#{binding.service_instance.guid}/service_bindings/#{binding.guid}", anything)
       end
 
       it 'makes a put request with correct message' do
-        client.bind(binding, arbitrary_parameters)
+        client.bind(binding)
 
         expect(http_client).to have_received(:put).
           with(anything,
@@ -981,7 +981,7 @@ module VCAP::Services::ServiceBrokers::V2
       end
 
       it 'sets the credentials on the binding' do
-        attributes = client.bind(binding, arbitrary_parameters)
+        attributes = client.bind(binding)
         # ensure attributes return match ones for the database
         binding.set(attributes[:binding])
         binding.save
@@ -993,7 +993,7 @@ module VCAP::Services::ServiceBrokers::V2
       end
 
       it 'returns async false for synchronous creation' do
-        response = client.bind(binding, arbitrary_parameters)
+        response = client.bind(binding)
         expect(response[:async]).to eq(false)
       end
 
@@ -1001,7 +1001,7 @@ module VCAP::Services::ServiceBrokers::V2
         let(:arbitrary_parameters) { { 'name' => 'value' } }
 
         it 'make a put request with arbitrary parameters' do
-          client.bind(binding, arbitrary_parameters)
+          client.bind(binding, arbitrary_parameters: arbitrary_parameters)
           expect(http_client).to have_received(:put).
             with(anything,
               hash_including(
@@ -1016,7 +1016,7 @@ module VCAP::Services::ServiceBrokers::V2
           let(:accepts_incomplete) { true }
 
           it 'make a put request with accepts_incomplete true' do
-            client.bind(binding, arbitrary_parameters, accepts_incomplete)
+            client.bind(binding, accepts_incomplete: accepts_incomplete)
             expect(http_client).to have_received(:put).
               with(/accepts_incomplete=true/, anything)
           end
@@ -1025,7 +1025,7 @@ module VCAP::Services::ServiceBrokers::V2
             let(:code) { 202 }
 
             it 'returns async true' do
-              response = client.bind(binding, arbitrary_parameters, accepts_incomplete)
+              response = client.bind(binding, accepts_incomplete: accepts_incomplete)
               expect(response[:async]).to eq(true)
             end
 
@@ -1033,7 +1033,7 @@ module VCAP::Services::ServiceBrokers::V2
               let(:response_data) { { operation: '123' } }
 
               it 'returns the operation attribute' do
-                response = client.bind(binding, arbitrary_parameters, accepts_incomplete)
+                response = client.bind(binding, accepts_incomplete: accepts_incomplete)
                 expect(response[:operation]).to eq('123')
               end
             end
@@ -1044,7 +1044,7 @@ module VCAP::Services::ServiceBrokers::V2
           let(:accepts_incomplete) { false }
 
           it 'make a put request without the accepts_incomplete query parameter' do
-            client.bind(binding, arbitrary_parameters, accepts_incomplete)
+            client.bind(binding, accepts_incomplete: accepts_incomplete)
             expect(http_client).to have_received(:put).
               with(/^((?!accepts_incomplete).)*$/, anything)
           end
@@ -1055,7 +1055,7 @@ module VCAP::Services::ServiceBrokers::V2
         let(:binding) { VCAP::CloudController::RouteBinding.make }
 
         it 'does not send the app_guid in the request' do
-          client.bind(binding, arbitrary_parameters)
+          client.bind(binding)
 
           expect(http_client).to have_received(:put).
             with(anything,
@@ -1077,7 +1077,7 @@ module VCAP::Services::ServiceBrokers::V2
         end
 
         it 'sets the syslog_drain_url on the binding' do
-          attributes = client.bind(binding, arbitrary_parameters)
+          attributes = client.bind(binding)
           # ensure attributes return match ones for the database
           binding.set(attributes[:binding])
           binding.save
@@ -1092,7 +1092,7 @@ module VCAP::Services::ServiceBrokers::V2
 
           it 'raises an error and initiates orphan mitigation' do
             expect {
-              client.bind(binding, arbitrary_parameters)
+              client.bind(binding)
             }.to raise_error(Errors::ServiceBrokerInvalidSyslogDrainUrl)
 
             expect(orphan_mitigator).to have_received(:cleanup_failed_bind).with(client_attrs, binding)
@@ -1108,7 +1108,7 @@ module VCAP::Services::ServiceBrokers::V2
         end
 
         it 'does not set the syslog_drain_url on the binding' do
-          client.bind(binding, arbitrary_parameters)
+          client.bind(binding)
           expect(binding.syslog_drain_url).to_not be
         end
       end
@@ -1128,7 +1128,7 @@ module VCAP::Services::ServiceBrokers::V2
         end
 
         it 'stores the volume mount on the service binding' do
-          attributes = client.bind(binding, arbitrary_parameters)
+          attributes = client.bind(binding)
 
           binding.set(attributes[:binding])
           binding.save
@@ -1148,7 +1148,7 @@ module VCAP::Services::ServiceBrokers::V2
 
           it 'raises an error and initiates orphan mitigation' do
             expect {
-              client.bind(binding, arbitrary_parameters)
+              client.bind(binding)
             }.to raise_error(Errors::ServiceBrokerInvalidVolumeMounts)
 
             expect(orphan_mitigator).to have_received(:cleanup_failed_bind).with(client_attrs, binding)
@@ -1174,7 +1174,7 @@ module VCAP::Services::ServiceBrokers::V2
 
             it 'propagates the error and cleans up the failed binding' do
               expect {
-                client.bind(binding, arbitrary_parameters)
+                client.bind(binding)
               }.to raise_error(Errors::HttpClientTimeout)
 
               expect(orphan_mitigator).to have_received(:cleanup_failed_bind).
@@ -1196,7 +1196,7 @@ module VCAP::Services::ServiceBrokers::V2
 
             it 'propagates the error but does not clean up the binding' do
               expect {
-                client.bind(binding, arbitrary_parameters)
+                client.bind(binding)
               }.to raise_error(Errors::ServiceBrokerApiTimeout)
 
               expect(orphan_mitigator).not_to have_received(:cleanup_failed_bind)
@@ -1208,7 +1208,7 @@ module VCAP::Services::ServiceBrokers::V2
 
             it 'propagates the error and follows up with a deprovision request' do
               expect {
-                client.bind(binding, arbitrary_parameters)
+                client.bind(binding)
               }.to raise_error(Errors::ServiceBrokerBadResponse)
 
               expect(orphan_mitigator).to have_received(:cleanup_failed_bind).with(client_attrs, binding)
@@ -1325,7 +1325,7 @@ module VCAP::Services::ServiceBrokers::V2
             let(:code) { 202 }
 
             it 'returns async true' do
-              response = client.unbind(binding, arbitrary_parameters, accepts_incomplete)
+              response = client.unbind(binding)
               expect(response[:async]).to eq(true)
             end
 


### PR DESCRIPTION
This is a non-behavior changing refactor to make the method signatures in the v2 service broker client all consistently use keyword args instead of optional positional args.

Associated story: [#158455043](https://www.pivotaltracker.com/story/show/158455043)

Thanks,
SAPI team (Jen and @ablease)

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
