### PR TITLE
Add maintenance_info in update service instance api docs

### DIFF
--- a/docs/v2/service_instances/update_a_service_instance.html
+++ b/docs/v2/service_instances/update_a_service_instance.html
@@ -200,6 +200,27 @@
                 </ul>
               </td>
             </tr>
+            <tr class=" ">
+              <td class=" ">
+                <span class="name">maintenance_info (experimental)</span>
+              </td>
+              <td>
+                <span class="description">This field can be used to perform maintenance on a service instance (for example, to upgrade the version of a service's software).</br>
+                NOTE: The `maintenance_info` object provided in the request must be supported by the service instance's plan.</span>
+              </td>
+              <td>
+                <span class="default"></span>
+              </td>
+              <td>
+                <ul class="valid_values">
+                </ul>
+              </td>
+              <td>
+                <ul class="example_values">
+                  <li>{ "version": "2.0" }</li>
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
 


### PR DESCRIPTION
This commit adds the parameter `maintenance_info` for update service instance endpoint  in to the cc api docs 