### PR TITLE
Add endpoint GET /v3/service_brokers/:guid

### DIFF
--- a/app/access/service_access.rb
+++ b/app/access/service_access.rb
@@ -70,20 +70,10 @@ module VCAP::CloudController
       return true if admin_user?
 
       unless service.nil?
-        return validate_broker_access(service.service_broker)
+        return ServiceBrokerAccess.validate_object_access(context, service.service_broker)
       end
 
       false
-    end
-
-    private
-
-    def validate_broker_access(service_broker)
-      if service_broker.private?
-        service_broker.space.has_developer?(context.user)
-      else
-        false
-      end
     end
   end
 end

--- a/app/access/service_broker_access.rb
+++ b/app/access/service_broker_access.rb
@@ -64,7 +64,7 @@ module VCAP::CloudController
       FeatureFlag.raise_unless_enabled!(:space_scoped_private_broker_creation)
 
       unless service_broker.nil?
-        return validate_object_access(service_broker)
+        return ServiceBrokerAccess.validate_object_access(context, service_broker)
       end
     end
 
@@ -72,7 +72,7 @@ module VCAP::CloudController
       return true if admin_user?
 
       unless service_broker.nil?
-        return validate_object_access(service_broker)
+        return ServiceBrokerAccess.validate_object_access(context, service_broker)
       end
 
       false
@@ -82,16 +82,14 @@ module VCAP::CloudController
       return true if admin_user?
 
       unless service_broker.nil?
-        return validate_object_access(service_broker)
+        return ServiceBrokerAccess.validate_object_access(context, service_broker)
       end
 
       false
     end
 
-    private
-
-    def validate_object_access(service_broker)
-      if service_broker.private?
+    def self.validate_object_access(context, service_broker)
+      if service_broker.space_scoped?
         service_broker.space.has_developer?(context.user)
       else
         false

--- a/app/access/service_instance_access.rb
+++ b/app/access/service_instance_access.rb
@@ -123,7 +123,9 @@ module VCAP::CloudController
     end
 
     def purge?(service_instance)
-      admin_user? || (service_instance.space&.has_developer?(context.user) && service_instance.service_broker.private?)
+      admin_user? ||
+        (service_instance.space&.has_developer?(context.user) &&
+         service_instance.service_broker.space_scoped?)
     end
 
     def purge_with_token?(instance)

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -94,7 +94,7 @@ module VCAP::CloudController
 
       invalid_service_instance!(service_instance) unless service_instance.valid?
 
-      if service_plan.broker_private?
+      if service_plan.broker_space_scoped?
         space_not_authorized! unless service_plan.service_broker.space == space
       else
         org_not_authorized! unless plan_visible_to_org?(organization, service_plan)

--- a/app/controllers/v3/service_brokers_controller.rb
+++ b/app/controllers/v3/service_brokers_controller.rb
@@ -10,14 +10,32 @@ class ServiceBrokersController < ApplicationController
     dataset = if permission_queryer.can_read_globally?
                 ServiceBrokerListFetcher.new.fetch(message: message)
               else
-                ServiceBrokerListFetcher.new.fetch(message: message, permitted_space_guids: permission_queryer.space_developer_space_guids)
+                ServiceBrokerListFetcher.new.fetch(message: message, permitted_space_guids: permission_queryer.readable_secret_space_guids)
               end
 
-    render status: :ok,
-           json: Presenters::V3::PaginatedListPresenter.new(
-             presenter: Presenters::V3::ServiceBrokerPresenter,
-             paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
-             path: '/v3/service_brokers',
-          )
+    presenter = Presenters::V3::PaginatedListPresenter.new(
+      presenter: Presenters::V3::ServiceBrokerPresenter,
+      paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
+      path: '/v3/service_brokers',
+    )
+
+    render status: :ok, json: presenter.to_json
+  end
+
+  def show
+    service_broker = VCAP::CloudController::ServiceBroker.find(guid: hashed_params[:guid])
+
+    broker_not_found! unless service_broker
+    broker_not_found! unless permission_queryer.can_read_service_broker?(service_broker)
+
+    presenter = Presenters::V3::ServiceBrokerPresenter.new(service_broker)
+
+    render status: :ok, json: presenter.to_json
+  end
+
+  private
+
+  def broker_not_found!
+    resource_not_found!(:service_broker)
   end
 end

--- a/app/fetchers/service_broker_list_fetcher.rb
+++ b/app/fetchers/service_broker_list_fetcher.rb
@@ -29,10 +29,7 @@ module VCAP::CloudController
     end
 
     def spaces_from(space_guids)
