### PR TITLE
Enable a second symmetric key to enable key rotation in UAA

### DIFF
--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -51,6 +51,7 @@ module VCAP::CloudController
             :ca_file => String,
             :client_timeout => Integer,
             optional(:symmetric_secret) => String,
+            optional(:symmetric_secret2) => String,
           },
 
           logging: {

--- a/lib/cloud_controller/uaa/uaa_token_decoder.rb
+++ b/lib/cloud_controller/uaa/uaa_token_decoder.rb
@@ -43,7 +43,16 @@ module VCAP::CloudController
     end
 
     def decode_token_with_symmetric_key(auth_token)
-      decode_token_with_key(auth_token, skey: symmetric_key)
+      last_error = nil
+
+      thekeys = [ symmetric_key, symmetric_key2 ]
+
+      thekeys.each do |key|
+        return decode_token_with_key(auth_token, skey: key)
+      rescue CF::UAA::InvalidSignature => e
+        last_error = e
+      end
+      raise last_error
     end
 
     def decode_token_with_asymmetric_key(auth_token)
@@ -83,6 +92,10 @@ module VCAP::CloudController
 
     def symmetric_key
       config[:symmetric_secret]
+    end
+
+    def symmetric_key2
+      config[:symmetric_secret2]
     end
 
     def asymmetric_key

--- a/lib/cloud_controller/uaa/uaa_token_decoder.rb
+++ b/lib/cloud_controller/uaa/uaa_token_decoder.rb
@@ -45,7 +45,7 @@ module VCAP::CloudController
     def decode_token_with_symmetric_key(auth_token)
       last_error = nil
 
-      thekeys = [ symmetric_key, symmetric_key2 ]
+      thekeys = [symmetric_key, symmetric_key2]
 
       thekeys.each do |key|
         return decode_token_with_key(auth_token, skey: key)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:  UAA supports mutliple keys for symmetric keys.  This change allows for CAPI to validate on two keys so that we can roll the symmetric keys in UAA with no downtime.

* An explanation of the use cases your change solves: Rotation of symmetric keys in UAA

* Links to any other associated PRs: There will be a corresponding change to capi-release I will post as soon as I have submitted that.   https://github.com/cloudfoundry/capi-release/pull/163

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
