### PR TITLE
Create broker audit events for V3 should reflect V3 request structure

### DIFF
--- a/app/actions/service_broker_create.rb
+++ b/app/actions/service_broker_create.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
           )
         end
 
-        service_event_repository.record_broker_event(:create, broker, params)
+        service_event_repository.record_broker_event_with_request(:create, broker, message.audit_hash)
 
         synchronization_job = SynchronizeBrokerCatalogJob.new(broker.guid)
         pollable_job = Jobs::Enqueuer.new(synchronization_job, queue: 'cc-generic').enqueue_pollable

--- a/app/messages/service_broker_create_message.rb
+++ b/app/messages/service_broker_create_message.rb
@@ -1,5 +1,6 @@
 require 'messages/base_message'
 require 'utils/hash_utils'
+require 'presenters/helpers/censorship'
 
 module VCAP::CloudController
   class ServiceBrokerCreateMessage < BaseMessage
@@ -77,6 +78,16 @@ module VCAP::CloudController
     end
 
     delegate :space_guid, to: :relationships_message
+
+    def audit_hash
+      result = super
+
+      if result['authentication'] && result['authentication']['credentials']
+        result['authentication']['credentials']['password'] = VCAP::CloudController::Presenters::Censorship::PRIVATE_DATA_HIDDEN
+      end
+
+      result
+    end
 
     class CredentialsMessage < BaseMessage
       register_allowed_keys [:type, :credentials]

--- a/app/repositories/service_event_repository.rb
+++ b/app/repositories/service_event_repository.rb
@@ -16,6 +16,7 @@ module VCAP::CloudController
       delegate(
         :record_service_plan_visibility_event,
         :record_broker_event,
+        :record_broker_event_with_request,
         :record_service_instance_event,
         :record_user_provided_service_instance_event,
         :record_service_key_event,
@@ -91,6 +92,16 @@ module VCAP::CloudController
 
         def record_broker_event(type, broker, params)
           metadata = metadata_for_broker_params(params)
+          actee    = {
+            actee:      broker.guid,
+            actee_type: 'service_broker',
+            actee_name: broker.name,
+          }
+          create_event("audit.service_broker.#{type}", user_actor, actee, metadata)
+        end
+
+        def record_broker_event_with_request(type, broker, request)
+          metadata = { request: request }
           actee    = {
             actee:      broker.guid,
             actee_type: 'service_broker',

--- a/spec/unit/messages/service_broker_create_message_spec.rb
+++ b/spec/unit/messages/service_broker_create_message_spec.rb
@@ -7,21 +7,21 @@ module VCAP::CloudController
   RSpec.describe ServiceBrokerCreateMessage do
     subject { ServiceBrokerCreateMessage }
 
-    describe 'validations' do
-      let(:valid_body) do
-        {
-          name: 'best-broker',
-          url: 'https://the-best-broker.url',
-          authentication: {
-            type: 'basic',
-            credentials: {
-              username: 'user',
-              password: 'pass',
-            }
-          },
-        }
-      end
+    let(:valid_body) do
+      {
+        name: 'best-broker',
+        url: 'https://the-best-broker.url',
+        authentication: {
+          type: 'basic',
+          credentials: {
+            username: 'user',
+            password: 'pass',
+          }
+        },
+      }
+    end
 
+    describe 'validations' do
       context 'when all values are correct' do
         let(:request_body) { valid_body }
 
@@ -301,6 +301,24 @@ module VCAP::CloudController
             expect(subject.errors_on(:relationships)).to include('Space guid must be between 1 and 200 characters')
           end
         end
+      end
+    end
+
+    describe '#audit_hash' do
+      it 'redacts the password' do
+        message = ServiceBrokerCreateMessage.new(valid_body)
+
+        expect(message.audit_hash).to eq({
+          name: 'best-broker',
+          url: 'https://the-best-broker.url',
+          authentication: {
+            type: 'basic',
+            credentials: {
+              username: 'user',
+              password: '[PRIVATE DATA HIDDEN]',
+            }
+          },
+        }.with_indifferent_access)
       end
     end
   end

--- a/spec/unit/repositories/service_event_repository_spec.rb
+++ b/spec/unit/repositories/service_event_repository_spec.rb
@@ -92,6 +92,33 @@ module VCAP::CloudController
         end
       end
 
+      describe '#record_broker_event_with_request' do
+        let(:service_broker) { VCAP::CloudController::ServiceBroker.make }
+        let(:request) do
+          {
+            fake: 'request'
+          }
+        end
+
+        it 'creates an event with the request' do
+          repository.record_broker_event_with_request(:create, service_broker, request)
+
+          event = Event.find(type: 'audit.service_broker.create')
+          expect(event.actor_type).to eq('user')
+          expect(event.timestamp).to be
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_name).to eq(email)
+          expect(event.actor_username).to eq(user_name)
+          expect(event.actee).to eq(service_broker.guid)
+          expect(event.actee_type).to eq('service_broker')
+          expect(event.actee_name).to eq(service_broker.name)
+          expect(event.space_guid).to be_empty
+          expect(event.organization_guid).to be_empty
+
+          expect(event.metadata['request']).to include('fake' => 'request')
+        end
+      end
+
       describe '#with_service_event' do
         let(:broker) { VCAP::CloudController::ServiceBroker.make }
 


### PR DESCRIPTION
Previously the audit events had v2-style requests recorded, but it's
more accurate to record the v3 request

[finishes #166898654](https://www.pivotaltracker.com/story/show/166898654)

Co-authored-by: Joao Lebre <jlebre@pivotal.io>
Co-authored-by: George Blue <gblue@pivotal.io>