### PR TITLE
Remove references to app port from copilot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'addressable'
 gem 'allowy'
-gem 'cf-copilot', '0.0.13'
+gem 'cf-copilot', '0.0.14'
 gem 'clockwork', require: false
 gem 'cloudfront-signer'
 gem 'em-http-request', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       steno
     builder (3.2.3)
     byebug (10.0.2)
-    cf-copilot (0.0.13)
+    cf-copilot (0.0.14)
       grpc (~> 1.0)
     cf-perm (0.0.10)
       grpc (~> 1.0)
@@ -464,7 +464,7 @@ DEPENDENCIES
   azure-storage (= 0.14.0.preview)
   bits_service_client (~> 3.0)
   byebug
-  cf-copilot (= 0.0.13)
+  cf-copilot (= 0.0.14)
   cf-perm (~> 0.0.10)
   cf-perm-test-helpers (~> 0.0.6)
   cf-uaa-lib (~> 3.14.0)

--- a/lib/cloud_controller/copilot/adapter.rb
+++ b/lib/cloud_controller/copilot/adapter.rb
@@ -26,8 +26,7 @@ module VCAP::CloudController
               copilot_client.map_route(
                 capi_process_guid: process.guid,
                 route_guid: route_mapping.route_guid,
-                route_weight: route_mapping.adapted_weight,
-                app_port: route_mapping.app_port
+                route_weight: route_mapping.adapted_weight
               )
             end
           end
@@ -39,8 +38,7 @@ module VCAP::CloudController
               copilot_client.unmap_route(
                 capi_process_guid: process.guid,
                 route_guid: route_mapping.route_guid,
-                route_weight: route_mapping.adapted_weight,
-                app_port: route_mapping.app_port
+                route_weight: route_mapping.adapted_weight
               )
             end
           end

--- a/lib/cloud_controller/copilot/sync.rb
+++ b/lib/cloud_controller/copilot/sync.rb
@@ -17,8 +17,7 @@ module VCAP::CloudController
             {
               capi_process_guid: rm.process.guid,
               route_guid: rm.route_guid,
-              route_weight: rm.adapted_weight,
-              app_port: rm.app_port
+              route_weight: rm.adapted_weight
             }
           end,
           capi_diego_process_associations: web_processes.map do |process|

--- a/spec/unit/actions/app_delete_spec.rb
+++ b/spec/unit/actions/app_delete_spec.rb
@@ -180,7 +180,7 @@ module VCAP::CloudController
             end
 
             it 'tells copilot to unmap the route' do
-              expect(copilot_client).to receive(:unmap_route).with({ capi_process_guid: process.guid, route_guid: route.guid, route_weight: 1, app_port: 8080 })
+              expect(copilot_client).to receive(:unmap_route).with({ capi_process_guid: process.guid, route_guid: route.guid, route_weight: 1 })
               app_delete.delete(app_dataset)
             end
 

--- a/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
@@ -113,8 +113,7 @@ module VCAP::CloudController
           app: app,
           route: route,
           process_type: 'web',
-          weight: 5,
-          app_port: 9090
+          weight: 5
         )
       end
 
@@ -123,14 +122,12 @@ module VCAP::CloudController
         expect(copilot_client).to have_received(:map_route).with(
           capi_process_guid: process1.guid,
           route_guid: route.guid,
-          route_weight: 5,
-          app_port: 9090
+          route_weight: 5
         )
         expect(copilot_client).to have_received(:map_route).with(
           capi_process_guid: process2.guid,
           route_guid: route.guid,
-          route_weight: 5,
-          app_port: 9090
+          route_weight: 5
         )
       end
 
@@ -140,8 +137,7 @@ module VCAP::CloudController
             app: app,
             route: route,
             process_type: 'web',
-            weight: nil,
-            app_port: 9090
+            weight: nil
           )
         end
 
@@ -151,15 +147,13 @@ module VCAP::CloudController
           expect(copilot_client).to have_received(:map_route).with(
             capi_process_guid: process1.guid,
             route_guid: route.guid,
-            route_weight: 1,
-            app_port: 9090
+            route_weight: 1
           )
 
           expect(copilot_client).to have_received(:map_route).with(
             capi_process_guid: process2.guid,
             route_guid: route.guid,
-            route_weight: 1,
-            app_port: 9090
+            route_weight: 1
           )
         end
       end
@@ -210,8 +204,7 @@ module VCAP::CloudController
           app: app,
           route: route,
           process_type: 'web',
-          weight: 5,
-          app_port: 9090
+          weight: 5
         )
       end
 
