### PR TITLE
Add maintenance_info description to instances and plans

### DIFF
--- a/docs/v2/apps/get_app_summary.html
+++ b/docs/v2/apps/get_app_summary.html
@@ -116,13 +116,15 @@ Cookie: </pre>
       "dashboard_url": null,
       "service_broker_name": "broker-name",
       "maintenance_info": {
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "description": "OS image update.\nExpect downtime."
       },
       "service_plan": {
         "guid": "a7229730-4c4a-418c-a449-9d9f1f2fb3c2",
         "name": "name-83",
         "maintenance_info": {
-          "version": "1.0.0"
+          "version": "2.0.0",
+          "description": "Stemcell update.\nExpect downtime."
         },
         "service": {
           "guid": "724a9245-900e-47cb-b924-0a7a98dea977",

--- a/docs/v2/service_instances/retrieve_a_particular_service_instance.html
+++ b/docs/v2/service_instances/retrieve_a_particular_service_instance.html
@@ -539,7 +539,7 @@ curl "https://api.[your-domain.com]/v2/service_instances/0d632575-bb06-4ea5-bb19
             </td>
             <td>
               <ul class="example_values">
-                <li>{"version":"2.1"}</li>
+                <li>{"version":"2.1.0", "description": "OS image update.\nExpect downtime."}</li>
               </ul>
             </td>
           </tr>
@@ -576,7 +576,10 @@ curl "https://api.[your-domain.com]/v2/service_instances/0d632575-bb06-4ea5-bb19
       "accounting",
       "mongodb"
     ],
-    "maintenance_info": {},
+    "maintenance_info": {
+      "version": "2.1.1",
+      "description": "OS image update.\nExpect downtime."
+    },
     "space_url": "/v2/spaces/38511660-89d9-4a6e-a889-c32c7e94f139",
     "service_url": "/v2/services/a14baddf-1ccc-5299-0152-ab9s49de4422",
     "service_plan_url": "/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1",

--- a/docs/v2/service_instances/update_a_service_instance.html
+++ b/docs/v2/service_instances/update_a_service_instance.html
@@ -581,7 +581,7 @@ Cookie: </pre>
                 </td>
                 <td>
                   <ul class="example_values">
-                    <li>{"version": "2.0"}</li>
+                    <li>{"version": "2.0.0", "description": "OS image update."}</li>
                   </ul>
                 </td>
               </tr>
@@ -616,7 +616,8 @@ Cookie: </pre>
 
     ],
     "maintenance_info": {
-        "version": "2.1"
+      "version": "2.1.0",
+      "description": "OS image update.\nExpect downtime."
     },
     "space_url": "/v2/spaces/da37b4b7-2439-4b30-9eb3-bded0dbf690f",
     "service_plan_url": "/v2/service_plans/4ec73bf4-9f3a-44c7-bbac-61ee9cb5a511",

--- a/docs/v2/service_plans/retrieve_a_particular_service_plan.html
+++ b/docs/v2/service_plans/retrieve_a_particular_service_plan.html
@@ -166,7 +166,8 @@ Cookie: </pre>
     "bindable": true,
     "plan_updateable": true,
     "maintenance_info": {
-      "version": "2.0"
+      "version": "2.0",
+      "description": "OS image update.\nExpect downtime."
     },
     "service_url": "/v2/services/a00cacc0-0ca6-422e-91d3-6b22bcd33450",
     "service_instances_url": "/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332/service_instances",

