### PR TITLE
Rationalise orphan mitigation

### DIFF
--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -157,7 +157,10 @@ module VCAP::Services::ServiceBrokers::V2
            Errors::ServiceBrokerInvalidVolumeMounts,
            Errors::ServiceBrokerInvalidSyslogDrainUrl,
            Errors::ServiceBrokerResponseMalformed => e
-      @orphan_mitigator.cleanup_failed_bind(@attrs, binding)
+      unless e.class == Errors::ServiceBrokerResponseMalformed && e.status == 200
+        @orphan_mitigator.cleanup_failed_bind(@attrs, binding)
+      end
+
       raise e
     end
 

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -105,7 +105,8 @@ module VCAP::Services::ServiceBrokers::V2
       parsed_response = @response_parser.parse_bind(path, response, service_guid: key.service.guid)
 
       { credentials: parsed_response['credentials'] }
-    rescue Errors::ServiceBrokerBadResponse => e
+    rescue Errors::ServiceBrokerBadResponse,
+           Errors::ServiceBrokerResponseMalformed => e
       @orphan_mitigator.cleanup_failed_key(@attrs, key)
       raise e
     end
@@ -154,7 +155,8 @@ module VCAP::Services::ServiceBrokers::V2
       }
     rescue Errors::ServiceBrokerBadResponse,
            Errors::ServiceBrokerInvalidVolumeMounts,
-           Errors::ServiceBrokerInvalidSyslogDrainUrl => e
+           Errors::ServiceBrokerInvalidSyslogDrainUrl,
+           Errors::ServiceBrokerResponseMalformed => e
       @orphan_mitigator.cleanup_failed_bind(@attrs, binding)
       raise e
     end

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -944,6 +944,18 @@ module VCAP::Services::ServiceBrokers::V2
               expect(orphan_mitigator).not_to have_received(:cleanup_failed_key)
             end
           end
+
+          context 'ServiceBrokerResponseMalformed error' do
+            let(:error) { Errors::ServiceBrokerResponseMalformed.new(uri, :put, response, '') }
+
+            it 'propagates the error and follows up with a deprovision request' do
+              expect {
+                client.create_service_key(key)
+              }.to raise_error(Errors::ServiceBrokerResponseMalformed)
+
+              expect(orphan_mitigator).to have_received(:cleanup_failed_key)
+            end
+          end
         end
       end
     end
@@ -1247,6 +1259,18 @@ module VCAP::Services::ServiceBrokers::V2
               }.to raise_error(Errors::ConcurrencyError)
 
               expect(orphan_mitigator).not_to have_received(:cleanup_failed_bind)
+            end
+          end
+
+          context 'ServiceBrokerResponseMalformed error' do
+            let(:error) { Errors::ServiceBrokerResponseMalformed.new(uri, :put, response, '') }
+
+            it 'propagates the error and follows up with a deprovision request' do
+              expect {
+                client.bind(binding)
+              }.to raise_error(Errors::ServiceBrokerResponseMalformed)
+
+              expect(orphan_mitigator).to have_received(:cleanup_failed_bind)
             end
           end
         end

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -1272,6 +1272,18 @@ module VCAP::Services::ServiceBrokers::V2
 
               expect(orphan_mitigator).to have_received(:cleanup_failed_bind)
             end
+
+            context 'when the status code was a 200' do
+              let(:response) { HttpResponse.new(code: 200, body: nil, message: nil) }
+
+              it 'does not initiate orphan mitigation' do
+                expect {
+                  client.bind(binding)
+                }.to raise_error(Errors::ServiceBrokerResponseMalformed)
+
+                expect(orphan_mitigator).not_to have_received(:cleanup_failed_bind).with(client_attrs, binding)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
This PR brings the Cloud Controller into alignment with the OSB API section on orphan mitigation.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
