### PR TITLE
Remove service broker url from error responses

### DIFF
--- a/lib/cloud_controller/http_response_error.rb
+++ b/lib/cloud_controller/http_response_error.rb
@@ -1,8 +1,7 @@
 class HttpResponseError < StructuredError
   attr_reader :uri, :method, :status
 
-  def initialize(message, uri, method, response)
-    @uri = uri
+  def initialize(message, method, response)
     @method = method.to_s.upcase
     @status = response.code.to_i
 
@@ -18,7 +17,6 @@ class HttpResponseError < StructuredError
   def to_h
     hash = super
     hash['http'] = {
-      'uri' => uri,
       'method' => method,
       'status' => status,
     }

--- a/lib/services/service_brokers/v2/errors/app_required.rb
+++ b/lib/services/service_brokers/v2/errors/app_required.rb
@@ -5,7 +5,7 @@ module VCAP::Services
         class AppRequired < HttpResponseError
           def initialize(uri, method, response)
             message = 'This service supports generation of credentials through binding an application only.'
-            super(message, uri, method, response)
+            super(message, method, response)
           end
 
           def response_code

--- a/lib/services/service_brokers/v2/errors/async_required.rb
+++ b/lib/services/service_brokers/v2/errors/async_required.rb
@@ -5,7 +5,7 @@ module VCAP::Services
         class AsyncRequired < HttpResponseError
           def initialize(uri, method, response)
             message = CloudController::Errors::ApiError.new_from_details('ServiceBrokerAsyncRequired').message
-            super(message, uri, method, response)
+            super(message, method, response)
           end
 
           def response_code

--- a/lib/services/service_brokers/v2/errors/concurrency_error.rb
+++ b/lib/services/service_brokers/v2/errors/concurrency_error.rb
@@ -5,7 +5,7 @@ module VCAP::Services
         class ConcurrencyError < HttpResponseError
           def initialize(uri, method, response)
             message = CloudController::Errors::ApiError.new_from_details('ServiceBrokerConcurrencyError').message
-            super(message, uri, method, response)
+            super(message, method, response)
           end
 
           def response_code

--- a/lib/services/service_brokers/v2/errors/maintenance_info_conflict.rb
+++ b/lib/services/service_brokers/v2/errors/maintenance_info_conflict.rb
@@ -16,7 +16,7 @@ module VCAP::Services
                         'catalog is up to date and you are providing a version supported by this service plan'
                       end
 
-            super(message, uri, method, response)
+            super(message, method, response)
           end
 
           def response_code

--- a/lib/services/service_brokers/v2/errors/service_broker_api_authentication_failed.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_api_authentication_failed.rb
@@ -5,8 +5,7 @@ module VCAP::Services
         class ServiceBrokerApiAuthenticationFailed < HttpResponseError
           def initialize(uri, method, response)
             super(
-              "Authentication with the service broker failed. Double-check that the username and password are correct: #{uri}",
-              uri,
+              'Authentication with the service broker failed. Double-check that the username and password are correct.',
               method,
               response
             )

--- a/lib/services/service_brokers/v2/errors/service_broker_bad_response.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_bad_response.rb
@@ -12,15 +12,24 @@ module VCAP::Services
             message = if hash.is_a?(Hash) && hash.key?('description') && !ignore_description_key
                         "Service broker error: #{hash['description']}"
                       else
-                        "The service broker returned an invalid response for the request to #{uri}. " \
+                        'The service broker returned an invalid response. ' \
                                   "Status Code: #{response.code} #{response.message}, Body: #{response.body}"
                       end
 
-            super(message, uri, method, response)
+            super(message, method, response)
           end
 
           def response_code
             502
+          end
+
+          def to_h
+            hash = super
+            hash['http'] = {
+              'method' => method,
+              'status' => status,
+            }
+            hash
           end
         end
       end

--- a/lib/services/service_brokers/v2/errors/service_broker_conflict.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_conflict.rb
@@ -13,7 +13,6 @@ module VCAP::Services
 
             super(
               error_message || "Resource conflict: #{uri}",
-              uri,
               method,
               response
             )

