### PR TITLE
Remove the Customer IP from the info log message in the request logs

### DIFF
--- a/middleware/request_logs.rb
+++ b/middleware/request_logs.rb
@@ -10,11 +10,10 @@ module CloudFoundry
         request = ActionDispatch::Request.new(env)
 
         @logger.info(
-          sprintf('Started %<method>s "%<path>s" for user: %<user>s, ip: %<ip>s with vcap-request-id: %<request_id>s at %<at>s',
+          sprintf('Started %<method>s "%<path>s" for user: %<user>s with vcap-request-id: %<request_id>s at %<at>s',
             method: request.request_method,
             path: request.filtered_path,
             user: env['cf.user_guid'],
-            ip: request.ip,
             request_id: env['cf.request_id'],
             at: Time.now.utc)
         )


### PR DESCRIPTION
This is a small change that removes the IPs in the log messages that are printed in the `info` log level in the request logs. We really want to keep the logs for as long as possible since we need them for debugging. However we can not do that because there is a policy in place that stops us from keeping specific customer information for longer than 3 days. Because the IPs in the log messages are customer specific we can not keep our logs longer than 3 days which really hurts debugging for now.

* A short explanation of the proposed change:

Remove the customer IPs from the log level `info` messages. 

* An explanation of the use cases your change solves:

We can not have the IP of customers in the log messages as it violates our corporate rules

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`
I run `bundle exec rspec spec/middleware/request_logs_spec.rb` specifically

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
