### PR TITLE
Respect max polling duration for binding operations set by the broker

### DIFF
--- a/app/jobs/services/asynchronous_operations.rb
+++ b/app/jobs/services/asynchronous_operations.rb
@@ -4,8 +4,13 @@ module VCAP::CloudController
       module AsynchronousOperations
         private
 
-        def new_end_timestamp
-          Time.now + Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
+        def new_end_timestamp(service_plan)
+          max_poll_duration_configured = VCAP::CloudController::Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
+          max_poll_duration_on_plan = service_plan.try(:maximum_polling_duration)
+
+          max_poll_duration_on_plan = (max_poll_duration_on_plan / 60).minutes if max_poll_duration_on_plan
+
+          Time.now + [max_poll_duration_configured, max_poll_duration_on_plan].compact.min
         end
 
         def retry_job(retry_after_header: '')

--- a/app/jobs/services/asynchronous_operations.rb
+++ b/app/jobs/services/asynchronous_operations.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
       module AsynchronousOperations
         private
 
-        def new_end_timestamp(service_plan)
+        def new_end_timestamp
           max_poll_duration_configured = VCAP::CloudController::Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
           max_poll_duration_on_plan = service_plan.try(:maximum_polling_duration)
 

--- a/app/jobs/services/service_binding_state_fetch.rb
+++ b/app/jobs/services/service_binding_state_fetch.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
 
         def initialize(service_binding_guid, user_info, request_attrs)
           @service_binding_guid = service_binding_guid
-          @end_timestamp = new_end_timestamp
+          @end_timestamp = new_end_timestamp(ServiceBinding.first(guid: service_binding_guid).try(:service_plan))
           @user_audit_info = user_info
           @request_attrs = request_attrs
           update_polling_interval

--- a/app/jobs/services/service_binding_state_fetch.rb
+++ b/app/jobs/services/service_binding_state_fetch.rb
@@ -88,9 +88,10 @@ module VCAP::CloudController
         end
 
         def end_timestamp_reached
