### PR TITLE
Allow updating service instance with inactive plan

### DIFF
--- a/app/access/managed_service_instance_access.rb
+++ b/app/access/managed_service_instance_access.rb
@@ -57,7 +57,11 @@ module VCAP::CloudController
     def allowed?(service_instance)
       return true if admin_user?
 
-      ServicePlan.user_visible(context.user, admin_user?).filter(guid: service_instance.service_plan.guid).count > 0
+      if service_instance.new? || service_instance.changed_columns.include?(:service_plan_id)
+        return ServicePlan.user_visible(context.user, admin_user?).filter(guid: service_instance.service_plan.guid).count > 0
+      end
+
+      true
     end
   end
 end

--- a/spec/unit/access/service_instance_access_spec.rb
+++ b/spec/unit/access/service_instance_access_spec.rb
@@ -97,22 +97,6 @@ module VCAP::CloudController
         end
       end
 
-      context 'updating a service instance that is currently part of an invisible plan' do
-        let(:service_plan_active) { false }
-
-        it 'is allowed' do
-          expect(subject).to allow_op_on_object(:read_for_update, service_instance)
-        end
-      end
-
-      context 'updating a service instance to become part of an invisible plan' do
-        let(:service_plan_active) { false }
-
-        it 'is not allowed' do
-          expect(subject).to_not allow_op_on_object(:update, service_instance)
-        end
-      end
-
       context 'when the service broker is space-scoped' do
         before do
           broker = service.service_broker

--- a/spec/unit/controllers/services/validators/service_update_validator_spec.rb
+++ b/spec/unit/controllers/services/validators/service_update_validator_spec.rb
@@ -256,6 +256,60 @@ module VCAP::CloudController
             end
           end
         end
+
+        context 'when the current user is an admin' do
+          context 'when the current plan is inactive and not public' do
+            let(:new_service_plan) { ServicePlan.make(:v2, service: service, active: false, public: false) }
+            let(:update_attrs) { { 'parameters' => '{foo: bar}' } }
+
+            it 'updates the parameters' do
+              user = VCAP::CloudController::User.make(admin: true)
+              set_current_user(user)
+              # set_current_user(user, { admin: true })
+              # set_current_user_as_admin
+              expect(ServiceUpdateValidator.validate!(service_instance, args)).to be true
+            end
+          end
+        end
+
+        context 'when the current user is space developer' do
+          before do
+            user = User.make
+            space.organization.add_user(user)
+            set_current_user_as_role(user: user, role: 'space_developer', space: space)
+          end
+
+          context 'when the current plan is active and public' do
+            let(:old_service_plan) { ServicePlan.make(:v2, service: service, active: true, public: true) }
+            let(:update_attrs) { { 'parameters' => '{foo: bar}' } }
+
+            it 'updates the parameters' do
+              expect(ServiceUpdateValidator.validate!(service_instance, args)).to be true
+            end
+          end
+
+          context 'when the current plan is not active' do
+            let(:old_service_plan) { ServicePlan.make(:v2, service: service, active: false) }
+            let(:update_attrs) { { 'parameters' => '{foo: bar}' } }
+
+            it 'should not allow update of parameters and raises a validation error' do
+              expect {
+                ServiceUpdateValidator.validate!(service_instance, args)
+              }.to raise_error(CloudController::Errors::ApiError, /Cannot update parameters of a service instance that belongs to inaccessible plan/)
+            end
+          end
+
+          context 'when the current plan is not public' do
+            let(:old_service_plan) { ServicePlan.make(:v2, service: service, active: true, public: false) }
+            let(:update_attrs) { { 'parameters' => '{foo: bar}' } }
+
+            it 'should not allow update of parameters and raises a validation error' do
+              expect {
+                ServiceUpdateValidator.validate!(service_instance, args)
+              }.to raise_error(CloudController::Errors::ApiError, /Cannot update parameters of a service instance that belongs to inaccessible plan/)
+            end
+          end
+        end
       end
     end
   end

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -323,6 +323,11 @@
   http_code: 404
   message: "The service instance could not be found: %s"
 
+60029:
+  name: ServiceInstanceWithInaccessiblePlanNotUpdateable
+  http_code: 403
+  message: "Cannot update %s of a service instance that belongs to inaccessible plan"
+
 70001:
   name: RuntimeInvalid
   http_code: 400


### PR DESCRIPTION
Previously, non-admin users could not update the service instance(name, tags)
if the plan is not active/public anymore. With this fix, they can.
Parameters are still not updateable since might they require an update to the instance,
which might not be allowed by the broker, since the plan is disabled.
Admins can still update all attributes.

For more information:
https://www.pivotaltracker.com/story/show/163189599

Fixes: #1278

Best,
Niki
On behalf of SAPI Team

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