@@ -220,14 +213,12 @@ module VCAP::CloudController
         expect(copilot_client).to have_received(:unmap_route).with(
           capi_process_guid: process1.guid,
           route_guid: route.guid,
-          route_weight: 5,
-          app_port: 9090
+          route_weight: 5
         )
         expect(copilot_client).to have_received(:unmap_route).with(
           capi_process_guid: process2.guid,
           route_guid: route.guid,
-          route_weight: 5,
-          app_port: 9090
+          route_weight: 5
         )
       end
 
@@ -237,8 +228,7 @@ module VCAP::CloudController
             app: app,
             route: route,
             process_type: 'web',
-            weight: nil,
-            app_port: 9090
+            weight: nil
           )
         end
 
@@ -248,15 +238,13 @@ module VCAP::CloudController
           expect(copilot_client).to have_received(:unmap_route).with(
             capi_process_guid: process1.guid,
             route_guid: route.guid,
-            route_weight: 1,
-            app_port: 9090
+            route_weight: 1
           )
 
           expect(copilot_client).to have_received(:unmap_route).with(
             capi_process_guid: process2.guid,
             route_guid: route.guid,
-            route_weight: 1,
-            app_port: 9090
+            route_weight: 1
           )
         end
       end

--- a/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/sync_spec.rb
@@ -17,10 +17,10 @@ module VCAP::CloudController
         let(:app) { VCAP::CloudController::AppModel.make }
 
         let(:route) { Route.make(domain: istio_domain, host: 'some-host', path: '/some/path') }
-        let!(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'web', app_port: 9191) }
+        let!(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'web') }
 
         let(:internal_route) { Route.make(domain: internal_istio_domain, host: 'internal-host', vip_offset: 1) }
-        let!(:internal_route_mapping) { RouteMappingModel.make(route: internal_route, app: app, process_type: 'web', app_port: 9191) }
+        let!(:internal_route_mapping) { RouteMappingModel.make(route: internal_route, app: app, process_type: 'web') }
 
         let(:legacy_domain) { SharedDomain.make }
         let(:legacy_route) { Route.make(domain: legacy_domain, host: 'some-host', path: '/some/path') }
@@ -58,13 +58,11 @@ module VCAP::CloudController
               route_mappings: [{
                 capi_process_guid: web_process_model.guid,
                 route_guid: route_mapping.route_guid,
-                route_weight: 1,
-                app_port: route_mapping.app_port
+                route_weight: 1
               }, {
                 capi_process_guid: web_process_model.guid,
                 route_guid: internal_route_mapping.route_guid,
-                route_weight: 1,
-                app_port: internal_route_mapping.app_port
+                route_weight: 1
               }],
               capi_diego_process_associations: [{
                 capi_process_guid: web_process_model.guid,
@@ -99,13 +97,11 @@ module VCAP::CloudController
                   route_mappings: [{
                     capi_process_guid: web_process_model.guid,
                     route_guid: route_mapping.route_guid,
-                    route_weight: 1,
-                    app_port: route_mapping.app_port
+                    route_weight: 1
                   }, {
                     capi_process_guid: web_process_model.guid,
                     route_guid: internal_route_mapping.route_guid,
-                    route_weight: 1,
-                    app_port: internal_route_mapping.app_port
+                    route_weight: 1
                   }],
                   capi_diego_process_associations: [{
                     capi_process_guid: web_process_model.guid,
@@ -146,14 +142,12 @@ module VCAP::CloudController
               {
                 capi_process_guid: web_process_model_1.guid,
                 route_guid: route_mapping_1.route_guid,
-                route_weight: 1,
-                app_port: route_mapping_1.app_port
+                route_weight: 1
               },
               {
                 capi_process_guid: web_process_model_2.guid,
                 route_guid: route_mapping_2.route_guid,
-                route_weight: 1,
-                app_port: route_mapping_2.app_port
+                route_weight: 1
               }
             ])
             expect(args[:capi_diego_process_associations]).to match_array([


### PR DESCRIPTION

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

#### A short explanation of the proposed change:

Bump the `cf-copilot` gem and make appropriate changes to the copilot syncer and adapter given the change in interface.

#### An explanation of the use cases your change solves

- we never used it, and never will
- its presence was confusing to other teams
- i want negative line numbers in my commit history

#### Links to any other associated PRs

jk none of these are prs 

https://www.pivotaltracker.com/story/show/167441185

https://cloudfoundry.slack.com/archives/CFX13JK7B/p1563487183216500
https://cloudfoundry.slack.com/archives/CFX13JK7B/p1562885895169700

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
