### PR TITLE
Remove experimental flag from retrieving parameters endpoints

### DIFF
--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -761,7 +761,7 @@
         <a href="service_bindings/retrieve_a_particular_service_binding.html">Retrieve a Particular Service Binding</a>
       </li>
       <li>
-        <a href="service_bindings/retrieve_a_particular_service_binding_parameters_experimental.html">Retrieve a Particular Service Binding's Parameters (Experimental)</a>
+        <a href="service_bindings/retrieve_a_particular_service_binding_parameters.html">Retrieve a Particular Service Binding's Parameters</a>
       </li>
     </ul>
   </div>
@@ -821,10 +821,10 @@
         <a href="service_instances/retrieve_a_particular_service_instance.html">Retrieve a Particular Service Instance</a>
       </li>
       <li>
-        <a href="service_instances/retrieve_a_particular_service_instance_parameters_experimental.html">Retrieve a Particular Service Instance's Parameters (Experimental)</a>
+        <a href="service_instances/retrieve_a_particular_service_instance_parameters.html">Retrieve a Particular Service Instance's Parameters</a>
       </li>
       <li>
-        <a href="service_instances/retrieve_a_particular_route_binding_parameters.html">Retrieve a Particular Route Binding's Parameters (Experimental)</a>
+        <a href="service_instances/retrieve_a_particular_route_binding_parameters.html">Retrieve a Particular Route Binding's Parameters</a>
       </li>
       <li>
         <a href="service_instances/retrieving_permissions_on_a_service_instance.html">Retrieving permissions on a Service Instance</a>

--- a/docs/v2/service_bindings/retrieve_a_particular_service_binding_parameters.html
+++ b/docs/v2/service_bindings/retrieve_a_particular_service_binding_parameters.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Service Instances API</title>
+  <title>Service Bindings API</title>
   <meta charset="utf-8">
   <link id="bootstrapcss" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" />
   <script>
@@ -63,15 +63,15 @@
 </head>
 <body>
 <div class="container">
-  <h1>Service Instances API</h1>
+  <h1>Service Bindings API</h1>
 
   <div class="article">
-    <h2>Retrieve a Particular Service Instance's Parameters (Experimental)</h2>
-    <h3>GET /v2/service_instances/:guid/parameters</h3>
+    <h2>Retrieve a Particular Service Binding's Parameters</h2>
+    <h3>GET /v2/service_bindings/:guid/parameters</h3>
 
       <h3>Request</h3>
       <h4>Route</h4>
-      <pre class="request route highlight">GET /v2/service_instances/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters</pre>
+      <pre class="request route highlight">GET /v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters</pre>
 
 
 
@@ -83,7 +83,7 @@ Host: example.org
 Cookie: </pre>
 
         <h4>cURL</h4>
-        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_instances/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters&quot; -X GET \
+        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters&quot; -X GET \
 	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTQzMCIsImVtYWlsIjoiZW1haWwtMjkyQHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg5MDN9.0MsVZ0mRjX1JYkb_CfI1sjMRuP0vy5IgtdK90ktWtGg&quot; \
 	-H &quot;Host: example.org&quot; \
 	-H &quot;Cookie: &quot;</pre>
@@ -102,6 +102,7 @@ Cookie: </pre>
 X-VCAP-Request-ID: 5f0b6b5a-990a-4798-bb6a-f7bdfd2ff0d2
 Content-Length: 0
 X-Content-Type-Options: nosniff</pre>
+
   </div>
 </div>
 </body>

--- a/docs/v2/service_instances/retrieve_a_particular_route_binding_parameters.html
+++ b/docs/v2/service_instances/retrieve_a_particular_route_binding_parameters.html
@@ -66,7 +66,7 @@
   <h1>Service Instances API</h1>
 
   <div class="article">
-    <h2>Retrieve a Particular Route Binding's Parameters (Experimental)</h2>
+    <h2>Retrieve a Particular Route Binding's Parameters</h2>
     <h3>GET /v2/service_instances/:service_instance_guid/routes/:route_guid/parameters</h3>
 
       <h3>Request</h3>

--- a/docs/v2/service_instances/retrieve_a_particular_service_instance_parameters.html
+++ b/docs/v2/service_instances/retrieve_a_particular_service_instance_parameters.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Service Bindings API</title>
+  <title>Service Instances API</title>
   <meta charset="utf-8">
   <link id="bootstrapcss" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" />
   <script>
@@ -63,15 +63,15 @@
 </head>
 <body>
 <div class="container">
-  <h1>Service Bindings API</h1>
+  <h1>Service Instances API</h1>
 
   <div class="article">
-    <h2>Retrieve a Particular Service Binding's Parameters (Experimental)</h2>
-    <h3>GET /v2/service_bindings/:guid/parameters</h3>
+    <h2>Retrieve a Particular Service Instance's Parameters</h2>
+    <h3>GET /v2/service_instances/:guid/parameters</h3>
 
       <h3>Request</h3>
       <h4>Route</h4>
-      <pre class="request route highlight">GET /v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters</pre>
+      <pre class="request route highlight">GET /v2/service_instances/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters</pre>
 
 
 
@@ -83,7 +83,7 @@ Host: example.org
 Cookie: </pre>
 
         <h4>cURL</h4>
-        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_bindings/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters&quot; -X GET \
+        <pre class="request curl">curl &quot;https://api.[your-domain.com]/v2/service_instances/ddd7fb26-c42d-4acf-a035-60fdd094a167/parameters&quot; -X GET \
 	-H &quot;Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWFhLWlkLTQzMCIsImVtYWlsIjoiZW1haWwtMjkyQHNvbWVkb21haW4uY29tIiwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5hZG1pbiJdLCJhdWQiOlsiY2xvdWRfY29udHJvbGxlciJdLCJleHAiOjE0NjYwMDg5MDN9.0MsVZ0mRjX1JYkb_CfI1sjMRuP0vy5IgtdK90ktWtGg&quot; \
 	-H &quot;Host: example.org&quot; \
 	-H &quot;Cookie: &quot;</pre>
@@ -102,7 +102,6 @@ Cookie: </pre>
 X-VCAP-Request-ID: 5f0b6b5a-990a-4798-bb6a-f7bdfd2ff0d2
 Content-Length: 0
 X-Content-Type-Options: nosniff</pre>
-
   </div>
 </div>
 </body>


### PR DESCRIPTION
With this commit the following resources are no longer experimental:
 * Retrieve a Particular Service Binding's Parameters
 * Retrieve a Particular Service Instance's Parameters
 * Retrieve a Particular Route Binding's Parameters

More info can be found [here](https://www.pivotaltracker.com/story/show/164071776)