### PR TITLE
Send maintenance_info on create service instance

### DIFF
--- a/app/actions/services/service_instance_create.rb
+++ b/app/actions/services/service_instance_create.rb
@@ -19,7 +19,8 @@ module VCAP::CloudController
       broker_response = client.provision(
         service_instance,
         accepts_incomplete: accepts_incomplete,
-        arbitrary_parameters: arbitrary_params
+        arbitrary_parameters: arbitrary_params,
+        maintenance_info: service_instance.service_plan.maintenance_info
       )
 
       service_instance_attributes = broker_response[:instance].merge({ maintenance_info: service_instance.service_plan.maintenance_info })

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -19,7 +19,7 @@ module VCAP::Services::ServiceBrokers::V2
       @response_parser.parse_catalog(CATALOG_PATH, response)
     end
 
-    def provision(instance, arbitrary_parameters: {}, accepts_incomplete: false)
+    def provision(instance, arbitrary_parameters: {}, accepts_incomplete: false, maintenance_info: nil)
       path = service_instance_resource_path(instance, accepts_incomplete: accepts_incomplete)
 
       body = {
@@ -31,6 +31,7 @@ module VCAP::Services::ServiceBrokers::V2
       }
 
       body[:parameters] = arbitrary_parameters if arbitrary_parameters.present?
+      body[:maintenance_info] = maintenance_info if maintenance_info.present?
 
       begin
         response = @http_client.put(path, body)

--- a/spec/support/fakes/fake_service_broker_v2_client.rb
+++ b/spec/support/fakes/fake_service_broker_v2_client.rb
@@ -34,7 +34,7 @@ class FakeServiceBrokerV2Client
     }
   end
 
-  def provision(_instance, arbitrary_parameters: {}, accepts_incomplete: false)
+  def provision(_instance, arbitrary_parameters: {}, accepts_incomplete: false, maintenance_info: {})
     {
       instance: {
         credentials:   {},

--- a/spec/unit/actions/services/service_instance_create_spec.rb
+++ b/spec/unit/actions/services/service_instance_create_spec.rb
@@ -114,7 +114,7 @@ module VCAP::CloudController
       end
 
       context 'when the service plan contains maintenance_info' do
-        let(:service_plan) { ServicePlan.make(maintenance_info: '{"version": "2.0"}') }
+        let(:service_plan) { ServicePlan.make(maintenance_info: { 'version' => '2.0' }) }
         let(:request_attrs) do
           {
             'space_guid' => space.guid,
@@ -127,7 +127,12 @@ module VCAP::CloudController
           create_action.create(request_attrs, false)
           service_instance = ManagedServiceInstance.last
 
-          expect(service_instance.maintenance_info).to eq('{"version": "2.0"}')
+          expect(service_instance.maintenance_info).to eq({ 'version' => '2.0' })
+        end
+
+        it 'passes the maintenance_info to the client' do
+          create_action.create(request_attrs, false)
+          expect(client).to have_received(:provision).with(anything, hash_including(maintenance_info: { 'version' => '2.0' }))
         end
       end
     end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -460,6 +460,18 @@ module VCAP::CloudController
           end
         end
 
+        context 'when the plan has maintenance_info' do
+          let(:plan) { ServicePlan.make(:v2, service: service, maintenance_info: { 'version': '2.0' }) }
+
+          it 'should pass along the maintenance_info to the service broker' do
+            create_managed_service_instance(accepts_incomplete: 'false')
+            expect(last_response).to have_status_code(201)
+            expect(a_request(:put, service_broker_url_regex).
+                                        with(body: hash_including(maintenance_info: { 'version': '2.0' }))).
+              to have_been_made.times(1)
+          end
+        end
+
         context 'when the client provides arbitrary parameters' do
           before do
             create_managed_service_instance(

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -189,6 +189,11 @@ module VCAP::Services::ServiceBrokers::V2
         expect(http_client).to have_received(:put).with(path, hash_including(parameters: arbitrary_parameters))
       end
 
+      it 'passes the maintenance_info to the broker' do
+        client.provision(instance, maintenance_info: { 'version': '2.0.0' })
+        expect(http_client).to have_received(:put).with(path, hash_including(maintenance_info: { 'version': '2.0.0' }))
+      end
+
       context 'when the broker returns 204 (No Content)' do
         let(:code) { 204 }
         let(:client) { Client.new(client_attrs) }


### PR DESCRIPTION
The broker should always create a service instance with the latest
maintenance_info
It is useful to send the service_plans maintenance_info on
provisioning a service instance, so that the broker knows it's on the
same version as the platform

For more information check the [pivotal tracker story](https://www.pivotaltracker.com/story/show/165348433)

Niki && @blgm 
On behalf of SAPI Team