### PR TITLE
Update service instance requests to Broker when contextual information in a Platform changes

### DIFF
--- a/app/actions/services/service_instance_update.rb
+++ b/app/actions/services/service_instance_update.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
 
       update_cc_only_attrs(service_instance, request_attrs)
 
-      if update_broker_needed?(request_attrs, cached_service_instance['service_plan_guid'])
+      if update_broker_needed?(request_attrs, cached_service_instance['service_plan_guid'], service_instance)
         handle_broker_update(cached_service_instance, lock, previous_values, request_attrs, service_instance)
         update_deferred_attrs(service_instance, service_plan_guid: request_attrs.fetch('service_plan_guid', false))
       else
@@ -35,8 +35,9 @@ module VCAP::CloudController
 
     private
 
-    def update_broker_needed?(attrs, old_service_plan_guid)
+    def update_broker_needed?(attrs, old_service_plan_guid, service_instance)
       return true if attrs['parameters']
+      return true if attrs['name'] && service_instance.service.allow_context_updates
       return false if !attrs['service_plan_guid']
 
       attrs['service_plan_guid'] != old_service_plan_guid

--- a/app/models/services/service.rb
+++ b/app/models/services/service.rb
@@ -10,12 +10,14 @@ module VCAP::CloudController
     export_attributes :label, :provider, :url, :description, :long_description,
                       :version, :info_url, :active, :bindable,
                       :unique_id, :extra, :tags, :requires, :documentation_url,
-                      :service_broker_guid, :plan_updateable, :bindings_retrievable, :instances_retrievable
+                      :service_broker_guid, :plan_updateable, :bindings_retrievable,
+                      :instances_retrievable, :allow_context_updates
 
     import_attributes :label, :description, :long_description, :info_url,
                       :active, :bindable, :unique_id, :extra,
                       :tags, :requires, :documentation_url, :plan_updateable,
-                      :bindings_retrievable, :instances_retrievable
+                      :bindings_retrievable, :instances_retrievable,
+                      :allow_context_updates
 
     strip_attributes :label
 

--- a/app/presenters/v2/service_presenter.rb
+++ b/app/presenters/v2/service_presenter.rb
@@ -28,7 +28,8 @@ module CloudController
             'service_broker_name'   => service&.service_broker&.name,
             'plan_updateable'       => service.plan_updateable,
             'bindings_retrievable'  => service.bindings_retrievable,
-            'instances_retrievable' => service.instances_retrievable
+            'instances_retrievable' => service.instances_retrievable,
+            'allow_context_updates' => service.allow_context_updates
           }.merge!(rel_hash)
         end
       end

--- a/db/migrations/20190227175600_add_allow_context_updates_to_services.rb
+++ b/db/migrations/20190227175600_add_allow_context_updates_to_services.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :services do
+      add_column :allow_context_updates, :boolean, default: false, null: false
+    end
+  end
+end

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -88,6 +88,7 @@ module VCAP::Services::ServiceBrokers
         plan_updateable: catalog_service.plan_updateable,
         bindings_retrievable: catalog_service.bindings_retrievable,
         instances_retrievable: catalog_service.instances_retrievable,
+        allow_context_updates: catalog_service.allow_context_updates,
       )
 
       @services_event_repository.with_service_event(service) do

--- a/lib/services/service_brokers/v2/catalog_service.rb
+++ b/lib/services/service_brokers/v2/catalog_service.rb
@@ -6,7 +6,8 @@ module VCAP::Services::ServiceBrokers::V2
 
     attr_reader :service_broker, :broker_provided_id, :metadata, :name,
       :description, :bindable, :tags, :plans, :requires, :dashboard_client,
-      :errors, :plan_updateable, :bindings_retrievable, :instances_retrievable
+      :errors, :plan_updateable, :bindings_retrievable, :instances_retrievable,
+      :allow_context_updates
 
     def initialize(service_broker, attrs)
       @service_broker     = service_broker
@@ -24,6 +25,7 @@ module VCAP::Services::ServiceBrokers::V2
       @plans              = []
       @bindings_retrievable = attrs.fetch('bindings_retrievable', false)
       @instances_retrievable = attrs.fetch('instances_retrievable', false)
+      @allow_context_updates = attrs.fetch('allow_context_updates', false)
 
       build_plans
     end
