### PR TITLE
Add maintenance_info to the service plan

### DIFF
--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -17,6 +17,7 @@ module VCAP::CloudController
                       :plan_updateable,
                       :active,
                       :maximum_polling_duration,
+                      :maintenance_info,
                       :create_instance_schema,
                       :update_instance_schema,
                       :create_binding_schema
@@ -33,6 +34,7 @@ module VCAP::CloudController
                       :bindable,
                       :plan_updateable,
                       :maximum_polling_duration,
+                      :maintenance_info,
                       :create_instance_schema,
                       :update_instance_schema,
                       :create_binding_schema

--- a/app/presenters/v2/service_plan_presenter.rb
+++ b/app/presenters/v2/service_plan_presenter.rb
@@ -9,6 +9,11 @@ module CloudController
         def entity_hash(controller, plan, opts, depth, parents, orphans=nil)
           entity = DefaultPresenter.new.entity_hash(controller, plan, opts, depth, parents, orphans)
 
+          entity['maintenance_info'] = {}
+          if plan.maintenance_info
+            entity['maintenance_info'] = JSON.parse(plan.maintenance_info)
+          end
+
           schemas = present_schemas(plan)
           entity.merge!(schemas)
           entity.delete('create_instance_schema')

--- a/db/migrations/20190409110217_add_maintenance_info_to_service_plan.rb
+++ b/db/migrations/20190409110217_add_maintenance_info_to_service_plan.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :service_plans, :maintenance_info, :text, null: true
+  end
+end

--- a/docs/v2/service_plans/retrieve_a_particular_service_plan.html
+++ b/docs/v2/service_plans/retrieve_a_particular_service_plan.html
@@ -165,6 +165,9 @@ Cookie: </pre>
     "active": true,
     "bindable": true,
     "plan_updateable": true,
+    "maintenance_info": {
+      "version": "2.0"
+    },
     "service_url": "/v2/services/a00cacc0-0ca6-422e-91d3-6b22bcd33450",
     "service_instances_url": "/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332/service_instances",
     "schemas": {

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -113,6 +113,7 @@ module VCAP::Services::ServiceBrokers
         extra:       catalog_plan.metadata.try(:to_json),
         plan_updateable: catalog_plan.plan_updateable,
         maximum_polling_duration: catalog_plan.maximum_polling_duration,
+        maintenance_info: catalog_plan.maintenance_info.try(:to_json),
         create_instance_schema: create_instance,
         update_instance_schema: update_instance,
         create_binding_schema: create_binding,

--- a/lib/services/service_brokers/v2/catalog_plan.rb
+++ b/lib/services/service_brokers/v2/catalog_plan.rb
@@ -2,7 +2,7 @@ module VCAP::Services::ServiceBrokers::V2
   class CatalogPlan
     include CatalogValidationHelper
 
-    attr_reader :broker_provided_id, :name, :description, :metadata, :maximum_polling_duration
+    attr_reader :broker_provided_id, :name, :description, :metadata, :maximum_polling_duration, :maintenance_info
     attr_reader :catalog_service, :errors, :free, :bindable, :schemas, :plan_updateable
 
     def initialize(catalog_service, attrs)
@@ -16,6 +16,7 @@ module VCAP::Services::ServiceBrokers::V2
       @bindable           = attrs['bindable']
       @plan_updateable    = attrs['plan_updateable']
       @maximum_polling_duration = attrs['maximum_polling_duration']
+      @maintenance_info = attrs['maintenance_info']
       build_schemas(attrs['schemas'])
     end
 
@@ -50,6 +51,7 @@ module VCAP::Services::ServiceBrokers::V2
       validate_bool!(:bindable, bindable) if bindable
       validate_bool!(:plan_updateable, plan_updateable) if plan_updateable
       validate_integer!(:maximum_polling_duration, maximum_polling_duration) if maximum_polling_duration
+      validate_hash!(:maintenance_info, @maintenance_info) if @maintenance_info
       validate_hash!(:schemas, @schemas_data) if @schemas_data
     end
 
@@ -69,6 +71,7 @@ module VCAP::Services::ServiceBrokers::V2
         bindable:                   'Plan bindable',
         plan_updateable:            'Plan updateable',
         schemas:                    'Plan schemas',
+        maintenance_info:           'Maintenance info',
         maximum_polling_duration:   'Maximum polling duration',
       }.fetch(name) { raise NotImplementedError }
     end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
