### PR TITLE
Change the metadata representation

### DIFF
--- a/app/presenters/v3/service_offering_presenter.rb
+++ b/app/presenters/v3/service_offering_presenter.rb
@@ -52,9 +52,7 @@ module VCAP::CloudController
         end
 
         def broker_metadata
-          JSON.parse(service_offering.extra)
-        rescue JSON::ParserError
-          {}
+          service_offering.extra
         end
 
         def build_links


### PR DESCRIPTION
At the moment, an API is returning a string field:

```
{
  "metadata": "\n{\"test\": \"yes\"}"
}
```

This means the client would need to parse the string into an object in
order to use it. It's not practical and provides an overhead.

We can remove the JSON parsing which will cause the object to expand
further into:

```
{
  "metadata": {"test": "yes"}
}
```

I haven't written any tests nor signed CLA, just creating a cause for discussion.