### PR TITLE
Access service usage events as global auditor

### DIFF
--- a/app/access/service_usage_event_access.rb
+++ b/app/access/service_usage_event_access.rb
@@ -66,7 +66,7 @@ module VCAP::CloudController
     end
 
     def index?(*_)
-      admin_user? || admin_read_only_user?
+      admin_user? || admin_read_only_user? || global_auditor?
     end
 
     def reset?(*_)

--- a/spec/unit/access/service_usage_event_access_spec.rb
+++ b/spec/unit/access/service_usage_event_access_spec.rb
@@ -17,6 +17,10 @@ module VCAP::CloudController
       it { is_expected.to allow_op_on_object :reset, VCAP::CloudController::ServiceUsageEvent }
     end
 
+    context 'a global auditor' do
+      it_behaves_like :global_auditor_access
+    end
+
     context 'a user that is not an admin (defensive)' do
       it_behaves_like :no_access
 


### PR DESCRIPTION
This PR closes #1403 

It provides a spec covering the fact that users with role global editor cannot fetch service usage events. Also included is the fix that enables users with role global auditor to fetch the events. 

For more information see #1403 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)
* [x] I have viewed, signed, and submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
