### PR TITLE
Respect 'retry-after' header for operations on service bindings

### DIFF
--- a/app/jobs/services/asynchronous_operations.rb
+++ b/app/jobs/services/asynchronous_operations.rb
@@ -1,0 +1,33 @@
+module VCAP::CloudController
+  module Jobs
+    module Services
+      module AsynchronousOperations
+        private
+
+        def new_end_timestamp
+          Time.now + Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
+        end
+
+        def retry_job(retry_after_header: '')
+          update_polling_interval(retry_after_header: retry_after_header)
+          if Time.now + poll_interval > end_timestamp
+            end_timestamp_reached
+          else
+            enqueue_again
+          end
+        end
+
+        def enqueue_again
+          opts = { queue: 'cc-generic', run_at: Delayed::Job.db_time_now + poll_interval }
+          Jobs::Enqueuer.new(self, opts).enqueue
+        end
+
+        def update_polling_interval(retry_after_header: '')
+          default_poll_interval = Config.config.get(:broker_client_default_async_poll_interval_seconds)
+          poll_interval = [default_poll_interval, retry_after_header.to_i].max
+          self.poll_interval = [poll_interval, 24.hours].min
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/services/service_binding_state_fetch.rb
+++ b/app/jobs/services/service_binding_state_fetch.rb
@@ -1,10 +1,16 @@
+require_relative 'asynchronous_operations'
+
 module VCAP::CloudController
   module Jobs
     module Services
       class ServiceBindingStateFetch < VCAP::CloudController::Jobs::CCJob
+        include AsynchronousOperations
+
+        attr_accessor :service_binding_guid, :end_timestamp, :user_audit_info, :request_attrs, :poll_interval
+
         def initialize(service_binding_guid, user_info, request_attrs)
           @service_binding_guid = service_binding_guid
-          @end_timestamp = Time.now + Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
+          @end_timestamp = new_end_timestamp
           @user_audit_info = user_info
           @request_attrs = request_attrs
           update_polling_interval
@@ -13,7 +19,7 @@ module VCAP::CloudController
         def perform
           logger = Steno.logger('cc-background')
 
-          service_binding = ServiceBinding.first(guid: @service_binding_guid)
+          service_binding = ServiceBinding.first(guid: service_binding_guid)
           return if service_binding.nil? # assume the binding has been purged
 
           client = VCAP::Services::ServiceClientProvider.provide(instance: service_binding.service_instance)
@@ -30,6 +36,7 @@ module VCAP::CloudController
 
           retry_job(retry_after_header: last_operation_result[:retry_after]) unless service_binding.terminal_state?
         rescue HttpResponseError,
+               HttpRequestError,
                Sequel::Error,
                VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerApiTimeout,
                VCAP::Services::ServiceBrokers::V2::Errors::HttpClientTimeout => e
@@ -60,7 +67,7 @@ module VCAP::CloudController
               'syslog_drain_url' => binding_response[:syslog_drain_url],
               'volume_mounts' => binding_response[:volume_mounts],
             })
-            record_event(service_binding, @request_attrs)
+            record_event(service_binding, request_attrs)
             service_binding.last_operation.update(last_operation_result[:last_operation])
             return { finished: true }
           end
@@ -72,7 +79,7 @@ module VCAP::CloudController
         def process_delete_operation(service_binding, last_operation_result)
           if state_succeeded?(last_operation_result)
             service_binding.destroy
-            record_event(service_binding, @request_attrs)
+            record_event(service_binding, request_attrs)
             return { finished: true }
           end
 
@@ -80,16 +87,11 @@ module VCAP::CloudController
           { finished: false }
         end
 
-        def retry_job(retry_after_header: '')
-          update_polling_interval(retry_after_header: retry_after_header)
-          if Time.now + @poll_interval > @end_timestamp
-            ServiceBinding.first(guid: @service_binding_guid).last_operation.update(
-              state: 'failed',
-              description: 'Service Broker failed to bind within the required time.'
-            )
-          else
-            enqueue_again
-          end
+        def end_timestamp_reached
+          ServiceBinding.first(guid: service_binding_guid).last_operation.update(
+            state: 'failed',
+            description: 'Service Broker failed to bind within the required time.'
+          )
         end
 
         def record_event(binding, request_attrs)
@@ -97,21 +99,10 @@ module VCAP::CloudController
           operation_type = binding.last_operation.type
 
           if operation_type == 'create'
-            repository.record_create(binding, @user_audit_info, request_attrs)
+            repository.record_create(binding, user_audit_info, request_attrs)
           elsif operation_type == 'delete'
-            repository.record_delete(binding, @user_audit_info)
+            repository.record_delete(binding, user_audit_info)
           end
