### PR TITLE
Remove experimental tag from label selectors

### DIFF
--- a/docs/v3/source/includes/experimental_resources/revisions/_list.md.erb
+++ b/docs/v3/source/includes/experimental_resources/revisions/_list.md.erb
@@ -31,7 +31,7 @@ Retrieve revisions for an app the user has access to.
 Name | Type | Description
 ---- | ---- | ------------
 **versions** | _list of strings_ | Comma-delimited list of revision versions to filter by
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`

--- a/docs/v3/source/includes/resources/apps/_list.md.erb
+++ b/docs/v3/source/includes/resources/apps/_list.md.erb
@@ -38,7 +38,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. Valid values are `created_at`, `updated_at`, `name`, `state`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **lifecycle_type** | _string_ | [Lifecycle](#lifecycles) type to filter by; valid values are `buildpack`, `docker`
 **include**| _list of strings_ | Optionally include a list of unique related resources in the response; valid values are `space` and `spaceorganization`
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)

--- a/docs/v3/source/includes/resources/buildpacks/_list.md.erb
+++ b/docs/v3/source/includes/resources/buildpacks/_list.md.erb
@@ -35,7 +35,7 @@ Name | Type | Description
 **names** | _list of strings_ | Comma-delimited list of buildpack names to filter by
 **stacks**| _list of strings_ | Comma-delimited list of stack names to filter by
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, and `position`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/builds/_list.md.erb
+++ b/docs/v3/source/includes/resources/builds/_list.md.erb
@@ -36,7 +36,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/builds/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/builds/_list_for_app.md.erb
@@ -34,7 +34,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/deployments/_list.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_list.md.erb
@@ -37,7 +37,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/domains/_list.md.erb
+++ b/docs/v3/source/includes/resources/domains/_list.md.erb
@@ -36,7 +36,7 @@ Retrieve all domains the user has access to.
 | **page**               | _integer_         | Page to display; valid values are integers >= 1
 | **per_page**           | _integer_         | Number of results per page; <br>valid values are 1 through 5000
 | **order_by**           | _string_          | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`
-| **label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+| **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/domains/_list_domains_for_an_org.md.erb
+++ b/docs/v3/source/includes/resources/domains/_list_domains_for_an_org.md.erb
@@ -38,7 +38,7 @@ organization), and domains that have been shared with the organization.
 | **page**               | _integer_         | Page to display; valid values are integers >= 1                                                             |
 | **per_page**           | _integer_         | Number of results per page; <br>valid values are 1 through 5000                                             |
 | **order_by**           | _string_          | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`
-| **label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements |
+| **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements |
 
 #### Permitted roles
 

--- a/docs/v3/source/includes/resources/droplets/_list.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_list.md.erb
@@ -38,7 +38,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at` and `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/droplets/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_list_for_app.md.erb
@@ -36,7 +36,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at` and `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/droplets/_list_for_package.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_list_for_package.md.erb
@@ -35,7 +35,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at` and `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/isolation_segments/_list.md.erb
+++ b/docs/v3/source/includes/resources/isolation_segments/_list.md.erb
@@ -36,7 +36,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, and `name`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/organizations/_list.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_list.md.erb
@@ -35,7 +35,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, and `name`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/packages/_list.md.erb
+++ b/docs/v3/source/includes/resources/packages/_list.md.erb
@@ -39,7 +39,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/processes/_list.md.erb
+++ b/docs/v3/source/includes/resources/processes/_list.md.erb
@@ -38,7 +38,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
@@ -35,7 +35,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/routes/_list.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list.md.erb
@@ -40,7 +40,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **include** | _string_ | Optionally include a list of unique related resources in the response <br>Valid values are `domain`, `space.organization`, `space`
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)

--- a/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
@@ -39,7 +39,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/service_brokers/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_list.md.erb
@@ -35,7 +35,7 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **space_guids** | _list of strings_ | Comma-delimited list of space GUIDs to filter by
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list.md.erb
@@ -40,7 +40,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`, and `name`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **fields** (*experimental*)| [_fields parameter_](#fields-parameter) | [_Allowed values_](#service-instances-list-fields)
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)

--- a/docs/v3/source/includes/resources/service_offerings/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_offerings/_list.md.erb
@@ -36,7 +36,7 @@ Name | Type | Description
 **service_broker_names** | _list of strings_ | Comma-delimited list of service broker names to filter by
 **space_guids** | _list of strings_ | Comma-delimited list of space GUIDs to filter by
 **organization_guids** | _list of strings_ | Comma-delimited list of organization GUIDs to filter by
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **fields** (*experimental*)| [_fields parameter_](#fields-parameter) | [_Allowed values_](#service-offerings-list-fields)
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/service_plans/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_plans/_list.md.erb
@@ -44,7 +44,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **fields** (*experimental*)| [_fields parameter_](#fields-parameter) | [_Allowed values_](#service-plans-list-fields)
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)

--- a/docs/v3/source/includes/resources/spaces/_list.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_list.md.erb
@@ -36,7 +36,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **include** | _string_ | Optionally include a list of unique related resources in the response; <br>valid value is `organization`
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)

--- a/docs/v3/source/includes/resources/stacks/_list.md.erb
+++ b/docs/v3/source/includes/resources/stacks/_list.md.erb
@@ -34,7 +34,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`, and `name`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/tasks/_list.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_list.md.erb
@@ -39,7 +39,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/tasks/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_list_for_app.md.erb
@@ -38,7 +38,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 

--- a/docs/v3/source/includes/resources/users/_list.md.erb
+++ b/docs/v3/source/includes/resources/users/_list.md.erb
@@ -36,7 +36,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at` and `updated_at`
-**label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 


### PR DESCRIPTION
I don't remember why they weren't GA'd with the rest of metadata. Is there any remaining work blocking GAing label selectors?