### PR TITLE
add batching to Copilot::Sync

### DIFF
--- a/lib/cloud_controller/copilot/sync.rb
+++ b/lib/cloud_controller/copilot/sync.rb
@@ -1,13 +1,15 @@
 module VCAP::CloudController
   module Copilot
     class Sync
+      BATCH_SIZE = 500
+
       def self.sync
         logger = Steno.logger('cc.copilot.sync')
         logger.info('run-copilot-sync')
 
-        routes = Route.eager(:domain).all
-        route_mappings = RouteMappingModel.eager(:process).all
-        web_processes = ProcessModel.where(type: ProcessTypes::WEB).all
+        routes = batch(route_batch_query)
+        route_mappings = batch(route_mappings_batch_query)
+        web_processes = batch(processes_batch_query)
 
         Adapter.bulk_sync(
           routes: routes.map { |r| { guid: r.guid, host: r.fqdn, path: r.path } },
@@ -27,6 +29,56 @@ module VCAP::CloudController
         )
 
         logger.info('finished-copilot-sync')
+      end
+
+      def self.batch(query)
+        last_id = 0
+
+        resources = []
+        loop do
+          batch = query.call(last_id).all
+
+          resources.concat(batch)
+
+          return resources if batch.count < BATCH_SIZE
+          last_id = resources.last.id
+        end
+      end
+
+      def self.route_batch_query
+        proc { |last_id|
+          routes = Route.
+                   where(Sequel.lit("#{Route.table_name}.id > ?", last_id)).
+                   order("#{Route.table_name}__id".to_sym).
+                   eager(:domain).
+                   limit(BATCH_SIZE)
+
+          routes.select_all(Route.table_name)
+        }
+      end
+
+      def self.route_mappings_batch_query
+        proc { |last_id|
+          route_mappings = RouteMappingModel.
+                           where(Sequel.lit("#{RouteMappingModel.table_name}.id > ?", last_id)).
+                           order("#{RouteMappingModel.table_name}__id".to_sym).
+                           eager(:process).
+                           limit(BATCH_SIZE)
+
+          route_mappings.select_all(RouteMappingModel.table_name)
+        }
+      end
+
+      def self.processes_batch_query
+        proc { |last_id|
+          processes = ProcessModel.
+                      where(Sequel.lit("#{ProcessModel.table_name}.id > ?", last_id)).
+                      where(type: ProcessTypes::WEB).
+                      order("#{ProcessModel.table_name}__id".to_sym).
+                      limit(BATCH_SIZE)
+
+          processes.select_all(ProcessModel.table_name)
+        }
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
@@ -5,67 +5,122 @@ require 'cloud_controller/copilot/sync'
 module VCAP::CloudController
   RSpec.describe Copilot::Sync do
     describe '#sync' do
-      let(:domain) { SharedDomain.make(name: 'example.org') }
-      let(:route) { Route.make(domain: domain, host: 'some-host', path: '/some/path') }
-
-      let(:app) { VCAP::CloudController::AppModel.make }
-      let!(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'web') }
-      let!(:web_process_model) { VCAP::CloudController::ProcessModel.make(type: 'web', app: app) }
-      let!(:worker_process_model) { VCAP::CloudController::ProcessModel.make(type: 'worker', app: app) }
-
       before do
         allow(Copilot::Adapter).to receive(:bulk_sync)
-        allow(Diego::ProcessGuid).to receive(:from_process).with(web_process_model).and_return('some-diego-process-guid')
       end
 
-      it 'syncs routes, route_mappings, and web processes' do
-        Copilot::Sync.sync
+      context 'syncing' do
+        let(:domain) { SharedDomain.make(name: 'example.org') }
+        let(:route) { Route.make(domain: domain, host: 'some-host', path: '/some/path') }
+        let(:app) { VCAP::CloudController::AppModel.make }
+        let!(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'web') }
+        let!(:web_process_model) { VCAP::CloudController::ProcessModel.make(type: 'web', app: app) }
+        let!(:worker_process_model) { VCAP::CloudController::ProcessModel.make(type: 'worker', app: app) }
 
