### PR TITLE
Change include paths to match relationship names

### DIFF
--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -45,8 +45,8 @@ class AppsV3Controller < ApplicationController
               end
 
     decorators = []
-    decorators << IncludeAppSpaceDecorator if message.include&.include?('space')
-    decorators << IncludeAppOrganizationDecorator if message.include&.include?('org')
+    decorators << IncludeAppSpaceDecorator if IncludeAppSpaceDecorator.match?(message.include)
+    decorators << IncludeAppOrganizationDecorator if IncludeAppOrganizationDecorator.match?(message.include)
 
     render status: :ok,
            json: Presenters::V3::PaginatedListPresenter.new(
@@ -68,8 +68,8 @@ class AppsV3Controller < ApplicationController
     app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
 
     decorators = []
-    decorators << IncludeAppSpaceDecorator if message.include&.include?('space')
-    decorators << IncludeAppOrganizationDecorator if message.include&.include?('org')
+    decorators << IncludeAppSpaceDecorator if IncludeAppSpaceDecorator.match?(message.include)
+    decorators << IncludeAppOrganizationDecorator if IncludeAppOrganizationDecorator.match?(message.include)
 
     render status: :ok, json: Presenters::V3::AppPresenter.new(
       app,

--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -20,7 +20,7 @@ class SpacesV3Controller < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     decorators = []
-    decorators << IncludeSpaceOrganizationDecorator if message.include&.include?('org')
+    decorators << IncludeSpaceOrganizationDecorator if IncludeSpaceOrganizationDecorator.match?(message.include)
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::SpacePresenter,
@@ -39,7 +39,7 @@ class SpacesV3Controller < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     decorators = []
-    decorators << IncludeSpaceOrganizationDecorator if message.include&.include?('org')
+    decorators << IncludeSpaceOrganizationDecorator if IncludeSpaceOrganizationDecorator.match?(message.include)
 
     render status: :ok, json: Presenters::V3::SpacePresenter.new(space, decorators: decorators)
   end

--- a/app/decorators/include_app_organization_decorator.rb
+++ b/app/decorators/include_app_organization_decorator.rb
@@ -1,6 +1,10 @@
 module VCAP::CloudController
   class IncludeAppOrganizationDecorator
     class << self
+      def match?(include)
+        include&.include?('org')
+      end
+
       def decorate(hash, apps)
         hash[:included] ||= {}
         organization_guids = apps.map(&:organization_guid).uniq

--- a/app/decorators/include_app_organization_decorator.rb
+++ b/app/decorators/include_app_organization_decorator.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   class IncludeAppOrganizationDecorator
     class << self
       def match?(include)
-        include&.include?('org')
+        include&.any? { |i| %w(org space.organization).include?(i) }
       end
 
       def decorate(hash, apps)

--- a/app/decorators/include_app_space_decorator.rb
+++ b/app/decorators/include_app_space_decorator.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   class IncludeAppSpaceDecorator
     class << self
       def match?(include)
-        include&.include?('space')
+        include&.any? { |i| %w(space space.organization).include?(i) }
       end
 
       def decorate(hash, apps)

--- a/app/decorators/include_app_space_decorator.rb
+++ b/app/decorators/include_app_space_decorator.rb
@@ -1,6 +1,10 @@
 module VCAP::CloudController
   class IncludeAppSpaceDecorator
     class << self
+      def match?(include)
+        include&.include?('space')
+      end
+
       def decorate(hash, apps)
         hash[:included] ||= {}
         space_guids = apps.map(&:space_guid).uniq

--- a/app/decorators/include_space_organization_decorator.rb
+++ b/app/decorators/include_space_organization_decorator.rb
@@ -1,6 +1,10 @@
 module VCAP::CloudController
   class IncludeSpaceOrganizationDecorator
     class << self
+      def match?(include)
+        include&.include?('org')
+      end
+
       def decorate(hash, spaces)
         hash[:included] ||= {}
         organization_guids = spaces.map(&:organization_guid).uniq

--- a/app/decorators/include_space_organization_decorator.rb
+++ b/app/decorators/include_space_organization_decorator.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   class IncludeSpaceOrganizationDecorator
     class << self
       def match?(include)
-        include&.include?('org')
+        include&.any? { |i| %w(org organization).include?(i) }
       end
 
       def decorate(hash, spaces)

--- a/app/messages/app_show_message.rb
+++ b/app/messages/app_show_message.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
     register_allowed_keys [:include]
 
     validates_with NoAdditionalParamsValidator
-    validates_with IncludeParamValidator, valid_values: ['space', 'org']
+    validates_with IncludeParamValidator, valid_values: ['space', 'org', 'space.organization']
 
     def self.from_params(params)
       super(params, %w(include))

--- a/app/messages/apps_list_message.rb
+++ b/app/messages/apps_list_message.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
     ]
 
     validates_with NoAdditionalParamsValidator
-    validates_with IncludeParamValidator, valid_values: ['space', 'org']
+    validates_with IncludeParamValidator, valid_values: ['space', 'org', 'space.organization']
     validates_with LifecycleTypeParamValidator
 
     validates :names, array: true, allow_nil: true

--- a/app/messages/space_show_message.rb
+++ b/app/messages/space_show_message.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
     register_allowed_keys [:include]
 
     validates_with NoAdditionalParamsValidator
-    validates_with IncludeParamValidator, valid_values: ['org']
+    validates_with IncludeParamValidator, valid_values: ['org', 'organization']
 
     def self.from_params(params)
       super(params, %w(include))

--- a/app/messages/spaces_list_message.rb
+++ b/app/messages/spaces_list_message.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
     ]
 
     validates_with NoAdditionalParamsValidator