@@ -64,6 +66,7 @@ module VCAP::Services::ServiceBrokers::V2
       validate_bool!(:plan_updateable, plan_updateable, required: true)
       validate_bool!(:bindings_retrievable, bindings_retrievable, required: false)
       validate_bool!(:instances_retrievable, instances_retrievable, required: false)
+      validate_bool!(:allow_context_updates, allow_context_updates, required: false)
 
       validate_tags!(:tags, tags)
       validate_array_of_strings!(:requires, requires)
@@ -179,6 +182,7 @@ module VCAP::Services::ServiceBrokers::V2
         dashboard_client_redirect_uri: 'Service dashboard client redirect_uri',
         bindings_retrievable: 'Service "bindings_retrievable" field',
         instances_retrievable: 'Service "instances_retrievable" field',
+        allow_context_updates: 'Service "allow_context_updates" field',
       }.fetch(name) { raise NotImplementedError }
     end
   end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
@@ -260,16 +260,6 @@ RSpec.describe 'Service Broker API integration' do
 
     context 'service instance context hash' do
       let(:catalog) { default_catalog(plan_updateable: true) }
-      let(:expected_context_attributes) { {
-        'platform' => 'cloudfoundry',
-        'organization_guid' => @org_guid,
-        'space_guid' => @space_guid,
-        'instance_name' => 'instance-007',
-        'organization_name' => @space.organization.name,
-        'space_name' => @space.name
-      }
-      }
-
       before do
         setup_broker(catalog)
         @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
@@ -278,6 +268,15 @@ RSpec.describe 'Service Broker API integration' do
 
       context 'service provision request' do
         it 'receives the correct attributes in the context' do
+          expected_context_attributes = {
+            'platform' => 'cloudfoundry',
+            'organization_guid' => @org_guid,
+            'space_guid' => @space_guid,
+            'instance_name' => 'instance-007',
+            'organization_name' => @space.organization.name,
+            'space_name' => @space.name
+          }
+
           expect(
             a_request(:put, %r{/v2/service_instances/#{@service_instance_guid}}).with { |req|
               context = JSON.parse(req.body)['context']
@@ -292,11 +291,57 @@ RSpec.describe 'Service Broker API integration' do
         end
 
         it 'receives the correct attributes in the context' do
+          expected_context_attributes = {
+            'platform' => 'cloudfoundry',
+            'organization_guid' => @org_guid,
+            'space_guid' => @space_guid,
+            'instance_name' => 'instance-007',
+            'organization_name' => @space.organization.name,
+            'space_name' => @space.name
+          }
+
           expect(
             a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with { |req|
               context = JSON.parse(req.body)['context']
               context >= expected_context_attributes
             }).to have_been_made
+        end
+      end
+
+      context 'service rename request' do
+        before do
+          rename_service_instance(200, { name: 'instance-014' })
+        end
+
+        context 'when broker has allow_context_updates enabled in catalog' do
+          let(:catalog) { default_catalog(allow_context_updates: true) }
+
+          it 'receives the correct attributes in the context' do
+            expected_context_attributes = {
+              'platform' => 'cloudfoundry',
+              'organization_guid' => @org_guid,
+              'space_guid' => @space_guid,
+              'instance_name' => 'instance-014',
+              'organization_name' => @space.organization.name,
+              'space_name' => @space.name
+            }
+
+            expect(
+              a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}}).with { |req|
+                context = JSON.parse(req.body)['context']
+                context >= expected_context_attributes
+              }).to have_been_made
+          end
+        end
+
+        context 'when broker has allow_context_updates disabled in catalog' do
+          let(:catalog) { default_catalog(allow_context_updates: false) }
+
+          it 'does not receive a patch update request' do
+            expect(
+              a_request(:patch, %r{/v2/service_instances/#{@service_instance_guid}})
+            ).not_to have_been_made
+          end
         end
       end
     end

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -773,6 +773,7 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         plan_updateable: false,
         bindings_retrievable: true,
         instances_retrievable: true,
+        allow_context_updates: true,
         active:          true,
       )
       service_event_repository.with_service_event(new_service) do
@@ -808,6 +809,7 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
           'plan_updateable'     => new_service.plan_updateable,
           'bindings_retrievable'   => new_service.bindings_retrievable,
           'instances_retrievable'  => new_service.instances_retrievable,
+          'allow_context_updates'  => new_service.allow_context_updates,
         }
       }
     end

