### PR TITLE
Add service broker name + guid to ServiceUsageEvent

### DIFF
--- a/app/models/services/service_usage_event.rb
+++ b/app/models/services/service_usage_event.rb
@@ -5,6 +5,7 @@ module VCAP::CloudController
     export_attributes :state, :org_guid, :space_guid, :space_name,
                       :service_instance_guid, :service_instance_name, :service_instance_type,
                       :service_plan_guid, :service_plan_name,
-                      :service_guid, :service_label
+                      :service_guid, :service_label,
+                      :service_broker_name, :service_broker_guid
   end
 end

--- a/app/repositories/service_usage_event_repository.rb
+++ b/app/repositories/service_usage_event_repository.rb
@@ -24,11 +24,14 @@ module VCAP::CloudController
         if service_instance.type == 'managed_service_instance'
           service_plan = service_instance.service_plan
           service      = service_plan.service
+          broker       = service_instance.service_broker
           values       = values.merge({
-            service_plan_guid: service_plan.guid,
-            service_plan_name: service_plan.name,
-            service_guid:      service.guid,
-            service_label:     service.label
+            service_plan_guid:   service_plan.guid,
+            service_plan_name:   service_plan.name,
+            service_guid:        service.guid,
+            service_label:       service.label,
+            service_broker_name: broker.name,
+            service_broker_guid: broker.guid
           })
         end
 
@@ -67,6 +70,8 @@ module VCAP::CloudController
           service_plan_name:     :service_plans__name,
           service_guid:          :services__guid,
           service_label:         :services__label,
+          service_broker_name:   :service_brokers__name,
+          service_broker_guid:   :service_brokers__guid,
           created_at:            Sequel.datetime_class.now,
         }
 
@@ -76,6 +81,7 @@ module VCAP::CloudController
                       join(:organizations, id: :spaces__organization_id).
                       left_outer_join(:service_plans, id: :service_instances__service_plan_id).
                       left_outer_join(:services, id: :service_plans__service_id).
+                      left_outer_join(:service_brokers, id: :services__service_broker_id).
                       select(*column_map.values).
                       order(:service_instances__id)
 

--- a/db/migrations/20180927105539_add_broker_name_and_guid_to_service_usage_event.rb
+++ b/db/migrations/20180927105539_add_broker_name_and_guid_to_service_usage_event.rb
@@ -1,12 +1,13 @@
 Sequel.migration do
   change do
-    # As service broker name and guid are stored as 'String' (with no length
+    # As service broker name is stored as 'String' (with no length
     # limit specified) in the service_brokers table, we have to use the same
     # field type here.
+    # For the guid we have control, so we explicitly set a limit.
 
     # rubocop:disable Migration/IncludeStringSize
     add_column :service_usage_events, :service_broker_name, String, null: true
-    add_column :service_usage_events, :service_broker_guid, String, null: true
     # rubocop:enable Migration/IncludeStringSize
+    add_column :service_usage_events, :service_broker_guid, String, null: true, size: 255
   end
 end

--- a/db/migrations/20180927105539_add_broker_name_and_guid_to_service_usage_event.rb
+++ b/db/migrations/20180927105539_add_broker_name_and_guid_to_service_usage_event.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  change do
+    # As service broker name and guid are stored as 'String' (with no length
+    # limit specified) in the service_brokers table, we have to use the same
+    # field type here.
+
+    # rubocop:disable Migration/IncludeStringSize
+    add_column :service_usage_events, :service_broker_name, String, null: true
+    add_column :service_usage_events, :service_broker_guid, String, null: true
+    # rubocop:enable Migration/IncludeStringSize
+  end
+end

--- a/docs/v2/service_usage_events/list_service_usage_events.html
+++ b/docs/v2/service_usage_events/list_service_usage_events.html
@@ -508,6 +508,44 @@ after_guid: 0947a8ec-2b8b-42d6-98a4-8708f7f2ce9f</pre>
                 </ul>
               </td>
             </tr>
+            <tr class=" readonly">
+              <td class=" ">
+                <span class="name">service_broker_name</span>
+              </td>
+              <td>
+                <span class="description">The name of the service broker.</span>
+              </td>
+              <td>
+                <span class="default"></span>
+              </td>
+              <td>
+                <ul class="valid_values">
+                </ul>
+              </td>
+              <td>
+                <ul class="example_values">
+                </ul>
+              </td>
+            </tr>
+            <tr class=" readonly">
+              <td class=" ">
+                <span class="name">service_broker_guid</span>
+              </td>
+              <td>
+                <span class="description">The GUID of the service broker.</span>
+              </td>
+              <td>
+                <span class="default"></span>
+              </td>
+              <td>
+                <ul class="valid_values">
+                </ul>
+              </td>
+              <td>
+                <ul class="example_values">
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
 
@@ -553,7 +591,9 @@ Cookie: </pre>
         "service_plan_guid": "guid-e9d2d5a0-69a6-46ef-bac5-43f3ed177614",
         "service_plan_name": "name-1983",
         "service_guid": "guid-34916716-31d7-40c1-9afd-f312996c9654",
