### PR TITLE
Use fully qualified column names in DB query

### DIFF
--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -96,7 +96,7 @@ module VCAP::CloudController
       included_ids = ServicePlanVisibility.visible_private_plan_ids_for_user(user).
                      concat(plan_ids_from_private_brokers(user))
 
-      Sequel.or({ public: true, id: included_ids }).&(active: true)
+      Sequel.or({ public: true, service_plans__id: included_ids }).&(service_plans__active: true)
     end
 
     def self.user_visibility_show_filter(user)


### PR DESCRIPTION
Fixed #1384

In #1384 a user described an error that occurs when querying service plans with a
service broker filter. The error were:

- PG::AmbiguousColumn: ERROR: column reference "id" is ambiguous
- PG::AmbiguousColumn: ERROR: column reference "active" is ambiguous

The captured DB query was:
```
SELECT count(*) AS "count" FROM "service_plans"
  LEFT JOIN "services" ON ("services"."id" = "service_plans"."service_id")
  LEFT JOIN "service_brokers" ON ("service_brokers"."id" = "services"."service_broker_id")
  WHERE ((("public" IS TRUE) OR ("id" IN (<long list of IDs>)))
    AND ("active" IS TRUE) AND ("service_brokers"."guid" = '<guid>'))
  LIMIT 1
```

It can be seen that the `active` and `id` columns are not qualified by
table name, so the DB is confused when doing a join where multiple
tables may contain the `active` and `id` columns.

The solution is to qualify the column names with the table name.