### PR TITLE
V3 service_offerings visibility for space-scoped offerings

### DIFF
--- a/app/controllers/v3/service_offerings_controller.rb
+++ b/app/controllers/v3/service_offerings_controller.rb
@@ -1,37 +1,52 @@
 require 'fetchers/service_offerings_fetcher'
+require 'fetchers/service_plan_visibility_fetcher'
 require 'presenters/v3/service_offering_presenter'
 
 class ServiceOfferingsController < ApplicationController
   def show
     guid = hashed_params[:guid]
 
-    offering = if !current_user
-                 ServiceOfferingsFetcher.fetch_one_anonymously(guid)
-               elsif permission_queryer.can_read_globally?
-                 ServiceOfferingsFetcher.fetch_one(guid)
-               else
-                 ServiceOfferingsFetcher.fetch_one(guid, org_guids: permission_queryer.readable_org_guids)
-               end
+    not_authenticated! if !current_user && VCAP::CloudController::FeatureFlag.enabled?(:hide_marketplace_from_unauthenticated_users)
 
+    offering, space, public = ServiceOfferingsFetcher.fetch(guid)
     service_offering_not_found! if offering.nil?
 
-    presenter = Presenters::V3::ServiceOfferingPresenter.new(offering)
-    render status: :ok, json: presenter.to_json
+    if permission_queryer.can_read_globally? || public || visible_space_scoped?(space) || visible_in_readable_orgs?(offering)
+      presenter = Presenters::V3::ServiceOfferingPresenter.new(offering)
+      render status: :ok, json: presenter.to_json
+    else
+      service_offering_not_found!
+    end
   end
 
   def enforce_authentication?
-    return false if action_name == 'show'
-
-    super
+    action_name == 'show' ? false : super
   end
 
   def enforce_read_scope?
-    return false if action_name == 'show'
+    action_name == 'show' ? false : super
+  end
 
-    super
+  private
+
+  def visible_in_readable_orgs?(offering)
+    return false if !current_user
+
+    ServicePlanVisibilityFetcher.service_plans_visible_in_orgs?(offering.service_plans.map(&:guid), permission_queryer.readable_org_guids)
+  end
+
+  def visible_space_scoped?(space)
+    return false if !current_user
+    return false if !space
+
+    space.has_member?(current_user)
   end
 
   def service_offering_not_found!
     resource_not_found!(:service_offering)
+  end
+
+  def not_authenticated!
+    raise CloudController::Errors::NotAuthenticated
   end
 end

--- a/app/fetchers/service_offerings_fetcher.rb
+++ b/app/fetchers/service_offerings_fetcher.rb
@@ -1,33 +1,14 @@
 module VCAP::CloudController
   class ServiceOfferingsFetcher
     class << self
-      def fetch_one(guid, org_guids: nil)
-        return Service.find(guid: guid) unless org_guids
+      def fetch(service_offering_guid)
+        service_offering = Service.where(guid: service_offering_guid).eager(:service_plans, :service_broker).first
+        return [nil, nil, false] if service_offering.nil?
 
-        guids = Service.dataset.
-                join(:service_plans, service_id: :id).
-                left_join(:service_plan_visibilities, service_plan_id: :id).
-                left_join(:organizations, id: :organization_id).
-                where do
-                  (Sequel[:services][:guid] =~ guid) &
-                    ((Sequel[:service_plans][:public] =~ true) | (Sequel[:organizations][:guid] =~ org_guids))
-                end.
-                select(Sequel[:services][:guid]).
-                all.
-                map(&:guid)
+        public = service_offering.service_plans.any?(&:public)
+        space = service_offering.service_broker.space
 
-        Service.find(guid: guids.first)
-      end
-
-      def fetch_one_anonymously(guid)
-        guids = Service.dataset.
-                join(:service_plans, service_id: :id).
-                where { (Sequel[:services][:guid] =~ guid) & (Sequel[:service_plans][:public] =~ true) }.
-                select(Sequel[:services][:guid]).
-                all.
-                map(&:guid)
-
-        Service.find(guid: guids.first)
+        [service_offering, space, public]
       end
     end
   end

--- a/app/fetchers/service_plan_visibility_fetcher.rb
+++ b/app/fetchers/service_plan_visibility_fetcher.rb
@@ -1,0 +1,15 @@
+module VCAP::CloudController
+  class ServicePlanVisibilityFetcher
+    class << self
+      def service_plans_visible_in_orgs?(service_plan_guids, readable_org_guids)
+        empty = ServicePlanVisibility.dataset.
+                left_join(:organizations, id: Sequel[:service_plan_visibilities][:organization_id]).
+                left_join(:service_plans, id: Sequel[:service_plan_visibilities][:service_plan_id]).
+                where { (Sequel[:service_plans][:guid] =~ service_plan_guids) & (Sequel[:organizations][:guid] =~ readable_org_guids) }.
+                empty?
+
+        !empty
+      end
+    end
+  end
+end

--- a/spec/unit/fetchers/service_plan_visibility_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_plan_visibility_fetcher_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'fetchers/service_plan_visibility_fetcher'
+
+module VCAP::CloudController
+  RSpec.describe ServicePlanVisibilityFetcher do
+    context 'when a specified plan has no visibility' do
+      let(:plan) { ServicePlan.make }
+      let(:org) { Organization.make }
+
+      it 'is not visible' do
+        expect(ServicePlanVisibilityFetcher.service_plans_visible_in_orgs?([plan.guid], [org.guid])).to eq(false)
+      end
+    end
+
+    context 'when a specified plan has visibility in a specified org' do
+      let(:plan) { ServicePlan.make }
+      let(:org) { Organization.make }
+      let!(:visibility) { ServicePlanVisibility.make(organization: org, service_plan: plan) }
+
+      it 'is visible' do
+        expect(ServicePlanVisibilityFetcher.service_plans_visible_in_orgs?([plan.guid], [org.guid])).to eq(true)
+      end
+    end
+
+    context 'when a specified plan has visibility in other org' do
+      let(:plan) { ServicePlan.make }
+      let(:org1) { Organization.make }
+      let(:org2) { Organization.make }
+      let(:org3) { Organization.make }
+      let!(:visibility) { ServicePlanVisibility.make(organization: org3, service_plan: plan) }
+
+      it 'is not visible' do
+        expect(ServicePlanVisibilityFetcher.service_plans_visible_in_orgs?([plan.guid], [org1.guid, org2.guid])).to eq(false)
+      end
+    end
+
+    context 'when many plans are specified and only one has visibility in a specified org' do
+      let(:plan1) { ServicePlan.make }
+      let(:plan2) { ServicePlan.make }
+      let(:plan3) { ServicePlan.make }
+      let(:org1) { Organization.make }
+      let(:org2) { Organization.make }
+      let(:org3) { Organization.make }
+      let!(:visibility) { ServicePlanVisibility.make(organization: org3, service_plan: plan2) }
+
+      it 'is visible' do
+        expect(ServicePlanVisibilityFetcher.service_plans_visible_in_orgs?([plan1.guid, plan2.guid, plan3.guid], [org2.guid, org3.guid])).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- service offerings from space-scoped can be seen
- split the ServiceOfferingsFetcher so that plan visibility is handled
with a new ServicePlanVisibilityFetcher
- now respects the `hide_marketplace_from_unauthenticated_users` feature flag

[more details in story #169482815](https://www.pivotaltracker.com/story/show/169482815)