### PR TITLE
Rename 'credentials' to 'authentication' when creating a service broker

### DIFF
--- a/app/actions/service_broker_create.rb
+++ b/app/actions/service_broker_create.rb
@@ -18,8 +18,8 @@ module VCAP::CloudController
         params = {
           name: message.name,
           broker_url: message.url,
-          auth_username: message.credentials_data.username,
-          auth_password: message.credentials_data.password,
+          auth_username: message.authentication_credentials.username,
+          auth_password: message.authentication_credentials.password,
           space_guid: message.relationships_message.space_guid
         }
 

--- a/docs/v3/source/includes/api_resources/_service_brokers.erb
+++ b/docs/v3/source/includes/api_resources/_service_brokers.erb
@@ -80,28 +80,28 @@
 <% end %>
 
 <% content_for :service_broker_credentials_object do %>
-#### The credentials object
+#### The authentication object
 
 Name | Type | Description
 ---- | ---- | -----------
 **type** | _string_ | Type of the authentication mechanisms that can be used. Valid value is `basic`.
-**data** | _object_ | Data is used to hold the actual credentials depending on the authentication mechanism.
+**credentials** | _object_ | Credentials for given authentication type.
 
 ```
-Example basic credentials
+Example basic authentication
 ```
 
 ```json
 {
   "type": "basic",
-  "data": {
+  "credentials": {
     "username": "admin",
     "password": "secretpassw0rd"
   }
 }
 ```
 
-##### Basic credentials data
+##### Basic authentication credentials
 
 Name | Type | Description
 ---- | ---- | -----------

--- a/docs/v3/source/includes/experimental_resources/service_brokers/_create.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_brokers/_create.md.erb
@@ -34,13 +34,12 @@ Example Response
 ```
 
 ```http
-HTTP/1.1 201 Created
+HTTP/1.1 202 Created
 Content-Type: application/json