@@ -477,6 +477,28 @@ RSpec.describe 'Service Broker API integration' do
         end
       end
     end
+
+    context 'when the broker provides maintenance_info' do
+      let(:catalog) do
+        catalog = default_catalog
+        catalog[:services].first[:plans].first[:maintenance_info] = { 'version' => '2.0' }
+        catalog
+      end
+
+      before do
+        setup_broker(catalog)
+      end
+
+      it 'is saved with the service plan' do
+        get("/v2/service_plans/#{@plan_guid}",
+            {}.to_json,
+            json_headers(admin_headers))
+
+        parsed_body = MultiJson.load(last_response.body)
+        maintenance_info = parsed_body['entity']['maintenance_info']
+        expect(maintenance_info).to eq({ 'version' => '2.0' })
+      end
+    end
   end
 end
 

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -625,7 +625,8 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         plan_updateable:        true,
         create_instance_schema: '{}',
         update_instance_schema: '{}',
-        create_binding_schema:  '{}'
+        create_binding_schema:  '{}',
+        maintenance_info: '{}'
       )
       service_event_repository.with_service_plan_event(new_plan) do
         new_plan.save
@@ -655,7 +656,8 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
           'maximum_polling_duration'   => new_plan.maximum_polling_duration,
           'create_instance_schema'     => new_plan.create_instance_schema,
           'update_instance_schema'     => new_plan.update_instance_schema,
-          'create_binding_schema'      => new_plan.create_binding_schema
+          'create_binding_schema'      => new_plan.create_binding_schema,
+          'maintenance_info'           => new_plan.maintenance_info,
         }
       }
     end

