### PR TITLE
When pruning app and service usage events, ensure at least one record is kept

### DIFF
--- a/app/repositories/app_usage_event_repository.rb
+++ b/app/repositories/app_usage_event_repository.rb
@@ -145,7 +145,7 @@ module VCAP::CloudController
       end
 
       def delete_events_older_than(cutoff_age_in_days)
-        Database::OldRecordCleanup.new(AppUsageEvent, cutoff_age_in_days).delete
+        Database::OldRecordCleanup.new(AppUsageEvent, cutoff_age_in_days, keep_at_least_one_record: true).delete
       end
 
       private

--- a/app/repositories/service_usage_event_repository.rb
+++ b/app/repositories/service_usage_event_repository.rb
@@ -91,7 +91,7 @@ module VCAP::CloudController
       end
 
       def delete_events_older_than(cutoff_age_in_days)
-        Database::OldRecordCleanup.new(ServiceUsageEvent, cutoff_age_in_days).delete
+        Database::OldRecordCleanup.new(ServiceUsageEvent, cutoff_age_in_days, keep_at_least_one_record: true).delete
       end
     end
   end

--- a/lib/database/old_record_cleanup.rb
+++ b/lib/database/old_record_cleanup.rb
@@ -3,17 +3,22 @@ require 'database/batch_delete'
 module Database
   class OldRecordCleanup
     class NoCurrentTimestampError < StandardError; end
-    attr_reader :model, :days_ago
+    attr_reader :model, :days_ago, :keep_at_least_one_record
 
-    def initialize(model, days_ago)
+    def initialize(model, days_ago, keep_at_least_one_record: false)
       @model = model
       @days_ago = days_ago
+      @keep_at_least_one_record = keep_at_least_one_record
     end
 
     def delete
       cutoff_date = current_timestamp_from_database - days_ago.to_i.days
 
       old_records = model.dataset.where(Sequel.lit('created_at < ?', cutoff_date))
+      if keep_at_least_one_record
+        last_id = model.order(:id).last.id
+        old_records = old_records.where(Sequel.lit('id < ?', last_id))
+      end
       logger.info("Cleaning up #{old_records.count} #{model.table_name} table rows")
 
       Database::BatchDelete.new(old_records, 1000).delete

--- a/spec/unit/jobs/services/service_usage_events_cleanup_spec.rb
+++ b/spec/unit/jobs/services/service_usage_events_cleanup_spec.rb
@@ -5,6 +5,8 @@ module VCAP::CloudController
     RSpec.describe ServiceUsageEventsCleanup, job_context: :worker do
       let(:cutoff_age_in_days) { 30 }
       let(:logger) { double(Steno::Logger, info: nil) }
+      let!(:event_before_threshold) { ServiceUsageEvent.make(created_at: (cutoff_age_in_days + 1).days.ago) }
+      let!(:event_after_threshold) { ServiceUsageEvent.make(created_at: (cutoff_age_in_days - 1).days.ago) }
 
       subject(:job) do
         ServiceUsageEventsCleanup.new(cutoff_age_in_days)
@@ -22,14 +24,12 @@ module VCAP::CloudController
 
       describe '#perform' do
         it 'deletes events created before the pruning threshold' do
-          event_before_threshold = ServiceUsageEvent.make(created_at: (cutoff_age_in_days + 1).days.ago)
           expect {
             job.perform
           }.to change { event_before_threshold.exists? }.to(false)
         end
 
         it 'keeps events created after the pruning threshold' do
-          event_after_threshold = ServiceUsageEvent.make(created_at: (cutoff_age_in_days - 1).days.ago)
           expect {
             job.perform
           }.not_to change { event_after_threshold.exists? }.from(true)

--- a/spec/unit/lib/database/old_record_cleanup_spec.rb
+++ b/spec/unit/lib/database/old_record_cleanup_spec.rb
@@ -25,5 +25,17 @@ RSpec.describe Database::OldRecordCleanup do
       record_cleanup = Database::OldRecordCleanup.new(VCAP::CloudController::Event, 1)
       record_cleanup.delete
     end
+
+    it 'keeps the last row when :keep_at_least_one_record is true and all rows would be deleted' do
+      record_cleanup = Database::OldRecordCleanup.new(VCAP::CloudController::Event, 0, keep_at_least_one_record: true)
+
+      expect {
+        record_cleanup.delete
+      }.to change { VCAP::CloudController::Event.count }.by(-2)
+
+      expect(fresh_event.reload).to be_present
+      expect { stale_event1.reload }.to raise_error(Sequel::NoExistingObject)
+      expect { stale_event2.reload }.to raise_error(Sequel::NoExistingObject)
+    end
   end
 end

--- a/spec/unit/repositories/app_usage_event_repository_spec.rb
+++ b/spec/unit/repositories/app_usage_event_repository_spec.rb
@@ -692,6 +692,16 @@ module VCAP::CloudController
 
           expect(AppUsageEvent.last).to match_app(process)
         end
+
+        it 'will keep the last record even if before the cutoff age' do
+          expect {
+            repository.delete_events_older_than(cutoff_age_in_days)
+          }.to change {
+            AppUsageEvent.count
+          }.to(1)
+
+          expect(AppUsageEvent.last.created_at).to be < cutoff_age_in_days.days.ago
+        end
       end
     end
   end

--- a/spec/unit/repositories/service_usage_event_repository_spec.rb
+++ b/spec/unit/repositories/service_usage_event_repository_spec.rb
@@ -180,6 +180,16 @@ module VCAP::CloudController
 
           expect(ServiceUsageEvent.last).to eq(new_event.reload)
         end
+
+        it 'will keep the last record even if before the cutoff age' do
+          expect {
+            repository.delete_events_older_than(cutoff_age_in_days)
+          }.to change {
+            ServiceUsageEvent.count
+          }.to(1)
+
+          expect(ServiceUsageEvent.last.created_at).to be < cutoff_age_in_days.days.ago
+        end
       end
     end
   end


### PR DESCRIPTION
This prevents the problem of api clients
getting an error when querying the endpoints with after_guid
and the whole table has been pruned.

* Links to any other associated PRs
Related issue: #1429

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch