### PR TITLE
Respect max polling duration for instance operations set by the broker

### DIFF
--- a/app/jobs/services/service_instance_state_fetch.rb
+++ b/app/jobs/services/service_instance_state_fetch.rb
@@ -43,6 +43,15 @@ module VCAP::CloudController
 
         private
 
+        def new_end_timestamp
+          max_poll_duration_configured = VCAP::CloudController::Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
+          max_poll_duration_on_plan = ManagedServiceInstance.first(guid: service_instance_guid).try(:service_plan).try(:maximum_polling_duration)
+
+          max_poll_duration_on_plan = (max_poll_duration_on_plan / 60).minutes if max_poll_duration_on_plan
+
+          Time.now + [max_poll_duration_configured, max_poll_duration_on_plan].compact.min
+        end
+
         def repository
           Repositories::ServiceEventRepository.new(user_audit_info)
         end

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -16,6 +16,7 @@ module VCAP::CloudController
                       :bindable,
                       :plan_updateable,
                       :active,
+                      :maximum_polling_duration,
                       :create_instance_schema,
                       :update_instance_schema,
                       :create_binding_schema
@@ -31,6 +32,7 @@ module VCAP::CloudController
                       :public,
                       :bindable,
                       :plan_updateable,
+                      :maximum_polling_duration,
                       :create_instance_schema,
                       :update_instance_schema,
                       :create_binding_schema

--- a/db/migrations/20190219161111_add_maximum_polling_duration_to_service_plans.rb
+++ b/db/migrations/20190219161111_add_maximum_polling_duration_to_service_plans.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :service_plans, :maximum_polling_duration, Integer, null: true
+  end
+end

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -111,6 +111,7 @@ module VCAP::Services::ServiceBrokers
         active:      true,
         extra:       catalog_plan.metadata.try(:to_json),
         plan_updateable: catalog_plan.plan_updateable,
+        maximum_polling_duration: catalog_plan.maximum_polling_duration,
         create_instance_schema: create_instance,
         update_instance_schema: update_instance,
         create_binding_schema: create_binding,

--- a/lib/services/service_brokers/v2/catalog_plan.rb
+++ b/lib/services/service_brokers/v2/catalog_plan.rb
@@ -2,7 +2,7 @@ module VCAP::Services::ServiceBrokers::V2
   class CatalogPlan
     include CatalogValidationHelper
 
-    attr_reader :broker_provided_id, :name, :description, :metadata
+    attr_reader :broker_provided_id, :name, :description, :metadata, :maximum_polling_duration
     attr_reader :catalog_service, :errors, :free, :bindable, :schemas, :plan_updateable
 
     def initialize(catalog_service, attrs)
@@ -15,6 +15,7 @@ module VCAP::Services::ServiceBrokers::V2
       @free               = attrs['free'].nil? ? true : attrs['free']
       @bindable           = attrs['bindable']
       @plan_updateable    = attrs['plan_updateable']
+      @maximum_polling_duration = attrs['maximum_polling_duration']
       build_schemas(attrs['schemas'])
     end
 
@@ -48,6 +49,7 @@ module VCAP::Services::ServiceBrokers::V2
       validate_bool!(:free, free) if free
       validate_bool!(:bindable, bindable) if bindable
       validate_bool!(:plan_updateable, plan_updateable) if plan_updateable
+      validate_integer!(:maximum_polling_duration, maximum_polling_duration) if maximum_polling_duration
       validate_hash!(:schemas, @schemas_data) if @schemas_data
     end
 
@@ -59,14 +61,15 @@ module VCAP::Services::ServiceBrokers::V2
 
     def human_readable_attr_name(name)
       {
-        broker_provided_id: 'Plan id',
-        name:               'Plan name',
-        description:        'Plan description',
-        metadata:           'Plan metadata',
-        free:               'Plan free',
-        bindable:           'Plan bindable',
-        plan_updateable:    'Plan updateable',
-        schemas:            'Plan schemas',
+        broker_provided_id:         'Plan id',
+        name:                       'Plan name',
+        description:                'Plan description',
+        metadata:                   'Plan metadata',
+        free:                       'Plan free',
+        bindable:                   'Plan bindable',
+        plan_updateable:            'Plan updateable',
+        schemas:                    'Plan schemas',
+        maximum_polling_duration:   'Maximum polling duration',
       }.fetch(name) { raise NotImplementedError }
     end
   end

