### PR TITLE
Send app port to Copilot on map/unmap route

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/cloudfoundry/copilot
-  revision: 36a84274c0733fb47674a2bbeb8c2c1150deaa23
+  revision: 6a31452d0423ea42150e414e4e01fa1b1c48adc6
   glob: sdk/ruby/*.gemspec
   specs:
     cf-copilot (0.0.11)
@@ -211,13 +211,13 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    grpc (1.17.0)
+    grpc (1.17.1)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
-    grpc (1.17.0-universal-darwin)
+    grpc (1.17.1-universal-darwin)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
-    grpc (1.17.0-x86_64-linux)
+    grpc (1.17.1-x86_64-linux)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
     hashdiff (0.3.7)

--- a/lib/cloud_controller/copilot/adapter.rb
+++ b/lib/cloud_controller/copilot/adapter.rb
@@ -24,7 +24,8 @@ module VCAP::CloudController
               copilot_client.map_route(
                 capi_process_guid: process.guid,
                 route_guid: route_mapping.route_guid,
-                route_weight: route_mapping.weight
+                route_weight: route_mapping.weight,
+                app_port: route_mapping.app_port
               )
             end
           end
@@ -36,7 +37,8 @@ module VCAP::CloudController
               copilot_client.unmap_route(
                 capi_process_guid: process.guid,
                 route_guid: route_mapping.route_guid,
-                route_weight: route_mapping.weight
+                route_weight: route_mapping.weight,
+                app_port: route_mapping.app_port
               )
             end
           end

--- a/lib/cloud_controller/copilot/sync.rb
+++ b/lib/cloud_controller/copilot/sync.rb
@@ -17,7 +17,8 @@ module VCAP::CloudController
             {
               capi_process_guid: rm.process.guid,
               route_guid: rm.route_guid,
-              route_weight: rm.weight
+              route_weight: rm.weight,
+              app_port: rm.app_port
             }
           end,
           capi_diego_process_associations: web_processes.map do |process|

--- a/spec/unit/actions/app_delete_spec.rb
+++ b/spec/unit/actions/app_delete_spec.rb
@@ -116,7 +116,7 @@ module VCAP::CloudController
           let(:process_type) { 'web' }
           let(:process) { ProcessModel.make(app: app, type: process_type) }
           let(:route) { Route.make }
-          let!(:route_mapping) { RouteMappingModel.make(app: app, route: route, process_type: process_type) }
+          let!(:route_mapping) { RouteMappingModel.make(app: app, route: route, process_type: process_type, app_port: 8080) }
 
           it 'deletes associated route mappings' do
             expect {
@@ -138,7 +138,7 @@ module VCAP::CloudController
             end
 
             it 'tells copilot to unmap the route' do
-              expect(copilot_client).to receive(:unmap_route).with({ capi_process_guid: process.guid, route_guid: route.guid, route_weight: 1 })
+              expect(copilot_client).to receive(:unmap_route).with({ capi_process_guid: process.guid, route_guid: route.guid, route_weight: 1, app_port: 8080 })
               app_delete.delete(app_dataset)
             end
 

--- a/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
@@ -105,7 +105,8 @@ module VCAP::CloudController
           app: app,
           route: route,
           process_type: 'web',
-          weight: 5
+          weight: 5,
+          app_port: 9090
         )
       end
 
@@ -114,12 +115,14 @@ module VCAP::CloudController
         expect(copilot_client).to have_received(:map_route).with(
           capi_process_guid: process1.guid,
           route_guid: route.guid,
-          route_weight: 5
+          route_weight: 5,
+          app_port: 9090
         )
         expect(copilot_client).to have_received(:map_route).with(
           capi_process_guid: process2.guid,
           route_guid: route.guid,
-          route_weight: 5
+          route_weight: 5,
+          app_port: 9090
         )
       end
 
@@ -170,7 +173,8 @@ module VCAP::CloudController
           app: app,
           route: route,
           process_type: 'web',
-          weight: 5
+          weight: 5,
+          app_port: 9090
         )
       end
 
@@ -179,12 +183,14 @@ module VCAP::CloudController
         expect(copilot_client).to have_received(:unmap_route).with(
           capi_process_guid: process1.guid,
           route_guid: route.guid,
-          route_weight: 5
+          route_weight: 5,
+          app_port: 9090
         )
         expect(copilot_client).to have_received(:unmap_route).with(
           capi_process_guid: process2.guid,
           route_guid: route.guid,
-          route_weight: 5
+          route_weight: 5,
+          app_port: 9090
         )
       end
 

--- a/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
@@ -17,10 +17,10 @@ module VCAP::CloudController
         let(:app) { VCAP::CloudController::AppModel.make }
 
         let(:route) { Route.make(domain: istio_domain, host: 'some-host', path: '/some/path') }
-        let!(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'web') }
+        let!(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'web', app_port: 9191) }
 
         let(:internal_route) { Route.make(domain: internal_istio_domain, host: 'internal-host') }
-        let!(:internal_route_mapping) { RouteMappingModel.make(route: internal_route, app: app, process_type: 'web') }
+        let!(:internal_route_mapping) { RouteMappingModel.make(route: internal_route, app: app, process_type: 'web', app_port: 9191) }
 
         let(:legacy_domain) { SharedDomain.make }
         let(:legacy_route) { Route.make(domain: legacy_domain, host: 'some-host', path: '/some/path') }
@@ -56,11 +56,13 @@ module VCAP::CloudController
               route_mappings: [{
                 capi_process_guid: web_process_model.guid,
                 route_guid: route_mapping.route_guid,
-                route_weight: route_mapping.weight
+                route_weight: route_mapping.weight,
+                app_port: route_mapping.app_port
               }, {
                 capi_process_guid: web_process_model.guid,
                 route_guid: internal_route_mapping.route_guid,
-                route_weight: internal_route_mapping.weight
+                route_weight: internal_route_mapping.weight,
+                app_port: internal_route_mapping.app_port
               }],
               capi_diego_process_associations: [{
                 capi_process_guid: web_process_model.guid,
@@ -93,11 +95,13 @@ module VCAP::CloudController
                   route_mappings: [{
                     capi_process_guid: web_process_model.guid,
                     route_guid: route_mapping.route_guid,
-                    route_weight: route_mapping.weight
+                    route_weight: route_mapping.weight,
+                    app_port: route_mapping.app_port
                   }, {
                     capi_process_guid: web_process_model.guid,
                     route_guid: internal_route_mapping.route_guid,
-                    route_weight: internal_route_mapping.weight
+                    route_weight: internal_route_mapping.weight,
+                    app_port: internal_route_mapping.app_port
                   }],
                   capi_diego_process_associations: [{
                     capi_process_guid: web_process_model.guid,
@@ -138,12 +142,14 @@ module VCAP::CloudController
               {
                 capi_process_guid: web_process_model_1.guid,
                 route_guid: route_mapping_1.route_guid,
-                route_weight: route_mapping_1.weight
+                route_weight: route_mapping_1.weight,
+                app_port: route_mapping_1.app_port
               },
               {
                 capi_process_guid: web_process_model_2.guid,
                 route_guid: route_mapping_2.route_guid,
-                route_weight: route_mapping_2.weight
+                route_weight: route_mapping_2.weight,
+                app_port: route_mapping_2.app_port
               }
             ])
             expect(args[:capi_diego_process_associations]).to match_array([


### PR DESCRIPTION
Sending this PR as part of #162390794

Signed-off-by: Christian Ang <cang@pivotal.io>

* A short explanation of the proposed change:

This will include `app_port` on `{un,}map_route`  in the message to copilot.

* An explanation of the use cases your change solves

We need this info to be able to map one route to apps running on different ports.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [-] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Acceptance tests do not cover this.

@christianang
