### PR TITLE
this globs the copilot gem again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'addressable'
 gem 'allowy'
-gem 'cf-copilot', '~> 0.0.10'
+gem 'cf-copilot', git: 'https://github.com/cloudfoundry/copilot', glob: 'sdk/ruby/*.gemspec'
 gem 'clockwork', require: false
 gem 'cloudfront-signer'
 gem 'em-http-request', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/cloudfoundry/copilot
+  revision: 36a84274c0733fb47674a2bbeb8c2c1150deaa23
+  glob: sdk/ruby/*.gemspec
+  specs:
+    cf-copilot (0.0.11)
+      grpc (~> 1.0)
+
+GIT
   remote: https://github.com/cloudfoundry/vcap-concurrency.git
   revision: 2a5b0179642cb3d3e7f912a6453ec5731979d115
   ref: 2a5b0179
@@ -95,8 +103,6 @@ GEM
       steno
     builder (3.2.3)
     byebug (10.0.2)
-    cf-copilot (0.0.11)
-      grpc (~> 1.0)
     cf-perm (0.0.10)
       grpc (~> 1.0)
     cf-perm-test-helpers (0.0.6)
@@ -205,13 +211,13 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    grpc (1.16.0)
+    grpc (1.17.0)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
-    grpc (1.16.0-universal-darwin)
+    grpc (1.17.0-universal-darwin)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
-    grpc (1.16.0-x86_64-linux)
+    grpc (1.17.0-x86_64-linux)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
     hashdiff (0.3.7)
@@ -454,7 +460,7 @@ DEPENDENCIES
   azure-storage (= 0.14.0.preview)
   bits_service_client (~> 3.0)
   byebug
-  cf-copilot (~> 0.0.10)
+  cf-copilot!
   cf-perm (~> 0.0.10)
   cf-perm-test-helpers (~> 0.0.6)
   cf-uaa-lib (~> 3.14.0)


### PR DESCRIPTION
- please talk to cf-routing before reverting
this or see our slack discussion about it

Co-authored-by: Teal Stannard <tstannard@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: reglobbing the ruby gem. See context here: https://cloudfoundry.slack.com/archives/C07C04W4Q/p1543883000033800 

* An explanation of the use cases your change solves

This allows the routing team to develop without having to make a PR every time we change something 

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [C] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