--- a/lib/services/service_brokers/v2/catalog_validation_helper.rb
+++ b/lib/services/service_brokers/v2/catalog_validation_helper.rb
@@ -34,6 +34,12 @@ module VCAP::Services::ServiceBrokers::V2
       end
     end
 
+    def validate_integer!(name, input, opts={})
+      if !input.is_a?(Integer) && !input.nil?
+        errors.add("#{human_readable_attr_name(name)} must be an integer, but has value #{input.inspect}")
+      end
+    end
+
     def validate_array_of_strings!(name, input)
       unless is_an_array_of(String, input)
         errors.add("#{human_readable_attr_name(name)} must be an array of strings, but has value #{input.inspect}")

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -642,19 +642,20 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         actee_name: new_plan.name,
         space_guid: '',
         metadata:   {
-          'name'                   => new_plan.name,
-          'free'                   => new_plan.free,
-          'description'            => new_plan.description,
-          'service_guid'           => new_plan.service.guid,
-          'extra'                  => new_plan.extra,
-          'unique_id'              => new_plan.unique_id,
-          'public'                 => new_plan.public,
-          'active'                 => new_plan.active,
-          'bindable'               => new_plan.bindable,
-          'plan_updateable'        => new_plan.plan_updateable,
-          'create_instance_schema' => new_plan.create_instance_schema,
-          'update_instance_schema' => new_plan.update_instance_schema,
-          'create_binding_schema'  => new_plan.create_binding_schema
+          'name'                       => new_plan.name,
+          'free'                       => new_plan.free,
+          'description'                => new_plan.description,
+          'service_guid'               => new_plan.service.guid,
+          'extra'                      => new_plan.extra,
+          'unique_id'                  => new_plan.unique_id,
+          'public'                     => new_plan.public,
+          'active'                     => new_plan.active,
+          'bindable'                   => new_plan.bindable,
+          'plan_updateable'            => new_plan.plan_updateable,
+          'maximum_polling_duration'   => new_plan.maximum_polling_duration,
+          'create_instance_schema'     => new_plan.create_instance_schema,
+          'update_instance_schema'     => new_plan.update_instance_schema,
+          'create_binding_schema'      => new_plan.create_binding_schema
         }
       }
     end

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController::BrokerApiHelper
         body: catalog.to_json)
   end
 
-  def default_catalog(plan_updateable: false, requires: [], plan_schemas: {}, bindings_retrievable: false)
+  def default_catalog(plan_updateable: false, requires: [], plan_schemas: {}, bindings_retrievable: false, maximum_polling_duration: nil)
     {
       services: [
         {
@@ -45,7 +45,8 @@ module VCAP::CloudController::BrokerApiHelper
               id: 'plan1-guid-here',
               name: 'small',
               description: 'A small shared database with 100mb storage quota and 10 connections',
-              schemas: plan_schemas
+              schemas: plan_schemas,
+              maximum_polling_duration: maximum_polling_duration,
             },
             {
               id: 'plan2-guid-here',

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -79,6 +79,7 @@ module VCAP::Services::ServiceBrokers
                 'plan_updateable' => true,
                 'free'        => false,
                 'bindable'    => true,
+                'maximum_polling_duration' => 3600,
               }.merge(plan_metadata_hash).merge(plan_schemas_hash)
             ]
           }.merge(service_metadata_hash)
@@ -183,6 +184,7 @@ module VCAP::Services::ServiceBrokers
           'free' => service_plan.free,
           'description' => service_plan.description,
           'plan_updateable' => service_plan.plan_updateable,
