### PR TITLE
Bump bits-service-client to 3.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     backports (3.11.4)
     beefcake (1.0.0)
     bit-struct (0.16)
-    bits_service_client (3.2.0)
+    bits_service_client (3.3.0)
       activesupport
       steno
     builder (3.2.3)


### PR DESCRIPTION
* A short explanation of the proposed change:
    Bump bits-service-client to 3.3.0
* An explanation of the use cases your change solves
    See https://github.com/cloudfoundry-incubator/bits-service-client/releases/tag/v3.3.0

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
