### PR TITLE
Pass internal route flag to copilot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'addressable'
 gem 'allowy'
-gem 'cf-copilot', git: 'https://github.com/cloudfoundry/copilot', glob: 'sdk/ruby/*.gemspec'
+gem 'cf-copilot', '~> 0.0.8'
 gem 'clockwork', require: false
 gem 'cloudfront-signer'
 gem 'em-http-request', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/cloudfoundry/copilot
-  revision: 3cef67a571f546fb36dafcfae7a52e75829721e6
-  glob: sdk/ruby/*.gemspec
-  specs:
-    cf-copilot (0.0.8)
-      grpc (~> 1.0)
-
-GIT
   remote: https://github.com/cloudfoundry/vcap-concurrency.git
   revision: 2a5b0179642cb3d3e7f912a6453ec5731979d115
   ref: 2a5b0179
@@ -103,6 +95,8 @@ GEM
       steno
     builder (3.2.3)
     byebug (10.0.2)
+    cf-copilot (0.0.8)
+      grpc (~> 1.0)
     cf-perm (0.0.10)
       grpc (~> 1.0)
     cf-perm-test-helpers (0.0.6)
@@ -460,7 +454,7 @@ DEPENDENCIES
   azure-storage (= 0.14.0.preview)
   bits_service_client (~> 3.0)
   byebug
-  cf-copilot!
+  cf-copilot (~> 0.0.8)
   cf-perm (~> 0.0.10)
   cf-perm-test-helpers (~> 0.0.6)
   cf-uaa-lib (~> 3.14.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/cloudfoundry/copilot
-  revision: 8d5c57eac99ecb356815dc016392fc342d5d72ef
+  revision: 3cef67a571f546fb36dafcfae7a52e75829721e6
   glob: sdk/ruby/*.gemspec
   specs:
-    cf-copilot (0.0.6)
+    cf-copilot (0.0.8)
       grpc (~> 1.0)
 
 GIT

--- a/lib/cloud_controller/copilot/adapter.rb
+++ b/lib/cloud_controller/copilot/adapter.rb
@@ -13,6 +13,7 @@ module VCAP::CloudController
               guid: route.guid,
               host: route.fqdn,
               path: route.path,
+              internal: route.internal?
             )
           end
         end

--- a/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
@@ -16,7 +16,7 @@ module VCAP::CloudController
     end
 
     describe '#create_route' do
-      let(:route) { instance_double(Route, guid: 'some-route-guid', fqdn: 'some-fqdn', path: '') }
+      let(:route) { instance_double(Route, guid: 'some-route-guid', fqdn: 'some-fqdn', internal?: false, path: '') }
 
       it 'calls copilot_client.upsert_route' do
         adapter.create_route(route)
@@ -24,11 +24,12 @@ module VCAP::CloudController
           guid: 'some-route-guid',
           host: 'some-fqdn',
           path: '',
+          internal: false,
         )
       end
 
       context 'when the route has a path' do
-        let(:route) { instance_double(Route, guid: 'some-route-guid', fqdn: 'some-fqdn', path: '/some/path') }
+        let(:route) { instance_double(Route, guid: 'some-route-guid', fqdn: 'some-fqdn', internal?: false, path: '/some/path') }
 
         it 'includes path in upsert call' do
           adapter.create_route(route)
@@ -36,6 +37,22 @@ module VCAP::CloudController
             guid: 'some-route-guid',
             host: 'some-fqdn',
             path: '/some/path',
+            internal: false,
+          )
+        end
+      end
+
+      context 'when the route is internal' do
+        let(:route) { instance_double(Route, guid: 'some-route-guid', fqdn: 'some-fqdn', internal?: true, path: '/some/path') }
+
+        it 'includes path in upsert call' do
+          adapter.create_route(route)
+          expect(route).to have_received(:internal?)
+          expect(copilot_client).to have_received(:upsert_route).with(
+            guid: 'some-route-guid',
+            host: 'some-fqdn',
+            path: '/some/path',
+            internal: true,
           )
         end
       end


### PR DESCRIPTION
[#161350158]

Signed-off-by: Slawek Ligus <sligus@pivotal.io>
Signed-off-by: Michael Oleske <moleske@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Currently we filter internal routes by a hardcoded `apps.internal` domain in Copilot. The internal domain is a property on a `route.domain` in CAPI. This change populates copilot with information about which routes are internal.

* An explanation of the use cases your change solves

Currently we hardcode `apps.internal`. With this change, we can support an arbitrary domain as an internal one. 

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [-] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

This feature is not covered by any CATs. 

