### PR TITLE
Add instance type to space summary

### DIFF
--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -130,6 +130,7 @@ module VCAP::CloudController
         'guid' => guid,
         'name' => name,
         'bound_app_count' => service_bindings_dataset.count,
+        'type' => type,
       }
     end
 

--- a/spec/api/documentation/summary_api_spec.rb
+++ b/spec/api/documentation/summary_api_spec.rb
@@ -105,6 +105,7 @@ RSpec.resource 'Spaces', type: [:api, :legacy_api] do
 
       expect(parsed_response['apps'][0]['name']).to eq(process.name)
       expect(parsed_response['services'][0]['name']).to eq(service_instance.name)
+      expect(parsed_response['services'][0]['type']).to eq('managed_service_instance')
     end
   end
 end

--- a/spec/unit/controllers/runtime/space_summaries_controller_spec.rb
+++ b/spec/unit/controllers/runtime/space_summaries_controller_spec.rb
@@ -94,6 +94,15 @@ module VCAP::CloudController
         expect(decoded_response['services'].first['shared_from']).to be_nil
       end
 
+      it 'includes the type of all service instances' do
+        get "/v2/spaces/#{space.guid}/summary"
+
+        parsed_response = MultiJson.load(last_response.body)
+        parsed_response['services'].each do |service_json|
+          expect(service_json.fetch('type')).to eq('managed_service_instance')
+        end
+      end
+
       context 'when a managed service has been shared into this space' do
         let(:receiver_space) { Space.make }
         let(:originating_space) { Space.make }

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -296,7 +296,7 @@ module VCAP::CloudController
     end
 
     describe '#as_summary_json' do
-      it 'contains name, guid, and binding count' do
+      it 'contains name, guid, binding count and type' do
         instance = VCAP::CloudController::ServiceInstance.make(
           guid: 'ABCDEFG12',
           name: 'Random-Number-Service',
@@ -307,6 +307,7 @@ module VCAP::CloudController
           'guid' => 'ABCDEFG12',
           'name' => 'Random-Number-Service',
           'bound_app_count' => 1,
+          'type' => 'service_instance',
         })
       end
     end


### PR DESCRIPTION
The `/v2/space/:space_guid/summary` endpoint will now return the type
of each service instance in the space (managed or user-provided) to
reduce the number of API calls the CLI needs to make when running
`cf services`.

More details [here](https://www.pivotaltracker.com/story/show/163455167)