### PR TITLE
make cc block until ccdb is current or newer than local migrations

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -2,6 +2,7 @@
 local_route: 127.0.0.1
 external_port: 8181
 tls_port: 8182
+readiness_port: 9999
 pid_filename: /tmp/cloud_controller.pid
 stacks_file: config/stacks.yml
 

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -303,7 +303,7 @@ newrelic_enabled: false
 
 max_annotations_per_resource: 200
 max_labels_per_resource: 50
-
+max_migration_duration_in_minutes: 45
 db:
   log_level: 'debug'
   ssl_verify_hostname: false

--- a/lib/cloud_controller/background_job_environment.rb
+++ b/lib/cloud_controller/background_job_environment.rb
@@ -1,3 +1,5 @@
+require 'socket'
+
 class BackgroundJobEnvironment
   def initialize(config)
     @config = config
@@ -8,9 +10,16 @@ class BackgroundJobEnvironment
     end
   end
 
+  READINESS_SOCKET_QUEUE_DEPTH = 100
+
   def setup_environment
     VCAP::CloudController::DB.load_models(@config.get(:db), Steno.logger('cc.background'))
     @config.configure_components
+
+    socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM)
+    sockaddr = Socket.pack_sockaddr_in(@config.get(:readiness_port), '127.0.0.1')
+    socket.bind(sockaddr)
+    socket.listen(READINESS_SOCKET_QUEUE_DEPTH)
 
     yield if block_given?
   end

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -72,6 +72,7 @@ module VCAP::CloudController
           stacks_file: String,
           newrelic_enabled: bool,
 
