### PR TITLE
Add V3 list service brokers endpoint

### DIFF
--- a/app/controllers/v3/root_controller.rb
+++ b/app/controllers/v3/root_controller.rb
@@ -19,6 +19,7 @@ class RootController < ActionController::Base
     links.merge!(create_link(:processes))
     links.merge!(create_link(:resource_matches, experimental: true))
     links.merge!(create_link(:routes, experimental: true))
+    links.merge!(create_link(:service_brokers))
     links.merge!(create_link(:service_instances))
     links.merge!(create_link(:spaces))
     links.merge!(create_link(:stacks))

--- a/app/controllers/v3/service_brokers_controller.rb
+++ b/app/controllers/v3/service_brokers_controller.rb
@@ -1,0 +1,23 @@
+require 'messages/service_brokers_list_message'
+require 'presenters/v3/service_broker_presenter'
+require 'fetchers/service_broker_list_fetcher'
+
+class ServiceBrokersController < ApplicationController
+  def index
+    message = ServiceBrokersListMessage.from_params(query_params)
+    invalid_param!(message.errors.full_messages) unless message.valid?
+
+    dataset = if permission_queryer.can_read_globally?
+                ServiceBrokerListFetcher.new.fetch(message: message)
+              else
+                ServiceBrokerListFetcher.new.fetch(message: message, permitted_space_guids: permission_queryer.space_developer_space_guids)
+              end
+
+    render status: :ok,
+           json: Presenters::V3::PaginatedListPresenter.new(
+             presenter: Presenters::V3::ServiceBrokerPresenter,
+             paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
+             path: '/v3/service_brokers',
+          )
+  end
+end

--- a/app/fetchers/service_broker_list_fetcher.rb
+++ b/app/fetchers/service_broker_list_fetcher.rb
@@ -1,0 +1,38 @@
+module VCAP::CloudController
+  class ServiceBrokerListFetcher
+    def fetch(message:, permitted_space_guids: nil)
+      if permitted_space_guids
+        dataset = ServiceBroker.dataset.where(space: spaces_from(permitted_space_guids))
+        return filter(message, dataset)
+      end
+
+      dataset = ServiceBroker.dataset
+      filter(message, dataset)
+    end
+
+    private
+
+    def filter(message, dataset)
+      if message.requested?(:space_guids)
+        dataset = dataset.where(
+          space: spaces_from(message.space_guids)
+        )
+      end
+
+      if message.requested?(:names)
+        dataset = dataset.where(
+          name: message.names
+        )
+      end
+
+      dataset
+    end
+
+    def spaces_from(space_guids)
+      spaces = space_guids.map do |space_guid|
+        Space.where(guid: space_guid).first
+      end
+      spaces.compact
+    end
+  end
+end

--- a/app/messages/service_brokers_list_message.rb
+++ b/app/messages/service_brokers_list_message.rb
@@ -1,0 +1,24 @@
+require 'messages/list_message'
+require 'messages/validators/label_selector_requirement_validator'
+
+module VCAP::CloudController
+  class ServiceBrokersListMessage < ListMessage
+    register_allowed_keys [
+      :space_guids,
+      :names
+    ]
+
+    validates_with NoAdditionalParamsValidator
+
+    validates :space_guids, array: true, allow_nil: true
+    validates :names, array: true, allow_nil: true
+
+    def valid_order_by_values
+      super << :name
+    end
+
+    def self.from_params(params)
+      super(params, %w(names space_guids))
+    end
+  end
+end

