### PR TITLE
Allows service brokers to be registered more than once with different names

### DIFF
--- a/app/models/services/service.rb
+++ b/app/models/services/service.rb
@@ -73,12 +73,7 @@ module VCAP::CloudController
       validates_presence :description, message: 'is required'
       validates_presence :bindable, message: 'is required'
       validates_url :info_url, message: 'must be a valid url'
-      validates_unique :unique_id, message: Sequel.lit('Service ids must be unique')
       validates_max_length 2048, :tag_contents, message: Sequel.lit("Service tags for service #{label} must be 2048 characters or less.")
-
-      validates_unique :label, message: Sequel.lit('Service name must be unique') do |ds|
-        ds.exclude(service_broker_id: nil)
-      end
     end
 
     serialize_attributes :json, :tags, :requires

--- a/app/models/services/service_broker.rb
+++ b/app/models/services/service_broker.rb
@@ -20,7 +20,6 @@ module VCAP::CloudController
       validates_presence :auth_username
       validates_presence :auth_password
       validates_unique :name
-      validates_unique :broker_url
       validates_url :broker_url
       validates_url_no_basic_auth
     end

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -46,7 +46,6 @@ module VCAP::CloudController
       validates_presence :service,             message: 'is required'
       validates_presence :unique_id,           message: 'is required'
       validates_unique [:service_id, :name],   message: Sequel.lit("Plan names must be unique within a service. Service #{service.try(:label)} already has a plan named #{name}")
-      validates_unique :unique_id,             message: Sequel.lit('Plan ids must be unique')
       validate_private_broker_plan_not_public
     end
 

--- a/db/migrations/20180921102908_remove_uniqueness_on_index_broker_url_from_service_brokers.rb
+++ b/db/migrations/20180921102908_remove_uniqueness_on_index_broker_url_from_service_brokers.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  up do
+    alter_table :service_brokers do
+      drop_index :broker_url, name: :sb_broker_url_index
+      add_index :broker_url, name: :sb_broker_url_index, unique: false
+    end
+  end
+
+  down do
+    alter_table :service_brokers do
+      drop_index :broker_url, name: :sb_broker_url_index
+      add_index :broker_url, name: :sb_broker_url_index, unique: true
+    end
+  end
+end

--- a/db/migrations/20180924142348_remove_uniqueness_on_index_unique_id_from_services.rb
+++ b/db/migrations/20180924142348_remove_uniqueness_on_index_unique_id_from_services.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  up do
+    alter_table :services do
+      drop_index :unique_id
+      add_index :unique_id, name: :services_unique_id_index, unique: false
+    end
+  end
+
+  down do
+    alter_table :services do
+      drop_index :unique_id
+      add_index :unique_id, name: :services_unique_id_index, unique: true
+    end
+  end
+end

--- a/db/migrations/20180924142407_remove_uniqueness_on_index_unique_id_from_service_plans.rb
+++ b/db/migrations/20180924142407_remove_uniqueness_on_index_unique_id_from_service_plans.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  up do
+    alter_table :service_plans do
+      drop_index :unique_id
+      add_index :unique_id, name: :service_plans_unique_id_index, unique: false
+    end
+  end
+
+  down do
+    alter_table :service_plans do
+      drop_index :unique_id
+      add_index :unique_id, name: :service_plans_unique_id_index, unique: true
+    end
+  end
+end

--- a/db/migrations/20180925150440_remove_services_label_provider_index.rb
+++ b/db/migrations/20180925150440_remove_services_label_provider_index.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    if indexes(:services)[:services_label_provider_index]
+      alter_table :services do
+        drop_index :label, name: :services_label_provider_index
+      end
+    end
+  end
+
+  down do
+    # This migration cannot be rolled back
+  end
+end

--- a/lib/services/service_brokers/v2/catalog.rb
+++ b/lib/services/service_brokers/v2/catalog.rb
@@ -18,6 +18,7 @@ module VCAP::Services::ServiceBrokers::V2
     def valid?
       validate_services
       validate_all_service_ids_are_unique