-        end
-
-        def enqueue_again
-          opts = { queue: 'cc-generic', run_at: Delayed::Job.db_time_now + @poll_interval }
-          Jobs::Enqueuer.new(self, opts).enqueue
-        end
-
-        def update_polling_interval(retry_after_header: '')
-          default_poll_interval = Config.config.get(:broker_client_default_async_poll_interval_seconds)
-          poll_interval = [default_poll_interval, retry_after_header.to_i].max
-          @poll_interval = [poll_interval, 24.hours].min
         end
 
         def set_binding_failed_state(service_binding, logger)

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -272,6 +272,7 @@ module VCAP::Services::ServiceBrokers::V2
         result[:last_operation] = {}
         result[:last_operation][:state] = extract_state(service_binding, last_operation_hash)
         result[:last_operation][:description] = last_operation_hash['description'] if last_operation_hash['description']
+        result[:retry_after] = response[HttpResponse::HEADER_RETRY_AFTER] if response[HttpResponse::HEADER_RETRY_AFTER]
       end
     end
 

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
@@ -34,76 +34,102 @@ RSpec.describe 'Service Broker API integration' do
       let(:retry_after_interval) { default_poll_interval * 4 }
 
       before do
-        setup_broker(default_catalog(plan_updateable: true))
+        setup_broker(default_catalog(plan_updateable: true, bindings_retrievable: true))
         @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
         stub_async_last_operation(body: { state: 'in progress' }, headers: { 'Retry-After': retry_after_interval })
       end
 
-      context 'when provisioning a service instance' do
-        it 'should poll the broker at the given retry interval' do
-          expect(async_provision_service).to have_status_code(202)
+      describe 'service instances' do
+        context 'when provisioning a service instance' do
+          it 'should poll the broker at the given retry interval' do
+            expect(async_provision_service).to have_status_code(202)
 
-          expect(
-            a_request(:put, provision_url_for_broker(@broker, accepts_incomplete: true))
-          ).to have_been_made
+            expect(
+              a_request(:put, provision_url_for_broker(@broker, accepts_incomplete: true))
+            ).to have_been_made
 
-          service_instance = VCAP::CloudController::ManagedServiceInstance.find(guid: @service_instance_guid)
+            service_instance = VCAP::CloudController::ManagedServiceInstance.find(guid: @service_instance_guid)
 
-          assert_cc_uses_specified_polling_interval(
-            service_instance,
-            default_poll_interval,
-            retry_after_interval
-          )
+            assert_cc_polls_service_instance_last_operation(
+              service_instance,
+              default_poll_interval,
+              retry_after_interval
+            )
+          end
+        end
+
+        context 'when deprovisioning a service instance' do
+          let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space_guid: @space_guid, service_plan_guid: @plan_guid) }
+
+          before do
+            @service_instance_guid = service_instance.guid
+          end
+
+          it 'should poll the broker at the given retry interval' do
+            expect(async_delete_service).to have_status_code(202)
+
+            expect(
+              a_request(:delete, deprovision_url(service_instance, accepts_incomplete: true))
+            ).to have_been_made
+
+            assert_cc_polls_service_instance_last_operation(
+              service_instance,
+              default_poll_interval,
+              retry_after_interval
+            )
+          end
+        end
+
+        context 'when updating a service instance' do
+          let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space_guid: @space_guid, service_plan_guid: @plan_guid) }
+
+          before do
+            @service_instance_guid = service_instance.guid
+          end
+
+          it 'should poll the broker at the given retry interval' do
+            expect(async_update_service).to have_status_code(202)
+
+            expect(
+              a_request(:patch, update_url_for_broker(@broker, accepts_incomplete: true))).to have_been_made
+
+            assert_cc_polls_service_instance_last_operation(
+              service_instance,
+              default_poll_interval,
+              retry_after_interval
+            )
+          end
         end
       end
 
-      context 'when deprovisioning a service instance' do
-        let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space_guid: @space_guid, service_plan_guid: @plan_guid) }
+      describe 'service bindings' do
+        context 'when creating a service binding' do
+          let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space_guid: @space_guid, service_plan_guid: @plan_guid) }
 
-        before do
-          @service_instance_guid = service_instance.guid
-        end
+          before do
+            @service_instance_guid = service_instance.guid
+            create_app
+          end
 
-        it 'should poll the broker at the given retry interval' do
-          expect(async_delete_service).to have_status_code(202)
+          it 'should poll the broker at the given retry interval' do
+            expect(async_bind_service(status: 202)).to have_status_code(202)
 
-          expect(
-            a_request(:delete, deprovision_url(service_instance, accepts_incomplete: true))
-          ).to have_been_made
+            expect(
+              a_request(:put, bind_url(service_instance, accepts_incomplete: true))).to have_been_made
 
