### PR TITLE
Service instance purger should record a purge audit event

### DIFF
--- a/app/controllers/services/lifecycle/service_instance_purger.rb
+++ b/app/controllers/services/lifecycle/service_instance_purger.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController
         end
 
         service_instance.destroy
-        @event_repository.record_service_instance_event('delete', service_instance, nil)
+        @event_repository.record_service_instance_event('purge', service_instance, nil)
       end
 
       logger.info("successfully purged service instance #{service_instance.guid}")

--- a/spec/unit/controllers/services/lifecycle/service_instance_purger_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_instance_purger_spec.rb
@@ -14,11 +14,11 @@ module VCAP::CloudController
         expect(service_instance).not_to exist
       end
 
-      it 'records a service instance delete event' do
+      it 'records a service instance purge event' do
         purger.purge(service_instance)
 
         event = Event.last
-        expect(event.type).to eq('audit.service_instance.delete')
+        expect(event.type).to eq('audit.service_instance.purge')
         expect(event.actee).to eq(service_instance.guid)
       end
 


### PR DESCRIPTION
Previously we recorded an 'audit.service_instance.delete' event when a
service instance was purged, which makes it harder for operators to
distinguish between purge and delete.

fixes #1208 

cc @georgi-lozev 