### PR TITLE
Remove a bunch of experimental tags from v3 docs

### DIFF
--- a/docs/v3/source/includes/api_resources/_app_features.erb
+++ b/docs/v3/source/includes/api_resources/_app_features.erb
@@ -16,7 +16,7 @@
     },
     {
       "name": "revisions",
-      "description": "Enable versioning of an application (experimental)",
+      "description": "Enable versioning of an application",
       "enabled": false
     }
   ],

--- a/docs/v3/source/includes/resources/apps/_object.md.erb
+++ b/docs/v3/source/includes/resources/apps/_object.md.erb
@@ -16,7 +16,7 @@ Name | Type | Description
 **guid** | _uuid_ | Unique identifier for the app.
 **created_at** | _datetime_ | The time with zone when the object was created.
 **updated_at** | _datetime_ | The time with zone when the object was last updated.
-**relationships.space** _(experimental)_| [_to-one relationship_](#to-one-relationships) | The space the app is contained in.
+**relationships.space** | [_to-one relationship_](#to-one-relationships) | The space the app is contained in.
 **links** | [_links object_](#links) | Links to related resources.
 **metadata.labels** | [_label object_](#labels) | Labels applied to the app.
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations added to the app.

--- a/docs/v3/source/includes/resources/builds/_object.md.erb
+++ b/docs/v3/source/includes/resources/builds/_object.md.erb
@@ -18,7 +18,7 @@ Name | Type | Description
 **created_at** | _datetime_ | The time with zone when the build was created.
 **updated_at** | _datetime_ | The time with zone when the build was last updated.
 **created_by** | _object_ | The user that created the build.
-**relationships.app** _(experimental)_| [_to-one relationship_](#to-one-relationships) | The app the build belongs to.
+**relationships.app** | [_to-one relationship_](#to-one-relationships) | The app the build belongs to.
 **links** | [_links object_](#links) | Links to related resources.
 **metadata.labels** | [_label object_](#labels) | Labels applied to the build.
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the build.

--- a/docs/v3/source/includes/resources/droplets/_object.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_object.md.erb
@@ -15,7 +15,7 @@ Name | Type | Description
 **guid** | _uuid_ | Unique identifier for the droplet.
 **created_at** | _datetime_ | The time with zone when the object was created.
 **updated_at** | _datetime_ | The time with zone when the object was last updated.
-**relationships.app** _(experimental)_| [_to-one relationship_](#to-one-relationships) | The app the droplet belongs to.
+**relationships.app** | [_to-one relationship_](#to-one-relationships) | The app the droplet belongs to.
 **links** | [_links object_](#links) | Links to related resources.
 **execution_metadata** | _string_ | Serialized JSON data resulting from staging for use when executing a droplet.
 **process_types** | _object_ | The process types (keys) and associated start commands (values) that will be created when the droplet is executed.

--- a/docs/v3/source/includes/resources/organizations/_create.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_create.md.erb
@@ -37,7 +37,7 @@ Name | Type | Description
 
 Name | Type | Description
 ---- | ---- | -----------
-**suspended** _(experimental)_| _boolean_ | Whether an organization is suspended or not.
+**suspended** | _boolean_ | Whether an organization is suspended or not.
 **metadata.labels** | [_label object_](#labels) | Labels applied to the organization.
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the organization.
 

--- a/docs/v3/source/includes/resources/organizations/_update.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_update.md.erb
@@ -32,7 +32,7 @@ Content-Type: application/json
 Name | Type | Description
 ---- | ---- | -----------
 **name** | _string_ | Organization name |
-**suspended** _(experimental)_| _boolean_ | Whether an organization is suspended or not.
+**suspended** | _boolean_ | Whether an organization is suspended or not.
 **metadata.labels** | [_label object_](#labels) | Labels applied to the organization.
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the organization.
 

--- a/docs/v3/source/includes/resources/packages/_object.md.erb
+++ b/docs/v3/source/includes/resources/packages/_object.md.erb
@@ -15,7 +15,7 @@ Name | Type | Description
 **guid** | _uuid_ | Unique identifier for the package.
 **created_at** | _datetime_ | The time with zone when the object was created.
 **updated_at** | _datetime_ | The time with zone when the object was last updated.
-**relationships.app** _(experimental)_| [_to-one relationship_](#to-one-relationships) | The app the package belongs to.
+**relationships.app** | [_to-one relationship_](#to-one-relationships) | The app the package belongs to.
 **links** | [_links object_](#links) | Links to related resources.
 **metadata.labels** | [_label object_](#labels) | Labels applied to the package.
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the package.

--- a/docs/v3/source/includes/resources/processes/_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_object.md.erb
@@ -15,7 +15,7 @@ Name | Type | Description
 **memory_in_mb** | _integer_ | The memory in MB allocated per instance.
 **disk_in_mb** | _integer_ | The disk in MB allocated per instance.
 **health_check** | [_health check object_](#the-health-check-object) | The health check to perform on the process.
-**relationships.app** _(experimental)_| [_to-one relationship_](#to-one-relationships) | The app the process belongs to.
+**relationships.app** | [_to-one relationship_](#to-one-relationships) | The app the process belongs to.
 **relationships.revision** _(experimental)_| [_to-one relationship_](#to-one-relationships) | The app revision the process is currently running.
 **guid** | _uuid_ | Unique identifier for the process.
 **created_at** | _datetime_ | The time with zone when the object was created.

--- a/docs/v3/source/includes/resources/tasks/_create.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_create.md.erb
@@ -52,7 +52,7 @@ Name | Type | Description | Default
 **disk_in_mb**<sup>[1]</sup> | _integer_ | Amount of disk to allocate for the task in MB. | operator-configured `default_app_disk_in_mb`
 **memory_in_mb**<sup>[1]</sup> | _integer_ | Amount of memory to allocate for the task in MB. | operator-configured `default_app_memory`
 **droplet_guid** | _uuid_ | The guid of the droplet that will be used to run the command. | the app's current droplet
-**template.process.guid** _(experimental)_ | _uuid_ | The guid of the process that will be used as a template. | `null`
+**template.process.guid** | _uuid_ | The guid of the process that will be used as a template. | `null`
 **metadata.labels** | [_label object_](#labels) | Labels applied to the package.
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the package.
 


### PR DESCRIPTION
Most of these fields are commonplace on other resources and/or in use by the CLI.

Removed experiments:
- Embedded relationships on various resources
- Fix out-of-date example response for app features
- `template.process.guid` on tasks
- `suspended` on organizations 