### PR TITLE
Add config flag for GDPR compliance. Remove last octet from ips in request-logs accordingly.

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -89,6 +89,7 @@ logging:
   file: /tmp/cloud_controller.log
   level: debug2
   syslog: vcap.example
+  anonymize_ips: false
 
 telemetry_log_path: spec/artifacts/cloud_controller_telemetry.log
 

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -58,6 +58,7 @@ module VCAP::CloudController
             level: String, # debug, info, etc.
             file: String, # Log file to use
             syslog: String, # Name to associate with syslog messages (should start with 'vcap.')
+            optional(:anonymize_ips) => bool,
           },
 
           telemetry_log_path: String, # path to log telemetry to, /dev/null to disable

--- a/middleware/request_logs.rb
+++ b/middleware/request_logs.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 module CloudFoundry
   module Middleware
     class RequestLogs
@@ -6,17 +8,31 @@ module CloudFoundry
         @logger = logger
       end
 
+      def anonymize_ip(request_ip)
+        # Remove last octet of ip if EU GDPR compliance is needed
+        ip = IPAddr.new(request_ip) rescue nil
+        if VCAP::CloudController::Config.config.get(:logging, :anonymize_ips) && ip.nil?.!
+           if ip.ipv4?
+             ip.to_string.split('.')[0...-1].join('.') + '.0'
+           else
+             ip.to_string.split(':')[0...-5].join(':') + ':0000:0000:0000:0000:0000'
+           end
+         else
+           ip.to_string rescue request_ip
+         end
+      end
+
       def call(env)
         request = ActionDispatch::Request.new(env)
 
         @logger.info(
           sprintf('Started %<method>s "%<path>s" for user: %<user>s, ip: %<ip>s with vcap-request-id: %<request_id>s at %<at>s',
-            method: request.request_method,
-            path: request.filtered_path,
-            user: env['cf.user_guid'],
-            ip: request.ip,
-            request_id: env['cf.request_id'],
-            at: Time.now.utc)
+                  method: request.request_method,
+                  path: request.filtered_path,
+                  user: env['cf.user_guid'],
+                  ip: anonymize_ip(request.ip),
+                  request_id: env['cf.request_id'],
+                  at: Time.now.utc)
         )
 
         status, headers, body = @app.call(env)

--- a/spec/unit/middleware/request_logs_spec.rb
+++ b/spec/unit/middleware/request_logs_spec.rb
@@ -28,6 +28,83 @@ module CloudFoundry
           middleware.call(env)
           expect(logger).to have_received(:info).with(/Completed.+vcap-request-id: ID/)
         end
+
+        context 'anonymize_ips flag is true' do
+          before do
+            TestConfig.override(logging: { anonymize_ips: 'true' })
+          end
+
+          it 'logs non ip adresses in ip field unaltered' do
+            middleware.call(env)
+            expect(logger).to have_received(:info).with(/ip: ip/)
+          end
+        end
+
+        context 'request with ipv4 adress' do
+          let(:fake_request) { double('request', request_method: 'request_method', ip: '192.168.1.80', filtered_path: 'filtered_path') }
+
+          context 'anonymize_ips flag is false' do
+            it 'logs full ipv4 adresses' do
+              middleware.call(env)
+              expect(logger).to have_received(:info).with(/ip: 192.168.1.80/)
+            end
+          end
+
+          context 'anonymize_ips flag is true' do
+            before do
+              TestConfig.override(logging: { anonymize_ips: 'true' })
+            end
+
+            it 'logs anonymized ipv4 adresses' do
+              middleware.call(env)
+              expect(logger).to have_received(:info).with(/ip: 192.168.1.0/)
+            end
+          end
+        end
+
+        context 'request with ipv6 adress' do
+          let(:fake_request) { double('request', request_method: 'request_method', ip: '2001:0db8:85a3:1234:0000:8a2e:0370:7334', filtered_path: 'filtered_path') }
+
+          context 'anonymize_ips flag is false' do
+            it 'logs canonical and unaltered ipv6 adresses' do
+              middleware.call(env)
+              expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:8a2e:0370:7334/)
+            end
+          end
+
+          context 'anonymize_ips flag is true' do
+            before do
+              TestConfig.override(logging: { anonymize_ips: 'true' })
+            end
+
+            it 'logs canonical and anonymized ipv6 adresses' do
+              middleware.call(env)
+              expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/)
+            end
+          end
+        end
+
+        context 'request with non canonical(shortened) ipv6 adress' do
+          let(:fake_request) { double('request', request_method: 'request_method', ip: '2001:db8:85a3:1234::370:0', filtered_path: 'filtered_path') }
+
+          context 'anonymize_ips flag is false' do
+            it 'logs canonical and unaltered ipv6 adresses' do
+              middleware.call(env)
+              expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:0000:0370:0000/)
+            end
+          end
+
+          context 'anonymize_ips flag is true' do
+            before do
+              TestConfig.override(logging: { anonymize_ips: 'true' })
+            end
+
+            it 'logs canonical and anonymized ipv6 adresses' do
+              middleware.call(env)
+              expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## A short explanation of the proposed change:

IP Adresses now get their last octet cut of and replaced by 0 if the
new config option logging.gdpr_compliant is true. E.g 192.168.1.80
will be logged as 192.168.1.0 which provides sufficent anonymization
to comply with european data protection regulations.

If the flag is false or not present, CC will have the old behaviour
which means logging the full ips.

This flag can also be used in other places that one may find needs
adoptions to comply to EU GDPR.

## An explanation of the use cases your change solves

It provides a way to comply to the european data protection regulations.
All EU Customers of Pivotal that save their logs would benefit from this change.
The IP is specifically called as Personal information: https://gdpr.eu/recital-30-online-identifiers-for-profiling-and-identification/
So either one has to:
- Not save it at all
- Request formal approval from all users for saving their ips
- Anonymise the IP so it can not be tracked down to an individual

This change enables customers to use the third option as the first ones are not practicable.

## Links to any other associated PRs

Followup of: #1575 
Issue: #1568 
Slack discussion: https://cloudfoundry.slack.com/archives/C07C04W4Q/p1584635872138900

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
Could not get CATS to run(having no bosh-lite atm). Would be thankful if some pivot can run it against one of you bosh-lites.