### PR TITLE
add container_purpose to container network info

### DIFF
--- a/lib/cloud_controller/diego/app_recipe_builder.rb
+++ b/lib/cloud_controller/diego/app_recipe_builder.rb
@@ -290,7 +290,7 @@ module VCAP::CloudController
       end
 
       def generate_network
-        Protocol::ContainerNetworkInfo.new(process.app).to_bbs_network
+        Protocol::ContainerNetworkInfo.new(process.app, Protocol::ContainerNetworkInfo::APP).to_bbs_network
       end
 
       def file_descriptor_limit

--- a/lib/cloud_controller/diego/protocol.rb
+++ b/lib/cloud_controller/diego/protocol.rb
@@ -66,7 +66,7 @@ module VCAP::CloudController
           'etag'                            => process.updated_at.to_f.to_s,
           'allow_ssh'                       => process.enable_ssh,
           'ports'                           => OpenProcessPorts.new(process).to_a,
-          'network'                         => ContainerNetworkInfo.new(process.app, 'desired app message').to_h,
+          'network'                         => ContainerNetworkInfo.new(process.app, Protocol::ContainerNetworkInfo::APP).to_h,
           'volume_mounts'                   => AppVolumeMounts.new(process.app),
           'isolation_segment'               => VCAP::CloudController::IsolationSegmentSelector.for_space(process.space),
         }.merge(LifecycleProtocol.protocol_for_type(process.app.lifecycle_type).desired_app_message(process))

--- a/lib/cloud_controller/diego/protocol.rb
+++ b/lib/cloud_controller/diego/protocol.rb
@@ -66,7 +66,7 @@ module VCAP::CloudController
           'etag'                            => process.updated_at.to_f.to_s,
           'allow_ssh'                       => process.enable_ssh,
           'ports'                           => OpenProcessPorts.new(process).to_a,
-          'network'                         => ContainerNetworkInfo.new(process.app).to_h,
+          'network'                         => ContainerNetworkInfo.new(process.app, 'desired app message').to_h,
           'volume_mounts'                   => AppVolumeMounts.new(process.app),
           'isolation_segment'               => VCAP::CloudController::IsolationSegmentSelector.for_space(process.space),
         }.merge(LifecycleProtocol.protocol_for_type(process.app.lifecycle_type).desired_app_message(process))

--- a/lib/cloud_controller/diego/protocol/container_network_info.rb
+++ b/lib/cloud_controller/diego/protocol/container_network_info.rb
@@ -2,15 +2,15 @@ module VCAP::CloudController
   module Diego
     class Protocol
       class ContainerNetworkInfo
-        attr_reader :app, :container_purpose
+        attr_reader :app, :container_workload
 
         APP = 'app'.freeze
         STAGING = 'staging'.freeze
         TASK = 'task'.freeze
 
-        def initialize(app, container_purpose)
+        def initialize(app, container_workload)
           @app = app
-          @container_purpose = container_purpose
+          @container_workload = container_workload
         end
 
         def to_h
@@ -21,7 +21,7 @@ module VCAP::CloudController
               'space_id' => app.space.guid,
               'org_id' => app.organization.guid,
               'ports' => app.processes.map { |p| Protocol::OpenProcessPorts.new(p).to_a }.flatten.sort.join(','),
-              'container_purpose' => container_purpose,
+              'container_workload' => container_workload,
             },
           }
         end

--- a/lib/cloud_controller/diego/protocol/container_network_info.rb
+++ b/lib/cloud_controller/diego/protocol/container_network_info.rb
@@ -2,10 +2,15 @@ module VCAP::CloudController
   module Diego
     class Protocol
       class ContainerNetworkInfo
-        attr_reader :app
+        attr_reader :app, :container_purpose
 
-        def initialize(app)
+        APP = 'app'.freeze
+        STAGING = 'staging'.freeze
+        TASK = 'task'.freeze
+
+        def initialize(app, container_purpose)
           @app = app
+          @container_purpose = container_purpose
         end
 
         def to_h
