### PR TITLE
Improve error messages for recursive instance delete

### DIFF
--- a/app/actions/service_binding_delete.rb
+++ b/app/actions/service_binding_delete.rb
@@ -70,7 +70,11 @@ module VCAP::CloudController
       client.unbind(service_binding, @user_audit_info.user_guid, @accepts_incomplete)
     rescue => e
       logger.error("Failed unbinding #{service_binding.guid}: #{e.message}")
-      raise e
+      raise_wrapped_error(service_binding, e)
+    end
+
+    def raise_wrapped_error(service_binding, err)
+      raise err.exception("Service broker failed to delete service binding for instance #{service_binding.service_instance.name}: #{err.message}")
     end
 
     def each_with_error_aggregation(list)

--- a/app/actions/service_binding_delete.rb
+++ b/app/actions/service_binding_delete.rb
@@ -74,7 +74,8 @@ module VCAP::CloudController
     end
 
     def raise_wrapped_error(service_binding, err)
-      raise err.exception("Service broker failed to delete service binding for instance #{service_binding.service_instance.name}: #{err.message}")
+      raise err.exception(
+        "An unbind operation for the service binding between app #{service_binding.app.name} and service instance #{service_binding.service_instance.name} failed: #{err.message}")
     end
 
     def each_with_error_aggregation(list)

--- a/app/actions/services/locks/lock_check.rb
+++ b/app/actions/services/locks/lock_check.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
 
     def raise_if_binding_locked(service_binding)
       if service_binding.operation_in_progress?
-        raise CloudController::Errors::ApiError.new_from_details('AsyncServiceBindingOperationInProgress')
+        raise CloudController::Errors::ApiError.new_from_details('AsyncServiceBindingOperationInProgress', service_binding.app.name, service_binding.service_instance.name)
       end
     end
   end

--- a/app/actions/services/service_key_delete.rb
+++ b/app/actions/services/service_key_delete.rb
@@ -20,13 +20,22 @@ module VCAP::CloudController
       begin
         raise_if_instance_locked(service_instance)
 
-        client.unbind(service_binding)
+        begin
+          client.unbind(service_binding)
+        rescue => e
+          raise_wrapped_error(service_binding, e)
+        end
+
         service_binding.destroy
       rescue => e
         errors << e
       end
 
       errors
+    end
+
+    def raise_wrapped_error(service_binding, err)
+      raise err.exception("Service broker failed to delete service binding for instance #{service_binding.service_instance.name}: #{err.message}")
     end
   end
 end

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -175,8 +175,6 @@ module VCAP::Services::ServiceBrokers::V2
         async: async_response?(response),
         operation: parsed_response['operation']
       }
-    rescue => e
-      raise e.exception("Service broker failed to delete service binding for instance #{service_binding&.service_instance&.name}: #{e.message}")
     end
 
     def fetch_service_binding_last_operation(service_binding)

--- a/spec/acceptance/async_bindings_spec.rb
+++ b/spec/acceptance/async_bindings_spec.rb
@@ -44,7 +44,7 @@ module VCAP::CloudController
           let(:target_app) { AppModel.make(space: target_space) }
           let!(:target_binding) { ServiceBinding.make(app: target_app, service_instance: service_instance) }
 
-          it 'can unbind if the service instance is deleted recursively and accepts_incomplete is true' do
+          it 'issues an unbind and fails the instance deletion if the service instance is deleted recursively and accepts_incomplete is true' do
             delete("/v2/service_instances/#{service_instance.guid}", 'recursive=true&accepts_incomplete=true', admin_headers)
 
             expect(a_request(:delete, unbind_url(target_binding)).with(query: { accepts_incomplete: true })).to have_been_made
@@ -56,7 +56,7 @@ module VCAP::CloudController
             expect(body['description']).to eq async_unbind_in_progress_error(service_instance.name, target_app.name)
           end
 