+      validate_all_service_names_are_unique
       validate_all_service_dashboard_clients_are_unique
       errors.empty?
     end
@@ -43,6 +44,12 @@ module VCAP::Services::ServiceBrokers::V2
     def validate_all_service_ids_are_unique
       if has_duplicates?(services.map(&:broker_provided_id).compact)
         errors.add('Service ids must be unique')
+      end
+    end
+
+    def validate_all_service_names_are_unique
+      if has_duplicates?(services.map(&:name))
+        errors.add('Service names must be unique within a broker')
       end
     end
 

--- a/lib/services/service_brokers/v2/catalog_plan.rb
+++ b/lib/services/service_brokers/v2/catalog_plan.rb
@@ -26,10 +26,6 @@ module VCAP::Services::ServiceBrokers::V2
       end
     end
 
-    def cc_plan
-      cc_service.service_plans_dataset.where(unique_id: broker_provided_id).first
-    end
-
     def valid?
       return @valid if defined? @valid
       validate!

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -676,7 +676,7 @@ RSpec.describe 'Service Broker' do
       end
     end
 
-    context 'when a service brokera already exists with the same URL' do
+    context 'when a service broker already exists with the same URL' do
       before do
         stub_catalog_fetch(200, catalog_with_small_plan)
 

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -198,6 +198,22 @@ RSpec.describe 'Service Broker' do
                 redirect_uri: 'http://example.com/client-1'
               },
               plans: []
+            },
+            {
+              id: '888444',
+              name: 'service-4',
+              description: 'Yet another service, duh!',
+              bindable: true,
+              dashboard_client: {
+                id: 'client-9',
+                secret: 'some-secret',
+                redirect_uri: 'http://example.com/client-1'
+              },
+              plans: [{
+                id: '999',
+                name: 'micro',
+                description: 'The smallest plan in the world'
+              }]
             }
           ]
         })
@@ -216,6 +232,7 @@ RSpec.describe 'Service Broker' do
         expect(decoded_response['description']).to eql(
           "Service broker catalog is invalid: \n" \
           "Service ids must be unique\n" \
+          "Service names must be unique within a broker\n" \
           "Service dashboard_client id must be unique\n" \
           "Service service-1\n" \
           "  Service id must be a string, but has value 12345\n" \

--- a/spec/unit/controllers/services/service_brokers_controller_spec.rb
+++ b/spec/unit/controllers/services/service_brokers_controller_spec.rb
@@ -291,23 +291,6 @@ module VCAP::CloudController
           expect(last_response).to have_status_code(400)
         end
 
-        it 'returns a 400 if a another broker (private or public) exists with that url' do
-          stub_catalog
-
-          public_body = {
-            name:          'other-name',
-            broker_url:    broker_url,
-            auth_username: auth_username,
-            auth_password: auth_password,
-          }.to_json
-
-          post '/v2/service_brokers', public_body
-          expect(last_response).to have_status_code(201)
-
-          post '/v2/service_brokers', body
-          expect(last_response).to have_status_code(400)
-        end
-
         it 'returns a 404 if the space does not exist' do
           space.destroy
           stub_catalog
@@ -352,12 +335,11 @@ module VCAP::CloudController
             ServiceBroker.make(broker_url: body_hash[:broker_url])
           end
 
-          it 'returns an error' do
+          it 'creates the broker' do
             stub_catalog
             post '/v2/service_brokers', body
 
-            expect(last_response).to have_status_code(400)
-            expect(decoded_response.fetch('code')).to eq(270003)
+            expect(last_response).to have_status_code(201)
           end
         end
 
@@ -772,19 +754,6 @@ module VCAP::CloudController
               expect(last_response).to have_status_code(400)
               expect(decoded_response.fetch('code')).to eq(270011)
               expect(decoded_response.fetch('description')).to match(/is not a valid URL/)
-            end
-          end
-
-          context 'when the broker url is taken' do
-            let!(:another_broker) { ServiceBroker.make(broker_url: 'http://example.com') }
-            before { body_hash[:broker_url] = another_broker.broker_url }
-
-            it 'returns an error' do
-              put "/v2/service_brokers/#{broker.guid}", body
-
-              expect(last_response.status).to eq(400)
-              expect(decoded_response.fetch('code')).to eq(270003)
-              expect(decoded_response.fetch('description')).to match(/The service broker url is taken/)
             end
           end
 

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -460,10 +460,18 @@ module VCAP::Services::ServiceBrokers
             )
           end
 