@@ -16,6 +21,7 @@ module VCAP::CloudController
               'space_id' => app.space.guid,
               'org_id' => app.organization.guid,
               'ports' => app.processes.map { |p| Protocol::OpenProcessPorts.new(p).to_a }.flatten.sort.join(','),
+              'container_purpose' => container_purpose,
             },
           }
         end

--- a/lib/cloud_controller/diego/task_recipe_builder.rb
+++ b/lib/cloud_controller/diego/task_recipe_builder.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController
           log_source:                       TASK_LOG_SOURCE,
           max_pids:                         config.get(:diego, :pid_limit),
           memory_mb:                        task.memory_in_mb,
-          network:                          generate_network(task),
+          network:                          generate_network(task, Protocol::ContainerNetworkInfo::TASK),
           privileged:                       config.get(:diego, :use_privileged_containers_for_running),
           trusted_system_certificates_path: STAGING_TRUSTED_SYSTEM_CERT_PATH,
           volume_mounts:                    generate_volume_mounts(app_volume_mounts),
@@ -62,7 +62,7 @@ module VCAP::CloudController
           log_guid:                         staging_details.package.app_guid,
           log_source:                       STAGING_LOG_SOURCE,
           memory_mb:                        staging_details.staging_memory_in_mb,
-          network:                          generate_network(staging_details.package),
+          network:                          generate_network(staging_details.package, Protocol::ContainerNetworkInfo::STAGING),
           privileged:                       config.get(:diego, :use_privileged_containers_for_staging),
           result_file:                      STAGING_RESULT_FILE,
           trusted_system_certificates_path: STAGING_TRUSTED_SYSTEM_CERT_PATH,
@@ -100,8 +100,8 @@ module VCAP::CloudController
         TaskCpuWeightCalculator.new(memory_in_mb: task.memory_in_mb).calculate
       end
 
-      def generate_network(task)
-        Protocol::ContainerNetworkInfo.new(task.app).to_bbs_network
+      def generate_network(task, container_purpose)
+        Protocol::ContainerNetworkInfo.new(task.app, container_purpose).to_bbs_network
       end
 
       def find_staging_isolation_segment(staging_details)

--- a/lib/cloud_controller/diego/task_recipe_builder.rb
+++ b/lib/cloud_controller/diego/task_recipe_builder.rb
@@ -100,8 +100,8 @@ module VCAP::CloudController
         TaskCpuWeightCalculator.new(memory_in_mb: task.memory_in_mb).calculate
       end
 
-      def generate_network(task, container_purpose)
-        Protocol::ContainerNetworkInfo.new(task.app, container_purpose).to_bbs_network
+      def generate_network(task, container_workload)
+        Protocol::ContainerNetworkInfo.new(task.app, container_workload).to_bbs_network
       end
 
       def find_staging_isolation_segment(staging_details)

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -74,6 +74,7 @@ module VCAP::CloudController
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app_model.space.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app_model.organization.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ports),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_purpose', value: Protocol::ContainerNetworkInfo::APP),
             ]
           )
         end

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -74,7 +74,7 @@ module VCAP::CloudController
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app_model.space.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app_model.organization.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ports),
-              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_purpose', value: Protocol::ContainerNetworkInfo::APP),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_workload', value: Protocol::ContainerNetworkInfo::APP),
             ]
           )
         end

--- a/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
@@ -10,8 +10,9 @@ module VCAP::CloudController
         let!(:no_exposed_port_process) { ProcessModel.make(app: app, type: 'woof') }
         let!(:docker_process) { ProcessModelFactory.make(app: app, type: 'docker', ports: [1111, 2222]) }
         let(:ports_str) { '1111,2222,8080,8765' }
+        let(:container_purpose) { 'im-an-app!' }
 
-        subject(:container_info) { ContainerNetworkInfo.new(app) }
+        subject(:container_info) { ContainerNetworkInfo.new(app, container_purpose) }
 
         describe '#to_h' do
           it 'returns the container network information hash' do