-      spaces = space_guids.map do |space_guid|
-        Space.where(guid: space_guid).first
-      end
-      spaces.compact
+      Space.where(guid: space_guids)
     end
   end
 end

--- a/app/models/services/service_broker.rb
+++ b/app/models/services/service_broker.rb
@@ -28,7 +28,7 @@ module VCAP::CloudController
       @client ||= VCAP::Services::ServiceBrokers::V2::Client.new(url: broker_url, auth_username: auth_username, auth_password: auth_password)
     end
 
-    def private?
+    def space_scoped?
       !!space_id
     end
 

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -134,8 +134,8 @@ module VCAP::CloudController
       service.service_broker if service
     end
 
-    def broker_private?
-      service_broker.private? if service_broker
+    def broker_space_scoped?
+      service_broker.space_scoped? if service_broker
     end
 
     def visible_in_space?(space)
@@ -151,7 +151,7 @@ module VCAP::CloudController
 
     def before_validation
       generate_unique_id if new?
-      self.public = !broker_private? if self.public.nil?
+      self.public = !broker_space_scoped? if self.public.nil?
       super
     end
 
@@ -160,7 +160,7 @@ module VCAP::CloudController
     end
 
     def validate_private_broker_plan_not_public
-      if broker_private? && self.public
+      if broker_space_scoped? && self.public
         errors.add(:public, 'may not be true for plans belonging to private service brokers')
       end
     end

--- a/app/models/services/service_plan_visibility.rb
+++ b/app/models/services/service_plan_visibility.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
     private
 
     def validate_plan_is_not_private
-      if service_plan&.broker_private?
+      if service_plan&.broker_space_scoped?
         errors.add(:service_plan, 'is from a private broker')
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,7 @@ Rails.application.routes.draw do
 
   # service_brokers
   get '/service_brokers', to: 'service_brokers#index'
+  get '/service_brokers/:guid', to: 'service_brokers#show'
 
   # space_manifests
   post '/spaces/:guid/actions/apply_manifest', to: 'space_manifests#apply_manifest'