--- a/lib/services/service_brokers/v2/errors/service_broker_invalid_syslog_drain_url.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_invalid_syslog_drain_url.rb
@@ -6,7 +6,6 @@ module VCAP::Services
           def initialize(uri, method, response)
             super(
               'The service is attempting to stream logs from your application, but is not registered as a logging service. Please contact the service provider.',
-              uri,
               method,
               response
             )

--- a/lib/services/service_brokers/v2/errors/service_broker_invalid_volume_mounts.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_invalid_volume_mounts.rb
@@ -5,8 +5,7 @@ module VCAP::Services
         class ServiceBrokerInvalidVolumeMounts < HttpResponseError
           def initialize(uri, method, response, description)
             super(
-              description_from_response(uri, description),
-              uri,
+              description_from_response(description),
               method,
               response
             )
@@ -18,8 +17,8 @@ module VCAP::Services
 
           private
 
-          def description_from_response(uri, description)
-            "The service broker returned an invalid response for the request to #{uri}: #{description}"
+          def description_from_response(description)
+            "The service broker returned an invalid response: #{description}"
           end
         end
       end

--- a/lib/services/service_brokers/v2/errors/service_broker_request_rejected.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_request_rejected.rb
@@ -12,10 +12,10 @@ module VCAP::Services
             message = if hash.is_a?(Hash) && hash.key?('description')
                         "Service broker error: #{hash['description']}"
                       else
-                        "The service broker rejected the request to #{uri}. Status Code: #{response.code} #{response.message}, Body: #{response.body}"
+                        "The service broker rejected the request. Status Code: #{response.code} #{response.message}, Body: #{response.body}"
                       end
 
-            super(message, uri, method, response)
+            super(message, method, response)
           end
 
           def response_code

--- a/lib/services/service_brokers/v2/errors/service_broker_response_malformed.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_response_malformed.rb
@@ -4,10 +4,8 @@ module VCAP::Services
       module Errors
         class ServiceBrokerResponseMalformed < HttpResponseError
           def initialize(uri, method, response, description)
-            @uri = uri
             super(
               description_from_response(description),
-              uri,
               method,
               response
             )
@@ -20,7 +18,7 @@ module VCAP::Services
           private
 
           def description_from_response(description)
-            "The service broker returned an invalid response for the request to #{@uri}: #{description}"
+            "The service broker returned an invalid response: #{description}"
           end
         end
       end

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -963,7 +963,7 @@ RSpec.describe 'V3 service brokers' do
         error = YAML.safe_load(job.cf_api_error)
         expect(error['errors'].first['code']).to eq(10001)
         expect(error['errors'].first['detail']).
-          to eq("The service broker rejected the request to http://example.org/broker-url/v2/catalog. Status Code: 418 I'm a Teapot, Body: {}")
+          to eq("The service broker rejected the request. Status Code: 418 I'm a Teapot, Body: {}")
       end
     end
 

--- a/spec/unit/actions/space_delete_spec.rb
+++ b/spec/unit/actions/space_delete_spec.rb
@@ -139,14 +139,14 @@ module VCAP::CloudController
               expect(results_messages).
                 to include("Deletion of space #{space_3.name} failed because one or more resources within could not be deleted.")
               expect(results_messages).
-                to include("\tService instance #{service_instance_1.name}: The service broker returned an invalid response for the request to #{instance_1_url}")
+                to include("\tService instance #{service_instance_1.name}: The service broker returned an invalid response.")
               expect(results_messages).
-                to include("\tService instance #{service_instance_2.name}: The service broker returned an invalid response for the request to #{instance_2_url}")
+                to include("\tService instance #{service_instance_2.name}: The service broker returned an invalid response.")
 
               expect(results_messages).
                 to include("Deletion of space #{space_4.name} failed because one or more resources within could not be deleted.")
               expect(results_messages).
-                to include("\tService instance #{service_instance_4.name}: The service broker returned an invalid response for the request to #{instance_4_url}")
+                to include("\tService instance #{service_instance_4.name}: The service broker returned an invalid response.")
             end
           end
 

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -1561,8 +1561,7 @@ module VCAP::CloudController
             end
 
             it 'fails the job with a OrganizationDeleteTimeout error' do
