### PR TITLE
Additional info to the broker in context hash on bind actions

### DIFF
--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -27,7 +27,7 @@ module VCAP::Services::ServiceBrokers::V2
         plan_id:           instance.service_plan.broker_provided_id,
         organization_guid: instance.organization.guid,
         space_guid:        instance.space.guid,
-        context:           context_hash_with_additional_details(instance)
+        context:           context_hash_with_instance_name(instance)
       }
 
       body[:parameters] = arbitrary_parameters if arbitrary_parameters.present?
@@ -170,7 +170,7 @@ module VCAP::Services::ServiceBrokers::V2
         service_id:      instance.service.broker_provided_id,
         plan_id:         plan.broker_provided_id,
         previous_values: previous_values,
-        context:         context_hash_with_additional_details(instance)
+        context:         context_hash_with_instance_name(instance)
       }
       body[:parameters] = arbitrary_parameters if arbitrary_parameters
       response          = @http_client.patch(path, body)
@@ -290,22 +290,17 @@ module VCAP::Services::ServiceBrokers::V2
 
     private
 
-    def context_hash_with_additional_details(service_instance)
-      {
-        platform:          PLATFORM,
-        organization_guid: service_instance.organization.guid,
-        space_guid:        service_instance.space.guid,
-        instance_name:     service_instance.name,
-        organization_name: service_instance.organization.name,
-        space_name:        service_instance.space.name
-      }
+    def context_hash_with_instance_name(service_instance)
+      context_hash(service_instance).merge(instance_name: service_instance.name)
     end
 
     def context_hash(service_instance)
       {
         platform:          PLATFORM,
         organization_guid: service_instance.organization.guid,
-        space_guid:        service_instance.space.guid
+        space_guid:        service_instance.space.guid,
+        organization_name: service_instance.organization.name,
+        space_name:        service_instance.space.name
       }
     end
 

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -496,15 +496,17 @@ RSpec.describe 'Service Broker API integration' do
         end
 
         it 'receives the correct attributes in the context' do
-          expected_body = hash_including(context: {
-            platform: 'cloudfoundry',
-            organization_guid: @org_guid,
-            space_guid: @space_guid,
-          })
+          expected_context_attributes = {
+            'platform' => 'cloudfoundry',
+            'organization_guid' => @org_guid,
+            'space_guid' => @space_guid
+          }
 
           expect(
-            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with(body: expected_body)
-          ).to have_been_made
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with { |req|
+              context = JSON.parse(req.body)['context']
+              context >= expected_context_attributes
+            }).to have_been_made
         end
       end
 
@@ -522,15 +524,17 @@ RSpec.describe 'Service Broker API integration' do
         end
 
         it 'receives the correct attributes in the context' do
-          expected_body = hash_including(context: {
-            platform: 'cloudfoundry',
-            organization_guid: @org_guid,
-            space_guid: @space_guid,
-          })
+          expected_context_attributes = {
+            'platform' => 'cloudfoundry',
+            'organization_guid' => @org_guid,
+            'space_guid' => @space_guid
+          }
 
           expect(
-            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with(body: expected_body)
-          ).to have_been_made
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with { |req|
+              context = JSON.parse(req.body)['context']
+              context >= expected_context_attributes
+            }).to have_been_made
         end
       end
 
@@ -550,15 +554,17 @@ RSpec.describe 'Service Broker API integration' do
         end
 
         it 'receives the correct attributes in the context' do
-          expected_body = hash_including(context: {
-            platform: 'cloudfoundry',
-            organization_guid: @org_guid,
-            space_guid: @space_guid,
-          })
+          expected_context_attributes = {
+            'platform' => 'cloudfoundry',
+            'organization_guid' => @org_guid,
+            'space_guid' => @space_guid
+          }
 
           expect(
-            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with(body: expected_body)
-          ).to have_been_made
+            a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/#{@binding_guid}}).with { |req|
+              context = JSON.parse(req.body)['context']
+              context >= expected_context_attributes
+            }).to have_been_made
         end
       end
     end

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.10_spec.rb' => '27e81c4c540e39a4e4eac70c8efb14ba',
       'broker_api_v2.11_spec.rb' => '99e61dc50ceb635b09b3bd16901a4fa6',
       'broker_api_v2.12_spec.rb' => '4023dffdcaae014556dcdba9f7d206bb',
-      'broker_api_v2.13_spec.rb' => 'c5918cfb98f1bb06915a18d7743fbf87',
+      'broker_api_v2.13_spec.rb' => '573bbe3234c33aeccb1f02399dffdfe5',
       'broker_api_v2.14_spec.rb' => 'a1e7485793ba1916ea2f4080943530a5',
     }
   end

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -386,7 +386,9 @@ module VCAP::CloudController
               context: {
                 platform: 'cloudfoundry',
                 organization_guid: service_instance.organization.guid,
-                space_guid:        service_instance.space.guid
+                space_guid:        service_instance.space.guid,
+                organization_name: service_instance.organization.name,
+                space_name:        service_instance.space.name,
               }
             }
 
@@ -547,7 +549,9 @@ module VCAP::CloudController
               context: {
                 platform: 'cloudfoundry',
                 organization_guid: service_instance.organization.guid,
-                space_guid:        service_instance.space.guid
+                space_guid:        service_instance.space.guid,
+                organization_name: service_instance.organization.name,
+                space_name:        service_instance.space.name,
               }
             }
 

--- a/spec/unit/controllers/services/service_keys_controller_spec.rb
+++ b/spec/unit/controllers/services/service_keys_controller_spec.rb
@@ -199,7 +199,9 @@ module VCAP::CloudController
             context: {
               platform: 'cloudfoundry',
               organization_guid: instance.organization.guid,
-              space_guid: instance.space.guid
+              space_guid: instance.space.guid,
+              organization_name: instance.organization.name,
+              space_name: instance.space.name,
             }
           }.to_json
 

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -867,7 +867,9 @@ module VCAP::Services::ServiceBrokers::V2
             context:    {
               platform:          'cloudfoundry',
               organization_guid: key.service_instance.organization.guid,
-              space_guid:        key.service_instance.space.guid
+              space_guid:        key.service_instance.space.guid,
+              organization_name: key.service_instance.organization.name,
+              space_name:        key.service_instance.space.name
             },
             bind_resource: {
               credential_client_id: cc_service_key_client_name,
@@ -1029,7 +1031,9 @@ module VCAP::Services::ServiceBrokers::V2
             context:       {
               platform:          'cloudfoundry',
               organization_guid: instance.organization.guid,
-              space_guid:        instance.space_guid
+              space_guid:        instance.space_guid,
+              organization_name: instance.organization.name,
+              space_name:        instance.space.name
             }
           )
       end


### PR DESCRIPTION
Warning: Merge only after [this PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/1302) is merged.
As part of an [OSBAPI](https://github.com/openservicebrokerapi/servicebroker/pull/633), the `context` object for Cloud Foundry now includes organization_name and space_name on bind actions which is useful for Service Brokers to understand Platform-side information for Service Bindings.

This PR adds the additional attributes in the context object on service instance bindings request.
Follow up PR for rename action based on `allow_context_updates` coming up next.

More details [here](https://www.pivotaltracker.com/story/show/163120008).