### PR TITLE
/v3/service_instances endpoints are not experimental

### DIFF
--- a/app/controllers/v3/root_controller.rb
+++ b/app/controllers/v3/root_controller.rb
@@ -32,8 +32,7 @@ class RootController < ActionController::Base
             href: build_api_uri(path: '/processes')
           },
           service_instances: {
-            href: build_api_uri(path: '/service_instances'),
-            experimental: true,
+            href: build_api_uri(path: '/service_instances')
           },
           spaces: {
             href: build_api_uri(path: '/spaces')

--- a/spec/request/v3_root_spec.rb
+++ b/spec/request/v3_root_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe 'App Features' do
             'href' => "#{link_prefix}/v3/processes"
           },
           'service_instances' => {
-            'href' => "#{link_prefix}/v3/service_instances",
-            'experimental' => true
+            'href' => "#{link_prefix}/v3/service_instances"
           },
           'spaces' => {
             'href' => "#{link_prefix}/v3/spaces"

--- a/spec/unit/controllers/v3/root_controller_spec.rb
+++ b/spec/unit/controllers/v3/root_controller_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe RootController, type: :controller do
       hash = MultiJson.load(response.body)
       expected_uri = "#{TestConfig.config[:external_protocol]}://#{TestConfig.config[:external_domain]}/v3/service_instances"
       expect(hash['links']['service_instances']['href']).to eq(expected_uri)
-      expect(hash['links']['service_instances']['experimental']).to eq(true)
     end
 
     it 'returns a link to spaces' do


### PR DESCRIPTION
Mark service_instances endpoints as non-experimental as part of the v3 root.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Thank you,
Georgi and @henryaj 
