### PR TITLE
update trafficcontroller decorator to handle container metrics split …

### DIFF
--- a/lib/logcache/traffic_controller_decorator.rb
+++ b/lib/logcache/traffic_controller_decorator.rb
@@ -37,7 +37,7 @@ module Logcache
 
       final_envelopes.
         select { |e| has_container_metrics_fields?(e) && logcache_filter.call(e) }.
-        uniq{ |e| e.gauge.metrics.keys << e.instance_id }.
+        uniq { |e| e.gauge.metrics.keys << e.instance_id }.
         sort_by(&:instance_id).
         chunk(&:instance_id).
         map { |envelopes_by_instance| convert_to_traffic_controller_envelope(source_guid, envelopes_by_instance) }
@@ -79,6 +79,9 @@ module Logcache
       tags = {}
       envelopes_by_instance.second.each { |e|
         tc_envelope.containerMetric.instanceIndex = e.instance_id
+        # rubocop seems to think that there is a 'key?' method
+        # on envelope.gauge.metrics - but it does not
+        # rubocop:disable Style/PreferredHashMethods
         if e.gauge.metrics.has_key?('cpu')
           tc_envelope.containerMetric.cpuPercentage = e.gauge.metrics['cpu'].value
         end
@@ -88,6 +91,7 @@ module Logcache
         if e.gauge.metrics.has_key?('disk')
           tc_envelope.containerMetric.diskBytes = e.gauge.metrics['disk'].value
         end
+        # rubocop:enable Style/PreferredHashMethods
 
         tags.merge!(e.tags)
       }

--- a/lib/logcache/traffic_controller_decorator.rb
+++ b/lib/logcache/traffic_controller_decorator.rb
@@ -37,8 +37,10 @@ module Logcache
 
       final_envelopes.
         select { |e| has_container_metrics_fields?(e) && logcache_filter.call(e) }.
-        uniq(&:instance_id).
-        map { |e| convert_to_traffic_controller_envelope(source_guid, e) }
+        uniq{ |e| e.gauge.metrics.keys << e.instance_id }.
+        sort_by(&:instance_id).
+        chunk(&:instance_id).
+        map { |envelopes_by_instance| convert_to_traffic_controller_envelope(source_guid, envelopes_by_instance) }
     end
 
     private
@@ -60,23 +62,39 @@ module Logcache
       # rubocop seems to think that there is a 'key?' method
       # on envelope.gauge.metrics - but it does not
       # rubocop:disable Style/PreferredHashMethods
-      envelope.gauge.metrics.has_key?('cpu') &&
-      envelope.gauge.metrics.has_key?('memory') &&
+      envelope.gauge.metrics.has_key?('cpu') ||
+      envelope.gauge.metrics.has_key?('memory') ||
       envelope.gauge.metrics.has_key?('disk')
       # rubocop:enable Style/PreferredHashMethods
     end
 
-    def convert_to_traffic_controller_envelope(source_guid, logcache_envelope)
-      TrafficController::Models::Envelope.new(
+    def convert_to_traffic_controller_envelope(source_guid, envelopes_by_instance)
+      tc_envelope = TrafficController::Models::Envelope.new(
         containerMetric: TrafficController::Models::ContainerMetric.new({
           applicationId: source_guid,
-          instanceIndex: logcache_envelope.instance_id,
-          cpuPercentage: logcache_envelope.gauge.metrics['cpu'].value,
-          memoryBytes: logcache_envelope.gauge.metrics['memory'].value,
-          diskBytes: logcache_envelope.gauge.metrics['disk'].value,
+          instanceIndex: envelopes_by_instance.first,
         }),
-        tags: logcache_envelope.tags.map { |k, v| TrafficController::Models::Envelope::TagsEntry.new(key: k, value: v) },
       )
+
+      tags = {}
+      envelopes_by_instance.second.each { |e|
+        tc_envelope.containerMetric.instanceIndex = e.instance_id
+        if e.gauge.metrics.has_key?('cpu')
+          tc_envelope.containerMetric.cpuPercentage = e.gauge.metrics['cpu'].value
+        end
+        if e.gauge.metrics.has_key?('memory')
+          tc_envelope.containerMetric.memoryBytes = e.gauge.metrics['memory'].value
+        end
+        if e.gauge.metrics.has_key?('disk')
+          tc_envelope.containerMetric.diskBytes = e.gauge.metrics['disk'].value
+        end
+
+        tags.merge!(e.tags)
+      }
+
+      tc_envelope.tags = tags.map { |k, v| TrafficController::Models::Envelope::TagsEntry.new(key: k, value: v) }
+
+      tc_envelope
     end
 
     def logger

--- a/spec/logcache/traffic_controller_decorator_spec.rb
+++ b/spec/logcache/traffic_controller_decorator_spec.rb
@@ -413,23 +413,23 @@ RSpec.describe Logcache::TrafficControllerDecorator do
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
+                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 11),
+              }),
+              instance_id: '1'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: {
+                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12),
+              }),
+              instance_id: '1'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: {
+                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 20),
                   'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 21),
-              }),
-              instance_id: '1'
-            ),
-            Loggregator::V2::Envelope.new(
-              source_id: process_guid,
-              gauge: Loggregator::V2::Gauge.new(metrics: {
-                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
-              }),
-              instance_id: '1'
-            ),
-            Loggregator::V2::Envelope.new(
-              source_id: process_guid,
-              gauge: Loggregator::V2::Gauge.new(metrics: {
-                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 30),
-                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 31),
-                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
+                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 22),
               }),
               instance_id: '2'
             )
