### PR TITLE
Default new_memory to 0 in sidecar validator

### DIFF
--- a/app/models/runtime/constraints/sidecar_memory_less_than_process_memory_policy.rb
+++ b/app/models/runtime/constraints/sidecar_memory_less_than_process_memory_policy.rb
@@ -3,7 +3,7 @@ class SidecarMemoryLessThanProcessMemoryPolicy
 
   # memory represents the amount of memory to add to the total sidecar amount
   def initialize(processes, new_memory=0)
-    @new_memory = new_memory
+    @new_memory = new_memory || 0
     @processes = Array(processes)
   end
 

--- a/spec/unit/models/runtime/constraints/sidecar_memory_less_than_process_memory_policy_spec.rb
+++ b/spec/unit/models/runtime/constraints/sidecar_memory_less_than_process_memory_policy_spec.rb
@@ -44,5 +44,13 @@ RSpec.describe 'max instance memory policies' do
         expect(validator.valid?).to eq true
       end
     end
+
+    context 'when newly added sidecar process memory is nil' do
+      let(:validator) { SidecarMemoryLessThanProcessMemoryPolicy.new(process, nil) }
+
+      it 'does not error' do
+        expect(validator.valid?).to eq true
+      end
+    end
   end
 end


### PR DESCRIPTION
**I've changed**
Set a sidecar memory to 0 when validating total memory, even if it is nil. See commit message for full context.

**I was**
Attempting to create a sidecar for the first time with no memory specified in manifest (following docs)

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] ~~I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)~~ Not setup to do this and believe unit test should cover change
