### PR TITLE
add ability to include domains on /v3/routes and /v3/routes/:guid

### DIFF
--- a/app/decorators/include_route_domain_decorator.rb
+++ b/app/decorators/include_route_domain_decorator.rb
@@ -1,0 +1,18 @@
+module VCAP::CloudController
+  class IncludeRouteDomainDecorator
+    class << self
+      def match?(include)
+        include&.any? { |i| %w(domain).include?(i) }
+      end
+
+      def decorate(hash, routes)
+        hash[:included] ||= {}
+        domain_guids = routes.map(&:domain_guid).uniq
+        domains = Domain.where(guid: domain_guids)
+
+        hash[:included][:domains] = domains.map { |domain| Presenters::V3::DomainPresenter.new(domain).to_hash }
+        hash
+      end
+    end
+  end
+end

--- a/app/messages/route_show_message.rb
+++ b/app/messages/route_show_message.rb
@@ -2,10 +2,15 @@ require 'messages/base_message'
 
 module VCAP::CloudController
   class RouteShowMessage < BaseMessage
-    register_allowed_keys [:guid]
+    register_allowed_keys [:guid, :include]
 
     validates_with NoAdditionalParamsValidator
+    validates_with IncludeParamValidator, valid_values: ['domain']
 
     validates :guid, presence: true, string: true
+
+    def self.from_params(params)
+      super(params, %w(include))
+    end
   end
 end

--- a/app/messages/routes_list_message.rb
+++ b/app/messages/routes_list_message.rb
@@ -8,10 +8,12 @@ module VCAP::CloudController
       :organization_guids,
       :domain_guids,
       :paths,
+      :include,
       :label_selector,
     ]
 
     validates_with NoAdditionalParamsValidator
+    validates_with IncludeParamValidator, valid_values: ['domain']
 
     validates :hosts, allow_nil: true, array: true
     validates :paths, allow_nil: true, array: true
@@ -22,7 +24,7 @@ module VCAP::CloudController
     attr_reader :app_guid
 
     def self.from_params(params)
-      super(params, %w(hosts space_guids organization_guids domain_guids paths))
+      super(params, %w(hosts space_guids organization_guids domain_guids paths include))
     end
 
     def for_app_guid(app_guid)

--- a/app/presenters/v3/route_presenter.rb
+++ b/app/presenters/v3/route_presenter.rb
@@ -16,13 +16,14 @@ module VCAP::CloudController::Presenters::V3
     def initialize(
       resource,
         show_secrets: false,
-        censored_message: VCAP::CloudController::Presenters::Censorship::REDACTED_CREDENTIAL
+        censored_message: VCAP::CloudController::Presenters::Censorship::REDACTED_CREDENTIAL,
+        decorators: []
     )
-      super(resource, show_secrets: show_secrets, censored_message: censored_message)
+      super(resource, show_secrets: show_secrets, censored_message: censored_message, decorators: decorators)
     end
 
     def to_hash
-      {
+      hash = {
         guid: route.guid,
         created_at: route.created_at,
         updated_at: route.updated_at,
@@ -43,6 +44,8 @@ module VCAP::CloudController::Presenters::V3
         },
         links: build_links
       }
+
+      @decorators.reduce(hash) { |memo, d| d.decorate(memo, [route]) }
     end
 
     private

--- a/docs/v3/source/includes/resources/routes/_get.md.erb
+++ b/docs/v3/source/includes/resources/routes/_get.md.erb
@@ -24,6 +24,12 @@ Content-Type: application/json
 #### Definition
 `GET /v3/routes/:guid`
 
+#### Query parameters
+
+Name | Type | Description
+---- | ---- | ------------
+**include** | _string_ | **Experimental** - Optionally include additional related resources in the response. <br>Valid value is `domain`
+
 #### Permitted roles
 
 Role  | Notes

