### PR TITLE
v3: fix pagination href when fields feature in use

### DIFF
--- a/app/messages/base_message.rb
+++ b/app/messages/base_message.rb
@@ -42,12 +42,20 @@ module VCAP::CloudController
       request.deep_stringify_keys
     end
 
-    def to_param_hash(opts={ exclude: [] })
+    def to_param_hash(exclude: [], fields: [])
       params = {}
-      (requested_keys - opts[:exclude]).each do |key|
+      (requested_keys - exclude).each do |key|
         val = self.try(key)
-        params[key] = val.is_a?(Array) ? val.map { |v| v.gsub(',', CGI.escape(',')) }.join(',') : val
+
+        if fields.include?(key)
+          val.each do |resource, selectors|
+            params["#{key}[#{resource}]".to_sym] = selectors.join(',')
+          end
+        else
+          params[key] = val.is_a?(Array) ? val.map { |v| v.gsub(',', CGI.escape(',')) }.join(',') : val
+        end
       end
+
       params
     end
 

--- a/app/messages/list_message.rb
+++ b/app/messages/list_message.rb
@@ -25,8 +25,8 @@ module VCAP::CloudController
       super(params)
     end
 
-    def to_param_hash(exclude: [])
-      super(exclude: ALLOWED_PAGINATION_KEYS + exclude)
+    def to_param_hash(exclude: [], fields: [])
+      super(exclude: ALLOWED_PAGINATION_KEYS + exclude, fields: fields)
     end
 
     class PaginationOrderValidator < ActiveModel::Validator

--- a/app/messages/service_instances_list_message.rb
+++ b/app/messages/service_instances_list_message.rb
@@ -37,6 +37,10 @@ module VCAP::CloudController
       super(params, @array_keys.map(&:to_s), fields: %w(fields))
     end
 
+    def to_param_hash
+      super(fields: [:fields])
+    end
+
     def valid_order_by_values
       super << :name
     end

--- a/app/messages/service_offerings_list_message.rb
+++ b/app/messages/service_offerings_list_message.rb
@@ -30,5 +30,9 @@ module VCAP::CloudController
     def self.from_params(params)
       super(params, @array_keys.map(&:to_s), fields: %w(fields))
     end
+
+    def to_param_hash
+      super(fields: [:fields])
+    end
   end
 end

--- a/app/messages/service_plans_list_message.rb
+++ b/app/messages/service_plans_list_message.rb
@@ -36,6 +36,10 @@ module VCAP::CloudController
       super(params, @array_keys.map(&:to_s), fields: %w(fields))
     end
 
+    def to_param_hash
+      super(fields: [:fields])
+    end
+
     def available?
       requested?(:available) && available == 'true'
     end

--- a/spec/field_message_spec_shared_examples.rb
+++ b/spec/field_message_spec_shared_examples.rb
@@ -56,3 +56,9 @@ RSpec.shared_examples 'fields query hash' do
     ))
   end
 end
+
+RSpec.shared_examples 'fields to_param_hash' do |resource, keys|
+  it 'correctly formats the fields' do
+    expect(message.to_param_hash).to include("fields[#{resource}]": keys)
+  end
+end

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -241,6 +241,10 @@ RSpec.describe 'V3 service instances' do
     describe 'pagination' do
       let(:resources) { [msi_1, msi_2, upsi_1, upsi_2, ssi] }
       it_behaves_like 'paginated response', '/v3/service_instances'
+
+      it_behaves_like 'paginated fields response', '/v3/service_instances', 'space', 'guid,name,relationships.organization'
+
+      it_behaves_like 'paginated fields response', '/v3/service_instances', 'space.organization', 'name,guid'
     end
 
     describe 'filters' do

--- a/spec/request/service_offerings_spec.rb
+++ b/spec/request/service_offerings_spec.rb
@@ -466,6 +466,8 @@ RSpec.describe 'V3 service offerings' do
 
       let(:resources) { [service_offering_1, service_offering_2] }
       it_behaves_like 'paginated response', '/v3/service_offerings'
