### PR TITLE
Add service_broker_name for space summary endpoint.

### DIFF
--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -61,6 +61,7 @@ module VCAP::CloudController
         'dashboard_url' => dashboard_url,
         'shared_from' => nil,
         'shared_to' => [],
+        'service_broker_name' => service_broker.name,
         'service_plan' => {
           'guid' => service_plan.guid,
           'name' => service_plan.name,

--- a/docs/v2/spaces/get_space_summary.html
+++ b/docs/v2/spaces/get_space_summary.html
@@ -264,6 +264,7 @@ Cookie: </pre>
         "created_at": "2016-06-08T16:41:28Z"
       },
       "dashboard_url": null,
+      "service_broker_name": "broker-name",
       "service_plan": {
         "guid": "0f8ad3ee-ca65-4849-ae52-d6539392fae2",
         "name": "name-1386",

--- a/spec/unit/models/services/managed_service_instance_spec.rb
+++ b/spec/unit/models/services/managed_service_instance_spec.rb
@@ -277,11 +277,13 @@ module VCAP::CloudController
     end
 
     describe '#as_summary_json' do
-      let(:service) { Service.make(label: 'YourSQL', guid: '9876XZ') }
+      let(:service_broker) { ServiceBroker.make(name: 'some_broker') }
+      let(:service) { Service.make(label: 'YourSQL', guid: '9876XZ', service_broker: service_broker) }
       let(:service_plan) { ServicePlan.make(name: 'Gold Plan', guid: '12763abc', service: service) }
-      subject(:service_instance) { ManagedServiceInstance.make(service_plan: service_plan) }
       let(:developer) { make_developer_for_space(service_instance.space) }
       let(:manager) { make_manager_for_space(service_instance.space) }
+
+      subject(:service_instance) { ManagedServiceInstance.make(service_plan: service_plan) }
 
       it 'returns detailed summary' do
         last_operation = ServiceInstanceOperation.make(
@@ -298,6 +300,7 @@ module VCAP::CloudController
           'name' => subject.name,
           'bound_app_count' => 0,
           'dashboard_url' => 'http://dashboard.example.com',
+          'service_broker_name' => service_broker.name,
           'service_plan' => {
             'guid' => '12763abc',
             'name' => 'Gold Plan',


### PR DESCRIPTION
This commit adds service_broker_name field for each service in the response of the space summary endpoint. i.e `/v2/spaces/:guid/summary`

More details can be found [here](https://www.pivotaltracker.com/story/show/163455079).