--- a/docs/v3/source/includes/resources/routes/_list.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list.md.erb
@@ -39,6 +39,7 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page. <br>Valid values are 1 through 5000.
 **order_by** | _string_ | Value to sort by. Defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`.
 **label_selector**     | _string_          | **Experimental** - A query string containing a list of [label selector](#labels-and-selectors) requirements. |
+**include** | _string_ | **Experimental** - Optionally include a list of unique related resources in the response. <br>Valid value is `domain`
 
 #### Permitted roles
  |

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -94,6 +94,119 @@ RSpec.describe 'Routes Request' do
       it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
+    describe 'includes' do
+      context 'when including domains' do
+        let(:domain1) { VCAP::CloudController::SharedDomain.make(name: 'first-domain.example.com') }
+        let(:domain1_json) do
+          {
+            guid: domain1.guid,
+            created_at: iso8601,
+            updated_at: iso8601,
+            name: domain1.name,
+            internal: false,
+            metadata: {
+              labels: {},
+              annotations: {}
+            },
+            relationships: {
+              organization: {
+                data: nil
+              },
+              shared_organizations: {
+                data: []
+              }
+            },
+            links: {
+              self: { href: "#{link_prefix}/v3/domains/#{domain1.guid}" },
+              route_reservations: { href: %r(#{Regexp.escape(link_prefix)}\/v3/domains/#{domain1.guid}/route_reservations) }
+            }
+          }
+        end
+
+        let(:domain2) { VCAP::CloudController::SharedDomain.make(name: 'second-domain.example.com') }
+        let(:domain2_json) do
+          {
+            guid: domain2.guid,
+            created_at: iso8601,
+            updated_at: iso8601,
+            name: domain2.name,
+            internal: false,
+            metadata: {
+              labels: {},
+              annotations: {}
+            },
+            relationships: {
+              organization: {
+                data: nil
+              },
+              shared_organizations: {
+                data: []
+              }
+            },
+            links: {
+              self: { href: "#{link_prefix}/v3/domains/#{domain2.guid}" },
+              route_reservations: { href: %r(#{Regexp.escape(link_prefix)}\/v3/domains/#{domain2.guid}/route_reservations) }
+            }
+          }
+        end
+
+        let!(:route1_domain1) do
+          VCAP::CloudController::Route.make(space: space, host: 'route1', domain: domain1, path: '/path1', guid: 'route1-guid')
+        end
+        let(:route1_domain1_json) do
+          {
+            guid: route1_domain1.guid,
+            created_at: iso8601,
+            updated_at: iso8601,
+            host: route1_domain1.host,
+            path: route1_domain1.path,
+            url: "#{route1_domain1.host}.#{domain1.name}#{route1_domain1.path}",
+            metadata: {
+              labels: {},
+              annotations: {}
+            },
+            relationships: {
+              space: {
+                data: {
+                  guid: space.guid
+                }
+              },
+              domain: {
+                data: {
+                  guid: domain1.guid
+                }
+              }
+            },
+            links: {
+              self: { href: "http://api2.vcap.me/v3/routes/#{route1_domain1.guid}" },
+              space: { href: "http://api2.vcap.me/v3/spaces/#{space.guid}" },
+              destinations: { href: %r(#{Regexp.escape(link_prefix)}\/v3\/routes\/#{route1_domain1.guid}\/destinations) },
+              domain: { href: "http://api2.vcap.me/v3/domains/#{domain1.guid}" }
+            }
+          }
+        end
+
+        let!(:route_in_org) do
+          VCAP::CloudController::Route.make(space: space, domain: domain1, host: 'host-1', path: '/path1', guid: 'route-in-org-guid')
+        end
+        let!(:route_in_other_org) do
+          VCAP::CloudController::Route.make(space: other_space, domain: domain2, host: 'host-2', path: '/path2', guid: 'route-in-other-org-guid')
+        end
+
+        it 'includes the unique domains for the routes' do
+          get '/v3/routes?include=domain', nil, admin_header
+          expect(last_response.status).to eq(200)
+          expect({
+            resources: parsed_response['resources'],
+            included: parsed_response['included']
+          }).to match_json_response({
+            resources: [route_in_org_json, route_in_other_org_json, route1_domain1_json],
+            included: { 'domains' => [domain1_json, domain2_json] }
+          })
+        end
+      end
+    end
+
     describe 'filters' do
       let!(:route_without_host_and_with_path) do
         VCAP::CloudController::Route.make(space: space, host: '', domain: domain, path: '/path1', guid: 'route-without-host')
@@ -108,7 +221,7 @@ RSpec.describe 'Routes Request' do
           updated_at: iso8601,
           host: '',
           path: '/path1',
-          url: "#{domain.name}/path1",
+          url: "#{route_without_host_and_with_path.host}.#{domain.name}/path1",
           metadata: {
             labels: {},
             annotations: {}
@@ -140,7 +253,7 @@ RSpec.describe 'Routes Request' do
           updated_at: iso8601,
           host: '',
           path: '/path2',
-          url: "#{domain.name}/path2",
+          url: "#{route1_domain1.host}.#{domain.name}/path2",
           metadata: {
             labels: {},
             annotations: {}
@@ -538,6 +651,73 @@ RSpec.describe 'Routes Request' do
       it 'returns 401 for Unauthenticated requests' do
         get "/v3/routes/#{route.guid}", nil, base_json_headers
         expect(last_response.status).to eq(401)
+      end
+    end
+
+    describe 'includes' do
+      context 'when including domains' do
+        let(:domain_json) do
+          {
+            guid: domain.guid,
+            created_at: iso8601,
+            updated_at: iso8601,
+            name: domain.name,
+            internal: false,
+            metadata: {
+              labels: {},
+              annotations: {}
+            },
+            relationships: {
+              organization: {
+                data: { guid: domain.owning_organization.guid }
+              },
+              shared_organizations: {
+                data: []
+              }
+            },
+            links: {
+              self: { href: "#{link_prefix}/v3/domains/#{domain.guid}" },
+              organization: { href: %r(#{Regexp.escape(link_prefix)}\/v3/organizations/#{domain.owning_organization.guid}) },
+              route_reservations: { href: %r(#{Regexp.escape(link_prefix)}\/v3/domains/#{domain.guid}/route_reservations) },
+              shared_organizations: { href: %r(#{Regexp.escape(link_prefix)}\/v3/domains/#{domain.guid}/relationships/shared_organizations) },
+            }
+          }
+        end
+        let(:route_json) do
+          {
+            guid: route.guid,
+            host: route.host,
+            path: route.path,
+            url: "#{route.host}.#{route.domain.name}#{route.path}",
+            created_at: iso8601,
+            updated_at: iso8601,
+            relationships: {
+              space: {
+                data: { guid: route.space.guid }
+              },
+              domain: {
+                data: { guid: route.domain.guid }
+              }
+            },
+            metadata: {
+              labels: {},
+              annotations: {}
+            },
+            links: {
+              self: { href: %r(#{Regexp.escape(link_prefix)}\/v3\/routes\/#{UUID_REGEX}) },
+              space: { href: %r(#{Regexp.escape(link_prefix)}\/v3\/spaces\/#{route.space.guid}) },
+              destinations: { href: %r(#{Regexp.escape(link_prefix)}\/v3\/routes\/#{UUID_REGEX}\/destinations) },
+              domain: { href: %r(#{Regexp.escape(link_prefix)}\/v3\/domains\/#{route.domain.guid}) }
+            },
+            included: { domains: [domain_json] }
+          }
+        end
+
+        it 'includes the domain for the route' do
+          get "/v3/routes/#{route.guid}?include=domain", nil, admin_header
+          expect(last_response.status).to eq(200), last_response.body
+          expect(parsed_response).to match_json_response(route_json)
+        end
       end
     end
   end

--- a/spec/unit/decorators/include_route_domain_decorator_spec.rb
+++ b/spec/unit/decorators/include_route_domain_decorator_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'decorators/include_route_domain_decorator'
+
+module VCAP::CloudController
+  RSpec.describe IncludeRouteDomainDecorator do
+    subject(:decorator) { IncludeRouteDomainDecorator }
+    let(:domain1) { SharedDomain.make(name: 'first-domain.example.com') }
+    let(:domain2) { SharedDomain.make(name: 'second-domain.example.com') }
+    let(:routes) { [Route.make(domain: domain1), Route.make(domain: domain2), Route.make(domain: domain1)] }
+
+    it 'decorates the given hash with domains from routes' do
+      undecorated_hash = { i_am: 'tim' }
+      hash = subject.decorate(undecorated_hash, routes)
+      expect(hash[:i_am]).to eq('tim')
+      expect(hash[:included][:domains]).to match_array([Presenters::V3::DomainPresenter.new(domain1).to_hash, Presenters::V3::DomainPresenter.new(domain2).to_hash])
+    end
+
+    it 'does not overwrite other included fields' do
+      undecorated_hash = { foo: 'bar', included: { favorite_fruits: ['tomato', 'cucumber'] } }
+      hash = subject.decorate(undecorated_hash, routes)
+      expect(hash[:foo]).to eq('bar')
+      expect(hash[:included][:domains]).to match_array([Presenters::V3::DomainPresenter.new(domain1).to_hash, Presenters::V3::DomainPresenter.new(domain2).to_hash])
+      expect(hash[:included][:favorite_fruits]).to match_array(['tomato', 'cucumber'])
+    end
+
+    describe '.match?' do
+      it 'matches include arrays containing "domain"' do
+        expect(decorator.match?(['potato', 'domain', 'turnip'])).to be true
+      end
+
+      it 'does not match other include arrays' do
+        expect(decorator.match?(['vegetal', 'turnip'])).to be false
+      end
+    end
+  end
+end

--- a/spec/unit/messages/route_show_message_spec.rb
+++ b/spec/unit/messages/route_show_message_spec.rb
@@ -5,26 +5,35 @@ module VCAP::CloudController
   RSpec.describe RouteShowMessage do
     describe 'fields' do
       it 'accepts a string guid param' do
-        message = RouteShowMessage.new({ 'guid' => 'some-guid' })
+        message = RouteShowMessage.from_params({ 'guid' => 'some-guid' })
         expect(message).to be_valid
       end
 
       it 'does not accept empty params' do
-        message = RouteShowMessage.new({})
+        message = RouteShowMessage.from_params({})
         expect(message).not_to be_valid
         expect(message.errors[:guid]).to include("can't be blank")
       end
 
       it 'does not accept guid params of incorrect type' do
-        message = RouteShowMessage.new({ 'guid' => 123 })
+        message = RouteShowMessage.from_params({ 'guid' => 123 })
         expect(message).not_to be_valid
         expect(message.errors[:guid]).to include('must be a string')
       end
 
       it 'does not accept any other params' do
-        message = RouteShowMessage.new({ 'foobar' => 'pants' })
+        message = RouteShowMessage.from_params({ 'foobar' => 'pants' })
         expect(message).not_to be_valid
         expect(message.errors[:base]).to include("Unknown query parameter(s): 'foobar'")
+      end
+    end
+
+    describe 'includes' do
+      it 'only allows domains to be included' do
+        message = RouteShowMessage.from_params({ 'guid' => 'some-guid', 'include' => 'domain' })
+        expect(message).to be_valid
+        message = RouteShowMessage.from_params({ 'guid' => 'some-guid', 'include' => 'kube' })
+        expect(message).not_to be_valid
       end
     end
   end

--- a/spec/unit/messages/routes_list_message_spec.rb
+++ b/spec/unit/messages/routes_list_message_spec.rb
@@ -89,6 +89,22 @@ module VCAP::CloudController
         expect(message).not_to be_valid
         expect(message.errors[:base]).to include("Unknown query parameter(s): 'app_guid'")
       end
+
+      it 'does not accept include that is not domain' do
+        message = RoutesListMessage.from_params({ 'include' => 'domain' })
+        expect(message).to be_valid
+        message = RoutesListMessage.from_params({ 'include' => 'space.organization' })
+        expect(message).not_to be_valid
+        message = RoutesListMessage.from_params({ 'include' => 'eli\'s buildpack' })
+        expect(message).not_to be_valid
+      end
+
+      it 'invalidates duplicates in the includes field' do
+        message = RoutesListMessage.from_params 'include' => 'domain,domain'
+        expect(message).to be_invalid
+        expect(message.errors[:base].length).to eq 1
+        expect(message.errors[:base][0]).to match(/Duplicate included resource: 'domain'/)
+      end
     end
   end
 end

--- a/spec/unit/presenters/v3/route_presenter_spec.rb
+++ b/spec/unit/presenters/v3/route_presenter_spec.rb
@@ -71,6 +71,26 @@ module VCAP::CloudController::Presenters::V3
           expect(subject[:url]).to eq("#{domain.name}#{route.path}")
         end
       end
+
+      context 'when there are decorators' do
+        let(:banana_decorator) do
+          Class.new do
+            class << self
+              def decorate(hash, routes)
+                hash[:included] ||= {}
+                hash[:included][:bananas] = routes.map { |route| "#{route.host} is bananas" }
+                hash
+              end
+            end
+          end
+        end
+
+        subject { RoutePresenter.new(route, decorators: [banana_decorator]).to_hash }
+
+        it 'runs the decorators' do
+          expect(subject[:included][:bananas]).to match_array(['host is bananas'])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Currently to get the raw domain name for a route and whether or not it is internal requires a separate call to /v3/domains/:guid. When listing all of the routes in a CF this ends up being a lot of API calls. This change allows domains to be included in the response payloads of `/v3/routes` and `/v3/routes/:guid`.

See issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/1470

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

cc/ @Gerg @ewrenn8 
