### PR TITLE
Send more info to staging tasks created by OPI

### DIFF
--- a/lib/cloud_controller/opi/stager_client.rb
+++ b/lib/cloud_controller/opi/stager_client.rb
@@ -62,6 +62,12 @@ module OPI
 
       {
           app_guid: staging_details.package.app_guid,
+          app_name: staging_details.package.app.name,
+          staging_guid: staging_guid,
+          org_name: staging_details.package.app.organization.name,
+          org_guid: staging_details.package.app.organization.guid,
+          space_name: staging_details.package.app.space.name,
+          space_guid: staging_details.package.app.space.guid,
           environment: build_env(staging_details.environment_variables) + action_builder.task_environment_variables,
           completion_callback: staging_completion_callback(staging_details),
           lifecycle_data: {


### PR DESCRIPTION
[#170206610]

Signed-off-by: Julian Skupnjak <skupnjak@de.ibm.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
We at the Eirini team would like to make staging jobs more easily identifiable by adding app specific info by setting additional `annotations` and `labels` in the k8s jobs.

* An explanation of the use cases your change solves
For more info: https://www.pivotaltracker.com/story/show/170206610

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