-          ServiceBinding.first(guid: service_binding_guid).last_operation.update(
+          binding_last_operation = ServiceBinding.first(guid: service_binding_guid).last_operation
+          binding_last_operation.update(
             state: 'failed',
-            description: 'Service Broker failed to bind within the required time.'
+            description: "Service Broker failed to #{binding_last_operation.type} binding within the required time."
           )
         end
 

--- a/app/jobs/services/service_binding_state_fetch.rb
+++ b/app/jobs/services/service_binding_state_fetch.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
 
         def initialize(service_binding_guid, user_info, request_attrs)
           @service_binding_guid = service_binding_guid
-          @end_timestamp = new_end_timestamp(ServiceBinding.first(guid: service_binding_guid).try(:service_plan))
+          @end_timestamp = new_end_timestamp
           @user_audit_info = user_info
           @request_attrs = request_attrs
           update_polling_interval
@@ -118,6 +118,13 @@ module VCAP::CloudController
 
         def valid_client_response?(last_operation_result)
           last_operation_result.key?(:last_operation)
+        end
+
+        def service_plan
+          ServiceBinding.first(guid: service_binding_guid).try(:service_plan)
+        rescue Sequel::Error => e
+          Steno.logger('cc-background').error("There was an error while fetching the service binding: #{e}")
+          nil
         end
       end
     end

--- a/app/jobs/services/service_instance_state_fetch.rb
+++ b/app/jobs/services/service_instance_state_fetch.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
           @name                  = name
           @service_instance_guid = service_instance_guid
           @request_attrs         = request_attrs
-          @end_timestamp         = end_timestamp || new_end_timestamp(ManagedServiceInstance.first(guid: service_instance_guid).try(:service_plan))
+          @end_timestamp         = end_timestamp || new_end_timestamp
           @user_audit_info       = user_audit_info
           update_polling_interval
         end
@@ -82,6 +82,13 @@ module VCAP::CloudController
           else
             service_instance.save_and_update_operation(service_instance.last_operation.proposed_changes)
           end
+        end
+
+        def service_plan
+          ManagedServiceInstance.first(guid: service_instance_guid).try(:service_plan)
+        rescue Sequel::Error => e
+          Steno.logger('cc-background').error("There was an error while fetching the service instance: #{e}")
+          nil
         end
       end
     end

--- a/app/jobs/services/service_instance_state_fetch.rb
+++ b/app/jobs/services/service_instance_state_fetch.rb
@@ -43,6 +43,15 @@ module VCAP::CloudController
 
         private
 
+        def new_end_timestamp
+          max_poll_duration_configured = VCAP::CloudController::Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
+          max_poll_duration_on_plan = ManagedServiceInstance.first(guid: service_instance_guid).try(:service_plan).try(:maximum_polling_duration)
+
+          max_poll_duration_on_plan = (max_poll_duration_on_plan / 60).minutes if max_poll_duration_on_plan
+
+          Time.now + [max_poll_duration_configured, max_poll_duration_on_plan].compact.min
+        end
+
         def repository
           Repositories::ServiceEventRepository.new(user_audit_info)
         end

--- a/app/jobs/services/service_instance_state_fetch.rb
+++ b/app/jobs/services/service_instance_state_fetch.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
           @name                  = name
           @service_instance_guid = service_instance_guid
           @request_attrs         = request_attrs
-          @end_timestamp         = end_timestamp || new_end_timestamp
+          @end_timestamp         = end_timestamp || new_end_timestamp(ManagedServiceInstance.first(guid: service_instance_guid).try(:service_plan))
           @user_audit_info       = user_audit_info
           update_polling_interval
         end
@@ -42,15 +42,6 @@ module VCAP::CloudController
         end
 
         private
-
-        def new_end_timestamp
-          max_poll_duration_configured = VCAP::CloudController::Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
-          max_poll_duration_on_plan = ManagedServiceInstance.first(guid: service_instance_guid).try(:service_plan).try(:maximum_polling_duration)
-
-          max_poll_duration_on_plan = (max_poll_duration_on_plan / 60).minutes if max_poll_duration_on_plan
-
-          Time.now + [max_poll_duration_configured, max_poll_duration_on_plan].compact.min
-        end
 
         def repository
           Repositories::ServiceEventRepository.new(user_audit_info)

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -16,6 +16,7 @@ module VCAP::CloudController
                       :bindable,
                       :plan_updateable,
                       :active,
+                      :maximum_polling_duration,
                       :create_instance_schema,
                       :update_instance_schema,
                       :create_binding_schema
@@ -31,6 +32,7 @@ module VCAP::CloudController
                       :public,
                       :bindable,
                       :plan_updateable,
+                      :maximum_polling_duration,
                       :create_instance_schema,
                       :update_instance_schema,
                       :create_binding_schema

--- a/db/migrations/20190219161111_add_maximum_polling_duration_to_service_plans.rb
+++ b/db/migrations/20190219161111_add_maximum_polling_duration_to_service_plans.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :service_plans, :maximum_polling_duration, Integer, null: true
+  end
+end

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -111,6 +111,7 @@ module VCAP::Services::ServiceBrokers
         active:      true,
         extra:       catalog_plan.metadata.try(:to_json),
         plan_updateable: catalog_plan.plan_updateable,
+        maximum_polling_duration: catalog_plan.maximum_polling_duration,
         create_instance_schema: create_instance,
         update_instance_schema: update_instance,
         create_binding_schema: create_binding,

--- a/lib/services/service_brokers/v2/catalog_plan.rb
+++ b/lib/services/service_brokers/v2/catalog_plan.rb
@@ -2,7 +2,7 @@ module VCAP::Services::ServiceBrokers::V2
   class CatalogPlan
     include CatalogValidationHelper
 
-    attr_reader :broker_provided_id, :name, :description, :metadata
+    attr_reader :broker_provided_id, :name, :description, :metadata, :maximum_polling_duration
     attr_reader :catalog_service, :errors, :free, :bindable, :schemas, :plan_updateable
 
     def initialize(catalog_service, attrs)
@@ -15,6 +15,7 @@ module VCAP::Services::ServiceBrokers::V2
       @free               = attrs['free'].nil? ? true : attrs['free']
       @bindable           = attrs['bindable']
       @plan_updateable    = attrs['plan_updateable']
+      @maximum_polling_duration = attrs['maximum_polling_duration']
       build_schemas(attrs['schemas'])
     end
 
@@ -48,6 +49,7 @@ module VCAP::Services::ServiceBrokers::V2
       validate_bool!(:free, free) if free
       validate_bool!(:bindable, bindable) if bindable
       validate_bool!(:plan_updateable, plan_updateable) if plan_updateable
+      validate_integer!(:maximum_polling_duration, maximum_polling_duration) if maximum_polling_duration
       validate_hash!(:schemas, @schemas_data) if @schemas_data
     end
 
@@ -59,14 +61,15 @@ module VCAP::Services::ServiceBrokers::V2
 
     def human_readable_attr_name(name)
       {
-        broker_provided_id: 'Plan id',
-        name:               'Plan name',
-        description:        'Plan description',
-        metadata:           'Plan metadata',
-        free:               'Plan free',
-        bindable:           'Plan bindable',
-        plan_updateable:    'Plan updateable',
-        schemas:            'Plan schemas',
+        broker_provided_id:         'Plan id',
+        name:                       'Plan name',
+        description:                'Plan description',
+        metadata:                   'Plan metadata',
+        free:                       'Plan free',
+        bindable:                   'Plan bindable',
+        plan_updateable:            'Plan updateable',
+        schemas:                    'Plan schemas',
+        maximum_polling_duration:   'Maximum polling duration',
       }.fetch(name) { raise NotImplementedError }
     end
   end

--- a/lib/services/service_brokers/v2/catalog_validation_helper.rb
+++ b/lib/services/service_brokers/v2/catalog_validation_helper.rb
@@ -34,6 +34,12 @@ module VCAP::Services::ServiceBrokers::V2
       end
     end
 
+    def validate_integer!(name, input, opts={})
+      if !input.is_a?(Integer) && !input.nil?
+        errors.add("#{human_readable_attr_name(name)} must be an integer, but has value #{input.inspect}")
+      end
+    end
+
     def validate_array_of_strings!(name, input)
       unless is_an_array_of(String, input)
         errors.add("#{human_readable_attr_name(name)} must be an array of strings, but has value #{input.inspect}")

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -642,19 +642,20 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         actee_name: new_plan.name,
         space_guid: '',
         metadata:   {
-          'name'                   => new_plan.name,
-          'free'                   => new_plan.free,
-          'description'            => new_plan.description,
-          'service_guid'           => new_plan.service.guid,
-          'extra'                  => new_plan.extra,
-          'unique_id'              => new_plan.unique_id,
-          'public'                 => new_plan.public,
-          'active'                 => new_plan.active,
-          'bindable'               => new_plan.bindable,
-          'plan_updateable'        => new_plan.plan_updateable,
-          'create_instance_schema' => new_plan.create_instance_schema,
-          'update_instance_schema' => new_plan.update_instance_schema,
-          'create_binding_schema'  => new_plan.create_binding_schema
+          'name'                       => new_plan.name,
+          'free'                       => new_plan.free,
+          'description'                => new_plan.description,
+          'service_guid'               => new_plan.service.guid,
+          'extra'                      => new_plan.extra,
+          'unique_id'                  => new_plan.unique_id,
+          'public'                     => new_plan.public,
+          'active'                     => new_plan.active,
+          'bindable'                   => new_plan.bindable,
+          'plan_updateable'            => new_plan.plan_updateable,
+          'maximum_polling_duration'   => new_plan.maximum_polling_duration,
+          'create_instance_schema'     => new_plan.create_instance_schema,
+          'update_instance_schema'     => new_plan.update_instance_schema,
+          'create_binding_schema'      => new_plan.create_binding_schema
         }
       }
     end

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController::BrokerApiHelper
         body: catalog.to_json)
   end
 
