### PR TITLE
Check for nil entries in bulk sync call

### DIFF
--- a/lib/cloud_controller/copilot/adapter.rb
+++ b/lib/cloud_controller/copilot/adapter.rb
@@ -54,9 +54,16 @@ module VCAP::CloudController
 
         def bulk_sync(routes:, route_mappings:, processes:)
           copilot_client.bulk_sync(
-            routes: routes.map { |r| { guid: r.guid, host: r.fqdn, path: r.path } },
-            route_mappings: route_mappings.map { |rm| { capi_process_guid: rm.process.guid, route_guid: rm.route.guid, route_weight: rm.weight } },
-            capi_diego_process_associations: processes.map do |process|
+            routes: routes.compact.map { |r| { guid: r.guid, host: r.fqdn, path: r.path } },
+            route_mappings: route_mappings.compact.map do |rm|
+              next if rm.process.nil? || rm.route.nil?
+              {
+                capi_process_guid: rm.process.guid,
+                route_guid: rm.route.guid,
+                route_weight: rm.weight
+              }
+            end.compact,
+            capi_diego_process_associations: processes.compact.map do |process|
               {
                   capi_process_guid: process.guid,
                   diego_process_guids: [Diego::ProcessGuid.from_process(process)]

--- a/lib/cloud_controller/copilot/adapter.rb
+++ b/lib/cloud_controller/copilot/adapter.rb
@@ -52,23 +52,11 @@ module VCAP::CloudController
           end
         end
 
-        def bulk_sync(routes:, route_mappings:, processes:)
+        def bulk_sync(routes:, route_mappings:, capi_diego_process_associations:)
           copilot_client.bulk_sync(
-            routes: routes.compact.map { |r| { guid: r.guid, host: r.fqdn, path: r.path } },
-            route_mappings: route_mappings.compact.map do |rm|
-              next if rm.process.nil? || rm.route.nil?
-              {
-                capi_process_guid: rm.process.guid,
-                route_guid: rm.route.guid,
-                route_weight: rm.weight
-              }
-            end.compact,
-            capi_diego_process_associations: processes.compact.map do |process|
-              {
-                  capi_process_guid: process.guid,
-                  diego_process_guids: [Diego::ProcessGuid.from_process(process)]
-              }
-            end
+            routes: routes,
+            route_mappings: route_mappings,
+            capi_diego_process_associations: capi_diego_process_associations,
           )
         rescue StandardError => e
           raise CopilotUnavailable.new(e.message)

--- a/lib/cloud_controller/copilot/sync.rb
+++ b/lib/cloud_controller/copilot/sync.rb
@@ -3,15 +3,29 @@ module VCAP::CloudController
     class Sync
       def self.sync
         logger = Steno.logger('cc.copilot.sync')
-
         logger.info('run-copilot-sync')
+
+        routes = Route.eager(:domain).all
+        route_mappings = RouteMappingModel.eager(:process).all
+        web_processes = ProcessModel.where(type: ProcessTypes::WEB).all
+
         Adapter.bulk_sync(
-          # please do not do Route.all, we need to only fetch Guid and fqdn,
-          # fqdn will require eager loading domains in the sql query
-          routes: Route.all,
-          route_mappings: RouteMappingModel.all,
-          processes: ProcessModel.where(type: ProcessTypes::WEB).all
+          routes: routes.map { |r| { guid: r.guid, host: r.fqdn, path: r.path } },
+          route_mappings: route_mappings.reject { |rm| rm.process.nil? }.map do |rm|
+            {
+              capi_process_guid: rm.process.guid,
+              route_guid: rm.route_guid,
+              route_weight: rm.weight
+            }
+          end,
+          capi_diego_process_associations: web_processes.map do |process|
+            {
+              capi_process_guid: process.guid,
+              diego_process_guids: [Diego::ProcessGuid.from_process(process)]
+            }
+          end
         )
+
         logger.info('finished-copilot-sync')
       end
     end

--- a/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
@@ -265,6 +265,30 @@ module VCAP::CloudController
         )
       end
 
+      context 'when a route, route_mapping, or capi_diego_process_association has nil entries' do
+        let(:nil_route) { nil }
+        let(:nil_process) { nil }
+        let(:bad_route_mapping) do
+          instance_double(
+            RouteMappingModel,
+            process: nil_process,
+            route: nil_route,
+            weight: 5
+          )
+        end
+        before do
+          adapter.bulk_sync(routes: [nil_route], route_mappings: [bad_route_mapping], processes: [nil_process])
+        end
+        it 'does not map or error on nil entries' do
+          expect(copilot_client).to have_received(:bulk_sync).with(
+            routes: [],
+            route_mappings: [],
+            capi_diego_process_associations: []
+          )
+        end
+      end
+
+
       context 'when copilot_client.bulk_sync returns an error' do
         before do
           allow(copilot_client).to receive(:bulk_sync).and_raise('uh oh')

--- a/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
@@ -235,59 +235,18 @@ module VCAP::CloudController
     end
 
     describe '#bulk_sync' do
-      let(:route_guid) { 'some-route-guid' }
-      let(:route) { instance_double(Route, guid: route_guid, fqdn: 'host.example.com', path: '/some/path') }
-      let(:capi_process_guid) { 'some-capi-process-guid' }
-      let(:process) { instance_double(ProcessModel, guid: capi_process_guid) }
-      let(:route_mapping) do
-        instance_double(
-          RouteMappingModel,
-          process: process,
-          route: route,
-          weight: 5
-        )
-      end
-      let(:diego_process_guid) { 'some-diego-process-guid' }
-
-      before do
-        allow(Diego::ProcessGuid).to receive(:from_process).with(process).and_return(diego_process_guid)
-      end
-
       it 'calls copilot_client.bulk_sync' do
-        adapter.bulk_sync(routes: [route], route_mappings: [route_mapping], processes: [process])
+        adapter.bulk_sync(routes: 'some-route',
+                          route_mappings: 'some-route-mapping',
+                          capi_diego_process_associations: 'kiwi',
+                         )
+
         expect(copilot_client).to have_received(:bulk_sync).with(
-          routes: [{ guid: 'some-route-guid', host: 'host.example.com', path: '/some/path' }],
-          route_mappings: [{ capi_process_guid: capi_process_guid, route_guid: route_guid, route_weight: 5 }],
-          capi_diego_process_associations: [{
-            capi_process_guid: capi_process_guid,
-            diego_process_guids: [diego_process_guid]
-          }]
+          routes: 'some-route',
+          route_mappings: 'some-route-mapping',
+          capi_diego_process_associations: 'kiwi',
         )
       end
-
-      context 'when a route, route_mapping, or capi_diego_process_association has nil entries' do
-        let(:nil_route) { nil }
-        let(:nil_process) { nil }
-        let(:bad_route_mapping) do
-          instance_double(
-            RouteMappingModel,
-            process: nil_process,
-            route: nil_route,
-            weight: 5
-          )
-        end
-        before do
-          adapter.bulk_sync(routes: [nil_route], route_mappings: [bad_route_mapping], processes: [nil_process])
-        end
-        it 'does not map or error on nil entries' do
-          expect(copilot_client).to have_received(:bulk_sync).with(
-            routes: [],
-            route_mappings: [],
-            capi_diego_process_associations: []
-          )
-        end
-      end
-
 
       context 'when copilot_client.bulk_sync returns an error' do
         before do
@@ -295,7 +254,7 @@ module VCAP::CloudController
         end
 
         it 'raises a CopilotUnavailable exception' do
-          expect { adapter.bulk_sync(routes: [route], route_mappings: [route_mapping], processes: [process]) }.to raise_error(Copilot::Adapter::CopilotUnavailable, 'uh oh')
+          expect { adapter.bulk_sync(routes: 'some-route', route_mappings: 'some-route-mapping', capi_diego_process_associations: 'kiwi') }.to raise_error(Copilot::Adapter::CopilotUnavailable, 'uh oh')
         end
       end
     end

--- a/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
@@ -254,7 +254,10 @@ module VCAP::CloudController
         end
 
         it 'raises a CopilotUnavailable exception' do
-          expect { adapter.bulk_sync(routes: 'some-route', route_mappings: 'some-route-mapping', capi_diego_process_associations: 'kiwi') }.to raise_error(Copilot::Adapter::CopilotUnavailable, 'uh oh')
+          expect { adapter.bulk_sync(routes: 'some-route',
+                                     route_mappings: 'some-route-mapping',
+                                     capi_diego_process_associations: 'kiwi')
+          }.to raise_error(Copilot::Adapter::CopilotUnavailable, 'uh oh')
         end
       end
     end

--- a/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
@@ -26,16 +26,16 @@ module VCAP::CloudController
             routes: [{
               guid: route.guid,
               host: route.fqdn,
-              path: route.path,
+              path: route.path
             }],
             route_mappings: [{
               capi_process_guid: web_process_model.guid,
               route_guid: route_mapping.route_guid,
-              route_weight: route_mapping.weight,
+              route_weight: route_mapping.weight
             }],
             capi_diego_process_associations: [{
               capi_process_guid: web_process_model.guid,
-              diego_process_guids: ['some-diego-process-guid'],
+              diego_process_guids: ['some-diego-process-guid']
             }]
           }
         )
