### PR TITLE
Cut oversize error messages down so they'll fit in a 16K database field

### DIFF
--- a/app/presenters/v3/job_presenter.rb
+++ b/app/presenters/v3/job_presenter.rb
@@ -48,7 +48,6 @@ module VCAP::CloudController
           return [] if job.cf_api_error.nil? || job.state == VCAP::CloudController::PollableJobModel::COMPLETE_STATE
 
           parsed_last_error = YAML.safe_load(job.cf_api_error)
-
           parsed_last_error['errors'].map(&:deep_symbolize_keys)
         end
 

--- a/spec/unit/jobs/pollable_job_wrapper_spec.rb
+++ b/spec/unit/jobs/pollable_job_wrapper_spec.rb
@@ -143,25 +143,20 @@ module VCAP::CloudController::Jobs
       end
 
       context 'with a big message' do
-        # postgres complains with 15,824
-        # mysql complains with 15,825, so test for failure at that point
-        # bracket the values with 100 each way to allow for differences on travis
+        # postgres complains with 15,826
+        # mysql complains with 15,828, so test for failure at that point
 
         it 'squeezes just right one in' do
-          raise BigException.new(message: 'x' * 15_823)
-        rescue BigException => exception
           expect {
-            pollable_job.error(job, exception)
+            pollable_job.error(job, BigException.new(message: 'x' * 15_825))
           }.to_not raise_error
         end
 
         it 'gives up' do
-          raise BigException.new(message: 'x' * 15_825)
-        rescue BigException => exception
           pg_error = /value too long for type character varying/
           mysql_error = /Data too long for column 'cf_api_error'/
           expect {
-            pollable_job.error(job, exception)
+            pollable_job.error(job, BigException.new(message: 'x' * 15_828))
           }.to raise_error(::Sequel::DatabaseError, /#{pg_error}|#{mysql_error}/)
         end
       end

--- a/spec/unit/jobs/pollable_job_wrapper_spec.rb
+++ b/spec/unit/jobs/pollable_job_wrapper_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 require 'jobs/pollable_job_wrapper'
+require 'yaml'
 
 module VCAP::CloudController::Jobs
+  class BigException < StandardError
+  end
+
   RSpec.describe PollableJobWrapper, job_context: :worker do
     let(:job) { double(job_name_in_configuration: 'my-job', max_attempts: 2, perform: nil) }
     let(:pollable_job) { PollableJobWrapper.new(job) }
@@ -115,6 +119,56 @@ module VCAP::CloudController::Jobs
           expect(job_model.state).to eq('COMPLETE')
           warnings = job_model.warnings
           expect(warnings.to_json).to eq('[]')
+        end
+      end
+    end
+
+    describe 'error' do
+      let(:job) { double(job_name_in_configuration: 'my-job', max_attempts: 2, perform: nil, guid: '15') }
+      let!(:actual_pollable_job) { VCAP::CloudController::PollableJobModel.create(delayed_job_guid: job.guid) }
+
+      context 'with a big backtrace' do
+        it 'culls it down' do
+          raise BigException.new
+        rescue BigException => exception
+          count = 256 - exception.backtrace.size
+          count.times do
+            exception.backtrace << '1000 character backtrace: ' + 'x' * 974
+          end
+          pollable_job.error(job, exception)
+          expect(actual_pollable_job.reload.cf_api_error).to_not be_empty
+          block = YAML.safe_load(actual_pollable_job.cf_api_error)
+          errors = block['errors']
+          expect(errors.size).to eq(1)
+          error = errors[0]['test_mode_info']
+          expect(error['detail']).to eq('VCAP::CloudController::Jobs::BigException')
+          # Normally should be 64 on a dev machine, 32 on travis due to longer paths :(
+          expect(error['backtrace'].size).to be >= 32
+          expect(error['backtrace'].size).to be <= 64
+        end
+      end
+
+      context 'with a big message' do
+        # postgres complains with 15,824
+        # mysql complains with 15,825, so test for failure at that point
+        # bracket the values with 100 each way to allow for differences on travis
+
+        it 'squeezes just right one in' do
+          raise BigException.new(message: 'x' * 15_823)
+        rescue BigException => exception
+          expect {
+            pollable_job.error(job, exception)
+          }.to_not raise_error
+        end
+
+        it 'gives up' do
+          raise BigException.new(message: 'x' * 15_825)
+        rescue BigException => exception
+          pg_error = /value too long for type character varying/
+          mysql_error = /Data too long for column 'cf_api_error'/
+          expect {
+            pollable_job.error(job, exception)
+          }.to raise_error(::Sequel::DatabaseError, /#{pg_error}|#{mysql_error}/)
         end
       end
     end

--- a/spec/unit/models/services/service_spec.rb
+++ b/spec/unit/models/services/service_spec.rb
@@ -320,7 +320,6 @@ module VCAP::CloudController
       let(:org) { Organization.make }
       let(:space) { Space.make(organization: org) }
       let(:dev) { make_developer_for_space(space) }
-      let(:outside_dev) { User.make(admin: false, active: true) }
 
       before(:each) do
         @private_broker = ServiceBroker.make(space: space)


### PR DESCRIPTION
Error handling can break with very large error messages, and it appears as if no error was encountered.  

This PR does two things:

1.) If a raw error message is too large, try cutting the backtrace down 1/2 at a time until the raw message will fit in a 16K field.

2.) If #1 fails, remove blocks, largest first, favoring ends of arrays, until the YAML-encoding of the object will fit in the field.

Four service-broker-related tests were breaking on travis because travis runs its tests from a path that is slightly longer than for concourse and the dev machines. This wasn't noticed until some change was made that created full error messages that exceeded the limits on travis, but not elsewhere.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