-    validates_with IncludeParamValidator, valid_values: ['org']
+    validates_with IncludeParamValidator, valid_values: ['org', 'organization']
 
     validates :names, array: true, allow_nil: true
     validates :organization_guids, array: true, allow_nil: true

--- a/docs/v3/source/includes/concepts/_includes.md.erb
+++ b/docs/v3/source/includes/concepts/_includes.md.erb
@@ -1,7 +1,7 @@
 ## Include
 
 The `include` parameter allows clients to fetch resources and ensure that information about the parent object(s) is part of the response.
-For example, a response to `/v3/spaces/:guid?include=org` will contain detailed information about the space and its parent org.
+For example, a response to `/v3/spaces/:guid?include=organization` will contain detailed information about the space and its parent organization.
 
 Developers may choose to use the `include` feature to reduce the number of API calls. The include
 query param can be used with a single resource or a list of resources.
@@ -12,10 +12,10 @@ The following resources can take an `include` parameter:
 
 Resource | Allowed values
 -------- | --------------
-**apps** | `org`, `space`
-**apps/[:guid]** | `org`, `space`
-**spaces** | `org`
-**spaces/[:guid]** | `org`
+**apps** | `space.organization`, `space`
+**apps/[:guid]** | `space.organization`, `space`
+**spaces** | `organization`
+**spaces/[:guid]** | `organization`
 
 ### Sample requests
 
@@ -25,7 +25,7 @@ Example request to apps resource to include parent orgs and spaces
 ```
 
 ```shell
-curl "https://api.example.org/v3/apps?include=org,space" \
+curl "https://api.example.org/v3/apps?include=space.organization" \
   -X GET \
   -H "Authorization: bearer [token]"
 ```
@@ -113,11 +113,11 @@ Example response
 ```
 
 ```
-Example request for all spaces including their parent orgs
+Example request for all spaces including their parent organizations
 ```
 
 ```shell
-curl "https://api.example.org/v3/spaces?include=org" \
+curl "https://api.example.org/v3/spaces?include=organization" \
   -X GET \
   -H "Authorization: bearer [token]"
 ```