-          it 'raises a database error' do
+          it 'creates the new plan' do
             expect {
               service_manager.sync_services_and_plans(catalog)
-            }.to raise_error Sequel::ValidationFailed
+            }.to change(VCAP::CloudController::ServicePlan, :count).by(1)
+
+            plan = VCAP::CloudController::ServicePlan.last
+            expect(plan.service).to eq(VCAP::CloudController::Service.last)
+            expect(plan.name).to eq(plan_name)
+            expect(plan.description).to eq(plan_description)
+
+            expect(plan.free).to be false
+            expect(plan.bindable).to be true
           end
         end
 

--- a/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
@@ -126,51 +126,5 @@ module VCAP::Services::ServiceBrokers::V2
         end
       end
     end
-
-    describe '#cc_plan' do
-      let(:service_broker) { VCAP::CloudController::ServiceBroker.make }
-      let(:cc_service) { VCAP::CloudController::Service.make(service_broker: service_broker) }
-      let(:plan_broker_provided_id) { SecureRandom.uuid }
-      let(:catalog_service) do
-        CatalogService.new(service_broker,
-          'id' => cc_service.broker_provided_id,
-          'name' => 'my-service-name',
-          'description' => 'my service description',
-          'bindable' => true,
-          'plans' => [{
-            'id' => plan_broker_provided_id,
-            'name' => 'my-plan-name',
-            'description' => 'my plan description'
-          }]
-        )
-      end
-      let(:catalog_plan) do
-        CatalogPlan.new(catalog_service,
-          'id' => plan_broker_provided_id,
-          'name' => 'my-plan-name',
-          'description' => 'my plan description',
-        )
-      end
-
-      context 'when a ServicePlan exists for the same Service with the same broker_provided_id' do
-        let!(:cc_plan) do
-          VCAP::CloudController::ServicePlan.make(service: cc_service, unique_id: plan_broker_provided_id)
-        end
-
-        it 'returns that ServicePlan' do
-          expect(catalog_plan.cc_plan).to eq(cc_plan)
-        end
-      end
-
-      context 'when a ServicePlan exists for a different Service with the same broker_provided_id' do
-        before do
-          VCAP::CloudController::ServicePlan.make(unique_id: plan_broker_provided_id)
-        end
-
-        it 'returns nil' do
-          expect(catalog_plan.cc_plan).to be_nil
-        end
-      end
-    end
   end
 end

--- a/spec/unit/lib/services/service_brokers/v2/catalog_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_spec.rb
@@ -80,6 +80,24 @@ module VCAP::Services::ServiceBrokers::V2
         end
       end
 
