### PR TITLE
Add maintenance info in space summary endpoint

### DIFF
--- a/app/actions/services/service_instance_create.rb
+++ b/app/actions/services/service_instance_create.rb
@@ -22,8 +22,10 @@ module VCAP::CloudController
         arbitrary_parameters: arbitrary_params
       )
 
+      service_instance_attributes = broker_response[:instance].merge({ maintenance_info: service_instance.service_plan.maintenance_info })
+
       begin
-        service_instance.save_with_new_operation(broker_response[:instance], broker_response[:last_operation])
+        service_instance.save_with_new_operation(service_instance_attributes, broker_response[:last_operation])
       rescue => e
         cleanup_instance_without_db(e, service_instance)
       end

--- a/app/actions/services/service_instance_update.rb
+++ b/app/actions/services/service_instance_update.rb
@@ -21,7 +21,10 @@ module VCAP::CloudController
 
       if update_broker_needed?(request_attrs, cached_service_instance['service_plan_guid'], service_instance)
         handle_broker_update(cached_service_instance, lock, previous_values, request_attrs, service_instance)
-        update_deferred_attrs(service_instance, service_plan_guid: request_attrs.fetch('service_plan_guid', false))
+        update_deferred_attrs(service_instance,
+                              service_plan_guid: request_attrs.fetch('service_plan_guid', false),
+                              maintenance_info: request_attrs.fetch('maintenance_info', false)
+                             )
       else
         lock.synchronous_unlock!
       end
@@ -76,7 +79,7 @@ module VCAP::CloudController
         accepts_incomplete: accepts_incomplete,
         arbitrary_parameters: request_attrs['parameters'],
         previous_values: previous_values,
-        maintenance_info: request_attrs['maintenance_info'],
+        maintenance_info: request_attrs['maintenance_info'] || service_plan.maintenance_info,
       )
 
       service_instance.last_operation.update_attributes(response[:last_operation])
@@ -88,9 +91,16 @@ module VCAP::CloudController
       err
     end
 
-    def update_deferred_attrs(service_instance, service_plan_guid:)
-      if service_plan_guid && !service_instance.operation_in_progress?
-        service_instance.update_service_instance(service_plan: ServicePlan.find(guid: service_plan_guid))
+    def update_deferred_attrs(service_instance, service_plan_guid:, maintenance_info:)
+      unless service_instance.operation_in_progress?
+        attrs_to_update = {}
+        if service_plan_guid
+          service_plan = ServicePlan.find(guid: service_plan_guid)
+          attrs_to_update[:service_plan] = service_plan
+          attrs_to_update[:maintenance_info] = service_plan.maintenance_info
+        end
+        attrs_to_update[:maintenance_info] = maintenance_info if maintenance_info
+        service_instance.update_service_instance(attrs_to_update)
       end
     end
 

--- a/app/controllers/services/validators/service_update_validator.rb
+++ b/app/controllers/services/validators/service_update_validator.rb
@@ -37,7 +37,7 @@ module VCAP::CloudController
       def validate_maintenance_info_update(service_plan, maintenance_info)
         return unless maintenance_info
 
-        if service_plan.maintenance_info.nil? || maintenance_info != service_plan.parsed_maintenance_info
+        if service_plan.maintenance_info.nil? || maintenance_info != service_plan.maintenance_info
           raise CloudController::Errors::ApiError.new_from_details('MaintenanceInfoMismatch')
         end
       end

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -8,14 +8,16 @@ module VCAP::CloudController
 
     export_attributes :name, :credentials, :service_plan_guid,
       :space_guid, :gateway_data, :dashboard_url, :type, :last_operation,
-      :tags
+      :tags, :maintenance_info
 
     import_attributes :name, :service_plan_guid,
-      :space_guid, :gateway_data
+      :space_guid, :gateway_data, :maintenance_info
 
     strip_attributes :name
 
     plugin :after_initialize
+
+    serialize_attributes :json, :maintenance_info
 
     add_association_dependencies service_instance_operation: :destroy
 

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -64,9 +64,11 @@ module VCAP::CloudController
         'shared_from' => nil,
         'shared_to' => [],
         'service_broker_name' => service_broker.name,