--- a/docs/v3/source/includes/resources/apps/_get.md.erb
+++ b/docs/v3/source/includes/resources/apps/_get.md.erb
@@ -28,7 +28,7 @@ Content-Type: application/json
 
 Name | Type | Description
 ---- | ---- | ------------
-**include** | _string_ | **Experimental** - Optionally include additional related resources in the response. <br>Valid values are `space`, `org` or `space,org`
+**include** | _string_ | **Experimental** - Optionally include additional related resources in the response. <br>Valid values are `space` and `space.organization`.
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/apps/_list.md.erb
+++ b/docs/v3/source/includes/resources/apps/_list.md.erb
@@ -39,7 +39,7 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page. <br>Valid values are 1 through 5000.
 **order_by** | _string_ | Value to sort by. Defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`.
 **label_selector** | _string_ | **Experimental** - A query string containing a list of [label selector](#labels-and-selectors) requirements.
-**include** | _string_ | **Experimental** - Optionally include a list of unique related resources in the response. <br>Valid values are `space` and `org`, and are separated by a `,`
+**include** | _string_ | **Experimental** - Optionally include a list of unique related resources in the response. <br>Valid values are `space` and `space.organization`
 **lifecycle_type** | _string_ | [Lifecycle](#lifecycles) type to filter by. Valid values are `buildpack`, `docker`.
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
@@ -31,7 +31,7 @@ This endpoint retrieves the specified space object.
 
 Name | Type | Description
 ---- | ---- | ------------
-**include** | _string_ | **Experimental** - Optionally include additional related resources in the response. <br>Valid value is `org`.
+**include** | _string_ | **Experimental** - Optionally include additional related resources in the response. <br>Valid value is `organization`.
 
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/spaces/_list.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_list.md.erb
@@ -37,7 +37,7 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page. <br>Valid values are 1 through 5000.
 **order_by** | _string_ | Value to sort by. Defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`.
 **label_selector** | _string_ | **Experimental** - A query string containing a list of [label selector](#labels-and-selectors) requirements.
-**include** | _string_ | **Experimental** - Optionally include a list of unique related resources in the response. <br>Valid value is `org`.
+**include** | _string_ | **Experimental** - Optionally include a list of unique related resources in the response. <br>Valid value is `organization`.
 
 #### Permitted roles
  |

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -822,7 +822,7 @@ RSpec.describe 'Apps' do
           space: space2
         )
 
-        get '/v3/apps?per_page=2&include=space,org', nil, admin_header
+        get '/v3/apps?per_page=2&include=space,space.organization', nil, admin_header
         expect(last_response.status).to eq(200)
 
         parsed_response = MultiJson.load(last_response.body)
@@ -876,7 +876,7 @@ RSpec.describe 'Apps' do
       end
 
       it 'flags unsupported includes that contain supported ones' do
-        get '/v3/apps?per_page=2&include=org,spaceship,borgs,space', nil, admin_header
+        get '/v3/apps?per_page=2&include=space.organization,spaceship,borgs,space', nil, admin_header
         expect(last_response.status).to eq(400)
       end
 
@@ -1026,7 +1026,7 @@ RSpec.describe 'Apps' do
     end
 
     it 'gets a specific app including space and org' do
-      get "/v3/apps/#{app_model.guid}?include=org,space", nil, user_header
+      get "/v3/apps/#{app_model.guid}?include=space.organization,space", nil, user_header
       expect(last_response.status).to eq(200)
 
       parsed_response = MultiJson.load(last_response.body)

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -1026,7 +1026,7 @@ RSpec.describe 'Apps' do
     end
 
     it 'gets a specific app including space and org' do
-      get "/v3/apps/#{app_model.guid}?include=space.organization,space", nil, user_header
+      get "/v3/apps/#{app_model.guid}?include=space.organization", nil, user_header
       expect(last_response.status).to eq(200)
 
       parsed_response = MultiJson.load(last_response.body)

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Spaces' do
     end
 
     it 'returns the requested space including org info' do