-              service_instance_error_string = ["#{service_instance.name}: The service broker returned an invalid",
-                                               "response for the request to #{service_instance.dashboard_url}"].join(' ')
+              service_instance_error_string = "#{service_instance.name}: The service broker returned an invalid response."
 
               delete "/v2/organizations/#{org.guid}?recursive=true&async=true"
               expect(last_response).to have_status_code(202)
@@ -1576,7 +1575,7 @@ module VCAP::CloudController
               expect(decoded_response['entity']['error_details']['description']).to include "Deletion of organization #{org.name}"
               expect(decoded_response['entity']['error_details']['description']).to include "Deletion of space #{space.name}"
               expect(decoded_response['entity']['error_details']['description']).to include service_instance_error_string
-              expect(decoded_response['entity']['error_details']['description']).to include 'The service broker returned an invalid response for the request'
+              expect(decoded_response['entity']['error_details']['description']).to include 'The service broker returned an invalid response'
             end
           end
         end

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -1116,7 +1116,7 @@ module VCAP::CloudController
 
               @expected_description = "Deletion of space #{space.name} failed because one or more resources within could not be deleted.
 
-\tService instance #{service_instance_2.name}: The service broker returned an invalid response for the request to #{instance_url}. Status Code: 500 Internal Server Error, Body: {}"
+\tService instance #{service_instance_2.name}: The service broker returned an invalid response. Status Code: 500 Internal Server Error, Body: {}"
             end
 
             context 'synchronous' do

--- a/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
@@ -630,7 +630,7 @@ module VCAP::CloudController
           context 'when calling last operation responds with an error HttpResponseError' do
             before do
               response = VCAP::Services::ServiceBrokers::V2::HttpResponse.new(code: 412, body: {})
-              err = HttpResponseError.new('oops', 'uri', 'GET', response)
+              err = HttpResponseError.new('oops', 'GET', response)
               allow(client).to receive(:fetch_service_binding_last_operation).and_raise(err)
 
               run_job(job)

--- a/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
@@ -426,7 +426,7 @@ module VCAP::CloudController
             context 'due to an HttpResponseError' do
               before do
                 response = VCAP::Services::ServiceBrokers::V2::HttpResponse.new(code: 412, body: {})
-                err = HttpResponseError.new('oops', 'uri', 'GET', response)
+                err = HttpResponseError.new('oops', 'GET', response)
                 allow(client).to receive(:fetch_service_instance_last_operation).and_raise(err)
               end
 

--- a/spec/unit/jobs/v3/create_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/create_service_instance_job_spec.rb
@@ -339,7 +339,7 @@ module VCAP
             context 'due to an HttpResponseError' do
               before do
                 response = VCAP::Services::ServiceBrokers::V2::HttpResponse.new(code: 412, body: {})
-                err = HttpResponseError.new('oops', 'uri', 'GET', response)
+                err = HttpResponseError.new('oops', 'GET', response)
                 allow(client).to receive(:fetch_service_instance_last_operation).and_raise(err)
               end
 

--- a/spec/unit/lib/http_response_error_spec.rb
+++ b/spec/unit/lib/http_response_error_spec.rb
@@ -1,19 +1,17 @@
 require 'spec_helper'
 
 RSpec.describe HttpResponseError do
-  let(:endpoint) { 'http://www.example.com/' }
-
   describe '#initialize' do
     context 'when the method is a symbol' do
       it 'converts method to an uppercase string' do
-        exception = HttpResponseError.new('message', endpoint, :put, double(code: 500, reason: '', body: ''))
+        exception = HttpResponseError.new('message', :put, double(code: 500, reason: '', body: ''))
         expect(exception.method).to eq('PUT')
       end
     end
 
     context 'when the status code is a string' do
       it 'converts the status to a number' do
-        exception = HttpResponseError.new('message', endpoint, 'PUT', double(code: '500', reason: '', body: ''))
+        exception = HttpResponseError.new('message', 'PUT', double(code: '500', reason: '', body: ''))
         expect(exception.status).to eq(500)
       end
     end
@@ -26,11 +24,10 @@ RSpec.describe HttpResponseError do
     let(:response) { double(code: 500, reason: 'Internal Server Error', body: response_hash.to_json) }
 
     it 'produces the correct hash' do