--- a/docs/v2/spaces/get_space_summary.html
+++ b/docs/v2/spaces/get_space_summary.html
@@ -266,13 +266,15 @@ Cookie: </pre>
       "dashboard_url": null,
       "service_broker_name": "broker-name",
       "maintenance_info": {
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "description": "OS image update.\nExpect downtime."
       },
       "service_plan": {
         "guid": "0f8ad3ee-ca65-4849-ae52-d6539392fae2",
         "name": "name-1386",
         "maintenance_info": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "description": "Stemcell update.\nExpect downtime."
         },
         "service": {
           "guid": "17752c54-ac25-46fb-9989-3f69017d0dbe",

--- a/lib/services/service_brokers/v2/catalog_plan.rb
+++ b/lib/services/service_brokers/v2/catalog_plan.rb
@@ -2,7 +2,7 @@ module VCAP::Services::ServiceBrokers::V2
   class CatalogPlan
     include CatalogValidationHelper
 
-    ALLOWED_MAINTENANCE_INFO_KEYS = ['version'].freeze
+    ALLOWED_MAINTENANCE_INFO_KEYS = ['version', 'description'].freeze
 
     attr_reader :broker_provided_id, :name, :description, :metadata, :maximum_polling_duration, :maintenance_info
     attr_reader :catalog_service, :errors, :free, :bindable, :schemas, :plan_updateable
@@ -61,6 +61,7 @@ module VCAP::Services::ServiceBrokers::V2
     def validate_maintenance_info!
       validate_hash!(:maintenance_info, @maintenance_info)
       validate_semver!(:maintenance_info_version, @maintenance_info['version'], required: true)
+      validate_string!(:maintenance_info_description, @maintenance_info['description'])
       validate_length_as_json!(:maintenance_info, @maintenance_info, 2000)
       validate_maintenance_info_keys! if @maintenance_info.is_a?(Hash)
     end
@@ -81,17 +82,18 @@ module VCAP::Services::ServiceBrokers::V2
 
     def human_readable_attr_name(name)
       {
-        broker_provided_id:         'Plan id',
-        name:                       'Plan name',
-        description:                'Plan description',
-        metadata:                   'Plan metadata',
-        free:                       'Plan free',
-        bindable:                   'Plan bindable',
-        plan_updateable:            'Plan updateable',
-        schemas:                    'Plan schemas',
-        maintenance_info:           'Maintenance info',
-        maintenance_info_version:   'Maintenance info version',
-        maximum_polling_duration:   'Maximum polling duration',
+        broker_provided_id:           'Plan id',
+        name:                         'Plan name',
+        description:                  'Plan description',
+        metadata:                     'Plan metadata',
+        free:                         'Plan free',
+        bindable:                     'Plan bindable',
+        plan_updateable:              'Plan updateable',
+        schemas:                      'Plan schemas',
+        maximum_polling_duration:     'Maximum polling duration',
+        maintenance_info:             'Maintenance info',
+        maintenance_info_version:     'Maintenance info version',
+        maintenance_info_description: 'Maintenance info description',
       }.fetch(name) { raise NotImplementedError }
     end
   end

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.15_spec.rb
@@ -481,7 +481,7 @@ RSpec.describe 'Service Broker API integration' do
     context 'when the broker provides maintenance_info' do
       let(:catalog) do
         catalog = default_catalog
-        catalog[:services].first[:plans].first[:maintenance_info] = { 'version' => '2.0.0' }
+        catalog[:services].first[:plans].first[:maintenance_info] = { 'version' => '2.0.0', 'description' => 'Test description' }
         catalog
       end
 
@@ -497,7 +497,7 @@ RSpec.describe 'Service Broker API integration' do
 
         parsed_body = MultiJson.load(last_response.body)
         maintenance_info = parsed_body['entity']['maintenance_info']
-        expect(maintenance_info).to eq({ 'version' => '2.0.0' })
+        expect(maintenance_info).to eq({ 'version' => '2.0.0', 'description' => 'Test description' })
       end
 
       context 'when updating the service with the provided maintanance_info' do
@@ -506,11 +506,11 @@ RSpec.describe 'Service Broker API integration' do
         end
 
         it 'should forward the maintanance info to the broker' do
-          response = async_update_service(maintenance_info: { 'version' => '2.0.0' })
+          response = async_update_service(maintenance_info: { 'version' => '2.0.0', 'description' => 'Test description' })
           expect(response).to have_status_code(202)
           expect(
             a_request(:patch, update_url_for_broker(@broker, accepts_incomplete: true)).with(
-              body: hash_including(maintenance_info: { version: '2.0.0' })
+              body: hash_including(maintenance_info: { version: '2.0.0', description: 'Test description' })
             )
           ).to have_been_made
         end

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'ServiceInstances' do
     before do
       service_instance.dashboard_url   = 'someurl.com'
       service_instance.service_plan_id = service_plan.id
-      service_instance.maintenance_info = { 'version': '2.0' }
+      service_instance.maintenance_info = { 'version': '2.0', 'description': 'Test description' }
       service_instance.save
     end
 
@@ -167,8 +167,9 @@ RSpec.describe 'ServiceInstances' do
                 'guid'       => service_instance.guid,
                 'url'        => "/v2/service_instances/#{service_instance.guid}",
                 'created_at' => iso8601,
-                'updated_at' => iso8601 },
-              'entity'   => {
+                'updated_at' => iso8601
+              },
+              'entity' => {
                 'name'                            => service_instance.name,
                 'credentials'                     => service_instance.credentials,
                 'service_guid'                    => service_instance.service.guid,
@@ -179,7 +180,7 @@ RSpec.describe 'ServiceInstances' do
                 'type'                            => service_instance.type,
                 'last_operation'                  => service_instance.last_operation,
                 'tags'                            => service_instance.tags,
-                'maintenance_info'                => { 'version' => '2.0' },
+                'maintenance_info'                => { 'version' => '2.0', 'description' => 'Test description' },
                 'space_url'                       => "/v2/spaces/#{space.guid}",
                 'service_url'                     => "/v2/services/#{service_instance.service.guid}",
                 'service_plan_url'                => "/v2/service_plans/#{service_plan.guid}",
@@ -214,8 +215,9 @@ RSpec.describe 'ServiceInstances' do
                 'guid'       => service_instance.guid,
                 'url'        => "/v2/service_instances/#{service_instance.guid}",
                 'created_at' => iso8601,
-                'updated_at' => iso8601 },
-              'entity'   => {
+                'updated_at' => iso8601
+              },
+              'entity' => {
                 'name'                            => service_instance.name,
                 'credentials'                     => service_instance.credentials,
                 'service_guid'                    => service_instance.service.guid,
@@ -226,7 +228,7 @@ RSpec.describe 'ServiceInstances' do
                 'type'                            => service_instance.type,
                 'last_operation'                  => service_instance.last_operation,
                 'tags'                            => service_instance.tags,
-                'maintenance_info'                => { 'version' => '2.0' },
+                'maintenance_info'                => { 'version' => '2.0', 'description' => 'Test description' },
                 'space_url'                       => "/v2/spaces/#{space.guid}",
                 'service_url'                     => "/v2/services/#{service_instance.service.guid}",
                 'service_bindings_url'            => "/v2/service_instances/#{service_instance.guid}/service_bindings",
@@ -259,8 +261,9 @@ RSpec.describe 'ServiceInstances' do
                 'guid'       => service_instance.guid,
                 'url'        => "/v2/service_instances/#{service_instance.guid}",
                 'created_at' => iso8601,
-                'updated_at' => iso8601 },
-              'entity'   => {
+                'updated_at' => iso8601
+              },
+              'entity' => {
                 'name'                            => service_instance.name,
                 'credentials'                     => service_instance.credentials,
                 'service_guid'                    => service_instance.service.guid,
@@ -271,7 +274,7 @@ RSpec.describe 'ServiceInstances' do
                 'type'                            => service_instance.type,
                 'last_operation'                  => service_instance.last_operation,
                 'tags'                            => service_instance.tags,
-                'maintenance_info'                => { 'version' => '2.0' },
+                'maintenance_info'                => { 'version' => '2.0', 'description' => 'Test description' },
                 'space_url'                       => "/v2/spaces/#{space.guid}",
                 'service_url'                     => "/v2/services/#{service_instance.service.guid}",
                 'service_bindings_url'            => "/v2/service_instances/#{service_instance.guid}/service_bindings",

--- a/spec/request/v2/service_plans_spec.rb
+++ b/spec/request/v2/service_plans_spec.rb
@@ -4,20 +4,20 @@ RSpec.describe 'ServicePlans' do
   let(:user) { VCAP::CloudController::User.make }
   let(:space) { VCAP::CloudController::Space.make }
 
+  let(:service) { VCAP::CloudController::Service.make }
+  let!(:service_plan) do
+    VCAP::CloudController::ServicePlan.make(
+      service: service,
+      maintenance_info: { 'version': '2.0', 'description': 'Test description' },
+    )
+  end
+
   before do
     space.organization.add_user(user)
     space.add_developer(user)
   end
 
   describe 'GET /v2/service_plans' do
-    let(:service) { VCAP::CloudController::Service.make }
-    let!(:service_plan) do
-      VCAP::CloudController::ServicePlan.make(
-        service: service,
-        maintenance_info: { 'version': '2.0' },
-      )
-    end
-
     it 'lists service plans' do
       get '/v2/service_plans', nil, headers_for(user)
       expect(last_response).to have_status_code(200)
@@ -44,7 +44,10 @@ RSpec.describe 'ServicePlans' do
                 'extra' => nil,
                 'free' => false,
                 'maximum_polling_duration' => nil,
-                'maintenance_info' => { 'version' => '2.0' },
+                'maintenance_info' => {
+                  'version' => '2.0',
+                  'description' => 'Test description'
+                },
                 'name' => service_plan.name,
                 'plan_updateable' => nil,
                 'public' => true,
@@ -76,14 +79,6 @@ RSpec.describe 'ServicePlans' do
   end
 
   describe 'GET /v2/service_plans/:guid' do
-    let(:service) { VCAP::CloudController::Service.make }
-    let!(:service_plan) do
-      VCAP::CloudController::ServicePlan.make(
-        service: service,
-        maintenance_info: { 'version': '2.0' },
-      )
-    end
-
     it 'lists service plans' do
       get "/v2/service_plans/#{service_plan.guid}", nil, headers_for(user)
       expect(last_response).to have_status_code(200)
@@ -104,7 +99,10 @@ RSpec.describe 'ServicePlans' do
             'extra' => nil,
             'free' => false,
             'maximum_polling_duration' => nil,
-            'maintenance_info' => { 'version' => '2.0' },
+            'maintenance_info' => {
+              'version' => '2.0',
+              'description' => 'Test description'
+            },
             'name' => service_plan.name,
             'plan_updateable' => nil,
             'public' => true,

--- a/spec/request/v2/spaces_spec.rb
+++ b/spec/request/v2/spaces_spec.rb
@@ -255,8 +255,9 @@ RSpec.describe 'Spaces' do
     let!(:space) { VCAP::CloudController::Space.make(organization: org) }
     let!(:app_model) { VCAP::CloudController::AppModel.make(space: space) }
     let!(:process) { VCAP::CloudController::ProcessModelFactory.make(state: 'STARTED', app: app_model) }
-    let!(:service_plan) { VCAP::CloudController::ServicePlan.make(maintenance_info: { 'version': '2.0.0' }) }
-    let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan, maintenance_info: { 'version': '1.0.0' }) }
+    let(:maintenance_info) { { 'version': '1.0.0', 'desciption': 'this is description about the maintenance' } }
+    let!(:service_plan) { VCAP::CloudController::ServicePlan.make(maintenance_info: maintenance_info) }
+    let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan, maintenance_info: maintenance_info) }
     let(:build_client) { instance_double(HTTPClient, post: nil) }
 
     before do

