### PR TITLE
Increase instances of CC to three

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
-- instances: 1
+- instances: 3
   disk_quota: 1.5G 


### PR DESCRIPTION
Three nodes will allow CC nodes to maintain quorum even if there is a single-node outage