### PR TITLE
Ability to trigger an update (of maintenance_info) on service instance

### DIFF
--- a/app/actions/services/service_instance_update.rb
+++ b/app/actions/services/service_instance_update.rb
@@ -38,6 +38,7 @@ module VCAP::CloudController
     def update_broker_needed?(attrs, old_service_plan_guid, service_instance)
       return true if attrs['parameters']
       return true if attrs['name'] && service_instance.service.allow_context_updates
+      return true if attrs['maintenance_info']
       return false if !attrs['service_plan_guid']
 
       attrs['service_plan_guid'] != old_service_plan_guid
@@ -74,7 +75,8 @@ module VCAP::CloudController
         service_plan,
         accepts_incomplete: accepts_incomplete,
         arbitrary_parameters: request_attrs['parameters'],
-        previous_values: previous_values
+        previous_values: previous_values,
+        maintenance_info: request_attrs['maintenance_info'],
       )
 
       service_instance.last_operation.update_attributes(response[:last_operation])

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -19,6 +19,7 @@ module VCAP::CloudController
       attribute :name, String
       attribute :parameters, Hash, default: nil
       attribute :tags, [String], default: []
+      attribute :maintenance_info, Hash, default: nil, exclude_in: [:create]
       to_one :space
       to_one :service_plan
       to_many :service_bindings, route_for: [:get], exclude_in: [:create, :update]

--- a/app/controllers/services/validators/service_update_validator.rb
+++ b/app/controllers/services/validators/service_update_validator.rb
@@ -11,6 +11,7 @@ module VCAP::CloudController
         validate_changing_plan(service_plan, service, service_instance, update_attrs['service_plan_guid'])
         check_plan_still_valid(service_instance, service_plan, update_attrs['service_plan_guid'])
         validate_update_of_service_parameters(service_instance, update_attrs['parameters'])
+        validate_maintenance_info_update(service_plan, update_attrs['maintenance_info'])
         true
       end
 
@@ -30,6 +31,14 @@ module VCAP::CloudController
 
         if update_attrs['name'] != service_instance.name
           raise CloudController::Errors::ApiError.new_from_details('SharedServiceInstanceCannotBeRenamed')
+        end
+      end
+
+      def validate_maintenance_info_update(service_plan, maintenance_info)
+        return unless maintenance_info
+
+        if service_plan.maintenance_info.nil? || maintenance_info != service_plan.parsed_maintenance_info
+          raise CloudController::Errors::ApiError.new_from_details('MaintenanceInfoMismatch')
         end
       end
 

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -143,6 +143,10 @@ module VCAP::CloudController
       visible_plans.include?(self)
     end
 
+    def parsed_maintenance_info
+      JSON.parse(maintenance_info)
+    end
+
     private
 
     def before_validation

--- a/app/presenters/v2/service_plan_presenter.rb
+++ b/app/presenters/v2/service_plan_presenter.rb
@@ -11,7 +11,7 @@ module CloudController
 
           entity['maintenance_info'] = {}
           if plan.maintenance_info
-            entity['maintenance_info'] = JSON.parse(plan.maintenance_info)
+            entity['maintenance_info'] = plan.parsed_maintenance_info
           end
 
           schemas = present_schemas(plan)

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -163,7 +163,7 @@ module VCAP::Services::ServiceBrokers::V2
       }
     end
 
-    def update(instance, plan, accepts_incomplete: false, arbitrary_parameters: nil, previous_values: {})
+    def update(instance, plan, accepts_incomplete: false, arbitrary_parameters: nil, previous_values: {}, maintenance_info: nil)
       path = service_instance_resource_path(instance, accepts_incomplete: accepts_incomplete)
 
       body = {
@@ -172,8 +172,9 @@ module VCAP::Services::ServiceBrokers::V2
         previous_values: previous_values,
         context:         context_hash_with_instance_name(instance)
       }
-      body[:parameters] = arbitrary_parameters if arbitrary_parameters
-      response          = @http_client.patch(path, body)
+      body[:parameters]       = arbitrary_parameters if arbitrary_parameters
+      body[:maintenance_info] = maintenance_info if maintenance_info
+      response                = @http_client.patch(path, body)
 
       parsed_response     = @response_parser.parse_update(path, response)
       last_operation_hash = parsed_response['last_operation'] || {}