-  def default_catalog(plan_updateable: false, requires: [], plan_schemas: {}, bindings_retrievable: false)
+  def default_catalog(plan_updateable: false, requires: [], plan_schemas: {}, bindings_retrievable: false, maximum_polling_duration: nil)
     {
       services: [
         {
@@ -45,7 +45,8 @@ module VCAP::CloudController::BrokerApiHelper
               id: 'plan1-guid-here',
               name: 'small',
               description: 'A small shared database with 100mb storage quota and 10 connections',
-              schemas: plan_schemas
+              schemas: plan_schemas,
+              maximum_polling_duration: maximum_polling_duration,
             },
             {
               id: 'plan2-guid-here',

--- a/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
@@ -8,8 +8,10 @@ module VCAP::CloudController
       RSpec.describe ServiceBindingStateFetch, job_context: :worker do
         let(:operation_type) { 'create' }
         let(:service_binding_operation) { ServiceBindingOperation.make(state: 'in progress', type: operation_type) }
+        let(:maximum_polling_duration_for_plan) {}
+        let(:service_plan) { ServicePlan.make(maximum_polling_duration: maximum_polling_duration_for_plan) }
         let(:service_binding) do
-          service_binding = ServiceBinding.make
+          service_binding = ServiceBinding.make(service_instance: ManagedServiceInstance.make(service_plan: service_plan))
           service_binding.service_binding_operation = service_binding_operation
           service_binding
         end
@@ -35,6 +37,30 @@ module VCAP::CloudController
         def run_job(job)
           Jobs::Enqueuer.new(job, { queue: 'cc-generic', run_at: Delayed::Job.db_time_now }).enqueue
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
+        end
+
+        describe '#initialize' do
+          let(:job) { VCAP::CloudController::Jobs::Services::ServiceBindingStateFetch.new(service_binding.guid, user_info, request_attrs) }
+          context 'when the service plan has maximum_polling_duration' do
+            context "when the config value is smaller than plan's maximum_polling_duration" do
+              let(:maximum_polling_duration_for_plan) { 36000000 } # in seconds
+              let(:max_duration) { 10 } # in minutes
+              it 'should set end_timestamp to config value' do
+                Timecop.freeze(Time.now)
+                expect(job.end_timestamp).to eq(Time.now + max_duration.minutes)
+              end
+            end
+
+            context "when the config value is greater than plan's maximum_polling_duration" do
+              let(:maximum_polling_duration_for_plan) { 36000000 } # in seconds
+              let(:max_duration) { 1068367346 } # in minutes
+
+              it "should set end_timestamp to the plan's maximum_polling_duration value" do
+                Timecop.freeze(Time.now)
+                expect(job.end_timestamp).to eq(Time.now + maximum_polling_duration_for_plan.seconds)
+              end
+            end
+          end
         end
 
         describe '#perform' do
@@ -623,6 +649,8 @@ module VCAP::CloudController
           end
 
           context 'when a database operation fails' do
+            let!(:job) { VCAP::CloudController::Jobs::Services::ServiceBindingStateFetch.new(service_binding.guid, user_info, request_attrs) }
+
             before do
               allow(ServiceBinding).to receive(:first).and_raise(Sequel::Error)
               run_job(job)

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -79,6 +79,7 @@ module VCAP::Services::ServiceBrokers
                 'plan_updateable' => true,
                 'free'        => false,
                 'bindable'    => true,
+                'maximum_polling_duration' => 3600,
               }.merge(plan_metadata_hash).merge(plan_schemas_hash)
             ]
           }.merge(service_metadata_hash)
