### PR TITLE
Rescue kpack errors when creating new image

### DIFF
--- a/lib/cloud_controller/kpack/stager.rb
+++ b/lib/cloud_controller/kpack/stager.rb
@@ -12,6 +12,9 @@ module Kpack
 
     def stage(staging_details)
       client.create_image(image_resource(staging_details))
+    rescue CloudController::Errors::ApiError => e
+      logger.error('stage.package', package_guid: staging_details.package.guid, staging_guid: staging_details.staging_guid, error: e)
+      raise e
     end
 
     def stop_stage
@@ -54,6 +57,10 @@ module Kpack
           }
         }
       })
+    end
+
+    def logger
+      @logger ||= Steno.logger('cc.stager')
     end
 
     def client

--- a/lib/cloud_controller/kpack/stager.rb
+++ b/lib/cloud_controller/kpack/stager.rb
@@ -13,6 +13,8 @@ module Kpack
     def stage(staging_details)
       client.create_image(image_resource(staging_details))
     rescue CloudController::Errors::ApiError => e
+      build = VCAP::CloudController::BuildModel.find(guid: staging_details.staging_guid)
+      mark_build_as_failed(build, e.message) if build
       logger.error('stage.package', package_guid: staging_details.package.guid, staging_guid: staging_details.staging_guid, error: e)
       raise e
     end
@@ -28,6 +30,13 @@ module Kpack
     private
 
     attr_reader :builder_namespace, :registry_service_account_name, :registry_tag_base
+
+    def mark_build_as_failed(build, message)
+      build.class.db.transaction do
+        build.lock!
+        build.fail_to_stage!('StagingError', %Q(Failed to create Image resource for Kpack: '#{message}'))
+      end
+    end
 
     def image_resource(staging_details)
       Kubeclient::Resource.new({

--- a/lib/cloud_controller/kpack/stager.rb
+++ b/lib/cloud_controller/kpack/stager.rb
@@ -34,7 +34,7 @@ module Kpack
     def mark_build_as_failed(build, message)
       build.class.db.transaction do
         build.lock!
-        build.fail_to_stage!('StagingError', %Q(Failed to create Image resource for Kpack: '#{message}'))
+        build.fail_to_stage!('StagingError', "Failed to create Image resource for Kpack: '#{message}'")
       end
     end
 

--- a/lib/kubernetes/kpack_client.rb
+++ b/lib/kubernetes/kpack_client.rb
@@ -8,6 +8,8 @@ module Kubernetes
 
     def create_image(*args)
       @client.create_image(*args)
+    rescue Kubeclient::HttpError => e
+      raise CloudController::Errors::ApiError.new_from_details('KpackImageCreateError', e.message)
     end
   end
 end

--- a/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
+++ b/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
@@ -77,6 +77,19 @@ module Kpack
         stager.stage(staging_details)
         expect(blobstore_url_generator).to have_received(:package_download_url).with(package)
       end
+
+      context 'when staging fails' do
+        before do
+          allow(client).to receive(:create_image).and_raise(CloudController::Errors::ApiError.new_from_details('StagerError', 'staging failed'))
+        end
+
+        # TODO: marks the build as failed too (need to bring in a "staging completion handler")
+        it 'bubbles the error' do
+          expect {
+            stager.stage(staging_details)
+          }.to raise_error(CloudController::Errors::ApiError)
+        end
+      end
     end
   end
 end

--- a/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
+++ b/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
@@ -91,7 +91,7 @@ module Kpack
           build.reload
           expect(build.state).to eq(VCAP::CloudController::BuildModel::FAILED_STATE)
           expect(build.error_id).to eq('StagingError')
-          expect(build.error_description).to eq(%q(StagingError: Failed to create Image resource for Kpack 'staging failed'))
+          expect(build.error_description).to eq("Staging error: Failed to create Image resource for Kpack 'Staging error: staging failed'")
         end
       end
     end

--- a/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
+++ b/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
@@ -83,11 +83,15 @@ module Kpack
           allow(client).to receive(:create_image).and_raise(CloudController::Errors::ApiError.new_from_details('StagerError', 'staging failed'))
         end
 
-        # TODO: marks the build as failed too (need to bring in a "staging completion handler")
         it 'bubbles the error' do
           expect {
             stager.stage(staging_details)
           }.to raise_error(CloudController::Errors::ApiError)
+
+          build.reload
+          expect(build.state).to eq(VCAP::CloudController::BuildModel::FAILED_STATE)
+          expect(build.error_id).to eq('StagingError')
+          expect(build.error_description).to eq(%q(StagingError: Failed to create Image resource for Kpack 'staging failed'))
         end
       end
     end

--- a/spec/unit/lib/kubernetes/kpack_client_spec.rb
+++ b/spec/unit/lib/kubernetes/kpack_client_spec.rb
@@ -14,5 +14,15 @@ RSpec.describe Kubernetes::KpackClient do
 
       expect(kube_client).to have_received(:create_image).with(*args).once
     end
+
+    context 'when there is an error' do
+      it 'raises as an ApiError' do
+        allow(kube_client).to receive(:create_image).and_raise(Kubeclient::HttpError.new(422, "foo", "bar"))
+
+        expect {
+          subject.create_image(*args)
+        }.to raise_error(CloudController::Errors::ApiError)
+      end
+    end
   end
 end

--- a/spec/unit/lib/kubernetes/kpack_client_spec.rb
+++ b/spec/unit/lib/kubernetes/kpack_client_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Kubernetes::KpackClient do
 
     context 'when there is an error' do
       it 'raises as an ApiError' do
-        allow(kube_client).to receive(:create_image).and_raise(Kubeclient::HttpError.new(422, "foo", "bar"))
+        allow(kube_client).to receive(:create_image).and_raise(Kubeclient::HttpError.new(422, 'foo', 'bar'))
 
         expect {
           subject.create_image(*args)

--- a/vendor/errors/v2.yml
+++ b/vendor/errors/v2.yml
@@ -1283,3 +1283,13 @@
   name: StopDisabledDuringDeployment
   http_code: 422
   message: "Cannot stop the app while it is deploying, please cancel the deployment before stopping the app."
+
+400001:
+  name: KubernetesRouteResourceError
+  http_code: 422
+  message: "Failed to create/update/delete Route resource with guid '%s' on Kubernetes"
+
+400002:
+  name: KpackImageCreateError
+  http_code: 422
+  message: "Failed to create Image resource for staging: '%s'"


### PR DESCRIPTION
Notes:
- Unsure on the best way to present a kubernetes error.
- Please don't merge yet, unit tests are still failing.

https://www.pivotaltracker.com/story/show/172138488

* A short explanation of the proposed change:

Improving errors emitted from k8s when building a Kpack Image resource

* An explanation of the use cases your change solves

Improving user feedback for commands like `cf stage`

* Links to any other associated PRs