--- a/spec/request/v2/organizations_spec.rb
+++ b/spec/request/v2/organizations_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe 'Organizations' do
                 'plan_updateable'       => service_1.plan_updateable,
                 'bindings_retrievable'  => service_1.bindings_retrievable,
                 'instances_retrievable' => service_1.instances_retrievable,
+                'allow_context_updates' => service_1.allow_context_updates,
                 'service_plans_url'     => "/v2/services/#{service_1.guid}/service_plans"
               }
             },
@@ -85,6 +86,7 @@ RSpec.describe 'Organizations' do
                 'plan_updateable'       => service_2.plan_updateable,
                 'bindings_retrievable'  => service_2.bindings_retrievable,
                 'instances_retrievable' => service_2.instances_retrievable,
+                'allow_context_updates' => service_2.allow_context_updates,
                 'service_plans_url'     => "/v2/services/#{service_2.guid}/service_plans"
               }
             }

--- a/spec/request/v2/services_spec.rb
+++ b/spec/request/v2/services_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'Services' do
                 'plan_updateable'       => service_1.plan_updateable,
                 'bindings_retrievable'  => service_1.bindings_retrievable,
                 'instances_retrievable' => service_1.instances_retrievable,
+                'allow_context_updates' => service_1.allow_context_updates,
                 'service_plans_url'     => "/v2/services/#{service_1.guid}/service_plans"
               }
             },
@@ -84,6 +85,7 @@ RSpec.describe 'Services' do
                 'plan_updateable'       => service_2.plan_updateable,
                 'bindings_retrievable'  => service_2.bindings_retrievable,
                 'instances_retrievable' => service_2.instances_retrievable,
+                'allow_context_updates' => service_2.allow_context_updates,
                 'service_plans_url'     => "/v2/services/#{service_2.guid}/service_plans"
               }
             }
@@ -130,6 +132,7 @@ RSpec.describe 'Services' do
             'plan_updateable'       => service.plan_updateable,
             'bindings_retrievable'  => service.bindings_retrievable,
             'instances_retrievable' => service.instances_retrievable,
+            'allow_context_updates' => service.allow_context_updates,
             'service_plans_url'     => "/v2/services/#{service.guid}/service_plans"
           }
         }

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController::BrokerApiHelper
         body: catalog.to_json)
   end
 