-      get "/v3/spaces/#{space1.guid}?include=org", nil, user_header
+      get "/v3/spaces/#{space1.guid}?include=organization", nil, user_header
       expect(last_response.status).to eq(200)
 
       parsed_response = MultiJson.load(last_response.body)
@@ -262,7 +262,7 @@ RSpec.describe 'Spaces' do
       let!(:org2)              { VCAP::CloudController::Organization.make name: 'Videogames', created_at: 1.days.ago }
 
       it 'can includes all orgs for spaces' do
-        get '/v3/spaces?include=org', nil, admin_header
+        get '/v3/spaces?include=organization', nil, admin_header
         expect(last_response.status).to eq(200)
         parsed_response = MultiJson.load(last_response.body)
 
@@ -321,7 +321,7 @@ RSpec.describe 'Spaces' do
       end
 
       it 'flags unsupported includes that contain supported ones' do
-        get '/v3/spaces?include=org,not_supported', nil, admin_header
+        get '/v3/spaces?include=organization,not_supported', nil, admin_header
         expect(last_response.status).to eq(400)
       end
 

--- a/spec/unit/decorators/include_app_organization_decorator_spec.rb
+++ b/spec/unit/decorators/include_app_organization_decorator_spec.rb
@@ -25,5 +25,15 @@ module VCAP::CloudController
                                                               Presenters::V3::OrganizationPresenter.new(organization2).to_hash])
       expect(hash[:included][:monkeys]).to match_array(['zach', 'greg'])
     end
+
+    describe '.match?' do
+      it 'matches include arrays containing "org"' do
+        expect(decorator.match?(['potato', 'org', 'turnip'])).to be_truthy
+      end
+
+      it 'does not match other include arrays' do
+        expect(decorator.match?(['potato', 'turnip'])).to be_falsey
+      end
+    end
   end
 end

--- a/spec/unit/decorators/include_app_organization_decorator_spec.rb
+++ b/spec/unit/decorators/include_app_organization_decorator_spec.rb
@@ -31,6 +31,10 @@ module VCAP::CloudController
         expect(decorator.match?(['potato', 'org', 'turnip'])).to be_truthy
       end
 
+      it 'matches include arrays containing "space.organization"' do
+        expect(decorator.match?(['potato', 'space.organization', 'turnip'])).to be_truthy
+      end
+
       it 'does not match other include arrays' do
         expect(decorator.match?(['potato', 'turnip'])).to be_falsey
       end

--- a/spec/unit/decorators/include_app_space_decorator_spec.rb
+++ b/spec/unit/decorators/include_app_space_decorator_spec.rb
@@ -27,6 +27,10 @@ module VCAP::CloudController
         expect(decorator.match?(['potato', 'space', 'turnip'])).to be_truthy
       end
 
+      it 'matches include arrays containing "space.organization"' do
+        expect(decorator.match?(['potato', 'space.organization', 'turnip'])).to be_truthy
+      end
+
       it 'does not match other include arrays' do
         expect(decorator.match?(['potato', 'turnip'])).to be_falsey
       end

--- a/spec/unit/decorators/include_app_space_decorator_spec.rb
+++ b/spec/unit/decorators/include_app_space_decorator_spec.rb
@@ -21,5 +21,15 @@ module VCAP::CloudController
       expect(hash[:included][:spaces]).to match_array([Presenters::V3::SpacePresenter.new(space1).to_hash, Presenters::V3::SpacePresenter.new(space2).to_hash])
       expect(hash[:included][:monkeys]).to match_array(['zach', 'greg'])
     end
+
+    describe '.match?' do
+      it 'matches include arrays containing "space"' do
+        expect(decorator.match?(['potato', 'space', 'turnip'])).to be_truthy
+      end
+
+      it 'does not match other include arrays' do
+        expect(decorator.match?(['potato', 'turnip'])).to be_falsey
+      end
+    end
   end
 end

