### PR TITLE
Provide artifact name in droplet download action

### DIFF
--- a/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
@@ -46,6 +46,7 @@ module VCAP::CloudController
 
           serial([
             ::Diego::Bbs::Models::DownloadAction.new({
+              artifact: 'droplet',
               from: @droplet_uri,
               to: '.',
               cache_key: "droplets-#{@process_guid}",

--- a/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
@@ -103,6 +103,7 @@ module VCAP::CloudController
                   actions: [
                     ::Diego::Bbs::Models::Action.new(
                       download_action: ::Diego::Bbs::Models::DownloadAction.new(
+                        artifact: 'droplet',
                         to: '.',
                         user: 'vcap',
                         from: 'http://droplet-uri.com:1234?token=&@home--->',
@@ -131,6 +132,7 @@ module VCAP::CloudController
                       actions: [
                         ::Diego::Bbs::Models::Action.new(
                           download_action: ::Diego::Bbs::Models::DownloadAction.new(
+                            artifact: 'droplet',
                             to: '.',
                             user: 'vcap',
                             from: 'http://droplet-uri.com:1234?token=&@home--->',


### PR DESCRIPTION
When an application crashes at the moment due to droplet download
failures, users just see `Downloading failed` in the crash reason
because the artifact name is not provided in the DownloadAction

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
