### PR TITLE
Support plan_updateable on plan level.

### DIFF
--- a/app/controllers/services/validators/service_update_validator.rb
+++ b/app/controllers/services/validators/service_update_validator.rb
@@ -45,7 +45,7 @@ module VCAP::CloudController
 
       def validate_changing_plan(current_plan, service, service_instance, requested_plan_guid)
         if plan_update_requested?(requested_plan_guid, current_plan)
-          plan_not_updateable! if service_disallows_plan_update?(service)
+          plan_not_updateable! unless service_allows_plan_update?(service, current_plan)
 
           requested_plan = ServicePlan.find(guid: requested_plan_guid)
           invalid_relation!('Plan') if invalid_plan?(requested_plan, service)
@@ -66,8 +66,8 @@ module VCAP::CloudController
         requested_plan_guid && requested_plan_guid != old_plan.guid
       end
 
-      def service_disallows_plan_update?(service)
-        !service.plan_updateable
+      def service_allows_plan_update?(service, current_plan)
+        current_plan.plan_updateable.nil? ? service.plan_updateable : current_plan.plan_updateable
       end
 
       def invalid_relation!(message)

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -14,6 +14,7 @@ module VCAP::CloudController
                       :unique_id,
                       :public,
                       :bindable,
+                      :plan_updateable,
                       :active,
                       :create_instance_schema,
                       :update_instance_schema,
@@ -29,6 +30,7 @@ module VCAP::CloudController
                       :unique_id,
                       :public,
                       :bindable,
+                      :plan_updateable,
                       :create_instance_schema,
                       :update_instance_schema,
                       :create_binding_schema

--- a/db/migrations/20181112143236_add_plan_updateable_to_service_plans.rb
+++ b/db/migrations/20181112143236_add_plan_updateable_to_service_plans.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :service_plans, :plan_updateable, TrueClass, null: true
+  end
+end

--- a/docs/v2/service_plans/list_all_service_plans.html
+++ b/docs/v2/service_plans/list_all_service_plans.html
@@ -314,6 +314,7 @@ Cookie: </pre>
         "public": true,
         "active": true,
         "bindable": true,