@@ -53,16 +53,16 @@ module VCAP::CloudController
                 routes: [{
                   guid: route.guid,
                   host: route.fqdn,
-                  path: route.path,
+                  path: route.path
                 }],
                 route_mappings: [{
                   capi_process_guid: web_process_model.guid,
                   route_guid: route_mapping.route_guid,
-                  route_weight: route_mapping.weight,
+                  route_weight: route_mapping.weight
                 }],
                 capi_diego_process_associations: [{
                   capi_process_guid: web_process_model.guid,
-                  diego_process_guids: ['some-diego-process-guid'],
+                  diego_process_guids: ['some-diego-process-guid']
                 }]
               }
             )

--- a/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
@@ -5,25 +5,68 @@ require 'cloud_controller/copilot/sync'
 module VCAP::CloudController
   RSpec.describe Copilot::Sync do
     describe '#sync' do
-      let(:route) { Route.make(domain: domain, host: 'some-host', path: '/some/path') }
       let(:domain) { SharedDomain.make(name: 'example.org') }
-      let!(:route_mapping) { RouteMappingModel.make(route: route) }
-      let!(:web_process_model) { VCAP::CloudController::ProcessModel.make(type: 'web') }
-      let!(:worker_process_model) { VCAP::CloudController::ProcessModel.make(type: 'worker') }
+      let(:route) { Route.make(domain: domain, host: 'some-host', path: '/some/path') }
+
+      let(:app) { VCAP::CloudController::AppModel.make }
+      let!(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'web') }
+      let!(:web_process_model) { VCAP::CloudController::ProcessModel.make(type: 'web', app: app) }
+      let!(:worker_process_model) { VCAP::CloudController::ProcessModel.make(type: 'worker', app: app) }
 
       before do
         allow(Copilot::Adapter).to receive(:bulk_sync)