+
+      it_behaves_like 'paginated fields response', '/v3/service_offerings', 'service_broker', 'guid,name'
     end
 
     context 'when the service offerings have labels and annotations' do

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -291,6 +291,8 @@ RSpec.describe 'V3 service plans' do
 
       let(:resources) { [service_plan_1, service_plan_2] }
       it_behaves_like 'paginated response', '/v3/service_plans'
+
+      it_behaves_like 'paginated fields response', '/v3/service_plans', 'service_offering.service_broker', 'name,guid'
     end
 
     describe 'filters' do

--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -41,6 +41,20 @@ def expect_filtered_resources(endpoint, filter, list)
   end
 end
 
+RSpec.shared_examples 'paginated fields response' do |endpoint, resource, keys|
+  it 'presents the fields correctly in first, last and next' do
+    filter = "fields[#{resource}]=#{keys}&per_page=1"
+    get "#{endpoint}?#{filter}", nil, admin_headers
+    expect(last_response).to have_status_code(200)
+
+    keys = keys.split(/,/).join('%2C')
+    last_page = resources.length
+    expect(parsed_response['pagination']['first']['href']).to include("#{endpoint}?fields%5B#{resource}%5D=#{keys}&page=1&per_page=1")
+    expect(parsed_response['pagination']['next']['href']).to include("#{endpoint}?fields%5B#{resource}%5D=#{keys}&page=2&per_page=1")
+    expect(parsed_response['pagination']['last']['href']).to include("#{endpoint}?fields%5B#{resource}%5D=#{keys}&page=#{last_page}&per_page=1")
+  end
+end
+
 RSpec.shared_examples 'permissions for list endpoint' do |roles|
   roles.each do |role|
     describe "as an #{role}" do

--- a/spec/unit/messages/base_message_spec.rb
+++ b/spec/unit/messages/base_message_spec.rb
@@ -62,24 +62,24 @@ module VCAP::CloudController
 
     describe '#to_param_hash' do
       class ParamsClass < BaseMessage
-        register_allowed_keys [:array_field, :num_field, :string_field, :nil_field]
+        register_allowed_keys [:array_field, :num_field, :string_field, :nil_field, :fields_field]
       end
 
       let(:opts) do
         {
-            array_field:  ['st ate1', 'sta,te2'],
-            num_field:    1.2,
-            string_field: 'stringval&',
-            nil_field:    nil
+          array_field: ['st ate1', 'sta,te2'],
+          num_field: 1.2,
+          string_field: 'stringval&',
+          nil_field: nil
         }
       end
 
       it 'returns query param hash with escaped commas in array members' do
         expected_params = {
-          array_field:  'st ate1,sta%2Cte2',
-          num_field:    1.2,
+          array_field: 'st ate1,sta%2Cte2',
+          num_field: 1.2,
           string_field: 'stringval&',
-          nil_field:    nil,
+          nil_field: nil,
         }
         expect(ParamsClass.new(opts).to_param_hash).to eq(expected_params)
       end
@@ -87,8 +87,8 @@ module VCAP::CloudController
       it 'does not return params that are not requested during initialization' do
         opts.delete(:nil_field)
         expected_params = {
-          array_field:  'st ate1,sta%2Cte2',
-          num_field:    1.2,
+          array_field: 'st ate1,sta%2Cte2',
+          num_field: 1.2,
           string_field: 'stringval&',
         }
         expect(ParamsClass.new(opts).to_param_hash).to eq(expected_params)
@@ -96,11 +96,27 @@ module VCAP::CloudController
 
       it 'can exclude params' do
         expected_params = {
-          array_field:  'st ate1,sta%2Cte2',
+          array_field: 'st ate1,sta%2Cte2',
           string_field: 'stringval&',
-          nil_field:    nil,
+          nil_field: nil,
         }
-        expect(ParamsClass.new(opts).to_param_hash({ exclude: [:num_field] })).to eq(expected_params)
+        expect(ParamsClass.new(opts).to_param_hash(exclude: [:num_field])).to eq(expected_params)
+      end
+
+      context 'when using fields' do
+        let(:opts) do
+          {
+            fields_field: { foo: %w(bar baz), quz: %w(lala gaga) },
+          }
+        end
+
+        it 'correctly formats the specified field' do
+          expected_params = {
+            'fields_field[foo]': 'bar,baz',
+            'fields_field[quz]': 'lala,gaga',
+          }
+          expect(ParamsClass.new(opts).to_param_hash(fields: [:fields_field])).to eq(expected_params)
+        end
       end
     end
 