-      exception = HttpResponseError.new('message', endpoint, 'PUT', response)
+      exception = HttpResponseError.new('message', 'PUT', response)
       expect(exception.to_h).to include({
         'description' => 'message',
         'http' => {
-          'uri' => endpoint,
           'method' => 'PUT',
           'status' => 500,
         },
@@ -44,11 +41,10 @@ RSpec.describe HttpResponseError do
     let(:response) { double(code: 500, reason: 'Internal Server Error', body: response_string) }
 
     it 'produces the correct hash' do
-      exception = HttpResponseError.new('message', endpoint, 'PUT', response)
+      exception = HttpResponseError.new('message', 'PUT', response)
       expect(exception.to_h).to include({
         'description' => 'message',
         'http' => {
-          'uri' => endpoint,
           'method' => 'PUT',
           'status' => 500,
         },

--- a/spec/unit/lib/services/service_brokers/v2/errors/app_required_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/app_required_spec.rb
@@ -15,7 +15,6 @@ module VCAP::Services
           it 'initializes the base class correctly' do
             exception = AppRequired.new(uri, method, response)
             expect(exception.message).to eq('This service supports generation of credentials through binding an application only.')
-            expect(exception.uri).to eq(uri)
             expect(exception.method).to eq(method)
             expect(exception.source).to eq(MultiJson.load(response.body))
           end

--- a/spec/unit/lib/services/service_brokers/v2/errors/async_required_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/async_required_spec.rb
@@ -15,7 +15,6 @@ module VCAP::Services
           it 'initializes the base class correctly' do
             exception = AsyncRequired.new(uri, method, response)
             expect(exception.message).to eq(CloudController::Errors::ApiError.new_from_details('ServiceBrokerAsyncRequired').message)
-            expect(exception.uri).to eq(uri)
             expect(exception.method).to eq(method)
             expect(exception.source).to eq(MultiJson.load(response.body))
           end

--- a/spec/unit/lib/services/service_brokers/v2/errors/service_broker_api_authentication_failed_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/service_broker_api_authentication_failed_spec.rb
@@ -15,8 +15,7 @@ module VCAP::Services
 
             it 'initializes the base class correctly' do
               exception = ServiceBrokerApiAuthenticationFailed.new(uri, method, response)
-              expect(exception.message).to eq("Authentication with the service broker failed. Double-check that the username and password are correct: #{uri}")
-              expect(exception.uri).to eq(uri)
+              expect(exception.message).to eq('Authentication with the service broker failed. Double-check that the username and password are correct.')
               expect(exception.method).to eq(method)
               expect(exception.source).to be(response.body)
             end

--- a/spec/unit/lib/services/service_brokers/v2/errors/service_broker_bad_response_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/service_broker_bad_response_spec.rb
@@ -25,7 +25,6 @@ module VCAP::Services
                 'backtrace' => ['/foo:1', '/bar:2'],
                 'http' => {
                   'status' => 500,
-                  'uri' => uri,
                   'method' => 'PUT'
                 },
                 'source' => {
@@ -50,12 +49,11 @@ module VCAP::Services
               exception.set_backtrace(['/foo:1', '/bar:2'])
 
               expect(exception.to_h).to eq({
-                'description' => 'The service broker returned an invalid response for the request to http://www.example.com/. ' \
+                'description' => 'The service broker returned an invalid response. ' \
                                  "Status Code: 500 Internal Server Error, Body: #{response_body}",
                 'backtrace' => ['/foo:1', '/bar:2'],
                 'http' => {
                   'status' => 500,
-                  'uri' => uri,
                   'method' => 'PUT'
                 },
                 'source' => { 'foo' => 'bar' }

--- a/spec/unit/lib/services/service_brokers/v2/errors/service_broker_conflict_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/service_broker_conflict_spec.rb
@@ -16,7 +16,6 @@ module VCAP::Services
           it 'initializes the base class correctly' do
             exception = ServiceBrokerConflict.new(uri, method, response)
             expect(exception.message).to eq("Service broker error: #{error_message}")
-            expect(exception.uri).to eq(uri)
             expect(exception.method).to eq(method)
             expect(exception.source).to eq(MultiJson.load(response.body))
           end
@@ -32,7 +31,6 @@ module VCAP::Services
             it 'initializes the base class correctly' do
               exception = ServiceBrokerConflict.new(uri, method, response)
               expect(exception.message).to eq("Resource conflict: #{uri}")
-              expect(exception.uri).to eq(uri)
               expect(exception.method).to eq(method)
               expect(exception.source).to eq(MultiJson.load(response.body))
             end
@@ -44,7 +42,6 @@ module VCAP::Services
             it 'initializes the base class correctly' do
               exception = ServiceBrokerConflict.new(uri, method, response)
               expect(exception.message).to eq("Resource conflict: #{uri}")
-              expect(exception.uri).to eq(uri)
               expect(exception.method).to eq(method)
               expect(exception.source).to eq(response.body)
             end

--- a/spec/unit/lib/services/service_brokers/v2/errors/service_broker_request_rejected_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/service_broker_request_rejected_spec.rb
@@ -25,7 +25,6 @@ module VCAP::Services
                 'backtrace' => ['/foo:1', '/bar:2'],
                 'http' => {
                   'status' => 400,
-                  'uri' => uri,
                   'method' => 'PUT'
                 },
                 'source' => {
@@ -50,11 +49,10 @@ module VCAP::Services
               exception.set_backtrace(['/foo:1', '/bar:2'])
 
               expect(exception.to_h).to eq({
-                'description' => "The service broker rejected the request to http://www.example.com/. Status Code: 400 status message, Body: #{response_body}",
+                'description' => "The service broker rejected the request. Status Code: 400 status message, Body: #{response_body}",
                 'backtrace' => ['/foo:1', '/bar:2'],
                 'http' => {
                   'status' => 400,
-                  'uri' => uri,
                   'method' => 'PUT'
                 },
                 'source' => { 'foo' => 'bar' }

--- a/spec/unit/lib/services/service_brokers/v2/errors/service_broker_response_malformed_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/service_broker_response_malformed_spec.rb
@@ -15,9 +15,8 @@ module VCAP::Services
           it 'initializes the base class correctly' do
             exception = ServiceBrokerResponseMalformed.new(uri, method, response, description)
             expect(exception.message).to eq(
-              'The service broker returned an invalid response for the request to http://uri.example.com: this is the error description'
+              'The service broker returned an invalid response: this is the error description'
             )
-            expect(exception.uri).to eq(uri)
             expect(exception.method).to eq(method)
             expect(exception.source).to be(response.body)
           end

--- a/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
@@ -7,11 +7,6 @@ module VCAP::Services
         describe 'UnvalidatedResponse' do
           let(:fake_response) { VCAP::Services::ServiceBrokers::V2::HttpResponse.new(code: 200, body: {}) }
 
-          it 'should serialize the uri as a string' do
-            unvalidated_response = ResponseParser::UnvalidatedResponse.new(:get, 'http://example.com', '/path', fake_response)
-            expect(unvalidated_response.uri).to eql('http://example.com/path')
-          end
-
           it 'should raise an error if the uri is invalid' do
             expect { ResponseParser::UnvalidatedResponse.new(:get, 'http://examp', 'bad path', fake_response) }.to raise_error(URI::InvalidURIError)
           end
@@ -70,7 +65,7 @@ module VCAP::Services
                 it 'raises' do
                   expect { json_validator.validate(broker_response.to_hash) }.to raise_error(Errors::ServiceBrokerResponseMalformed) do |e|
                     expect(e.to_h['description']).to eq(
-                      "The service broker returned an invalid response for the request to https://example.com/path: expected valid JSON object in body, broker returned '#{body}'")
+                      "The service broker returned an invalid response: expected valid JSON object in body, broker returned '#{body}'")
                     expect(e.response_code).to eq(502)
                     expect(e.to_h['http']['method']).to eq('GET')
                     expect(e.to_h['http']['status']).to eq(200)
@@ -121,7 +116,7 @@ module VCAP::Services
               it 'raises a ServiceBrokerResponseMalformed error' do
                 expect { json_validator.validate(broker_response.to_hash) }.to raise_error(Errors::ServiceBrokerResponseMalformed) do |e|
                   description_lines = e.to_h['description'].split("\n")
-                  expect(description_lines[0]).to eq('The service broker returned an invalid response for the request to https://example.com/path: ')
+                  expect(description_lines[0]).to eq('The service broker returned an invalid response: ')
                   expect(description_lines.drop(1)).to contain_exactly("The property '#/' did not contain a required property of 'prop2'")
                   expect(e.response_code).to eq(502)
                   expect(e.to_h['http']['method']).to eq('GET')
@@ -139,7 +134,7 @@ module VCAP::Services
               it 'raises a ServiceBrokerResponseMalformed error' do
                 expect { json_validator.validate(broker_response.to_hash) }.to raise_error(Errors::ServiceBrokerResponseMalformed) do |e|
                   description_lines = e.to_h['description'].split("\n")
-                  expect(description_lines[0]).to eq('The service broker returned an invalid response for the request to https://example.com/path: ')
+                  expect(description_lines[0]).to eq('The service broker returned an invalid response: ')
                   expect(description_lines.drop(1)).to contain_exactly(
                     "The property '#/' did not contain a required property of 'prop2'",
                     "The property '#/' did not contain a required property of 'prop1'")
@@ -441,57 +436,57 @@ module VCAP::Services
 
         def self.response_not_understood(expected_state, actual_state, uri)
           actual_state = actual_state ? "'#{actual_state}'" : 'null'
-          "The service broker returned an invalid response for the request to #{uri}: " \
+          'The service broker returned an invalid response: ' \
           "expected state was '#{expected_state}', broker returned #{actual_state}."
         end
 
         def self.invalid_json_error(body, uri)
-          "The service broker returned an invalid response for the request to #{uri}: " \
+          'The service broker returned an invalid response: ' \
           "expected valid JSON object in body, broker returned '#{body}'"
         end
 
         def self.broker_returned_an_error(status, body, uri)
-          "The service broker returned an invalid response for the request to #{uri}. " \
+          'The service broker returned an invalid response. ' \
           "Status Code: #{status} message, Body: #{body}"
         end
 
         def self.invalid_volume_mounts_error(body, uri)
-          "The service broker returned an invalid response for the request to #{uri}: " \
+          'The service broker returned an invalid response: ' \
           "expected \"volume_mounts\" key to contain an array of JSON objects in body, broker returned '#{body}'"
         end
 
         def self.invalid_volume_mounts_missing_field_error(field, uri)
-          "The service broker returned an invalid response for the request to #{uri}: " \
+          'The service broker returned an invalid response: ' \
           "missing required field '#{field}'"
         end
 
         def self.invalid_volume_mounts_missing_volume_id_error(uri)
-          "The service broker returned an invalid response for the request to #{uri}: " \
+          'The service broker returned an invalid response: ' \
           "required field 'device.volume_id' must be a non-empty string"
         end
 
         def self.invalid_volume_mounts_bad_mount_config_error(uri)
-          "The service broker returned an invalid response for the request to #{uri}: " \
+          'The service broker returned an invalid response: ' \
           "field 'device.mount_config' must be an object if it is defined"
         end
 
         def self.invalid_volume_mounts_device_type_error(uri)
-          "The service broker returned an invalid response for the request to #{uri}: " \
+          'The service broker returned an invalid response: ' \
           "required field 'device' must be an object but is String"
         end
 
         def self.volume_mounts_not_required_error(uri)
-          "The service broker returned an invalid response for the request to #{uri}: " \
+          'The service broker returned an invalid response: ' \
           'The service is attempting to supply volume mounts from your application, but is not registered as a volume mount service. ' \
           'Please contact the service provider.'
         end
 
         def self.malformed_response_error(uri, message)
-          "The service broker returned an invalid response for the request to #{uri}: #{message}"
+          "The service broker returned an invalid response: #{message}"
         end
 
         def self.broker_bad_response_error(uri, message)
-          "The service broker returned an invalid response for the request to #{uri}. #{message}"
+          "The service broker returned an invalid response. #{message}"
         end
 
         def self.broker_timeout_error(uri)


### PR DESCRIPTION
Remove url usage in messages and uri from json representation from
service_brokers' http error hierarchy.

[#172146628](https://www.pivotaltracker.com/story/show/172146628)

Notes:

Haven't removed the URI parameter from error classes as that would imply changes in the actual code as well as specs. Will evaluate the impact of that change afterwards.