### PR TITLE
Filter by temporary istio domains

### DIFF
--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -326,6 +326,7 @@ module VCAP::CloudController
             optional(:client_ca_file) => String,
             optional(:client_key_file) => String,
             optional(:client_chain_file) => String,
+            optional(:temporary_istio_domains) => Array,
           },
 
           max_labels_per_resource: Integer,

--- a/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
@@ -94,6 +94,7 @@ module VCAP::CloudController
             optional(:client_ca_file) => String,
             optional(:client_key_file) => String,
             optional(:client_chain_file) => String,
+            optional(:temporary_istio_domains) => Array,
           },
 
           staging: {

--- a/lib/cloud_controller/config_schemas/route_syncer_schema.rb
+++ b/lib/cloud_controller/config_schemas/route_syncer_schema.rb
@@ -43,6 +43,7 @@ module VCAP::CloudController
             client_ca_file: String,
             client_key_file: String,
             client_chain_file: String,
+            optional(:temporary_istio_domains) => Array,
           }
         }
       end

--- a/lib/cloud_controller/copilot/sync.rb
+++ b/lib/cloud_controller/copilot/sync.rb
@@ -51,6 +51,7 @@ module VCAP::CloudController
           routes = Route.
                    where(Sequel.lit("#{Route.table_name}.id > ?", last_id)).
                    order("#{Route.table_name}__id".to_sym).
+                   join(:domains, [[:id, :domain_id], [:name, allowed_domains]]).
                    eager(:domain).
                    limit(BATCH_SIZE)
 
@@ -63,6 +64,8 @@ module VCAP::CloudController
           route_mappings = RouteMappingModel.
                            where(Sequel.lit("#{RouteMappingModel.table_name}.id > ?", last_id)).
                            order("#{RouteMappingModel.table_name}__id".to_sym).
+                           join(:routes, guid: :route_guid).
+                           join(:domains, [[:id, :domain_id], [:name, allowed_domains]]).
                            eager(:process).
                            limit(BATCH_SIZE)
 
@@ -80,6 +83,10 @@ module VCAP::CloudController
 
           processes.select_all(ProcessModel.table_name)
         }
+      end
+
+      def self.allowed_domains
+        Config.config.get(:copilot, :temporary_istio_domains)
       end
     end
   end

--- a/spec/unit/actions/app_delete_spec.rb
+++ b/spec/unit/actions/app_delete_spec.rb
@@ -128,9 +128,11 @@ module VCAP::CloudController
 
           context 'when copilot is enabled', isolation: :truncation do
             let(:copilot_client) { instance_double(Cloudfoundry::Copilot::Client, unmap_route: nil, delete_capi_diego_process_association: nil) }
+            let(:route) { Route.make(domain: istio_domain) }
+            let(:istio_domain) { SharedDomain.make(name: 'istio.example.com') }
 
             before do
-              TestConfig.override(copilot: { enabled: true })
+              TestConfig.override(copilot: { enabled: true, temporary_istio_domains: ['istio.example.com'] })
               allow_any_instance_of(Diego::Messenger).to receive(:send_stop_app_request)
               allow(CloudController::DependencyLocator.instance).to receive(:copilot_client).and_return(copilot_client)
             end


### PR DESCRIPTION

* A short explanation of the proposed change:

Operators can add a list of istio domains to the `copilot.temporary_istio_domains` property in the manifest. Cloud Controller then filters routes sent to Copilot based on whether they're associated with an Istio domain.

* An explanation of the use cases your change solves
[Tracker Story](https://www.pivotaltracker.com/story/show/159944349)

* Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/pull/111

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
