### PR TITLE
Update opi apps client tests to reflect changes in eirini

### DIFF
--- a/spec/integration/opi_apps_client_spec.rb
+++ b/spec/integration/opi_apps_client_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe(OPI::Client, opi: skip_opi_tests) do
 
       it 'returns the correct process' do
         actual_process = client.get_app(process)
-        expect(actual_process.process_guid).to eq('jeff')
+        expect(actual_process.process_guid).to eq('guid_1234-0.1.0')
       end
     end
 

--- a/spec/integration/opi_apps_client_spec.rb
+++ b/spec/integration/opi_apps_client_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe(OPI::Client, opi: skip_opi_tests) do
   subject(:client) { described_class.new(opi_url) }
   let(:app) {
     double(
+      guid: 'guid_1234',
       service_bindings: []
     )
   }


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

**A short explanation of the proposed change:**
The get app endpoint in eirini was returning wrong process guid and the test was also expecting wrong guid. It has been fixed.
This PR also fixes a test broken by a52dab8c75

**An explanation of the use cases your change solves**
It just makes the tests :)

**Links to any other associated PRs**
N/A

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