--- a/spec/request/v2/service_plans_spec.rb
+++ b/spec/request/v2/service_plans_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+RSpec.describe 'ServicePlans' do
+  let(:user) { VCAP::CloudController::User.make }
+  let(:space) { VCAP::CloudController::Space.make }
+
+  before do
+    space.organization.add_user(user)
+    space.add_developer(user)
+  end
+
+  describe 'GET /v2/service_plans' do
+    let(:service) { VCAP::CloudController::Service.make }
+    let!(:service_plan) { VCAP::CloudController::ServicePlan.make(
+      service: service,
+      maintenance_info: '{ "version":  "2.0" }')
+    }
+
+    it 'lists service plans' do
+      get '/v2/service_plans', nil, headers_for(user)
+      expect(last_response.status).to eq(200)
+
+      parsed_response = MultiJson.load(last_response.body)
+      expect(parsed_response).to be_a_response_like(
+        {
+          'total_results' => 1,
+          'total_pages' => 1,
+          'prev_url' => nil,
+          'next_url' => nil,
+          'resources' => [
+            {
+              'metadata' => {
+                'guid' => service_plan.guid,
+                'url' => "/v2/service_plans/#{service_plan.guid}",
+                'created_at' => iso8601,
+                'updated_at' => iso8601
+              },
+              'entity' => {
+                'active' => true,
+                'bindable' => true,
+                'description' => service_plan.description,
+                'extra' => nil,
+                'free' => false,
+                'maximum_polling_duration' => nil,
+                'maintenance_info' => { 'version' => '2.0' },
+                'name' => service_plan.name,
+                'plan_updateable' => nil,
+                'public' => true,
+                'schemas' => {
+                   'service_instance' => {
+                      'create' => {
+                         'parameters' => {}
+                      },
+                      'update' => {
+                         'parameters' => {}
+                      }
+                   },
+                   'service_binding' => {
+                      'create' => {
+                         'parameters' => {}
+                      }
+                   }
+                },
+                'service_guid' => service.guid,
+                'service_instances_url' => "/v2/service_plans/#{service_plan.guid}/service_instances",
+                'service_url' => "/v2/services/#{service.guid}",
+                'unique_id' => service_plan.unique_id
+              }
+            }
+          ]
+        }
+      )
+    end
+  end
+
+  describe 'GET /v2/service_plans/:guid' do
+    let(:service) { VCAP::CloudController::Service.make }
+    let!(:service_plan) { VCAP::CloudController::ServicePlan.make(
+      service: service,
+      maintenance_info: '{ "version":  "2.0" }')
+    }
+
+    it 'lists service plans' do
+      get "/v2/service_plans/#{service_plan.guid}", nil, headers_for(user)
+      expect(last_response.status).to eq(200)
+
+      parsed_response = MultiJson.load(last_response.body)
+      expect(parsed_response).to be_a_response_like(
+        {
+          'metadata' => {
+            'guid' => service_plan.guid,
+            'url' => "/v2/service_plans/#{service_plan.guid}",
+            'created_at' => iso8601,
+            'updated_at' => iso8601
+          },
+          'entity' => {
+            'active' => true,
+            'bindable' => true,
+            'description' => service_plan.description,
+            'extra' => nil,
+            'free' => false,
+            'maximum_polling_duration' => nil,
+            'maintenance_info' => { 'version' => '2.0' },
+            'name' => service_plan.name,
+            'plan_updateable' => nil,
+            'public' => true,
+            'schemas' => {
+               'service_instance' => {
+                  'create' => {
+                     'parameters' => {}
+                  },
+                  'update' => {
+                     'parameters' => {}
+                  }
+               },
+               'service_binding' => {
+                  'create' => {
+                     'parameters' => {}
+                  }
+               }
+            },
+            'service_guid' => service.guid,
+            'service_instances_url' => "/v2/service_plans/#{service_plan.guid}/service_instances",
+            'service_url' => "/v2/services/#{service.guid}",
+            'unique_id' => service_plan.unique_id
+          }
+        },
+      )
+    end
+  end
+end

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -19,6 +19,9 @@ module VCAP::Services::ServiceBrokers
     let(:plan_id) { Sham.guid }
     let(:plan_name) { Sham.name }
     let(:plan_description) { Sham.description }
+    let(:plan_maintenance_info) do
+      { 'version' => '2.0' }
+    end
     let(:service_metadata_hash) do
       { 'metadata' => { 'foo' => 'bar' } }
     end
@@ -81,6 +84,7 @@ module VCAP::Services::ServiceBrokers
                 'free'        => false,
                 'bindable'    => true,
                 'maximum_polling_duration' => 3600,
+                'maintenance_info' => plan_maintenance_info,
               }.merge(plan_metadata_hash).merge(plan_schemas_hash)
             ]
           }.merge(service_metadata_hash)
@@ -188,6 +192,7 @@ module VCAP::Services::ServiceBrokers
           'description' => service_plan.description,
           'plan_updateable' => service_plan.plan_updateable,
           'maximum_polling_duration' => service_plan.maximum_polling_duration,
+          'maintenance_info' => service_plan.maintenance_info,
           'service_guid' => service_plan.service.guid,
           'extra' => '{"cost":"0.0"}',
           'unique_id' => service_plan.unique_id,
@@ -232,6 +237,7 @@ module VCAP::Services::ServiceBrokers
           expect(plan.description).to eq(plan_description)
           expect(plan.plan_updateable).to eq(true)
           expect(plan.maximum_polling_duration).to eq(3600)
+          expect(JSON.parse(plan.maintenance_info)).to eq(plan_maintenance_info)
           expect(JSON.parse(plan.extra)).to eq({ 'cost' => '0.0' })
           expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
           expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
@@ -587,6 +593,8 @@ module VCAP::Services::ServiceBrokers
               unique_id: plan_id,
               free: true,
               bindable: false,
+              maximum_polling_duration: 0,
+              maintenance_info: nil,
               create_instance_schema: nil,
               update_instance_schema: nil
             )
@@ -598,6 +606,8 @@ module VCAP::Services::ServiceBrokers
             expect(plan.free).to be true
             expect(plan.bindable).to be false
             expect(plan.plan_updateable).to be_nil