-          it 'can unbind if the service instance is deleted recursively and accepts_incomplete is not set' do
+          it 'fails to unbind if the service instance is deleted recursively and accepts_incomplete is not set' do
             delete("/v2/service_instances/#{service_instance.guid}", 'recursive=true', admin_headers)
 
             expect(a_request(:delete, unbind_url(target_binding))).to have_been_made
@@ -73,7 +73,7 @@ module VCAP::CloudController
             let(:source_app) { AppModel.make(space: source_space) }
             let!(:source_binding) { ServiceBinding.make(app: source_app, service_instance: service_instance) }
 
-            it 'can unbind if the service instance is deleted recursively and accepts_incomplete is true' do
+            it 'issues unbinds and fails the instance deletion if the service instance is deleted recursively and accepts_incomplete is true' do
               delete("/v2/service_instances/#{service_instance.guid}", 'recursive=true&accepts_incomplete=true', admin_headers)
 
               expect(last_response).to have_status_code(502)
@@ -87,7 +87,7 @@ module VCAP::CloudController
               expect(body['description']).to match multiple_async_unbind_in_progress_error(service_instance.name, source_app.name, target_app.name)
             end
 
-            it 'can unbind if the service instance is deleted recursively' do
+            it 'fails to unbind if the service instance is deleted recursively' do
               delete("/v2/service_instances/#{service_instance.guid}", 'recursive=true', admin_headers)
 
               expect(last_response).to have_status_code(502)

--- a/spec/unit/actions/service_binding_delete_spec.rb
+++ b/spec/unit/actions/service_binding_delete_spec.rb
@@ -74,10 +74,11 @@ module VCAP::CloudController
           allow(client).to receive(:unbind).and_raise(error)
         end
 
-        it 're-raises the same error' do
+        it 'decorates the error with app name and service instance name' do
           expect {
             service_binding_delete.foreground_delete_request(service_binding)
-          }.to raise_error(error)
+          }.to raise_error(
+            "An unbind operation for the service binding between app #{service_binding.app.name} and service instance #{service_binding.service_instance.name} failed: kablooey")
         end
       end
     end

--- a/spec/unit/actions/services/service_instance_delete_spec.rb
+++ b/spec/unit/actions/services/service_instance_delete_spec.rb
@@ -237,7 +237,8 @@ module VCAP::CloudController
             expect(msg).to match "^Deletion of service instance #{instance_name} failed because one or more associated resources could not be deleted\.\n\n"
             expect(msg).to match "\tAn operation for the service binding between app #{service_binding_1.app.name} and service instance #{instance_name} is in progress\."
             expect(msg).to match "\tAn operation for the service binding between app #{service_binding_2.app.name} and service instance #{instance_name} is in progress\."
-            expect(msg).not_to match 'A service binding operation is in progress.'
+
+            expect(msg.split("\t")).to have(3).items
           end
         end
 

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1158,6 +1158,18 @@ module VCAP::CloudController
             expect(ServiceBinding.find(guid: service_binding.guid)).not_to be_nil
           end
         end
+
+        context 'when the broker returns an error' do
+          before do
+            stub_unbind(service_binding, status: 500)
+          end
+
+          it 'is decorated with service instance information' do
+            delete "/v2/service_bindings/#{service_binding.guid}"
+
+            expect(decoded_response['description']).to include("Service broker failed to delete service binding for instance #{service_instance.name}")
+          end
+        end
       end
     end
 

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1167,7 +1167,8 @@ module VCAP::CloudController
           it 'is decorated with service instance information' do
             delete "/v2/service_bindings/#{service_binding.guid}"
 
-            expect(decoded_response['description']).to include("Service broker failed to delete service binding for instance #{service_instance.name}")
+            expect(decoded_response['description']).to(
+              include("An unbind operation for the service binding between app #{service_binding.app.name} and service instance #{service_binding.service_instance.name} failed"))
           end
         end
       end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3880,6 +3880,17 @@ module VCAP::CloudController
           service_binding_uri = service_binding_url(route_binding, query)
           expect(a_request(:delete, service_binding_uri)).to have_been_made
         end
