### PR TITLE
Add deployable property to revisions endpoints.

### DIFF
--- a/app/fetchers/app_revisions_fetcher.rb
+++ b/app/fetchers/app_revisions_fetcher.rb
@@ -1,10 +1,14 @@
 module VCAP::CloudController
   class AppRevisionsFetcher
     def self.fetch(app, message)
-      dataset = RevisionModel.where(app_guid: app.guid)
+      dataset = RevisionModel.where(Sequel[:revisions][:app_guid] => app.guid)
 
       if message.requested?(:versions)
-        dataset = dataset.where(app_guid: app.guid, version: message.versions)
+        dataset = dataset.where(Sequel[:revisions][:app_guid] => app.guid, version: message.versions)
+      end
+
+      if message.requested?(:deployable)
+        dataset = dataset.join(:droplets, guid: :droplet_guid).where(Sequel[:revisions][:app_guid] => app.guid, Sequel[:droplets][:state] => DropletModel::STAGED_STATE)
       end
 
       if message.requested?(:label_selector)

--- a/app/messages/app_revisions_list_message.rb
+++ b/app/messages/app_revisions_list_message.rb
@@ -4,11 +4,15 @@ module VCAP::CloudController
   class AppRevisionsListMessage < MetadataListMessage
     register_allowed_keys [
       :versions,
+      :deployable,
     ]
 
     validates_with NoAdditionalParamsValidator
 
     validates :versions, array: true, allow_nil: true
+    validates :deployable,
+      inclusion: { in: [true, false], message: 'must be a boolean' },
+      allow_nil: true
 
     def self.from_params(params)
       super(params, %w(versions))

--- a/app/presenters/v3/revision_presenter.rb
+++ b/app/presenters/v3/revision_presenter.rb
@@ -30,7 +30,9 @@ module VCAP::CloudController
             metadata: {
               labels: hashified_labels(revision.labels),
               annotations: hashified_annotations(revision.annotations),
-            }
+            },
+            deployable: deployable
+
           }
         end
 
@@ -67,6 +69,10 @@ module VCAP::CloudController
               process_types: sidecar.revision_sidecar_process_types.map(&:type),
             }
           end
+        end
+
+        def deployable
+          revision.droplet.staged?
         end
       end
     end

--- a/docs/v3/source/includes/api_resources/_revisions.erb
+++ b/docs/v3/source/includes/api_resources/_revisions.erb
@@ -19,6 +19,7 @@
     }
   ],
   "description": "Initial revision.",
+  "deployable": true,
   "relationships": {
     "app": {
       "data": {
@@ -81,6 +82,7 @@
         }
       ],
       "description": "Initial revision.",
+      "deployable": true,
       "relationships": {
         "app": {
           "data": {

--- a/docs/v3/source/includes/experimental_resources/revisions/_object.md.erb
+++ b/docs/v3/source/includes/experimental_resources/revisions/_object.md.erb
@@ -17,6 +17,7 @@ Name | Type | Description
 **created_at** | _datetime_ | The time with zone when the object was created.
 **updated_at** | _datetime_ | The time with zone when the object was last updated.
 **description** | _string_ | A short description of the reason for revision.
+**deployable** _(experimental)_ | _boolean_ | Indicates if the revision's droplet is staged and the revision can be used to [create a deployment](#create-a-deployment).
 **relationships.app** | [_to-one relationship_](#to-one-relationships) | The app the revision is associated with.
 **metadata.labels** | [_label object_](#labels) | Labels applied to the revision.
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the revision.

--- a/spec/request/revisions_spec.rb
+++ b/spec/request/revisions_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe 'Revisions' do
             'command' => 'run-sidecar',
             'process_types' => ['web'],
             'memory_in_mb' => 300,
-          }]
+          }],
+          'deployable' => true
         }
       )
     end
@@ -146,6 +147,7 @@ RSpec.describe 'Revisions' do
                 },
               },
               'sidecars' => [],
+              'deployable' => true
             },
             {
               'guid' => revision2.guid,
@@ -181,6 +183,7 @@ RSpec.describe 'Revisions' do
                 },
               },
               'sidecars' => [],
+              'deployable' => true
             }
           ]
         }
@@ -244,6 +247,7 @@ RSpec.describe 'Revisions' do
                   },
                 },
                 'sidecars' => [],
+                'deployable' => true
               },
               {
                 'guid' => revision3.guid,
@@ -279,6 +283,7 @@ RSpec.describe 'Revisions' do
                   },
                 },
                 'sidecars' => [],
+                'deployable' => true
               }
             ]
           }