--- a/spec/unit/messages/service_instances_list_message_spec.rb
+++ b/spec/unit/messages/service_instances_list_message_spec.rb
@@ -4,26 +4,26 @@ require 'field_message_spec_shared_examples'
 
 module VCAP::CloudController
   RSpec.describe ServiceInstancesListMessage do
+    let(:params) do
+      {
+        'page'      => 1,
+        'per_page'  => 5,
+        'order_by'  => 'name',
+        'names' => 'rabbitmq, redis,mysql',
+        'space_guids' => 'space-1, space-2, space-3',
+        'label_selector' => 'key=value',
+        'type' => 'managed',
+        'service_plan_names' => 'plan1, plan2',
+        'service_plan_guids' => 'guid1, guid2',
+        'fields' => { 'space.organization' => 'name' },
+      }.with_indifferent_access
+    end
+
     describe '.from_params' do
-      let(:params) do
-        {
-          'page'      => 1,
-          'per_page'  => 5,
-          'order_by'  => 'name',
-          'names' => 'rabbitmq, redis,mysql',
-          'space_guids' => 'space-1, space-2, space-3',
-          'label_selector' => 'key=value',
-          'type' => 'managed',
-          'service_plan_names' => 'plan1, plan2',
-          'service_plan_guids' => 'guid1, guid2',
-          'fields' => { 'space.organization' => 'name' },
-        }.with_indifferent_access
-      end
+      it 'returns the correct message' do
+        message = described_class.from_params(params)
 
-      it 'returns the correct ServiceInstancesListMessage' do
-        message = ServiceInstancesListMessage.from_params(params)
-
-        expect(message).to be_a(ServiceInstancesListMessage)
+        expect(message).to be_a(described_class)
         expect(message).to be_valid
         expect(message.page).to eq(1)
         expect(message.per_page).to eq(5)
@@ -38,7 +38,7 @@ module VCAP::CloudController
       end
 
       it 'converts requested keys to symbols' do
-        message = ServiceInstancesListMessage.from_params(params)
+        message = described_class.from_params(params)
 
         expect(message.requested?(:page)).to be_truthy
         expect(message.requested?(:per_page)).to be_truthy
@@ -51,23 +51,21 @@ module VCAP::CloudController
         expect(message.requested?(:service_plan_names)).to be_truthy
         expect(message.requested?(:fields)).to be_truthy
       end
-    end
 
-    describe 'validations' do
       it 'accepts an empty set' do
-        message = ServiceInstancesListMessage.from_params({})
+        message = described_class.from_params({})
         expect(message).to be_valid
       end
 
       it 'does not accept a field not in this set' do
-        message = ServiceInstancesListMessage.from_params({ foobar: 'pants' }.with_indifferent_access)
+        message = described_class.from_params({ foobar: 'pants' }.with_indifferent_access)
 
         expect(message).not_to be_valid
         expect(message.errors[:base][0]).to include("Unknown query parameter(s): 'foobar'")
       end
 
       it 'validates metadata requirements' do
-        message = ServiceInstancesListMessage.from_params({ 'label_selector' => '' }.with_indifferent_access)
+        message = described_class.from_params({ 'label_selector' => '' }.with_indifferent_access)
 
         expect_any_instance_of(Validators::LabelSelectorRequirementValidator).
           to receive(:validate).
@@ -92,21 +90,27 @@ module VCAP::CloudController
 
       context 'type' do
         it 'allows `managed`' do
-          message = ServiceInstancesListMessage.from_params({ type: 'managed' }.with_indifferent_access)
+          message = described_class.from_params({ type: 'managed' }.with_indifferent_access)
           expect(message).to be_valid
         end
 
         it 'allows `user-provided`' do
-          message = ServiceInstancesListMessage.from_params({ type: 'managed' }.with_indifferent_access)
+          message = described_class.from_params({ type: 'managed' }.with_indifferent_access)
           expect(message).to be_valid
         end
 
         it 'does not allow other values' do
