### PR TITLE
Send buildpack cache information to OPI

### DIFF
--- a/spec/unit/lib/cloud_controller/opi/stager_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/stager_client_spec.rb
@@ -75,7 +75,11 @@ RSpec.describe(OPI::StagerClient) do
             buildpack_lifecycle: {
               droplet_upload_uri: "http://cc-uploader.service.cf.internal:9091/v1/droplet/#{staging_guid}?cc-droplet-upload-uri=http://upload.me",
                               app_bits_download_uri: 'http://download.me',
-                              buildpacks: [{ name: 'ruby', key: 'idk', url: 'www.com', skip_detect: false }]
+                              buildpacks: [{ name: 'ruby', key: 'idk', url: 'www.com', skip_detect: false }],
+                              buildpack_cache_download_uri: 'buildpacks-artifacts-cache-url-download',
+                              buildpack_cache_checksum: 'sumcheck',
+                              buildpack_cache_checksum_algorithm: 'sha256',
+                              buildpack_cache_upload_uri: 'https://cc-uploader.service.cf.internal:9091/v1/build_artifacts/some_staging_guid?cc-build-artifacts-upload-uri=buildpacks-artifacts-cache-url-upload&timeout=42'
             }
           },
           cpu_weight: VCAP::CloudController::Diego::STAGING_TASK_CPU_WEIGHT,
@@ -109,7 +113,11 @@ RSpec.describe(OPI::StagerClient) do
               buildpack_lifecycle: {
                 droplet_upload_uri: "http://cc-uploader.service.cf.internal:9091/v1/droplet/#{staging_guid}?cc-droplet-upload-uri=http://upload.me",
                                 app_bits_download_uri: 'http://download.me',
-                                buildpacks: [{ name: 'ruby', key: 'idk', url: 'www.com', skip_detect: false }]
+                                buildpacks: [{ name: 'ruby', key: 'idk', url: 'www.com', skip_detect: false }],
+                                buildpack_cache_download_uri: 'buildpacks-artifacts-cache-url-download',
+                                buildpack_cache_checksum: 'sumcheck',
+                                buildpack_cache_checksum_algorithm: 'sha256',
+                                buildpack_cache_upload_uri: 'https://cc-uploader.service.cf.internal:9091/v1/build_artifacts/some_staging_guid?cc-build-artifacts-upload-uri=buildpacks-artifacts-cache-url-upload&timeout=42'
               }
             },
             cpu_weight: VCAP::CloudController::Diego::STAGING_TASK_CPU_WEIGHT,
@@ -229,10 +237,10 @@ RSpec.describe(OPI::StagerClient) do
        }
     ]
     data.droplet_upload_uri                         = 'http://upload.me'
-    data.build_artifacts_cache_download_uri         = 'dont care'
+    data.build_artifacts_cache_download_uri         = 'buildpacks-artifacts-cache-url-download'
     data.stack                                      = 'dont care'
-    data.build_artifacts_cache_upload_uri           = 'dont care'
-    data.buildpack_cache_checksum                   = 'dont care'
+    data.build_artifacts_cache_upload_uri           = 'buildpacks-artifacts-cache-url-upload'
+    data.buildpack_cache_checksum                   = 'sumcheck'
     data.app_bits_checksum                          = { type: 'sha256', value: 'also dont care' }
     data.message
   end


### PR DESCRIPTION
* A short explanation of the proposed change:
Same as title.

* An explanation of the use cases your change solves
This is required for buildpack caching support in Eirini. [Story for reference](https://www.pivotaltracker.com/story/show/170891721).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

cc @danail-branekov
