### PR TITLE
Make label-selector parser friendlier

### DIFF
--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -37,6 +37,7 @@ class AppsV3Controller < ApplicationController
   def index
     message = AppsListMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?
+    # add_warning_headers(message.warnings) if message.warnings.size > 0
 
     dataset = if permission_queryer.can_read_globally?
                 AppListFetcher.new.fetch_all(message, eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)

--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -37,8 +37,6 @@ class AppsV3Controller < ApplicationController
   def index
     message = AppsListMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?
-    # add_warning_headers(message.warnings) if message.warnings.size > 0
-
     dataset = if permission_queryer.can_read_globally?
                 AppListFetcher.new.fetch_all(message, eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
               else

--- a/app/messages/list_message.rb
+++ b/app/messages/list_message.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
       params = params.symbolize_keys
       @pagination_params = params.slice(*ALLOWED_PAGINATION_KEYS)
       @pagination_options = PaginationOptions.from_params(params)
-      @requirements = parse_label_selector(params[:label_selector]) if params[:label_selector]
+      @requirements = parse_label_selector(params[:label_selector]) if params.key?(:label_selector)
       super(params)
     end
 
@@ -90,8 +90,6 @@ module VCAP::CloudController
 
     def parse_label_selector(label_selector)
       @label_selector_parser = LabelSelectorParser.new
-      return [] unless label_selector
-
       @label_selector_parser.parse(label_selector)
       @label_selector_parser.requirements
     end

--- a/app/messages/list_message.rb
+++ b/app/messages/list_message.rb
@@ -81,11 +81,7 @@ module VCAP::CloudController
       to_array_keys.each do |attribute|
         to_array! opts, attribute
       end
-
-      message = new(opts.symbolize_keys)
-      message.requirements = parse_label_selector(opts.symbolize_keys[:label_selector]) if message.requested?(:label_selector)
-
-      message
+      new(opts.symbolize_keys)
     end
 
     def parse_label_selector(label_selector)

--- a/app/messages/metadata_list_message.rb
+++ b/app/messages/metadata_list_message.rb
@@ -8,7 +8,9 @@ module VCAP::CloudController
     end
 
     def self.label_selector_requested?
-      @label_selector_requested ||= proc { |a| a.requested?(:label_selector) }
+      @label_selector_requested ||= proc { |a|
+        a.requested?(:label_selector)
+      }
     end
 
     validates_with LabelSelectorRequirementValidator, if: label_selector_requested?

--- a/app/models/helpers/label_selector_requirement.rb
+++ b/app/models/helpers/label_selector_requirement.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
       @key = key
       @key_prefix, @key_name = VCAP::CloudController::MetadataHelpers.extract_prefix(key)
       @operator = operator
-      @values = values.split(',')
+      @values = values
     end
   end
 end

--- a/app/models/helpers/metadata_helpers.rb
+++ b/app/models/helpers/metadata_helpers.rb
@@ -1,24 +1,6 @@
 module VCAP::CloudController
   class MetadataHelpers
     KEY_SEPARATOR = '/'.freeze
-    # REQUIREMENT_SPLITTER = /(?:\(.*?\)|[^,])+/.freeze
-    # KEY_CHARACTERS = %r{[\w\-\.\_\/]+}.freeze
-    #
-    # IN_PATTERN = /\A(?<key>.*?) in \((?<values>.*)\)\z/.freeze                     # foo in (bar,baz)
-    # NOT_IN_PATTERN = /\A(?<key>.*?) notin \((?<values>.*)\)\z/.freeze              # funky notin (uptown,downtown)
-    # EQUAL_PATTERN = /\A(?<key>#{KEY_CHARACTERS})(==?)(?<values>.*)\z/.freeze       # foo=bar or foo==bar
-    # NOT_EQUAL_PATTERN = /\A(?<key>#{KEY_CHARACTERS})(!=)(?<values>.*)\z/.freeze    # foo!=bar
-    # EXISTS_PATTERN = /^\A(?<key>#{KEY_CHARACTERS})(?<values>)\z/.freeze            # foo
-    # NOT_EXISTS_PATTERN = /\A!(?<key>#{KEY_CHARACTERS})(?<values>)\z/.freeze        # !foo
-    #
-    # REQUIREMENT_OPERATOR_PAIRS = [
-    #   { pattern: IN_PATTERN, operator: :in },
-    #   { pattern: NOT_IN_PATTERN, operator: :notin },
-    #   { pattern: EQUAL_PATTERN, operator: :equal },
-    #   { pattern: NOT_EQUAL_PATTERN, operator: :not_equal },
-    #   { pattern: EXISTS_PATTERN, operator: :exists }, # foo
-    #   { pattern: NOT_EXISTS_PATTERN, operator: :not_exists },
-    # ].freeze
 
     class << self
       def extract_prefix(metadata_key)

--- a/app/models/helpers/metadata_helpers.rb
+++ b/app/models/helpers/metadata_helpers.rb
@@ -1,24 +1,24 @@
 module VCAP::CloudController
   class MetadataHelpers
     KEY_SEPARATOR = '/'.freeze
-    REQUIREMENT_SPLITTER = /(?:\(.*?\)|[^,])+/.freeze
-    KEY_CHARACTERS = %r{[\w\-\.\_\/]+}.freeze
-
-    IN_PATTERN = /\A(?<key>.*?) in \((?<values>.*)\)\z/.freeze                     # foo in (bar,baz)
-    NOT_IN_PATTERN = /\A(?<key>.*?) notin \((?<values>.*)\)\z/.freeze              # funky notin (uptown,downtown)
-    EQUAL_PATTERN = /\A(?<key>#{KEY_CHARACTERS})(==?)(?<values>.*)\z/.freeze       # foo=bar or foo==bar
-    NOT_EQUAL_PATTERN = /\A(?<key>#{KEY_CHARACTERS})(!=)(?<values>.*)\z/.freeze    # foo!=bar
-    EXISTS_PATTERN = /^\A(?<key>#{KEY_CHARACTERS})(?<values>)\z/.freeze            # foo
-    NOT_EXISTS_PATTERN = /\A!(?<key>#{KEY_CHARACTERS})(?<values>)\z/.freeze        # !foo
-
-    REQUIREMENT_OPERATOR_PAIRS = [
-      { pattern: IN_PATTERN, operator: :in },
-      { pattern: NOT_IN_PATTERN, operator: :notin },
-      { pattern: EQUAL_PATTERN, operator: :equal },
-      { pattern: NOT_EQUAL_PATTERN, operator: :not_equal },
-      { pattern: EXISTS_PATTERN, operator: :exists }, # foo
-      { pattern: NOT_EXISTS_PATTERN, operator: :not_exists },
-    ].freeze
+    # REQUIREMENT_SPLITTER = /(?:\(.*?\)|[^,])+/.freeze
+    # KEY_CHARACTERS = %r{[\w\-\.\_\/]+}.freeze
+    #
+    # IN_PATTERN = /\A(?<key>.*?) in \((?<values>.*)\)\z/.freeze                     # foo in (bar,baz)
+    # NOT_IN_PATTERN = /\A(?<key>.*?) notin \((?<values>.*)\)\z/.freeze              # funky notin (uptown,downtown)
+    # EQUAL_PATTERN = /\A(?<key>#{KEY_CHARACTERS})(==?)(?<values>.*)\z/.freeze       # foo=bar or foo==bar
+    # NOT_EQUAL_PATTERN = /\A(?<key>#{KEY_CHARACTERS})(!=)(?<values>.*)\z/.freeze    # foo!=bar
+    # EXISTS_PATTERN = /^\A(?<key>#{KEY_CHARACTERS})(?<values>)\z/.freeze            # foo
+    # NOT_EXISTS_PATTERN = /\A!(?<key>#{KEY_CHARACTERS})(?<values>)\z/.freeze        # !foo
+    #
+    # REQUIREMENT_OPERATOR_PAIRS = [
+    #   { pattern: IN_PATTERN, operator: :in },
+    #   { pattern: NOT_IN_PATTERN, operator: :notin },
+    #   { pattern: EQUAL_PATTERN, operator: :equal },
+    #   { pattern: NOT_EQUAL_PATTERN, operator: :not_equal },
+    #   { pattern: EXISTS_PATTERN, operator: :exists }, # foo
+    #   { pattern: NOT_EXISTS_PATTERN, operator: :not_exists },
+    # ].freeze
 
     class << self
       def extract_prefix(metadata_key)

--- a/lib/cloud_controller/label_selector/label_selector_lexer.rb
+++ b/lib/cloud_controller/label_selector/label_selector_lexer.rb
@@ -1,0 +1,28 @@
+module VCAP::CloudController
+  class LabelSelectorLexer
+    def initialize
+      @token_types = [
+        [:comma, ','],
+        [:open_paren, '\\('],
+        [:close_paren, '\\)'],
+        [:space, '\\s+'],
+        [:equal, '==?'],
+        [:not_equal, '!='],
+        [:not_op, '!'], # as in !foo<END> -- no label named foo
+        [:word, '[-_.\w]+(?:/[-_.\w]+)?'],
+        [:error, '.'],  # [^\w\(\)\s=?!]+
+      ]
+      @ptn = Regexp.new(@token_types.map { |t| "(#{t[1]})" }.join('|'))
+    end
+
+    def scan(input)
+      @num_chars_read = 0
+      input.scan(@ptn).map do |g|
+        idx = g.find_index { |x| !x.nil? }
+        tok = [@token_types[idx][0], g[idx], @num_chars_read]
+        @num_chars_read += tok[1].size
+        tok
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/label_selector/label_selector_parser.rb
+++ b/lib/cloud_controller/label_selector/label_selector_parser.rb
@@ -144,6 +144,7 @@ module VCAP::CloudController
       @nodes = []
       @requirements = []
       @errors = []
+      raise LabelSelectorParseError.new('Missing label_selector value') if input.nil?
       raise LabelSelectorParseError.new('empty label selector not allowed') if input.empty?
 
       @input = input

--- a/lib/cloud_controller/label_selector/label_selector_parser.rb
+++ b/lib/cloud_controller/label_selector/label_selector_parser.rb
@@ -1,0 +1,199 @@
+require 'cloud_controller/label_selector/label_selector_lexer'
+
+module VCAP::CloudController
+  class LabelSelectorNode
+    attr_accessor :operator, :name, :values
+
+    def initialize(name, operator=nil)
+      @name = name
+      @operator = operator
+      @values = []
+    end
+
+    def add(value)
+      @values << value
+    end
+
+    def generate
+      LabelSelectorRequirement.new(key: @name,
+        operator: operator,
+        values: @values,
+      )
+    end
+  end
+
+  class LabelSelectorParseError < RuntimeError
+    def initialize(msg, input=nil, token=nil)
+      if input && token
+        msg +=  %/, got "#{show_token_state(input, token)}"/
+      end
+      super(msg)
+    end
+
+    private
+
+    def show_token_state(input, tok)
+      parts = []
+      if tok[2] > 0
+        start_part = input[0...tok[2]]
+        if start_part.size > 30
+          start_part = '...' + start_part[-27..-1]
+        end
+        parts << start_part
+      end
+      parts << "<<#{tok[1]}>>"
+      if tok[2] + tok[1].size < input.size
+        end_part = input[(tok[2] + tok[1].size)..-1]
+        if end_part.size > 30
+          end_part = end_part[0..27] + '...'
+        end
+        parts << end_part
+      end
+      parts.join('')
+    end
+  end
+
+  class LabelSelectorParser
+    attr_accessor :requirements, :errors
+
+    # rubocop:disable Metrics/MethodLength
+    def initialize
+      @action_table = {
+        at_start: {
+          word: proc {
+            @node = LabelSelectorNode.new(@token[1])
+            @state = :has_key
+          },
+          not_op: :has_not_op,
+          not_equal: "a key or '!' not followed by '='",
+          default: "a key or '!'",
+        },
+        has_not_op: {
+          word: proc {
+            @nodes << LabelSelectorNode.new(@token[1], :not_exists)
+            @state = :expecting_comma_or_eof
+          },
+          default: 'a key',
+        },
+        has_key: {
+          equal: proc do
+            @node.operator = @token[0]
+            @state = :expect_value
+          end,
+          not_equal: proc  do
+            @node.operator = @token[0]
+            @state = :expect_value
+          end,
+          word: proc {
+            if ['in', 'notin'].member?(@token[1])
+              @node.operator = @token[1].to_sym
+              @state = :expecting_open_paren
+            else
+              raise LabelSelectorParseError.new("expecting a ',', operator, or end", @input, @token)
+            end
+          },
+          comma: proc {
+            @node.operator = :exists
+            @nodes << @node
+            @state = :at_start
+          },
+          eof: proc {
+            @node.operator = :exists
+            @nodes << @node
+            @done = true
+          },
+          default: "a ',', operator, or end",
+        },
+        expect_value: {
+          word: proc {
+            @node.values << @token[1]
+            @nodes << @node
+            @state = :expecting_comma_or_eof
+          },
+          default: 'a value',
+        },
+        expecting_open_paren: {
+          open_paren: :expecting_set_value,
+          default: "a '('",
+        },
+        expecting_set_value: {
+          word: proc {
+            @node.values << @token[1]
+            @state = :expecting_comma_or_close_paren
+          },
+          default: 'a value',
+        },
+        expecting_comma_or_close_paren: {
+          comma: :expecting_set_value,
+          close_paren: proc {
+            @nodes << @node
+            @state = :expecting_comma_or_eof
+          },
+          default: "a ',' or ')'",
+        },
+        expecting_comma_or_eof: {
+          comma: :at_start,
+          eof: proc { @done = true },
+          default: "a ',' or end"
+        },
+      }
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def parse(input)
+      @nodes = []
+      @requirements = []
+      @errors = []
+      raise LabelSelectorParseError.new('empty label selector not allowed') if input.empty?
+
+      @input = input
+
+      tokens = LabelSelectorLexer.new.scan(input)
+      bad_token = tokens.find { |tok| tok[0] == :error }
+      if bad_token
+        raise LabelSelectorParseError.new('disallowed character(s)', input, bad_token)
+      end
+
+      tokens = tokens.reject { |tok| tok[0] == :space } + [[:eof, '', input.size],]
+
+      @state = :at_start
+      @done = false
+      tokens.each do |tok|
+        @token = tok
+        entry = @action_table[@state]
+        if !entry
+          raise Exception.new("internal error: Can't find an entry for #{token.inspect} at state #{@state}")
+        end
+
+        if !entry.key?(tok[0])
+          action = entry[:default]
+          raise LabelSelectorParseError.new("expecting #{entry[:default]}", input, tok) if action.nil?
+        else
+          action = entry[tok[0]]
+        end
+
+        case action
+        when Symbol
+          @state = action
+        when Proc
+          action.call
+          break if @done
+        when String
+          raise LabelSelectorParseError.new("expecting #{action}", input, tok)
+        else
+          raise LabelSelectorParseError.new('internal error: unexpected input', input, tok)
+        end
+      end
+
+      if !@done
+        raise LabelSelectorParseError.new('Expecting completion of the selector, hit the end')
+      end
+
+      @requirements = @nodes.map(&:generate)
+      true
+    rescue LabelSelectorParseError => ex
+      @errors << ex.message
+      false
+    end
+  end
+end

--- a/lib/cloud_controller/label_selector/label_selector_parser.rb
+++ b/lib/cloud_controller/label_selector/label_selector_parser.rb
@@ -140,6 +140,7 @@ module VCAP::CloudController
     end
     # rubocop:enable Metrics/MethodLength
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def parse(input)
       @nodes = []
       @requirements = []
@@ -196,5 +197,6 @@ module VCAP::CloudController
       @errors << ex.message
       false
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
   end
 end

--- a/spec/request/organizations_spec.rb
+++ b/spec/request/organizations_spec.rb
@@ -699,7 +699,7 @@ module VCAP::CloudController
         it "returns a 400 when the label selector's value is invalid" do
           get "#{base_link}?label_selector=!", nil, admin_header
           expect(last_response.status).to eq(400)
-          expect(parsed_response['errors'].first['detail']).to match(/Invalid label_selector value/)
+          expect(parsed_response['errors'].first['detail']).to match(/The query parameter is invalid: expecting a key, got "!<<>>"/)
         end
       end
     end

--- a/spec/unit/controllers/v3/apps_controller_spec.rb
+++ b/spec/unit/controllers/v3/apps_controller_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe AppsV3Controller, type: :controller do
 
         expect(response.status).to eq(400)
 
-        expect(parsed_body['errors'].first['detail']).to match(/Invalid label_selector value/)
+        expect(parsed_body['errors'].first['detail']).to match(/The query parameter is invalid: expecting a ',', operator, or end, got \"buncha <<nonsense>>\"/)
       end
     end
   end

--- a/spec/unit/fetchers/label_selector_query_generator_spec.rb
+++ b/spec/unit/fetchers/label_selector_query_generator_spec.rb
@@ -5,13 +5,13 @@ module VCAP::CloudController
     subject(:label_selector_parser) { LabelSelectorQueryGenerator }
 
     describe '.add_selector_queries' do
-      let!(:app1) { AppModel.make }
+      let!(:app1) { AppModel.make(guid: 'app1-bar') }
       let!(:app1_label) { AppLabelModel.make(resource_guid: app1.guid, key_name: 'foo', value: 'bar') }
 
-      let!(:app2) { AppModel.make }
+      let!(:app2) { AppModel.make(guid: 'app2-funky') }
       let!(:app2_label) { AppLabelModel.make(resource_guid: app2.guid, key_name: 'foo', value: 'funky') }
 
-      let!(:app3) { AppModel.make }
+      let!(:app3) { AppModel.make(guid: 'app3-town') }
       let!(:app3_label) { AppLabelModel.make(resource_guid: app3.guid, key_name: 'foo', value: 'town') }
       let!(:app3_exclusive_label) { AppLabelModel.make(resource_guid: app3.guid, key_name: 'easter', value: 'bunny') }
 
@@ -23,7 +23,7 @@ module VCAP::CloudController
         let(:operator) { :in }
 
         context 'with a single value' do
-          let(:values) { 'funky' }
+          let(:values) { ['funky'] }
 
           it 'returns the models that satisfy the requirements' do
             dataset = subject.add_selector_queries(
@@ -38,7 +38,7 @@ module VCAP::CloudController
         end
 
         context 'with multiple values' do
-          let(:values) { 'funky,town' }
+          let(:values) { %w/funky town/ }
 
           it 'returns the models that satisfy the requirements' do
             dataset = subject.add_selector_queries(
@@ -94,7 +94,7 @@ module VCAP::CloudController
         let(:operator) { :notin }
 
         context 'with a single value' do
-          let(:values) { 'funky' }
+          let(:values) { ['funky'] }
 
           it 'returns the models that satisfy the requirements' do
             dataset = subject.add_selector_queries(
@@ -109,7 +109,7 @@ module VCAP::CloudController
         end
 
         context 'with multiple values' do
-          let(:values) { 'funky,town' }
+          let(:values) { %w/funky town/ }
 
           it 'returns the models that satisfy the requirements' do
             dataset = subject.add_selector_queries(
@@ -141,7 +141,7 @@ module VCAP::CloudController
 
       describe 'equality requirements' do
         let(:operator) { :equal }
-        let(:values) { 'funky' }
+        let(:values) { ['funky'] }
 
         it 'returns the models that satisfy the "=" requirements' do
           dataset = subject.add_selector_queries(
@@ -203,7 +203,7 @@ module VCAP::CloudController
           dataset = subject.add_selector_queries(
             label_klass: AppLabelModel,
             resource_dataset: AppModel.dataset,
-            requirements: [VCAP::CloudController::LabelSelectorRequirement.new(key: 'easter', operator: :not_exists, values: '')],
+            requirements: [VCAP::CloudController::LabelSelectorRequirement.new(key: 'easter', operator: :not_exists, values: [''])],
             resource_klass: AppModel,
           )
 
@@ -230,8 +230,8 @@ module VCAP::CloudController
             label_klass: AppLabelModel,
             resource_dataset: AppModel.dataset,
             requirements: [
-              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :in, values: 'funky,town'),
-              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :notin, values: 'bar')
+              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :in, values: %w/funky town/),
+              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :notin, values: ['bar'])
             ],
             resource_klass: AppModel,
           )
@@ -244,8 +244,8 @@ module VCAP::CloudController
             label_klass: AppLabelModel,
             resource_dataset: AppModel.dataset,
             requirements: [
-              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :not_equal, values: 'bar'),
-              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :not_equal, values: 'town')
+              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :not_equal, values: ['bar']),
+              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :not_equal, values: ['town'])
             ],
             resource_klass: AppModel,
           )
@@ -258,8 +258,8 @@ module VCAP::CloudController
             label_klass: AppLabelModel,
             resource_dataset: AppModel.dataset,
             requirements: [
-              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :equal, values: 'bar'),
-              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :equal, values: 'town')
+              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :equal, values: ['bar']),
+              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :equal, values: ['town'])
             ],
             resource_klass: AppModel,
           )
