### PR TITLE
Send staging task resource requests to OPI

### DIFF
--- a/lib/cloud_controller/opi/stager_client.rb
+++ b/lib/cloud_controller/opi/stager_client.rb
@@ -68,7 +68,10 @@ module OPI
               droplet_upload_uri: droplet_upload_uri,
               app_bits_download_uri: lifecycle_data[:app_bits_download_uri],
               buildpacks: lifecycle_data[:buildpacks]
-          }
+          },
+          cpu_weight: VCAP::CloudController::Diego::STAGING_TASK_CPU_WEIGHT,
+          disk_mb: staging_details.staging_disk_in_mb,
+          memory_mb: staging_details.staging_memory_in_mb
       }
     end
 

--- a/spec/unit/lib/cloud_controller/opi/stager_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/stager_client_spec.rb
@@ -60,11 +60,15 @@ RSpec.describe(OPI::StagerClient) do
           environment: [{ name: 'VCAP_APPLICATION', value: '{"wow":"pants"}' },
                         { name: 'MEMORY_LIMIT', value: '256m' },
                         { name: 'VCAP_SERVICES', value: '{}' }],
-           completion_callback: 'https://internal_user:internal_password@api.internal.cf:8182/internal/v3/staging//build_completed?start=',
+          completion_callback: 'https://internal_user:internal_password@api.internal.cf:8182/internal/v3/staging//build_completed?start=',
           lifecycle_data: { droplet_upload_uri: 'http://cc-uploader.service.cf.internal:9091/v1/droplet/guid?cc-droplet-upload-uri=http://upload.me',
                             app_bits_download_uri: 'http://download.me',
                             buildpacks: [{ name: 'ruby', key: 'idk', url: 'www.com', skip_detect: false }]
-        } }.to_json
+          },
+          cpu_weight: VCAP::CloudController::Diego::STAGING_TASK_CPU_WEIGHT,
+          disk_mb: 100,
+          memory_mb: 200
+        }.to_json
         )
       end
 
@@ -81,11 +85,15 @@ RSpec.describe(OPI::StagerClient) do
                           { name: 'VCAP_APPLICATION', value: '{"wow":"pants"}' },
                           { name: 'MEMORY_LIMIT', value: '256m' },
                           { name: 'VCAP_SERVICES', value: '{}' }],
-             completion_callback: 'https://internal_user:internal_password@api.internal.cf:8182/internal/v3/staging//build_completed?start=',
+            completion_callback: 'https://internal_user:internal_password@api.internal.cf:8182/internal/v3/staging//build_completed?start=',
             lifecycle_data: { droplet_upload_uri: 'http://cc-uploader.service.cf.internal:9091/v1/droplet/guid?cc-droplet-upload-uri=http://upload.me',
                               app_bits_download_uri: 'http://download.me',
                               buildpacks: [{ name: 'ruby', key: 'idk', url: 'www.com', skip_detect: false }]
-          } }.to_json
+            },
+            cpu_weight: VCAP::CloudController::Diego::STAGING_TASK_CPU_WEIGHT,
+            disk_mb: 100,
+            memory_mb: 200
+          }.to_json
           )
         end
       end
@@ -162,6 +170,8 @@ RSpec.describe(OPI::StagerClient) do
     staging_details                                 = VCAP::CloudController::Diego::StagingDetails.new
     staging_details.package                         = double(app_guid: 'thor', image: 'docker.io/some/image')
     staging_details.lifecycle                       = double(type: lifecycle_type)
+    staging_details.staging_disk_in_mb              = 100
+    staging_details.staging_memory_in_mb            = 200
     staging_details
   end
 


### PR DESCRIPTION
[#170075431]

* A short explanation of the proposed change:

This change sends CPU, memory and disk resource requests for staging tasks when using OPI.

* An explanation of the use cases your change solves

This should improve cluster resource management.

--------------
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
