### PR TITLE
Implement the OPI task client

### DIFF
--- a/app/actions/task_create.rb
+++ b/app/actions/task_create.rb
@@ -82,8 +82,7 @@ module VCAP::CloudController
     end
 
     def submit_task(task)
-      task_definition = Diego::TaskRecipeBuilder.new.build_app_task(config, task)
-      dependency_locator.bbs_task_client.desire_task(task.guid, task_definition, Diego::TASKS_DOMAIN)
+      dependency_locator.bbs_task_client.desire_task(task, Diego::TASKS_DOMAIN)
       mark_task_as_running(task)
     rescue => e
       fail_task(task)

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -432,11 +432,19 @@ module CloudController
     end
 
     def build_opi_task_client
-      ::OPI::TaskClient.new(config)
+      ::OPI::TaskClient.new(config, build_task_completion_callback_generator, VCAP::CloudController::Diego::TaskEnvironmentVariableCollector)
     end
 
     def build_bbs_task_client
-      VCAP::CloudController::Diego::BbsTaskClient.new(build_bbs_client)
+      VCAP::CloudController::Diego::BbsTaskClient.new(config, build_bbs_client, build_task_recipe_builder)
+    end
+
+    def build_task_recipe_builder
+      VCAP::CloudController::Diego::TaskRecipeBuilder.new
+    end
+
+    def build_task_completion_callback_generator
+      VCAP::CloudController::Diego::TaskCompletionCallbackGenerator.new(config)
     end
 
     def build_instances_client

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -432,19 +432,11 @@ module CloudController
     end
 
     def build_opi_task_client
-      ::OPI::TaskClient.new(config, build_task_completion_callback_generator, VCAP::CloudController::Diego::TaskEnvironmentVariableCollector)
+      ::OPI::TaskClient.new(config, VCAP::CloudController::Diego::TaskEnvironmentVariableCollector)
     end
 
     def build_bbs_task_client
-      VCAP::CloudController::Diego::BbsTaskClient.new(config, build_bbs_client, build_task_recipe_builder)
-    end
-
-    def build_task_recipe_builder
-      VCAP::CloudController::Diego::TaskRecipeBuilder.new
-    end
-
-    def build_task_completion_callback_generator
-      VCAP::CloudController::Diego::TaskCompletionCallbackGenerator.new(config)
+      VCAP::CloudController::Diego::BbsTaskClient.new(config, build_bbs_client)
     end
 
     def build_instances_client

--- a/lib/cloud_controller/diego/bbs_task_client.rb
+++ b/lib/cloud_controller/diego/bbs_task_client.rb
@@ -4,16 +4,15 @@ require 'cloud_controller/diego/constants'
 module VCAP::CloudController
   module Diego
     class BbsTaskClient
-      def initialize(config, client, recipe_builder)
+      def initialize(config, client)
         @config = config
         @client = client
-        @recipe_builder = recipe_builder
       end
 
       def desire_task(task, domain)
         logger.info('task.request', task_guid: task.guid)
 
-        task_definition = @recipe_builder.build_app_task(@config, task)
+        task_definition = VCAP::CloudController::Diego::TaskRecipeBuilder.new.build_app_task(@config, task)
         handle_diego_errors do
           response = client.desire_task(task_guid: task.guid, task_definition: task_definition, domain: domain)
           logger.info('task.response', task_guid: task.guid, error: response.error)

--- a/lib/cloud_controller/diego/bbs_task_client.rb
+++ b/lib/cloud_controller/diego/bbs_task_client.rb
@@ -4,16 +4,19 @@ require 'cloud_controller/diego/constants'
 module VCAP::CloudController
   module Diego
     class BbsTaskClient
-      def initialize(client)
+      def initialize(config, client, recipe_builder)
+        @config = config
         @client = client
+        @recipe_builder = recipe_builder
       end
 
-      def desire_task(task_guid, task_definition, domain)
-        logger.info('task.request', task_guid: task_guid)
+      def desire_task(task, domain)
+        logger.info('task.request', task_guid: task.guid)
 
+        task_definition = @recipe_builder.build_app_task(@config, task)
         handle_diego_errors do
-          response = client.desire_task(task_guid: task_guid, task_definition: task_definition, domain: domain)
-          logger.info('task.response', task_guid: task_guid, error: response.error)
+          response = client.desire_task(task_guid: task.guid, task_definition: task_definition, domain: domain)
+          logger.info('task.response', task_guid: task.guid, error: response.error)
           response
         end
 

