### PR TITLE
only create start usage events for RUNNING tasks

### DIFF
--- a/spec/unit/models/runtime/task_model_spec.rb
+++ b/spec/unit/models/runtime/task_model_spec.rb
@@ -5,13 +5,11 @@ module VCAP::CloudController
     let(:parent_app) { AppModel.make }
 
     describe 'after create' do
-      it 'creates a TASK_STARTED event' do
+      it 'does not create a TASK_STARTED event' do
         task = TaskModel.make(app: parent_app, state: TaskModel::PENDING_STATE)
 
         event = AppUsageEvent.find(task_guid: task.guid, state: 'TASK_STARTED')
-        expect(event).not_to be_nil
-        expect(event.task_guid).to eq(task.guid)
-        expect(event.parent_app_guid).to eq(task.app.guid)
+        expect(event).to be_nil
       end
     end
 
@@ -46,6 +44,15 @@ module VCAP::CloudController
 
           event = AppUsageEvent.find(task_guid: task.guid, state: 'TASK_STOPPED')
           expect(event).to be_nil
+        end
+
+        it 'creates a TASK_STARTED event' do
+          task.update(state: TaskModel::RUNNING_STATE)
+
+          event = AppUsageEvent.find(task_guid: task.guid, state: 'TASK_STARTED')
+          expect(event).not_to be_nil
+          expect(event.task_guid).to eq(task.guid)
+          expect(event.parent_app_guid).to eq(task.app.guid)
         end
       end
 


### PR DESCRIPTION
Related issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/1365 has more context. I've felt personally invested in this issue for a couple years now, so here's a PR. 🙂 

- [App Usage Events](https://docs.cloudfoundry.org/running/managing-cf/usage-events.html#app-usage-events) are used to inform consumers (such as billing
systems) of changes of app/task state that affect resource consumption
on the underlying platform
- A CF Task is not actually consuming resources until it is scheduled on
the runtime and transitions into the RUNNING state so this change
creates the `TASK_STARTED` event when the task is RUNNING instead of
PENDING
- A separate bug (https://www.pivotaltracker.com/story/show/152831505)
where the Task Syncer ignores PENDING tasks forever can cause tasks that
are never scheduled to linger in the PENDING state for a very long time.
This change mitigates the impact of that issue on billing.

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