-          message = ServiceInstancesListMessage.from_params({ type: 'magic' }.with_indifferent_access)
+          message = described_class.from_params({ type: 'magic' }.with_indifferent_access)
           expect(message).to be_invalid
           expect(message.errors[:type]).to include("must be one of 'managed', 'user-provided'")
         end
       end
+    end
+
+    describe '.to_param_hash' do
+      let(:message) { described_class.from_params(params) }
+
+      it_behaves_like 'fields to_param_hash', 'space.organization', 'name'
     end
   end
 end

--- a/spec/unit/messages/service_offerings_list_message_spec.rb
+++ b/spec/unit/messages/service_offerings_list_message_spec.rb
@@ -4,23 +4,24 @@ require 'field_message_spec_shared_examples'
 
 module VCAP::CloudController
   RSpec.describe ServiceOfferingsListMessage do
-    describe '.from_params' do
-      let(:params) do
-        {
-          'available' => 'true',
-          'service_broker_guids' => 'one,two',
-          'service_broker_names' => 'zhou,qin',
-          'names' => 'service_offering1,other_2',
-          'space_guids' => 'space_1,space_2',
-          'organization_guids' => 'organization_1,organization_2',
-        }.with_indifferent_access
-      end
+    let(:params) do
+      {
+        'available' => 'true',
+        'service_broker_guids' => 'one,two',
+        'service_broker_names' => 'zhou,qin',
+        'names' => 'service_offering1,other_2',
+        'space_guids' => 'space_1,space_2',
+        'organization_guids' => 'organization_1,organization_2',
+        'fields' => { 'service_broker' => 'guid,name' }
+      }.with_indifferent_access
+    end
 
-      it 'returns the correct ServiceOfferingsListMessage' do
-        message = ServiceOfferingsListMessage.from_params(params)
+    describe '.from_params' do
+      it 'returns the correct message' do
+        message = described_class.from_params(params)
 
         expect(message).to be_valid
-        expect(message).to be_a(ServiceOfferingsListMessage)
+        expect(message).to be_a(described_class)
         expect(message.available).to eq('true')
         expect(message.service_broker_guids).to eq(%w(one two))
         expect(message.service_broker_names).to eq(%w(zhou qin))
@@ -30,7 +31,7 @@ module VCAP::CloudController
       end
 
       it 'converts requested keys to symbols' do
-        message = ServiceOfferingsListMessage.from_params(params)
+        message = described_class.from_params(params)
 
         expect(message.requested?(:available)).to be_truthy
         expect(message.requested?(:names)).to be_truthy
@@ -41,12 +42,12 @@ module VCAP::CloudController
       end
 
       it 'accepts an empty set' do
-        message = ServiceOfferingsListMessage.from_params({})
+        message = described_class.from_params({})
         expect(message).to be_valid
       end
 
       it 'does not accept arbitrary fields' do
-        message = ServiceOfferingsListMessage.from_params({ foobar: 'pants' }.with_indifferent_access)
+        message = described_class.from_params({ foobar: 'pants' }.with_indifferent_access)
 
         expect(message).not_to be_valid
         expect(message.errors[:base][0]).to include("Unknown query parameter(s): 'foobar'")
@@ -54,19 +55,19 @@ module VCAP::CloudController
 
       context 'values for `available`' do
         it 'accepts `true`' do
-          message = ServiceOfferingsListMessage.from_params({ available: 'true' }.with_indifferent_access)
+          message = described_class.from_params({ available: 'true' }.with_indifferent_access)
           expect(message).to be_valid
           expect(message.available).to eq('true')
         end
 
         it 'accepts `false`' do
-          message = ServiceOfferingsListMessage.from_params({ available: 'false' }.with_indifferent_access)
+          message = described_class.from_params({ available: 'false' }.with_indifferent_access)
           expect(message).to be_valid
           expect(message.available).to eq('false')
         end
 
         it 'does not accept other values' do
-          message = ServiceOfferingsListMessage.from_params({ available: 'nope' }.with_indifferent_access)
+          message = described_class.from_params({ available: 'nope' }.with_indifferent_access)
 
           expect(message).not_to be_valid
           expect(message.errors[:available]).to include("only accepts values 'true' or 'false'")
