### PR TITLE
Implement stop_index method for the opi app client

### DIFF
--- a/lib/cloud_controller/opi/apps_client.rb
+++ b/lib/cloud_controller/opi/apps_client.rb
@@ -56,6 +56,13 @@ module OPI
       @client.put(path)
     end
 
+    def stop_index(versioned_guid, index)
+      guid = VCAP::CloudController::Diego::ProcessGuid.cc_process_guid(versioned_guid)
+      version = VCAP::CloudController::Diego::ProcessGuid.cc_process_version(versioned_guid)
+      path = "/apps/#{guid}/#{version}/stop/#{index}"
+      @client.put(path)
+    end
+
     def bump_freshness; end
 
     private

--- a/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
@@ -450,4 +450,27 @@ RSpec.describe(OPI::Client) do
       expect(response.status).to equal(200)
     end
   end
+
+  context 'stop an app instance' do
+    let(:opi_url) { 'http://opi.service.cf.internal:8077' }
+    let(:guid) { 'd082417c-c5aa-488c-aaf8-845a580eb11f' }
+    let(:version) { 'e2fe80f5-fd0c-4699-a4d1-ae06bc48a923' }
+    let(:index) { 1 }
+    subject(:client) { described_class.new(opi_url) }
+
+    before do
+      stub_request(:put, "#{opi_url}/apps/#{guid}/#{version}/stop/#{index}").
+        to_return(status: 200)
+    end
+
+    it 'executes an HTTP request' do
+      client.stop_index("#{guid}-#{version}", index)
+      expect(WebMock).to have_requested(:put, "#{opi_url}/apps/#{guid}/#{version}/stop/#{index}")
+    end
+
+    it 'returns status OK' do
+      response = client.stop_index("#{guid}-#{version}", index)
+      expect(response.status).to equal(200)
+    end
+  end
 end


### PR DESCRIPTION
In order to enable Eirini to restart a single app instance (based on an index), this PR adds the `stop_index` method to the OPI apps client.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

/cc @gdankov 