+        'maintenance_info' => maintenance_info || {},
         'service_plan' => {
           'guid' => service_plan.guid,
           'name' => service_plan.name,
+          'maintenance_info' => service_plan.maintenance_info || {},
           'service' => {
             'guid' => service.guid,
             'label' => service.label,

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -4,6 +4,8 @@ module VCAP::CloudController
     one_to_many :service_instances
     one_to_many :service_plan_visibilities
 
+    plugin :serialization
+
     add_association_dependencies service_plan_visibilities: :destroy
 
     export_attributes :name,
@@ -38,6 +40,8 @@ module VCAP::CloudController
                       :create_instance_schema,
                       :update_instance_schema,
                       :create_binding_schema
+
+    serialize_attributes :json, :maintenance_info
 
     strip_attributes :name
 
@@ -141,10 +145,6 @@ module VCAP::CloudController
     def visible_in_space?(space)
       visible_plans = ServicePlan.space_visible(space)
       visible_plans.include?(self)
-    end
-
-    def parsed_maintenance_info
-      JSON.parse(maintenance_info)
     end
 
     private

--- a/app/presenters/mixins/services_presentation_helpers.rb
+++ b/app/presenters/mixins/services_presentation_helpers.rb
@@ -1,0 +1,13 @@
+module VCAP::CloudController::Presenters::Mixins
+  module ServicesPresentationHelpers
+    private
+
+    def parse_maintenance_info(maintenance_info)
+      return maintenance_info if maintenance_info.is_a?(Hash)
+
+      JSON.parse(maintenance_info)
+    rescue JSON::ParserError
+      {}
+    end
+  end
+end

--- a/app/presenters/v2/service_instance_presenter.rb
+++ b/app/presenters/v2/service_instance_presenter.rb
@@ -1,11 +1,13 @@
 require 'presenters/v2/base_presenter'
 require 'presenters/v2/presenter_provider'
+require 'presenters/mixins/services_presentation_helpers'
 
 module CloudController
   module Presenters
     module V2
       class ServiceInstancePresenter < BasePresenter
         extend PresenterProvider
+        include VCAP::CloudController::Presenters::Mixins::ServicesPresentationHelpers
 
         present_for_class 'VCAP::CloudController::ServiceInstance'
         present_for_class 'VCAP::CloudController::ManagedServiceInstance'
@@ -42,14 +44,6 @@ module CloudController
 
         def managed_service_instance(service_instance)
           service_instance.service_plan_id
-        end
-
-        def parse_maintenance_info(maintenance_info)
-          return maintenance_info if maintenance_info.is_a?(Hash)
-
-          JSON.parse(maintenance_info)
-        rescue JSON::ParserError
-          {}
         end
       end
     end

--- a/app/presenters/v2/service_plan_presenter.rb
+++ b/app/presenters/v2/service_plan_presenter.rb
@@ -1,18 +1,18 @@
+require 'presenters/mixins/services_presentation_helpers'
+
 module CloudController
   module Presenters
     module V2
       class ServicePlanPresenter < BasePresenter
         extend PresenterProvider
+        include VCAP::CloudController::Presenters::Mixins::ServicesPresentationHelpers
 
         present_for_class 'VCAP::CloudController::ServicePlan'
 
         def entity_hash(controller, plan, opts, depth, parents, orphans=nil)
           entity = DefaultPresenter.new.entity_hash(controller, plan, opts, depth, parents, orphans)
 
-          entity['maintenance_info'] = {}
-          if plan.maintenance_info
-            entity['maintenance_info'] = plan.parsed_maintenance_info
-          end
+          entity['maintenance_info'] = parse_maintenance_info(plan.maintenance_info)
 
           schemas = present_schemas(plan)
           entity.merge!(schemas)

--- a/db/migrations/20190503090026_add_maintenance_info_to_service_instance.rb
+++ b/db/migrations/20190503090026_add_maintenance_info_to_service_instance.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :service_instances, :maintenance_info, :text, null: true
+  end
+end

--- a/docs/v2/apps/get_app_summary.html
+++ b/docs/v2/apps/get_app_summary.html
@@ -114,9 +114,16 @@ Cookie: </pre>
       "bound_app_count": 1,
       "last_operation": null,
       "dashboard_url": null,
+      "service_broker_name": "broker-name",
+      "maintenance_info": {
+        "version": "1.0.0"
+      },
       "service_plan": {
         "guid": "a7229730-4c4a-418c-a449-9d9f1f2fb3c2",
         "name": "name-83",
+        "maintenance_info": {
+          "version": "1.0.0"
+        },
         "service": {
           "guid": "724a9245-900e-47cb-b924-0a7a98dea977",
           "label": "label-1",

--- a/docs/v2/service_instances/creating_a_service_instance.html
+++ b/docs/v2/service_instances/creating_a_service_instance.html
@@ -605,6 +605,23 @@ Cookie: </pre>
                   </ul>
                 </td>
               </tr>
+              <tr class="">
+                <td class="experimental">
+                  <span class="name">maintenance_info</span>
+                </td>
+                <td>
+                  <span class="description">A maintenance information associated with the service instance. May be an empty object. </span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                    <li>{"version":"2.1"}</li>
+                  </ul>
+                </td>
+              </tr>
             </tbody>
           </table>
 
@@ -636,6 +653,9 @@ Cookie: </pre>
       "accounting",
       "mongodb"
     ],
+    "maintenance_info": {
+        "version": "2.1"
+    },
     "space_url": "/v2/spaces/bbbeed31-f908-477a-aab9-8cdcd19e1348",
     "service_plan_url": "/v2/service_plans/fe173a83-df28-4891-8d91-46334e04600d",
     "service_bindings_url": "/v2/service_instances/cc3b67fa-cda6-4df7-ba47-eb5f2a123992/service_bindings",

--- a/docs/v2/service_instances/delete_a_service_instance.html
+++ b/docs/v2/service_instances/delete_a_service_instance.html
@@ -540,6 +540,7 @@ Cookie: </pre>
       "accounting",
       "mongodb"
     ],
+    "maintenance_info": {},
     "space_url": "/v2/spaces/dd68a2ba-04a3-4125-99ea-643b96e07ef6",
     "service_plan_url": "/v2/service_plans/8ea19d29-2e20-469e-8b91-917a6410e2f2",
     "service_bindings_url": "/v2/service_instances/1aaeb02d-16c3-4405-bc41-80e83d196dff/service_bindings",

--- a/docs/v2/service_instances/list_all_service_instances.html
+++ b/docs/v2/service_instances/list_all_service_instances.html
@@ -704,6 +704,25 @@ curl "https://api.[your-domain.com]/v2/service_instances" -X GET \
               </ul>
             </td>
           </tr>
+
+
+          <tr class="">
+            <td class="experimental">
+              <span class="name">maintenance_info</span>
+            </td>
+            <td>
+              <span class="description">A maintenance information associated with the service instance. May be an empty object. </span>
+            </td>
+            <td>
+              <ul class="valid_values">
+              </ul>
+            </td>
+            <td>
+              <ul class="example_values">
+                <li>{"version":"2.1"}</li>
+              </ul>
+            </td>
+          </tr>
         </tbody>
       </table>
 
@@ -743,6 +762,7 @@ curl "https://api.[your-domain.com]/v2/service_instances" -X GET \
           "accounting",
           "mongodb"
         ],
+        "maintenance_info": {},
         "space_url": "/v2/spaces/53b78e76-23d6-476d-8cd8-5ccaf5ad0770",
         "service_url": "/v2/services/3ab19880-ab42-4d0e-a229-ac93fc02beb4",
         "service_plan_url": "/v2/service_plans/05a372c6-6dc2-4f7f-8f65-a90ebe5fa6e2",

--- a/docs/v2/service_instances/retrieve_a_particular_service_instance.html
+++ b/docs/v2/service_instances/retrieve_a_particular_service_instance.html
@@ -524,6 +524,25 @@ curl "https://api.[your-domain.com]/v2/service_instances/0d632575-bb06-4ea5-bb19
               </ul>
             </td>
           </tr>
+
+
+          <tr class="">
+            <td class="experimental">
+              <span class="name">maintenance_info</span>
+            </td>
+            <td>
+              <span class="description">A maintenance information associated with the service instance. May be an empty object. </span>
+            </td>
+            <td>
+              <ul class="valid_values">
+              </ul>
+            </td>
+            <td>
+              <ul class="example_values">
+                <li>{"version":"2.1"}</li>
+              </ul>
+            </td>
+          </tr>
         </tbody>
       </table>
 
@@ -557,6 +576,7 @@ curl "https://api.[your-domain.com]/v2/service_instances/0d632575-bb06-4ea5-bb19
       "accounting",
       "mongodb"
     ],