@@ -78,6 +79,12 @@ module VCAP::CloudController
 
         it_behaves_like 'field query parameter', 'service_broker', 'guid,name'
       end
+    end
+
+    describe '.to_param_hash' do
+      let(:message) { described_class.from_params(params) }
+
+      it_behaves_like 'fields to_param_hash', 'service_broker', 'guid,name'
     end
   end
 end

--- a/spec/unit/messages/service_plans_list_message_spec.rb
+++ b/spec/unit/messages/service_plans_list_message_spec.rb
@@ -4,29 +4,29 @@ require 'field_message_spec_shared_examples'
 
 module VCAP::CloudController
   RSpec.describe ServicePlansListMessage do
-    describe '.from_params' do
-      let(:params) do
-        {
-          'available' => 'true',
-          'broker_catalog_ids' => 'broker_catalog_id_1,broker_catalog_id_2',
-          'include' => 'space.organization,service_offering',
-          'names' => 'name_1,name_2',
-          'organization_guids' => 'org_guid_1,org_guid_2',
-          'service_broker_guids' => 'broker_guid_1,broker_guid_2',
-          'service_broker_names' => 'broker_name_1,broker_name_2',
-          'service_instance_guids' => 'instance_guid_1,instance_guid_2',
-          'service_offering_guids' => 'offering_guid_1,offering_guid_2',
-          'service_offering_names' => 'offering_name_1,offering_name_2',
-          'space_guids' => 'space_guid_1,space_guid_2',
-          'fields' => { 'service_offering.service_broker' => 'guid,name' },
-        }.with_indifferent_access
-      end
+    let(:params) do
+      {
+        'available' => 'true',
+        'broker_catalog_ids' => 'broker_catalog_id_1,broker_catalog_id_2',
+        'include' => 'space.organization,service_offering',
+        'names' => 'name_1,name_2',
+        'organization_guids' => 'org_guid_1,org_guid_2',
+        'service_broker_guids' => 'broker_guid_1,broker_guid_2',
+        'service_broker_names' => 'broker_name_1,broker_name_2',
+        'service_instance_guids' => 'instance_guid_1,instance_guid_2',
+        'service_offering_guids' => 'offering_guid_1,offering_guid_2',
+        'service_offering_names' => 'offering_name_1,offering_name_2',
+        'space_guids' => 'space_guid_1,space_guid_2',
+        'fields' => { 'service_offering.service_broker' => 'guid,name' },
+      }.with_indifferent_access
+    end
 
-      it 'returns the correct ServicePlansListMessage' do
+    describe '.from_params' do
+      it 'returns the correct message' do
         message = described_class.from_params(params)
 
         expect(message).to be_valid
-        expect(message).to be_a(ServicePlansListMessage)
+        expect(message).to be_a(described_class)
         expect(message.available).to eq('true')
         expect(message.broker_catalog_ids).to contain_exactly('broker_catalog_id_1', 'broker_catalog_id_2')
         expect(message.include).to contain_exactly('space.organization', 'service_offering')
@@ -42,7 +42,7 @@ module VCAP::CloudController
       end
 
       it 'converts requested keys to symbols' do
-        message = ServicePlansListMessage.from_params(params)
+        message = described_class.from_params(params)
 
         expect(message.requested?(:available)).to be_truthy
         expect(message.requested?(:broker_catalog_ids)).to be_truthy
@@ -113,6 +113,12 @@ module VCAP::CloudController
 
         it_behaves_like 'field query parameter', 'service_offering.service_broker', 'guid,name'
       end
+    end
+
+    describe '.to_param_hash' do
+      let(:message) { described_class.from_params(params) }
+
+      it_behaves_like 'fields to_param_hash', 'service_offering.service_broker', 'guid,name'
     end
   end
 end


### PR DESCRIPTION
[#173248802](https://www.pivotaltracker.com/story/show/173248802)

We had written some custom parsing of fields, but not the equivalent serialisation. This resulted in unexpected data when the query string was serialised to generate the pagination links.

This change adds custom serialisation of fields.