@@ -367,6 +372,7 @@ RSpec.describe 'Revisions' do
             },
           },
           'sidecars' => [],
+          'deployable' => true
         }
       )
     end
@@ -461,6 +467,7 @@ RSpec.describe 'Revisions' do
                 },
               },
               'sidecars' => [],
+              'deployable' => true
             },
             {
               'guid' => revision2.guid,
@@ -496,6 +503,7 @@ RSpec.describe 'Revisions' do
                 },
               },
               'sidecars' => [],
+              'deployable' => true
             }
           ]
         }

--- a/spec/unit/messages/app_revisions_list_message_spec.rb
+++ b/spec/unit/messages/app_revisions_list_message_spec.rb
@@ -10,6 +10,7 @@ module VCAP::CloudController
           'page'     => 1,
           'per_page' => 5,
           'label_selector' => 'key=value',
+          'deployable' => true
         }
       end
 
@@ -20,6 +21,7 @@ module VCAP::CloudController
         expect(message.page).to eq(1)
         expect(message.per_page).to eq(5)
         expect(message.versions).to eq(['1', '3'])
+        expect(message.deployable).to eq(true)
         expect(message.label_selector).to eq('key=value')
       end
 
@@ -29,6 +31,7 @@ module VCAP::CloudController
         expect(message.requested?(:page)).to be_truthy
         expect(message.requested?(:per_page)).to be_truthy
         expect(message.requested?(:versions)).to be_truthy
+        expect(message.requested?(:deployable)).to be_truthy
         expect(message.requested?(:label_selector)).to be_truthy
       end
     end
@@ -55,7 +58,8 @@ module VCAP::CloudController
           AppRevisionsListMessage.from_params({
             page:               1,
             per_page:           5,
-            versions:          ['1'],
+            versions:           ['1'],
+            deployable:         true,
             label_selector:     'key=value',
           })
         }.not_to raise_error
@@ -84,6 +88,19 @@ module VCAP::CloudController
 
         it 'allows versions to be nil' do
           message = AppRevisionsListMessage.from_params(versions: nil)
+          expect(message).to be_valid
+        end
+      end
+
+      context 'deployable' do
+        it 'validates deployable to be a boolean' do
+          message = AppRevisionsListMessage.from_params(deployable: 'not a boolean')
+          expect(message).to be_invalid
+          expect(message.errors[:deployable]).to include('must be a boolean')
+        end
+
+        it 'allows deployable to be nil' do
+          message = AppRevisionsListMessage.from_params(deployable: nil)
           expect(message).to be_valid
         end
       end

--- a/spec/unit/presenters/v3/revision_presenter_spec.rb
+++ b/spec/unit/presenters/v3/revision_presenter_spec.rb
@@ -96,6 +96,24 @@ module VCAP::CloudController::Presenters::V3
         expect(result[:sidecars][0][:memory_in_mb]).to eq(300)
         expect(result[:sidecars][0][:process_types]).to eq(['web'])
         expect(result[:description]).to eq('Initial revision')
+        expect(result[:deployable]).to eq(true)
+      end
+
+      context 'when the droplet is not staged' do
+        let(:droplet) do
+          VCAP::CloudController::DropletModel.make(
+            app: app_model,
+            state: VCAP::CloudController::DropletModel::EXPIRED_STATE,
+            process_types: {
+              'web' => 'droplet_web_command',
+              'worker' => 'droplet_worker_command',
+            })
+        end
+
+        it 'returns deployable is false' do
+          result = RevisionPresenter.new(revision).to_hash
+          expect(result[:deployable]).to eq(false)
+        end
       end
     end
   end


### PR DESCRIPTION
Meant to resolve https://github.com/cloudfoundry/cloud_controller_ng/issues/1567

@ssisil @selzoc  @JenGoldstrich   Wanted to get feedback on this solution since it's a little different from the issue's suggested solution. 

Instead of a `status` property, this PR just surfaces a `deployable` property which indicates whether or not the revision can be rolled back to (i.e. the droplet is in the STAGED state).

We were hesitant to introduce `state: DEPLOYED` because that implies around whether or not the process is actually started.  Two revisions may also be `DEPLOYED` at the same time (during rolling deployments)--it doesn't necessarily indicate which revision is the "current" revision.  So we weren't sure if we should go down the path of figuring out if we needed to add states like `DEPLOYED_AND_CURRENT`, `DEPLOYED_AND_NOT_CURRENT`, `state: NOT_DEPLOYED_AND_CURRENT`, etc if being able to tell if a revision could be used to create a deployment would was the main use case here.  

We can also consider adding a `current` and `deployed` flag.


TODO:
- [x] documentation