-          assert_cc_uses_specified_polling_interval(
-            service_instance,
-            default_poll_interval,
-            retry_after_interval
-          )
-        end
-      end
-
-      context 'when updating a service instance' do
-        let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space_guid: @space_guid, service_plan_guid: @plan_guid) }
-
-        before do
-          @service_instance_guid = service_instance.guid
-        end
-
-        it 'should poll the broker at the given retry interval' do
-          expect(async_update_service).to have_status_code(202)
-
-          expect(
-            a_request(:patch, update_url_for_broker(@broker, accepts_incomplete: true))).to have_been_made
-
-          assert_cc_uses_specified_polling_interval(
-            service_instance,
-            default_poll_interval,
-            retry_after_interval
-          )
+            assert_cc_polls_service_binding_last_operation(
+              service_instance,
+              default_poll_interval,
+              retry_after_interval
+            )
+          end
         end
       end
     end
   end
 end
 
-def assert_cc_uses_specified_polling_interval(service_instance, default_poll_interval, retry_after_interval)
+def assert_cc_polls_service_instance_last_operation(service_instance, default_poll_interval, retry_after_interval)
   Timecop.freeze(Time.now) do
     Delayed::Worker.new.work_off
     expect(a_request(:get, %r{#{service_instance_url(service_instance)}/last_operation})).to have_been_made
@@ -115,5 +141,20 @@ def assert_cc_uses_specified_polling_interval(service_instance, default_poll_int
     Timecop.travel(retry_after_interval.seconds)
     Delayed::Worker.new.work_off
     expect(a_request(:get, %r{#{service_instance_url(service_instance)}/last_operation})).to have_been_made.twice
+  end
+end
+
+def assert_cc_polls_service_binding_last_operation(service_instance, default_poll_interval, retry_after_interval)
+  Timecop.freeze(Time.now) do
+    Delayed::Worker.new.work_off
+    expect(a_request(:get, %r{#{bind_url(service_instance)}/last_operation})).to have_been_made
+
+    Timecop.travel(default_poll_interval.seconds)
+    Delayed::Worker.new.work_off
+    expect(a_request(:get, %r{#{bind_url(service_instance)}/last_operation})).to have_been_made.once
+
+    Timecop.travel(retry_after_interval.seconds)
+    Delayed::Worker.new.work_off
+    expect(a_request(:get, %r{#{bind_url(service_instance)}/last_operation})).to have_been_made.twice
   end
 end

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -289,6 +289,8 @@ module VCAP::CloudController::BrokerApiHelper
 
     metadata = JSON.parse(last_response.body).fetch('metadata', {})
     @binding_guid = metadata.fetch('guid', nil)
+
+    last_response
   end
 
   def async_bind_service(opts={})

--- a/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
@@ -645,6 +645,77 @@ module VCAP::CloudController
               end
             end
           end
+
+          context 'when brokers return Retry-After header' do
+            let(:state) { 'in progress' }
+            let(:default_polling_interval) { VCAP::CloudController::Config.config.get(:broker_client_default_async_poll_interval_seconds) }
+            let(:last_operation_response) { { last_operation: { state: state, description: description }, retry_after: broker_polling_interval } }
+
+            before do
+              allow(client).to receive(:fetch_service_binding_last_operation).and_return(last_operation_response)
+            end
+
+            context 'when the broker returns interval' do
+              context 'when the interval is greater than the default configuration' do
+                let(:broker_polling_interval) { default_polling_interval * 2 }
+
+                it 'the polling interval should be the one broker returned' do
+                  Timecop.freeze(Time.now)
+                  first_run_time = Time.now
+
+                  Jobs::Enqueuer.new(job, { queue: 'cc-generic', run_at: first_run_time }).enqueue
+                  execute_all_jobs(expected_successes: 1, expected_failures: 0)
+                  expect(Delayed::Job.count).to eq(1)
+
+                  run_time_default_interval = first_run_time + default_polling_interval.seconds + 1.second
+                  Timecop.travel(run_time_default_interval) do
+                    execute_all_jobs(expected_successes: 0, expected_failures: 0)
+                  end
+
+                  run_time_broker_interval = first_run_time + broker_polling_interval.seconds + 1.second
+                  Timecop.travel(run_time_broker_interval) do
+                    execute_all_jobs(expected_successes: 1, expected_failures: 0)
+                  end
+                end
+              end
+
+              context 'when the interval is less than the default configuration' do
+                let(:broker_polling_interval) { default_polling_interval / 2 }
+
+                it 'the polling interval should be the default specified in the configuration' do
+                  Timecop.freeze(Time.now)
+                  first_run_time = Time.now
+
+                  Jobs::Enqueuer.new(job, { queue: 'cc-generic', run_at: first_run_time }).enqueue
+                  execute_all_jobs(expected_successes: 1, expected_failures: 0)
+                  expect(Delayed::Job.count).to eq(1)
+
+                  run_time_default_interval = first_run_time + default_polling_interval.seconds + 1.second
+                  Timecop.travel(run_time_default_interval) do
+                    execute_all_jobs(expected_successes: 1, expected_failures: 0)
+                  end
+                end
+              end
+
+              context 'when the interval is greater than the max value (24 hours)' do
+                let(:broker_polling_interval) { 24.hours.seconds + 1.minutes }
+
+                it 'the polling interval should not exceed the max' do
+                  Timecop.freeze(Time.now)
+                  first_run_time = Time.now
+
+                  Jobs::Enqueuer.new(job, { queue: 'cc-generic', run_at: first_run_time }).enqueue
+                  execute_all_jobs(expected_successes: 1, expected_failures: 0)
+                  expect(Delayed::Job.count).to eq(1)
+
+                  run_time_max_interval = first_run_time + 24.hours + 1.second
+                  Timecop.travel(run_time_max_interval) do
+                    execute_all_jobs(expected_successes: 1, expected_failures: 0)
+                  end
+                end
+              end
+            end
+          end
         end
       end
     end

--- a/spec/unit/jobs/services/shared/when_broker_returns_retry_after_header.rb
+++ b/spec/unit/jobs/services/shared/when_broker_returns_retry_after_header.rb
@@ -1,0 +1,72 @@
+RSpec.shared_examples 'when brokers return Retry-After header' do |last_operation_method_name|
+  context 'when brokers return Retry-After header' do
+    let(:state) { 'in progress' }
+    let(:default_polling_interval) { VCAP::CloudController::Config.config.get(:broker_client_default_async_poll_interval_seconds) }
+    let(:last_operation_response) { { last_operation: { state: state, description: description }, retry_after: broker_polling_interval } }
+
+    before do
+      allow(client).to receive(last_operation_method_name).and_return(last_operation_response)
+    end
+
+    context 'when the broker returns interval' do
+      context 'when the interval is greater than the default configuration' do
+        let(:broker_polling_interval) { default_polling_interval * 2 }
+
+        it 'the polling interval should be the one broker returned' do
+          Timecop.freeze(Time.now)
+          first_run_time = Time.now
+
+          VCAP::CloudController::Jobs::Enqueuer.new(job, { queue: 'cc-generic', run_at: first_run_time }).enqueue
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          expect(Delayed::Job.count).to eq(1)
+
+          run_time_default_interval = first_run_time + default_polling_interval.seconds + 1.second
+          Timecop.travel(run_time_default_interval) do
+            execute_all_jobs(expected_successes: 0, expected_failures: 0)
+          end
+
+          run_time_broker_interval = first_run_time + broker_polling_interval.seconds + 1.second
+          Timecop.travel(run_time_broker_interval) do
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          end
+        end
+      end
+
+      context 'when the interval is less than the default configuration' do
+        let(:broker_polling_interval) { default_polling_interval / 2 }
+
+        it 'the polling interval should be the default specified in the configuration' do
+          Timecop.freeze(Time.now)
+          first_run_time = Time.now
+
+          VCAP::CloudController::Jobs::Enqueuer.new(job, { queue: 'cc-generic', run_at: first_run_time }).enqueue
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          expect(Delayed::Job.count).to eq(1)
+
+          run_time_default_interval = first_run_time + default_polling_interval.seconds + 1.second
+          Timecop.travel(run_time_default_interval) do
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          end
+        end
+      end
+
+      context 'when the interval is greater than the max value (24 hours)' do
+        let(:broker_polling_interval) { 24.hours.seconds + 1.minutes }
+
+        it 'the polling interval should not exceed the max' do
+          Timecop.freeze(Time.now)
+          first_run_time = Time.now
+
+          VCAP::CloudController::Jobs::Enqueuer.new(job, { queue: 'cc-generic', run_at: first_run_time }).enqueue
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          expect(Delayed::Job.count).to eq(1)
+
+          run_time_max_interval = first_run_time + 24.hours + 1.second
+          Timecop.travel(run_time_max_interval) do
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -1730,6 +1730,15 @@ module VCAP::Services::ServiceBrokers::V2
           end
         end
       end
+
+      context 'when the broker returns headers' do
+        let(:broker_response) { HttpResponse.new(code: 200, body: response_body, headers: { 'Retry-After' => 10 }) }
+
+        it 'returns the retry after header in the result' do
+          attrs = client.fetch_service_binding_last_operation(service_binding)
+          expect(attrs).to include(retry_after: 10)
+        end
+      end
     end
 
     def unwrap_delayed_job(job)


### PR DESCRIPTION
This (OSBAPI specification change)[openservicebrokerapi/servicebroker#621] introduces a 'Retry-After' header that allows a broker to specify a longer polling duration than the platform would otherwise default to.

This commit implements that change on the Cloud Controller API for operations on **service bindings**. (Sibling PR at #1296)