--- a/spec/unit/decorators/include_space_organization_decorator_spec.rb
+++ b/spec/unit/decorators/include_space_organization_decorator_spec.rb
@@ -35,6 +35,10 @@ module VCAP::CloudController
         expect(decorator.match?(['potato', 'org', 'turnip'])).to be_truthy
       end
 
+      it 'matches include arrays containing "organization"' do
+        expect(decorator.match?(['potato', 'organization', 'turnip'])).to be_truthy
+      end
+
       it 'does not match other include arrays' do
         expect(decorator.match?(['potato', 'turnip'])).to be_falsey
       end

--- a/spec/unit/decorators/include_space_organization_decorator_spec.rb
+++ b/spec/unit/decorators/include_space_organization_decorator_spec.rb
@@ -29,5 +29,15 @@ module VCAP::CloudController
       ])
       expect(hash[:included][:monkeys]).to match_array(['zach', 'greg'])
     end
+
+    describe '.match?' do
+      it 'matches include arrays containing "org"' do
+        expect(decorator.match?(['potato', 'org', 'turnip'])).to be_truthy
+      end
+
+      it 'does not match other include arrays' do
+        expect(decorator.match?(['potato', 'turnip'])).to be_falsey
+      end
+    end
   end
 end

--- a/spec/unit/messages/app_show_message_spec.rb
+++ b/spec/unit/messages/app_show_message_spec.rb
@@ -13,6 +13,8 @@ module VCAP::CloudController
       expect(message).to be_valid
       message = AppShowMessage.from_params({ 'include' => 'org' })
       expect(message).to be_valid
+      message = AppShowMessage.from_params({ 'include' => 'space.organization' })
+      expect(message).to be_valid
       message = AppShowMessage.from_params({ 'include' => 'greg\'s buildpack' })
       expect(message).not_to be_valid
     end

--- a/spec/unit/messages/apps_list_message_spec.rb
+++ b/spec/unit/messages/apps_list_message_spec.rb
@@ -14,7 +14,7 @@ module VCAP::CloudController
           'page' => 1,
           'per_page' => 5,
           'order_by' => 'created_at',
-          'include' => 'space,org',
+          'include' => 'space,space.organization',
           'label_selector' => 'foo in (stuff,things)',
           'lifecycle_type' => 'buildpack',
         }
@@ -32,7 +32,7 @@ module VCAP::CloudController
         expect(message.page).to eq(1)
         expect(message.per_page).to eq(5)
         expect(message.order_by).to eq('created_at')
-        expect(message.include).to eq(['space', 'org'])
+        expect(message.include).to eq(['space', 'space.organization'])
         expect(message.label_selector).to eq('foo in (stuff,things)')
         expect(message.requirements.first.key).to eq('foo')
         expect(message.requirements.first.operator).to eq(:in)
@@ -66,7 +66,7 @@ module VCAP::CloudController
           page: 1,
           per_page: 5,
           order_by: 'created_at',
-          include: ['space', 'org'],
+          include: ['space', 'space.organization'],
           label_selector: 'foo in (stuff,things)',
           lifecycle_type: 'buildpack'
         }
@@ -89,7 +89,7 @@ module VCAP::CloudController
                                 page: 1,
                                 per_page: 5,
                                 order_by: 'created_at',
-                                include: ['space', 'org'],
+                                include: ['space', 'space.organization'],
                                 label_selector: 'foo in (stuff,things)',
                                 lifecycle_type: 'buildpack',
                               })
@@ -111,9 +111,9 @@ module VCAP::CloudController
       it 'does not accept include that is not space' do
         message = AppsListMessage.from_params({ 'include' => 'space' })
         expect(message).to be_valid
-        message = AppsListMessage.from_params({ 'include' => 'org' })
+        message = AppsListMessage.from_params({ 'include' => 'space.organization' })
         expect(message).to be_valid