+          max_migration_duration_in_minutes: Integer,
           db: {
             optional(:database) => Hash, # db connection hash for sequel
             max_connections: Integer, # max connections in the connection pool

--- a/lib/cloud_controller/config_schemas/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/clock_schema.rb
@@ -42,6 +42,7 @@ module VCAP::CloudController
 
           newrelic_enabled: bool,
 
+          max_migration_duration_in_minutes: Integer,
           db: {
             optional(:database) => Hash, # db connection hash for sequel
             max_connections: Integer, # max connections in the connection pool

--- a/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
@@ -15,6 +15,7 @@ module VCAP::CloudController
 
           pid_filename: String, # Pid filename to use
 
+          max_migration_duration_in_minutes: Integer,
           db: {
             optional(:database) => Hash, # db connection hash for sequel
             max_connections: Integer, # max connections in the connection pool

--- a/lib/cloud_controller/config_schemas/migrate_schema.rb
+++ b/lib/cloud_controller/config_schemas/migrate_schema.rb
@@ -5,6 +5,8 @@ module VCAP::CloudController
     class MigrateSchema < VCAP::Config
       define_schema do
         {
+          max_migration_duration_in_minutes: Integer,
+
           db: {
             optional(:database) => Hash, # db connection hash for sequel
             :max_connections => Integer, # max connections in the connection pool

--- a/lib/cloud_controller/config_schemas/rotatate_database_key_schema.rb
+++ b/lib/cloud_controller/config_schemas/rotatate_database_key_schema.rb
@@ -13,6 +13,7 @@ module VCAP::CloudController
 
           pid_filename: String, # Pid filename to use
 
+          max_migration_duration_in_minutes: Integer,
           db: {
             optional(:database) => Hash, # db connection hash for sequel\
             max_connections: Integer, # max connections in the connection pool

--- a/lib/cloud_controller/config_schemas/route_syncer_schema.rb
+++ b/lib/cloud_controller/config_schemas/route_syncer_schema.rb
@@ -13,6 +13,7 @@ module VCAP::CloudController
 
           pid_filename: String, # Pid filename to use
 
+          max_migration_duration_in_minutes: Integer,
           db: {
             optional(:database) => Hash, # db connection hash for sequel
             max_connections: Integer, # max connections in the connection pool

--- a/lib/cloud_controller/config_schemas/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/worker_schema.rb
@@ -33,6 +33,7 @@ module VCAP::CloudController
           stacks_file: String,
           newrelic_enabled: bool,
 
+          max_migration_duration_in_minutes: Integer,
           db: {
             optional(:database) => Hash, # db connection hash for sequel
             max_connections: Integer, # max connections in the connection pool

--- a/lib/cloud_controller/config_schemas/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/worker_schema.rb
@@ -11,6 +11,7 @@ module VCAP::CloudController
           system_hostnames: [String],
           system_domain: String,
           tls_port: Integer,
+          readiness_port: Integer,
           external_protocol: String,
           internal_service_hostname: String,
           disable_private_domain_cross_space_context_path_route_sharing: bool,

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -49,7 +49,7 @@ module VCAP::CloudController
 
     def self.load_models(db_config, logger)
       db = connect(db_config, logger)
-      DBMigrator.new(db).check_migrations!
+      DBMigrator.new(db).wait_for_migrations!
 
       require 'models'
       require 'delayed_job_sequel'

--- a/lib/cloud_controller/db_migrator.rb
+++ b/lib/cloud_controller/db_migrator.rb
@@ -28,7 +28,7 @@ class DBMigrator
     apply_migrations(current: recent_migrations.first, target: recent_migrations.last)
   end
 
-  def check_migrations!
+  def wait_for_migrations!
     Sequel.extension :migration
     logger = Steno.logger('cc.db.wait_until_current')
 
@@ -36,7 +36,7 @@ class DBMigrator
       logger.info('waiting indefinitely for database schema to be current')
     end
 
-    timeout_message = 'cc.max_migration_duration_in_minutes exceeded'
+    timeout_message = 'ccdb.max_migration_duration_in_minutes exceeded'
     Timeout.timeout(@max_migration_duration_in_minutes * 60, message: timeout_message) do
       sleep(1) until db_is_current_or_newer_than_local_migrations?
     end

--- a/lib/cloud_controller/db_migrator.rb
+++ b/lib/cloud_controller/db_migrator.rb
@@ -26,6 +26,18 @@ class DBMigrator
 
   def check_migrations!
     Sequel.extension :migration
-    Sequel::Migrator.check_current(@db, SEQUEL_MIGRATIONS)
+    logger = Steno.logger('cc.db.wait_until_current')
+
+    unless db_is_current_or_newer_than_local_migrations?
+      logger.info('waiting indefinitely for database schema to be current')
+    end
+
+    sleep(1) until db_is_current_or_newer_than_local_migrations?
+
+    logger.info('database schema is as new or newer than locally available migrations')
+  end
+
+  def db_is_current_or_newer_than_local_migrations?
+    Sequel::Migrator.is_current?(@db, SEQUEL_MIGRATIONS, allow_missing_migration_files: true)
   end
 end

--- a/lib/cloud_controller/db_migrator.rb
+++ b/lib/cloud_controller/db_migrator.rb
@@ -1,15 +1,19 @@
+require 'timeout'
+
 class DBMigrator
   MIGRATIONS_DIR = File.expand_path('../../db', File.dirname(__FILE__))
   SEQUEL_MIGRATIONS = File.join(MIGRATIONS_DIR, 'migrations')
+  TWO_WEEKS = 20160
 
   def self.from_config(config, db_logger)
     VCAP::CloudController::Encryptor.db_encryption_key = config.get(:db_encryption_key)
     db = VCAP::CloudController::DB.connect(config.get(:db), db_logger)
-    new(db)
+    new(db, config.get(:max_migration_duration_in_minutes))
   end
 
-  def initialize(db)
+  def initialize(db, max_migration_duration_in_minutes=TWO_WEEKS)
     @db = db
+    @max_migration_duration_in_minutes = max_migration_duration_in_minutes
   end
 
   def apply_migrations(opts={})
@@ -32,7 +36,10 @@ class DBMigrator
       logger.info('waiting indefinitely for database schema to be current')
     end
 
-    sleep(1) until db_is_current_or_newer_than_local_migrations?
+    timeout_message = 'cc.max_migration_duration_in_minutes exceeded'
+    Timeout.timeout(@max_migration_duration_in_minutes * 60, message: timeout_message) do
+      sleep(1) until db_is_current_or_newer_than_local_migrations?
+    end
 
     logger.info('database schema is as new or newer than locally available migrations')
   end

--- a/spec/unit/lib/cloud_controller/db_migrator_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_migrator_spec.rb
@@ -3,14 +3,15 @@ require 'spec_helper'
 RSpec.describe DBMigrator do
   describe '#check_migrations!' do
     context 'when the migrations have not run' do
-      it 'raises an exception' do
+      it 'blocks until migrations are current or newer' do
         db = double(:db)
         migrator = DBMigrator.new(db)
 
-        expect(Sequel::Migrator).to receive(:check_current).with(db, DBMigrator::SEQUEL_MIGRATIONS).and_raise(Sequel::Migrator::NotCurrentError)
+        expect(Sequel::Migrator).to receive(:is_current?).with(db, DBMigrator::SEQUEL_MIGRATIONS, allow_missing_migration_files: true).and_return(false, false, true)
+        allow_any_instance_of(Object).to receive(:sleep).with(1).and_return(1)
         expect {
           migrator.check_migrations!
-        }.to raise_error(Sequel::Migrator::NotCurrentError)
+        }.not_to raise_error
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/db_migrator_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_migrator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe DBMigrator do
-  describe '#check_migrations!' do
+  describe '#wait_for_migrations!' do
     let(:migrator) { DBMigrator.new(db, 1) }
     let(:db) { double(:db) }
 
@@ -15,7 +15,7 @@ RSpec.describe DBMigrator do
       expect(Timeout).to receive(:timeout).with(60, anything).and_yield
       allow_any_instance_of(Object).to receive(:sleep).with(1).and_return(1)
       expect {
-        migrator.check_migrations!
+        migrator.wait_for_migrations!
       }.not_to raise_error
     end
 
@@ -29,7 +29,7 @@ RSpec.describe DBMigrator do
       expect(Timeout).to receive(:timeout).with(60, anything).and_yield
       expect_any_instance_of(Object).not_to receive(:sleep)
       expect {
-        migrator.check_migrations!
+        migrator.wait_for_migrations!
       }.not_to raise_error
     end
 
@@ -43,7 +43,7 @@ RSpec.describe DBMigrator do
       ).and_return(false)
 
       expect {
-        migrator.check_migrations!
+        migrator.wait_for_migrations!
       }.to raise_error(UncaughtThrowError)
     end
   end

--- a/spec/unit/lib/cloud_controller/db_migrator_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_migrator_spec.rb
@@ -2,17 +2,49 @@ require 'spec_helper'
 
 RSpec.describe DBMigrator do
   describe '#check_migrations!' do
-    context 'when the migrations have not run' do
-      it 'blocks until migrations are current or newer' do
-        db = double(:db)
-        migrator = DBMigrator.new(db)
+    let(:migrator) { DBMigrator.new(db, 1) }
+    let(:db) { double(:db) }
 
-        expect(Sequel::Migrator).to receive(:is_current?).with(db, DBMigrator::SEQUEL_MIGRATIONS, allow_missing_migration_files: true).and_return(false, false, true)
-        allow_any_instance_of(Object).to receive(:sleep).with(1).and_return(1)
-        expect {
-          migrator.check_migrations!
-        }.not_to raise_error
-      end
+    it 'blocks until migrations are current or newer' do
+      expect(Sequel::Migrator).to receive(:is_current?).with(
+        db,
+        DBMigrator::SEQUEL_MIGRATIONS,
+        allow_missing_migration_files: true,
+      ).and_return(false, false, true)
+
+      expect(Timeout).to receive(:timeout).with(60, anything).and_yield
+      allow_any_instance_of(Object).to receive(:sleep).with(1).and_return(1)
+      expect {
+        migrator.check_migrations!
+      }.not_to raise_error
+    end
+
+    it 'doesnt block when migrations are already current' do
+      expect(Sequel::Migrator).to receive(:is_current?).with(
+        db,
+        DBMigrator::SEQUEL_MIGRATIONS,
+        allow_missing_migration_files: true,
+      ).and_return(true).at_most(2).times
+
+      expect(Timeout).to receive(:timeout).with(60, anything).and_yield
+      expect_any_instance_of(Object).not_to receive(:sleep)
+      expect {
+        migrator.check_migrations!
+      }.not_to raise_error
+    end
+
+    it 'times out after max_migration_duration_in_minutes' do
+      expect(Timeout).to receive(:timeout).with(60, anything).and_throw(Timeout::Error)
+
+      expect(Sequel::Migrator).to receive(:is_current?).with(
+        db,
+        DBMigrator::SEQUEL_MIGRATIONS,
+        allow_missing_migration_files: true,
+      ).and_return(false)
+
+      expect {
+        migrator.check_migrations!
+      }.to raise_error(UncaughtThrowError)
     end
   end
 end


### PR DESCRIPTION
following advice from https://srcco.de/posts/kubernetes-liveness-probes-are-dangerous.html

make sure that your Readiness Probe includes database initialization/migration
the simplest way to achieve this is to start the HTTP server listening only after the initialization finished,
i.e. instead of changing the health check status, just don't start the web server until the DB migration is complete

this also makes capi more conformant with https://github.com/cloudfoundry-incubator/kubernetes-guidelines/blob/master/DETAILED.md#rollback

[#171394379]

fixes https://github.com/cloudfoundry/capi-release/issues/165