### PR TITLE
Add audit events to async service operations

### DIFF
--- a/app/actions/service_binding_create.rb
+++ b/app/actions/service_binding_create.rb
@@ -53,6 +53,7 @@ module VCAP::CloudController
           job = Jobs::Services::ServiceBindingStateFetch.new(binding.guid, @user_audit_info, message.audit_hash)
           enqueuer = Jobs::Enqueuer.new(job, queue: 'cc-generic')
           enqueuer.enqueue
+          Repositories::ServiceBindingEventRepository.record_start_create(binding, @user_audit_info, message.audit_hash, manifest_triggered: @manifest_triggered)
         else
           binding.save
           Repositories::ServiceBindingEventRepository.record_create(binding, @user_audit_info, message.audit_hash, manifest_triggered: @manifest_triggered)

--- a/app/actions/service_binding_delete.rb
+++ b/app/actions/service_binding_delete.rb
@@ -38,9 +38,10 @@ module VCAP::CloudController
           job = VCAP::CloudController::Jobs::Services::ServiceBindingStateFetch.new(service_binding.guid, @user_audit_info, {})
           enqueuer = Jobs::Enqueuer.new(job, queue: 'cc-generic')
           enqueuer.enqueue
+          Repositories::ServiceBindingEventRepository.record_start_delete(service_binding, @user_audit_info)
         else
-          Repositories::ServiceBindingEventRepository.record_delete(service_binding, @user_audit_info)
           service_binding.destroy
+          Repositories::ServiceBindingEventRepository.record_delete(service_binding, @user_audit_info)
         end
 
         if broker_responded_async_for_accepts_incomplete_false?(broker_response)

--- a/app/actions/services/service_instance_create.rb
+++ b/app/actions/services/service_instance_create.rb
@@ -48,6 +48,7 @@ module VCAP::CloudController
       )
       enqueuer = Jobs::Enqueuer.new(job, queue: 'cc-generic')
       enqueuer.enqueue
+      @services_event_repository.record_service_instance_event(:start_create, service_instance, request_attrs)
     end
 
     def cleanup_instance_without_db(e, service_instance, message: 'Failed to save while creating service instance')

--- a/app/actions/services/service_instance_delete.rb
+++ b/app/actions/services/service_instance_delete.rb
@@ -88,6 +88,7 @@ module VCAP::CloudController
           log_audit_event(service_instance)
         else
           lock.enqueue_unlock!(attributes_to_update, build_fetch_job(service_instance))
+          @event_repository.record_service_instance_event(:start_delete, service_instance, {})
         end
       rescue => e
         errors << e

--- a/app/actions/services/service_instance_update.rb
+++ b/app/actions/services/service_instance_update.rb
@@ -53,6 +53,7 @@ module VCAP::CloudController
       if service_instance.operation_in_progress?
         job = build_fetch_job(service_instance, request_attrs)
         lock.enqueue_unlock!(job)
+        @services_event_repository.record_service_instance_event(:start_update, service_instance, request_attrs)
       else
         lock.synchronous_unlock!
       end

--- a/spec/unit/actions/service_binding_create_spec.rb
+++ b/spec/unit/actions/service_binding_create_spec.rb
@@ -313,9 +313,13 @@ module VCAP::CloudController
             expect(service_binding.last_operation.state).to eq('in progress')
           end
 
-          it 'does not audit a create binding event' do
-            service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)
-            expect(Event.count).to eq(0)
+          it 'creates an audit.service_binding.start_create event' do
+            service_binding = service_binding_create.create(app, service_instance, message, volume_mount_services_enabled, accepts_incomplete)
+
+            event = Event.last
+            expect(event.type).to eq('audit.service_binding.start_create')
+            expect(event.actee).to eq(service_binding.guid)
+            expect(event.actee_type).to eq('service_binding')
           end
 
           it 'enqueues a fetch job' do

--- a/spec/unit/actions/service_binding_delete_spec.rb
+++ b/spec/unit/actions/service_binding_delete_spec.rb
@@ -139,10 +139,13 @@ module VCAP::CloudController
             expect(service_binding.exists?).to be_truthy
           end
 
