### PR TITLE
Keep AppUsageEvent records for running apps

### DIFF
--- a/app/repositories/app_usage_event_repository.rb
+++ b/app/repositories/app_usage_event_repository.rb
@@ -145,7 +145,7 @@ module VCAP::CloudController
       end
 
       def delete_events_older_than(cutoff_age_in_days)
-        Database::OldRecordCleanup.new(AppUsageEvent, cutoff_age_in_days, keep_at_least_one_record: true).delete
+        Database::OldRecordCleanup.new(AppUsageEvent, cutoff_age_in_days, keep_at_least_one_record: true, keep_running_app_records: true).delete
       end
 
       private

--- a/spec/unit/lib/database/old_record_cleanup_spec.rb
+++ b/spec/unit/lib/database/old_record_cleanup_spec.rb
@@ -3,39 +3,69 @@ require 'database/old_record_cleanup'
 
 RSpec.describe Database::OldRecordCleanup do
   describe '#delete' do
-    let!(:stale_event1) { VCAP::CloudController::Event.make(created_at: 1.day.ago - 1.minute) }
-    let!(:stale_event2) { VCAP::CloudController::Event.make(created_at: 2.days.ago) }
+    context ':keep_running_app_records is false (default)' do
+      let!(:stale_event1) { VCAP::CloudController::Event.make(created_at: 1.day.ago - 1.minute) }
+      let!(:stale_event2) { VCAP::CloudController::Event.make(created_at: 2.days.ago) }
 
-    let!(:fresh_event) { VCAP::CloudController::Event.make(created_at: 1.day.ago + 1.minutes) }
+      let!(:fresh_event) { VCAP::CloudController::Event.make(created_at: 1.day.ago + 1.minutes) }
 
-    it 'deletes records older than specified days' do
-      record_cleanup = Database::OldRecordCleanup.new(VCAP::CloudController::Event, 1)
+      it 'deletes records older than specified days' do
+        record_cleanup = Database::OldRecordCleanup.new(VCAP::CloudController::Event, 1)
 
-      expect {
+        expect {
+          record_cleanup.delete
+        }.to change { VCAP::CloudController::Event.count }.by(-2)
+
+        expect(fresh_event.reload).to be_present
+        expect { stale_event1.reload }.to raise_error(Sequel::NoExistingObject)
+        expect { stale_event2.reload }.to raise_error(Sequel::NoExistingObject)
+      end
+
+      it 'only retrieves the current timestamp from the database once' do
+        expect(VCAP::CloudController::Event.db).to receive(:fetch).with('SELECT CURRENT_TIMESTAMP as now').once.and_call_original
+        record_cleanup = Database::OldRecordCleanup.new(VCAP::CloudController::Event, 1)
         record_cleanup.delete
-      }.to change { VCAP::CloudController::Event.count }.by(-2)
+      end
 
-      expect(fresh_event.reload).to be_present
-      expect { stale_event1.reload }.to raise_error(Sequel::NoExistingObject)
-      expect { stale_event2.reload }.to raise_error(Sequel::NoExistingObject)
+      it 'keeps the last row when :keep_at_least_one_record is true even if it is older than the cutoff date' do
+        record_cleanup = Database::OldRecordCleanup.new(VCAP::CloudController::Event, 0, keep_at_least_one_record: true)
+
+        expect {
+          record_cleanup.delete
+        }.to change { VCAP::CloudController::Event.count }.by(-2)
+
+        expect(fresh_event.reload).to be_present
+        expect { stale_event1.reload }.to raise_error(Sequel::NoExistingObject)
+        expect { stale_event2.reload }.to raise_error(Sequel::NoExistingObject)
+      end
     end
 
-    it 'only retrieves the current timestamp from the database once' do
-      expect(VCAP::CloudController::Event.db).to receive(:fetch).with('SELECT CURRENT_TIMESTAMP as now').once.and_call_original
-      record_cleanup = Database::OldRecordCleanup.new(VCAP::CloudController::Event, 1)
-      record_cleanup.delete
-    end
+    context ':keep_running_app_records is true' do
+      START_STATE = 'STARTED'.freeze
+      STOP_STATE = 'STOPPED'.freeze
 
-    it 'keeps the last row when :keep_at_least_one_record is true even if it is older than the cutoff date' do
-      record_cleanup = Database::OldRecordCleanup.new(VCAP::CloudController::Event, 0, keep_at_least_one_record: true)
+      let!(:start_event_of_running_app) { VCAP::CloudController::AppUsageEvent.make(app_guid: 'app-guid-1', state: START_STATE, created_at: 3.days.ago) }
 
-      expect {
-        record_cleanup.delete
-      }.to change { VCAP::CloudController::Event.count }.by(-2)
+      let!(:stale_start_event_of_app_2) { VCAP::CloudController::AppUsageEvent.make(app_guid: 'app-guid-2', state: START_STATE, created_at: 3.days.ago) }
+      let!(:fresh_stop_event_of_app_2) { VCAP::CloudController::AppUsageEvent.make(app_guid: 'app-guid-2', state: STOP_STATE, created_at: 1.minute.ago) }
 
-      expect(fresh_event.reload).to be_present
-      expect { stale_event1.reload }.to raise_error(Sequel::NoExistingObject)
-      expect { stale_event2.reload }.to raise_error(Sequel::NoExistingObject)
+      let!(:stale_start_event_of_app_3) { VCAP::CloudController::AppUsageEvent.make(app_guid: 'app-guid-3', state: START_STATE, created_at: 3.days.ago) }
+      let!(:stale_stop_event_of_app_3) { VCAP::CloudController::AppUsageEvent.make(app_guid: 'app-guid-3', state: STOP_STATE, created_at: 2.days.ago) }
+
+      it 'does not prune records of running apps when :keep_running_app_records is true even if it is older than cutoff date' do
+        record_cleanup = Database::OldRecordCleanup.new(VCAP::CloudController::AppUsageEvent, 1, keep_running_app_records: true)
+
+        expect {
+          record_cleanup.delete
+        }.to change { VCAP::CloudController::AppUsageEvent.count }.by(-2)
+
+        expect(start_event_of_running_app.reload).to be_present
+        expect(stale_start_event_of_app_2.reload).to be_present
+        expect(fresh_stop_event_of_app_2.reload).to be_present
+
+        expect { stale_start_event_of_app_3.reload }.to raise_error(Sequel::NoExistingObject)
+        expect { stale_stop_event_of_app_3.reload }.to raise_error(Sequel::NoExistingObject)
+      end
     end
   end
 end


### PR DESCRIPTION
**Proposed Change**
Maintain AppUsageEvent records for running apps

**Use Cases**
By default, AppUsageEvents are purged every 30 days. This means
applications that want to track application usage in CloudFoundry must be started within
30 days of a foundation starting. The only way for applications to track
usage after 30 days is for the app to first make a `purge_and_seed`
request. This has the effect of pruning all exising AppUsageEvents and creating fake start events
for any currently running applications.

By saving the AppUsageEvents of running applications, applications that
begin tracking usage after 30 days will not have to make a
`purge_and_seed` request. Their knowledge of running applications will
be accurate and multiple applications that wish to track usage can do so
without effecting other applications that are already doing so.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
