### PR TITLE
Make sure V2 endpoints can delete service offerings, brokers, instances

### DIFF
--- a/app/models/services/service.rb
+++ b/app/models/services/service.rb
@@ -4,10 +4,12 @@ module VCAP::CloudController
 
     many_to_one :service_broker
     one_to_many :service_plans
+    add_association_dependencies service_plans: :destroy
+
     one_to_many :labels, class: 'VCAP::CloudController::ServiceOfferingLabelModel', key: :resource_guid, primary_key: :guid
     one_to_many :annotations, class: 'VCAP::CloudController::ServiceOfferingAnnotationModel', key: :resource_guid, primary_key: :guid
-
-    add_association_dependencies service_plans: :destroy
+    add_association_dependencies labels: :destroy
+    add_association_dependencies annotations: :destroy
 
     export_attributes :label, :provider, :url, :description, :long_description,
                       :version, :info_url, :active, :bindable,

--- a/app/models/services/service_broker.rb
+++ b/app/models/services/service_broker.rb
@@ -2,9 +2,9 @@ module VCAP::CloudController
   class ServiceBroker < Sequel::Model
     one_to_many :services
     one_to_many :service_dashboard_client
+
     one_to_many :labels, class: 'VCAP::CloudController::ServiceBrokerLabelModel', key: :resource_guid, primary_key: :guid
     one_to_many :annotations, class: 'VCAP::CloudController::ServiceBrokerAnnotationModel', key: :resource_guid, primary_key: :guid
-
     add_association_dependencies labels: :destroy
     add_association_dependencies annotations: :destroy
 

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -27,8 +27,11 @@ module VCAP::CloudController
 
     one_to_many :service_bindings, before_add: :validate_service_binding, key: :service_instance_guid, primary_key: :guid
     one_to_many :service_keys
+
     one_to_many :labels, class: 'VCAP::CloudController::ServiceInstanceLabelModel', key: :resource_guid, primary_key: :guid
     one_to_many :annotations, class: 'VCAP::CloudController::ServiceInstanceAnnotationModel', key: :resource_guid, primary_key: :guid
+    add_association_dependencies labels: :destroy
+    add_association_dependencies annotations: :destroy
 
     many_to_many :shared_spaces,
           left_key:          :service_instance_guid,

--- a/spec/unit/models/services/service_broker_spec.rb
+++ b/spec/unit/models/services/service_broker_spec.rb
@@ -101,17 +101,14 @@ module VCAP::CloudController
         service_plan = ServicePlan.make(service: service)
         label = ServiceBrokerLabelModel.make(resource_guid: service_broker.guid, key_name: 'foo', value: 'bar')
         annotation = ServiceBrokerAnnotationModel.make(resource_guid: service_broker.guid, key: 'alpha', value: 'beta')
-        expect {
-          begin
-            service_broker.destroy
-          rescue Sequel::ForeignKeyConstraintViolation
-          end
-        }.to change {
-          Service.where(id: service.id).any? ||
-            ServicePlan.where(id: service_plan.id).any? ||
-            ServiceBrokerLabelModel.where(id: label.id).any? ||
-            ServiceBrokerAnnotationModel.where(id: annotation.id).any?
-        }.to(false)
+
+        service_broker.destroy
+
+        expect(ServiceBroker.where(id: service_broker.id)).to be_empty
+        expect(Service.where(id: service.id)).to be_empty
+        expect(ServicePlan.where(id: service_plan.id)).to be_empty
+        expect(ServiceBrokerLabelModel.where(id: label.id)).to be_empty
+        expect(ServiceBrokerAnnotationModel.where(id: annotation.id)).to be_empty
       end
 
       context 'when a service instance exists' do

--- a/spec/unit/models/services/service_broker_spec.rb
+++ b/spec/unit/models/services/service_broker_spec.rb
@@ -96,15 +96,21 @@ module VCAP::CloudController
     describe '#destroy' do
       let(:service_broker) { ServiceBroker.make }
 