--- a/lib/cloud_controller/opi/task_client.rb
+++ b/lib/cloud_controller/opi/task_client.rb
@@ -1,10 +1,45 @@
 require 'httpclient'
 require 'cloud_controller/opi/base_client'
+require 'cloud_controller/diego/task_completion_callback_generator'
+require 'cloud_controller/diego/task_environment_variable_collector'
 
 module OPI
   class TaskClient < BaseClient
-    def desire_task(task_guid, task_definition, domain)
-      nil
+    def initialize(config, task_completion_callback_generator, environment_collector)
+      super(config)
+      @task_completion_callback_generator = task_completion_callback_generator
+      @environment_collector = environment_collector
+    end
+
+    def desire_task(task, domain)
+      task_request = to_request(config, task)
+      payload = MultiJson.dump(task_request)
+      response = client.post("/tasks/#{task.guid}", body: payload)
+      if response.status_code != 202
+        response_json = OPI.recursive_ostruct(JSON.parse(response.body))
+        logger.info('tasks.response', task_guid: task.guid, error: response_json.message)
+        raise CloudController::Errors::ApiError.new_from_details('RunnerError', response_json.message)
+      end
+    end
+
+    def to_request(config, task)
+      {
+        app_guid: task.app.guid,
+        app_name: task.app.name,
+        org_guid: task.space.organization.guid,
+        org_name: task.space.organization.name,
+        space_guid: task.space.guid,
+        space_name: task.space.name,
+        environment: @environment_collector.for_task(task),
+        completion_callback: @task_completion_callback_generator.generate(task),
+        lifecycle: {
+          buildpack_lifecycle: {
+            droplet_hash: task.droplet.droplet_hash,
+            droplet_guid: task.droplet.guid,
+            start_command: task.command
+          }
+        }
+      }
     end
 
     def fetch_task(_)
@@ -18,5 +53,9 @@ module OPI
     def cancel_task(_); end
 
     def bump_freshness; end
+
+    def logger
+      @logger ||= Steno.logger('cc.opi.task_client')
+    end
   end
 end

--- a/lib/cloud_controller/opi/task_client.rb
+++ b/lib/cloud_controller/opi/task_client.rb
@@ -5,14 +5,13 @@ require 'cloud_controller/diego/task_environment_variable_collector'
 
 module OPI
   class TaskClient < BaseClient
-    def initialize(config, task_completion_callback_generator, environment_collector)
+    def initialize(config, environment_collector)
       super(config)
-      @task_completion_callback_generator = task_completion_callback_generator
       @environment_collector = environment_collector
     end
 
     def desire_task(task, domain)
-      task_request = to_request(config, task)
+      task_request = to_request(task)
       payload = MultiJson.dump(task_request)
       response = client.post("/tasks/#{task.guid}", body: payload)
       if response.status_code != 202
@@ -20,26 +19,6 @@ module OPI
         logger.info('tasks.response', task_guid: task.guid, error: response_json.message)
         raise CloudController::Errors::ApiError.new_from_details('RunnerError', response_json.message)
       end
-    end
-
-    def to_request(config, task)
-      {
-        app_guid: task.app.guid,
-        app_name: task.app.name,
-        org_guid: task.space.organization.guid,
-        org_name: task.space.organization.name,
-        space_guid: task.space.guid,
-        space_name: task.space.name,
-        environment: @environment_collector.for_task(task),
-        completion_callback: @task_completion_callback_generator.generate(task),
-        lifecycle: {
-          buildpack_lifecycle: {
-            droplet_hash: task.droplet.droplet_hash,
-            droplet_guid: task.droplet.guid,
-            start_command: task.command
-          }
-        }
-      }
     end
 
     def fetch_task(_)
@@ -53,6 +32,29 @@ module OPI
     def cancel_task(_); end
 
     def bump_freshness; end
+
+    private
+
+    def to_request(task)
+      task_completion_callback_generator = VCAP::CloudController::Diego::TaskCompletionCallbackGenerator.new(@config)
+      {
+        app_guid: task.app.guid,
+        app_name: task.app.name,
+        org_guid: task.space.organization.guid,
+        org_name: task.space.organization.name,
+        space_guid: task.space.guid,
+        space_name: task.space.name,
+        environment: @environment_collector.for_task(task),
+        completion_callback: task_completion_callback_generator.generate(task),
+        lifecycle: {
+          buildpack_lifecycle: {
+            droplet_hash: task.droplet.droplet_hash,
+            droplet_guid: task.droplet.guid,
+            start_command: task.command
+          }
+        }
+      }
+    end
 
     def logger
       @logger ||= Steno.logger('cc.opi.task_client')