--- a/docs/v3/source/includes/experimental_resources/service_brokers/_get.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_brokers/_get.md.erb
@@ -1,0 +1,35 @@
+### Get a service broker
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/service_brokers/[guid]" \
+  -X GET \
+  -H "Authorization: bearer [token]"
+```
+
+```
+Example Response
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+<%= yield_content :single_service_broker %>
+```
+
+This endpoint retrieves the service broker by GUID.
+
+#### Definition
+`GET /v3/service_brokers/:guid`
+
+#### Permitted Roles
+ |
+--- | ---
+Admin |
+Admin Read-Only |
+Global Auditor |
+Space Developer |

--- a/docs/v3/source/index.md
+++ b/docs/v3/source/index.md
@@ -233,6 +233,7 @@ includes:
   - experimental_resources/service_brokers/header
   - experimental_resources/service_brokers/object
   - experimental_resources/service_brokers/list
+  - experimental_resources/service_brokers/get
   - experimental_resources/sidecars/header
   - experimental_resources/sidecars/object
   - experimental_resources/sidecars/create_from_app

--- a/lib/cloud_controller/perm/permissions.rb
+++ b/lib/cloud_controller/perm/permissions.rb
@@ -111,6 +111,14 @@ module VCAP
           ])
         end
 
+        def readable_secret_space_guids
+          if can_read_secrets_globally?
+            VCAP::CloudController::Space.select(:guid).all.map(&:guid)
+          else
+            space_guids_for_actions([SPACE_DEVELOPER_ACTION], [])
+          end
+        end
+
         def can_write_to_space?(space_id)
           can_write_globally? || has_any_permission?([
             { action: SPACE_DEVELOPER_ACTION, resource: space_id },

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -126,8 +126,8 @@ class VCAP::CloudController::Permissions
     VCAP::CloudController::Route.user_visible(@user, can_read_globally?).map(&:guid)
   end
 
-  def space_developer_space_guids
-    if can_read_globally?
+  def readable_secret_space_guids
+    if can_read_secrets_globally?
       VCAP::CloudController::Space.select(:guid).all.map(&:guid)
     else
       membership.space_guids_for_roles(ROLES_FOR_SPACE_SECRETS_READING)

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -1,261 +1,414 @@
 require 'spec_helper'
 
 RSpec.describe 'V3 service brokers' do
-  describe 'getting a list of service brokers' do
-    it 'paginates lists of service brokers' do
-      get('/v3/service_brokers', {}, admin_headers)
+  context 'as an admin user' do
+    describe 'getting a single service broker' do
+      context 'when there are no service brokers' do
+        before(:each) do
+          get('/v3/service_brokers/does-not-exist', {}, admin_headers)
+        end
 
-      json_body = JSON.parse(last_response.body)
-      expect(json_body).to have_key('pagination')
+        it 'responds with 404 Not Found' do
+          expect(last_response.status).to eq(404)
+        end
+      end
+
+      context 'when there is a service broker' do
+        let!(:service_broker) {
+          VCAP::CloudController::ServiceBroker.make(name: 'test-broker',
+                                                    broker_url: 'http://test-broker.example.com')
+        }
+
+        before(:each) do
+          get("/v3/service_brokers/#{service_broker.guid}", {}, admin_headers)
+        end
+
+        let(:parsed_body) {
+          JSON.parse(last_response.body)
+        }
+
+        let(:returned_service_broker) {
+          parsed_body
+        }
+
+        it 'returns 200 OK and a body containing the single broker' do
+          expect(last_response).to have_status_code(200)
+
+          expect(parsed_body).not_to be_nil
+        end
+
+        describe 'the returned service broker' do
+          it 'contains the guid' do
+            expect(returned_service_broker.fetch('guid')).to eq(service_broker.guid)
+          end
+
+          it 'contains the name' do
+            expect(returned_service_broker.fetch('name')).to eq(service_broker.name)
+          end
+
+          it 'contains the url' do
+            expect(returned_service_broker.fetch('url')).to eq(service_broker.broker_url)
+          end
+
+          it 'contains the datetimes' do
+            expect(returned_service_broker.fetch('created_at')).to eq(service_broker.created_at.iso8601)
+            expect(returned_service_broker.fetch('updated_at')).to eq(service_broker.updated_at.iso8601)
+          end
+
+          it 'contains a link to itself' do
+            expect(returned_service_broker).to have_key('links')
+            expect(returned_service_broker['links']).to have_key('self')
+            expect(returned_service_broker['links']['self'].fetch('href')).to include("/v3/service_brokers/#{service_broker.guid}")
+          end
+
+          context 'when the broker is not space scoped' do
+            it 'contains no relationships' do
+              expect(returned_service_broker.fetch('relationships').length).to eq(0)
+            end
+          end
+
+          context 'when the broker is space scoped' do
+            let(:space) { VCAP::CloudController::Space.make }
+            let!(:service_broker) {
+              VCAP::CloudController::ServiceBroker.make(name: 'test-space-scoped-broker',
+                                                        broker_url: 'http://test-space-scoped-broker.example.com',
+                                                        space: space)
+            }
+
+            it 'there is a relationships field with key called space' do
+              expect(returned_service_broker).to have_key('relationships')
+              expect(returned_service_broker['relationships']).to have_key('space')
+              expect(returned_service_broker['relationships']['space']).to have_key('data')
+              expect(returned_service_broker['relationships']['space']['data'].fetch('guid')).to eq(space.guid)
+            end
+          end
+        end
+      end
     end
 
-    context 'when there are no service brokers' do
-      it 'returns 200 OK and a body with no service brokers' do
+    describe 'getting a list of service brokers' do
+      it 'paginates lists of service brokers' do
         get('/v3/service_brokers', {}, admin_headers)
-
-        expect(last_response).to have_status_code(200)
 
         json_body = JSON.parse(last_response.body)
-        expect(json_body).to have_key('resources')
-        expect(json_body['resources'].length).to eq(0)
+        expect(json_body).to have_key('pagination')
+      end
+
+      context 'when there are no service brokers' do
+        it 'returns 200 OK and a body with no service brokers' do
+          get('/v3/service_brokers', {}, admin_headers)
+
+          expect(last_response).to have_status_code(200)
+
+          json_body = JSON.parse(last_response.body)
+          expect(json_body).to have_key('resources')
+          expect(json_body['resources'].length).to eq(0)
+        end
+      end
+
+      context 'when there is a service broker' do
+        let!(:service_broker) {
+          VCAP::CloudController::ServiceBroker.make(name: 'test-broker',
+                                                    broker_url: 'http://test-broker.example.com')
+        }
+
+        before(:each) do
+          get('/v3/service_brokers', {}, admin_headers)
+        end
+
+        let(:parsed_body) {
+          JSON.parse(last_response.body)
+        }
+
+        let(:returned_service_broker) {
+          parsed_body.fetch('resources').first
+        }
+
+        it 'returns 200 OK and a body containing the single broker' do
+          expect(last_response).to have_status_code(200)
+
+          expect(parsed_body.fetch('resources').length).to eq(1)
+        end
+
+        describe 'the returned service broker' do
+          it 'contains the guid' do
+            expect(returned_service_broker.fetch('guid')).to eq(service_broker.guid)
+          end
+
+          it 'contains the name' do
+            expect(returned_service_broker.fetch('name')).to eq(service_broker.name)
+          end
+
+          it 'contains the url' do
+            expect(returned_service_broker.fetch('url')).to eq(service_broker.broker_url)
+          end
+
+          it 'contains the datetimes' do
+            expect(returned_service_broker.fetch('created_at')).to eq(service_broker.created_at.iso8601)
+            expect(returned_service_broker.fetch('updated_at')).to eq(service_broker.updated_at.iso8601)
+          end
+
+          it 'contains a link to itself' do
+            expect(returned_service_broker).to have_key('links')
+            expect(returned_service_broker['links']).to have_key('self')
+            expect(returned_service_broker['links']['self'].fetch('href')).to include("/v3/service_brokers/#{service_broker.guid}")
+          end
+
+          context 'when the broker is not space scoped' do
+            it 'contains no relationships' do
+              expect(returned_service_broker.fetch('relationships').length).to eq(0)
+            end
+          end
+
+          context 'when the broker is space scoped' do
+            let(:space) { VCAP::CloudController::Space.make }
+            let!(:service_broker) {
+              VCAP::CloudController::ServiceBroker.make(name: 'test-space-scoped-broker',
+                                                        broker_url: 'http://test-space-scoped-broker.example.com',
+                                                        space: space)
+            }
+
+            it 'there is a relationships field with key called space' do
+              expect(returned_service_broker).to have_key('relationships')
+              expect(returned_service_broker['relationships']).to have_key('space')
+              expect(returned_service_broker['relationships']['space']).to have_key('data')
+              expect(returned_service_broker['relationships']['space']['data'].fetch('guid')).to eq(space.guid)
+            end
+          end
+        end
+      end
+
+      context 'when there are multiple service brokers' do
+        let!(:service_broker1) {
+          VCAP::CloudController::ServiceBroker.make(name: 'test-broker-1',
+                                                    broker_url: 'http://test-broker-1.example.com')
+        }
+
+        let(:space) { VCAP::CloudController::Space.make }
+        let!(:service_broker2) {
+          VCAP::CloudController::ServiceBroker.make(name: 'test-broker-2',
+                                                    broker_url: 'http://test-broker-2.example.com',
+                                                    space: space)
+        }
+
+        it 'returns 200 OK and a body containing all the brokers' do
+          get('/v3/service_brokers', {}, admin_headers)
+          expect(last_response).to have_status_code(200)
+
+          parsed_body = JSON.parse(last_response.body)
+          expect(parsed_body.fetch('resources').length).to eq(2)
+          expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-1')
+          expect(parsed_body.fetch('resources').second.fetch('name')).to eq('test-broker-2')
+        end
+
+        context 'when requesting one broker per page' do
+          before(:each) do
+            get('/v3/service_brokers?per_page=1', {}, admin_headers)
+          end
+
+          it 'returns 200 OK and a body containing one broker with pagination information for the next' do
+            expect(last_response).to have_status_code(200)
+
+            parsed_body = JSON.parse(last_response.body)
+            expect(parsed_body.fetch('pagination').fetch('total_results')).to eq(2)
+            expect(parsed_body.fetch('pagination').fetch('total_pages')).to eq(2)
+
+            expect(parsed_body.fetch('resources').length).to eq(1)
+          end
+        end
+
+        context 'when requesting with a specific order by name' do
+          context 'in ascending order' do
+            before(:each) do
+              get('/v3/service_brokers?order_by=name', {}, admin_headers)
+            end
+
+            it 'returns 200 OK and a body containg the brokers ordered by created at time' do
+              expect(last_response).to have_status_code(200)
+
+              parsed_body = JSON.parse(last_response.body)
+
+              expect(parsed_body.fetch('resources').length).to eq(2)
+              expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-1')
+              expect(parsed_body.fetch('resources').last.fetch('name')).to eq('test-broker-2')
+            end
+          end
+
+          context 'descending order' do
+            before(:each) do
+              get('/v3/service_brokers?order_by=-name', {}, admin_headers)
+            end
+
+            it 'returns 200 OK and a body containg the brokers ordered by created at time' do
+              expect(last_response).to have_status_code(200)
+
+              parsed_body = JSON.parse(last_response.body)
+
+              expect(parsed_body.fetch('resources').length).to eq(2)
+              expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-2')
+              expect(parsed_body.fetch('resources').last.fetch('name')).to eq('test-broker-1')
+            end
+          end
+        end
+
+        context 'when requesting with a space guid filter' do
+          before(:each) do
+            get("/v3/service_brokers?space_guids=#{space.guid}", {}, admin_headers)
+          end
+
+          it 'returns 200 OK and a body containing one broker matching the space guid filter' do
+            expect(last_response).to have_status_code(200)
+
+            parsed_body = JSON.parse(last_response.body)
+
+            expect(parsed_body.fetch('resources').length).to eq(1)
+            expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-2')
+          end
+        end
+
+        context 'when requesting with a space guid filter for a random space guid' do
+          before(:each) do
+            get('/v3/service_brokers?space_guids=random-space-guid', {}, admin_headers)
+          end
+
+          it 'returns 200 OK and a body containing no broker' do
+            expect(last_response).to have_status_code(200)
+
+            parsed_body = JSON.parse(last_response.body)
+
+            expect(parsed_body.fetch('resources').length).to eq(0)
+          end
+        end
+
+        context 'when requesting with a names filter' do
+          before(:each) do
+            get("/v3/service_brokers?names=#{service_broker1.name}", {}, admin_headers)
+          end
+
+          it 'returns 200 OK and a body containing one broker matching the names filter' do
+            expect(last_response).to have_status_code(200)
+
+            parsed_body = JSON.parse(last_response.body)
+
+            expect(parsed_body.fetch('resources').length).to eq(1)
+            expect(parsed_body.fetch('resources').first.fetch('name')).to eq(service_broker1.name)
+          end
+        end
       end
     end
+  end
 
-    context 'when there is a service broker' do
-      let!(:service_broker) {
-        VCAP::CloudController::ServiceBroker.make(name: 'test-broker',
-                                                  broker_url: 'http://test-broker.example.com')
-      }
+  context 'as a non-admin user who is a space developer' do
+    let(:user) { VCAP::CloudController::User.make }
+    let(:org) { VCAP::CloudController::Organization.make }
+    let(:space) { VCAP::CloudController::Space.make(organization: org) }
+    let!(:object) { VCAP::CloudController::ServiceBroker.make }
 
-      before(:each) do
-        get('/v3/service_brokers', {}, admin_headers)
-      end
+    let!(:broker_with_space) { VCAP::CloudController::ServiceBroker.make space: space }
+    let!(:broker_non_spaced) { VCAP::CloudController::ServiceBroker.make }
 
+    before(:each) do
+      set_current_user(user)
+      org.add_user(user)
+      space.add_developer(user)
+    end
+
+    describe 'getting a single service broker' do
       let(:parsed_body) {
         JSON.parse(last_response.body)
       }
 
       let(:returned_service_broker) {
-        parsed_body.fetch('resources').first
+        parsed_body
       }
 
-      it 'returns 200 OK and a body containing the single broker' do
-        expect(last_response).to have_status_code(200)
+      context 'when requested broker is space-scoped' do
+        before(:each) do
+          get("/v3/service_brokers/#{broker_with_space.guid}", {}, headers_for(user))
+        end
 
-        expect(parsed_body.fetch('resources').length).to eq(1)
+        it 'returns 200 OK and a body containing the single broker' do
+          expect(last_response).to have_status_code(200)
+
+          expect(parsed_body).not_to be_nil
+
+          expect(returned_service_broker['guid']).to eq(broker_with_space.guid)
+        end
       end
 
-      describe 'the returned service broker' do
-        it 'contains the guid' do
-          expect(returned_service_broker.fetch('guid')).to eq(service_broker.guid)
+      context 'when requested broker is not space-scoped' do
+        before(:each) do
+          get("/v3/service_brokers/#{broker_non_spaced.guid}", {}, headers_for(user))
         end
 
-        it 'contains the name' do
-          expect(returned_service_broker.fetch('name')).to eq(service_broker.name)
-        end
-
-        it 'contains the url' do
-          expect(returned_service_broker.fetch('url')).to eq(service_broker.broker_url)
-        end
-
-        it 'contains the datetimes' do
-          expect(returned_service_broker.fetch('created_at')).to eq(service_broker.created_at.iso8601)
-          expect(returned_service_broker.fetch('updated_at')).to eq(service_broker.updated_at.iso8601)
-        end
-
-        it 'contains a link to itself' do
-          expect(returned_service_broker).to have_key('links')
-          expect(returned_service_broker['links']).to have_key('self')
-          expect(returned_service_broker['links']['self'].fetch('href')).to include("/v3/service_brokers/#{service_broker.guid}")
-        end
-
-        context 'when the broker is not space scoped' do
-          it 'contains no relationships' do
-            expect(returned_service_broker.fetch('relationships').length).to eq(0)
-          end
-        end
-
-        context 'when the broker is space scoped' do
-          let(:space) { VCAP::CloudController::Space.make }
-          let!(:service_broker) {
-            VCAP::CloudController::ServiceBroker.make(name: 'test-space-scoped-broker',
-                                                      broker_url: 'http://test-space-scoped-broker.example.com',
-                                                      space: space)
-          }
-
-          it 'there is a relationships field with key called space' do
-            expect(returned_service_broker).to have_key('relationships')
-            expect(returned_service_broker['relationships']).to have_key('space')
-            expect(returned_service_broker['relationships']['space']).to have_key('data')
-            expect(returned_service_broker['relationships']['space']['data'].fetch('guid')).to eq(space.guid)
-          end
+        it 'responds with 404 Not Found' do
+          expect(last_response.status).to eq(404)
         end
       end
     end
 
-    context 'when there are multiple service brokers' do
-      let!(:service_broker1) {
-        VCAP::CloudController::ServiceBroker.make(name: 'test-broker-1',
-                                                  broker_url: 'http://test-broker-1.example.com')
-      }
+    describe 'getting a list of service brokers' do
+      it 'only returns brokers visible to the user' do
+        get('/v3/service_brokers', {}, headers_for(user))
 
-      let(:space) { VCAP::CloudController::Space.make }
-      let!(:service_broker2) {
-        VCAP::CloudController::ServiceBroker.make(name: 'test-broker-2',
-                                                  broker_url: 'http://test-broker-2.example.com',
-                                                  space: space)
-      }
-
-      it 'returns 200 OK and a body containing all the brokers' do
-        get('/v3/service_brokers', {}, admin_headers)
         expect(last_response).to have_status_code(200)
 
         parsed_body = JSON.parse(last_response.body)
-        expect(parsed_body.fetch('resources').length).to eq(2)
-        expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-1')
-        expect(parsed_body.fetch('resources').second.fetch('name')).to eq('test-broker-2')
+        expect(parsed_body.fetch('resources').length).to eq(1)
+        expect(parsed_body.fetch('resources').first.fetch('guid')).to eq(broker_with_space.guid)
       end
+    end
+  end
 
-      context 'when requesting one broker per page' do
+  context 'as a non-admin user who is an org/space auditor/manager/billing manager' do
+    let(:user) { VCAP::CloudController::User.make }
+    let(:org) { VCAP::CloudController::Organization.make }
+    let(:space) { VCAP::CloudController::Space.make(organization: org) }
+    let!(:object) { VCAP::CloudController::ServiceBroker.make }
+
+    let!(:broker_with_space) { VCAP::CloudController::ServiceBroker.make space: space }
+    let!(:broker_non_spaced) { VCAP::CloudController::ServiceBroker.make }
+
+    before(:each) do
+      set_current_user(user)
+      org.add_user(user)
+      org.add_auditor(user)
+      org.add_manager(user)
+      org.add_billing_manager(user)
+      space.add_auditor(user)
+      space.add_manager(user)
+    end
+
+    describe 'getting a single service broker' do
+      context 'when requested broker is space-scoped' do
         before(:each) do
-          get('/v3/service_brokers?per_page=1', {}, admin_headers)
+          get("/v3/service_brokers/#{broker_with_space.guid}", {}, headers_for(user))
         end
 
-        it 'returns 200 OK and a body containing one broker with pagination information for the next' do
-          expect(last_response).to have_status_code(200)
-
-          parsed_body = JSON.parse(last_response.body)
-          expect(parsed_body.fetch('pagination').fetch('total_results')).to eq(2)
-          expect(parsed_body.fetch('pagination').fetch('total_pages')).to eq(2)
-
-          expect(parsed_body.fetch('resources').length).to eq(1)
+        it 'responds with 404 Not Found' do
+          expect(last_response.status).to eq(404)
         end
       end
 
-      context 'when requesting with a specific order by name' do
-        context 'in ascending order' do
-          before(:each) do
-            get('/v3/service_brokers?order_by=name', {}, admin_headers)
-          end
-
-          it 'returns 200 OK and a body containg the brokers ordered by created at time' do
-            expect(last_response).to have_status_code(200)
-
-            parsed_body = JSON.parse(last_response.body)
-
-            expect(parsed_body.fetch('resources').length).to eq(2)
-            expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-1')
-            expect(parsed_body.fetch('resources').last.fetch('name')).to eq('test-broker-2')
-          end
-        end
-
-        context 'descending order' do
-          before(:each) do
-            get('/v3/service_brokers?order_by=-name', {}, admin_headers)
-          end
-
-          it 'returns 200 OK and a body containg the brokers ordered by created at time' do
-            expect(last_response).to have_status_code(200)
-
-            parsed_body = JSON.parse(last_response.body)
-
-            expect(parsed_body.fetch('resources').length).to eq(2)
-            expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-2')
-            expect(parsed_body.fetch('resources').last.fetch('name')).to eq('test-broker-1')
-          end
-        end
-      end
-
-      context 'when requesting with a space guid filter' do
+      context 'when requested broker is not space-scoped' do
         before(:each) do
-          get("/v3/service_brokers?space_guids=#{space.guid}", {}, admin_headers)
+          get("/v3/service_brokers/#{broker_non_spaced.guid}", {}, headers_for(user))
         end
 
-        it 'returns 200 OK and a body containing one broker matching the space guid filter' do
-          expect(last_response).to have_status_code(200)
-
-          parsed_body = JSON.parse(last_response.body)
-
-          expect(parsed_body.fetch('resources').length).to eq(1)
-          expect(parsed_body.fetch('resources').first.fetch('name')).to eq('test-broker-2')
-        end
-      end
-
-      context 'when requesting with a space guid filter for a random space guid' do
-        before(:each) do
-          get('/v3/service_brokers?space_guids=random-space-guid', {}, admin_headers)
-        end
-
-        it 'returns 200 OK and a body containing no broker' do
-          expect(last_response).to have_status_code(200)
-
-          parsed_body = JSON.parse(last_response.body)
-
-          expect(parsed_body.fetch('resources').length).to eq(0)
-        end
-      end
-
-      context 'when requesting with a names filter' do
-        before(:each) do
-          get("/v3/service_brokers?names=#{service_broker1.name}", {}, admin_headers)
-        end
-
-        it 'returns 200 OK and a body containing one broker matching the names filter' do
-          expect(last_response).to have_status_code(200)
-
-          parsed_body = JSON.parse(last_response.body)
-
-          expect(parsed_body.fetch('resources').length).to eq(1)
-          expect(parsed_body.fetch('resources').first.fetch('name')).to eq(service_broker1.name)
+        it 'responds with 404 Not Found' do
+          expect(last_response.status).to eq(404)
         end
       end
     end
 
-    context 'fetching brokers as a non-admin user' do
-      let(:user) { VCAP::CloudController::User.make }
-      let(:org) { VCAP::CloudController::Organization.make }
-      let(:space) { VCAP::CloudController::Space.make(organization: org) }
-      let!(:object) { VCAP::CloudController::ServiceBroker.make }
-      let!(:broker_with_space) { VCAP::CloudController::ServiceBroker.make space: space }
-      let!(:broker_non_spaced) { VCAP::CloudController::ServiceBroker.make }
+    describe 'getting a list of service brokers' do
+      it 'returns no brokers' do
+        get('/v3/service_brokers', {}, headers_for(user))
 
-      context 'the user is a space developer' do
-        before(:each) do
-          set_current_user(user)
-          org.add_user(user)
-          space.add_developer(user)
+        expect(last_response).to have_status_code(200)
 
-          get('/v3/service_brokers', {}, headers_for(user))
-        end
-
-        it 'only returns brokers visible to the user' do
-          expect(last_response).to have_status_code(200)
-
-          parsed_body = JSON.parse(last_response.body)
-          expect(parsed_body.fetch('resources').length).to eq(1)
-          expect(parsed_body.fetch('resources').first.fetch('guid')).to eq(broker_with_space.guid)
-        end
-      end
-
-      context 'the user is an org/space auditor/manager/billing manager' do
-        before(:each) do
-          set_current_user(user)
-          org.add_user(user)
-          org.add_auditor(user)
-          org.add_manager(user)
-          org.add_billing_manager(user)
-          space.add_auditor(user)
-          space.add_manager(user)
-
-          get('/v3/service_brokers', {}, headers_for(user))
-        end
-
-        it 'returns no brokers' do
-          expect(last_response).to have_status_code(200)
-
-          parsed_body = JSON.parse(last_response.body)
-          expect(parsed_body.fetch('resources').length).to eq(0)
-        end
+        parsed_body = JSON.parse(last_response.body)
+        expect(parsed_body.fetch('resources').length).to eq(0)
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -421,6 +421,65 @@ module VCAP::CloudController
       end
     end
 
+    describe '#readable_secret_space_guids' do
+      it 'returns all the space guids for admins' do
+        user = set_current_user_as_admin
+        subject = Permissions.new(user)
+
+        org1 = Organization.make
+        space1 = Space.make(organization: org1)
+        org2 = Organization.make
+        space2 = Space.make(organization: org2)
+
+        space_guids = subject.readable_secret_space_guids
+
+        expect(space_guids).to include(space1.guid)
+        expect(space_guids).to include(space2.guid)
+      end
+
+      it 'returns all the space guids for read-only admins' do
+        user = set_current_user_as_admin_read_only
+        subject = Permissions.new(user)
+
+        org1 = Organization.make
+        space1 = Space.make(organization: org1)
+        org2 = Organization.make
+        space2 = Space.make(organization: org2)
+
+        space_guids = subject.readable_secret_space_guids
+
+        expect(space_guids).to include(space1.guid)
+        expect(space_guids).to include(space2.guid)
+      end
+
+      it 'returns no space guids for global auditors' do
+        user = set_current_user_as_global_auditor
+        subject = Permissions.new(user)
+
+        org1 = Organization.make
+        Space.make(organization: org1)
+        org2 = Organization.make
+        Space.make(organization: org2)
+
+        space_guids = subject.readable_secret_space_guids
+
+        expect(space_guids).to be_empty
+      end
+
+      it 'returns space guids from membership' do
+        space_guids = double
+        membership = instance_double(Membership)
+        expect(Membership).to receive(:new).with(user).and_return(membership)
+        expect(membership).to receive(:space_guids_for_roles).
+          with(VCAP::CloudController::Permissions::ROLES_FOR_SPACE_SECRETS_READING).
+          and_return(space_guids)
+
+        actual_space_guids = permissions.readable_secret_space_guids
+
+        expect(actual_space_guids).to eq(space_guids)
+      end
+    end
+
     describe '#can_write_to_space?' do
       context 'user has no membership' do
         context 'and user is an admin' do

--- a/spec/unit/lib/permissions/queryer_spec.rb
+++ b/spec/unit/lib/permissions/queryer_spec.rb
@@ -920,5 +920,9 @@ module VCAP::CloudController
         expect(perm_permissions).to have_received(:can_read_task?).with(space_guid: 'my-space-guid', org_guid: 'my-org-guid')
       end
     end
+
+    describe '#readable_secret_space_guids' do
+      it_behaves_like 'readable guids', 'secret_space'
+    end
   end
 end

--- a/spec/unit/models/services/service_broker_spec.rb
+++ b/spec/unit/models/services/service_broker_spec.rb
@@ -118,7 +118,7 @@ module VCAP::CloudController
       end
     end
 
-    describe 'private?' do
+    describe 'space_scoped?' do
       context 'when the broker has an associated space' do
         let(:space) { Space.make }
         let(:broker) do
@@ -132,12 +132,12 @@ module VCAP::CloudController
         end
 
         it 'is true' do
-          expect(broker.private?).to be_truthy
+          expect(broker.space_scoped?).to be_truthy
         end
       end
 
       it 'is false if the broker does not have a space id' do
-        expect(broker.private?).to be_falsey
+        expect(broker.space_scoped?).to be_falsey
       end
     end
   end

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -356,20 +356,20 @@ module VCAP::CloudController
       end
     end
 
-    describe '#broker_private?' do
+    describe '#broker_space_scoped?' do
       it 'returns true if the plan belongs to a service that belongs to a private broker' do
         space = Space.make
         broker = ServiceBroker.make space: space
         service = Service.make service_broker: broker
         plan = ServicePlan.make service: service
 
-        expect(plan.broker_private?).to be_truthy
+        expect(plan.broker_space_scoped?).to be_truthy
       end
 
       it 'returns false if the plan belongs to a service that belongs to a public broker' do
         plan = ServicePlan.make
 
-        expect(plan.broker_private?).to be_falsey
+        expect(plan.broker_space_scoped?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
As an API consumer with the correct permissions, I can make a GET request to /v3/service_brokers/:guid

More details:
- https://www.pivotaltracker.com/story/show/162196911
- https://www.pivotaltracker.com/story/show/162196956

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
