### PR TITLE
Ignore updates of buildpack (e.g. second cf push)

### DIFF
--- a/app/models/runtime/kpack_lifecycle_data_model.rb
+++ b/app/models/runtime/kpack_lifecycle_data_model.rb
@@ -38,8 +38,12 @@ module VCAP::CloudController
       []
     end
 
+    def buildpacks=(new_buildpacks) end
+
     def stack
       nil
     end
+
+    def stack=(new_value) end
   end
 end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

When running a `cf push` twice with a `manifest.yml` which includes a `buildpacks` setting, the second push fails with `undefined method 'buildpacks='`

* An explanation of the use cases your change solves

This also relates to https://github.com/cloudfoundry/cf-for-k8s/issues/88 which was closed.
The current behaviour is not consitent. The first push succeeds and the second fails. It should either fail in both cases or succeed in both cases. We would vote for the later.

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
  Not require for this simple change.