@@ -183,6 +184,7 @@ module VCAP::Services::ServiceBrokers
           'free' => service_plan.free,
           'description' => service_plan.description,
           'plan_updateable' => service_plan.plan_updateable,
+          'maximum_polling_duration' => service_plan.maximum_polling_duration,
           'service_guid' => service_plan.service.guid,
           'extra' => '{"cost":"0.0"}',
           'unique_id' => service_plan.unique_id,
@@ -226,6 +228,7 @@ module VCAP::Services::ServiceBrokers
           expect(plan.name).to eq(plan_name)
           expect(plan.description).to eq(plan_description)
           expect(plan.plan_updateable).to eq(true)
+          expect(plan.maximum_polling_duration).to eq(3600)
           expect(JSON.parse(plan.extra)).to eq({ 'cost' => '0.0' })
           expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
           expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')

--- a/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
@@ -13,14 +13,15 @@ module VCAP::Services::ServiceBrokers::V2
         'free'        => opts.fetch(:free, true),
         'bindable'    => opts[:bindable],
         'schemas'     => opts[:schemas] || {},
-        'plan_updateable' => opts[:plan_updateable]
+        'plan_updateable' => opts[:plan_updateable],
+        'maximum_polling_duration' => opts[:maximum_polling_duration]
       }
     end
     let(:catalog_service) { instance_double(VCAP::Services::ServiceBrokers::V2::CatalogService) }
     let(:opts) { {} }
 
     describe 'initializing' do
