### PR TITLE
Remove deployment state from API

### DIFF
--- a/app/presenters/v3/deployment_presenter.rb
+++ b/app/presenters/v3/deployment_presenter.rb
@@ -10,7 +10,6 @@ module VCAP::CloudController::Presenters::V3
         guid: deployment.guid,
         created_at: deployment.created_at,
         updated_at: deployment.updated_at,
-        state: deployment.state,
         status: {
           value: deployment.status_value,
           reason: deployment.status_reason,

--- a/docs/v3/source/includes/api_resources/_deployments.erb
+++ b/docs/v3/source/includes/api_resources/_deployments.erb
@@ -2,7 +2,6 @@
 
 {
   "guid": "59c3d133-2b83-46f3-960e-7765a129aea4",
-  "state": "DEPLOYING",
   "status": {
     "value": "ACTIVE",
     "reason": "DEPLOYING",
@@ -72,7 +71,6 @@
   "resources": [
     {
       "guid": "59c3d133-2b83-46f3-960e-7765a129aea4",
-      "state": "DEPLOYED",
       "status": {
         "value": "FINALIZED",
         "reason": "DEPLOYED"

--- a/docs/v3/source/includes/resources/deployments/_object.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_object.md.erb
@@ -12,7 +12,6 @@ Name | Type | Description
 **guid** | _uuid_ | Unique identifier for the deployment
 **created_at** | _[timestamp](#timestamps)_ | The time with zone when the object was created
 **updated_at** | _[timestamp](#timestamps)_ | The time with zone when the object was last updated
-**state** | _string_ | **(deprecated)** This field will be removed in the future; use the `status` fields to determine deployment state instead
 **status.value** | _string_ | The current status of the deployment; valid values are `ACTIVE` (meaning in progress) and `FINALIZED` (meaning finished, either successfully or not)
 **status.reason** | _string_ | The reason for the status of the deployment;<br>following list represents valid values:<br>1. If **status.value** is `ACTIVE`<br>- `DEPLOYING`<br>- `CANCELING`<br>2. If **status.value** is `FINALIZED`<br>- `DEPLOYED`<br>- `CANCELED`<br>- `SUPERSEDED` (another deployment created for app before completion)<br>- `DEGENERATE` (the deployment was created incorrectly by the system)
 **status.details** | _object_ | The details for the status of the deployment shows a timestamp of the last successful healthcheck

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe 'Deployments' do
 
         expect(parsed_response).to be_a_response_like({
           'guid' => deployment.guid,
-          'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
           'status' => {
             'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
             'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -116,7 +115,6 @@ RSpec.describe 'Deployments' do
 
         expect(parsed_response).to be_a_response_like({
           'guid' => deployment.guid,
-          'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
           'status' => {
             'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
             'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -198,7 +196,6 @@ RSpec.describe 'Deployments' do
 
         expect(parsed_response).to be_a_response_like({
           'guid' => deployment.guid,
-          'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
           'status' => {
             'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
             'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -316,7 +313,6 @@ RSpec.describe 'Deployments' do
 
         expect(parsed_response).to be_a_response_like({
           'guid' => deployment.guid,
-          'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
           'status' => {
             'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
             'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -393,7 +389,6 @@ RSpec.describe 'Deployments' do
         parsed_response = MultiJson.load(last_response.body)
         expect(parsed_response).to be_a_response_like({
           'guid' => deployment.guid,
-          'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
           'status' => {
             'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
             'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -473,7 +468,6 @@ RSpec.describe 'Deployments' do
 
         expect(parsed_response).to be_a_response_like({
           'guid' => deployment.guid,
-          'state' => VCAP::CloudController::DeploymentModel::DEPLOYED_STATE,
           'status' => {
             'value' => VCAP::CloudController::DeploymentModel::FINALIZED_STATUS_VALUE,
             'reason' => VCAP::CloudController::DeploymentModel::DEPLOYED_STATUS_REASON,
@@ -638,7 +632,6 @@ RSpec.describe 'Deployments' do
 
           expect(parsed_response).to be_a_response_like({
             'guid' => deployment.guid,
-            'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
             'status' => {
               'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
               'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -698,7 +691,6 @@ RSpec.describe 'Deployments' do
 
           expect(parsed_response).to be_a_response_like({
             'guid' => deployment.guid,
-            'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
             'status' => {
               'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
               'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -815,7 +807,6 @@ RSpec.describe 'Deployments' do
       parsed_response = MultiJson.load(last_response.body)
       expect(parsed_response).to be_a_response_like({
         'guid' => deployment.guid,
-        'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
         'status' => {
           'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
           'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -877,7 +868,6 @@ RSpec.describe 'Deployments' do
       parsed_response = MultiJson.load(last_response.body)
       expect(parsed_response).to be_a_response_like({
         'guid' => deployment.guid,
-        'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
         'status' => {
           'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
           'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -986,10 +976,9 @@ RSpec.describe 'Deployments' do
         status_reason: VCAP::CloudController::DeploymentModel::SUPERSEDED_STATUS_REASON)
       }
 
-      def json_for_deployment(deployment, app_model, droplet, state, status_value, status_reason, cancel_link=true)
+      def json_for_deployment(deployment, app_model, droplet, status_value, status_reason, cancel_link=true)
         {
           guid: deployment.guid,
-          state: state,
           status: {
             value: status_value,
             reason: status_reason,
@@ -1063,11 +1052,9 @@ RSpec.describe 'Deployments' do
           },
           resources: [
             json_for_deployment(deployment, app_model, droplet,
-              VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
               VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
               VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON),
             json_for_deployment(deployment2, app2, droplet2,
-              VCAP::CloudController::DeploymentModel::CANCELING_STATE,
               VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
               VCAP::CloudController::DeploymentModel::CANCELING_STATUS_REASON),
           ]
@@ -1086,19 +1073,16 @@ RSpec.describe 'Deployments' do
               code: 200,
               response_objects: [
                 json_for_deployment(deployment3, app3, droplet3,
-                  VCAP::CloudController::DeploymentModel::DEPLOYED_STATE,
                   VCAP::CloudController::DeploymentModel::FINALIZED_STATUS_VALUE,
                   VCAP::CloudController::DeploymentModel::DEPLOYED_STATUS_REASON,
                 false
                 ),
                 json_for_deployment(deployment4, app4, droplet4,
-                  VCAP::CloudController::DeploymentModel::CANCELED_STATE,
                   VCAP::CloudController::DeploymentModel::FINALIZED_STATUS_VALUE,
                   VCAP::CloudController::DeploymentModel::CANCELED_STATUS_REASON,
                 false
                 ),
                 json_for_deployment(deployment5, app5, droplet5,
-                  VCAP::CloudController::DeploymentModel::DEPLOYED_STATE,
                   VCAP::CloudController::DeploymentModel::FINALIZED_STATUS_VALUE,
                   VCAP::CloudController::DeploymentModel::SUPERSEDED_STATUS_REASON,
                 false
@@ -1143,13 +1127,11 @@ RSpec.describe 'Deployments' do
               code: 200,
               response_objects: [
                 json_for_deployment(deployment3, app3, droplet3,
-                  VCAP::CloudController::DeploymentModel::DEPLOYED_STATE,
                   VCAP::CloudController::DeploymentModel::FINALIZED_STATUS_VALUE,
                   VCAP::CloudController::DeploymentModel::DEPLOYED_STATUS_REASON,
                   false
                 ),
                 json_for_deployment(deployment5, app5, droplet5,
-                  VCAP::CloudController::DeploymentModel::DEPLOYED_STATE,
                   VCAP::CloudController::DeploymentModel::FINALIZED_STATUS_VALUE,
                   VCAP::CloudController::DeploymentModel::SUPERSEDED_STATUS_REASON,
                   false
@@ -1194,7 +1176,6 @@ RSpec.describe 'Deployments' do
               code: 200,
               response_objects: [
                 json_for_deployment(deployment, app_model, droplet,
-                  VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
                   VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                   VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON),
               ]
@@ -1300,7 +1281,6 @@ RSpec.describe 'Deployments' do
           'resources' => [
             {
               'guid' => deployment.guid,
-              'state' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
               'status' => {
                 'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                 'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
@@ -1373,7 +1353,6 @@ RSpec.describe 'Deployments' do
 
         expect(last_response.body).to be_empty
         deployment.reload
-        expect(deployment.state).to eq(VCAP::CloudController::DeploymentModel::CANCELING_STATE)
         expect(deployment.status_value).to eq(VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE)
         expect(deployment.status_reason).to eq(VCAP::CloudController::DeploymentModel::CANCELING_STATUS_REASON)
 
@@ -1382,7 +1361,6 @@ RSpec.describe 'Deployments' do
         require 'cloud_controller/deployment_updater/scheduler'
         VCAP::CloudController::DeploymentUpdater::Updater.new(deployment, Steno.logger('blah')).cancel
         deployment.reload
-        expect(deployment.state).to eq(VCAP::CloudController::DeploymentModel::CANCELED_STATE)
         expect(deployment.status_value).to eq(VCAP::CloudController::DeploymentModel::FINALIZED_STATUS_VALUE)
         expect(deployment.status_reason).to eq(VCAP::CloudController::DeploymentModel::CANCELED_STATUS_REASON)
       end

--- a/spec/unit/presenters/v3/deployment_presenter_spec.rb
+++ b/spec/unit/presenters/v3/deployment_presenter_spec.rb
@@ -26,7 +26,6 @@ module VCAP::CloudController::Presenters::V3
         result = DeploymentPresenter.new(deployment).to_hash
         expect(result[:guid]).to eq(deployment.guid)
 
-        expect(result[:state]).to eq(VCAP::CloudController::DeploymentModel::DEPLOYING_STATE)
         expect(result[:status][:value]).to eq(VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE)
         expect(result[:status][:reason]).to eq(VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON)
         expect(result[:status][:details][:last_successful_healthcheck]).to eq('2019-07-12 19:01:54')
@@ -71,7 +70,6 @@ module VCAP::CloudController::Presenters::V3
           result = DeploymentPresenter.new(deployment).to_hash
           expect(result[:guid]).to eq(deployment.guid)
 
-          expect(result[:state]).to eq(VCAP::CloudController::DeploymentModel::DEPLOYING_STATE)
           expect(result[:status][:value]).to eq(VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE)
           expect(result[:status][:reason]).to eq(VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON)
 


### PR DESCRIPTION
It's currently marked as deprecated in the docs. Not sure what the blockers are for removing it, but it might make sense to remove when GAing deployments.

I removed state from the presenter, but did not touch any of the internal logic that currently depends on deployment state. Not sure if y'all were thinking of doing a larger, internal refactor as part of removing the field. Examples where it is used:
- https://github.com/cloudfoundry/cloud_controller_ng/blob/8af9682bcb0510538567f9113eb719fd8b95c636/lib/cloud_controller/deployment_updater/dispatcher.rb#L14-L15
- https://github.com/cloudfoundry/cloud_controller_ng/blob/8af9682bcb0510538567f9113eb719fd8b95c636/app/actions/deployment_cancel.rb#L33-L35