-          it 'should NOT create an audit event' do
+          it 'should create an audit event' do
             service_binding_delete.foreground_delete_request(service_binding)
 
-            expect(Event.last).to be_nil
+            event = Event.last
+            expect(event.type).to eq('audit.service_binding.start_delete')
+            expect(event.actee).to eq(service_binding.guid)
+            expect(event.actee_type).to eq('service_binding')
           end
 
           context 'when the binding already has an operation' do

--- a/spec/unit/actions/services/service_instance_create_spec.rb
+++ b/spec/unit/actions/services/service_instance_create_spec.rb
@@ -84,9 +84,9 @@ module VCAP::CloudController
           expect(Delayed::Job.first).to be_a_fully_wrapped_job_of Jobs::Services::ServiceInstanceStateFetch
         end
 
-        it 'does not log an audit event' do
+        it 'logs an audit event' do
           create_action.create(request_attrs, true)
-          expect(event_repository).not_to have_received(:record_service_instance_event)
+          expect(event_repository).to have_received(:record_service_instance_event).with(:start_create, an_instance_of(ManagedServiceInstance), request_attrs)
         end
       end
 

--- a/spec/unit/actions/services/service_instance_delete_spec.rb
+++ b/spec/unit/actions/services/service_instance_delete_spec.rb
@@ -271,6 +271,11 @@ module VCAP::CloudController
             expect(job.run_at).to be < Time.now.utc + poll_interval
           end
         end
+
+        it 'logs audit event start_delete' do
+          expect(event_repository).to receive(:record_service_instance_event).with(:start_delete, service_instance, {}).once
+          service_instance_delete.delete([service_instance])
+        end
       end
 
       context 'when unbinding a service instance fails' do

--- a/spec/unit/actions/services/service_instance_update_spec.rb
+++ b/spec/unit/actions/services/service_instance_update_spec.rb
@@ -325,5 +325,26 @@ module VCAP::CloudController
         end
       end
     end
+
+    context 'when accepts_incomplete is true' do
+      let(:service_instance_update) do
+        ServiceInstanceUpdate.new(
+          accepts_incomplete: true,
+          services_event_repository: services_event_repo
+        )
+      end
+
+      context 'when the broker responds asynchronously' do
+        before do
+          stub_update(service_instance, accepts_incomplete: true, status: 202)
+        end
+
+        it 'creates audit log event start_update' do
+          expect(services_event_repo).to receive(:record_service_instance_event).with(:start_update, service_instance, request_attrs).once
+
+          service_instance_update.update_service_instance(service_instance, request_attrs)
+        end
+      end
+    end
   end
 end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -571,11 +571,11 @@ module VCAP::CloudController
             expect(a_request(:delete, service_broker_url)).to have_been_made.times(0)
           end
 
-          it 'does not create an audit event' do
+          it 'creates an audit event' do
             create_managed_service_instance
 
-            event = VCAP::CloudController::Event.first(type: 'audit.service_instance.create')
-            expect(event).to be_nil
+            event = VCAP::CloudController::Event.first
+            expect(event.type).to eq('audit.service_instance.start_create')
           end
 
           it 'returns a 202 with the last operation state as in progress' do
@@ -2123,11 +2123,11 @@ module VCAP::CloudController
             expect(service_instance.service_plan.guid).not_to eq(new_service_plan.guid)
           end
 
-          it 'does not create an audit event' do
+          it 'creates an audit event' do
             put "/v2/service_instances/#{service_instance.guid}?accepts_incomplete=true", body
 
-            event = VCAP::CloudController::Event.first(type: 'audit.service_instance.update')
-            expect(event).to be_nil
+            event = VCAP::CloudController::Event.last
+            expect(event.type).to eq('audit.service_instance.start_update')
           end
 
           it 'returns a 202' do
@@ -2875,10 +2875,11 @@ module VCAP::CloudController
               {}.to_json
             end
 
