### PR TITLE
Add v2 logging endpoint to CAPI root

### DIFF
--- a/app/controllers/runtime/root_controller.rb
+++ b/app/controllers/runtime/root_controller.rb
@@ -48,6 +48,10 @@ module VCAP::CloudController
             href: config.get(:doppler, :url)
           },
 
+          log_stream:             {
+              href: config.get(:log_stream, :url)
+          },
+
           app_ssh:             {
             href: config.get(:info, :app_ssh_endpoint),
             meta: {

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -98,6 +98,9 @@ logcache_tls:
 doppler:
   url: 'wss://doppler.example.com:443'
 
+log_stream:
+  url: 'https://log-stream.example.com'
+
 uaa:
   url: "http://localhost:8080/uaa"
   internal_url: "http://localhost:6789"

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -219,6 +219,10 @@ module VCAP::CloudController
             url: String
           },
 
+          log_stream: {
+              url: String
+          },
+
           request_timeout_in_seconds: Integer,
           skip_cert_verify: bool,
 

--- a/spec/unit/controllers/runtime/root_controller_spec.rb
+++ b/spec/unit/controllers/runtime/root_controller_spec.rb
@@ -116,6 +116,14 @@ module VCAP::CloudController
         expect(hash['links']['logging']['href']).to eq(expected_uri)
       end
 
+      it 'returns a link to the v2 logging API' do
+        expected_uri = 'https://log-stream.example.com'
+
+        get '/'
+        hash = MultiJson.load(last_response.body)
+        expect(hash['links']['log_stream']['href']).to eq(expected_uri)
+      end
+
       it 'returns a link for app_ssh with metadata' do
         expected_ssh_endpoint = 'ssh://ssh.example.org:2222'
         expected_host_key_fingerprint = 'the-host-key-fingerprint'


### PR DESCRIPTION
[#164094017]

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

This adds the v2 logging endpoint to the CAPI root. We've announced deprecation of the v1 API and this change will make the v2 api more discoverable.

* Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/pull/128

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
