### PR TITLE
V3 service brokers contain a link to the associated space

### DIFF
--- a/app/presenters/v3/service_broker_presenter.rb
+++ b/app/presenters/v3/service_broker_presenter.rb
@@ -40,12 +40,17 @@ module VCAP::CloudController
 
         def build_links
           url_builder = VCAP::CloudController::Presenters::ApiUrlBuilder.new
-
-          { self:
-            {
+          links = {
+            self: {
               href: url_builder.build_url(path: "/v3/service_brokers/#{broker.guid}")
             }
           }
+
+          if broker.space_guid
+            links[:space] = { href: url_builder.build_url(path: "/v3/spaces/#{broker.space_guid}") }
+          end
+
+          links
         end
       end
     end

--- a/docs/v3/source/includes/api_resources/_service_brokers.erb
+++ b/docs/v3/source/includes/api_resources/_service_brokers.erb
@@ -15,6 +15,9 @@
   "links": {
     "self": {
       "href": "https://api.example.org/v3/service_brokers/dde5ad2a-d8f4-44dc-a56f-0452d744f1c3"
+    },
+    "space": {
+      "href": "https://api.example.org/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576"
     }
   }
 }
@@ -43,13 +46,7 @@
       "url": "https://example.service-broker.com",
       "created_at": "2015-11-13T17:02:56Z",
       "updated_at": "2016-06-08T16:41:26Z",
-      "relationships": {
-        "space": {
-          "data": {
-            "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
-          }
-        }
-      },
+      "relationships": {} ,
       "links": {
         "self": {
           "href": "https://api.example.org/v3/service_brokers/dde5ad2a-d8f4-44dc-a56f-0452d744f1c3"
@@ -72,6 +69,9 @@
       "links": {
         "self": {
           "href": "https://api.example.org/v3/service_brokers/7aa37bad-6ccb-4ef9-ba48-9ce3a91b2b62"
+        },
+        "space": {
+          "href": "https://api.example.org/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576"
         }
       }
     }

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe 'V3 service brokers' do
             it 'contains no relationships' do
               expect(returned_service_broker.fetch('relationships').length).to eq(0)
             end
+
+            it 'contains no space in links' do
+              expect(returned_service_broker['links']).not_to have_key('space')
+            end
           end
 
           context 'when the broker is space scoped' do
@@ -80,6 +84,12 @@ RSpec.describe 'V3 service brokers' do
               expect(returned_service_broker['relationships']).to have_key('space')
               expect(returned_service_broker['relationships']['space']).to have_key('data')
               expect(returned_service_broker['relationships']['space']['data'].fetch('guid')).to eq(space.guid)
+            end
+
+            it 'there is a links field with key called space' do
+              expect(returned_service_broker).to have_key('links')
+              expect(returned_service_broker['links']).to have_key('space')
+              expect(returned_service_broker['links']['space'].fetch('href')).to include("/v3/spaces/#{space.guid}")
             end
           end
         end
@@ -158,6 +168,10 @@ RSpec.describe 'V3 service brokers' do
             it 'contains no relationships' do
               expect(returned_service_broker.fetch('relationships').length).to eq(0)
             end
+
+            it 'contains no space in links' do
+              expect(returned_service_broker['links']).not_to have_key('space')
+            end
           end
 
           context 'when the broker is space scoped' do
@@ -173,6 +187,12 @@ RSpec.describe 'V3 service brokers' do
               expect(returned_service_broker['relationships']).to have_key('space')
               expect(returned_service_broker['relationships']['space']).to have_key('data')
               expect(returned_service_broker['relationships']['space']['data'].fetch('guid')).to eq(space.guid)
+            end
+
+            it 'there is a links field with key called space' do
+              expect(returned_service_broker).to have_key('links')
+              expect(returned_service_broker['links']).to have_key('space')
+              expect(returned_service_broker['links']['space'].fetch('href')).to include("/v3/spaces/#{space.guid}")
             end
           end
         end

--- a/spec/unit/presenters/v3/service_broker_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_broker_presenter_spec.rb
@@ -47,6 +47,10 @@ module VCAP::CloudController::Presenters::V3
           }
           expect(result[:relationships]).to eq(relationships)
         end
+
+        it 'includes a space link in the JSON' do
+          expect(result[:links][:space][:href]).to eq("#{link_prefix}/v3/spaces/#{space.guid}")
+        end
       end
     end
   end


### PR DESCRIPTION
v3 service brokers contain links to the associated space.
The PR adapts the corresponding v3 docs as well.

For more details https://www.pivotaltracker.com/story/show/165997167

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

BR,
Georgi && @nmaslarski 