### PR TITLE
Suggest logging in when unauthenticated users get rate-limited

### DIFF
--- a/spec/unit/middleware/rate_limiter_spec.rb
+++ b/spec/unit/middleware/rate_limiter_spec.rb
@@ -363,6 +363,25 @@ module CloudFoundry
             )
           end
         end
+
+        context 'when the user is unauthenticated' do
+          let(:path_info) { '/v3/foo' }
+          let(:unauthenticated_env) { { 'some' => 'env', 'PATH_INFO' => path_info } }
+
+          it 'suggests they log in' do
+            10.times do
+              middleware.call(unauthenticated_env)
+            end
+            _, response_headers, body = middleware.call(unauthenticated_env)
+            expect(response_headers['X-RateLimit-Remaining']).to eq('0')
+            json_body = JSON.parse(body.first)
+            expect(json_body['errors'].first).to include(
+              'code' => 10014,
+              'detail' => 'Rate Limit Exceeded: please log in again',
+              'title' => 'CF-IPBasedRateLimitExceeded',
+            )
+          end
+        end
       end
 
       context 'with multiple servers' do

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -88,6 +88,11 @@
   http_code: 429
   message: "Rate Limit Exceeded"
 
+10014:
+  name: IPBasedRateLimitExceeded
+  http_code: 429
+  message: "Rate Limit Exceeded: please log in again"
+
 20001:
   name: UserInvalid
   http_code: 400
@@ -512,7 +517,7 @@
   name: ServiceInstanceAlreadyBoundToSameRoute
   http_code: 400
   message: "The route and service instance are already bound."
-  
+
 130009:
   name: InternalDomainCannotBeDeleted
   http_code: 422
@@ -522,7 +527,7 @@
   name: RouteServiceCannotBeBoundToInternalRoute
   http_code: 400
   message: "Route services cannot be bound to internal routes."
-  
+
 140001:
   name: LegacyApiWithoutDefaultSpace
   http_code: 400


### PR DESCRIPTION
## Short explanation of the proposed change:

This commit changes Cloud Controller's rate limiting middleware to suggest that unauthenticated users log in.

## Explanation of the use cases your change solves

This change helps users navigate the rate limits themselves rather than getting stuck and needing support. Without this change we've seen an awkward series of events:

1. A user was running something periodically against Cloud Controller;
2. They suspended their laptop overnight;
3. The next morning their login session had expired;
4. They hit our unauthenticated rate limit;
5. Other users on the same IP address got errors from `cf` that they did not know how to solve:
     ```
     Unexpected Response
     Response code: 429
     CC code:       10013
     CC error code: CF-RateLimitExceeded
     Request ID:    9cd9b261-9e4b-44d9-6edc-50ecee164f60::d3aeee04-32aa-4cb8-8d12-4ae2a19d4e11
     Description:   Rate Limit Exceeded
     ```
6. Those users came to us confused;
7. We eventually figured out they were logged out or their own login session had expired, so they had hit the IP-based rate limit;
8. They ran `cf login` and all was fine.

If this PR is merged, the error message users got would be a little more helpful:

```
Unexpected Response
Response code: 429
CC code:       10014
CC error code: CF-IPBasedRateLimitExceeded
Request ID:    9cd9b261-9e4b-44d9-6edc-50ecee164f60::d3aeee04-32aa-4cb8-8d12-4ae2a19d4e11
Description:   Rate Limit Exceeded: please log in again
```

That message prompts users to log in again, and suggests the rate limit is IP-based, giving them ways to solve their own issue. Without this change we wouldn't feel confident setting a low unauthenticated rate limit.

## Tickboxes

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