+    "maintenance_info": {},
     "space_url": "/v2/spaces/38511660-89d9-4a6e-a889-c32c7e94f139",
     "service_url": "/v2/services/a14baddf-1ccc-5299-0152-ab9s49de4422",
     "service_plan_url": "/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1",

--- a/docs/v2/service_instances/update_a_service_instance.html
+++ b/docs/v2/service_instances/update_a_service_instance.html
@@ -200,13 +200,13 @@
                 </ul>
               </td>
             </tr>
-            <tr class=" ">
-              <td class=" ">
-                <span class="name">maintenance_info (experimental)</span>
+            <tr class="">
+              <td class="experimental">
+                <span class="name">maintenance_info</span>
               </td>
               <td>
-                <span class="description">This field can be used to perform maintenance on a service instance (for example, to upgrade the version of a service's software).</br>
-                NOTE: The `maintenance_info` object provided in the request must be supported by the service instance's plan.</span>
+                <span class="description"> A maintenance information for the service instance to pass along to the service broker.</br>
+                NOTE: The maintenance_info object provided in the request must be supported by the service instance's plan. Must be a JSON object.</span>
               </td>
               <td>
                 <span class="default"></span>
@@ -568,6 +568,23 @@ Cookie: </pre>
                   </ul>
                 </td>
               </tr>
+              <tr class="">
+                <td class="experimental">
+                  <span class="name">maintenance_info</span>
+                </td>
+                <td>
+                  <span class="description">A maintenance information for the service instance.</span>
+                </td>
+                <td>
+                  <ul class="valid_values">
+                  </ul>
+                </td>
+                <td>
+                  <ul class="example_values">
+                    <li>{"version": "2.0"}</li>
+                  </ul>
+                </td>
+              </tr>
             </tbody>
           </table>
 
@@ -598,6 +615,9 @@ Cookie: </pre>
     "tags": [
 
     ],
+    "maintenance_info": {
+        "version": "2.1"
+    },
     "space_url": "/v2/spaces/da37b4b7-2439-4b30-9eb3-bded0dbf690f",
     "service_plan_url": "/v2/service_plans/4ec73bf4-9f3a-44c7-bbac-61ee9cb5a511",
     "service_bindings_url": "/v2/service_instances/a34f1423-4b84-4727-ab49-3f1522c4cb16/service_bindings",

--- a/docs/v2/service_plans/list_all_service_instances_for_the_service_plan.html
+++ b/docs/v2/service_plans/list_all_service_instances_for_the_service_plan.html
@@ -299,6 +299,7 @@ Cookie: </pre>
         "tags": [
 
         ],
+        "maintenance_info": {},
         "space_url": "/v2/spaces/162dc5a3-ddb9-41bc-9fb0-38cc7aec73f9",
         "service_plan_url": "/v2/service_plans/85615ea0-9d23-4de8-aabd-89bffcce39d5",
         "service_bindings_url": "/v2/service_instances/0fac6687-69fd-4567-afb0-dd39503523ff/service_bindings",

--- a/docs/v2/spaces/get_space_summary.html
+++ b/docs/v2/spaces/get_space_summary.html
@@ -265,9 +265,15 @@ Cookie: </pre>
       },
       "dashboard_url": null,
       "service_broker_name": "broker-name",