-        expect(Copilot::Adapter).to have_received(:bulk_sync).with(
-          {
-            routes: [{
-              guid: route.guid,
-              host: route.fqdn,
-              path: route.path
-            }],
-            route_mappings: [{
-              capi_process_guid: web_process_model.guid,
-              route_guid: route_mapping.route_guid,
-              route_weight: route_mapping.weight
-            }],
-            capi_diego_process_associations: [{
-              capi_process_guid: web_process_model.guid,
-              diego_process_guids: ['some-diego-process-guid']
-            }]
-          }
-        )
+        before do
+          allow(Diego::ProcessGuid).to receive(:from_process).with(web_process_model).and_return('some-diego-process-guid')
+        end
+
+        it 'sends routes, route_mappings and CDPAs over to the adapter' do
+          Copilot::Sync.sync
+
+          expect(Copilot::Adapter).to have_received(:bulk_sync).with(
+            {
+              routes: [{
+                guid: route.guid,
+                host: route.fqdn,
+                path: route.path
+              }],
+              route_mappings: [{
+                capi_process_guid: web_process_model.guid,
+                route_guid: route_mapping.route_guid,
+                route_weight: route_mapping.weight
+              }],
+              capi_diego_process_associations: [{
+                capi_process_guid: web_process_model.guid,
+                diego_process_guids: ['some-diego-process-guid']
+              }]
+            }
+          )
+        end
+
+        context 'race conditions' do
+          context "when a route mapping's process has been deleted" do
+            let!(:bad_route_mapping) { RouteMappingModel.make(process: nil, route: route) }
+
+            it 'does not sync that route mapping' do
+              Copilot::Sync.sync
+
+              expect(Copilot::Adapter).to have_received(:bulk_sync).with(
+                {
+                  routes: [{
+                    guid: route.guid,
+                    host: route.fqdn,
+                    path: route.path
+                  }],
+                  route_mappings: [{
+                    capi_process_guid: web_process_model.guid,
+                    route_guid: route_mapping.route_guid,
+                    route_weight: route_mapping.weight
+                  }],
+                  capi_diego_process_associations: [{
+                    capi_process_guid: web_process_model.guid,
+                    diego_process_guids: ['some-diego-process-guid']
+                  }]
+                }
+              )
+            end
+          end
+        end
       end
 
-      context 'race conditions' do
-        context "when a route mapping's process has been deleted" do
-          let!(:bad_route_mapping) { RouteMappingModel.make(process: nil, route: route) }
+      context 'batching' do
+        before do
+          stub_const('VCAP::CloudController::Copilot::Sync::BATCH_SIZE', 1)
+          allow(Diego::ProcessGuid).to receive(:from_process).with(web_process_model_1).and_return('some-diego-process-guid-1')
+          allow(Diego::ProcessGuid).to receive(:from_process).with(web_process_model_2).and_return('some-diego-process-guid-2')
+        end
 
-          it 'does not sync that route mapping' do
-            Copilot::Sync.sync
+        let(:domain) { SharedDomain.make(name: 'example.org') }
+        let(:route_1) { Route.make(domain: domain, host: 'some-host', path: '/some/path') }
+        let(:route_2) { Route.make(domain: domain, host: 'some-other-host', path: '/some/other/path') }
+        let(:app_1) { VCAP::CloudController::AppModel.make }
+        let(:app_2) { VCAP::CloudController::AppModel.make }
+        let!(:route_mapping_1) { RouteMappingModel.make(route: route_1, app: app_1, process_type: 'web') }
+        let!(:route_mapping_2) { RouteMappingModel.make(route: route_2, app: app_2, process_type: 'web') }
+        let!(:web_process_model_1) { VCAP::CloudController::ProcessModel.make(type: 'web', app: app_1) }
+        let!(:web_process_model_2) { VCAP::CloudController::ProcessModel.make(type: 'web', app: app_2) }
 
-            expect(Copilot::Adapter).to have_received(:bulk_sync).with(
+        it 'syncs all of the resources in one go after querying the DB in batches' do
+          Copilot::Sync.sync
+
+          expect(Copilot::Adapter).to have_received(:bulk_sync) do |args|
+            expect(args[:routes]).to match_array([
+              { guid: route_1.guid, host: route_1.fqdn, path: route_1.path },
+              { guid: route_2.guid, host: route_2.fqdn, path: route_2.path }
+            ])
+            expect(args[:route_mappings]).to match_array([
               {
-                routes: [{
-                  guid: route.guid,
-                  host: route.fqdn,
-                  path: route.path
-                }],
-                route_mappings: [{
-                  capi_process_guid: web_process_model.guid,
-                  route_guid: route_mapping.route_guid,
-                  route_weight: route_mapping.weight
-                }],
-                capi_diego_process_associations: [{
-                  capi_process_guid: web_process_model.guid,
-                  diego_process_guids: ['some-diego-process-guid']
-                }]
+                capi_process_guid: web_process_model_1.guid,
+                route_guid: route_mapping_1.route_guid,
+                route_weight: route_mapping_1.weight
+              },
+              {
+                capi_process_guid: web_process_model_2.guid,
+                route_guid: route_mapping_2.route_guid,
+                route_weight: route_mapping_2.weight
               }
-            )
+            ])
+            expect(args[:capi_diego_process_associations]).to match_array([
+              {
+                capi_process_guid: web_process_model_1.guid,
+                diego_process_guids: ['some-diego-process-guid-1']
+              },
+              {
+                capi_process_guid: web_process_model_2.guid,
+                diego_process_guids: ['some-diego-process-guid-2']
+              }
+            ])
           end
         end
       end


### PR DESCRIPTION
* A short explanation of the proposed change:

  Add batching to Copilot::Sync per our discussion with @tcdowney and @cwlbraa 

  * Copilot::Sync only batches queries to the database.
  * It does not send batched resources to Copilot. Sending batched resources will be a bigger change and will be considered in the future.

[#161293119]

* An explanation of the use cases your change solves

  When there are hella routes, route mappings and processes, database queries should be less expensive

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/1227

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