-  def default_catalog(plan_updateable: false, requires: [], plan_schemas: {}, bindings_retrievable: false, maximum_polling_duration: nil)
+  def default_catalog(plan_updateable: false, requires: [], plan_schemas: {}, bindings_retrievable: false, maximum_polling_duration: nil, allow_context_updates: false)
     {
       services: [
         {
@@ -40,6 +40,7 @@ module VCAP::CloudController::BrokerApiHelper
           requires: requires,
           plan_updateable: plan_updateable,
           bindings_retrievable: bindings_retrievable,
+          allow_context_updates: allow_context_updates,
           plans: [
             {
               id: 'plan1-guid-here',
@@ -215,6 +216,15 @@ module VCAP::CloudController::BrokerApiHelper
 
     response = JSON.parse(last_response.body)
     @service_instance_guid = response['metadata']['guid']
+  end
+
+  def rename_service_instance(return_code, opts={})
+    stub_request(:patch, %r{broker-url/v2/service_instances/[[:alnum:]-]+}).to_return(status: return_code, body: {}.to_json)
+
+    put("/v2/service_instances/#{@service_instance_guid}",
+        { name: opts[:name] || 'new-name' }.to_json,
+        admin_headers
+    )
   end
 
   def update_service_instance(return_code, opts={})

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -71,6 +71,7 @@ module VCAP::Services::ServiceBrokers
             'plan_updateable' => true,
             'bindings_retrievable' => true,
             'instances_retrievable' => true,
+            'allow_context_updates' => true,
             'plans' => [
               {
                 'id'          => plan_id,
@@ -129,6 +130,7 @@ module VCAP::Services::ServiceBrokers
         expect(service.plan_updateable).to eq true
         expect(service.bindings_retrievable).to eq true
         expect(service.instances_retrievable).to eq true
+        expect(service.allow_context_updates).to eq true
       end
 
       it 'records an audit event for each service and plan' do
@@ -165,6 +167,7 @@ module VCAP::Services::ServiceBrokers
           'plan_updateable' => service.plan_updateable,
           'bindings_retrievable' => service.bindings_retrievable,
           'instances_retrievable' => service.instances_retrievable,
+          'allow_context_updates' => service.allow_context_updates,
         })
 
         event = VCAP::CloudController::Event.first(type: 'audit.service_plan.create')
@@ -722,6 +725,7 @@ module VCAP::Services::ServiceBrokers
                     'plan_updateable' => true,
                     'bindings_retrievable' => true,
                     'instances_retrievable' => true,
+                    'allow_context_updates' => true,
                     'plans' => [
                       {
                         'id'          => 'new-plan-id',

--- a/spec/unit/lib/services/service_brokers/v2/catalog_service_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_service_spec.rb
@@ -47,6 +47,18 @@ module VCAP::Services::ServiceBrokers::V2
         service = CatalogService.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
         expect(service.plan_updateable).to eq true
       end
+
+      it 'defaults @allow_context_updates to false' do
+        attrs = build_valid_service_attrs
+        service = CatalogService.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
+        expect(service.allow_context_updates).to eq false
+      end
+
+      it 'sets @allow_context_updates if it is provided in the hash' do
+        attrs = build_valid_service_attrs(allow_context_updates: true)
+        service = CatalogService.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
+        expect(service.allow_context_updates).to eq true
+      end
     end
 
     describe 'validations' do
@@ -265,6 +277,14 @@ module VCAP::Services::ServiceBrokers::V2
         expect(service).not_to be_valid
 
         expect(service.errors.messages).to include 'Service "instances_retrievable" field must be a boolean, but has value "foo"'
+      end
+
+      it 'validates that @allow_context_updates is a boolean' do
+        attrs = build_valid_service_attrs(allow_context_updates: 'foo')
+        service = CatalogService.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
+        expect(service).not_to be_valid
+
+        expect(service.errors.messages).to include 'Service "allow_context_updates" field must be a boolean, but has value "foo"'
       end
 
       context 'when there are multiple duplicate plan names' do

--- a/spec/unit/models/services/service_spec.rb
+++ b/spec/unit/models/services/service_spec.rb
@@ -35,10 +35,12 @@ module VCAP::CloudController
 
     describe 'Serialization' do
       it { is_expected.to export_attributes :label, :provider, :url, :description, :long_description, :version, :info_url, :active, :bindable,
-                                    :unique_id, :extra, :tags, :requires, :documentation_url, :service_broker_guid, :plan_updateable, :bindings_retrievable, :instances_retrievable
+                                    :unique_id, :extra, :tags, :requires, :documentation_url, :service_broker_guid, :plan_updateable, :bindings_retrievable,
+                                    :instances_retrievable, :allow_context_updates
       }
       it { is_expected.to import_attributes :label, :description, :long_description, :info_url,
-                                    :active, :bindable, :unique_id, :extra, :tags, :requires, :documentation_url, :plan_updateable, :bindings_retrievable, :instances_retrievable
+                                    :active, :bindable, :unique_id, :extra, :tags, :requires, :documentation_url, :plan_updateable, :bindings_retrievable,
+                                    :instances_retrievable, :allow_context_updates
       }
     end
 

--- a/spec/unit/presenters/v2/service_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_presenter_spec.rb
@@ -48,6 +48,7 @@ module CloudController::Presenters::V2
             'plan_updateable'       => service.plan_updateable,
             'bindings_retrievable'  => service.bindings_retrievable,
             'instances_retrievable' => service.instances_retrievable,
+            'allow_context_updates' => service.allow_context_updates,
             'relationship_url'      => 'http://relationship.example.com'
           }
         )
@@ -78,6 +79,7 @@ module CloudController::Presenters::V2
               'plan_updateable'       => service.plan_updateable,
               'bindings_retrievable'  => service.bindings_retrievable,
               'instances_retrievable' => service.instances_retrievable,
+              'allow_context_updates' => service.allow_context_updates,
               'relationship_url'      => 'http://relationship.example.com'
             }
           )


### PR DESCRIPTION
Warning: Merge only after [this PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/1303) is merged.
As part of an [OSBAPI](https://github.com/openservicebrokerapi/servicebroker/pull/633), Service Broker authors can opt-in to receive update service instance requests when contextual information in a Platform changes (i.e. the name of the service instance) by specifying "allow_context_updates": true in its catalog.

Prior to this change, if the service instance update request had only `name` changes, no request was made to the broker, but now, if the broker sets `allow_context_updates` on the catalog for an instance, a request to the broker with the context hash will be sent.

More details [here](https://www.pivotaltracker.com/story/show/163861852).