-            it 'should not create a delete event' do
+            it 'creates a delete event' do
               delete "/v2/service_instances/#{service_instance.guid}?accepts_incomplete=true"
 
-              expect(Event.find(type: 'audit.service_instance.delete')).to be_nil
+              event = VCAP::CloudController::Event.first
+              expect(event.type).to eq('audit.service_instance.start_delete')
             end
 
             it 'should create a delete event after the polling finishes' do

--- a/spec/unit/repositories/service_binding_event_repository_spec.rb
+++ b/spec/unit/repositories/service_binding_event_repository_spec.rb
@@ -10,6 +10,51 @@ module VCAP::CloudController
       let(:user_audit_info) { UserAuditInfo.new(user_guid: user_guid, user_name: user_name, user_email: user_email) }
       let(:service_binding) { ServiceBinding.make }
 
+      describe '.record_start_create' do
+        it 'creates an audit.service_binding.start_create event' do
+          request = { 'big' => 'data' }
+          event   = ServiceBindingEventRepository.record_start_create(service_binding, user_audit_info, request)
+
+          expect(event.type).to eq('audit.service_binding.start_create')
+          expect(event.actor).to eq(user_guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.actor_username).to eq(user_name)
+          expect(event.actee).to eq(service_binding.guid)
+          expect(event.actee_type).to eq('service_binding')
+          expect(event.actee_name).to eq('')
+          expect(event.space_guid).to eq(service_binding.space.guid)
+          expect(event.organization_guid).to eq(service_binding.space.organization.guid)
+          expect(event.metadata[:request]).to eq(
+            {
+              'big' => 'data'
+            }
+          )
+        end
+
+        it 'censors metadata.request.data' do
+          request = { 'big' => 'data', 'data' => 'lake', :data => 'tolerates symbols' }
+          event   = ServiceBindingEventRepository.record_start_create(service_binding, user_audit_info, request)
+
+          expect(event.metadata[:request]).to eq(
+            {
+              'big'  => 'data',
+              'data' => '[PRIVATE DATA HIDDEN]'
+            }
+          )
+          expect(event.metadata[:manifest_triggered]).to eq(nil)
+        end
+
+        context 'when the event is manifest triggered' do
+          it 'tags the event as manifest_triggered: true' do
+            request = { 'big' => 'data' }
+            event   = ServiceBindingEventRepository.record_start_create(service_binding, user_audit_info, request, manifest_triggered: true)
+
+            expect(event.metadata[:manifest_triggered]).to eq(true)
+          end
+        end
+      end
+
       describe '.record_create' do
         it 'creates an audit.service_binding.create event' do
           request = { 'big' => 'data' }
@@ -52,6 +97,29 @@ module VCAP::CloudController
 
             expect(event.metadata[:manifest_triggered]).to eq(true)
           end
+        end
+      end
+
+      describe '.record_start_delete' do
+        it 'creates an audit.service_binding.start_delete event' do
+          event = ServiceBindingEventRepository.record_start_delete(service_binding, user_audit_info)
+
+          expect(event.type).to eq('audit.service_binding.start_delete')
+          expect(event.actor).to eq(user_guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.actor_username).to eq(user_name)
+          expect(event.actee).to eq(service_binding.guid)
+          expect(event.actee_type).to eq('service_binding')
+          expect(event.actee_name).to eq('')
+          expect(event.space_guid).to eq(service_binding.space.guid)
+          expect(event.organization_guid).to eq(service_binding.space.organization.guid)
+          expect(event.metadata).to eq(
+            request: {
+              app_guid: service_binding.app_guid,
+              service_instance_guid: service_binding.service_instance_guid,
+            },
+          )
         end
       end
 


### PR DESCRIPTION
Adds start_* audit events to service instance create/update/delete and
service binding create/delete. This provides better visibility into
long-running service events.

Also updates logging so that when deleting a service binding
synchronously, the 'delete' audit event is only logged once the delete
finishes.

More context [here](https://www.pivotaltracker.com/n/projects/2105761/stories/161249256)

Niki && @georgi-lozev 
on behalf of the SAPI Team




* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
