### PR TITLE
Update random route generation to add 2 letter suffix

### DIFF
--- a/lib/cloud_controller/random_route_generator.rb
+++ b/lib/cloud_controller/random_route_generator.rb
@@ -7,7 +7,10 @@ module VCAP::CloudController
     end
 
     def route
-      @adjective_noun_generator.generate
+      ascii_letter_a = 97
+      first_letter = (rand(26) + ascii_letter_a).chr
+      second_letter = (rand(26) + ascii_letter_a).chr
+      @adjective_noun_generator.generate + "-#{first_letter}#{second_letter}"
     end
   end
 end

--- a/spec/unit/lib/cloud_controller/random_route_generator_spec.rb
+++ b/spec/unit/lib/cloud_controller/random_route_generator_spec.rb
@@ -17,9 +17,9 @@ module VCAP::CloudController
       expect(routes2.difference(routes1)).not_to be_empty
     end
 
-    it 'returns an adjective-noun' do
+    it 'returns an adjective-noun-twoRandomLetters' do
       route = generator.route
-      expect(route).to match(/^\w+-\w+$/)
+      expect(route).to match(/^\w+-\w+-[a-z]{2}$/)
     end
   end
 end


### PR DESCRIPTION
Decreases odds of collisions being reported by users.

We've updated the random route generation in cli v6 to match this new behavior.

[#169141312](https://www.pivotaltracker.com/story/show/169141312)

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