+          'maximum_polling_duration' => service_plan.maximum_polling_duration,
           'service_guid' => service_plan.service.guid,
           'extra' => '{"cost":"0.0"}',
           'unique_id' => service_plan.unique_id,
@@ -226,6 +228,7 @@ module VCAP::Services::ServiceBrokers
           expect(plan.name).to eq(plan_name)
           expect(plan.description).to eq(plan_description)
           expect(plan.plan_updateable).to eq(true)
+          expect(plan.maximum_polling_duration).to eq(3600)
           expect(JSON.parse(plan.extra)).to eq({ 'cost' => '0.0' })
           expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
           expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')

--- a/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
@@ -13,14 +13,15 @@ module VCAP::Services::ServiceBrokers::V2
         'free'        => opts.fetch(:free, true),
         'bindable'    => opts[:bindable],
         'schemas'     => opts[:schemas] || {},
-        'plan_updateable' => opts[:plan_updateable]
+        'plan_updateable' => opts[:plan_updateable],
+        'maximum_polling_duration' => opts[:maximum_polling_duration]
       }
     end
     let(:catalog_service) { instance_double(VCAP::Services::ServiceBrokers::V2::CatalogService) }
     let(:opts) { {} }
 
     describe 'initializing' do
-      let(:opts) { { free: false, bindable: true, plan_updateable: true } }
+      let(:opts) { { free: false, bindable: true, plan_updateable: true, maximum_polling_duration: 3600 } }
 
       it 'should assign attributes' do
         expect(plan.broker_provided_id).to eq 'broker-provided-plan-id'
@@ -31,6 +32,7 @@ module VCAP::Services::ServiceBrokers::V2
         expect(plan.free).to be false
         expect(plan.bindable).to be true
         expect(plan.plan_updateable).to be true
+        expect(plan.maximum_polling_duration).to be 3600
         expect(plan.errors).to be_empty
       end
 
@@ -135,6 +137,13 @@ module VCAP::Services::ServiceBrokers::V2
 
         expect(plan).to_not be_valid
         expect(plan.errors.messages.first).to include 'Plan schemas must be a hash, but has value "true"'
+      end
+
+      it 'validates that @maximum_polling_duration is an integer' do
+        plan_attrs['maximum_polling_duration'] = 'true'
+
+        expect(plan).to_not be_valid
+        expect(plan.errors.messages).to include 'Maximum polling duration must be an integer, but has value "true"'
       end
 
       describe '#valid?' do

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -50,6 +50,7 @@ module VCAP::CloudController
                                          :public,
                                          :bindable,
                                          :plan_updateable,
+                                         :maximum_polling_duration,
                                          :active,
                                          :create_instance_schema,
                                          :update_instance_schema,
@@ -66,6 +67,7 @@ module VCAP::CloudController
                                          :public,
                                          :bindable,
                                          :plan_updateable,
+                                         :maximum_polling_duration,
                                          :create_instance_schema,
                                          :update_instance_schema,
                                          :create_binding_schema

--- a/spec/unit/presenters/v2/service_plan_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_plan_presenter_spec.rb
@@ -39,6 +39,7 @@ module CloudController::Presenters::V2
            'description' => service_plan.description,
            'extra' => nil,
            'free' => false,
+           'maximum_polling_duration' => nil,
            'name' => service_plan.name,
            'public' => true,
            'relationship_url' => 'http://relationship.example.com',


### PR DESCRIPTION
This (OSBAPI specification change)[[openservicebrokerapi/servicebroker#627](https://github.com/openservicebrokerapi/servicebroker/pull/627)] introduces a  timeout value (at the catalog level for a service) a broker to specify a polling duration other than what the platform would default to.
This commit implements that change on the Cloud Controller API for operations on **service instances**.  Operations on bindings will be done as part of a following PR.

More details in the following stories:
https://www.pivotaltracker.com/story/show/163861066
https://www.pivotaltracker.com/story/show/163861093
https://www.pivotaltracker.com/story/show/163861101

Aarti, @williammartin , @nmaslarski 