--- a/lib/cloud_controller/opi/task_client.rb
+++ b/lib/cloud_controller/opi/task_client.rb
@@ -29,7 +29,17 @@ module OPI
       []
     end
 
-    def cancel_task(_); end
+    def cancel_task(guid)
+      response = client.delete("/tasks/#{guid}")
+      if response.status_code > 400
+        logger.info('tasks.delete.response_code', task_guid: guid, status_code: response.status_code)
+
+        if response.status_code != 404
+          response_json = OPI.recursive_ostruct(JSON.parse(response.body))
+          raise CloudController::Errors::ApiError.new_from_details('TaskError', response_json.message)
+        end
+      end
+    end
 
     def bump_freshness; end
 

--- a/lib/cloud_controller/opi/task_client.rb
+++ b/lib/cloud_controller/opi/task_client.rb
@@ -38,6 +38,7 @@ module OPI
     def to_request(task)
       task_completion_callback_generator = VCAP::CloudController::Diego::TaskCompletionCallbackGenerator.new(@config)
       {
+        name: task.name,
         app_guid: task.app.guid,
         app_name: task.app.name,
         org_guid: task.space.organization.guid,

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -673,15 +673,13 @@ RSpec.describe CloudController::DependencyLocator do
   describe '#bbs_task_client' do
     context 'opi is disabled' do
       let(:diego_client) { double }
-      let(:recipe_builder) { double }
 
       before do
         allow(::Diego::Client).to receive(:new).and_return(diego_client)
-        allow(VCAP::CloudController::Diego::TaskRecipeBuilder).to receive(:new).and_return(recipe_builder)
       end
 
       it 'uses diego' do
-        expect(VCAP::CloudController::Diego::BbsTaskClient).to receive(:new).with(config, diego_client, recipe_builder)
+        expect(VCAP::CloudController::Diego::BbsTaskClient).to receive(:new).with(config, diego_client)
         expect(::OPI::TaskClient).to_not receive(:new)
         locator.bbs_task_client
       end
@@ -707,7 +705,6 @@ RSpec.describe CloudController::DependencyLocator do
       it 'uses the configured opi url' do
         expect(::OPI::TaskClient).to receive(:new).with(
           locator.config,
-          instance_of(VCAP::CloudController::Diego::TaskCompletionCallbackGenerator),
           VCAP::CloudController::Diego::TaskEnvironmentVariableCollector)
         locator.bbs_task_client
       end

--- a/spec/unit/lib/cloud_controller/diego/bbs_task_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/bbs_task_client_spec.rb
@@ -10,13 +10,14 @@ module VCAP::CloudController::Diego
     let(:bbs_client) { instance_double(::Diego::Client) }
     let(:recipe_builder) { instance_double(TaskRecipeBuilder) }
 
-    subject(:client) { BbsTaskClient.new(config, bbs_client, recipe_builder) }
+    subject(:client) { BbsTaskClient.new(config, bbs_client) }
 
     describe '#desire_task' do
       let(:task_definition) { instance_double(::Diego::Bbs::Models::TaskDefinition) }
 
       before do
         allow(bbs_client).to receive(:desire_task).and_return(::Diego::Bbs::Models::TaskLifecycleResponse.new)
+        allow(VCAP::CloudController::Diego::TaskRecipeBuilder).to receive(:new).and_return(recipe_builder)
         allow(recipe_builder).to receive(:build_app_task).with(config, task).and_return(task_definition)
       end
 

--- a/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
@@ -11,17 +11,67 @@ RSpec.describe(OPI::TaskClient) do
       },
     )
   end
+  let(:task) {
+    instance_double(
+      VCAP::CloudController::TaskModel,
+      guid: 'GUID',
+      command: 'COMMAND',
+      droplet: double(droplet_hash: 'DROPLET_HASH', guid: 'DROPLET_GUID'),
+      app: double(guid: 'APP_GUID', name: 'APP_NAME'),
+      space: double(
+        guid: 'SPACE_GUID',
+        name: 'SPACE_NAME',
+        organization: double(guid: 'ORG_GUID', name: 'ORG_NAME')
+      )
+    )
+  }
+  let(:task_completion_callback_generator) { instance_double(VCAP::CloudController::Diego::TaskCompletionCallbackGenerator) }
+  let(:environment_collector) { class_double(VCAP::CloudController::Diego::TaskEnvironmentVariableCollector) }
+  let(:environment) { [{ name: 'FOO', value: 'BAR' }] }
 