+
+        context 'when the broker returns an error' do
+          before do
+            stub_unbind(route_binding, status: 500)
+          end
+
+          it 'is decorated with service instance information' do
+            delete "/v2/service_instances/#{service_instance.guid}/routes/#{route.guid}"
+            expect(decoded_response['description']).to include("Service broker failed to delete service binding for instance #{service_instance.name}")
+          end
+        end
       end
 
       context 'when the service_instance does not exist' do

--- a/spec/unit/controllers/services/service_keys_controller_spec.rb
+++ b/spec/unit/controllers/services/service_keys_controller_spec.rb
@@ -584,6 +584,15 @@ module VCAP::CloudController
         expect(decoded_response.fetch('description')).to eq("The service key could not be found: #{service_key_guid}")
       end
 
+      context 'when the broker returns an error' do
+        let(:unbind_status) { 500 }
+
+        it 'is decorated with service instance information' do
+          delete "/v2/service_keys/#{service_key.guid}"
+          expect(decoded_response['description']).to include("Service broker failed to delete service binding for instance #{instance.name}")
+        end
+      end
+
       context 'Not authorized to perform delete operation' do
         let(:manager) { make_manager_for_space(instance.space) }
         let(:auditor) { make_auditor_for_space(instance.space) }
@@ -645,6 +654,7 @@ module VCAP::CloudController
         expect(event.metadata).to include({ 'request' => {} })
       end
     end
+
     describe 'GET', '/v2/service_keys/:service_key_guid/parameters' do
       let(:space) { Space.make }
       let(:developer) { make_developer_for_space(space) }

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -1281,11 +1281,11 @@ module VCAP::Services::ServiceBrokers::V2
         end
         let(:response_body) { response_data.to_json }
 
-        it 'raises a ServiceBrokerBadResponse error with the instance name' do
+        it 're-raises the error ' do
           expect {
             client.unbind(binding)
           }.to raise_error(Errors::ServiceBrokerBadResponse).
-            with_message("Service broker failed to delete service binding for instance #{binding.service_instance.name}: Service broker error: Could not delete binding")
+            with_message('Service broker error: Could not delete binding')
         end
       end
 

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -391,7 +391,7 @@
 90008:
   name: AsyncServiceBindingOperationInProgress
   http_code: 409
-  message: "A service binding operation is in progress."
+  message: "An operation for the service binding between app %s and service instance %s is in progress."
 
 100001:
   name: AppInvalid


### PR DESCRIPTION
Prior to this PR when a client tries to delete a service instance by providing the `recursive=true` flag and there are multiple bindings that fail to delete, the aggregated error message looks like there are duplicate messages.

For example, this was the error message when a service instance called `s1` failed to be recursively deleted because two of its bindings couldn't be deleted from the broker (500 errors):
```
Deletion of service instance s1 failed because one or more associated resources could not be deleted.
  Service instance s1: Service broker error: Error mode enabled (servererror)
  Service instance s1: Service broker error: Error mode enabled (servererror)"
```

As part of this PR the error message is improved and now contains information about the binding between which particular app and service instance has caused the failure.
```
{
  "description": "Deletion of service instance s1 failed because one or more associated resources could not be deleted.\n\n\tAn unbind operation for the service binding between app a1 and service instance s1 failed: Service broker error: Error mode enabled (servererror)\n\n\tAn unbind operation for the service binding between app a2 and service instance s1 failed: Service broker error: Error mode enabled (servererror)",
  "error_code": "CF-ServiceInstanceRecursiveDeleteFailed",
  "code": 60028
}
```

For more details [#158655855](https://www.pivotaltracker.com/story/show/158655855).

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

BR,
@nmaslarski and Georgi on behalf of SAPI Team