+      context 'when a service in the catalog has the same id as a service from a different broker' do
+        let(:catalog_hash) do
+          {
+            'services' => [build_service('id' => '1'), build_service('id' => '2')]
+          }
+        end
+        let(:broker) { VCAP::CloudController::ServiceBroker.make }
+        let(:another_broker) { VCAP::CloudController::ServiceBroker.make }
+
+        it 'is valid' do
+          existing_catalog = Catalog.new(another_broker, catalog_hash)
+          catalog = Catalog.new(broker, catalog_hash)
+
+          expect(catalog.valid?).to eq true
+          expect(existing_catalog.valid?).to eq true
+        end
+      end
+
       context 'when two services in the catalog have the same dashboard_client id' do
         let(:catalog_hash) do
           {

--- a/spec/unit/lib/services/service_brokers/v2/catalog_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_spec.rb
@@ -80,6 +80,23 @@ module VCAP::Services::ServiceBrokers::V2
         end
       end
 
+      context 'when two services in the catalog have the same name' do
+        let(:catalog_hash) do
+          {
+            'services' => [
+              build_service('id' => '1', 'name' => 'my-service'),
+              build_service('id' => '2', 'name' => 'my-service')
+            ]
+          }
+        end
+
+        it 'gives an error' do
+          catalog = Catalog.new(broker, catalog_hash)
+          expect(catalog.valid?).to eq false
+          expect(catalog.errors.messages).to include('Service names must be unique within a broker')
+        end
+      end
+
       context 'when a service in the catalog has the same id as a service from a different broker' do
         let(:catalog_hash) do
           {

--- a/spec/unit/models/services/service_broker_spec.rb
+++ b/spec/unit/models/services/service_broker_spec.rb
@@ -34,7 +34,6 @@ module VCAP::CloudController
       it { is_expected.to validate_presence :auth_username }
       it { is_expected.to validate_presence :auth_password }
       it { is_expected.to validate_uniqueness :name }
-      it { is_expected.to validate_uniqueness :broker_url }
 
       it 'validates the url is a valid http/https url' do
         expect(broker).to be_valid

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -17,17 +17,12 @@ module VCAP::CloudController
       it { is_expected.to validate_presence :service, message: 'is required' }
       it { is_expected.to strip_whitespace :name }
 
-      context 'when the unique_id is not unique' do
+      context 'when the unique_id is not unique across different services' do
         let(:existing_service_plan) { ServicePlan.make }
-        let(:service_plan) { ServicePlan.make_unsaved(unique_id: existing_service_plan.unique_id, service: Service.make) }
+        let(:service_plan) { ServicePlan.make(unique_id: existing_service_plan.unique_id, service: Service.make) }
 
-        it 'is not valid' do
-          expect(service_plan).not_to be_valid
-        end
-
-        it 'raises an error on save' do
-          expect { service_plan.save }.
-            to raise_error(Sequel::ValidationFailed, 'Plan ids must be unique')
+        it 'is valid' do
+          expect(service_plan).to be_valid
         end
       end
 

--- a/spec/unit/models/services/service_spec.rb
+++ b/spec/unit/models/services/service_spec.rb
@@ -13,8 +13,6 @@ module VCAP::CloudController
       it { is_expected.to validate_presence :label, message: 'Service name is required' }
       it { is_expected.to validate_presence :description, message: 'is required' }
       it { is_expected.to validate_presence :bindable, message: 'is required' }
-      it { is_expected.to validate_uniqueness :unique_id, message: 'Service ids must be unique' }
-      it { is_expected.to validate_uniqueness :label, message: 'Service name must be unique' }
       it { is_expected.to strip_whitespace :label }
 
       describe 'urls' do


### PR DESCRIPTION
This PR is the initial effort to solve the problem about multiple brokers registration within the same cf deployment. 
For more detailed description and a list of the considered solutions have  a look at the following [document](https://docs.google.com/document/d/1_OBnFCsL3ru43PEXocsCc3EuGaM0YLHjr0iAoXnakt4/edit#heading=h.wkjkf6foqxir ).

As part of the PR we :
- remove uniqueness constraints on DB indexes and models on services related fields.
- add validation that prevents registering a broker whose catalog contains multiple services with the same service name

Related stories [#159950844](https://www.pivotaltracker.com/story/show/159950844), [#159950846](https://www.pivotaltracker.com/story/show/159950846)


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

BR,
Luis and @georgi-lozev on behalf of SAPI Team
