### PR TITLE
Additional info to the broker in context hash on provision and update actions

### DIFF
--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -27,7 +27,7 @@ module VCAP::Services::ServiceBrokers::V2
         plan_id:           instance.service_plan.broker_provided_id,
         organization_guid: instance.organization.guid,
         space_guid:        instance.space.guid,
-        context:           context_hash(instance)
+        context:           context_hash_with_additional_details(instance)
       }
 
       body[:parameters] = arbitrary_parameters if arbitrary_parameters.present?
@@ -170,7 +170,7 @@ module VCAP::Services::ServiceBrokers::V2
         service_id:      instance.service.broker_provided_id,
         plan_id:         plan.broker_provided_id,
         previous_values: previous_values,
-        context:         context_hash(instance)
+        context:         context_hash_with_additional_details(instance)
       }
       body[:parameters] = arbitrary_parameters if arbitrary_parameters
       response          = @http_client.patch(path, body)
@@ -289,6 +289,17 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     private
+
+    def context_hash_with_additional_details(service_instance)
+      {
+        platform:          PLATFORM,
+        organization_guid: service_instance.organization.guid,
+        space_guid:        service_instance.space.guid,
+        instance_name:     service_instance.name,
+        organization_name: service_instance.organization.name,
+        space_name:        service_instance.space.name
+      }
+    end
 
     def context_hash(service_instance)
       {

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.12_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.12_spec.rb
@@ -25,15 +25,17 @@ RSpec.describe 'Service Broker API integration' do
       end
 
       it 'receives the correct attributes in the context' do
-        expected_body = hash_including(context: {
-          platform: 'cloudfoundry',
-          organization_guid: @org_guid,
-          space_guid: @space_guid,
-        })
+        expected_context_attributes = {
+          'platform' => 'cloudfoundry',
+          'organization_guid' => @org_guid,
+          'space_guid' => @space_guid
+        }
 
         expect(
-          a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}}).with(body: expected_body)
-        ).to have_been_made
+          a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}}).with { |req|
+            context = JSON.parse(req.body)['context']
+            context >= expected_context_attributes
+          }).to have_been_made
       end
     end
 
@@ -52,15 +54,17 @@ RSpec.describe 'Service Broker API integration' do
       end
 
       it 'receives the correct attributes in the context' do
-        expected_body = hash_including(context: {
-          platform: 'cloudfoundry',
-          organization_guid: @org_guid,
-          space_guid: @space_guid,
-        })
+        expected_context_attributes = {
+          'platform' => 'cloudfoundry',
+          'organization_guid' => @org_guid,
+          'space_guid' => @space_guid
+        }
 
         expect(
-          a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with(body: expected_body)
-        ).to have_been_made
+          a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with { |req|
+            context = JSON.parse(req.body)['context']
+            context >= expected_context_attributes
+          }).to have_been_made
       end
     end
   end

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.9_spec.rb' => 'c297d302b57dd5b1aba9c92f0c9c4c4f',
       'broker_api_v2.10_spec.rb' => '27e81c4c540e39a4e4eac70c8efb14ba',
       'broker_api_v2.11_spec.rb' => '99e61dc50ceb635b09b3bd16901a4fa6',
-      'broker_api_v2.12_spec.rb' => '45db41892336b8bf8748fd5ae484bc29',
+      'broker_api_v2.12_spec.rb' => '4023dffdcaae014556dcdba9f7d206bb',
       'broker_api_v2.13_spec.rb' => 'c5918cfb98f1bb06915a18d7743fbf87',
       'broker_api_v2.14_spec.rb' => 'a1e7485793ba1916ea2f4080943530a5',
     }

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -199,7 +199,7 @@ module VCAP::CloudController::BrokerApiHelper
       to_return(status: return_code, body: { dashboard_url: 'https://your.service.com/dashboard' }.to_json)
 
     body = {
-      name: 'test-service',
+      name: opts[:name] || 'test-service',
       space_guid: @space_guid,
       service_plan_guid: @plan_guid
     }

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -85,7 +85,8 @@ module VCAP::Services::ServiceBrokers::V2
       let(:instance) do
         VCAP::CloudController::ManagedServiceInstance.make(
           service_plan: plan,
-          space:        space
+          space:        space,
+          name:     'instance-007'
         )
       end
 
@@ -140,7 +141,10 @@ module VCAP::Services::ServiceBrokers::V2
           context:           {
             platform:          'cloudfoundry',
             organization_guid: instance.organization.guid,
-            space_guid:        instance.space_guid
+            space_guid:        instance.space_guid,
+            instance_name:     instance.name,
+            organization_name: instance.organization.name,
+            space_name:        instance.space.name
           }
         )
       end
@@ -504,7 +508,8 @@ module VCAP::Services::ServiceBrokers::V2
       let(:instance) do
         VCAP::CloudController::ManagedServiceInstance.make(
           service_plan: old_plan,
-          space:        space
+          space:        space,
+          name:         'instance-007'
         )
       end
 
@@ -540,7 +545,10 @@ module VCAP::Services::ServiceBrokers::V2
             context: {
               platform:          'cloudfoundry',
               organization_guid: instance.organization.guid,
-              space_guid:        instance.space_guid
+              space_guid:        instance.space_guid,
+              instance_name:     instance.name,
+              organization_name: instance.organization.name,
+              space_name:        instance.space.name
             }
           })
         )


### PR DESCRIPTION
As part of an [OSBAPI](https://github.com/openservicebrokerapi/servicebroker/pull/633), the `context` object for Cloud Foundry now includes instance_name, organization_name and space_name  which useful for Service Brokers to understand Platform-side information for Service Instances.

This PR adds the additional attributes in the context object on a provision and update request.
Follow up PR for binding and rename based on `allow_context_updates` coming up next.

More details [here](https://www.pivotaltracker.com/story/show/163861690).