### PR TITLE
V3 maintenance info noop 171702179

### DIFF
--- a/app/actions/service_instance_update_managed.rb
+++ b/app/actions/service_instance_update_managed.rb
@@ -156,7 +156,9 @@ module VCAP::CloudController
     end
 
     def raise_if_version_mismatch!(service_instance, message)
-      return if service_instance.service_plan.maintenance_info['version'] == message.maintenance_info_version
+      is_plan_version = service_instance.service_plan.maintenance_info['version'] == message.maintenance_info_version
+      is_current_version = service_instance.maintenance_info && message.maintenance_info_version == service_instance.maintenance_info['version']
+      return if is_plan_version || is_current_version
 
       raise UnprocessableUpdate.new_from_details('MaintenanceInfoConflict')
     end

--- a/spec/unit/actions/service_instance_update_managed_spec.rb
+++ b/spec/unit/actions/service_instance_update_managed_spec.rb
@@ -561,10 +561,16 @@ module VCAP::CloudController
         let(:body) do
           {
             maintenance_info: {
-              version: service_plan.maintenance_info[:version]
+              version: original_maintenance_info[:version]
             }
           }
         end
+
+        let(:service_plan) { ServicePlan.make(
+          service: service_offering,
+          maintenance_info: { version: '2.2.0', description: 'new version of plan' }
+          )
+        }
 
         it 'returns the current instance unchanged instance and a nil job' do
           si, job = action.update(service_instance, message)


### PR DESCRIPTION
[#171702179](https://www.pivotaltracker.com/story/show/171702179)

no-op scenario: avoid raising error when requesting current instance's version and the plan has been updated in the catalog.