-      let(:opts) { { free: false, bindable: true, plan_updateable: true } }
+      let(:opts) { { free: false, bindable: true, plan_updateable: true, maximum_polling_duration: 3600 } }
 
       it 'should assign attributes' do
         expect(plan.broker_provided_id).to eq 'broker-provided-plan-id'
@@ -31,6 +32,7 @@ module VCAP::Services::ServiceBrokers::V2
         expect(plan.free).to be false
         expect(plan.bindable).to be true
         expect(plan.plan_updateable).to be true
+        expect(plan.maximum_polling_duration).to be 3600
         expect(plan.errors).to be_empty
       end
 
@@ -135,6 +137,13 @@ module VCAP::Services::ServiceBrokers::V2
 
         expect(plan).to_not be_valid
         expect(plan.errors.messages.first).to include 'Plan schemas must be a hash, but has value "true"'
+      end
+
+      it 'validates that @maximum_polling_duration is an integer' do
+        plan_attrs['maximum_polling_duration'] = 'true'
+
+        expect(plan).to_not be_valid
+        expect(plan.errors.messages).to include 'Maximum polling duration must be an integer, but has value "true"'
       end
 
       describe '#valid?' do

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -50,6 +50,7 @@ module VCAP::CloudController
                                          :public,
                                          :bindable,
                                          :plan_updateable,
+                                         :maximum_polling_duration,
                                          :active,
                                          :create_instance_schema,
                                          :update_instance_schema,
@@ -66,6 +67,7 @@ module VCAP::CloudController
                                          :public,
                                          :bindable,
                                          :plan_updateable,
+                                         :maximum_polling_duration,
                                          :create_instance_schema,
                                          :update_instance_schema,
                                          :create_binding_schema

--- a/spec/unit/presenters/v2/service_plan_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_plan_presenter_spec.rb
@@ -39,6 +39,7 @@ module CloudController::Presenters::V2
            'description' => service_plan.description,
            'extra' => nil,
            'free' => false,
+           'maximum_polling_duration' => nil,
            'name' => service_plan.name,
            'public' => true,
            'relationship_url' => 'http://relationship.example.com',


### PR DESCRIPTION
**WARNING:** This PR builds on top of #1299 make sure it is merged first

This [OSBAPI specification change](https://github.com/openservicebrokerapi/servicebroker/pull/627) introduces a timeout value (at the catalog level for a service) a broker to specify a polling duration other than what the platform would default to.
This commit implements that change on the Cloud Controller API for operations on **service bindings**. 

More details in the following stories:
https://www.pivotaltracker.com/story/show/163861123
https://www.pivotaltracker.com/story/show/163861136