+            expect(plan.maximum_polling_duration).to be_zero
+            expect(plan.maintenance_info).to be_nil
             expect(plan.create_instance_schema).to be_nil
             expect(plan.update_instance_schema).to be_nil
             expect(plan.create_binding_schema).to be_nil
@@ -612,6 +622,8 @@ module VCAP::Services::ServiceBrokers
             expect(plan.free).to be false
             expect(plan.bindable).to be true
             expect(plan.plan_updateable).to be true
+            expect(plan.maximum_polling_duration).to eq(3600)
+            expect(JSON.parse(plan.maintenance_info)).to eq(plan_maintenance_info)
             expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
             expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
             expect(plan.create_binding_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')

--- a/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
@@ -14,7 +14,8 @@ module VCAP::Services::ServiceBrokers::V2
         'bindable'    => opts[:bindable],
         'schemas'     => opts[:schemas] || {},
         'plan_updateable' => opts[:plan_updateable],
-        'maximum_polling_duration' => opts[:maximum_polling_duration]
+        'maximum_polling_duration' => opts[:maximum_polling_duration],
+        'maintenance_info' => opts[:maintenance_info] || {}
       }
     end
     let(:catalog_service) { instance_double(VCAP::Services::ServiceBrokers::V2::CatalogService) }
@@ -33,6 +34,7 @@ module VCAP::Services::ServiceBrokers::V2
         expect(plan.bindable).to be true
         expect(plan.plan_updateable).to be true
         expect(plan.maximum_polling_duration).to be 3600
+        expect(plan.maintenance_info).to eq({})
         expect(plan.errors).to be_empty
       end
 
@@ -137,6 +139,13 @@ module VCAP::Services::ServiceBrokers::V2
 
         expect(plan).to_not be_valid
         expect(plan.errors.messages.first).to include 'Plan schemas must be a hash, but has value "true"'
+      end
+
+      it 'validates that @maintenance_info is a hash' do
+        plan_attrs['maintenance_info'] = 'true'
+
+        expect(plan).to_not be_valid
+        expect(plan.errors.messages.first).to include 'Maintenance info must be a hash, but has value "true"'
       end
 
       it 'validates that @maximum_polling_duration is an integer' do

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -51,6 +51,7 @@ module VCAP::CloudController
                                          :bindable,
                                          :plan_updateable,
                                          :maximum_polling_duration,
+                                         :maintenance_info,
                                          :active,
                                          :create_instance_schema,
                                          :update_instance_schema,
@@ -68,6 +69,7 @@ module VCAP::CloudController
                                          :bindable,
                                          :plan_updateable,
                                          :maximum_polling_duration,
+                                         :maintenance_info,
                                          :create_instance_schema,
                                          :update_instance_schema,
                                          :create_binding_schema

--- a/spec/unit/presenters/v2/service_plan_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_plan_presenter_spec.rb
@@ -19,7 +19,8 @@ module CloudController::Presenters::V2
       let(:service_plan) do
         VCAP::CloudController::ServicePlan.make(create_instance_schema: create_instance_schema,
                                                 update_instance_schema: update_instance_schema,
-                                                create_binding_schema: create_binding_schema)
+                                                create_binding_schema: create_binding_schema,
+                                                maintenance_info: '{ "version":  "2.0" }')
       end
 
       let(:create_instance_schema) { nil }
@@ -39,6 +40,7 @@ module CloudController::Presenters::V2
            'description' => service_plan.description,
            'extra' => nil,
            'free' => false,
+           'maintenance_info' => { 'version' => '2.0' },
            'maximum_polling_duration' => nil,
            'name' => service_plan.name,
            'public' => true,


### PR DESCRIPTION
Cloud Controller validates that maintenance_info can be parsed as a hash
and stores it in the database as text.
When maintenance_info is not provided by the broker, Cloud Controller
presents it as an empty JSON object.

More information in the pivotal tracker [story](https://www.pivotaltracker.com/story/show/164957708)

Niki,
On behalf of SAPI Team