### PR TITLE
Provide disk quota when desiring lrp from opi

### DIFF
--- a/lib/cloud_controller/opi/apps_client.rb
+++ b/lib/cloud_controller/opi/apps_client.rb
@@ -77,6 +77,7 @@ module OPI
         environment: hash_values_to_s(environment_variables(process)),
         instances: process.desired_instances,
         memory_mb: process.memory,
+        disk_mb: process.disk_quota,
         cpu_weight: cpu_weight,
         droplet_hash: process.desired_droplet.droplet_hash,
         droplet_guid: process.desired_droplet.guid,

--- a/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe(OPI::Client) do
             },
             instances: 21,
             memory_mb: 128,
+            disk_mb: 256,
             cpu_weight: 1,
             droplet_hash: lrp.droplet_hash,
             droplet_guid: 'some-droplet-guid',


### PR DESCRIPTION
[#167725778](https://www.pivotaltracker.com/story/show/167725778)

* A short explanation of the proposed change:
Sends over the desired disk limit to eirini, so it can be properly set in the pod spec.

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
NOTE: We only ran the ones which work with Eirni. But since the change is only in the opi apps client, it should give us enough confidence.
