### PR TITLE
Refine metadata api doc alphanumeric wording

### DIFF
--- a/docs/v3/source/includes/concepts/_metadata.md.erb
+++ b/docs/v3/source/includes/concepts/_metadata.md.erb
@@ -53,14 +53,14 @@ A annotation key `prefix` must adhere to the following restrictions:
 A annotation key `name` must adhere to the following restrictions:
 
 * Length: 1-63 characters
-* Allowed characters: alphanumeric , `-`, `_`, and `.`
+* Allowed characters: alphanumeric ( \[a-z0-9A-Z\] ) , `-`, `_`, and `.`
 * Must begin and end with an alphanumeric character
 
 #### Annotation value
 
 Annotation values must adhere to the following restrictions:
 
-* Length: 0-5000 characters
+* Length: 0-5000 unicode characters
 
 ### Labels and selectors
 
@@ -118,13 +118,13 @@ Prefixes are dns names intended to enable namespacing of label keys.
 A label key `prefix` must adhere to the following restrictions:
 
 * Length: 0-253 characters
-* Allowed characters: alphanumeric, `-`, and `.`
+* Allowed characters: alphanumeric ( \[a-z0-9A-Z\] ), `-`, and `.`
 * DNS subdomain format (series of subdomain labels separated by `.`)
 
 A label key `name` must adhere to the following restrictions:
 
 * Length: 1-63 characters
-* Allowed characters: alphanumeric , `-`, `_`, and `.`
+* Allowed characters: alphanumeric ( \[a-z0-9A-Z\] ), `-`, `_`, and `.`
 * Must begin and end with an alphanumeric character
 
 ##### Label values
@@ -132,7 +132,7 @@ A label key `name` must adhere to the following restrictions:
 Label values must adhere to the following restrictions:
 
 * Length: 0-63 characters
-* Allowed characters: alphanumeric , `-`, `_`, and `.`
+* Allowed characters: alphanumeric ( \[a-z0-9A-Z\] ), `-`, `_`, and `.`
 * Must begin and end with an alphanumeric character
 * Empty values are allowed
 


### PR DESCRIPTION
## A short explanation of the proposed change:

Refine metadata alphanumeric wording:
- with normative regexp inspired from K8S documentation at https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
- mention that annotation values allow any unicode character until a max size.

The actual regexp used in the validator is slightly different but should be semantically equivalent AFAIK https://github.com/cloudfoundry/cloud_controller_ng/blob/0aa7d6c307bede69c3457dd08d25bc1d6f678bd5/app/messages/metadata_validator_helper.rb#L12 

## An explanation of the use cases your change solves

Discovery of annotations limitations, 

## Links to any other associated PRs

Suggested by @tcdowney  into https://github.com/cloudfoundry/docs-cf-admin/pull/162#issuecomment-540234348 


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