--- a/app/presenters/v3/service_broker_presenter.rb
+++ b/app/presenters/v3/service_broker_presenter.rb
@@ -1,0 +1,53 @@
+require 'presenters/v3/base_presenter'
+require 'models/helpers/label_helpers'
+require 'presenters/mixins/metadata_presentation_helpers'
+
+module VCAP::CloudController
+  module Presenters
+    module V3
+      class ServiceBrokerPresenter < BasePresenter
+        def to_hash
+          {
+            guid: broker.guid,
+            name: broker.name,
+            url: broker.broker_url,
+            created_at: broker.created_at,
+            updated_at: broker.updated_at,
+            relationships: build_relationships,
+            links: build_links,
+          }
+        end
+
+        private
+
+        def broker
+          @resource
+        end
+
+        def build_relationships
+          if broker.space_guid.nil?
+            {}
+          else
+            {
+              space: {
+                data: {
+                  guid: broker.space_guid
+                }
+              }
+            }
+          end
+        end
+
+        def build_links
+          url_builder = VCAP::CloudController::Presenters::ApiUrlBuilder.new
+
+          { self:
+            {
+              href: url_builder.build_url(path: "/v3/service_brokers/#{broker.guid}")
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,9 @@ Rails.application.routes.draw do
   get '/service_bindings', to: 'service_bindings#index'
   delete '/service_bindings/:guid', to: 'service_bindings#destroy'
 
+  # service_brokers
+  get '/service_brokers', to: 'service_brokers#index'
+
   # space_manifests
   post '/spaces/:guid/actions/apply_manifest', to: 'space_manifests#apply_manifest'
 

--- a/docs/v3/source/includes/api_resources/_service_brokers.erb
+++ b/docs/v3/source/includes/api_resources/_service_brokers.erb
@@ -1,0 +1,110 @@
+<% content_for :single_service_broker do %>
+{
+  "guid": "dde5ad2a-d8f4-44dc-a56f-0452d744f1c3",
+  "name": "my_service_broker",
+  "url": "https://example.service-broker.com",
+  "created_at": "2015-11-13T17:02:56Z",
+  "updated_at": "2016-06-08T16:41:26Z",
+  "relationships": {
+    "space": {
+      "data": {
+        "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+      }
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/service_brokers/dde5ad2a-d8f4-44dc-a56f-0452d744f1c3"
+    }
+  }
+}
+<% end %>
+
+<% content_for :paginated_list_of_service_brokers do |base_url| %>
+{
+  "pagination": {
+    "total_results": 3,
+    "total_pages": 2,
+    "first": {
+      "href": "https://api.example.org<%= base_url %>?page=1&per_page=2"
+    },
+    "last": {
+      "href": "https://api.example.org<%= base_url %>?page=2&per_page=2"
+    },
+    "next": {
+      "href": "https://api.example.org<%= base_url %>?page=2&per_page=2"
+    },
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "dde5ad2a-d8f4-44dc-a56f-0452d744f1c3",
+      "name": "my_service_broker",
+      "url": "https://example.service-broker.com",
+      "created_at": "2015-11-13T17:02:56Z",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "relationships": {
+        "space": {
+          "data": {
+            "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/service_brokers/dde5ad2a-d8f4-44dc-a56f-0452d744f1c3"
+        }
+      }
+    },
+    {
+      "guid": "7aa37bad-6ccb-4ef9-ba48-9ce3a91b2b62",
+      "name": "another_service_broker",
+      "url": "https://another-example.service-broker.com",
+      "created_at": "2015-11-13T17:02:56Z",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "relationships": {
+        "space": {
+          "data": {
+            "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/service_brokers/7aa37bad-6ccb-4ef9-ba48-9ce3a91b2b62"
+        }
+      }
+    }
+  ]
+}
+<% end %>
+
+<% content_for :service_broker_credentials_object do %>
+#### The credentials object
+
+Name | Type | Description
+---- | ---- | -----------
+**type** | _string_ | Type of the authentication mechanisms that can be used. Valid value is `basic`.
+**data** | _object_ | Data is used to hold the actual credentials depending on the authentication mechanism.
+
+```
+Example basic credentials
+```
+
+```json
+{
+  "type": "basic",
+  "data": {
+    "username": "admin",
+    "password": "secretpassw0rd"
+  }
+}
+```
+
+##### Basic credentials data
+
+Name | Type | Description
+---- | ---- | -----------
+**username** | _string_ | The username with which to authenticate against the service broker.
+**password** | _string_ | The password with which to authenticate against the service broker.
+<% end %>

--- a/docs/v3/source/includes/experimental_resources/service_brokers/_header.md
+++ b/docs/v3/source/includes/experimental_resources/service_brokers/_header.md
@@ -1,0 +1,3 @@
+## Service Brokers
+
+Service brokers manage the lifecycle of services. On behalf of users, Cloud Controller will interact with service brokers to provision, get access to and manage access to the services and plans they offer.

--- a/docs/v3/source/includes/experimental_resources/service_brokers/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_brokers/_list.md.erb
@@ -1,0 +1,45 @@
+### List service brokers
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/service_brokers" \
+  -X GET \
+  -H "Authorization: bearer [token]"
+```
+
+```
+Example Response
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+<%= yield_content :paginated_list_of_service_brokers, '/v3/service_brokers' %>
+```
+
+This endpoint retrieves the service brokers the user has access to.
+
+#### Definition
+`GET /v3/service_brokers`
+
+#### Query Parameters
+
+Name | Type | Description
+---- | ---- | ------------
+**names** | _list of strings_ | Comma-delimited list of service broker names to filter by.
+**page** | _integer_ | Page to display. Valid values are integers >= 1.
+**per_page** | _integer_ | Number of results per page. <br>Valid values are 1 through 5000.
+**space_guids** | _list of strings_ | Comma-delimited list of space GUIDs to filter by.
+**order_by** | _string_ | Value to sort by. Defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`.
+
+#### Permitted Roles
+ |
+--- | ---
+Admin |
+Admin Read-Only |
+Global Auditor |
+Space Developer |

--- a/docs/v3/source/includes/experimental_resources/service_brokers/_object.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_brokers/_object.md.erb
@@ -1,0 +1,17 @@
+### The service_broker object
+
+```
+Example Service Broker object
+```
+```json
+<%= yield_content :single_service_broker %>
+```
+
+Name | Type | Description
+---- | ---- | -----------
+**guid** | _uuid_ | Unique identifier for the service broker.
+**name** | _string_ | Name of the service broker.
+**url** | _string_ | URL of the service broker.
+**created_at** | _datetime_ | The time with zone when the object was created.
+**updated_at** | _datetime_ | The time with zone when the object was last updated.
+**links** | [_links object_](#links) | Links to related resources.

--- a/docs/v3/source/index.md
+++ b/docs/v3/source/index.md
@@ -27,6 +27,7 @@ includes:
   - api_resources/route_mappings
   - api_resources/routes
   - api_resources/service_bindings
+  - api_resources/service_brokers
   - api_resources/service_instances
   - api_resources/sidecars
   - api_resources/spaces
@@ -218,6 +219,9 @@ includes:
   - experimental_resources/service_bindings/get
   - experimental_resources/service_bindings/list
   - experimental_resources/service_bindings/delete
+  - experimental_resources/service_brokers/header
+  - experimental_resources/service_brokers/object
+  - experimental_resources/service_brokers/list
   - experimental_resources/sidecars/header
   - experimental_resources/sidecars/object
   - experimental_resources/sidecars/create_from_app

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -126,6 +126,14 @@ class VCAP::CloudController::Permissions
     VCAP::CloudController::Route.user_visible(@user, can_read_globally?).map(&:guid)
   end
 
+  def space_developer_space_guids
+    if can_read_globally?
+      VCAP::CloudController::Space.select(:guid).all.map(&:guid)
+    else
+      membership.space_guids_for_roles(ROLES_FOR_SPACE_SECRETS_READING)
+    end
+  end
+
   def can_read_route?(space_guid, org_guid)
     return true if can_read_globally?
 

--- a/lib/cloud_controller/permissions/queryer.rb
+++ b/lib/cloud_controller/permissions/queryer.rb
@@ -188,6 +188,10 @@ class VCAP::CloudController::Permissions::Queryer
     end
   end
 
+  def space_developer_space_guids
+    db_permissions.space_developer_space_guids
+  end
+
   def readable_route_mapping_guids
     science 'readable_route_mapping_guids' do |e|
       e.use { db_permissions.readable_route_mapping_guids }

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -1,0 +1,262 @@
+require 'spec_helper'
+
+RSpec.describe 'V3 service brokers' do
+  describe 'getting a list of service brokers' do
+    it 'paginates lists of service brokers' do
+      get('/v3/service_brokers', {}, admin_headers)
+
+      json_body = JSON.parse(last_response.body)
+      expect(json_body).to have_key('pagination')
+    end
+
+    context 'when there are no service brokers' do
+      it 'returns 200 OK and a body with no service brokers' do
+        get('/v3/service_brokers', {}, admin_headers)
+
+        expect(last_response).to have_status_code(200)
+
+        json_body = JSON.parse(last_response.body)
+        expect(json_body).to have_key('resources')
+        expect(json_body['resources'].length).to eq(0)
+      end
+    end
+
+    context 'when there is a service broker' do
+      let!(:service_broker) {
+        VCAP::CloudController::ServiceBroker.make(name: 'test-broker',
+                                                  broker_url: 'http://test-broker.example.com')
+      }
+
+      before(:each) do
+        get('/v3/service_brokers', {}, admin_headers)
+      end
+
+      let(:parsed_body) {
+        JSON.parse(last_response.body)
+      }
+
+      let(:returned_service_broker) {
+        parsed_body.fetch('resources').first
+      }
+
+      it 'returns 200 OK and a body containing the single broker' do
+        expect(last_response).to have_status_code(200)
+
+        expect(parsed_body.fetch('resources').length).to eq(1)
+      end
+
+      describe 'the returned service broker' do
+        it 'contains the guid' do
+          expect(returned_service_broker.fetch('guid')).to eq(service_broker.guid)
+        end
+
+        it 'contains the name' do
+          expect(returned_service_broker.fetch('name')).to eq(service_broker.name)
+        end
+
+        it 'contains the url' do
+          expect(returned_service_broker.fetch('url')).to eq(service_broker.broker_url)
+        end
+
+        it 'contains the datetimes' do
+          expect(returned_service_broker.fetch('created_at')).to eq(service_broker.created_at.iso8601)
+          expect(returned_service_broker.fetch('updated_at')).to eq(service_broker.updated_at.iso8601)
+        end
+
+        it 'contains a link to itself' do
+          expect(returned_service_broker).to have_key('links')
+          expect(returned_service_broker['links']).to have_key('self')
+          expect(returned_service_broker['links']['self'].fetch('href')).to include("/v3/service_brokers/#{service_broker.guid}")
+        end
+
+        context 'when the broker is not space scoped' do
+          it 'contains no relationships' do
+            expect(returned_service_broker.fetch('relationships').length).to eq(0)
+          end
+        end
+
+        context 'when the broker is space scoped' do
+          let(:space) { VCAP::CloudController::Space.make }
+          let!(:service_broker) {
+            VCAP::CloudController::ServiceBroker.make(name: 'test-space-scoped-broker',
+                                                      broker_url: 'http://test-space-scoped-broker.example.com',
+                                                      space: space)
+          }
+
+          it 'there is a relationships field with key called space' do
+            expect(returned_service_broker).to have_key('relationships')
+            expect(returned_service_broker['relationships']).to have_key('space')
+            expect(returned_service_broker['relationships']['space']).to have_key('data')
+            expect(returned_service_broker['relationships']['space']['data'].fetch('guid')).to eq(space.guid)
+          end
+        end
+      end
+    end
+
+    context 'when there are multiple service brokers' do
+      let!(:service_broker1) {
+        VCAP::CloudController::ServiceBroker.make(name: 'test-broker-1',
+                                                  broker_url: 'http://test-broker-1.example.com')
+      }
+
+      let(:space) { VCAP::CloudController::Space.make }
+      let!(:service_broker2) {
+        VCAP::CloudController::ServiceBroker.make(name: 'test-broker-2',
+                                                  broker_url: 'http://test-broker-2.example.com',
+                                                  space: space)
+      }
+
+      it 'returns 200 OK and a body containing all the brokers' do
+        get('/v3/service_brokers', {}, admin_headers)
+        expect(last_response).to have_status_code(200)
+
+        parsed_body = JSON.parse(last_response.body)
+        expect(parsed_body.fetch('resources').length).to eq(2)
+        expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-1')
+        expect(parsed_body.fetch('resources').second.fetch('name')).to eq('test-broker-2')
+      end
+
+      context 'when requesting one broker per page' do
+        before(:each) do
+          get('/v3/service_brokers?per_page=1', {}, admin_headers)
+        end
+
+        it 'returns 200 OK and a body containing one broker with pagination information for the next' do
+          expect(last_response).to have_status_code(200)
+
+          parsed_body = JSON.parse(last_response.body)
+          expect(parsed_body.fetch('pagination').fetch('total_results')).to eq(2)
+          expect(parsed_body.fetch('pagination').fetch('total_pages')).to eq(2)
+
+          expect(parsed_body.fetch('resources').length).to eq(1)
+        end
+      end
+
+      context 'when requesting with a specific order by name' do
+        context 'in ascending order' do
+          before(:each) do
+            get('/v3/service_brokers?order_by=name', {}, admin_headers)
+          end
+
+          it 'returns 200 OK and a body containg the brokers ordered by created at time' do
+            expect(last_response).to have_status_code(200)
+
+            parsed_body = JSON.parse(last_response.body)
+
+            expect(parsed_body.fetch('resources').length).to eq(2)
+            expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-1')
+            expect(parsed_body.fetch('resources').last.fetch('name')).to eq('test-broker-2')
+          end
+        end
+
+        context 'descending order' do
+          before(:each) do
+            get('/v3/service_brokers?order_by=-name', {}, admin_headers)
+          end
+
+          it 'returns 200 OK and a body containg the brokers ordered by created at time' do
+            expect(last_response).to have_status_code(200)
+
+            parsed_body = JSON.parse(last_response.body)
+
+            expect(parsed_body.fetch('resources').length).to eq(2)
+            expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-2')
+            expect(parsed_body.fetch('resources').last.fetch('name')).to eq('test-broker-1')
+          end
+        end
+      end
+
+      context 'when requesting with a space guid filter' do
+        before(:each) do
+          get("/v3/service_brokers?space_guids=#{space.guid}", {}, admin_headers)
+        end
+
+        it 'returns 200 OK and a body containing one broker matching the space guid filter' do
+          expect(last_response).to have_status_code(200)
+
+          parsed_body = JSON.parse(last_response.body)
+
+          expect(parsed_body.fetch('resources').length).to eq(1)
+          expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-2')
+        end
+      end
+
+      context 'when requesting with a space guid filter for a random space guid' do
+        before(:each) do
+          get('/v3/service_brokers?space_guids=random-space-guid', {}, admin_headers)
+        end
+
+        it 'returns 200 OK and a body containing no broker' do
+          expect(last_response).to have_status_code(200)
+
+          parsed_body = JSON.parse(last_response.body)
+
+          expect(parsed_body.fetch('resources').length).to eq(0)
+        end
+      end
+
+      context 'when requesting with a names filter' do
+        before(:each) do
+          get("/v3/service_brokers?names=#{service_broker1.name}", {}, admin_headers)
+        end
+
+        it 'returns 200 OK and a body containing one broker matching the names filter' do
+          expect(last_response).to have_status_code(200)
+
+          parsed_body = JSON.parse(last_response.body)
+
+          expect(parsed_body.fetch('resources').length).to eq(1)
+          expect(parsed_body.fetch('resources').first.fetch('name')).to eq(service_broker1.name)
+        end
+      end
+    end
+
+    context 'fetching brokers as a non-admin user' do
+      let(:user) { VCAP::CloudController::User.make }
+      let(:org) { VCAP::CloudController::Organization.make }
+      let(:space) { VCAP::CloudController::Space.make(organization: org) }
+      let!(:object) { VCAP::CloudController::ServiceBroker.make }
+      let!(:broker_with_space) { VCAP::CloudController::ServiceBroker.make space: space }
+      let!(:broker_non_spaced) { VCAP::CloudController::ServiceBroker.make }
+
+      context 'the user is a space developer' do
+        before(:each) do
+          set_current_user(user)
+          org.add_user(user)
+          space.add_developer(user)
+
+          get('/v3/service_brokers', {}, headers_for(user))
+        end
+
+        it 'only returns brokers visible to the user' do
+          expect(last_response).to have_status_code(200)
+
+          parsed_body = JSON.parse(last_response.body)
+          expect(parsed_body.fetch('resources').length).to eq(1)
+          expect(parsed_body.fetch('resources').first.fetch('guid')).to eq(broker_with_space.guid)
+        end
+      end
+
+      context 'the user is an org/space auditor/manager/billing manager' do
+        before(:each) do
+          set_current_user(user)
+          org.add_user(user)
+          org.add_auditor(user)
+          org.add_manager(user)
+          org.add_billing_manager(user)
+          space.add_auditor(user)
+          space.add_manager(user)
+
+          get('/v3/service_brokers', {}, headers_for(user))
+        end
+
+        it 'returns no brokers' do
+          expect(last_response).to have_status_code(200)
+
+          parsed_body = JSON.parse(last_response.body)
+          expect(parsed_body.fetch('resources').length).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/request/v3_root_spec.rb
+++ b/spec/request/v3_root_spec.rb
@@ -53,6 +53,9 @@ RSpec.describe 'v3 root' do
             'href' => "#{link_prefix}/v3/routes",
             'experimental' => true
           },
+          'service_brokers' => {
+            'href' => "#{link_prefix}/v3/service_brokers"
+          },
           'service_instances' => {
             'href' => "#{link_prefix}/v3/service_instances"
           },

--- a/spec/unit/controllers/v3/root_controller_spec.rb
+++ b/spec/unit/controllers/v3/root_controller_spec.rb
@@ -104,6 +104,13 @@ RSpec.describe RootController, type: :controller do
       expect(hash['links']['routes']['experimental']).to eq(true)
     end
 
+    it 'returns a link to service brokers' do
+      get :v3_root
+      hash = MultiJson.load(response.body)
+      expected_uri = "#{TestConfig.config[:external_protocol]}://#{TestConfig.config[:external_domain]}/v3/service_brokers"
+      expect(hash['links']['service_brokers']['href']).to eq(expected_uri)
+    end
+
     it 'returns a link to service instances' do
       get :v3_root
       hash = MultiJson.load(response.body)

--- a/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
@@ -1,0 +1,150 @@
+require 'spec_helper'
+require 'fetchers/service_broker_list_fetcher'
+require 'messages/service_brokers_list_message'
+
+module VCAP::CloudController
+  RSpec.describe ServiceBrokerListFetcher do
+    describe '#fetch' do
+      let(:broker) { ServiceBroker.make }
+
+      let(:space_1) { Space.make }
+      let(:space_scoped_broker_1) { ServiceBroker.make(space_guid: space_1.guid, name: 'broker-1') }
+
+      let(:space_2) { Space.make }
+      let(:space_scoped_broker_2) { ServiceBroker.make(space_guid: space_2.guid, name: 'broker-2') }
+
+      let(:space_3) { Space.make }
+      let(:space_scoped_broker_3) { ServiceBroker.make(space_guid: space_3.guid, name: 'broker-3') }
+
+      let(:fetcher) { ServiceBrokerListFetcher.new }
+      let(:message) { ServiceBrokersListMessage.from_params(filters) }
+
+      before do
+        broker.save
+        space_scoped_broker_1.save
+        space_scoped_broker_2.save
+        space_scoped_broker_3.save
+
+        expect(message).to be_valid
+      end
+
+      context 'when no filters are provided' do
+        let(:filters) { {} }
+
+        it 'includes all the brokers' do
+          brokers = fetcher.fetch(message: message).all
+
+          expect(brokers).to contain_exactly(
+            broker, space_scoped_broker_1, space_scoped_broker_2, space_scoped_broker_3
+          )
+        end
+      end
+
+      context 'when filtering by space GUIDs' do
+        let(:filters) { { space_guids: [space_1.guid, space_2.guid] } }
+
+        it 'includes the relevant brokers' do
+          brokers = fetcher.fetch(message: message).all
+
+          expect(brokers).to contain_exactly(space_scoped_broker_1, space_scoped_broker_2)
+        end
+      end
+
+      context 'when filtering by invalid space GUIDs' do
+        let(:filters) { { space_guids: ['invalid-space-guid'] } }
+
+        it 'includes no brokers' do
+          brokers = fetcher.fetch(message: message).all
+
+          expect(brokers).to be_empty
+        end
+      end
+
+      context 'when filtering by names' do
+        let(:filters) { { names: [space_scoped_broker_1.name, space_scoped_broker_3.name] } }
+
+        it 'includes the relevant brokers' do
+          brokers = fetcher.fetch(message: message).all
+
+          expect(brokers).to contain_exactly(space_scoped_broker_1, space_scoped_broker_3)
+        end
+      end
+
+      context 'when filtering by space guid and names' do
+        let(:filters) { {  space_guids: [space_1.guid, space_2.guid],
+                           names: [space_scoped_broker_1.name, space_scoped_broker_3.name] }
+        }
+
+        it 'includes the relevant brokers' do
+          brokers = fetcher.fetch(message: message).all
+
+          expect(brokers).to contain_exactly(space_scoped_broker_1)
+        end
+      end
+
+      context 'when filtering by space guid and invalid name' do
+        let(:filters) { {  space_guids: [space_1.guid, space_2.guid],
+                           names: ['invalid-name'] }
+        }
+
+        it 'includes the relevant brokers' do
+          brokers = fetcher.fetch(message: message).all
+
+          expect(brokers).to be_empty
+        end
+      end
+
+      context 'when filtering by invalid space guid and names' do
+        let(:filters) { {  space_guids: ['invalid-space-1'],
+                           names: [space_scoped_broker_1.name, space_scoped_broker_3.name] }
+        }
+
+        it 'includes the relevant brokers' do
+          brokers = fetcher.fetch(message: message).all
+
+          expect(brokers).to be_empty
+        end
+      end
+
+      context 'when a list of permitted space_guids is provided' do
+        let(:permitted_space_guids) { [space_1.guid, space_2.guid] }
+
+        context 'when no filters are provided' do
+          let(:filters) { {} }
+
+          it 'includes only the brokers in the permitted spaces' do
+            brokers = fetcher.fetch(message: message, permitted_space_guids: permitted_space_guids).all
+
+            expect(brokers).to contain_exactly(
+              space_scoped_broker_1, space_scoped_broker_2
+            )
+          end
+        end
+
+        context 'when space guid filter is provided' do
+          let(:permitted_space_guids) { [space_1.guid] }
+          let(:filters) { { space_guids: [space_1.guid, space_2.guid] } }
+
+          it 'includes only the brokers in the permitted spaces' do
+            brokers = fetcher.fetch(message: message, permitted_space_guids: permitted_space_guids).all
+
+            expect(brokers).to contain_exactly(
+              space_scoped_broker_1
+            )
+          end
+        end
+
+        context 'when space guid filter is something thats not permitted' do
+          let(:permitted_space_guids) { [space_1.guid] }
+          let(:filters) { { space_guids: [space_2.guid] } }
+
+          it 'includes no brokers' do
+            brokers = fetcher.fetch(message: message, permitted_space_guids: permitted_space_guids).all
+
+            expect(brokers).to be_empty
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/messages/service_brokers_list_message_spec.rb
+++ b/spec/unit/messages/service_brokers_list_message_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require 'messages/service_brokers_list_message'
+
+module VCAP::CloudController
+  RSpec.describe ServiceBrokersListMessage do
+    describe '.from_params' do
+      let(:params) do
+        {
+          'page'      => 1,
+          'per_page'  => 5,
+          'space_guids' => 'space-guid-1,space-guid-2,space-guid-3',
+          'names' => 'name-1,name-2'
+        }
+      end
+
+      it 'returns the correct ServiceBrokersListMessage' do
+        message = ServiceBrokersListMessage.from_params(params)
+
+        expect(message).to be_a(ServiceBrokersListMessage)
+
+        expect(message.page).to eq(1)
+        expect(message.per_page).to eq(5)
+        expect(message.space_guids).to eq(['space-guid-1', 'space-guid-2', 'space-guid-3'])
+        expect(message.names).to eq(['name-1', 'name-2'])
+      end
+
+      it 'converts requested keys to symbols' do
+        message = ServiceBrokersListMessage.from_params(params)
+
+        expect(message.requested?(:page)).to be_truthy
+        expect(message.requested?(:per_page)).to be_truthy
+        expect(message.requested?(:space_guids)).to be_truthy
+        expect(message.requested?(:names)).to be_truthy
+      end
+    end
+
+    describe 'order_by' do
+      it 'allows name' do
+        message = ServiceBrokersListMessage.from_params(order_by: 'name')
+        expect(message).to be_valid
+      end
+    end
+
+    describe 'validation' do
+      it 'accepts an empty set' do
+        message = ServiceBrokersListMessage.from_params({})
+        expect(message).to be_valid
+      end
+
+      it 'accepts defined fields' do
+        message = ServiceBrokersListMessage.from_params({
+            page: 1,
+            per_page: 5,
+            space_guids: ['space-guid-1', 'space-guid2'],
+            names: ['name-1', 'name-2']
+          })
+        expect(message).to be_valid
+      end
+
+      it 'does not accept arbitrary fields' do
+        message = ServiceBrokersListMessage.from_params({ foobar: 'pants' })
+
+        expect(message).not_to be_valid
+        expect(message.errors[:base]).to include("Unknown query parameter(s): 'foobar'")
+      end
+
+      it 'does not accept non-array values for space_guids' do
+        message = ServiceBrokersListMessage.from_params({
+            space_guids: 'not-an-array'
+          })
+        expect(message).not_to be_valid
+        expect(message.errors.first).to(eq([:space_guids, 'must be an array']))
+      end
+
+      it 'does not accept non-array values for names' do
+        message = ServiceBrokersListMessage.from_params({
+            names: 'not-an-array'
+          })
+        expect(message).not_to be_valid
+        expect(message.errors.first).to(eq([:names, 'must be an array']))
+      end
+    end
+  end
+end

--- a/spec/unit/presenters/v3/service_broker_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_broker_presenter_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'presenters/v3/app_presenter'
+
+module VCAP::CloudController::Presenters::V3
+  RSpec.describe ServiceBrokerPresenter do
+    let(:space) { VCAP::CloudController::Space.make }
+    let(:service_broker) do
+      VCAP::CloudController::ServiceBroker.make(
+        name: 'greg',
+        broker_url: 'https://best-broker.io'
+      )
+    end
+
+    describe '#to_hash' do
+      let(:result) { ServiceBrokerPresenter.new(service_broker).to_hash }
+
+      it 'presents the service broker as JSON' do
+        expect(result[:guid]).to eq(service_broker.guid)
+        expect(result[:name]).to eq(service_broker.name)
+        expect(result[:url]).to eq(service_broker.broker_url)
+
+        expect(result[:created_at]).to eq(service_broker.created_at)
+        expect(result[:updated_at]).to eq(service_broker.updated_at)
+
+        expect(result[:relationships].length).to eq(0)
+      end
+
+      it 'includes a link to itself in the JSON' do
+        links = {
+          self: { href: "#{link_prefix}/v3/service_brokers/#{service_broker.guid}" }
+        }
+        expect(result[:links]).to eq(links)
+      end
+
+      context 'when the service broker has an associated space' do
+        let(:service_broker) do
+          VCAP::CloudController::ServiceBroker.make(
+            name: 'greg',
+            space: space,
+            broker_url: 'https://best-broker.io'
+          )
+        end
+
+        it 'includes a space relationship in the JSON' do
+          relationships = {
+            space: { data: { guid: space.guid } }
+          }
+          expect(result[:relationships]).to eq(relationships)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a `GET /v3/service_brokers` endpoint for listing service brokers registered with the platform. Documentation is included.

Tracker stories for reference: [[1]](https://www.pivotaltracker.com/story/show/161809195) [[2]](https://www.pivotaltracker.com/story/show/162088299) [[3]](https://www.pivotaltracker.com/story/show/162088407)

cc @AartiKriplani @williammartin @georgi-lozev @FlorentFlament 