### PR TITLE
Allow cancel of the creation of an asynchronous service instance

### DIFF
--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -238,6 +238,8 @@ module VCAP::Services::ServiceBrokers::V2
       }
     rescue VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerConflict => e
       raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceDeprovisionFailed', e.message)
+    rescue VCAP::Services::ServiceBrokers::V2::Errors::ConcurrencyError
+      raise CloudController::Errors::ApiError.new_from_details('AsyncServiceInstanceOperationInProgress', instance.name)
     rescue => e
       raise e.exception("Service instance #{instance.name}: #{e.message}")
     end

--- a/lib/services/service_brokers/v2/response_parser.rb
+++ b/lib/services/service_brokers/v2/response_parser.rb
@@ -113,8 +113,10 @@ module VCAP::Services
               @logger.warn("Already deleted: #{unvalidated_response.uri}")
               SuccessValidator.new { |res| {} }
             when 422
-              FailWhenValidator.new('error', { 'AsyncRequired' => Errors::AsyncRequired },
-                FailingValidator.new(Errors::ServiceBrokerBadResponse))
+              FailWhenValidator.new('error', {
+                'AsyncRequired' => Errors::AsyncRequired,
+                'ConcurrencyError' => Errors::ConcurrencyError
+              }, FailingValidator.new(Errors::ServiceBrokerBadResponse))
             else
               FailingValidator.new(Errors::ServiceBrokerBadResponse)
             end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.9_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.9_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Service Broker API integration' do
         let(:operation_data) { 'some_operation_data' }
 
         it 'calls the endpoint with state that was returned in delete' do
-          async_delete_service(operation_data: operation_data)
+          async_delete_service(broker_response_body: %({"operation": "#{operation_data}"}))
           stub_async_last_operation(operation_data: operation_data)
 
           expect(a_request(:delete, deprovision_url(service_instance, accepts_incomplete: true))).to have_been_made

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.6_spec.rb' => 'a1608878f601819c90b44be5f317ec44',
       'broker_api_v2.7_spec.rb' => '6db4cba42ac923ddf748b4f53914d057',
       'broker_api_v2.8_spec.rb' => '2b1b662b4874f5bac4481de7cf15b363',
-      'broker_api_v2.9_spec.rb' => 'c297d302b57dd5b1aba9c92f0c9c4c4f',
+      'broker_api_v2.9_spec.rb' => '0df16ae4742381714ea5664b3796b61a',
       'broker_api_v2.10_spec.rb' => '27e81c4c540e39a4e4eac70c8efb14ba',
       'broker_api_v2.11_spec.rb' => '99e61dc50ceb635b09b3bd16901a4fa6',
       'broker_api_v2.12_spec.rb' => '4023dffdcaae014556dcdba9f7d206bb',

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -145,15 +145,17 @@ module VCAP::CloudController::BrokerApiHelper
     delete("/v2/service_brokers/#{@broker_guid}", '{}', admin_headers)
   end
 
-  def async_delete_service(status: 202, operation_data: nil)
-    broker_response_body = operation_data.nil? ? '{}' : %({"operation": "#{operation_data}"})
-
+  def delete_service(status: 200, broker_response_body: '{}', accepts_incomplete: false)
     stub_request(:delete, %r{broker-url/v2/service_instances/[[:alnum:]-]+}).
       to_return(status: status, body: broker_response_body)
 
