### PR TITLE
Create consistent AppUsageEvent records

### DIFF
--- a/app/repositories/app_usage_event_repository.rb
+++ b/app/repositories/app_usage_event_repository.rb
@@ -110,6 +110,8 @@ module VCAP::CloudController
           space_name:                         "#{Space.table_name}__name".to_sym,
           org_guid:                           "#{Organization.table_name}__guid".to_sym,
           created_at:                         Sequel.datetime_class.now,
+          parent_app_name:                    :parent_app__name,
+          parent_app_guid:                    :parent_app__guid,
         }
 
         latest_package_query = PackageModel.select(:app_guid).select_append { max(id).as(:id) }.group(:app_guid)

--- a/spec/unit/repositories/app_usage_event_repository_spec.rb
+++ b/spec/unit/repositories/app_usage_event_repository_spec.rb
@@ -546,6 +546,13 @@ module VCAP::CloudController
             expect(AppUsageEvent.last).to match_app(process)
           end
 
+          it 'sets the parent_app_name and parent_app_guid' do
+            repository.purge_and_reseed_started_apps!
+
+            expect(AppUsageEvent.last.parent_app_name).to eq(process.app.name)
+            expect(AppUsageEvent.last.parent_app_guid).to eq(process.app.guid)
+          end
+
           context 'with associated buildpack information' do
             before do
               process.desired_droplet.update(


### PR DESCRIPTION
When a user makes a POST to
/v2/app_usage_events/destructively_purge_all_and_reseed_started_apps,
all existing AppUsageEvent records are purged from the database and new
AppUsageEvent records are created for any running processes. This action
is taken by clients who may have missed previous events that have now
been pruned from the database as part of routeine mainteance and now
need a new starting spot for tracking usage.

All AppUsageEvent records created outside of a purge and reseed action
will have their parent_app_name and parent_app_guid fields set. This
change makes AppUsageEvent recoreds created as a result of a purge
consistent with all other records in that respect.

Not having the parent_app_name and parent_app_guid fields set was
causing 3rd party usage monitoring systems that expected their presence
to break.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