--- a/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_plan_spec.rb
@@ -48,7 +48,14 @@ module VCAP::Services::ServiceBrokers::V2
         expect(plan.schemas).to be {}
       end
 
-      it 'allows a valid maintenance_info object' do
+      it 'allows a full maintenance_info object' do
+        plan_attrs['maintenance_info'] = { 'version' => '1.2.3-alpha1', 'description' => 'OS update.' }
+
+        expect(plan).to be_valid
+        expect(plan.errors.messages).to be_empty
+      end
+
+      it 'allows a maintenance_info object with required version only' do
         plan_attrs['maintenance_info'] = { 'version' => '1.2.3-alpha1' }
 
         expect(plan).to be_valid
@@ -174,6 +181,13 @@ module VCAP::Services::ServiceBrokers::V2
 
         expect(plan).to_not be_valid
         expect(plan.errors.messages.first).to include 'Maintenance info version must be a string, but has value 42'
+      end
+
+      it 'validates that @maintenance_info description is a string' do
+        plan_attrs['maintenance_info'] = { 'version' => '1.0.0', 'description' => true }
+
+        expect(plan).to_not be_valid
+        expect(plan.errors.messages.first).to include 'Maintenance info description must be a string, but has value true'
       end
 
       it 'validates that @maintenance_info version is semver compliant' do


### PR DESCRIPTION
Allow new `description` field as part of maintenace_info and present it on some of the resources.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