-    delete("/v2/service_instances/#{@service_instance_guid}?accepts_incomplete=true",
+    delete("/v2/service_instances/#{@service_instance_guid}?accepts_incomplete=#{accepts_incomplete}",
            {}.to_json,
            admin_headers)
+  end
+
+  def async_delete_service(status: 202, broker_response_body: '{}')
+    delete_service(status: status, broker_response_body: broker_response_body, accepts_incomplete: true)
   end
 
   def async_provision_service(status: 202, operation_data: nil)

--- a/spec/unit/actions/services/locks/deleter_lock_spec.rb
+++ b/spec/unit/actions/services/locks/deleter_lock_spec.rb
@@ -7,6 +7,12 @@ module VCAP::CloudController
     let(:deleter_lock) { DeleterLock.new service_instance }
     let(:operation) { ServiceInstanceOperation.make(state: 'override me') }
 
+    # in MySQL, milliseconds will get truncated, so to make the test
+    # deterministic we need to truncate them in the setup as well,
+    # so that we can compare the date in memory to the date loaded
+    # from the database
+    let(:previous_operation_time) { 10.seconds.ago.change(usec: 0) }
+
     before do
       service_instance.service_instance_operation = operation
     end
@@ -27,26 +33,119 @@ module VCAP::CloudController
       it 'sets the last operation type to "delete"' do
         expect(service_instance.last_operation.type).to eq('delete')
       end
+    end
 
-      it 'does not let you lock again' do
-        expect {
-          deleter_lock.lock!
-        }.to raise_error CloudController::Errors::ApiError
+    describe 'locking again' do
+      context 'when previous operation is not create in progress' do
+        let(:operation) do
+          ServiceInstanceOperation.make(
+            state: 'in progress',
+            type: 'NOT create',
+          )
+        end
+
+        it 'does not let you lock again' do
+          expect {
+            DeleterLock.new(service_instance).lock!
+          }.to raise_error(CloudController::Errors::ApiError)
+        end
+      end
+
+      context 'when previous operation is create in progress' do
+        let(:operation) do
+          ServiceInstanceOperation.make(
+            state: 'in progress',
+            type: 'create',
+          )
+        end
+
+        it 'lets you lock again' do
+          expect {
+            DeleterLock.new(service_instance).lock!
+          }.not_to raise_error
+        end
+      end
+
+      context 'when previous operation is create not in progress' do
+        let(:operation) do
+          ServiceInstanceOperation.make(
+            state: 'NOT in progress',
+            type: 'create',
+          )
+        end
+
+        it 'lets you lock again' do
+          expect {
+            DeleterLock.new(service_instance).lock!
+          }.not_to raise_error
+        end
       end
     end
 
     describe 'unlocking' do
       describe 'unlocking and failing' do
         before do
+          deleter_lock.lock!
+          @operation_id_after_lock = service_instance.last_operation.reload.id
           deleter_lock.unlock_and_fail!
         end
 
-        it 'sets the last operation of the service instance to "failed"' do
-          expect(service_instance.last_operation.state).to eq('failed')
+        context 'when previous operation did not exist' do
+          let(:operation) { nil }
+
+          it 'sets the last operation of the service instance to delete failed' do
+            expect(service_instance.last_operation.type).to eq('delete')
+            expect(service_instance.last_operation.state).to eq('failed')
+          end
+
+          it 'visibly unlocks' do
+            expect(deleter_lock.needs_unlock?).to be_falsey
+          end
         end
 
-        it 'sets the last operation type to "delete"' do
-          expect(service_instance.last_operation.type).to eq('delete')
+        context 'when previous operation is create and NOT in progress' do
+          let(:operation) do
+            ServiceInstanceOperation.make(
+              state: 'NOT in progress',
+              type: 'create',
+            )
+          end
+
+          it 'sets the last operation of the service instance to delete failed' do
+            expect(service_instance.last_operation.type).to eq('delete')
+            expect(service_instance.last_operation.state).to eq('failed')
+          end
+
+          it 'visibly unlocks' do
+            expect(deleter_lock.needs_unlock?).to be_falsey
+          end
+        end
+
+        context 'when previous operation is create and in progress' do
+          let(:operation) do
+            ServiceInstanceOperation.make(
+              state: 'in progress',
+              type: 'create',
+              created_at: previous_operation_time
+            )
+          end
+
+          it 'sets the last operation of the service instance to create in progress' do
+            expect(service_instance.last_operation.type).to eq('create')
+            expect(service_instance.last_operation.state).to eq('in progress')
+          end
+
+          it 'retains created_at from the previous operation' do
+            expect(service_instance.last_operation.created_at).to eq(previous_operation_time)
+          end
+
+          it 'updates the operation created during locking instead of creating new one' do
+            expect(service_instance.last_operation.id).to eq(@operation_id_after_lock)
+          end
+
+          it 'visibly unlocks' do
+            expect(deleter_lock.needs_unlock?).to be_falsey
+          end
         end
       end
 
@@ -68,13 +167,13 @@ module VCAP::CloudController
         it 'updates the attributes on the service instance' do
           job = instance_double(Jobs::Services::ServiceInstanceStateFetch)
           new_description = 'new description'
-          deleter_lock.enqueue_unlock!({ last_operation: { description: new_description } }, job)
+          deleter_lock.enqueue_and_unlock!({ last_operation: { description: new_description } }, job)
           expect(service_instance.last_operation.description).to eq new_description
         end
 
         it 'enqueues the job' do
           job = Jobs::Services::ServiceInstanceStateFetch.new(nil, nil, nil, nil, nil)
-          deleter_lock.enqueue_unlock!({}, job)
+          deleter_lock.enqueue_and_unlock!({}, job)
           expect(Delayed::Job.first).to be_a_fully_wrapped_job_of Jobs::Services::ServiceInstanceStateFetch
         end
       end
@@ -106,7 +205,7 @@ module VCAP::CloudController
 
         it 'is false if you enqueue an unlock' do
           job = double(Jobs::Services::ServiceInstanceStateFetch)
-          deleter_lock.enqueue_unlock!({}, job)
+          deleter_lock.enqueue_and_unlock!({}, job)
           expect(deleter_lock.needs_unlock?).to be_falsey
         end
       end

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -1133,7 +1133,7 @@ module VCAP::CloudController
           end
 
           context 'when an instance has an operation in progress' do
-            let(:last_operation) { ServiceInstanceOperation.make(state: 'in progress') }
+            let(:last_operation) { ServiceInstanceOperation.make(type: 'update', state: 'in progress') }
 
             before do
               service_instance_1.service_instance_operation = last_operation

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3235,8 +3235,8 @@ module VCAP::CloudController
           end
         end
 
-        context 'and the instance operation is in progress' do
-          let(:last_operation) { ServiceInstanceOperation.make(state: 'in progress') }
+        context 'and the instance operation is update in progress' do
+          let(:last_operation) { ServiceInstanceOperation.make(state: 'in progress', type: 'update') }
           before do
             service_instance.service_instance_operation = last_operation
           end
@@ -3245,6 +3245,21 @@ module VCAP::CloudController
             delete "/v2/service_instances/#{service_instance.guid}"
             expect(last_response.status).to eq 409
             expect(last_response.body).to match 'AsyncServiceInstanceOperationInProgress'
+            # expect(last_response.status).to eq(204)
+            # expect(ManagedServiceInstance.find(guid: service_instance.guid)).to be_nil
+          end
+        end
+
+        context 'and the instance operation is create in progress' do
+          let(:last_operation) { ServiceInstanceOperation.make(state: 'in progress', type: 'create') }
+          before do
+            service_instance.service_instance_operation = last_operation
+          end
+
+          it 'should show an error message for delete operation' do
+            delete "/v2/service_instances/#{service_instance.guid}"
+            expect(last_response.status).to eq(204)
+            expect(ManagedServiceInstance.find(guid: service_instance.guid)).to be_nil
           end
         end
 

--- a/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
@@ -826,6 +826,7 @@ module VCAP::Services
         test_case(:deprovision, 422, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
         test_case(:deprovision, 422, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
         test_case(:deprovision, 422, { error: 'AsyncRequired' }.to_json,                        error: Errors::AsyncRequired)
+        test_case(:deprovision, 422, { error: 'ConcurrencyError' }.to_json,                     error: Errors::ConcurrencyError)
         test_common_error_cases(:deprovision)
 
         test_case(:unbind, 200, broker_partial_json,                                            error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))


### PR DESCRIPTION
Before this commit CC was rejecting any request to a service instance if
there was ongoing operation in progress for it.
As part of [this OSBAPI spec](https://github.com/openservicebrokerapi/servicebroker/pull/581) a behaviour for the broker was defined for
situations where delete is sent while create is in progress:
It can cancel the create or it can reject the delete because of
the ongoing operation.

With this commit CC forwards the delete request to the broker
and acts accordingly to the response.
By allowing delete while create is in progress, there is a possiblity
that the delayed job for create runs at the same time as the delete
request and cause the instance to be in bad state. To avoid this race
condition, we have added a check on the delayed worker job to check the
last operation to be the same for which it was intended for (when
locking).

More details can be found [here](https://www.pivotaltracker.com/story/show/164046291).