+      "maintenance_info": {
+        "version": "1.0.0"
+      },
       "service_plan": {
         "guid": "0f8ad3ee-ca65-4849-ae52-d6539392fae2",
         "name": "name-1386",
+        "maintenance_info": {
+          "version": "2.0.0"
+        },
         "service": {
           "guid": "17752c54-ac25-46fb-9989-3f69017d0dbe",
           "label": "label-27",

--- a/docs/v2/spaces/list_all_service_instances_for_the_space.html
+++ b/docs/v2/spaces/list_all_service_instances_for_the_space.html
@@ -361,6 +361,7 @@ curl "https://api.[your-domain.com]/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657f
         "tags": [
 
         ],
+        "maintenance_info": {},
         "space_url": "/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe",
         "service_plan_url": "/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab",
         "service_bindings_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_bindings",

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -113,7 +113,7 @@ module VCAP::Services::ServiceBrokers
         extra:       catalog_plan.metadata.try(:to_json),
         plan_updateable: catalog_plan.plan_updateable,
         maximum_polling_duration: catalog_plan.maximum_polling_duration,
-        maintenance_info: catalog_plan.maintenance_info.try(:to_json),
+        maintenance_info: catalog_plan.maintenance_info,
         create_instance_schema: create_instance,
         update_instance_schema: update_instance,
         create_binding_schema: create_binding,

--- a/lib/services/service_brokers/v2/catalog_plan.rb
+++ b/lib/services/service_brokers/v2/catalog_plan.rb
@@ -51,8 +51,15 @@ module VCAP::Services::ServiceBrokers::V2
       validate_bool!(:bindable, bindable) if bindable
       validate_bool!(:plan_updateable, plan_updateable) if plan_updateable
       validate_integer!(:maximum_polling_duration, maximum_polling_duration) if maximum_polling_duration
-      validate_hash!(:maintenance_info, @maintenance_info) if @maintenance_info
       validate_hash!(:schemas, @schemas_data) if @schemas_data
+
+      validate_maintenance_info! if @maintenance_info
+    end
+
+    def validate_maintenance_info!
+      validate_hash!(:maintenance_info, @maintenance_info)
+      validate_semver!(:maintenance_info_version, @maintenance_info['version'], required: true)
+      validate_length_as_json!(:maintenance_info, @maintenance_info, 2000)
     end
 
     def validate_schemas!
@@ -72,6 +79,7 @@ module VCAP::Services::ServiceBrokers::V2
         plan_updateable:            'Plan updateable',
         schemas:                    'Plan schemas',
         maintenance_info:           'Maintenance info',
+        maintenance_info_version:   'Maintenance info version',
         maximum_polling_duration:   'Maximum polling duration',
       }.fetch(name) { raise NotImplementedError }
     end

--- a/lib/services/service_brokers/v2/catalog_validation_helper.rb
+++ b/lib/services/service_brokers/v2/catalog_validation_helper.rb
@@ -1,3 +1,5 @@
+require 'vcap/semver_validator'
+
 module VCAP::Services::ServiceBrokers::V2
   module CatalogValidationHelper
     def validate_description!(name, input, opts={})
@@ -72,7 +74,7 @@ module VCAP::Services::ServiceBrokers::V2
     def validate_semver!(name, input, opts={})
       validate_string!(name, input, opts)
 
-      unless Gem::Version.correct?(input)
+      unless VCAP::SemverValidator.valid?(input)
         errors.add("#{human_readable_attr_name(name)} must be a Semantic Version, but has value #{input.inspect}")
       end
     end

--- a/lib/services/service_brokers/v2/catalog_validation_helper.rb
+++ b/lib/services/service_brokers/v2/catalog_validation_helper.rb
@@ -69,6 +69,21 @@ module VCAP::Services::ServiceBrokers::V2
       end
     end
 
+    def validate_semver!(name, input, opts={})
+      validate_string!(name, input, opts)
+
+      unless Gem::Version.correct?(input)
+        errors.add("#{human_readable_attr_name(name)} must be a Semantic Version, but has value #{input.inspect}")
+      end
+    end
+
+    def validate_length_as_json!(name, input, limit)
+      length = input.to_json.length
+      if length > limit
+        errors.add("#{human_readable_attr_name(name)} must serialize to #{limit} characters or fewer in JSON, but serializes to #{length} characters")
+      end
+    end
+
     def is_an_array_of(klass, input)
       input.is_a?(Array) && input.all? { |i| i.is_a?(klass) }
     end

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -197,7 +197,9 @@ module VCAP::Services::ServiceBrokers::V2
       end
 
       if state == 'in progress'
-        attributes[:last_operation][:proposed_changes] = { service_plan_guid: plan.guid }
+        proposed_changes = { service_plan_guid: plan.guid }
+        proposed_changes[:maintenance_info] = maintenance_info if maintenance_info
+        attributes[:last_operation][:proposed_changes] = proposed_changes
       end
 
       [attributes, nil]

--- a/lib/vcap/semver_validator.rb
+++ b/lib/vcap/semver_validator.rb
@@ -1,0 +1,29 @@
+module VCAP
+  module SemverValidator
+    # regex credit: [DavidFichtmueller](https://github.com/DavidFichtmueller)
+    # (https://github.com/semver/semver/issues/232#issuecomment-405596809)
+    SEMVER_REGEX =
+      /
+      			^
+      			(?<major>0|[1-9]\d*)\.
+      			(?<minor>0|[1-9]\d*)\.
+      			(?<patch>0|[1-9]\d*)
+      			(?:-
+      				(?<prerelease>
+      					(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
+      					(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
+      				)
+      			)?
+      			(?:\+
+      				(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)
+      			)?
+      			$
+      /x.freeze
+
+    class << self
+      def valid?(version)
+        SEMVER_REGEX.match?(version.to_s)
+      end
+    end
+  end
+end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
@@ -481,7 +481,7 @@ RSpec.describe 'Service Broker API integration' do
     context 'when the broker provides maintenance_info' do
       let(:catalog) do
         catalog = default_catalog
-        catalog[:services].first[:plans].first[:maintenance_info] = { 'version' => '2.0' }
+        catalog[:services].first[:plans].first[:maintenance_info] = { 'version' => '2.0.0' }
         catalog
       end
 
@@ -497,7 +497,7 @@ RSpec.describe 'Service Broker API integration' do
 
         parsed_body = MultiJson.load(last_response.body)
         maintenance_info = parsed_body['entity']['maintenance_info']
-        expect(maintenance_info).to eq({ 'version' => '2.0' })
+        expect(maintenance_info).to eq({ 'version' => '2.0.0' })
       end
 
       context 'when updating the service with the provided maintanance_info' do
@@ -506,18 +506,18 @@ RSpec.describe 'Service Broker API integration' do
         end
 
         it 'should forward the maintanance info to the broker' do
-          response = async_update_service(maintenance_info: { 'version' => '2.0' })
+          response = async_update_service(maintenance_info: { 'version' => '2.0.0' })
           expect(response).to have_status_code(202)
           expect(
             a_request(:patch, update_url_for_broker(@broker, accepts_incomplete: true)).with(
-              body: hash_including(maintenance_info: { version: '2.0' })
+              body: hash_including(maintenance_info: { version: '2.0.0' })
             )
           ).to have_been_made
         end
 
         context 'when the maintenance_info does not match the one from the service plan' do
           it 'should not forward the maintanance info to the broker' do
-            response = async_update_service(maintenance_info: { 'version' => '1.0' })
+            response = async_update_service(maintenance_info: { 'version' => '1.0.0' })
             expect(response).to have_status_code(422)
             expect(JSON.parse(response.body)['error_code']).to eq('CF-MaintenanceInfoMismatch')
             expect(

--- a/spec/request/v2/service_bindings_spec.rb
+++ b/spec/request/v2/service_bindings_spec.rb
@@ -216,6 +216,7 @@ RSpec.describe 'ServiceBindings' do
                       'type' => 'managed_service_instance',
                       'last_operation' => nil,
                       'tags' => [],
+                      'maintenance_info' => {},
                       'space_url' => "/v2/spaces/#{space.guid}",
                       'service_url' => "/v2/services/#{service_instance.service.guid}",
                       'service_plan_url' => "/v2/service_plans/#{service_instance.service_plan.guid}",

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'ServiceInstances' do
               'created_at'  => iso8601
             },
             'tags'                            => ['no-sql', 'georeplicated'],
+            'maintenance_info'                => {},
             'space_url'                       => "/v2/spaces/#{space.guid}",
             'service_url'                     => "/v2/services/#{service_instance.service.guid}",
             'service_plan_url'                => "/v2/service_plans/#{service_plan.guid}",
@@ -121,6 +122,7 @@ RSpec.describe 'ServiceInstances' do
               'created_at'  => iso8601
             },
             'tags'                            => ['no-sql', 'georeplicated'],
+            'maintenance_info'                => {},
             'space_url'                       => "/v2/spaces/#{space.guid}",
             'service_url'                     => "/v2/services/#{service_instance.service.guid}",
             'service_plan_url'                => "/v2/service_plans/#{new_service_plan.guid}",
@@ -143,6 +145,7 @@ RSpec.describe 'ServiceInstances' do
     before do
       service_instance.dashboard_url   = 'someurl.com'
       service_instance.service_plan_id = service_plan.id
+      service_instance.maintenance_info = { 'version': '2.0' }
       service_instance.save
     end
 
@@ -176,6 +179,7 @@ RSpec.describe 'ServiceInstances' do
                 'type'                            => service_instance.type,
                 'last_operation'                  => service_instance.last_operation,
                 'tags'                            => service_instance.tags,
+                'maintenance_info'                => { 'version' => '2.0' },
                 'space_url'                       => "/v2/spaces/#{space.guid}",
                 'service_url'                     => "/v2/services/#{service_instance.service.guid}",
                 'service_plan_url'                => "/v2/service_plans/#{service_plan.guid}",
@@ -222,6 +226,7 @@ RSpec.describe 'ServiceInstances' do
                 'type'                            => service_instance.type,
                 'last_operation'                  => service_instance.last_operation,
                 'tags'                            => service_instance.tags,
+                'maintenance_info'                => { 'version' => '2.0' },
                 'space_url'                       => "/v2/spaces/#{space.guid}",
                 'service_url'                     => "/v2/services/#{service_instance.service.guid}",
                 'service_bindings_url'            => "/v2/service_instances/#{service_instance.guid}/service_bindings",
@@ -266,6 +271,7 @@ RSpec.describe 'ServiceInstances' do
                 'type'                            => service_instance.type,
                 'last_operation'                  => service_instance.last_operation,
                 'tags'                            => service_instance.tags,
+                'maintenance_info'                => { 'version' => '2.0' },
                 'space_url'                       => "/v2/spaces/#{space.guid}",
                 'service_url'                     => "/v2/services/#{service_instance.service.guid}",
                 'service_bindings_url'            => "/v2/service_instances/#{service_instance.guid}/service_bindings",

--- a/spec/request/v2/service_plans_spec.rb
+++ b/spec/request/v2/service_plans_spec.rb
@@ -11,14 +11,16 @@ RSpec.describe 'ServicePlans' do
 
   describe 'GET /v2/service_plans' do
     let(:service) { VCAP::CloudController::Service.make }
-    let!(:service_plan) { VCAP::CloudController::ServicePlan.make(
-      service: service,
-      maintenance_info: '{ "version":  "2.0" }')
-    }
+    let!(:service_plan) do
+      VCAP::CloudController::ServicePlan.make(
+        service: service,
+        maintenance_info: { 'version': '2.0' },
+      )
+    end
 
     it 'lists service plans' do
       get '/v2/service_plans', nil, headers_for(user)
-      expect(last_response.status).to eq(200)
+      expect(last_response).to have_status_code(200)
 
       parsed_response = MultiJson.load(last_response.body)
       expect(parsed_response).to be_a_response_like(
@@ -75,14 +77,16 @@ RSpec.describe 'ServicePlans' do
 
   describe 'GET /v2/service_plans/:guid' do
     let(:service) { VCAP::CloudController::Service.make }
-    let!(:service_plan) { VCAP::CloudController::ServicePlan.make(
-      service: service,
-      maintenance_info: '{ "version":  "2.0" }')
-    }
+    let!(:service_plan) do
+      VCAP::CloudController::ServicePlan.make(
+        service: service,
+        maintenance_info: { 'version': '2.0' },
+      )
+    end
 
     it 'lists service plans' do
       get "/v2/service_plans/#{service_plan.guid}", nil, headers_for(user)
-      expect(last_response.status).to eq(200)
+      expect(last_response).to have_status_code(200)
 
       parsed_response = MultiJson.load(last_response.body)
       expect(parsed_response).to be_a_response_like(

--- a/spec/request/v2/spaces_spec.rb
+++ b/spec/request/v2/spaces_spec.rb
@@ -255,7 +255,8 @@ RSpec.describe 'Spaces' do
     let!(:space) { VCAP::CloudController::Space.make(organization: org) }
     let!(:app_model) { VCAP::CloudController::AppModel.make(space: space) }
     let!(:process) { VCAP::CloudController::ProcessModelFactory.make(state: 'STARTED', app: app_model) }
-    let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
+    let!(:service_plan) { VCAP::CloudController::ServicePlan.make(maintenance_info: { 'version': '2.0.0' }) }
+    let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan, maintenance_info: { 'version': '1.0.0' }) }
     let(:build_client) { instance_double(HTTPClient, post: nil) }
 
     before do
@@ -319,12 +320,14 @@ RSpec.describe 'Spaces' do
             'last_operation' => nil,
             'name' => service_instance.name,
             'service_broker_name' => service_instance.service_broker.name,
+            'maintenance_info' => service_instance.maintenance_info,
             'service_plan' => {
-              'guid' => service_instance.service_plan.guid,
-              'name' => service_instance.service_plan.name,
+              'guid' => service_plan.guid,
+              'name' => service_plan.name,
+              'maintenance_info' => service_plan.maintenance_info,
               'service' => {
-                'guid' => service_instance.service_plan.service.guid,
-                'label' => service_instance.service_plan.service.label,
+                'guid' => service_plan.service.guid,
+                'label' => service_plan.service.label,
                 'provider' => nil,
                 'version' => nil
               }

--- a/spec/request/v2/spaces_spec.rb
+++ b/spec/request/v2/spaces_spec.rb
@@ -212,6 +212,7 @@ RSpec.describe 'Spaces' do
             'type' => 'managed_service_instance',
             'last_operation' => nil,
             'tags' => [],
+            'maintenance_info' => {},
             'service_guid' => shared_service_instance.service_plan.service_guid,
             'space_url' => "/v2/spaces/#{originating_space.guid}",
             'service_plan_url' => "/v2/service_plans/#{shared_service_instance.service_plan_guid}",

--- a/spec/support/service_broker_helpers.rb
+++ b/spec/support/service_broker_helpers.rb
@@ -101,8 +101,9 @@ module ServiceBrokerHelpers
     /#{build_broker_url(broker)}#{path}#{query_params}/
   end
 
-  def update_url(service_instance)
-    service_instance_url(service_instance, '')
+  def update_url(service_instance, accepts_incomplete: nil)
+    query = 'accepts_incomplete=true' if accepts_incomplete
+    service_instance_url(service_instance, query)
   end
 
   def bind_url(service_instance, accepts_incomplete: nil)

--- a/spec/unit/controllers/runtime/app_summaries_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_summaries_controller_spec.rb
@@ -123,6 +123,7 @@ module VCAP::CloudController
             'service_plan'    => {
               'guid'    => svc.service_plan.guid,
               'name'    => svc.service_plan.name,
+              'maintenance_info' => {},
               'service' => {
                 'guid'     => svc.service_plan.service.guid,
                 'label'    => svc.service_plan.service.label,

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -1049,7 +1049,7 @@ module VCAP::CloudController
         end
 
         context 'when the broker returns "maintenance_info" in the catalog' do
-          let(:plan) { ServicePlan.make(:v2, service: service, maintenance_info: '{"version": "2.0"}') }
+          let(:plan) { ServicePlan.make(:v2, service: service, maintenance_info: { 'version': '2.0' }) }
 
           it 'should store it on a service instance level' do
             create_managed_service_instance
@@ -2520,7 +2520,7 @@ module VCAP::CloudController
         end
 
         context 'when maintenance_info is NOT provided in the request, but it exists for the new plan' do
-          let(:new_service_plan) { ServicePlan.make(:v2, service: service, maintenance_info: '{"version": "1.0"}') }
+          let(:new_service_plan) { ServicePlan.make(:v2, service: service, maintenance_info: { 'version': '1.0' }) }
           let(:status) { 202 }
 
           context 'when the delayed job finishes successfully' do
@@ -2571,7 +2571,7 @@ module VCAP::CloudController
           { maintenance_info: { version: '2.0' } }.to_json
         end
         let(:old_maintenance_info) { { 'version' => '1.0' } }
-        let(:service_plan) { ServicePlan.make(:v2, service: service, maintenance_info: '{"version": "2.0"}') }
+        let(:service_plan) { ServicePlan.make(:v2, service: service, maintenance_info: { 'version': '2.0' }) }
         let(:service_instance) { ManagedServiceInstance.make(service_plan: service_plan, maintenance_info: old_maintenance_info) }
 
         context 'when the broker responds synchronously' do

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -1032,6 +1032,7 @@ module VCAP::CloudController
             end
           end
         end
+
         context 'when broker returns a null dashboard_url value' do
           let(:response_body) do
             {
@@ -1044,6 +1045,18 @@ module VCAP::CloudController
 
             expect(last_response).to have_status_code(201)
             expect(decoded_response['entity']['dashboard_url']).to be_nil
+          end
+        end
+
+        context 'when the broker returns "maintenance_info" in the catalog' do
+          let(:plan) { ServicePlan.make(:v2, service: service, maintenance_info: '{"version": "2.0"}') }
+
+          it 'should store it on a service instance level' do
+            create_managed_service_instance
+
+            expect(last_response).to have_status_code(201)
+            maintenance_info = decoded_response['entity']['maintenance_info']
+            expect(maintenance_info).to eq({ 'version' => '2.0' })
           end
         end
       end
@@ -2505,6 +2518,29 @@ module VCAP::CloudController
             expect(instance.last_operation.state).to eq 'succeeded'
           end
         end
+
+        context 'when maintenance_info is NOT provided in the request, but it exists for the new plan' do
+          let(:new_service_plan) { ServicePlan.make(:v2, service: service, maintenance_info: '{"version": "1.0"}') }
+          let(:status) { 202 }
+
+          context 'when the delayed job finishes successfully' do
+            before do
+              put "/v2/service_instances/#{service_instance.guid}?accepts_incomplete=true", body
+
+              stub_request(:get, last_operation_state_url(service_instance)).
+                to_return(status: 200, body: {
+                state: 'succeeded',
+                description: 'Done'
+              }.to_json)
+
+              Delayed::Job.last.invoke_job
+            end
+
+            it 'stores the new plan maintenance_info for the instance' do
+              expect(service_instance.reload.maintenance_info).to eq(new_service_plan.maintenance_info)
+            end
+          end
+        end
       end
 
       context 'when accepts_incomplete is not true or false strings' do
@@ -2527,6 +2563,61 @@ module VCAP::CloudController
           put "/v2/service_instances/#{service_instance.guid}?accepts_incomplete=true", '{}'
           expect(last_response.status).to eq(400)
           expect(last_response.body).to match /paid service plans are not allowed/
+        end
+      end
+
+      context 'when maintenance_info is provided' do
+        let(:body) do
+          { maintenance_info: { version: '2.0' } }.to_json
+        end
+        let(:old_maintenance_info) { { 'version' => '1.0' } }
+        let(:service_plan) { ServicePlan.make(:v2, service: service, maintenance_info: '{"version": "2.0"}') }
+        let(:service_instance) { ManagedServiceInstance.make(service_plan: service_plan, maintenance_info: old_maintenance_info) }
+
+        context 'when the broker responds synchronously' do
+          let(:status) { 200 }
+
+          before do
+            stub_request(:patch, service_broker_url).
+              with(basic_auth: basic_auth(service_instance: service_instance)).
+              to_return(status: status, body: response_body)
+          end
+
+          it 'updates the service instance model with the new value' do
+            put "/v2/service_instances/#{service_instance.guid}", body
+
+            expect(last_response).to have_status_code 201
+            expect(service_instance.reload.maintenance_info).to eq({ 'version' => '2.0' })
+          end
+        end
+
+        context 'when the broker responds asynchronously' do
+          before do
+            stub_request(:patch, "#{service_broker_url}?accepts_incomplete=true").
+              to_return(status: 202, body: response_body)
+
+            put "/v2/service_instances/#{service_instance.guid}?accepts_incomplete=true", body
+          end
+
+          it 'keeps the old maintenance_info in the model' do
+            expect(service_instance.reload.maintenance_info).to eq(old_maintenance_info)
+          end
+
+          context 'when the delayed job finishes successfully' do
+            before do
+              stub_request(:get, last_operation_state_url(service_instance)).
+                to_return(status: 200, body: {
+                state: 'succeeded',
+                description: 'Done'
+              }.to_json)
+              Delayed::Job.last.invoke_job
+            end
+
+            it 'updates the maintenance_info for the instance' do
+              expect(service_instance.reload.maintenance_info).to eq({ 'version' => '2.0' })
+              expect(a_request(:patch, /#{service_broker_url}/)).to have_been_made.times(1)
+            end
+          end
         end
       end
     end
@@ -4900,6 +4991,7 @@ module VCAP::CloudController
         end
       end
     end
+
     describe 'Validation messages' do
       let(:paid_quota) { QuotaDefinition.make(total_services: 1) }
       let(:free_quota_with_no_services) do

--- a/spec/unit/controllers/services/validators/service_update_validator_spec.rb
+++ b/spec/unit/controllers/services/validators/service_update_validator_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
       let(:service_broker_url) { "http://example.com/v2/service_instances/#{service_instance.guid}" }
       let(:service_broker) { ServiceBroker.make(broker_url: 'http://example.com', auth_username: 'auth_username', auth_password: 'auth_password') }
       let(:service) { Service.make(plan_updateable: true, service_broker: service_broker) }
-      let(:old_service_plan) { ServicePlan.make(:v2, service: service, free: true, maintenance_info: '{ "version": "2.0" }') }
+      let(:old_service_plan) { ServicePlan.make(:v2, service: service, free: true, maintenance_info: { 'version': '2.0' }) }
       let(:new_service_plan) { ServicePlan.make(:v2, service: service) }
       let(:service_instance) { ManagedServiceInstance.make(service_plan: old_service_plan) }
       let(:space) { service_instance.space }

--- a/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
@@ -7,12 +7,14 @@ module VCAP::CloudController
     module Services
       RSpec.describe ServiceInstanceStateFetch, job_context: :worker do
         let(:proposed_service_plan) { ServicePlan.make }
+        let(:proposed_maintenance_info) { { 'version' => '2.0' } }
         let(:maximum_polling_duration_for_plan) {}
         let(:service_plan) { ServicePlan.make(maximum_polling_duration: maximum_polling_duration_for_plan) }
         let(:service_instance) do
           operation = ServiceInstanceOperation.make(proposed_changes: {
             name: 'new-fake-name',
             service_plan_guid: proposed_service_plan.guid,
+            maintenance_info: proposed_maintenance_info,
           })
           operation.save
           service_instance = ManagedServiceInstance.make(service_plan: service_plan)
@@ -229,6 +231,7 @@ module VCAP::CloudController
               run_job(job)
 
               db_service_instance = ManagedServiceInstance.first(guid: service_instance.guid)
+              expect(db_service_instance.maintenance_info).to eq(proposed_maintenance_info)
               expect(db_service_instance.service_plan).to eq(proposed_service_plan)
               expect(db_service_instance.name).to eq('new-fake-name')
             end

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -237,7 +237,7 @@ module VCAP::Services::ServiceBrokers
           expect(plan.description).to eq(plan_description)
           expect(plan.plan_updateable).to eq(true)
           expect(plan.maximum_polling_duration).to eq(3600)
-          expect(plan.parsed_maintenance_info).to eq(plan_maintenance_info)
+          expect(plan.maintenance_info).to eq(plan_maintenance_info)
           expect(JSON.parse(plan.extra)).to eq({ 'cost' => '0.0' })
           expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
           expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
@@ -623,7 +623,7 @@ module VCAP::Services::ServiceBrokers
             expect(plan.bindable).to be true
             expect(plan.plan_updateable).to be true
             expect(plan.maximum_polling_duration).to eq(3600)
-            expect(plan.parsed_maintenance_info).to eq(plan_maintenance_info)
+            expect(plan.maintenance_info).to eq(plan_maintenance_info)
             expect(plan.create_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
             expect(plan.update_instance_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')
             expect(plan.create_binding_schema).to eq('{"$schema":"http://json-schema.org/draft-04/schema","type":"object"}')

--- a/spec/unit/lib/services/service_brokers/service_manager_spec.rb
+++ b/spec/unit/lib/services/service_brokers/service_manager_spec.rb
@@ -781,6 +781,27 @@ module VCAP::Services::ServiceBrokers
               expect(plan.public).to be true
             end
           end
+
+          context 'when the plan has maintenance_info' do
+            before do
+              plan.update(maintenance_info: { 'version': '1.1' })
+            end
+
+            context 'when maintenance_info was deleted from the catalog for the plan' do
+              before do
+                catalog_hash['services'].first['plans'].first.delete('maintenance_info')
+              end
+
+              it 'should remove the maintenance_info information for the updated plan' do
+                expect(plan.maintenance_info).to eq({ 'version': '1.1' })
+
+                service_manager.sync_services_and_plans(catalog)
+                plan.reload
+
+                expect(plan.maintenance_info).to be_nil
+              end
+            end
+          end
         end
 
         context 'and a plan exists that has been removed from the broker catalog' do

--- a/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
@@ -184,7 +184,8 @@ module VCAP::Services::ServiceBrokers::V2
       end
 
       it 'validates that @maintenance_info object serializes to 2000 characters or fewer' do
-        plan_attrs['maintenance_info'] = { 'version' => '2' * 2000 }
+        very_long_semantic_version = '2' * 1000 + '.' + '1' * 499 + '.' + '3' * 499
+        plan_attrs['maintenance_info'] = { 'version' => very_long_semantic_version }
 
         expect(plan).to_not be_valid
         expect(plan.errors.messages.first).to include 'Maintenance info must serialize to 2000 characters or fewer in JSON, but serializes to 2014 characters'

--- a/spec/unit/lib/vcap/semver_validator_spec.rb
+++ b/spec/unit/lib/vcap/semver_validator_spec.rb
@@ -1,0 +1,99 @@
+require 'rspec'
+require 'vcap/semver_validator'
+
+module VCAP
+  RSpec.describe 'SemverValidator' do
+    valid_versions = [
+      '0.0.4',
+      '1.2.3',
+      '10.20.30',
+      '1.1.2-prerelease+meta',
+      '1.1.2+meta',
+      '1.1.2+meta-valid',
+      '1.0.0-alpha',
+      '1.0.0-beta',
+      '1.0.0-alpha.beta',
+      '1.0.0-alpha.beta.1',
+      '1.0.0-alpha.1',
+      '1.0.0-alpha0.valid',
+      '1.0.0-alpha.0valid',
+      '1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay',
+      '1.0.0-rc.1+build.1',
+      '2.0.0-rc.1+build.123',
+      '1.2.3-beta',
+      '10.2.3-DEV-SNAPSHOT',
+      '1.2.3-SNAPSHOT-123',
+      '1.0.0',
+      '2.0.0',
+      '1.1.7',
+      '2.0.0+build.1848',
+      '2.0.1-alpha.1227',
+      '1.0.0-alpha+beta',
+      '1.2.3----RC-SNAPSHOT.12.9.1--.12+788',
+      '1.2.3----R-S.12.9.1--.12+meta',
+      '1.2.3----RC-SNAPSHOT.12.9.1--.12',
+      '1.0.0+0.build.1-rc.10000aaa-kk-0.1',
+      '99999999999999999999999.999999999999999999.99999999999999999',
+      '1.0.0-0A.is.legal',
+    ]
+
+    invalid_versions = [
+      '1',
+      '1.2',
+      '1.2.3-0123',
+      '1.2.3-0123.0123',
+      '1.1.2+.123',
+      '+invalid',
+      '-invalid',
+      '-invalid+invalid',
+      '-invalid.01',
+      'alpha',
+      'alpha.beta',
+      'alpha.beta.1',
+      'alpha.1',
+      'alpha+beta',
+      'alpha_beta',
+      'alpha.',
+      'alpha..',
+      'beta',
+      '1.0.0-alpha_beta',
+      '-alpha.',
+      '1.0.0-alpha..',
+      '1.0.0-alpha..1',
+      '1.0.0-alpha...1',
+      '1.0.0-alpha....1',
+      '1.0.0-alpha.....1',
+      '1.0.0-alpha......1',
+      '1.0.0-alpha.......1',
+      '01.1.1',
+      '1.01.1',
+      '1.1.01',
+      '1.2',
+      '1.2.3.DEV',
+      '1.2-SNAPSHOT',
+      '1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788',
+      '1.2-RC-SNAPSHOT',
+      '-1.0.3-gamma+b7718',
+      '+justmeta',
+      '9.8.7+meta+meta',
+      '9.8.7-whatever+meta+meta',
+      '99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12',
+    ]
+
+    valid_versions.each do |version|
+      describe "version #{version}" do
+        it 'is valid' do
+          expect(SemverValidator.valid?(version)).to eq(true)
+        end
+      end
+    end
+
+    invalid_versions.each do |version|
+      describe "version #{version}" do
+        it 'is invalid' do
+          expect(SemverValidator.valid?(version)).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/models/services/managed_service_instance_spec.rb
+++ b/spec/unit/models/services/managed_service_instance_spec.rb
@@ -132,8 +132,8 @@ module VCAP::CloudController
     end
 
     describe 'Serialization' do
-      it { is_expected.to export_attributes :name, :credentials, :service_plan_guid, :space_guid, :gateway_data, :dashboard_url, :type, :last_operation, :tags }
-      it { is_expected.to import_attributes :name, :service_plan_guid, :space_guid, :gateway_data }
+      it { is_expected.to export_attributes :name, :credentials, :service_plan_guid, :space_guid, :gateway_data, :dashboard_url, :type, :last_operation, :tags, :maintenance_info }
+      it { is_expected.to import_attributes :name, :service_plan_guid, :space_guid, :gateway_data, :maintenance_info }
     end
 
     describe '#create' do
@@ -632,6 +632,17 @@ module VCAP::CloudController
         })
 
         expect(service_instance.to_hash['last_operation']['updated_at']).to be
+      end
+    end
+
+    describe 'maintenance_info' do
+      let(:expected_value) { { version: '1.0' }.stringify_keys }
+      let(:maintenance_info) { { maintenance_info: expected_value } }
+
+      it 'should serialize and deserialize it as a JSON' do
+        service_instance.update_service_instance(maintenance_info)
+        service_instance.reload
+        expect(service_instance.maintenance_info).to eq(expected_value)
       end
     end
   end

--- a/spec/unit/presenters/v2/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_instance_presenter_spec.rb
@@ -30,6 +30,7 @@ module CloudController::Presenters::V2
           expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)).to eq(
             {
               'name'              => service_instance.name,
+              'maintenance_info'  => {},
               'service_plan_guid' => service_plan.guid,
               'service_guid'      => service_plan.service.guid,
               'relationship_url'  => 'http://relationship.example.com',
@@ -39,6 +40,38 @@ module CloudController::Presenters::V2
               'service_instance_parameters_url' => "/v2/service_instances/#{service_instance.guid}/parameters",
             }
           )
+        end
+
+        context 'when maintenance_info is available as string' do
+          let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(maintenance_info: '{ "version": "2.0" }') }
+
+          it 'includes `maintenance_info` in the entity' do
+            expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)['maintenance_info']).to eq(
+              {
+                'version' => '2.0',
+              }
+            )
+          end
+        end
+
+        context 'when maintenance_info is available as Hash' do
+          let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(maintenance_info: { 'version': '3.0' }) }
+
+          it 'includes `maintenance_info` in the entity' do
+            expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)['maintenance_info']).to eq(
+              {
+                'version' => '3.0',
+              }
+            )
+          end
+        end
+
+        context 'when maintenance_info is invalid JSON' do
+          let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(maintenance_info: 'invalid') }
+
+          it 'returns empty JSON object for maintenance_info' do
+            expect(subject.entity_hash(controller, service_instance, opts, depth, parents, orphans)['maintenance_info']).to eq({})
+          end
         end
       end
     end

