### PR TITLE
V2 apps return correct app guid in links

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -122,6 +122,10 @@ module VCAP::CloudController
       end
     end
 
+    def self.url_for_guid(_, process)
+      super(process.app_guid, process)
+    end
+
     def inject_dependencies(dependencies)
       super
       @app_event_repository = dependencies.fetch(:app_event_repository)
@@ -194,10 +198,6 @@ module VCAP::CloudController
       end
 
       [HTTP::CREATED, JobPresenter.new(enqueued_job).to_json]
-    end
-
-    def url_for_guid(_, process)
-      super(process.app_guid, process)
     end
 
     def read(guid)

--- a/app/presenters/v2/relations_presenter.rb
+++ b/app/presenters/v2/relations_presenter.rb
@@ -89,7 +89,7 @@ module CloudController
           if association.is_a?(VCAP::CloudController::RestController::ControllerDSL::ToOneAttribute)
             associated_model_instance = get_preloaded_association_contents!(obj, association)
             if associated_model_instance
-              associated_url = associated_controller.url_for_guid(associated_model_instance.guid)
+              associated_url = associated_controller.url_for_guid(associated_model_instance.guid, associated_model_instance)
             end
           else
             associated_url = "#{controller.url_for_guid(obj.guid, obj)}/#{relationship_name}"

--- a/spec/unit/controllers/runtime/apps_controller_spec.rb
+++ b/spec/unit/controllers/runtime/apps_controller_spec.rb
@@ -622,10 +622,13 @@ module VCAP::CloudController
       context 'when the app has rolled to a new web process' do
         before do
           process.destroy
-          ProcessModelFactory.make(instances: 1, app: app_model)
         end
 
+        let!(:new_process) { ProcessModel.make(type: ProcessTypes::WEB, app: app_model) }
+
         it 'returns the app with the appropriate app guid' do
+          expect(app_guid).not_to eq(new_process.guid)
+
           get "/v2/apps/#{app_guid}"
           expect(decoded_response['metadata']).to include({
             'guid' => app_guid.to_s,


### PR DESCRIPTION
- Fix incorrect implementation from 0ae0b8a50715f3f9df35d3cb11145bc777e5c237
- Fix setup for test so process guid is actually different than the app
guid
- url_for_guid should be a class method instead of an instance method

[#1523]