### PR TITLE
Remove magic number 90008 in code

### DIFF
--- a/app/actions/services/service_instance_delete.rb
+++ b/app/actions/services/service_instance_delete.rb
@@ -108,7 +108,9 @@ module VCAP::CloudController
       service_binding_deleter = ServiceBindingDelete.new(@event_repository.user_audit_info, @accepts_incomplete)
 
       errors, warnings = service_binding_deleter.delete(service_instance.service_bindings)
-      errors.reject! { |err| err.instance_of?(CloudController::Errors::ApiError) && err.code == 90008 }
+      errors.reject! do |err|
+        err.instance_of?(CloudController::Errors::ApiError) && err.name == 'AsyncServiceBindingOperationInProgress'
+      end
       bindings_in_progress(service_instance).each do |service_binding|
         errors << StandardError.new(
           "An operation for the service binding between app #{service_binding.app.name} and service instance #{service_binding.service_instance.name} is in progress."


### PR DESCRIPTION
This PR makes a non behaviour change refactor. 

We are now removing duplicate errors by referencing them by a human readable string, rather than a magic number. 

Thanks, Sapi team

Alex + @jenspinney 

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
