### PR TITLE
Allow cancel of creation of async service binding

### DIFF
--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -146,6 +146,7 @@ module VCAP::CloudController
 
     def save_with_new_operation(last_operation)
       ServiceBinding.db.transaction do
+        self.lock!
         save_changes
 
         if self.last_operation

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -161,6 +161,8 @@ module VCAP::Services::ServiceBrokers::V2
         async: async_response?(response),
         operation: parsed_response['operation']
       }
+    rescue VCAP::Services::ServiceBrokers::V2::Errors::ConcurrencyError
+      raise CloudController::Errors::ApiError.new_from_details('AsyncServiceBindingOperationInProgress', service_binding.app.name, service_binding.service_instance.name)
     end
 
     def update(instance, plan, accepts_incomplete: false, arbitrary_parameters: nil, previous_values: {})

--- a/lib/services/service_brokers/v2/response_parser.rb
+++ b/lib/services/service_brokers/v2/response_parser.rb
@@ -83,9 +83,10 @@ module VCAP::Services
               @logger.warn("Already deleted: #{unvalidated_response.uri}")
               SuccessValidator.new { |res| {} }
             when 422
-              FailWhenValidator.new('error',
-                                    { 'AsyncRequired' => Errors::AsyncRequired },
-                                      FailingValidator.new(Errors::ServiceBrokerBadResponse))
+              FailWhenValidator.new('error', {
+                'AsyncRequired' => Errors::AsyncRequired,
+                'ConcurrencyError' => Errors::ConcurrencyError
+              }, FailingValidator.new(Errors::ServiceBrokerBadResponse))
             else
               FailingValidator.new(Errors::ServiceBrokerBadResponse)
             end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe 'Service Broker API integration' do
       end
     end
 
-    describe 'cancel create async operation' do
+    describe 'cancel service instance create async operation' do
       before do
         setup_broker(default_catalog)
         @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
@@ -497,6 +497,77 @@ RSpec.describe 'Service Broker API integration' do
         parsed_body = MultiJson.load(last_response.body)
         maintenance_info = parsed_body['entity']['maintenance_info']
         expect(maintenance_info).to eq({ 'version' => '2.0' })