-        "service_label": "label-64"
+        "service_label": "label-64",
+        "service_broker_name": "name-2929",
+        "service_broker_guid": "guid-7cc11646-bf38-4f4e-b6e0-9581916a74d9"
       }
     }
   ]

--- a/docs/v2/service_usage_events/retrieve_a_particular_service_usage_event.html
+++ b/docs/v2/service_usage_events/retrieve_a_particular_service_usage_event.html
@@ -112,7 +112,9 @@ Cookie: </pre>
     "service_plan_guid": "guid-af7b1577-16fa-4ca3-a1ff-c90917382378",
     "service_plan_name": "name-1989",
     "service_guid": "guid-01954caf-cc7b-4242-b5f8-569cfedba078",
-    "service_label": "label-66"
+    "service_label": "label-66",
+    "service_broker_name": "name-2929",
+    "service_broker_guid": "guid-7cc11646-bf38-4f4e-b6e0-9581916a74d9"
   }
 }</pre>
 

--- a/spec/support/matchers/match_service_instance.rb
+++ b/spec/support/matchers/match_service_instance.rb
@@ -27,6 +27,7 @@ RSpec::Matchers.define :match_service_instance do |expected_service_instance|
   if expected_service_instance.type == 'managed_service_instance'
     service_plan = expected_service_instance.service_plan
     service = service_plan.service
+    broker = service.service_broker
     match do |actual_event|
       unless actual_event.service_plan_guid == service_plan.guid
         problems << "event.service_plan_guid: #{actual_event.service_plan_guid}, service_instance.service_plan.guid: #{service_plan.guid}"
@@ -39,6 +40,12 @@ RSpec::Matchers.define :match_service_instance do |expected_service_instance|
       end
       unless actual_event.service_label == service.label
         problems << "event.service_label: #{actual_event.service_label}, service_instance.service.label: #{service.label}"
+      end
+      unless actual_event.service_broker_name == broker.name
+        problems << "event.service_broker_name: #{actual_event.service_broker_name}, service_instance.service_broker.name: #{broker.name}"
+      end
+      unless actual_event.service_broker_guid == broker.guid
+        problems << "event.service_broker_guid: #{actual_event.service_broker_guid}, service_instance.service_broker.guid: #{broker.guid}"
       end
       problems.empty?
     end

--- a/spec/unit/models/services/service_usage_event_spec.rb
+++ b/spec/unit/models/services/service_usage_event_spec.rb
@@ -15,7 +15,8 @@ module VCAP::CloudController
 
     describe 'Serialization' do
       it { is_expected.to export_attributes :state, :org_guid, :space_guid, :space_name, :service_instance_guid, :service_instance_name,
-                                    :service_instance_type, :service_plan_guid, :service_plan_name, :service_guid, :service_label
+                                    :service_instance_type, :service_plan_guid, :service_plan_name, :service_guid, :service_label,
+                                    :service_broker_name, :service_broker_guid
       }
       it { is_expected.to import_attributes }
     end

--- a/spec/unit/repositories/service_usage_event_repository_spec.rb
+++ b/spec/unit/repositories/service_usage_event_repository_spec.rb
@@ -114,8 +114,8 @@ module VCAP::CloudController
             service_usage_event_count = ServiceUsageEvent.count
             created_event_count       = ServiceUsageEvent.where(state: ServiceUsageEventRepository::CREATED_EVENT_STATE).count
 
-            expect(service_instance_count).to eq(service_usage_event_count)
-            expect(service_usage_event_count).to eq(created_event_count)
+            expect(service_usage_event_count).to eq(service_instance_count)
+            expect(created_event_count).to eq(service_instance_count)
           end
 
           it 'reseeds events with the current time' do
@@ -137,8 +137,19 @@ module VCAP::CloudController
             managed_event_count       = ServiceUsageEvent.where(service_instance_type: 'managed_service_instance').count
             user_provided_event_count = ServiceUsageEvent.where(service_instance_type: 'user_provided_service_instance').count
 
-            expect(managed_instance_count).to eq(managed_event_count)
-            expect(user_provided_instance_count).to eq(user_provided_event_count)
+            expect(managed_event_count).to eq(managed_instance_count)
+            expect(user_provided_event_count).to eq(user_provided_instance_count)
+          end
+
+          it 'reseeds events with the correct fields' do
+            repository.purge_and_reseed_service_instances!
+
+            service_instance = ManagedServiceInstance.first
+            reseeded_event = ServiceUsageEvent.where(
+              service_instance_guid: service_instance.guid
+            ).first
+
+            expect(reseeded_event).to match_service_instance(service_instance)
           end
         end
       end


### PR DESCRIPTION
This PR adds `service_broker_name` and `service_broker_guid` fields to service usage events.

In the future, there will potentially be multiple services with the same name. We provide the broker name and guid to help operators disambiguate between identically-named services.

[#159951293]

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

cc @jenspinney 