@@ -22,6 +23,7 @@ module VCAP::CloudController
                 'space_id' => app.space.guid,
                 'org_id' => app.organization.guid,
                 'ports' => ports_str,
+                'container_purpose' => container_purpose
               },
             })
           end
@@ -37,6 +39,7 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
                   ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
                   ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ports_str),
+                  ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_purpose', value: container_purpose),
                 ]
               )
             )

--- a/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/container_network_info_spec.rb
@@ -10,9 +10,9 @@ module VCAP::CloudController
         let!(:no_exposed_port_process) { ProcessModel.make(app: app, type: 'woof') }
         let!(:docker_process) { ProcessModelFactory.make(app: app, type: 'docker', ports: [1111, 2222]) }
         let(:ports_str) { '1111,2222,8080,8765' }
-        let(:container_purpose) { 'im-an-app!' }
+        let(:container_workload) { 'im-an-app!' }
 
-        subject(:container_info) { ContainerNetworkInfo.new(app, container_purpose) }
+        subject(:container_info) { ContainerNetworkInfo.new(app, container_workload) }
 
         describe '#to_h' do
           it 'returns the container network information hash' do
@@ -23,7 +23,7 @@ module VCAP::CloudController
                 'space_id' => app.space.guid,
                 'org_id' => app.organization.guid,
                 'ports' => ports_str,
-                'container_purpose' => container_purpose
+                'container_workload' => container_workload
               },
             })
           end
@@ -39,7 +39,7 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
                   ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
                   ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ports_str),
-                  ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_purpose', value: container_purpose),
+                  ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_workload', value: container_workload),
                 ]
               )
             )

--- a/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
@@ -195,7 +195,7 @@ module VCAP::CloudController
                 'space_id' => process.space.guid,
                 'org_id' => process.organization.guid,
                 'ports' => '2222,3333',
-                'container_purpose' => 'desired app message',
+                'container_workload' => 'desired app message',
               }
             },
             'volume_mounts' => an_instance_of(Array),

--- a/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
@@ -194,7 +194,8 @@ module VCAP::CloudController
                 'app_id' => process.guid,
                 'space_id' => process.space.guid,
                 'org_id' => process.organization.guid,
-                'ports' => '2222,3333'
+                'ports' => '2222,3333',
+                'container_purpose' => 'desired app message',
               }
             },
             'volume_mounts' => an_instance_of(Array),

--- a/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol_spec.rb
@@ -195,7 +195,7 @@ module VCAP::CloudController
                 'space_id' => process.space.guid,
                 'org_id' => process.organization.guid,
                 'ports' => '2222,3333',
-                'container_workload' => 'desired app message',
+                'container_workload' => Protocol::ContainerNetworkInfo::APP,
               }
             },
             'volume_mounts' => an_instance_of(Array),

--- a/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
@@ -37,7 +37,7 @@ module VCAP::CloudController
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ''),
-              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_purpose', value: Protocol::ContainerNetworkInfo::STAGING),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_workload', value: Protocol::ContainerNetworkInfo::STAGING),
             ]
           )
         end
@@ -345,7 +345,7 @@ module VCAP::CloudController
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ''),
-              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_purpose', value: Protocol::ContainerNetworkInfo::TASK),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_workload', value: Protocol::ContainerNetworkInfo::TASK),
             ]
           )
         end

--- a/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
@@ -37,6 +37,7 @@ module VCAP::CloudController
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ''),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_purpose', value: Protocol::ContainerNetworkInfo::STAGING),
             ]
           )
         end
@@ -344,6 +345,7 @@ module VCAP::CloudController
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'space_id', value: app.space.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'org_id', value: app.organization.guid),
               ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'ports', value: ''),
+              ::Diego::Bbs::Models::Network::PropertiesEntry.new(key: 'container_purpose', value: Protocol::ContainerNetworkInfo::TASK),
             ]
           )
         end


### PR DESCRIPTION
- so it can be known if a container is an app, staging, or an app task
- so network policies can be applied for running vs staging similar to ASGs
[#161904323]

Signed-off-by: Michael Oleske <moleske@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
