### PR TITLE
Rename ModelController run/enqueue delete method

### DIFF
--- a/app/controllers/base/model_controller.rb
+++ b/app/controllers/base/model_controller.rb
@@ -75,10 +75,10 @@ module VCAP::CloudController::RestController
     def do_delete(obj)
       raise_if_has_dependent_associations!(obj) if v2_api? && !recursive_delete?
       model_deletion_job = Jobs::Runtime::ModelDeletion.new(obj.class, obj.guid)
-      enqueue_deletion_job(model_deletion_job)
+      run_or_enqueue_deletion_job(model_deletion_job)
     end
 
-    def enqueue_deletion_job(deletion_job)
+    def run_or_enqueue_deletion_job(deletion_job)
       if async?
         job = Jobs::Enqueuer.new(deletion_job, queue: 'cc-generic').enqueue
         [HTTP::ACCEPTED, JobPresenter.new(job).to_json]

--- a/app/controllers/runtime/buildpacks_controller.rb
+++ b/app/controllers/runtime/buildpacks_controller.rb
@@ -74,7 +74,7 @@ module VCAP::CloudController
       find_guid_and_validate_access(:delete, guid)
 
       job = Jobs::Runtime::BuildpackDelete.new(guid: guid, timeout: @config.get(:staging, :timeout_in_seconds))
-      enqueue_deletion_job(job)
+      run_or_enqueue_deletion_job(job)
     end
 
     def self.not_found_exception_name(_model_class)

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -272,7 +272,7 @@ module VCAP::CloudController
       delete_action = OrganizationDelete.new(org_roles_delete_action, space_delete_action)
 
       deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Organization, guid, delete_action)
-      response = enqueue_deletion_job(deletion_job)
+      response = run_or_enqueue_deletion_job(deletion_job)
 
       @organization_event_repository.record_organization_delete_request(org, UserAuditInfo.from_context(SecurityContext), request_attrs)
 

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -175,7 +175,7 @@ module VCAP::CloudController
       delete_action = SpaceDelete.new(UserAuditInfo.from_context(SecurityContext), @services_event_repository, role_delete_action)
 
       deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Space, guid, delete_action)
-      enqueue_deletion_job(deletion_job)
+      run_or_enqueue_deletion_job(deletion_job)
     end
 
     VCAP::CloudController::Roles::SPACE_ROLE_NAMES.each do |role|

--- a/app/controllers/services/service_plan_visibilities_controller.rb
+++ b/app/controllers/services/service_plan_visibilities_controller.rb
@@ -82,7 +82,7 @@ module VCAP::CloudController
         {}
       )
 
-      enqueue_deletion_job(delete_and_audit_job)
+      run_or_enqueue_deletion_job(delete_and_audit_job)
     end
 
     define_messages

--- a/app/controllers/services/user_provided_service_instances_controller.rb
+++ b/app/controllers/services/user_provided_service_instances_controller.rb
@@ -107,7 +107,7 @@ module VCAP::CloudController
         {}
       )
 
-      enqueue_deletion_job(delete_and_audit_job)
+      run_or_enqueue_deletion_job(delete_and_audit_job)
     end
 
     def get_filtered_dataset_for_enumeration(model, dataset, query_params, opts)


### PR DESCRIPTION
The method `enqueue_deletion_job` technically only enqueues if the `async` param is passed - otherwise it runs synchronously. Renamed the method to be clearer.

https://www.pivotaltracker.com/story/show/159951480