### PR TITLE
fix passing application env vars to eirini

### DIFF
--- a/lib/cloud_controller/opi/env_hash.rb
+++ b/lib/cloud_controller/opi/env_hash.rb
@@ -1,0 +1,19 @@
+require 'presenters/system_environment/system_env_presenter'
+
+module OPI
+  class EnvHash
+    def self.muse(hash)
+      return [] if hash.nil?
+
+      hash.map do |k, v|
+        case v
+        when Array, Hash
+          v = MultiJson.dump(v)
+        else
+          v = v.to_s
+        end
+        { 'name' => k.to_s, 'value' => v }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

eirini was previously ignoring the env vars in the staging_details. this PR makes sure the env vars get passed along when staging applications.

* [X ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [ X] I have viewed, signed, and submitted the Contributor License Agreement

* [ X] I have made this pull request to the `master` branch

* [X ] I have run all the unit tests using `bundle exec rake`

* [X ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) 

I have run acceptance tests against eirini but since this change is scoped to eirini that should be sufficient.