+        allow(Diego::ProcessGuid).to receive(:from_process).with(web_process_model).and_return('some-diego-process-guid')
       end
 
       it 'syncs routes, route_mappings, and web processes' do
         Copilot::Sync.sync
 
-        expect(Copilot::Adapter).to have_received(:bulk_sync) do |args|
-          expect(args[:routes].first.guid).to eq(route.guid)
-          expect(args[:routes].first.fqdn).to eq('some-host.example.org')
-          expect(args[:routes].first.path).to eq('/some/path')
-          expect(args[:route_mappings]).to eq([route_mapping])
-          expect(args[:processes]).to eq([web_process_model])
+        expect(Copilot::Adapter).to have_received(:bulk_sync).with(
+          {
+            routes: [{
+              guid: route.guid,
+              host: route.fqdn,
+              path: route.path,
+            }],
+            route_mappings: [{
+              capi_process_guid: web_process_model.guid,
+              route_guid: route_mapping.route_guid,
+              route_weight: route_mapping.weight,
+            }],
+            capi_diego_process_associations: [{
+              capi_process_guid: web_process_model.guid,
+              diego_process_guids: ['some-diego-process-guid'],
+            }]
+          }
+        )
+      end
+
+      context 'race conditions' do
+        context "when a route mapping's process has been deleted" do
+          let!(:bad_route_mapping) { RouteMappingModel.make(process: nil, route: route) }
+
+          it 'does not sync that route mapping' do
+            Copilot::Sync.sync
+
+            expect(Copilot::Adapter).to have_received(:bulk_sync).with(
+              {
+                routes: [{
+                  guid: route.guid,
+                  host: route.fqdn,
+                  path: route.path,
+                }],
+                route_mappings: [{
+                  capi_process_guid: web_process_model.guid,
+                  route_guid: route_mapping.route_guid,
+                  route_weight: route_mapping.weight,
+                }],
+                capi_diego_process_associations: [{
+                  capi_process_guid: web_process_model.guid,
+                  diego_process_guids: ['some-diego-process-guid'],
+                }]
+              }
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
[#160866520]

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
https://www.pivotaltracker.com/story/show/160866520
As noted in the above story, we observed a problem with route_syncer when a route was being deleted at the same time a bulk_sync was occurring. Basically, the bulk_sync would try to 'sync' a route that had already been deleted, causing some nil error.

To fix this, we added checks to remove any nil objects that were deleted before making the bulk_sync call on the copilot client.

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
