### PR TITLE
Fix service broker plan updates requiring strict ordering

### DIFF
--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -51,8 +51,9 @@ module VCAP::Services::ServiceBrokers
     end
 
     def update_or_create_plans(catalog)
-      existing_plans, new_plans = catalog.plans.partition do |plan|
-        VCAP::CloudController::ServicePlan.where(unique_id: plan.broker_provided_id).present?
+      existing_plans, new_plans = catalog.plans.partition do |catalog_plan|
+        VCAP::CloudController::ServicePlan.where(unique_id: catalog_plan.broker_provided_id,
+                                                 service: catalog_plan.catalog_service.cc_service).present?
       end
 
       existing_plans.each do |catalog_plan|

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -24,29 +24,28 @@ module VCAP::Services::ServiceBrokers
     private
 
     def update_or_create_services(catalog)
-      catalog.services.each do |catalog_service|
+      existing_services, new_services = catalog.services.partition do |service|
+        VCAP::CloudController::Service.where(
+          service_broker: service.service_broker,
+          unique_id: service.broker_provided_id
+        ).present?
+      end
+
+      existing_services.each do |catalog_service|
         cond = {
           service_broker: catalog_service.service_broker,
           unique_id:      catalog_service.broker_provided_id,
         }
-        obj = find_or_new_model(VCAP::CloudController::Service, cond)
+        service = VCAP::CloudController::Service.find(cond)
+        update_service_from_catalog(service, catalog_service)
+      end
 
-        obj.set(
-          label:       catalog_service.name,
-          description: catalog_service.description,
-          bindable:    catalog_service.bindable,
-          tags:        catalog_service.tags,
-          extra:       catalog_service.metadata ? catalog_service.metadata.to_json : nil,
-          active:      catalog_service.plans_present?,
-          requires:    catalog_service.requires,
-          plan_updateable: catalog_service.plan_updateable,
-          bindings_retrievable: catalog_service.bindings_retrievable,
-          instances_retrievable: catalog_service.instances_retrievable,
+      new_services.each do |catalog_service|
+        service = VCAP::CloudController::Service.new(
+          unique_id: catalog_service.broker_provided_id,
+          service_broker: catalog_service.service_broker,
         )
-
-        @services_event_repository.with_service_event(obj) do
-          obj.save(changed: true)
-        end
+        update_service_from_catalog(service, catalog_service)
       end
     end
 
@@ -74,6 +73,25 @@ module VCAP::Services::ServiceBrokers
         })
 
         update_plan_from_catalog(plan, catalog_plan)
+      end
+    end
+
+    def update_service_from_catalog(service, catalog_service)
+      service.set(
+        label:       catalog_service.name,
+        description: catalog_service.description,
+        bindable:    catalog_service.bindable,
+        tags:        catalog_service.tags,
+        extra:       catalog_service.metadata ? catalog_service.metadata.to_json : nil,
+        active:      catalog_service.plans_present?,
+        requires:    catalog_service.requires,
+        plan_updateable: catalog_service.plan_updateable,
+        bindings_retrievable: catalog_service.bindings_retrievable,
+        instances_retrievable: catalog_service.instances_retrievable,
+      )
+
+      @services_event_repository.with_service_event(service) do
+        service.save(changed: true)
       end
     end
 

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -1167,6 +1167,69 @@ RSpec.describe 'Service Broker' do
       end
     end
 
+    context 'when a service is re-named and another service is added to the front of the list with the old name' do
+      let(:catalog1) do
+        {
+          services:
+          [{
+            id:          'service-guid-here',
+            name:        'mysql',
+            description: 'A MySQL-compatible relational database',
+            bindable:    true,
+            plans:
+            [{
+              id:          'plan-guid-here',
+              name:        'small',
+              description: 'A small shared database with 100mb storage quota and 10 connections'
+            }]
+          }]
+        }
+      end
+
+      let(:catalog2) do
+        {
+          services:
+          [
+            {
+            id:          'new-service-guid-here',
+            name:        'mysql',
+            description: 'A MySQL-compatible relational database',
+            bindable:    true,
+            plans:
+            [{
+              id:          'new-plan-guid-here',
+              name:        'small',
+              description: 'A small shared database with 100mb storage quota and 10 connections'
+            }
+            ]
+          },
+            {
+            id:          'service-guid-here',
+            name:        'legacy-mysql',
+            description: 'A MySQL-compatible relational database',
+            bindable:    true,
+            plans:
+            [{
+              id:          'plan-guid-here',
+              name:        'small',
+              description: 'A small shared database with 100mb storage quota and 10 connections'
+            }
+            ]
+          },
+          ]
+        }
+      end
+
+      it 'renames the plan and adds a new plan with the old name' do
+        setup_broker(catalog1)
+        update_broker(catalog2)
+        expect(last_response).to have_status_code(200)
+
+        expect(VCAP::CloudController::Service.find(unique_id: 'service-guid-here')[:label]).to eq('legacy-mysql')
+        expect(VCAP::CloudController::Service.find(unique_id: 'new-service-guid-here')[:label]).to eq('mysql')
+      end
+    end
+
     context 'when a service plan disappears from the catalog' do
       before do
         setup_broker(catalog_with_two_plans)

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -502,6 +502,9 @@ module VCAP::Services::ServiceBrokers
             expect(plan.update_instance_schema).to be_nil
             expect(plan.create_binding_schema).to be_nil
 
+            expect(VCAP::CloudController::ServicePlan).to receive(:where).with(unique_id: plan_id, service: service).and_call_original
+            expect(VCAP::CloudController::ServicePlan).to receive(:find).with(unique_id: plan_id, service: service).and_call_original
+
             expect {
               service_manager.sync_services_and_plans(catalog)
             }.to_not change(VCAP::CloudController::ServicePlan, :count)


### PR DESCRIPTION
Includes work done for https://www.pivotaltracker.com/story/show/160603176 and https://www.pivotaltracker.com/story/show/160957250.

This fixes issues arising from service broker plan updates requiring the service broker catalog having the plans in a specific order.

cc @Samze 

---

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
