### PR TITLE
Bump bits_service_client to 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'railties', '~> 5.2.0'
 
 # Blobstore and Bits Service Dependencies
 gem 'azure-storage', '0.14.0.preview' # https://github.com/Azure/azure-storage-ruby/issues/122
-gem 'bits_service_client', '~> 3.0'
+gem 'bits_service_client', '~> 4.0'
 gem 'fog-aliyun'
 gem 'fog-aws'
 gem 'fog-azure-rm', git: 'https://github.com/fog/fog-azure-rm.git', branch: 'fog-arm-cf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,9 +90,10 @@ GEM
     backports (3.11.4)
     beefcake (1.0.0)
     bit-struct (0.16)
-    bits_service_client (3.3.0)
+    bits_service_client (4.0.0)
       activesupport
       steno
+      statsd-ruby (~> 1.4.0)
     builder (3.2.3)
     byebug (10.0.2)
     cf-copilot (0.0.12)
@@ -450,7 +451,7 @@ DEPENDENCIES
   allowy
   awesome_print
   azure-storage (= 0.14.0.preview)
-  bits_service_client (~> 3.0)
+  bits_service_client (~> 4.0)
   byebug
   cf-copilot
   cf-perm (~> 0.0.10)

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -262,8 +262,6 @@ module VCAP::CloudController
             enabled: bool,
             optional(:public_endpoint) => enum(String, NilClass),
             optional(:private_endpoint) => enum(String, NilClass),
-            optional(:username) => enum(String, NilClass),
-            optional(:password) => enum(String, NilClass),
           },
 
           rate_limiter: {

--- a/lib/cloud_controller/config_schemas/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/clock_schema.rb
@@ -140,8 +140,6 @@ module VCAP::CloudController
             enabled: bool,
             optional(:public_endpoint) => enum(String, NilClass),
             optional(:private_endpoint) => enum(String, NilClass),
-            optional(:username) => enum(String, NilClass),
-            optional(:password) => enum(String, NilClass),
           },
 
           diego: {

--- a/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
@@ -143,8 +143,6 @@ module VCAP::CloudController
             enabled: bool,
             optional(:public_endpoint) => enum(String, NilClass),
             optional(:private_endpoint) => enum(String, NilClass),
-            optional(:username) => enum(String, NilClass),
-            optional(:password) => enum(String, NilClass),
           },
 
           skip_cert_verify: bool,

--- a/lib/cloud_controller/config_schemas/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/worker_schema.rb
@@ -135,8 +135,6 @@ module VCAP::CloudController
             enabled: bool,
             optional(:public_endpoint) => enum(String, NilClass),
             optional(:private_endpoint) => enum(String, NilClass),
-            optional(:username) => enum(String, NilClass),
-            optional(:password) => enum(String, NilClass),
           },
 
           diego: {

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -327,12 +327,9 @@ module CloudController
       return nil unless use_bits_service
 
       BitsService::ResourcePool.new(
-        endpoint: bits_service_options[:private_endpoint],
+        bits_service_options: bits_service_options,
         request_timeout_in_seconds: config.get(:request_timeout_in_seconds),
-        ca_cert_path: bits_service_options[:ca_cert_path],
-        vcap_request_id: VCAP::Request.current_id,
-        username: bits_service_options[:username],
-        password: bits_service_options[:password]
+        vcap_request_id: VCAP::Request.current_id
       )
     end
 


### PR DESCRIPTION
* A short explanation of the proposed change:

    Use bits_service_client 4.0.0 and adjust configuration to match this new major version.

* An explanation of the use cases your change solves

    bits_service_client 4.0.0 uses **client side** signed URLs instead of requesting the signed URLs from Bits-Service.

* Links to any other associated PRs

    https://github.com/cloudfoundry/capi-release/pull/129 should be merged first.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
