### PR TITLE
Return empty Loggregator envelope if Logcache is unavailable

### DIFF
--- a/lib/logcache/client.rb
+++ b/lib/logcache/client.rb
@@ -1,4 +1,5 @@
 require 'logcache/logcache_egress_services_pb'
+require 'logcache/v2/envelope_pb'
 
 module Logcache
   class Client
@@ -18,7 +19,7 @@ module Logcache
     end
 
     def container_metrics(source_guid:, envelope_limit: DEFAULT_LIMIT, start_time:, end_time:)
-      with_request_error_handling do
+      with_request_error_handling(source_guid) do
         service.read(
           Logcache::V1::ReadRequest.new(
             source_id: source_guid,
@@ -34,18 +35,54 @@ module Logcache
 
     private
 
-    def with_request_error_handling(&blk)
+    def with_request_error_handling(source_guid, &blk)
       tries ||= 3
       yield
-    rescue
+    rescue => e
       if (tries -= 1) > 0
         sleep 0.1
         retry
       end
 
-      raise
+      if e.is_a?(GRPC::BadStatus) && e.to_status.code == 14
+        logger.warn("rescuing GRPC Unavailable error: #{e.to_status}")
+
+        return EmptyEnvelope.new(source_guid)
+      end
+
+      raise e
+    end
+
+    def logger
+      @logger ||= Steno.logger('cc.logcache.client')
     end
 
     attr_reader :service
+  end
+
+  class EmptyEnvelope
+    def initialize(source_guid)
+      @empty_envelope = Loggregator::V2::Envelope.new(
+        timestamp: Time.now.to_i,
+        source_id: source_guid,
+        gauge: Loggregator::V2::Gauge.new(
+          metrics: {
+            'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 0),
+            'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 0),
+            'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 0),
+          }
+        ),
+        instance_id: '0',
+        tags: {
+            'source_id' => source_guid,
+        }
+      )
+    end
+
+    def envelopes
+      Loggregator::V2::EnvelopeBatch.new(batch: [self.empty_envelope])
+    end
+
+    attr_accessor :empty_envelope
   end
 end

--- a/spec/logcache/client_spec.rb
+++ b/spec/logcache/client_spec.rb
@@ -4,7 +4,7 @@ require 'openssl'
 
 module Logcache
   RSpec.describe Client do
-    let(:logcache_envelopes) { [42, :woof] }
+    let(:logcache_envelopes) { [:fake_envelope_1, :fake_envelope_2] }
     let(:logcache_service) { instance_double(Logcache::V1::Egress::Stub, read: logcache_envelopes) }
     let(:logcache_request) { instance_double(Logcache::V1::ReadRequest) }
 
@@ -17,7 +17,7 @@ module Logcache
     let(:credentials) { instance_double(GRPC::Core::ChannelCredentials) }
     let(:channel_arg_hash) do
       {
-        channel_args: { GRPC::Core::Channel::SSL_TARGET => tls_subject_name }
+          channel_args: { GRPC::Core::Channel::SSL_TARGET => tls_subject_name }
       }
     end
     let(:client) do
@@ -46,7 +46,7 @@ module Logcache
       it 'calls Logcache with the correct parameters and returns envelopes' do
         expect(
           client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
-        ).to eq([42, :woof])
+        ).to eq([:fake_envelope_1, :fake_envelope_2])
 
         expect(Logcache::V1::ReadRequest).to have_received(:new).with(
           source_id: process.guid,
@@ -58,20 +58,59 @@ module Logcache
         )
         expect(logcache_service).to have_received(:read).with(logcache_request)
       end
+    end
 
-      context 'when an error occurs' do
-        before do
-          allow(client).to receive(:sleep)
-          allow(logcache_service).to receive(:read).and_raise(StandardError)
-        end
+    describe 'when logcache is unavailable' do
+      let(:instance_count) { 0 }
+      let(:bad_status) { GRPC::BadStatus.new(14) }
+      let!(:process) { VCAP::CloudController::ProcessModel.make(instances: instance_count) }
 
-        it 'retries the request three times' do
-          expect {
-            client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
-          }.to raise_error(StandardError)
+      before do
+        expect(GRPC::Core::ChannelCredentials).to receive(:new).
+          with(client_ca, client_key, client_cert).
+          and_return(credentials)
+        expect(Logcache::V1::Egress::Stub).to receive(:new).
+          with("#{host}:#{port}", credentials, channel_arg_hash).
+          and_return(logcache_service)
+        allow(client).to receive(:sleep)
+        allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
+        allow(logcache_service).to receive(:read).and_raise(bad_status)
+      end
 
-          expect(logcache_service).to have_received(:read).with(logcache_request).exactly(3).times
-        end
+      it 'returns an empty envelope' do
+        expect(
+          client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
+        ).to be_a(Logcache::EmptyEnvelope)
+      end
+
+      it 'retries the request three times' do
+        client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
+
+        expect(logcache_service).to have_received(:read).with(logcache_request).exactly(3).times
+      end
+    end
+
+    describe 'when the logcache service has any other error' do
+      let(:bad_status) { GRPC::BadStatus.new(13) }
+      let!(:process) { VCAP::CloudController::ProcessModel.make(instances: instance_count) }
+      let(:instance_count) { 2 }
+
+      before do
+        expect(GRPC::Core::ChannelCredentials).to receive(:new).
+          with(client_ca, client_key, client_cert).
+          and_return(credentials)
+        expect(Logcache::V1::Egress::Stub).to receive(:new).
+          with("#{host}:#{port}", credentials, channel_arg_hash).
+          and_return(logcache_service)
+        allow(client).to receive(:sleep)
+        allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
+        allow(logcache_service).to receive(:read).and_raise(bad_status)
+      end
+
+      it 'raises the exception' do
+        expect {
+          client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
+        }.to raise_error(bad_status)
       end
     end
   end


### PR DESCRIPTION
[#170267522]

Co-authored-by: David Timm <dtimm@pivotal.io>

* A short explanation of the proposed change:
This will allow `cf push` and `cf app` to work even if log-cache is unavailable or removed.

* An explanation of the use cases your change solves
If log-cache is rolling, users cannot `cf push` apps.
https://github.com/cloudfoundry/log-cache-release/issues/25#issuecomment-548294752

* Links to any other associated PRs
N/A

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)