### PR TITLE
send process type to Eirini when desiring LRPs

### DIFF
--- a/lib/cloud_controller/opi/apps_client.rb
+++ b/lib/cloud_controller/opi/apps_client.rb
@@ -120,6 +120,7 @@ module OPI
         guid: process.guid,
         environment: hash_values_to_s(environment_variables(process)),
         version: process.version,
+        process_type: process.type,
         process_guid: process_guid(process),
         instances: process.desired_instances,
         memory_mb: process.memory,

--- a/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe(OPI::Client) do
         {
             guid: 'process-guid',
             version: lrp.version.to_s,
+            process_type: lrp.type,
             process_guid: "process-guid-#{lrp.version}",
             environment: {
               'BISH': 'BASH',


### PR DESCRIPTION
This will be used by Eirini to include process_type labels on the underlying StatefulSet/Pods so that the next-gen CF on k8s routing tier can directly tie the data on route destinations with the deployed workloads.

⚠️  **Required Eirini PR:** ⚠️ 
https://github.com/cloudfoundry-incubator/eirini/pull/77

Related doc:
https://docs.google.com/document/d/1EYRBVuQedU1r0zexgi8oMSOEFgaMNzM8JWBje3XuweU/edit?ts=5d9b9436

Eirini issue explaining this a bit more:
https://github.com/cloudfoundry-incubator/eirini/issues/76

[#168812438](https://www.pivotaltracker.com/n/projects/2172361/stories/168812438)

This requires https://github.com/cloudfoundry-incubator/eirini/pull/77 be merged before this works end-to-end, but I don't think it should break things if it is merged first.

* [x] I have viewed, signed, and submitted the Contributor License Agreement