-  subject(:client) { described_class.new(config) }
+  subject(:client) { described_class.new(config, task_completion_callback_generator, environment_collector) }
 
   describe 'can desire a task' do
-    it 'should return nothing' do
-      response = client.desire_task(nil, nil, nil)
-      expect(response).to be_nil
+    before(:each) do
+      allow(environment_collector).to receive(:for_task).with(task).and_return(environment)
+      allow(task_completion_callback_generator).to receive(:generate).with(task).and_return('CALLBACK')
+      stub_request(:post, "#{opi_url}/tasks/GUID").to_return(status: 202)
     end
 
-    it 'should not send any request to opi' do
-      expect(a_request(:any, opi_url)).not_to have_been_made
+    it 'posts the task to the http client' do
+      client.desire_task(task, 'some-domain')
+
+      expect(WebMock).to have_requested(:post, "#{opi_url}/tasks/GUID").with(body: {
+        app_guid: 'APP_GUID',
+        app_name: 'APP_NAME',
+        org_guid: 'ORG_GUID',
+        org_name: 'ORG_NAME',
+        space_guid: 'SPACE_GUID',
+        space_name: 'SPACE_NAME',
+        environment: [{ name: 'FOO', value: 'BAR' }],
+        completion_callback: 'CALLBACK',
+        lifecycle: {
+          buildpack_lifecycle: {
+            droplet_hash: 'DROPLET_HASH',
+            droplet_guid: 'DROPLET_GUID',
+            start_command: 'COMMAND'
+          }
+        }
+      }.to_json)
+    end
+
+    context 'the http client returns an error' do
+      before(:each) do
+        stub_request(:post, "#{opi_url}/tasks/GUID").to_return(status: 500, body: '{}')
+      end
+
+      it 'raises an API error' do
+        expect {
+          client.desire_task(task, 'some-domain')
+        }.to raise_error(CloudController::Errors::ApiError) do |e|
+          expect(e.name).to eq('RunnerError')
+        end
+      end
     end
   end
 

--- a/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
@@ -29,10 +29,11 @@ RSpec.describe(OPI::TaskClient) do
   let(:environment_collector) { class_double(VCAP::CloudController::Diego::TaskEnvironmentVariableCollector) }
   let(:environment) { [{ name: 'FOO', value: 'BAR' }] }
 
-  subject(:client) { described_class.new(config, task_completion_callback_generator, environment_collector) }
+  subject(:client) { described_class.new(config, environment_collector) }
 
   describe 'can desire a task' do
     before(:each) do
+      allow(VCAP::CloudController::Diego::TaskCompletionCallbackGenerator).to receive(:new).and_return(task_completion_callback_generator)
       allow(environment_collector).to receive(:for_task).with(task).and_return(environment)
       allow(task_completion_callback_generator).to receive(:generate).with(task).and_return('CALLBACK')
       stub_request(:post, "#{opi_url}/tasks/GUID").to_return(status: 202)

--- a/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe(OPI::TaskClient) do
     instance_double(
       VCAP::CloudController::TaskModel,
       guid: 'GUID',
+      name: 'NAME',
       command: 'COMMAND',
       droplet: double(droplet_hash: 'DROPLET_HASH', guid: 'DROPLET_GUID'),
       app: double(guid: 'APP_GUID', name: 'APP_NAME'),
@@ -43,6 +44,7 @@ RSpec.describe(OPI::TaskClient) do
       client.desire_task(task, 'some-domain')
 
       expect(WebMock).to have_requested(:post, "#{opi_url}/tasks/GUID").with(body: {
+        name: 'NAME',
         app_guid: 'APP_GUID',
         app_name: 'APP_NAME',
         org_guid: 'ORG_GUID',


### PR DESCRIPTION
Implement task creation in the OPI task client. Note that we do not support other task operations yet, such as `cancel`, i.e. tasks CATS tests would fail if run against CF+Eirini deployment.

The task client `desire_task` method has its signature changed to
receive the task rather than the task definition. This caused the bbs
task client to build the task definition via an injected recipe builder.
This also brought some changes in the dependency locator wiring.

[#171785772]

Co-authored-by: Julian Skupnjak <skupnjak@de.ibm.com>
Co-authored-by: Georgi Sabev <gcapizzi@pivotal.io>
Co-authored-by: Danail Branekov <danailster@gmail.com>
Co-authored-by: Giuseppe Capizzi <gcapizzi@pivotal.io>


* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