@@ -443,13 +443,13 @@ RSpec.describe Logcache::TrafficControllerDecorator do
 
         expect(subject.first.containerMetric.instanceIndex).to eq(1)
         expect(subject.first.containerMetric.cpuPercentage).to eq(10)
-        expect(subject.first.containerMetric.memoryBytes).to eq(21)
-        expect(subject.first.containerMetric.diskBytes).to eq(32)
+        expect(subject.first.containerMetric.memoryBytes).to eq(11)
+        expect(subject.first.containerMetric.diskBytes).to eq(12)
 
         expect(subject.second.containerMetric.instanceIndex).to eq(2)
-        expect(subject.second.containerMetric.cpuPercentage).to eq(30)
-        expect(subject.second.containerMetric.memoryBytes).to eq(31)
-        expect(subject.second.containerMetric.diskBytes).to eq(32)
+        expect(subject.second.containerMetric.cpuPercentage).to eq(20)
+        expect(subject.second.containerMetric.memoryBytes).to eq(21)
+        expect(subject.second.containerMetric.diskBytes).to eq(22)
       end
     end
 

--- a/spec/logcache/traffic_controller_decorator_spec.rb
+++ b/spec/logcache/traffic_controller_decorator_spec.rb
@@ -402,39 +402,54 @@ RSpec.describe Logcache::TrafficControllerDecorator do
     context 'when given container metrics in separate envelopes' do
       let(:envelopes) {
         Loggregator::V2::EnvelopeBatch.new(
-            batch: [ #TODO multiple instances
-                Loggregator::V2::Envelope.new(
-                    source_id: process_guid,
-                    gauge: Loggregator::V2::Gauge.new(metrics: {
-                        'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
-                    }),
-                    instance_id: '1'
-                ),
-                Loggregator::V2::Envelope.new(
-                    source_id: process_guid,
-                    gauge: Loggregator::V2::Gauge.new(metrics: {
-                        'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 21),
-                    }),
-                    instance_id: '1'
-                ),
-                Loggregator::V2::Envelope.new(
-                    source_id: process_guid,
-                    gauge: Loggregator::V2::Gauge.new(metrics: {
-                        'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
-                    }),
-                    instance_id: '1'
-                )
-            ]
+          batch: [
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: {
+                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
+              }),
+              instance_id: '1'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: {
+                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 21),
+              }),
+              instance_id: '1'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: {
+                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
+              }),
+              instance_id: '1'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: {
+                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 30),
+                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 31),
+                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
+              }),
+              instance_id: '2'
+            )
+          ]
         )
       }
-      let(:num_instances) { 1 }
+      let(:num_instances) { 2 }
 
-      it 'returns a single envelope' do
-        expect(subject.count).to eq(1)
+      it 'returns a single envelope per instance' do
+        expect(subject.count).to eq(2)
+
         expect(subject.first.containerMetric.instanceIndex).to eq(1)
         expect(subject.first.containerMetric.cpuPercentage).to eq(10)
         expect(subject.first.containerMetric.memoryBytes).to eq(21)
         expect(subject.first.containerMetric.diskBytes).to eq(32)
+
+        expect(subject.second.containerMetric.instanceIndex).to eq(2)
+        expect(subject.second.containerMetric.cpuPercentage).to eq(30)
+        expect(subject.second.containerMetric.memoryBytes).to eq(31)
+        expect(subject.second.containerMetric.diskBytes).to eq(32)
       end
     end
 

--- a/spec/logcache/traffic_controller_decorator_spec.rb
+++ b/spec/logcache/traffic_controller_decorator_spec.rb
@@ -399,6 +399,45 @@ RSpec.describe Logcache::TrafficControllerDecorator do
       end
     end
 
+    context 'when given container metrics in separate envelopes' do
+      let(:envelopes) {
+        Loggregator::V2::EnvelopeBatch.new(
+            batch: [ #TODO multiple instances
+                Loggregator::V2::Envelope.new(
+                    source_id: process_guid,
+                    gauge: Loggregator::V2::Gauge.new(metrics: {
+                        'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
+                    }),
+                    instance_id: '1'
+                ),
+                Loggregator::V2::Envelope.new(
+                    source_id: process_guid,
+                    gauge: Loggregator::V2::Gauge.new(metrics: {
+                        'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 21),
+                    }),
+                    instance_id: '1'
+                ),
+                Loggregator::V2::Envelope.new(
+                    source_id: process_guid,
+                    gauge: Loggregator::V2::Gauge.new(metrics: {
+                        'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
+                    }),
+                    instance_id: '1'
+                )
+            ]
+        )
+      }
+      let(:num_instances) { 1 }
+
+      it 'returns a single envelope' do
+        expect(subject.count).to eq(1)
+        expect(subject.first.containerMetric.instanceIndex).to eq(1)
+        expect(subject.first.containerMetric.cpuPercentage).to eq(10)
+        expect(subject.first.containerMetric.memoryBytes).to eq(21)
+        expect(subject.first.containerMetric.diskBytes).to eq(32)
+      end
+    end
+
     describe 'walking the log cache' do
       let(:lookback_window) { 2.minutes }
 


### PR DESCRIPTION
…across several envelopes

Signed-off-by: Tom Chen <tochen@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
We updated the trafficcontroller decorator to be able to handle both the case where all container metrics are in one envelope and the case where container metrics are split across envelopes

* An explanation of the use cases your change solves
Log cache will be switching to ingressing via syslog which will cause the container metrics to be in separate envelopes

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