+      end
+    end
+
+    describe 'cancel service binding create async operation' do
+      before do
+        setup_broker(default_catalog(bindings_retrievable: true))
+        @broker = VCAP::CloudController::ServiceBroker.find guid: @broker_guid
+        provision_service
+      end
+
+      context 'when binding is in progress' do
+        let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.find(guid: @service_instance_guid) }
+
+        before do
+          create_app
+          async_bind_service
+          expect(a_request(:put, bind_url(service_instance, accepts_incomplete: true))).to have_been_made
+        end
+
+        context 'broker responds synchronously to the unbind request' do
+          it 'deletes the binding' do
+            service_binding = VCAP::CloudController::ServiceBinding.find(guid: @binding_guid)
+            expect(unbind_service).to have_status_code(204)
+
+            expect(a_request(:delete, unbind_url(service_binding))).to have_been_made
+
+            expect(VCAP::CloudController::Event.order(:id).all.map(&:type)).to end_with(
+              'audit.service_binding.start_create',
+              'audit.service_binding.delete'
+            )
+
+            expect { service_binding.reload }.to raise_error(Sequel::Error)
+          end
+        end
+
+        context 'broker rejects the unbind request' do
+          it 'raise concurrency error' do
+            service_binding = VCAP::CloudController::ServiceBinding.find(guid: @binding_guid)
+            expect(unbind_service(status: 422, response_body: { "error": 'ConcurrencyError' })).to have_status_code(409)
+
+            expect(a_request(:delete, unbind_url(service_binding))).to have_been_made
+
+            expect(VCAP::CloudController::Event.order(:id).all.map(&:type)).to end_with(
+              'audit.service_binding.start_create',
+            )
+
+            expect(service_binding.reload).not_to be_nil
+          end
+        end
+
+        it 'unbind request should cancel the bind and delete the binding asynchronously' do
+          stub_async_last_operation
+          service_binding = VCAP::CloudController::ServiceBinding.find(guid: @binding_guid)
+          expect(async_unbind_service).to have_status_code(202)
+
+          expect(a_request(:delete, unbind_url(service_binding, accepts_incomplete: true))).to have_been_made
+
+          expect(service_binding.reload).not_to be_nil
+
+          Timecop.freeze(Time.now) do
+            Delayed::Worker.new.work_off
+            expect(a_request(:get, %r{#{service_binding_url(service_binding)}/last_operation})).to have_been_made
+          end
+
+          expect(VCAP::CloudController::Event.order(:id).all.map(&:type)).to end_with(
+            'audit.service_binding.start_create',
+            'audit.service_binding.start_delete',
+            'audit.service_binding.delete'
+          )
+          expect { service_binding.reload }.to raise_error(Sequel::Error)
+        end
       end
     end
   end

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -309,16 +309,18 @@ module VCAP::CloudController::BrokerApiHelper
 
   def async_bind_service(opts={})
     opts[:accepts_incomplete] = 'true'
+    opts[:status] = opts[:status] || 202
     bind_service(opts)
   end
 
   def async_unbind_service(opts={})
     opts[:accepts_incomplete] = 'true'
+    opts[:status] = opts[:status] || 202
     unbind_service(opts)
   end
 
   def unbind_service(opts={})
-    status = opts[:status] || 204
+    status = opts[:status] || 200
     res_body = opts[:response_body] || {}
     stub_request(:delete, %r{/v2/service_instances/#{@service_instance_guid}/service_bindings/[[:alnum:]-]+}).
       to_return(status: status, body: res_body.to_json)

--- a/spec/unit/actions/service_binding_delete_spec.rb
+++ b/spec/unit/actions/service_binding_delete_spec.rb
@@ -55,9 +55,20 @@ module VCAP::CloudController
         end
       end
 
-      context 'when the service binding has an operation in progress' do
+      context 'when the service binding has create operation in progress' do
         before do
-          service_binding.service_binding_operation = ServiceBindingOperation.make(state: 'in progress')
+          service_binding.service_binding_operation = ServiceBindingOperation.make(state: 'in progress', type: 'create')
+        end
+
+        it 'deletes the binding' do
+          service_binding_delete.foreground_delete_request(service_binding)
+          expect(service_binding.exists?).to be_falsey
+        end
+      end
+
+      context 'when the service binding has anything other than create operation in progress' do
+        before do
+          service_binding.service_binding_operation = ServiceBindingOperation.make(state: 'in progress', type: 'delete')
         end
 
         it 'raises an error' do

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1123,11 +1123,10 @@ module VCAP::CloudController
             service_binding.save
           end
 
-          it 'should not be able to delete binding' do
+          it 'should be able to trigger delete binding' do
             delete "/v2/service_bindings/#{service_binding.guid}"
-            expect(last_response).to have_status_code 409
-            expect(last_response.body).to match 'AsyncServiceBindingOperationInProgress'
-            expect(ServiceBinding.find(guid: service_binding.guid)).not_to be_nil
+            expect(last_response).to have_status_code 204
+            expect(ServiceBinding.find(guid: service_binding.guid)).to be_nil
           end
         end
 

--- a/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
@@ -855,6 +855,7 @@ module VCAP::Services
         test_case(:unbind, 422, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse)
         test_case(:unbind, 422, broker_malformed_json,                                          error: Errors::ServiceBrokerBadResponse)
         test_case(:unbind, 422, { error: 'AsyncRequired' }.to_json,                             error: Errors::AsyncRequired)
+        test_case(:unbind, 422, { error: 'ConcurrencyError' }.to_json,                          error: Errors::ConcurrencyError)
         test_common_error_cases(:unbind)
         test_case(:update, 200, broker_partial_json,                                            error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
         test_case(:update, 200, broker_malformed_json,                                          error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))


### PR DESCRIPTION
Before this commit CC was rejecting any request to a service binding if
there was ongoing operation in progress for it.
In v2.15 of the OSBAPI spec a behaviour for the broker was defined for
situations where unbind is sent while bind is in progress:
It can cancel the bind or it can reject the unbind because of
the ongoing operation.

With this commit CC forwards the unbind request to the broker
and acts accordingly to the response.
By allowing unbind while bind is in progress, there is a possibility
that the delayed job for bind state fetch runs at the same time as the unbind
request and cause the binding to be in bad state. To avoid this race
condition, we have added a check on the delayed worker job to check the
last operation to be the same for which it was intended for (when
locking).

More information in the [story](https://www.pivotaltracker.com/story/show/164046295)

Best Regards
@blgm and Niki,
on behalf of the SAPI Team