--- a/spec/support/broker_api_helper.rb
+++ b/spec/support/broker_api_helper.rb
@@ -254,7 +254,7 @@ module VCAP::CloudController::BrokerApiHelper
     )
   end
 
-  def async_update_service(status: 202, operation_data: nil, dashboard_url: nil)
+  def async_update_service(status: 202, operation_data: nil, dashboard_url: nil, maintenance_info: nil)
     broker_update_response_body = {}
 
     if operation_data
@@ -268,9 +268,8 @@ module VCAP::CloudController::BrokerApiHelper
     stub_request(:patch, %r{broker-url/v2/service_instances/[[:alnum:]-]+}).
       to_return(status: status, body: broker_update_response_body.to_json)
 
-    body = {
-      service_plan_guid: @large_plan_guid
-    }
+    body = { service_plan_guid: @large_plan_guid }
+    body = { maintenance_info: maintenance_info } if maintenance_info
 
     put("/v2/service_instances/#{@service_instance_guid}?accepts_incomplete=true",
         body.to_json,

--- a/spec/support/fakes/fake_service_broker_v2_client.rb
+++ b/spec/support/fakes/fake_service_broker_v2_client.rb
@@ -58,7 +58,7 @@ class FakeServiceBrokerV2Client
     }
   end
 
-  def update(_instance, _plan, accepts_incomplete: false, arbitrary_parameters: nil, previous_values: {})
+  def update(_instance, _plan, accepts_incomplete: false, arbitrary_parameters: nil, previous_values: {}, maintenance_info: nil)
     [{
       last_operation: {
         type:        'update',

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -34,6 +34,7 @@ module VCAP::CloudController
           service_key_guids: { type: '[string]' },
           tags: { type: '[string]' },
           parameters: { type: 'hash' },
+          maintenance_info: { type: 'hash' },
         })
       end
     end

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -237,7 +237,7 @@ module VCAP::Services::ServiceBrokers
           expect(plan.description).to eq(plan_description)
           expect(plan.plan_updateable).to eq(true)
           expect(plan.maximum_polling_duration).to eq(3600)
-          expect(JSON.parse(plan.maintenance_info)).to eq(plan_maintenance_info)
+          expect(plan.parsed_maintenance_info).to eq(plan_maintenance_info)
           expect(JSON.parse(plan.extra)).to eq({ 'cost' => '0.0' })
           expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
           expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
@@ -623,7 +623,7 @@ module VCAP::Services::ServiceBrokers
             expect(plan.bindable).to be true
             expect(plan.plan_updateable).to be true
             expect(plan.maximum_polling_duration).to eq(3600)
-            expect(JSON.parse(plan.maintenance_info)).to eq(plan_maintenance_info)
+            expect(plan.parsed_maintenance_info).to eq(plan_maintenance_info)
             expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
             expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
             expect(plan.create_binding_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -589,6 +589,20 @@ module VCAP::Services::ServiceBrokers::V2
         end
       end
 
+      context 'when the caller passes maintenance_info' do
+        it 'includes the maintenance_info in the request to the broker' do
+          client.update(instance, old_plan, maintenance_info: { version: '2.0' })
+
+          expect(http_client).to have_received(:patch).with(
+            anything,
+            hash_including({
+              maintenance_info: { version: '2.0' },
+              previous_values: {}
+            })
+          )
+        end
+      end
+
       context 'when the caller passes the accepts_incomplete flag' do
         let(:path) { "/v2/service_instances/#{instance.guid}?accepts_incomplete=true" }
 

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1194,6 +1194,11 @@
   http_code: 403
   message: 'You cannot delete service instances that have been shared with you'
 
+390006:
+  name: MaintenanceInfoMismatch
+  http_code: 422
+  message: "The maintenance requested is not available for this service instance. Please confirm your maintenance_info is available for the service plan"
+
 390011:
   name: BuildpackStacksDontMatch
   http_code: 422


### PR DESCRIPTION
As part of the `update-one` feature users can test an individual instance of the service to gauge the difficulty and risk associated with upgrading that particular service before running an `upgrade-all` errand (on the broker)
This PR enables that feature by accepting PUT requests to `/v2/service_instances/:guid ` for a service instance with `{"maintenance_info": {"version":"2.0"}}` in the body and forwards it as a PATCH to the broker to trigger update/upgrade of service instance. 
And, additionally validate for outdated maintenance_info updates.

More info can be found [here](https://www.pivotaltracker.com/story/show/164961906).

