### PR TITLE
Fix dummy desired LRP for opi

### DIFF
--- a/lib/cloud_controller/opi/instances_client.rb
+++ b/lib/cloud_controller/opi/instances_client.rb
@@ -61,7 +61,7 @@ module OPI
     # Currently opi does not support isolation segments. This stub is necessary
     # because cc relies that at least one placement tag will be available
     def desired_lrp_instance(process)
-      DesiredLRP.new(['placeholder'], [])
+      DesiredLRP.new(['placeholder'], {"process_id": 0})
     end
 
     private

--- a/lib/cloud_controller/opi/instances_client.rb
+++ b/lib/cloud_controller/opi/instances_client.rb
@@ -61,7 +61,7 @@ module OPI
     # Currently opi does not support isolation segments. This stub is necessary
     # because cc relies that at least one placement tag will be available
     def desired_lrp_instance(process)
-      DesiredLRP.new(['placeholder'], {"process_id": 0})
+      DesiredLRP.new(['placeholder'], { "process_id": 0 })
     end
 
     private


### PR DESCRIPTION
* A short explanation of the proposed change:
The current ccng is broken for opi/eirini, because of [this change](https://github.com/cloudfoundry/cloud_controller_ng/commit/118677a7d517e89c2222b9630215bbfb69662885#diff-87c4a5fb697b073910f9ee2e7c117737R73).
This will fix the problem.

* An explanation of the use cases your change solves
ccng working with eirini

