### PR TITLE
Clarify plan_updateable overrides

### DIFF
--- a/docs/v3/source/includes/experimental_resources/service_offerings/_object.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_offerings/_object.md.erb
@@ -22,7 +22,7 @@ Name | Type | Description
 **broker_catalog** | _object_ | This object contains information obtained from the Service Broker Catalog.
 **broker_catalog.id** | _string_ | The identifier that the Service Broker provided for this Service Offering.
 **broker_catalog.metadata** | _object_ | Additional information provided by the Service Broker.
-**broker_catalog.features.plan_updateable** | _boolean_ | Whether the Service Offering supports upgrade/downgrade for Service Plans by default
+**broker_catalog.features.plan_updateable** | _boolean_ | Whether the Service Offering supports upgrade/downgrade for Service Plans by default. Service Plans can override this field.
 **broker_catalog.features.bindable** | _boolean_ | Specifies whether Service Instances of the service can be bound to applications.
 **broker_catalog.features.instances_retrievable** | _boolean_ | Specifies whether the Fetching a Service Instance endpoint is supported for all Service Plans.
 **broker_catalog.features.bindings_retrievable** | _boolean_ | Specifies whether the Fetching a Service Binding endpoint is supported for all Service Plans.

--- a/docs/v3/source/includes/experimental_resources/service_plans/_object.md.erb
+++ b/docs/v3/source/includes/experimental_resources/service_plans/_object.md.erb
@@ -22,7 +22,7 @@ Name | Type | Description
 **broker_catalog.id** | _string_ | The identifier that the Service Broker provided for this Service Plan.
 **broker_catalog.metadata** | _object_ | Additional information provided by the Service Broker.
 **broker_catalog.maximum_polling_duration** | _integer_ | The maximum number of seconds that Cloud Foundry will wait for an asynchronous Service Broker operation.
-**broker_catalog.features.plan_updateable** | _boolean_ | Whether the Service Plan supports upgrade/downgrade for Service Plans by default
+**broker_catalog.features.plan_updateable** | _boolean_ | Whether the Service Plan supports upgrade/downgrade for Service Plans by default. If specified, this takes precedence over the Service Offering's plan_updateable field. If not specified, the default is derived from the Service Offering. 
 **broker_catalog.features.bindable** | _boolean_ | Specifies whether Service Instances of the service can be bound to applications.
 **schemas** | _object_ | Schema definitions for Service Instances and Service Bindings for the Service Plan.
 **schemas.service_instance.create** | _object_ | Schema definition for Service Instance creation.


### PR DESCRIPTION
* A short explanation of the proposed change:

The OSB API states regarding a service offering metadata that its updateable flag can be overriden in plans.

https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#service-offering-object

> Response Field | Type | Description
> -- | -- | --
> [...]
> plan_updateable | boolean | Whether the Service Offering supports upgrade/downgrade for Service  Plans by default. Service Plans can override this field (see Service Plan). Please note that the misspelling of the attribute plan_updatable as plan_updateable  was done by mistake. We have opted to keep that misspelling instead of  fixing it and thus breaking backward compatibility. Defaults to false.
> 

https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#service-plan-object

> Response Field | Type | Description
> -- | -- | --
> [...]
> plan_updateable | boolean | Whether the Plan supports upgrade/downgrade/sidegrade to another  version. This field is OPTIONAL. If specified, this takes precedence  over the Service Offering's plan_updateable field. If not  specified, the default is derived from the Service Offering. Please note  that the attribute is intentionally misspelled as plan_updateable for legacy reasons.
> 

Unfortunately the CC API reuses the two fields, but isn't precise enough to state that plan.updateable override serviceoffering.plan_updateable


* An explanation of the use cases your change solves

Clarify the expected CC behavior, to avoid CC API clients to make wrong assumptions, see related https://github.com/cloudfoundry/cf-java-client/issues/1044

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