-      it 'destroys all services associated with the broker' do
+      it 'destroys all resources associated with the broker' do
         service = Service.make(service_broker: service_broker)
+        service_plan = ServicePlan.make(service: service)
+        label = ServiceBrokerLabelModel.make(resource_guid: service_broker.guid, key_name: 'foo', value: 'bar')
+        annotation = ServiceBrokerAnnotationModel.make(resource_guid: service_broker.guid, key: 'alpha', value: 'beta')
         expect {
           begin
             service_broker.destroy
           rescue Sequel::ForeignKeyConstraintViolation
           end
         }.to change {
-          Service.where(id: service.id).any?
+          Service.where(id: service.id).any? ||
+            ServicePlan.where(id: service_plan.id).any? ||
+            ServiceBrokerLabelModel.where(id: label.id).any? ||
+            ServiceBrokerAnnotationModel.where(id: annotation.id).any?
         }.to(false)
       end
 

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -176,14 +176,11 @@ module VCAP::CloudController
       it 'deletes associated resources' do
         label = ServiceInstanceLabelModel.make(resource_guid: service_instance.guid, key_name: 'foo', value: 'bar')
         annotation = ServiceInstanceAnnotationModel.make(resource_guid: service_instance.guid, key: 'alpha', value: 'beta')
-        expect {
-          begin
-            service_instance.destroy
-          rescue Sequel::ForeignKeyConstraintViolation
-          end
-        }.to change {
-          ServiceInstanceLabelModel.where(id: label.id).any? || ServiceInstanceAnnotationModel.where(id: annotation.id).any?
-        }.to(false)
+
+        service_instance.destroy
+
+        expect(ServiceInstanceLabelModel.where(id: label.id)).to be_empty
+        expect(ServiceInstanceAnnotationModel.where(id: annotation.id)).to be_empty
       end
 
       it 'creates a DELETED service usage event' do

--- a/spec/unit/models/services/service_spec.rb
+++ b/spec/unit/models/services/service_spec.rb
@@ -44,6 +44,23 @@ module VCAP::CloudController
       }
     end
 
+    describe '#destroy' do
+      let(:service_offering) { Service.make }
+
+      it 'deletes associated resources' do
+        label = ServiceOfferingLabelModel.make(resource_guid: service_offering.guid, key_name: 'foo', value: 'bar')
+        annotation = ServiceOfferingAnnotationModel.make(resource_guid: service_offering.guid, key: 'alpha', value: 'beta')
+        expect {
+          begin
+            service_offering.destroy
+          rescue Sequel::ForeignKeyConstraintViolation
+          end
+        }.to change {
+          ServiceOfferingLabelModel.where(id: label.id).any? || ServiceOfferingAnnotationModel.where(id: annotation.id).any?
+        }.to(false)
+      end
+    end
+
     describe '#user_visibility_filter' do
       let(:private_service) { Service.make }
       let(:public_service) { Service.make }

--- a/spec/unit/models/services/service_spec.rb
+++ b/spec/unit/models/services/service_spec.rb
@@ -50,14 +50,11 @@ module VCAP::CloudController
       it 'deletes associated resources' do
         label = ServiceOfferingLabelModel.make(resource_guid: service_offering.guid, key_name: 'foo', value: 'bar')
         annotation = ServiceOfferingAnnotationModel.make(resource_guid: service_offering.guid, key: 'alpha', value: 'beta')
-        expect {
-          begin
-            service_offering.destroy
-          rescue Sequel::ForeignKeyConstraintViolation
-          end
-        }.to change {
-          ServiceOfferingLabelModel.where(id: label.id).any? || ServiceOfferingAnnotationModel.where(id: annotation.id).any?
-        }.to(false)
+
+        service_offering.destroy
+
+        expect(ServiceOfferingLabelModel.where(id: label.id)).to be_empty
+        expect(ServiceOfferingAnnotationModel.where(id: annotation.id)).to be_empty
       end
     end
 


### PR DESCRIPTION
When resources have metadata (annotations and labels) it can be impossible to delete them due to database constraints

https://www.pivotaltracker.com/story/show/170893626