@@ -278,8 +278,8 @@ module VCAP::CloudController
             label_klass: AppLabelModel,
             resource_dataset: join_table_dataset,
             requirements: [
-              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :equal, values: 'town'),
-              VCAP::CloudController::LabelSelectorRequirement.new(key: 'easter', operator: :equal, values: 'bunny')
+              VCAP::CloudController::LabelSelectorRequirement.new(key: 'foo', operator: :equal, values: ['town']),
+              VCAP::CloudController::LabelSelectorRequirement.new(key: 'easter', operator: :equal, values: ['bunny'])
             ],
             resource_klass: AppModel,
           )

--- a/spec/unit/lib/cloud_controller/label_selector/label_selector_lexer_spec.rb
+++ b/spec/unit/lib/cloud_controller/label_selector/label_selector_lexer_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'cloud_controller/label_selector/label_selector_lexer.rb'
+
+module VCAP::CloudController
+  RSpec.describe LabelSelectorLexer do
+    subject(:target_state) { LabelSelectorLexer.new }
+
+    describe 'tokens' do
+      context 'invalid label_selector' do
+        let(:input) { '* pickles in  (foo)' }
+
+        context 'the revision exists' do
+          it 'contains an error token' do
+            tokens = subject.scan(input)
+            expect(tokens[0]).to eq([:error, '*', 0])
+            expect(tokens.find { |tok| tok[0] == :error }).not_to be_nil
+            expect(tokens.size).to eq(9)
+            expect(tokens[1]).to eq([:space, ' ', 1])
+            expect(tokens[2]).to eq([:word, 'pickles', 2])
+
+            expect(tokens.reject { |tok| tok[0] == :space }.size).to eq(6)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cloud_controller/label_selector/label_selector_parser_spec.rb
+++ b/spec/unit/lib/cloud_controller/label_selector/label_selector_parser_spec.rb
@@ -1,0 +1,179 @@
+require 'spec_helper'
+require 'cloud_controller/label_selector/label_selector_parser.rb'
+
+module VCAP::CloudController
+  RSpec.describe LabelSelectorParser do
+    subject(:parser) { LabelSelectorParser.new }
+
+    describe 'parser' do
+      let(:input) { '' }
+
+      context 'empty string' do
+        it 'complains' do
+          result = parser.parse(input)
+          expect(result).to be_falsey
+          expect(parser.errors.size).to be(1)
+          expect(parser.errors).to match_array('empty label selector not allowed')
+          expect(parser.requirements).to be_empty
+        end
+      end
+
+      context 'simple key-test' do
+        it 'complains about errors' do
+          [
+            ['<<*>>'],
+            ['<<*>>abc'],
+            ['abc<<*>>'],
+            ['abc<<*>>=def'],
+            ['abc in (fish  ,<<?>>'],
+          ].each_with_index do |augmented_input, index|
+            augmented_input = augmented_input[0]
+            input = augmented_input.sub('<<', '').sub('>>', '')
+            result = parser.parse(input)
+            expect(result).to be_falsey
+            expect(parser.errors.size).to be(1)
+            exp = %@disallowed character(s), got "#{augmented_input}"@
+            expect(parser.errors[0]).to eq(exp), "Expected
+[[#{exp}]], got
+[[#{parser.errors[0]}]]
+for input #{index}"
+          end
+        end
+      end
+
+      context 'state table coverage' do
+        it 'complains' do
+          [
+            ['!<<>>',                'a key'],
+            ['!<<,>>',               'a key'],
+            ['!<<)>>',               'a key'],
+            ['<<!=>> chips', "a key or '!' not followed by '='"],
+            ['!abc<<=>>',            "a ',' or end"],
+            ['abc=<<,>>',            'a value'],
+            ['abc!=<<,>>',           'a value'],
+            ['<<=>>flapjacks=1921', "a key or '!'"],
+
+            ['abc in<<>>',           "a '('"],
+            ['abc in <<>>',          "a '('"],
+            ['abc in  <<>>',         "a '('"],
+            ['abc in<<)>>',          "a '('"],
+            ['abc in<<,>>',          "a '('"],
+
+            ['abc in(<<>>',          'a value'],
+            ['abc in (<<>>',         'a value'],
+            ['abc in (fish<<>>',     "a ',' or ')'"],
+            ['abc in (fish  ,<<>>',      'a value'],
+            ['abc in (fish  ,<<)>>',     'a value'],
+
+            ['abc in (fish,beef<<>>', "a ',' or ')'"],
+            ['abc in (fish,beef,<<>>', 'a value'],
+            ['abc in (fish,beef),<<>>', "a key or '!'"],
+            ['abc in (fish,beef),<<(>>', "a key or '!'"],
+
+            ['abc notin<<>>',           "a '('"],
+            ['abc notin <<>>',          "a '('"],
+            ['abc notin  <<>>',         "a '('"],
+            ['abc notin<<)>>',          "a '('"],
+            ['abc notin<<,>>',          "a '('"],
+
+            ['abc notin(<<>>',          'a value'],
+            ['abc notin (<<>>',         'a value'],
+            ['abc notin (fish<<>>',     "a ',' or ')'"],
+            ['abc notin (fish  ,<<>>',      'a value'],
+            ['abc notin (fish  ,<<)>>',     'a value'],
+
+            ['abc notin (fish,beef<<>>', "a ',' or ')'"],
+            ['abc notin (fish,beef,<<>>', 'a value'],
+            ['abc notin (fish,beef),<<>>', "a key or '!'"],
+            ['abc notin (fish,beef),<<(>>', "a key or '!'"],
+
+            ['abc =<<>>',           'a value'],
+            ['abc = <<>>',          'a value'],
+            ['abc =  <<>>',         'a value'],
+            ['abc =<<)>>',          'a value'],
+            ['abc =<<,>>',          'a value'],
+
+            ['abc =<<(>>',          'a value'],
+            ['abc = <<(>>',         'a value'],
+            ['abc = fish  ,<<>>',      "a key or '!'"],
+            ['abc = fish  ,<<)>>',     "a key or '!'"],
+            ['abc = fish,<<>>', "a key or '!'"],
+            ['abc = fish<<)>>,', "a ',' or end"],
+            ['abc = fish <<(>>,', "a ',' or end"],
+            ['abc = fish<<)>>,', "a ',' or end"],
+            ['abc = fish <<flakes>>', "a ',' or end"],
+
+            ['abc ==<<>>',           'a value'],
+            ['abc == <<>>',          'a value'],
+            ['abc ==  <<>>',         'a value'],
+            ['abc ==<<)>>',          'a value'],
+            ['abc ==<<,>>',          'a value'],
+
+            ['abc ==<<(>>',          'a value'],
+            ['abc == <<(>>',         'a value'],
+            ['abc == fish  ,<<>>',      "a key or '!'"],
+            ['abc == fish  ,<<)>>',     "a key or '!'"],
+            ['abc == fish,<<>>', "a key or '!'"],
+            ['abc == fish<<)>>,', "a ',' or end"],
+            ['abc == fish <<(>>,', "a ',' or end"],
+            ['abc == fish<<)>>,', "a ',' or end"],
+            ['abc == fish <<flakes>>', "a ',' or end"],
+
+            ['abc !=<<>>',           'a value'],
+            ['abc != <<>>',          'a value'],
+            ['abc !=  <<>>',         'a value'],
+            ['abc !=<<)>>',          'a value'],
+            ['abc !=<<,>>',          'a value'],
+
+            ['abc !=<<(>>',          'a value'],
+            ['abc != <<(>>',         'a value'],
+            ['abc != fish  ,<<>>',      "a key or '!'"],
+            ['abc != fish  ,<<)>>',     "a key or '!'"],
+            ['abc != fish,<<>>', "a key or '!'"],
+            ['abc != fish<<)>>,', "a ',' or end"],
+            ['abc != fish <<(>>,', "a ',' or end"],
+            ['abc != fish<<)>>,', "a ',' or end"],
+            ['abc != fish <<flakes>>', "a ',' or end"],
+
+            ['fish<<)>>,', "a ',', operator, or end"],
+            ['fish <<(>>,', "a ',', operator, or end"],
+            ['fish<<)>>,', "a ',', operator, or end"],
+            ['fish <<flakes>>', "a ',', operator, or end"],
+
+          ].each_with_index do |pair, index|
+            augmented_input, reduced_expected_message = pair
+            input = augmented_input.sub('<<', '').sub('>>', '')
+            expected_message = %@expecting #{reduced_expected_message}, got "#{augmented_input}"@
+            result = parser.parse(input)
+            expect(result).to be_falsey
+            expect(parser.errors.size).to be(1)
+            expect(parser.errors[0]).to eq(expected_message), "Expected
+[[#{expected_message}]], got
+[[#{parser.errors[0]}]]
+for input #{index} ('#{augmented_input}' => '#{input}')"
+          end
+        end
+      end
+
+      context 'state table coverage' do
+        it 'complains' do
+          [
+            ['fish <<flakes>>', "a ',', operator, or end"],
+
+          ].each_with_index do |pair, index|
+            augmented_input, reduced_expected_message = pair
+            input = augmented_input.sub('<<', '').sub('>>', '')
+            expected_message = %@expecting #{reduced_expected_message}, got "#{augmented_input}"@
+            result = parser.parse(input)
+            expect(result).to be_falsey
+            expect(parser.errors.size).to be(1)
+            expect(parser.errors[0]).to eq(expected_message), "Expected
+[[#{expected_message}]], got
+[[#{parser.errors[0]}]]
+for input #{index} ('#{augmented_input}' => '#{input}')"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/messages/list_message_spec.rb
+++ b/spec/unit/messages/list_message_spec.rb
@@ -117,28 +117,28 @@ module VCAP::CloudController
       end
 
       context 'invalid operators' do
-        it 'parses incorrect "in" operations as nil requirement' do
+        it 'parses incorrect "in" operations as empty array of requirements' do
           message = list_message_klass.from_params('label_selector' => 'foo inn (bar,baz)')
 
-          expect(message.requirements).to contain_exactly(nil)
+          expect(message.requirements).to be_empty
         end
 
-        it 'parses incorrect "notin" operations as nil requirement' do
+        it 'parses incorrect "notin" operations as empty array of requirements' do
           message = list_message_klass.from_params('label_selector' => 'foo notinn (bar,baz)')
 
-          expect(message.requirements).to contain_exactly(nil)
+          expect(message.requirements).to be_empty
         end
 
-        it 'parses incorrect set operations as nil requirement' do
+        it 'parses incorrect set operations as empty array of requirements' do
           message = list_message_klass.from_params('label_selector' => 'foo == (bar,baz)')
 
-          expect(message.requirements).to contain_exactly(nil)
+          expect(message.requirements).to be_empty
         end
 
-        it 'parses multiple incorrect operations as nil requirements' do
+        it 'parses multiple incorrect operations as empty array of requirementss' do
           message = list_message_klass.from_params('label_selector' => 'foo == (bar,baz),foo narp doggie,bar inn (bat)')
 
-          expect(message.requirements).to contain_exactly(nil, nil, nil)
+          expect(message.requirements).to be_empty
         end
       end
 

--- a/spec/unit/messages/metadata_list_message_spec.rb
+++ b/spec/unit/messages/metadata_list_message_spec.rb
@@ -8,13 +8,15 @@ module VCAP::CloudController
         register_allowed_keys []
       end
     end
+    let(:params) do { label_selector: label_selector } end
+    let(:label_selector) { 'need something here' }
 
     subject do
       fake_class.from_params(params, [])
     end
 
     context 'when given a valid label_selector' do
-      let(:params) { { 'label_selector' => '!fruit,env=prod,animal in (dog,horse)' } }
+      let(:label_selector) { '!fruit,env=prod,animal in (dog,horse)' }
 
       it 'is valid' do
         expect(subject).to be_valid
@@ -26,11 +28,167 @@ module VCAP::CloudController
     end
 
     context 'when given an invalid label_selector' do
-      let(:params) { { 'label_selector' => '' } }
+      let(:label_selector) { '' }
 
       it 'is invalid' do
         expect(subject).to_not be_valid
-        expect(subject.errors[:base]).to include('Missing label_selector value')
+        expect(subject.errors[:base]).to include('empty label selector not allowed')
+      end
+    end
+
+    describe 'label_selector parsing' do
+      context 'invalid operators' do
+        context 'inn' do
+          let(:label_selector) { 'foo inn (bar,baz)' }
+
+          it 'parses incorrect "in" operations as empty requirements' do
+            expect(subject.requirements.size).to be(0)
+            expect(subject).to_not be_valid
+            expect(subject.errors.size).to be(1)
+            expect(subject.errors.full_messages).to contain_exactly(%q@expecting a ',', operator, or end, got "foo <<inn>> (bar,baz)"@)
+          end
+        end
+
+        context 'notinn' do
+          let(:label_selector) { 'foo notinn (bar,baz)' }
+
+          it 'parses incorrect "notin" operations as empty requirements' do
+            expect(subject.requirements.size).to be(0)
+            expect(subject).to_not be_valid
+            expect(subject.errors.size).to be(1)
+            expect(subject.errors.full_messages).to contain_exactly(%q@expecting a ',', operator, or end, got "foo <<notinn>> (bar,baz)"@)
+          end
+        end
+      end
+    end
+
+    context 'equal on sets' do
+      let(:label_selector) { 'foo == (bar,baz)' }
+
+      it 'parses incorrect set operations as empty requirements' do
+        expect(subject.requirements.size).to be(0)
+        expect(subject).to_not be_valid
+        expect(subject.errors.size).to be(1)
+        expect(subject.errors.full_messages).to contain_exactly('expecting a value, got "foo == <<(>>bar,baz)"')
+      end
+    end
+
+    context 'narp operator' do
+      let(:label_selector) { 'foo notin (bar,baz),foo narp doggie,bar inn (bat)' }
+
+      it 'parses multiple incorrect operations as empty requirementss' do
+        expect(subject.requirements.size).to be(0)
+        expect(subject).to_not be_valid
+        expect(subject.errors.size).to be(1)
+        expect(subject.errors.full_messages).to contain_exactly(%q@expecting a ',', operator, or end, got "foo notin (bar,baz),foo <<narp>> doggie,bar inn (bat)"@)
+      end
+    end
+
+    context 'set operations' do
+      context 'in' do
+        let(:label_selector) { 'example.com/foo in (bar,baz)' }
+
+        it 'parses correct in operation' do
+          expect(subject).to be_valid
+          expect(subject.requirements.size).to be(1)
+          expect(subject.requirements.first.key).to eq('example.com/foo')
+          expect(subject.requirements.first.operator).to eq(:in)
+          expect(subject.requirements.first.values).to contain_exactly('bar', 'baz')
+        end
+      end
+
+      context 'notin' do
+        let(:label_selector) { 'example.com/foo notin (bar,baz)' }
+
+        it 'parses correct notin operation' do
+          expect(subject).to be_valid
+          expect(subject.requirements.size).to be(1)
+          expect(subject.requirements.first.key).to eq('example.com/foo')
+          expect(subject.requirements.first.operator).to eq(:notin)
+          expect(subject.requirements.first.values).to contain_exactly('bar', 'baz')
+        end
+      end
+    end
+
+    context 'equality operation' do
+      context 'equals' do
+        let(:label_selector) { 'example.com/foo=bar' }
+
+        it 'parses correct = operation' do
+          expect(subject).to be_valid
+          expect(subject.requirements.size).to be(1)
+          expect(subject.requirements.first.key).to eq('example.com/foo')
+          expect(subject.requirements.first.operator).to eq(:equal)
+          expect(subject.requirements.first.values).to contain_exactly('bar')
+        end
+      end
+
+      context 'double equals' do
+        let(:label_selector) { 'example.com/foo==bar' }
+
+        it 'parses correct == operation' do
+          expect(subject).to be_valid
+          expect(subject.requirements.size).to be(1)
+          expect(subject.requirements.first.key).to eq('example.com/foo')
+          expect(subject.requirements.first.operator).to eq(:equal)
+          expect(subject.requirements.first.values).to contain_exactly('bar')
+        end
+      end
+
+      context 'not equals' do
+        let(:label_selector) { 'example.com/foo!=bar' }
+
+        it 'parses correct != operation' do
+          expect(subject).to be_valid
+          expect(subject.requirements.size).to be(1)
+          expect(subject.requirements.first.key).to eq('example.com/foo')
+          expect(subject.requirements.first.operator).to eq(:not_equal)
+          expect(subject.requirements.first.values).to contain_exactly('bar')
+        end
+      end
+    end
+
+    context 'existence operations' do
+      let(:label_selector) { 'example.com/foo' }
+
+      it 'parses correct existence operation' do
+        expect(subject).to be_valid
+        expect(subject.requirements.size).to be(1)
+        expect(subject.requirements.first.key).to eq('example.com/foo')
+        expect(subject.requirements.first.operator).to eq(:exists)
+        expect(subject.requirements.first.values).to be_empty
+      end
+    end
+
+    context 'non-existence operations' do
+      let(:label_selector) { '!example.com/foo' }
+
+      it 'parses correct non-existence operation' do
+        expect(subject).to be_valid
+        expect(subject.requirements.size).to be(1)
+        expect(subject.requirements.first.key).to eq('example.com/foo')
+        expect(subject.requirements.first.operator).to eq(:not_exists)
+        expect(subject.requirements.first.values).to be_empty
+      end
+    end
+
+    context 'multiple operations' do
+      let(:label_selector) { 'example.com/foo,bar!=baz,spork in (fork,spoon)' }
+      it 'parses multiple operations' do
+        expect(subject).to be_valid
+        expect(subject.requirements.size).to be(3)
+
+        expect(subject.requirements.first.key).to eq('example.com/foo')
+        expect(subject.requirements.first.operator).to eq(:exists)
+        expect(subject.requirements.first.values).to be_empty
+
+        expect(subject.requirements.second.key).to eq('bar')
+        expect(subject.requirements.second.operator).to eq(:not_equal)
+        expect(subject.requirements.second.values).to contain_exactly('baz')
+
+        expect(subject.requirements.third.key).to eq('spork')
+        expect(subject.requirements.third.operator).to eq(:in)
+        expect(subject.requirements.third.values).to contain_exactly('fork', 'spoon')
       end
     end
   end


### PR DESCRIPTION
The current back-end is hard to use from the CLI.  Its parser is
too strict, and the error messages tend to leave command-line
users struggling to see what they need to fix.

* Accept ignorable white-space everywhere
* For syntax-errors, contextually highlight the first error
  so user can see what they need to fix
* Complain about some things that current implementation accepts,
  like the trailing comma in 'fish=scale,'

[#168488761](https://www.pivotaltracker.com/story/show/168488761)

For examples, use a v7 version of the CLI and target `pre-fix.capi.land`
and `post-fix.capi.land`

### pre fix:

```
$ cf7 apps --labels 'abc= def'
Getting apps in org org / space space as admin...

The query parameter is invalid: ' def' contains invalid characters
FAILED

$ cf7 apps --labels 'abc=def,'
Getting apps in org org / space space as admin...

No apps found
```

### post-fix

```
$ cf7 apps --labels 'abc= def'
Getting apps in org org / space space as admin...

No apps found

$ cf7 apps --labels 'abc=def,'
cf7 apps --labels 'abc=def,'
Getting apps in org org / space space as admin...

The query parameter is invalid: expecting a key or '!', got "abc=def,<<>>"
FAILED
```

* A short explanation of the proposed change:
Better usability

* An explanation of the use cases your change solves
Really, I watched the other CLI devs try to use this, and they were all puzzled.

* Links to any other associated PRs
None

* [x ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [ x] I have made this pull request to the `master` branch

* [ x] I have run all the unit tests using `bundle exec rake`

* [x ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