--- a/spec/unit/presenters/v2/service_plan_presenter_spec.rb
+++ b/spec/unit/presenters/v2/service_plan_presenter_spec.rb
@@ -17,11 +17,15 @@ module CloudController::Presenters::V2
       end
 
       let(:service_plan) do
-        VCAP::CloudController::ServicePlan.make(create_instance_schema: create_instance_schema,
-                                                update_instance_schema: update_instance_schema,
-                                                create_binding_schema: create_binding_schema,
-                                                maintenance_info: '{ "version":  "2.0" }')
+        VCAP::CloudController::ServicePlan.make(
+          create_instance_schema: create_instance_schema,
+          update_instance_schema: update_instance_schema,
+          create_binding_schema: create_binding_schema,
+          maintenance_info: maintenance_info,
+        )
       end
+
+      let(:maintenance_info) { { 'version': '2.0' } }
 
       let(:create_instance_schema) { nil }
       let(:update_instance_schema) { nil }
@@ -188,6 +192,26 @@ module CloudController::Presenters::V2
               }
             }
           )
+        end
+      end
+
+      context 'when maintenance_info is available as string' do
+        let(:maintenance_info) { '{"version": "2.0"}' }
+
+        it 'includes `maintenance_info` in the entity' do
+          expect(subject.entity_hash(controller, service_plan, opts, depth, parents, orphans)['maintenance_info']).to eq(
+            {
+              'version' => '2.0',
+            }
+          )
+        end
+      end
+
+      context 'when maintenance_info is invalid JSON' do
+        let(:maintenance_info) { 'invalid_json' }
+
+        it 'returns empty JSON object for maintenance_info' do
+          expect(subject.entity_hash(controller, service_plan, opts, depth, parents, orphans)['maintenance_info']).to eq({})
         end
       end
     end


### PR DESCRIPTION
`maintenance_info` field in the service plan and instance resource(s) in the `/v2/spaces/:guid/summary`

More info [here](https://www.pivotaltracker.com/story/show/165763251)