### PR TITLE
Change MaintenanceInfoMismatch to MaintenanceInfoNotSupported

### DIFF
--- a/app/controllers/services/validators/service_update_validator.rb
+++ b/app/controllers/services/validators/service_update_validator.rb
@@ -38,7 +38,7 @@ module VCAP::CloudController
         return unless maintenance_info
 
         if service_plan.maintenance_info.nil?
-          raise CloudController::Errors::ApiError.new_from_details('MaintenanceInfoMismatch')
+          raise CloudController::Errors::ApiError.new_from_details('MaintenanceInfoNotSupported')
         end
       end
 

--- a/spec/unit/controllers/services/validators/service_update_validator_spec.rb
+++ b/spec/unit/controllers/services/validators/service_update_validator_spec.rb
@@ -249,8 +249,7 @@ module VCAP::CloudController
               ServiceUpdateValidator.validate!(service_instance, args)
             }.to raise_error(
               CloudController::Errors::ApiError,
-              'The maintenance requested is not available for this service instance. ' \
-              'Please confirm your maintenance_info is available for the service plan'
+              'The service broker does not support upgrades for service instances created from this plan.'
             )
           end
         end

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1205,9 +1205,9 @@
   message: 'You cannot delete service instances that have been shared with you'
 
 390006:
-  name: MaintenanceInfoMismatch
+  name: MaintenanceInfoNotSupported
   http_code: 422
-  message: "The maintenance requested is not available for this service instance. Please confirm your maintenance_info is available for the service plan"
+  message: "The service broker does not support upgrades for service instances created from this plan."
 
 390011:
   name: BuildpackStacksDontMatch


### PR DESCRIPTION

The MaintenanceInfoMismatch error has too generic description and does not reflect very well the conditions under which it's raised.

For more details [#166541966](https://www.pivotaltracker.com/story/show/166541966)

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
