### PR TITLE
Remove API version checks from v2 controllers

### DIFF
--- a/app/controllers/base/base_controller.rb
+++ b/app/controllers/base/base_controller.rb
@@ -45,11 +45,9 @@ module VCAP::CloudController::RestController
       @env     = env
       @params  = params
       @body    = body
-      if v2_api? || unversioned_api?
-        common_params = CommonParams.new(logger)
-        query_string = sinatra.request.query_string if sinatra
-        @opts = common_params.parse(params, query_string)
-      end
+      common_params = CommonParams.new(logger)
+      query_string = sinatra.request.query_string if sinatra
+      @opts = common_params.parse(params, query_string)
       @sinatra = sinatra
 
       @queryer = VCAP::CloudController::Permissions::Queryer.build(
@@ -146,14 +144,6 @@ module VCAP::CloudController::RestController
                        "or admin scope. Token hash: #{VCAP::CloudController::SecurityContext.token}"
         raise CloudController::Errors::InvalidAuthToken
       end
-    end
-
-    def v2_api?
-      env['PATH_INFO'] =~ /\A#{V2_ROUTE_PREFIX}/
-    end
-
-    def unversioned_api?
-      env['PATH_INFO'] !~ %r{\A/v\d}
     end
 
     def recursive_delete?

--- a/app/controllers/base/model_controller.rb
+++ b/app/controllers/base/model_controller.rb
@@ -73,7 +73,7 @@ module VCAP::CloudController::RestController
     end
 
     def do_delete(obj)
-      raise_if_has_dependent_associations!(obj) if v2_api? && !recursive_delete?
+      raise_if_has_dependent_associations!(obj) unless recursive_delete?
       model_deletion_job = Jobs::Runtime::ModelDeletion.new(obj.class, obj.guid)
       run_or_enqueue_deletion_job(model_deletion_job)
     end

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -255,7 +255,7 @@ module VCAP::CloudController
 
     def delete(guid)
       org = find_guid_and_validate_access(:delete, guid)
-      raise_if_has_dependent_associations!(org) if v2_api? && !recursive_delete?
+      raise_if_has_dependent_associations!(org) unless recursive_delete?
 
       if !org.spaces.empty? && !recursive_delete?
         raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'spaces', Organization.table_name)

--- a/app/controllers/services/service_plan_visibilities_controller.rb
+++ b/app/controllers/services/service_plan_visibilities_controller.rb
@@ -69,7 +69,7 @@ module VCAP::CloudController
 
     def delete(guid)
       service_plan_visibility = find_guid_and_validate_access(:delete, guid, ServicePlanVisibility)
-      raise_if_has_dependent_associations!(service_plan_visibility) if v2_api? && !recursive_delete?
+      raise_if_has_dependent_associations!(service_plan_visibility) unless recursive_delete?
 
       model_deletion_job = Jobs::Runtime::ModelDeletion.new(ServicePlanVisibility, guid)
       delete_and_audit_job = Jobs::AuditEventJob.new(

--- a/app/controllers/services/user_provided_service_instances_controller.rb
+++ b/app/controllers/services/user_provided_service_instances_controller.rb
@@ -94,7 +94,7 @@ module VCAP::CloudController
 
     def delete(guid)
       service_instance = UserProvidedServiceInstance.find(guid: guid)
-      raise_if_has_dependent_associations!(service_instance) if v2_api? && !recursive_delete?
+      raise_if_has_dependent_associations!(service_instance) unless recursive_delete?
 
       deletion_job = Jobs::Runtime::ModelDeletion.new(ServiceInstance, guid)
       delete_and_audit_job = Jobs::AuditEventJob.new(

--- a/spec/unit/controllers/base/base_controller_spec.rb
+++ b/spec/unit/controllers/base/base_controller_spec.rb
@@ -239,46 +239,6 @@ module VCAP::CloudController
       end
     end
 
-    describe '#v2_api?' do
-      subject(:base_controller) do
-        VCAP::CloudController::RestController::BaseController.new(config, logger, env, params, double(:body), nil, dependencies)
-      end
-      context 'when the endpoint is v2' do
-        let(:env) { { 'PATH_INFO' => '/v2/foobar' } }
-        it { is_expected.to be_v2_api }
-      end
-
-      context 'when the endpoint is not v2' do
-        let(:env) { { 'PATH_INFO' => '/v1/foobar' } }
-        it { is_expected.not_to be_v2_api }
-
-        context 'and the v2 is in capitals' do
-          let(:env) { { 'PATH_INFO' => '/V2/foobar' } }
-          it { is_expected.not_to be_v2_api }
-        end
-
-        context 'and the v2 is somewhere in the middle (for example, the app is called v2)' do
-          let(:env) { { 'PATH_INFO' => '/v1/apps/v2' } }
-          it { is_expected.not_to be_v2_api }
-        end
-      end
-    end
-
-    describe '#unversioned_api?' do
-      subject(:base_controller) do
-        VCAP::CloudController::RestController::BaseController.new(config, logger, env, params, double(:body), nil, dependencies)
-      end
-      context 'when the endpoint is unversioned' do
-        let(:env) { { 'PATH_INFO' => '/foobar' } }
-        it { is_expected.to be_unversioned_api }
-      end
-
-      context 'when the endpoint is not unversioned' do
-        let(:env) { { 'PATH_INFO' => '/v1/foobar' } }
-        it { is_expected.not_to be_unversioned_api }
-      end
-    end
-
     describe '#async?' do
       subject(:base_controller) do
         VCAP::CloudController::RestController::BaseController.new(config, logger, env, params, double(:body), nil, dependencies)


### PR DESCRIPTION
- The version check in BaseController init was from when the v3 API also used
it. V3 now uses Rails ActionController
- The version check in BaseController do_delete was from when there was also a v1 API (based on commit message)
- The version checks in the org/services controllers were from inlining
the do_delete method from BaseController and were not needed (since they
are already in v2 controllers)

Relevant Commits:
- 21e56c86ed9a26b62661aa527082d3c43505d72c
- b83b01d53278f79a9513a77b26c9102336d55fa9
- d6047fa804f7dabda7aec69739040da58e0a8f32
- 601211e1fdf3a3ef622393b92957084037ae5806
- 48c5ae9691ce254103b3c5db5d863c1d21de8efc

