### PR TITLE
Implement no-op Task client for OPI

### DIFF
--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -29,6 +29,7 @@ require 'credhub/client'
 require 'cloud_controller/opi/apps_client'
 require 'cloud_controller/opi/instances_client'
 require 'cloud_controller/opi/stager_client'
+require 'cloud_controller/opi/task_client'
 
 require 'bits_service_client'
 
@@ -84,7 +85,7 @@ module CloudController
     end
 
     def bbs_task_client
-      @dependencies[:bbs_task_client] || register(:bbs_task_client, build_bbs_task_client)
+      @dependencies[:bbs_task_client] || register(:bbs_task_client, build_task_client)
     end
 
     def bbs_instances_client
@@ -407,6 +408,18 @@ module CloudController
 
     def build_bbs_apps_client
       VCAP::CloudController::Diego::BbsAppsClient.new(build_bbs_client, config)
+    end
+
+    def build_task_client
+      if config.get(:opi, :enabled)
+        build_opi_task_client
+      else
+        build_bbs_task_client
+      end
+    end
+
+    def build_opi_task_client
+      ::OPI::TaskClient.new(config)
     end
 
     def build_bbs_task_client

--- a/lib/cloud_controller/opi/task_client.rb
+++ b/lib/cloud_controller/opi/task_client.rb
@@ -1,0 +1,22 @@
+require 'httpclient'
+require 'cloud_controller/opi/base_client'
+
+module OPI
+  class TaskClient < BaseClient
+    def desire_task(task_guid, task_definition, domain)
+      nil
+    end
+
+    def fetch_task(_)
+      Diego::Bbs::Models::Task.new
+    end
+
+    def fetch_tasks
+      []
+    end
+
+    def cancel_task(_); end
+
+    def bump_freshness; end
+  end
+end

--- a/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
@@ -1,0 +1,71 @@
+# require 'support/bootstrap/test_config'
+require 'spec_helper'
+require 'cloud_controller/opi/task_client'
+
+RSpec.describe(OPI::TaskClient) do
+  let(:opi_url) { 'http://opi.service.cf.internal:8077' }
+  let(:config) do
+    TestConfig.override(
+      opi: {
+        url: opi_url
+      },
+    )
+  end
+
+  subject(:client) { described_class.new(config) }
+
+  describe 'can desire a task' do
+    it 'should return nothing' do
+      response = client.desire_task(nil, nil, nil)
+      expect(response).to be_nil
+    end
+
+    it 'should not send any request to opi' do
+      expect(a_request(:any, opi_url)).not_to have_been_made
+    end
+  end
+
+  describe 'can fetch a task' do
+    it 'should return a empty dummy task' do
+      task = client.fetch_task('some-guid')
+      expect(task).to eq(Diego::Bbs::Models::Task.new)
+    end
+
+    it 'should not send any request to opi' do
+      expect(a_request(:any, opi_url)).not_to have_been_made
+    end
+  end
+
+  describe 'can fetch all tasks' do
+    it 'should return an empty list' do
+      tasks = client.fetch_tasks
+      expect(tasks).to be_empty
+    end
+
+    it 'should not send any request to opi' do
+      expect(a_request(:any, opi_url)).not_to have_been_made
+    end
+  end
+
+  describe 'can cancel a task' do
+    it 'should return nothing' do
+      response = client.cancel_task(nil)
+      expect(response).to be_nil
+    end
+
+    it 'should not send any request to opi' do
+      expect(a_request(:any, opi_url)).not_to have_been_made
+    end
+  end
+
+  describe 'can bump freshness' do
+    it 'should return nothing' do
+      response = client.bump_freshness
+      expect(response).to be_nil
+    end
+
+    it 'should not send any request to opi' do
+      expect(a_request(:any, opi_url)).not_to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
* A short explanation of the proposed change:

This PR adds a no-op task client that will be used when OPI is enabled.

Currently, CC always uses `bbs_task_client` which tries to connect to Diego when CC clock runs its `tasks_sync` loop. With Eirini, Diego is no longer used for staging (by default) and is not deployed. Therefore `bbs_task_client` constantly returns the following errors in CC clock:
```
VCAP::CloudController::Diego::TasksSync::BBSFetchError: Task workers are unavailable: getaddrinfo: Name or service not known (diego-api-bbs.scf.svc.cluster.local:8889)
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/lib/cloud_controller/diego/tasks_sync.rb:58:in `rescue in sync'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/lib/cloud_controller/diego/tasks_sync.rb:71:in `sync'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/app/jobs/diego/sync.rb:18:in `block in perform'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/statsd-ruby-1.4.0/lib/statsd.rb:412:in `time'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/app/jobs/diego/sync.rb:16:in `perform'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/app/jobs/wrapping_job.rb:11:in `perform'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/app/jobs/timeout_job.rb:13:in `block in perform'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/app/jobs/timeout_job.rb:12:in `perform'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/backend/base.rb:81:in `block in invoke_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/lifecycle.rb:61:in `block in initialize'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/lifecycle.rb:66:in `execute'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/backend/base.rb:78:in `invoke_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/backend/base.rb:19:in `block (2 levels) in enqueue_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/lifecycle.rb:61:in `block in initialize'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/lifecycle.rb:66:in `execute'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/backend/base.rb:17:in `block in enqueue_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/backend/base.rb:16:in `tap'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/backend/base.rb:16:in `enqueue_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/delayed_job-4.1.5/lib/delayed/backend/base.rb:12:in `enqueue'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/app/jobs/enqueuer.rb:31:in `block in run_inline'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/app/jobs/enqueuer.rb:56:in `run_immediately'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/app/jobs/enqueuer.rb:30:in `run_inline'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/lib/cloud_controller/clock/clock.rb:51:in `block in schedule_frequent_inline_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/lib/cloud_controller/clock/clock.rb:58:in `block in schedule_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/lib/cloud_controller/clock/distributed_scheduler.rb:12:in `block (2 levels) in schedule_periodic_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/lib/cloud_controller/clock/distributed_executor.rb:30:in `execute_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/cloud_controller_ng/lib/cloud_controller/clock/distributed_scheduler.rb:12:in `block in schedule_periodic_job'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/clockwork-2.0.3/lib/clockwork/event.rb:58:in `execute'
/var/vcap/packages/.src/4f233290b34ea859bfacecc196e7c35541e4290e/gem_home/ruby/2.4.0/gems/clockwork-2.0.3/lib/clockwork/event.rb:41:in `block in run'

```

By adding this dummy client, the errors mentioned above are no longer there.

For more info, [here's a link to the story in tracker](https://www.pivotaltracker.com/story/show/166813738).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
