### PR TITLE
Use binding_guid in broker api compatibility tests

### DIFF
--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.0_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.0_spec.rb
@@ -313,7 +313,6 @@ RSpec.describe 'Service Broker API integration' do
       let(:broker_response_body) { '{}' }
       let(:app_guid) { @app_guid }
       let(:service_instance_guid) { @service_instance_guid }
-      let(:binding_id) { @binding_id }
 
       before do
         setup_broker
@@ -328,10 +327,10 @@ RSpec.describe 'Service Broker API integration' do
 
       describe 'service unbinding request' do
         before do
-          stub_request(:delete, %r{/v2/service_instances/#{service_instance_guid}/service_bindings/#{binding_id}}).
+          stub_request(:delete, %r{/v2/service_instances/#{service_instance_guid}/service_bindings/#{@binding_guid}}).
             to_return(status: broker_response_status, body: '{}')
 
-          delete("v2/service_bindings/#{binding_id}",
+          delete("v2/service_bindings/#{@binding_guid}",
             '{}',
             admin_headers
           )

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe 'Service Broker API integration' do
         it 'receives a context object' do
           expected_body = hash_including(:context)
           expect(
-            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with(body: expected_body)
           ).to have_been_made
         end
 
@@ -503,7 +503,7 @@ RSpec.describe 'Service Broker API integration' do
           })
 
           expect(
-            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with(body: expected_body)
           ).to have_been_made
         end
       end
@@ -517,7 +517,7 @@ RSpec.describe 'Service Broker API integration' do
         it 'receives a context object' do
           expected_body = hash_including(:context)
           expect(
-            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with(body: expected_body)
           ).to have_been_made
         end
 
@@ -529,7 +529,7 @@ RSpec.describe 'Service Broker API integration' do
           })
 
           expect(
-            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with(body: expected_body)
           ).to have_been_made
         end
       end
@@ -545,7 +545,7 @@ RSpec.describe 'Service Broker API integration' do
         it 'receives a context object' do
           expected_body = hash_including(:context)
           expect(
-            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with(body: expected_body)
           ).to have_been_made
         end
 
@@ -557,7 +557,7 @@ RSpec.describe 'Service Broker API integration' do
           })
 
           expect(
-            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_id}}).with(body: expected_body)
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with(body: expected_body)
           ).to have_been_made
         end
       end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.7_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.7_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Service Broker API integration' do
 
         it 'marks the service instance as failed if the initial request succeeds, but the async provision fails' do
           async_update_service
