### PR TITLE
Fix ./bin/console script

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,5 +2,6 @@
 
 require File.expand_path('../config/boot', __dir__)
 ENV['RAILS_ENV'] ||= 'production'
+ENV['DB_CONNECTION_STRING'] ||= 'mysql2://root:password@localhost:3306/cc_test_'
 
 require 'cloud_controller/console'


### PR DESCRIPTION
- This script started depending on `DB_CONNECTION_STRING` to run locally
- My guess is this was broken by ccbf6c3266e2bf999bc0a64753b19d81c05f425f
- There is probably a more correct way to fix this, but this will work if you have mysql and the database `cc_test_` locally