### PR TITLE
Enable docker support for OPI staging

### DIFF
--- a/spec/unit/lib/cloud_controller/opi/stager_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/stager_client_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe(OPI::StagerClient) do
   end
   let(:eirini_url) { 'http://eirini.loves.heimdall:777' }
 
-  let(:staging_details) { stub_staging_details }
+  let(:staging_details) { stub_staging_details(lifecycle_type) }
   let(:lifecycle_data) { stub_lifecycle_data }
 
   let(:lifecycle_environment_variables) { [
@@ -51,32 +51,13 @@ RSpec.describe(OPI::StagerClient) do
         to_return(status: 202)
     end
 
-    it 'should send the expected request' do
-      stager_client.stage('guid', staging_details)
-      expect(WebMock).to have_requested(:post, "#{eirini_url}/stage/guid").with(body: {
-        app_guid: 'thor',
-        environment: [{ name: 'VCAP_APPLICATION', value: '{"wow":"pants"}' },
-                      { name: 'MEMORY_LIMIT', value: '256m' },
-                      { name: 'VCAP_SERVICES', value: '{}' }],
-         completion_callback: 'https://internal_user:internal_password@api.internal.cf:8182/internal/v3/staging//build_completed?start=',
-        lifecycle_data: { droplet_upload_uri: 'http://cc-uploader.service.cf.internal:9091/v1/droplet/guid?cc-droplet-upload-uri=http://upload.me',
-                          app_bits_download_uri: 'http://download.me',
-                          buildpacks: [{ name: 'ruby', key: 'idk', url: 'www.com', skip_detect: false }]
-      } }.to_json
-      )
-    end
-
-    context 'when staging details includes env vars' do
-      before do
-        staging_details.environment_variables = { 'GOPACKAGE': 'github.com/some/go/pkg' }
-      end
-
-      it 'should include the staging details env vars in the request' do
+    context 'when lifecycle type is buildpack' do
+      let(:lifecycle_type) { VCAP::CloudController::Lifecycles::BUILDPACK }
+      it 'should send the expected request' do
         stager_client.stage('guid', staging_details)
         expect(WebMock).to have_requested(:post, "#{eirini_url}/stage/guid").with(body: {
           app_guid: 'thor',
-          environment: [{ name: 'GOPACKAGE', value: 'github.com/some/go/pkg' },
-                        { name: 'VCAP_APPLICATION', value: '{"wow":"pants"}' },
+          environment: [{ name: 'VCAP_APPLICATION', value: '{"wow":"pants"}' },
                         { name: 'MEMORY_LIMIT', value: '256m' },
                         { name: 'VCAP_SERVICES', value: '{}' }],
            completion_callback: 'https://internal_user:internal_password@api.internal.cf:8182/internal/v3/staging//build_completed?start=',
@@ -86,24 +67,101 @@ RSpec.describe(OPI::StagerClient) do
         } }.to_json
         )
       end
-    end
 
-    context 'when the response contains an error' do
-      before do
-        stub_request(:post, "#{eirini_url}/stage/guid").
-          to_return(status: 501, body: { 'message' => 'failed to stage' }.to_json)
+      context 'when staging details includes env vars' do
+        before do
+          staging_details.environment_variables = { 'GOPACKAGE': 'github.com/some/go/pkg' }
+        end
+
+        it 'should include the staging details env vars in the request' do
+          stager_client.stage('guid', staging_details)
+          expect(WebMock).to have_requested(:post, "#{eirini_url}/stage/guid").with(body: {
+            app_guid: 'thor',
+            environment: [{ name: 'GOPACKAGE', value: 'github.com/some/go/pkg' },
+                          { name: 'VCAP_APPLICATION', value: '{"wow":"pants"}' },
+                          { name: 'MEMORY_LIMIT', value: '256m' },
+                          { name: 'VCAP_SERVICES', value: '{}' }],
+             completion_callback: 'https://internal_user:internal_password@api.internal.cf:8182/internal/v3/staging//build_completed?start=',
+            lifecycle_data: { droplet_upload_uri: 'http://cc-uploader.service.cf.internal:9091/v1/droplet/guid?cc-droplet-upload-uri=http://upload.me',
+                              app_bits_download_uri: 'http://download.me',
+                              buildpacks: [{ name: 'ruby', key: 'idk', url: 'www.com', skip_detect: false }]
+          } }.to_json
+          )
+        end
       end
 
+      context 'when the response contains an error' do
+        before do
+          stub_request(:post, "#{eirini_url}/stage/guid").
+            to_return(status: 501, body: { 'message' => 'failed to stage' }.to_json)
+        end
+
+        it 'should raise an error' do
+          expect { stager_client.stage('guid', staging_details) }.to raise_error(CloudController::Errors::ApiError, 'Runner error: failed to stage')
+        end
+      end
+    end
+
+    context 'when lifecycle type is docker' do
+      let(:lifecycle_type) { VCAP::CloudController::Lifecycles::DOCKER }
+      let(:staging_completion_handler) { instance_double(VCAP::CloudController::Diego::Docker::StagingCompletionHandler) }
+      let(:build_model) { instance_double(VCAP::CloudController::BuildModel) }
+      let(:payload) {
+        {
+        result: {
+          lifecycle_type: 'docker',
+          lifecycle_metadata: {
+            docker_image: 'docker.io/some/image'
+          },
+          process_types: { web: '' },
+          execution_metadata: '{\"cmd\":[],\"ports\":[{\"Port\":8080,\"Protocol\":\"tcp\"}]}'
+        }
+      }
+      }
+
+      it 'should not make any http calls to eirini' do
+        allow(VCAP::CloudController::BuildModel).to receive(:find).and_return(build_model)
+        allow(VCAP::CloudController::Diego::Docker::StagingCompletionHandler).to receive(:new).and_return(staging_completion_handler)
+        allow(staging_completion_handler).to receive(:staging_complete)
+
+        stager_client.stage('some_staging_guid', staging_details)
+        expect(WebMock).not_to have_requested(:any, "#{eirini_url}/stage/some_staging_guid")
+      end
+
+      it 'should mark staging as completed' do
+        expect(VCAP::CloudController::BuildModel).to receive(:find).with(guid: 'some_staging_guid').and_return(build_model)
+        expect(VCAP::CloudController::Diego::Docker::StagingCompletionHandler).to receive(:new).with(build_model).and_return(staging_completion_handler)
+        expect(staging_completion_handler).to receive(:staging_complete).with(payload, true)
+
+        staging_details.start_after_staging = true
+        stager_client.stage('some_staging_guid', staging_details)
+      end
+
+      context 'when build is not found' do
+        it 'should raise an error' do
+          expect(VCAP::CloudController::BuildModel).to receive(:find).with(guid: 'some_staging_guid').and_return(nil)
+          expect {
+            stager_client.stage('some_staging_guid', staging_details)
+          }.to raise_error(CloudController::Errors::ApiError, 'Build not found')
+        end
+      end
+    end
+
+    context 'when lifecycle type is invalid' do
+      let(:lifecycle_type) { 'dockerpack' }
+
       it 'should raise an error' do
-        expect { stager_client.stage('guid', staging_details) }.to raise_error(CloudController::Errors::ApiError, 'Runner error: failed to stage')
+        expect {
+          stager_client.stage('some_staging_guid', staging_details)
+        }.to raise_error(RuntimeError, 'lifecycle type `dockerpack` is invalid')
       end
     end
   end
 
-  def stub_staging_details
+  def stub_staging_details(lifecycle_type)
     staging_details                                 = VCAP::CloudController::Diego::StagingDetails.new
-    staging_details.package                         = double(app_guid: 'thor')
-    staging_details.lifecycle                       = double(type: VCAP::CloudController::Lifecycles::BUILDPACK)
+    staging_details.package                         = double(app_guid: 'thor', image: 'docker.io/some/image')
+    staging_details.lifecycle                       = double(type: lifecycle_type)
     staging_details
   end
 


### PR DESCRIPTION
* A short explanation of the proposed change:
  This PR enables support for pushing Docker images with OPI staging. This is done by calling the staging completion handler in OPI StagerClient when the lifecycle_type is DOCKER.

* An explanation of the use cases your change solves:
  As a developer, I want to push Docker images in an OPI staging environment.

* Links to any other associated PRs:
  #1417
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

cc: @gdankov 