### PR TITLE
Bundle install before running check_docs_links

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ task :check_doc_links do
   puts Rainbow('Checking links in all docs...').green
   Bundler.with_clean_env do
     Dir.chdir('docs/v3') do
-      status = system('npm install && npm run checkdocs')
+      status = system('bundle install && npm install && npm run checkdocs')
       exit $CHILD_STATUS.exitstatus if !status
       puts Rainbow('check_doc_links OK').green
     end


### PR DESCRIPTION
This command otherwise fails if you don't already have the docs gem dependencies installed.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