-          stub_async_last_operation(state: 'failed')
+          stub_async_last_operation(body: { state: 'failed' })
 
           expect(
             a_request(:patch, update_url_for_broker(@broker, accepts_incomplete: true))
@@ -103,7 +103,8 @@ RSpec.describe 'Service Broker API integration' do
 
         it 'marks the service instance as failed if the initial request succeeds, but the async provision fails' do
           async_delete_service
-          stub_async_last_operation(state: 'failed')
+
+          stub_async_last_operation(body: { state: 'failed' })
 
           expect(
             a_request(:delete, deprovision_url(service_instance, accepts_incomplete: true))
@@ -152,7 +153,7 @@ RSpec.describe 'Service Broker API integration' do
 
         it 'marks the service instance as failed if the initial request succeeds, but the async provision fails' do
           async_provision_service
-          stub_async_last_operation(state: 'failed')
+          stub_async_last_operation(body: { state: 'failed' })
 
           expect(
             a_request(:put, provision_url_for_broker(@broker, accepts_incomplete: true))

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -3,21 +3,21 @@ require 'spec_helper'
 RSpec.describe 'Broker API Versions' do
   let(:spec_sha) do
     {
-      'broker_api_v2.0_spec.rb' => '71f9fc0ae1aed639e801fd60c1bad104',
+      'broker_api_v2.0_spec.rb' => 'b6b5916361307ed626e88a713415c8af',
       'broker_api_v2.1_spec.rb' => 'd0559352542dda5cbd3f010cbdc622f2',
       'broker_api_v2.2_spec.rb' => '4fc472fc502b50aa7451b3e376823fe0',
       'broker_api_v2.3_spec.rb' => 'b226a2bcd068ba6db28dd4ea26a94cdb',
       'broker_api_v2.4_spec.rb' => '229f05a3f6fab68163418794bd9bfab2',
       'broker_api_v2.5_spec.rb' => 'efc346680280b2f7bb8c5d2443fed810',
       'broker_api_v2.6_spec.rb' => 'a1608878f601819c90b44be5f317ec44',
-      'broker_api_v2.7_spec.rb' => '6ac3a8f83f3bc2492715b42a8fecb2a0',
+      'broker_api_v2.7_spec.rb' => '6db4cba42ac923ddf748b4f53914d057',
       'broker_api_v2.8_spec.rb' => '2b1b662b4874f5bac4481de7cf15b363',
       'broker_api_v2.9_spec.rb' => 'c297d302b57dd5b1aba9c92f0c9c4c4f',
       'broker_api_v2.10_spec.rb' => '27e81c4c540e39a4e4eac70c8efb14ba',
       'broker_api_v2.11_spec.rb' => '99e61dc50ceb635b09b3bd16901a4fa6',
       'broker_api_v2.12_spec.rb' => '45db41892336b8bf8748fd5ae484bc29',
-      'broker_api_v2.13_spec.rb' => '06b4683ffd7f69d800c3b9097bc9cd73',
-      'broker_api_v2.14_spec.rb' => '91bfc73795c55bfbaedcbfa7de537bec',
+      'broker_api_v2.13_spec.rb' => 'c5918cfb98f1bb06915a18d7743fbf87',
+      'broker_api_v2.14_spec.rb' => 'a1e7485793ba1916ea2f4080943530a5',
     }
   end
   let(:digester) { Digester.new(algorithm: Digest::MD5) }

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -176,26 +176,7 @@ module VCAP::CloudController::BrokerApiHelper
     @service_instance_guid = response['metadata']['guid']
   end
 
-  def stub_async_last_operation(state: 'succeeded', operation_data: nil)
-    fetch_body = {
-      state: state
-    }
-
-    url = "http://#{stubbed_broker_host}/v2/service_instances/#{@service_instance_guid}/last_operation"
-    if !operation_data.nil?
-      url += "\\?operation=#{operation_data}"
-    end
-
-    stub_request(:get,
-      Regexp.new(url)).
-      with(basic_auth: [stubbed_broker_username, stubbed_broker_password]).
-      to_return(
-        status: 200,
-        body: fetch_body.to_json)
-  end
-
-  def stub_async_binding_last_operation(body: { state: 'succeeded' }, operation_data: nil, return_code: 200)
-    url = "http://#{stubbed_broker_host}/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+/last_operation"
+  def stub_async_last_operation(body: { state: 'succeeded' }, operation_data: nil, return_code: 200, url: '')
     if !operation_data.nil?
       url += "\\?operation=#{operation_data}"
     end
@@ -304,7 +285,7 @@ module VCAP::CloudController::BrokerApiHelper
     )
 
     metadata = JSON.parse(last_response.body).fetch('metadata', {})
-    @binding_id = metadata.fetch('guid', nil)
+    @binding_guid = metadata.fetch('guid', nil)
   end
 
   def async_bind_service(opts={})
@@ -326,7 +307,7 @@ module VCAP::CloudController::BrokerApiHelper
     headers = opts[:user] ? admin_headers_for(opts[:user]) : admin_headers
     params = opts[:async] ? { async: true } : '{}'
     params = opts[:accepts_incomplete] ? { accepts_incomplete: true } : params
-    delete("/v2/service_bindings/#{@binding_id}", params, headers)
+    delete("/v2/service_bindings/#{@binding_guid}", params, headers)
   end
 
   def create_service_key(opts={})


### PR DESCRIPTION
This commit also refactors a helper method when stubbing async requests.

See https://www.pivotaltracker.com/story/show/156085630 for context.

cc @ablease 