+        "plan_updateable": true,
         "service_url": "/v2/services/1ccab853-87c9-45a6-bf99-603032d17fe5",
         "service_instances_url": "/v2/service_plans/6fecf53b-7553-4cb3-b97e-930f9c4e3385/service_instances",
         "schemas": {

--- a/docs/v2/service_plans/retrieve_a_particular_service_plan.html
+++ b/docs/v2/service_plans/retrieve_a_particular_service_plan.html
@@ -164,6 +164,7 @@ Cookie: </pre>
     "public": true,
     "active": true,
     "bindable": true,
+    "plan_updateable": true,
     "service_url": "/v2/services/a00cacc0-0ca6-422e-91d3-6b22bcd33450",
     "service_instances_url": "/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332/service_instances",
     "schemas": {

--- a/docs/v2/service_plans/updating_a_service_plan.html
+++ b/docs/v2/service_plans/updating_a_service_plan.html
@@ -170,6 +170,7 @@ Cookie: </pre>
     "public": false,
     "active": true,
     "bindable": true,
+    "plan_updateable": true,
     "service_url": "/v2/services/518cf8f5-9002-4c63-aab1-6ad2737444b1",
     "service_instances_url": "/v2/service_plans/078cb2c1-e036-4dca-a3b7-ad7f3f36f9cc/service_instances",
     "schemas": {

--- a/docs/v2/services/list_all_service_plans_for_the_service.html
+++ b/docs/v2/services/list_all_service_plans_for_the_service.html
@@ -294,6 +294,8 @@ Cookie: </pre>
         "unique_id": "e192866f-470d-4b8a-8b33-6b8d543854f1",
         "public": true,
         "active": true,
+        "bindable": true,
+        "plan_updateable": true,
         "service_url": "/v2/services/66039cd9-3d8b-46b3-8d70-62eb197b7a39",
         "service_instances_url": "/v2/service_plans/377cf4c4-3987-4fdb-aa65-1104cec440d6/service_instances",
         "schemas": {

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -110,6 +110,7 @@ module VCAP::Services::ServiceBrokers
         bindable:    catalog_plan.bindable,
         active:      true,
         extra:       catalog_plan.metadata.try(:to_json),
+        plan_updateable: catalog_plan.plan_updateable,
         create_instance_schema: create_instance,
         update_instance_schema: update_instance,
         create_binding_schema: create_binding,

--- a/lib/services/service_brokers/v2/catalog_plan.rb
+++ b/lib/services/service_brokers/v2/catalog_plan.rb
@@ -3,7 +3,7 @@ module VCAP::Services::ServiceBrokers::V2
     include CatalogValidationHelper
 
     attr_reader :broker_provided_id, :name, :description, :metadata
-    attr_reader :catalog_service, :errors, :free, :bindable, :schemas
+    attr_reader :catalog_service, :errors, :free, :bindable, :schemas, :plan_updateable
 
     def initialize(catalog_service, attrs)
       @catalog_service    = catalog_service
@@ -14,6 +14,7 @@ module VCAP::Services::ServiceBrokers::V2
       @errors             = VCAP::Services::ValidationErrors.new
       @free               = attrs['free'].nil? ? true : attrs['free']
       @bindable           = attrs['bindable']
+      @plan_updateable    = attrs['plan_updateable']
       build_schemas(attrs['schemas'])
     end
 
@@ -46,6 +47,7 @@ module VCAP::Services::ServiceBrokers::V2
       validate_hash!(:metadata, metadata) if metadata
       validate_bool!(:free, free) if free
       validate_bool!(:bindable, bindable) if bindable
+      validate_bool!(:plan_updateable, plan_updateable) if plan_updateable
       validate_hash!(:schemas, @schemas_data) if @schemas_data
     end
 
@@ -63,6 +65,7 @@ module VCAP::Services::ServiceBrokers::V2
         metadata:           'Plan metadata',
         free:               'Plan free',
         bindable:           'Plan bindable',
+        plan_updateable:    'Plan updateable',
         schemas:            'Plan schemas',
       }.fetch(name) { raise NotImplementedError }
     end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe 'Service Broker API integration' do
+  describe 'v2.15' do
+    include VCAP::CloudController::BrokerApiHelper
+
+    before { setup_cc }
+
+    describe 'updates service instances based on the plan object of the catalog' do
+      context 'when the broker supports plan_updateable on plan level' do
+        let(:catalog) do
+          catalog = default_catalog
+          catalog[:services].first[:plans].first[:plan_updateable] = true
+          catalog
+        end
+
+        before do
+          setup_broker(catalog)
+        end
+
+        it 'successfully updates the service instance plan' do
+          provision_service
+          expect(VCAP::CloudController::ServiceInstance.find(guid: @service_instance_guid).service_plan_guid).to eq @plan_guid
+
+          update_service_instance(200)
+          expect(last_response).to have_status_code(201)
+          expect(VCAP::CloudController::ServiceInstance.find(guid: @service_instance_guid).service_plan_guid).to eq @large_plan_guid
+        end
+      end
+    end
+  end
+end

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -622,6 +622,7 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         public:                 true,
         active:                 true,
         bindable:               true,
+        plan_updateable:        true,
         create_instance_schema: '{}',
         update_instance_schema: '{}',
         create_binding_schema:  '{}'
@@ -650,6 +651,7 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
           'public'                 => new_plan.public,
           'active'                 => new_plan.active,
           'bindable'               => new_plan.bindable,
+          'plan_updateable'        => new_plan.plan_updateable,
           'create_instance_schema' => new_plan.create_instance_schema,
           'update_instance_schema' => new_plan.update_instance_schema,
           'create_binding_schema'  => new_plan.create_binding_schema

--- a/spec/unit/controllers/services/service_brokers_controller_spec.rb
+++ b/spec/unit/controllers/services/service_brokers_controller_spec.rb
@@ -27,6 +27,7 @@ module VCAP::CloudController
                 'name' => 'fake-plan',
                 'id' => 'f52eabf8-e38d-422f-8ef9-9dc83b75cc05',
                 'description' => 'Shared fake Server, 5tb persistent disk, 40 max concurrent connections',
+                'plan_updateable' => true,
                 'max_storage_tb' => 5,
                 'metadata' => {
                   'cost' => 0.0,

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -76,6 +76,7 @@ module VCAP::Services::ServiceBrokers
                 'id'          => plan_id,
                 'name'        => plan_name,
                 'description' => plan_description,
+                'plan_updateable' => true,
                 'free'        => false,
                 'bindable'    => true,
               }.merge(plan_metadata_hash).merge(plan_schemas_hash)
@@ -181,6 +182,7 @@ module VCAP::Services::ServiceBrokers
           'name' => service_plan.name,
           'free' => service_plan.free,
           'description' => service_plan.description,
+          'plan_updateable' => service_plan.plan_updateable,
           'service_guid' => service_plan.service.guid,
           'extra' => '{"cost":"0.0"}',
           'unique_id' => service_plan.unique_id,
@@ -223,6 +225,7 @@ module VCAP::Services::ServiceBrokers
           expect(plan.service).to eq(VCAP::CloudController::Service.last)
           expect(plan.name).to eq(plan_name)
           expect(plan.description).to eq(plan_description)
+          expect(plan.plan_updateable).to eq(true)
           expect(JSON.parse(plan.extra)).to eq({ 'cost' => '0.0' })
           expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
           expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
@@ -588,6 +591,7 @@ module VCAP::Services::ServiceBrokers
             expect(plan.description).to_not eq(plan_description)
             expect(plan.free).to be true
             expect(plan.bindable).to be false
+            expect(plan.plan_updateable).to be_nil
             expect(plan.create_instance_schema).to be_nil
             expect(plan.update_instance_schema).to be_nil
             expect(plan.create_binding_schema).to be_nil
@@ -601,6 +605,7 @@ module VCAP::Services::ServiceBrokers
             expect(plan.description).to eq(plan_description)
             expect(plan.free).to be false
             expect(plan.bindable).to be true
+            expect(plan.plan_updateable).to be true
             expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
             expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
             expect(plan.create_binding_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')

--- a/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
@@ -12,14 +12,15 @@ module VCAP::Services::ServiceBrokers::V2
         'description' => opts[:description] || 'The description of the service plan',
         'free'        => opts.fetch(:free, true),
         'bindable'    => opts[:bindable],
-        'schemas'     => opts[:schemas] || {}
+        'schemas'     => opts[:schemas] || {},
+        'plan_updateable' => opts[:plan_updateable]
       }
     end
     let(:catalog_service) { instance_double(VCAP::Services::ServiceBrokers::V2::CatalogService) }
     let(:opts) { {} }
 
     describe 'initializing' do
-      let(:opts) { { free: false, bindable: true } }
+      let(:opts) { { free: false, bindable: true, plan_updateable: true } }
 
       it 'should assign attributes' do
         expect(plan.broker_provided_id).to eq 'broker-provided-plan-id'
@@ -29,6 +30,7 @@ module VCAP::Services::ServiceBrokers::V2
         expect(plan.catalog_service).to eq catalog_service
         expect(plan.free).to be false
         expect(plan.bindable).to be true
+        expect(plan.plan_updateable).to be true
         expect(plan.errors).to be_empty
       end
 
@@ -119,6 +121,13 @@ module VCAP::Services::ServiceBrokers::V2
 
         expect(plan).to_not be_valid
         expect(plan.errors.messages).to include 'Plan bindable must be a boolean, but has value "true"'
+      end
+
+      it 'validates that @plan_updateable is a boolean' do
+        plan_attrs['plan_updateable'] = 'true'
+
+        expect(plan).to_not be_valid
+        expect(plan.errors.messages).to include 'Plan updateable must be a boolean, but has value "true"'
       end
 
       it 'validates that @schemas is a hash' do

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -49,6 +49,7 @@ module VCAP::CloudController
                                          :unique_id,
                                          :public,
                                          :bindable,
+                                         :plan_updateable,
                                          :active,
                                          :create_instance_schema,
                                          :update_instance_schema,
@@ -64,6 +65,7 @@ module VCAP::CloudController
                                          :unique_id,
                                          :public,
                                          :bindable,
+                                         :plan_updateable,
                                          :create_instance_schema,
                                          :update_instance_schema,
                                          :create_binding_schema

--- a/spec/unit/presenters/v2/service_plan_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_plan_presenter_spec.rb
@@ -35,6 +35,7 @@ module CloudController::Presenters::V2
           {
            'active' => true,
            'bindable' => true,
+           'plan_updateable' => nil,
            'description' => service_plan.description,
            'extra' => nil,
            'free' => false,


### PR DESCRIPTION
The latest version of the OSBAPI spec has a `plan_updateable` field
for each service plan object in the broker catalog. This PR adds the support
for the feature in CC. For more details https://www.pivotaltracker.com/story/show/161257412


Co-authored-by: Niki Maslarski <nikolay.maslarski@sap.com>
Signed-off-by: Georgi Lozev <georgi.lozev@sap.com>
Co-authored-by: Georgi Lozev <georgi.lozev@sap.com>
