### PR TITLE
Add log-cache endpoint to /

### DIFF
--- a/app/controllers/runtime/root_controller.rb
+++ b/app/controllers/runtime/root_controller.rb
@@ -50,6 +50,10 @@ module VCAP::CloudController
             href: config.get(:doppler, :url)
           },
 
+          log_cache:             {
+              href: config.get(:log_cache, :url)
+          },
+
           log_stream:             {
               href: config.get(:log_stream, :url)
           },

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -101,6 +101,9 @@ logcache_tls:
 doppler:
   url: 'wss://doppler.example.com:443'
 
+log_cache:
+  url: 'https://log-cache.example.com'
+
 log_stream:
   url: 'https://log-stream.example.com'
 

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -222,6 +222,10 @@ module VCAP::CloudController
             url: String
           },
 
+          log_cache: {
+              url: String
+          },
+
           log_stream: {
               url: String
           },

--- a/spec/unit/controllers/runtime/root_controller_spec.rb
+++ b/spec/unit/controllers/runtime/root_controller_spec.rb
@@ -152,6 +152,14 @@ module VCAP::CloudController
         expect(hash['links']['logging']['href']).to eq(expected_uri)
       end
 
+      it 'returns a link to the log cache API' do
+        expected_uri = 'https://log-cache.example.com'
+
+        get '/'
+        hash = MultiJson.load(last_response.body)
+        expect(hash['links']['log_cache']['href']).to eq(expected_uri)
+      end
+
       it 'returns a link to the v2 logging API' do
         expected_uri = 'https://log-stream.example.com'
 


### PR DESCRIPTION
[#168083320]

Signed-off-by: Tom Chen tochen@pivotal.io

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

A short explanation of the proposed change:
Add the log-cache url to /info endpoint

An explanation of the use cases your change solves
Promotes log-cache to a first class citizen (CF CLI wants).

Links to any other associated PRs
cloudfoundry/capi-release#153

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