-        message = AppsListMessage.from_params({ 'include' => 'space,org' })
+        message = AppsListMessage.from_params({ 'include' => 'space,space.organization' })
         expect(message).to be_valid
         message = AppsListMessage.from_params({ 'include' => 'greg\'s buildpack' })
         expect(message).not_to be_valid
@@ -165,19 +165,19 @@ module VCAP::CloudController
         end
 
         it 'validates possible includes' do
-          message = AppsListMessage.from_params 'include' => 'org,space'
+          message = AppsListMessage.from_params 'include' => 'space.organization,space'
           expect(message).to be_valid
           message = AppsListMessage.from_params 'include' => 'borg,spaceship'
           expect(message).to be_invalid
-          message = AppsListMessage.from_params 'include' => 'org,spaceship'
+          message = AppsListMessage.from_params 'include' => 'space.organization,spaceship'
           expect(message).to be_invalid
         end
 
         it 'invalidates duplicates in the includes field' do
-          message = AppsListMessage.from_params 'include' => 'org,org'
+          message = AppsListMessage.from_params 'include' => 'space.organization,space.organization'
           expect(message).to be_invalid
           expect(message.errors[:base].length).to eq 1
-          expect(message.errors[:base][0]).to match(/Duplicate included resource: 'org'/)
+          expect(message.errors[:base][0]).to match(/Duplicate included resource: 'space.organization'/)
         end
 
         it 'validates lifecycle_type is one of two values' do

--- a/spec/unit/messages/space_show_message_spec.rb
+++ b/spec/unit/messages/space_show_message_spec.rb
@@ -11,6 +11,8 @@ module VCAP::CloudController
     it 'does not accept include that is not space or org' do
       message = SpaceShowMessage.from_params({ 'include' => 'org' })
       expect(message).to be_valid
+      message = SpaceShowMessage.from_params({ 'include' => 'organization' })
+      expect(message).to be_valid
       message = SpaceShowMessage.from_params({ 'include' => 'sunny\'s droplet' })
       expect(message).not_to be_valid
     end

--- a/spec/unit/messages/spaces_list_message_spec.rb
+++ b/spec/unit/messages/spaces_list_message_spec.rb
@@ -11,7 +11,7 @@ module VCAP::CloudController
           'names' => 'foo,bar',
           'organization_guids' => 'org1-guid,org2-guid',
           'guids' => 'space1-guid,space2-guid',
-          'include' => 'org'
+          'include' => 'organization'
         }
       end
 
@@ -25,7 +25,7 @@ module VCAP::CloudController
         expect(message.names).to eql(['foo', 'bar'])
         expect(message.organization_guids).to eql(['org1-guid', 'org2-guid'])
         expect(message.guids).to eql(['space1-guid', 'space2-guid'])
-        expect(message.include).to eql(['org'])
+        expect(message.include).to eql(['organization'])
       end
 
       it 'converts requested keys to symbols' do
@@ -67,6 +67,8 @@ module VCAP::CloudController
 
       it 'validates possible includes' do
         message = SpacesListMessage.from_params 'include' => 'org'
+        expect(message).to be_valid
+        message = SpacesListMessage.from_params 'include' => 'organization'
         expect(message).to be_valid
         message = SpacesListMessage.from_params 'include' => 'spaceship'
         expect(message).to be_invalid


### PR DESCRIPTION
Update current includes on v3 API to conform to https://docs.google.com/document/d/1iLsVoRm03Iy6rMWJGKENVo-2_3p2Ecr51AH5szmplF4/edit

Old include strings will still work, but are no longer documented.

`GET /v3/apps(/:guid)?include=org` is now `GET /v3/apps(/:guid)?include=space.organization`
`GET /v3/spaces(/:guid)?include=org` is now `GET /v3/apps(/:guid)?include=organization`

Also, specifying multi-step include paths will now automatically include intermediate resources. This is because the relationships on the intermediate resources are needed to link the included resources to the root resource. For example: `include=space.organization` will include spaces and organizations.