-
-<%= yield_content :single_service_broker %>
+Location: https://api.example.org/v3/jobs/af5c57f6-8769-41fa-a499-2c84ed896788
 ```
 
-This endpoint creates a new service broker.
+This endpoint creates a new service broker and a job to synchronize the service offerings and service plans with those in the broker's catalog.  The `Location` header refers to the created job which syncs the broker with the catalog.
 
 #### Definition
 `POST /v3/service_brokers`
@@ -51,7 +50,7 @@ Name | Type | Description
 ---- | ---- | -----------
 **name** | _string_ | Name of the service broker.
 **url** | _string_ | URL of the service broker.
-**credentials** | [_credentials_](#the-credentials-object) | Credentials used to authenticate against the service broker.
+**authentication** | [_authentication_](#the-authentication-object) | Credentials used to authenticate against the service broker.
 
 #### Optional parameters
 

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe 'V3 service brokers' do
     {
       name: 'broker name',
       url: 'http://example.org/broker-url',
-      credentials: {
+      authentication: {
         type: 'basic',
-        data: {
+        credentials: {
           username: 'admin',
           password: 'welcome',
         }
@@ -102,7 +102,7 @@ RSpec.describe 'V3 service brokers' do
     {
       name: global_broker_request_body[:name],
       url: 'http://example.org/different-broker-url',
-      credentials: global_broker_request_body[:credentials]
+      authentication: global_broker_request_body[:authentication]
     }
   }
 
@@ -110,7 +110,7 @@ RSpec.describe 'V3 service brokers' do
     {
       name: 'different broker name',
       url: global_broker_request_body[:url],
-      credentials: global_broker_request_body[:credentials]
+      authentication: global_broker_request_body[:authentication]
     }
   }
 
@@ -118,9 +118,9 @@ RSpec.describe 'V3 service brokers' do
     {
       name: 'space-scoped broker name',
       url: 'http://example.org/space-broker-url',
-      credentials: {
+      authentication: {
         type: 'basic',
-        data: {
+        credentials: {
           username: 'admin',
           password: 'welcome',
         },
@@ -383,8 +383,8 @@ RSpec.describe 'V3 service brokers' do
         broker = VCAP::CloudController::ServiceBroker.last
         expect(broker.name).to eq(global_broker_request_body[:name])
         expect(broker.broker_url).to eq(global_broker_request_body[:url])
-        expect(broker.auth_username).to eq(global_broker_request_body.dig(:credentials, :data, :username))
-        expect(broker.auth_password).to eq(global_broker_request_body.dig(:credentials, :data, :password))
+        expect(broker.auth_username).to eq(global_broker_request_body.dig(:authentication, :credentials, :username))
+        expect(broker.auth_password).to eq(global_broker_request_body.dig(:authentication, :credentials, :password))
         expect(broker.space).to be_nil
         expect(broker.service_broker_state.state).to eq(VCAP::CloudController::ServiceBrokerStateEnum::SYNCHRONIZING)
       end
@@ -642,9 +642,9 @@ RSpec.describe 'V3 service brokers' do
           {
             name: 'space-scoped broker name',
             url: 'http://example.org/space-broker-url',
-            credentials: {
+            authentication: {
               type: 'basic',
-              data: {
+              credentials: {
                 username: 'admin',
                 password: 'welcome',
               },
@@ -710,8 +710,8 @@ RSpec.describe 'V3 service brokers' do
           broker = VCAP::CloudController::ServiceBroker.last
           expect(broker.name).to eq(space_scoped_broker_request_body[:name])
           expect(broker.broker_url).to eq(space_scoped_broker_request_body[:url])
-          expect(broker.auth_password).to eq(space_scoped_broker_request_body.dig(:credentials, :data, :password))
-          expect(broker.auth_username).to eq(space_scoped_broker_request_body.dig(:credentials, :data, :username))
+          expect(broker.auth_password).to eq(space_scoped_broker_request_body.dig(:authentication, :credentials, :password))
+          expect(broker.auth_username).to eq(space_scoped_broker_request_body.dig(:authentication, :credentials, :username))
           expect(broker.space.guid).to eq(space_scoped_broker_request_body.dig(:relationships, :space, :data, :guid))
         end
 
@@ -793,9 +793,9 @@ RSpec.describe 'V3 service brokers' do
           {
             name: 'space-scoped broker name',
             url: 'http://example.org/space-broker-url',
-            credentials: {
+            authentication: {
               type: 'basic',
-              data: {
+              credentials: {
                 username: 'admin',
                 password: 'welcome',
               },
@@ -845,12 +845,12 @@ RSpec.describe 'V3 service brokers' do
       expect(service_broker).to include(
         'name' => expected_broker[:name],
         'broker_url' => expected_broker[:url],
-        'auth_username' => expected_broker.dig(:credentials, :data, :username),
+        'auth_username' => expected_broker.dig(:authentication, :credentials, :username),
         'space_guid' => expected_broker.dig(:relationships, :space, :data, :guid),
       )
 
       # asserting password separately because it is not exported in to_hash
-      expect(service_broker.auth_password).to eq(expected_broker[:credentials][:data][:password])
+      expect(service_broker.auth_password).to eq(expected_broker[:authentication][:credentials][:password])
     end
 
     def expect_broker_status(available:, status:, with:)

--- a/spec/unit/actions/service_broker_create_spec.rb
+++ b/spec/unit/actions/service_broker_create_spec.rb
@@ -17,7 +17,7 @@ module VCAP
         double('create broker message', {
           name: name,
           url: broker_url,
-          credentials_data: double('credentials', {
+          authentication_credentials: double('credentials', {
             username: auth_username,
             password: auth_password
           }),
@@ -31,7 +31,7 @@ module VCAP
         double('create broker message 2', {
           name: "#{name}-2",
           url: broker_url + '2',
-          credentials_data: double('credentials 2', {
+          authentication_credentials: double('credentials 2', {
             username: auth_username + '2',
             password: auth_password + '2'
           }),

--- a/spec/unit/messages/service_broker_create_message_spec.rb
+++ b/spec/unit/messages/service_broker_create_message_spec.rb
@@ -12,9 +12,9 @@ module VCAP::CloudController
         {
           name: 'best-broker',
           url: 'https://the-best-broker.url',
-          credentials: {
+          authentication: {
             type: 'basic',
-            data: {
+            credentials: {
               username: 'user',
               password: 'pass',
             }
@@ -130,7 +130,7 @@ module VCAP::CloudController
           it 'is not valid' do
             message = ServiceBrokerCreateMessage.new(request_body)
             expect(message).not_to be_valid
-            expect(message.errors_on(:url)).to include('must not contain credentials')
+            expect(message.errors_on(:url)).to include('must not contain authentication')
           end
         end
 
@@ -142,28 +142,28 @@ module VCAP::CloudController
           it 'is not valid' do
             message = ServiceBrokerCreateMessage.new(request_body)
             expect(message).not_to be_valid
-            expect(message.errors_on(:url)).to include('must not contain credentials')
+            expect(message.errors_on(:url)).to include('must not contain authentication')
           end
         end
       end
 
-      context 'credentials' do
-        context 'when credentials is not a hash' do
+      context 'authentication' do
+        context 'when authentication is not a hash' do
           let(:request_body) do
-            valid_body.except(:credentials)
+            valid_body.except(:authentication)
           end
 
           it 'is not valid' do
             message = ServiceBrokerCreateMessage.new(request_body)
 
             expect(message).not_to be_valid
-            expect(message.errors_on(:credentials)).to include('must be a hash')
+            expect(message.errors_on(:authentication)).to include('must be a hash')
           end
         end
 
-        context 'when credentials.type is invalid' do
+        context 'when authentication.type is invalid' do
           let(:request_body) do
-            valid_body.merge(credentials: {
+            valid_body.merge(authentication: {
               type: 'oopsie'
             })
           end
@@ -172,13 +172,13 @@ module VCAP::CloudController
             message = ServiceBrokerCreateMessage.new(request_body)
 
             expect(message).not_to be_valid
-            expect(message.errors_on(:credentials_type)).to include('credentials.type must be one of ["basic"]')
+            expect(message.errors_on(:authentication_type)).to include('authentication.type must be one of ["basic"]')
           end
         end
 
-        context 'when username and password are missing from data' do
+        context 'when username and password are missing from credentials' do
           let(:request_body) do
-            valid_body.merge(credentials: {
+            valid_body.merge(authentication: {
               type: 'basic',
               data: {},
             })
@@ -188,13 +188,13 @@ module VCAP::CloudController
             message = ServiceBrokerCreateMessage.new(request_body)
 
             expect(message).not_to be_valid
-            expect(message.errors_on(:credentials_data)).to include(/Field\(s\) \["username", "password"\] must be valid/)
+            expect(message.errors_on(:authentication_credentials)).to include(/Field\(s\) \["username", "password"\] must be valid/)
           end
         end
 
-        context 'when data is missing from credentials' do
+        context 'when data is missing from authentication' do
           let(:request_body) do
-            valid_body.merge(credentials: {
+            valid_body.merge(authentication: {
               type: 'basic'
             })
           end
@@ -203,13 +203,13 @@ module VCAP::CloudController
             message = ServiceBrokerCreateMessage.new(request_body)
 
             expect(message).not_to be_valid
-            expect(message.errors_on(:credentials_data)).to include('must be a hash')
+            expect(message.errors_on(:authentication_credentials)).to include('must be a hash')
           end
         end
 
-        context 'when credentials has extra fields' do
+        context 'when authentication has extra fields' do
           let(:request_body) do
-            valid_body.merge(credentials: {
+            valid_body.merge(authentication: {
               extra: 'value',
               type: 'basic',
             })
@@ -219,7 +219,7 @@ module VCAP::CloudController
             message = ServiceBrokerCreateMessage.new(request_body)
 
             expect(message).not_to be_valid
-            expect(message.errors_on(:credentials)).to include("Unknown field(s): 'extra'")
+            expect(message.errors_on(:authentication)).to include("Unknown field(s): 'extra'")
           end
         end
       end
@@ -227,7 +227,7 @@ module VCAP::CloudController
       context 'space guid relationship' do
         subject { ServiceBrokerCreateMessage.new(request_body) }
 
-        context 'when replationships is structured properly' do
+        context 'when relationships are structured properly' do
           let(:request_body) { valid_body.merge(relationships: { space: { data: { guid: 'space-guid-here' } } }) }
 
           it 'is valid' do
@@ -256,7 +256,7 @@ module VCAP::CloudController
           end
         end
 
-        context 'when replationships.space is not a hash' do
+        context 'when relationships.space is not a hash' do
           let(:request_body) { valid_body.merge(relationships: { space: 42 }) }
 
           it 'is not valid' do
@@ -274,7 +274,7 @@ module VCAP::CloudController
           end
         end
 
-        context 'when replationships.space.data is not a hash' do
+        context 'when relationships.space.data is not a hash' do
           let(:request_body) { valid_body.merge(relationships: { space: { data: 42 } }) }
 
           it 'is not valid' do
@@ -292,7 +292,7 @@ module VCAP::CloudController
           end
         end
 
-        context 'when replationships.space.data.guid is not a string' do
+        context 'when relationships.space.data.guid is not a string' do
           let(:request_body) { valid_body.merge(relationships: { space: { data: { guid: 42 } } }) }
 
           it 'is not valid' do


### PR DESCRIPTION
[finishes #168373589](https://www.pivotaltracker.com/story/show/168373589)

Co-authored-by: Joao Lebre <jlebre@pivotal.io>
