### PR TITLE
Set internal flag on the route during bulk syncs

### DIFF
--- a/lib/cloud_controller/copilot/sync.rb
+++ b/lib/cloud_controller/copilot/sync.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
         web_processes = batch(processes_batch_query)
 
         Adapter.bulk_sync(
-          routes: routes.map { |r| { guid: r.guid, host: r.fqdn, path: r.path } },
+          routes: routes.map { |r| { guid: r.guid, host: r.fqdn, path: r.path, internal: r.internal? } },
           route_mappings: route_mappings.reject { |rm| rm.process.nil? }.map do |rm|
             {
               capi_process_guid: rm.process.guid,


### PR DESCRIPTION
[#157437921]

Signed-off-by: Slawek Ligus <sligus@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

We previously updated capi to set internal flag on Upserts, but forgot about bulk syncs. This change corrects that.

* An explanation of the use cases your change solves

Bulk sync will now correctly mark internal routes as such.

* Links to any other associated PRs

https://github.com/cloudfoundry/cloud_controller_ng/pull/1244

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [-] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

CATs do not cover this experimental functionality.
