### PR TITLE
Cloud Controller now sends its VIPs to copilot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'addressable'
 gem 'allowy'
-gem 'cf-copilot'
+gem 'cf-copilot', '0.0.13'
 gem 'clockwork', require: false
 gem 'cloudfront-signer'
 gem 'em-http-request', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       steno
     builder (3.2.3)
     byebug (10.0.2)
-    cf-copilot (0.0.12)
+    cf-copilot (0.0.13)
       grpc (~> 1.0)
     cf-perm (0.0.10)
       grpc (~> 1.0)
@@ -452,7 +452,7 @@ DEPENDENCIES
   azure-storage (= 0.14.0.preview)
   bits_service_client (~> 3.0)
   byebug
-  cf-copilot
+  cf-copilot (= 0.0.13)
   cf-perm (~> 0.0.10)
   cf-perm-test-helpers (~> 0.0.6)
   cf-uaa-lib (~> 3.14.0)

--- a/lib/cloud_controller/config_schemas/route_syncer_schema.rb
+++ b/lib/cloud_controller/config_schemas/route_syncer_schema.rb
@@ -36,6 +36,8 @@ module VCAP::CloudController
             optional(:pbkdf2_hmac_iterations) => Integer
           },
 
+          internal_route_vip_range: String,
+
           copilot: {
             sync_frequency_in_seconds: Integer,
             enabled: bool,

--- a/lib/cloud_controller/copilot/adapter.rb
+++ b/lib/cloud_controller/copilot/adapter.rb
@@ -13,7 +13,8 @@ module VCAP::CloudController
               guid: route.guid,
               host: route.fqdn,
               path: route.path,
-              internal: route.internal?
+              internal: route.internal?,
+              vip: route.vip
             )
           end
         end

--- a/lib/cloud_controller/copilot/adapter.rb
+++ b/lib/cloud_controller/copilot/adapter.rb
@@ -17,6 +17,7 @@ module VCAP::CloudController
               vip: route.vip
             )
           end
+          logger.debug("Upsert route with GUID: #{route.guid} and vip: #{route.vip}")
         end
 
         def map_route(route_mapping)

--- a/lib/cloud_controller/copilot/sync.rb
+++ b/lib/cloud_controller/copilot/sync.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
         web_processes = batch(processes_batch_query)
 
         Adapter.bulk_sync(
-          routes: routes.map { |r| { guid: r.guid, host: r.fqdn, path: r.path, internal: r.internal? } },
+          routes: routes.map { |r| { guid: r.guid, host: r.fqdn, path: r.path, internal: r.internal?, vip: r.vip } },
           route_mappings: route_mappings.reject { |rm| rm.process.nil? }.map do |rm|
             {
               capi_process_guid: rm.process.guid,

--- a/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
@@ -27,6 +27,7 @@ module VCAP::CloudController
           host: route.fqdn,
           path: '',
           internal: false,
+          vip: nil
         )
       end
 
@@ -40,6 +41,7 @@ module VCAP::CloudController
             host: route.fqdn,
             path: '/some/path',
             internal: false,
+            vip: route.vip
           )
         end
       end
@@ -54,6 +56,7 @@ module VCAP::CloudController
             host: route.fqdn,
             path: '',
             internal: true,
+            vip: '127.128.0.1'
           )
         end
       end
@@ -68,6 +71,7 @@ module VCAP::CloudController
             host: route.fqdn,
             path: '',
             internal: false,
+            vip: route.vip
           )
         end
       end

--- a/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
@@ -14,6 +14,7 @@ module VCAP::CloudController
     before do
       allow(CloudController::DependencyLocator.instance).to receive(:copilot_client).and_return(copilot_client)
       allow(Steno).to receive(:logger).and_return(fake_logger)
+      allow(fake_logger).to receive(:debug)
       TestConfig.override(copilot: { enabled: true, temporary_istio_domains: [istio_domain.name, internal_istio_domain.name] })
     end
 
@@ -29,6 +30,7 @@ module VCAP::CloudController
           internal: false,
           vip: nil
         )
+        expect(fake_logger).to have_received(:debug).with("Upsert route with GUID: #{route.guid} and vip: #{route.vip}")
       end
 
       context 'when the route has a path' do
@@ -43,6 +45,7 @@ module VCAP::CloudController
             internal: false,
             vip: route.vip
           )
+          expect(fake_logger).to have_received(:debug).with("Upsert route with GUID: #{route.guid} and vip: #{route.vip}")
         end
       end
 
@@ -58,6 +61,7 @@ module VCAP::CloudController
             internal: true,
             vip: '127.128.0.1'
           )
+          expect(fake_logger).to have_received(:debug).with("Upsert route with GUID: #{route.guid} and vip: #{route.vip}")
         end
       end
 

--- a/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
         let(:route) { Route.make(domain: istio_domain, host: 'some-host', path: '/some/path') }
         let!(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'web', app_port: 9191) }
 
-        let(:internal_route) { Route.make(domain: internal_istio_domain, host: 'internal-host') }
+        let(:internal_route) { Route.make(domain: internal_istio_domain, host: 'internal-host', vip_offset: 1) }
         let!(:internal_route_mapping) { RouteMappingModel.make(route: internal_route, app: app, process_type: 'web', app_port: 9191) }
 
         let(:legacy_domain) { SharedDomain.make }
@@ -46,12 +46,14 @@ module VCAP::CloudController
                 guid: route.guid,
                 host: route.fqdn,
                 path: route.path,
-                internal: false
+                internal: false,
+                vip: nil
               }, {
                 guid: internal_route.guid,
                 host: internal_route.fqdn,
                 path: '',
-                internal: true
+                internal: true,
+                vip: internal_route.vip
               }],
               route_mappings: [{
                 capi_process_guid: web_process_model.guid,
@@ -85,12 +87,14 @@ module VCAP::CloudController
                     guid: route.guid,
                     host: route.fqdn,
                     path: route.path,
-                    internal: false
+                    internal: false,
+                    vip: nil
                   }, {
                     guid: internal_route.guid,
                     host: internal_route.fqdn,
                     path: '',
-                    internal: true
+                    internal: true,
+                    vip: internal_route.vip
                   }],
                   route_mappings: [{
                     capi_process_guid: web_process_model.guid,
@@ -135,8 +139,8 @@ module VCAP::CloudController
 
           expect(Copilot::Adapter).to have_received(:bulk_sync) do |args|
             expect(args[:routes]).to match_array([
-              { guid: route_1.guid, host: route_1.fqdn, path: route_1.path, internal: false },
-              { guid: route_2.guid, host: route_2.fqdn, path: route_2.path, internal: false }
+              { guid: route_1.guid, host: route_1.fqdn, path: route_1.path, internal: false, vip: nil },
+              { guid: route_2.guid, host: route_2.fqdn, path: route_2.path, internal: false, vip: nil }
             ])
             expect(args[:route_mappings]).to match_array([
               {


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

These changes allow Cloud Controller to send the VIPs it **already** generates for routes to copilot.

* An explanation of the use cases your change solves:

The use of VIPs allow us to go through both the source and destination applications' envoys. With this change, we will no longer use hard-coded VIPs from the bosh DNS adapter. This prevents VIP collision and will round out this feature. 


Links to any other associated PRs:
https://github.com/cloudfoundry/capi-release/pull/144

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Story: 

https://www.pivotaltracker.com/story/show/161849257

Regards,
The CF Networking Team
