### PR TITLE
V3 update async si 171670119

### DIFF
--- a/app/jobs/v3/update_service_instance_job.rb
+++ b/app/jobs/v3/update_service_instance_job.rb
@@ -41,6 +41,7 @@ module VCAP::CloudController
 
           if service_instance.last_operation.state == 'succeeded'
             update_service_instance(broker_response, maintenance_info)
+            logger.info("Service instance update complete #{service_instance_guid}")
             finish
           end
         rescue => err
@@ -57,8 +58,6 @@ module VCAP::CloudController
           logger.info("Service instance update failed: #{service_instance.last_operation.description}")
           operation_failed!(service_instance.last_operation.description)
         end
-
-        logger.info("Service instance update complete #{service_instance_guid}")
       end
 
       def handle_timeout
@@ -104,7 +103,7 @@ module VCAP::CloudController
           maintenance_info: maintenance_info,
           name: message.requested?(:name) ? message.name : service_instance.name,
         )
-        raise err if err # TODO: create rewrites this errors with an api error keeping the message
+        raise err if err
 
         service_instance.save_with_new_operation({}, broker_response[:last_operation])
       end
@@ -218,7 +217,7 @@ module VCAP::CloudController
       end
 
       def operation_failed!(msg)
-        raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceUpdateFailed', msg)
+        raise CloudController::Errors::ApiError.new_from_details('UnableToPerform', 'Update', msg)
       end
     end
   end

--- a/docs/v3/source/includes/resources/service_instances/_update.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_update.md.erb
@@ -132,6 +132,7 @@ The response will be asynchronous if:
 
 * `parameters` are specified
 * `service_plan` is specified
+* `maintenance_info` is specified
 * `name` is specified and the service offering has the `allow_context_updates` feature enabled
 
 Otherwise the response will be synchronous.

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -348,11 +348,6 @@
   http_code: 400
   message: "The service broker reported an error during provisioning: %s"
 
-60031:
-  name: ServiceInstanceUpdateFailed
-  http_code: 400
-  message: "The service broker reported an error during update: %s"
-
 70001:
   name: RuntimeInvalid
   http_code: 400

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -348,6 +348,11 @@
   http_code: 400
   message: "The service broker reported an error during provisioning: %s"
 
+60031:
+  name: ServiceInstanceUpdateFailed
+  http_code: 400
+  message: "The service broker reported an error during update: %s"
+
 70001:
   name: RuntimeInvalid
   http_code: 400

--- a/spec/support/shared_examples/jobs/service_instance_last_operation_polling_job.rb
+++ b/spec/support/shared_examples/jobs/service_instance_last_operation_polling_job.rb
@@ -1,0 +1,254 @@
+require 'spec_helper'
+require 'models/runtime/pollable_job_model'
+
+RSpec.shared_examples 'service instance last operation polling job' do |operation_type|
+  describe 'when the broker client response is asynchronous' do
+    let(:broker_response) {
+      {
+        instance: { dashboard_url: 'example.foo' },
+        last_operation: {
+          type: operation_type,
+          state: 'in progress',
+          description: 'abc',
+          broker_provided_operation: 'task1',
+        }
+      }
+    }
+
+    let(:in_progress_last_operation) { { last_operation: { state: 'in progress' } } }
+    let(:operation_type_client_method) { operation_type == 'update' ? :update : :provision }
+
+    before do
+      allow(client).to receive(operation_type_client_method).and_return([broker_response, nil])
+      allow(client).to receive(:fetch_service_instance_last_operation).and_return(in_progress_last_operation)
+      run_job(job, jobs_succeeded: 1, jobs_to_execute: 1)
+    end
+
+    it 'updates the last operation and job' do
+      service_instance.reload
+      expect(service_instance.last_operation.type).to eq(operation_type)
+      expect(service_instance.last_operation.state).to eq('in progress')
+      expect(service_instance.last_operation.description).to eq('abc')
+
+      pollable_job = VCAP::CloudController::PollableJobModel.last
+      expect(pollable_job.resource_guid).to eq(service_instance.guid)
+      expect(pollable_job.state).to eq(VCAP::CloudController::PollableJobModel::POLLING_STATE)
+    end
+
+    it 'immediately asks for a progress update' do
+      expect(client).to have_received(:fetch_service_instance_last_operation).with(service_instance)
+    end
+
+    it 'sends the request to the broker' do
+      broker_request_expect
+    end
+
+    context 'waiting for broker to finish' do
+      context 'when a retry_after header is returned' do
+        let(:in_progress_last_operation) do
+          {
+            last_operation: { state: 'in progress', description: 'abc' },
+            retry_after: 430,
+          }
+        end
+
+        it 'updates the polling interval' do
+          Timecop.freeze(Time.now + 420.seconds) do
+            execute_all_jobs(expected_successes: 0, expected_failures: 0)
+          end
+
+          Timecop.freeze(Time.now + 440.seconds) do
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          end
+        end
+      end
+
+      context 'polling the last operation' do
+        let(:description) { 'doing stuff' }
+
+        let(:in_progress_last_operation_2) { { last_operation: { state: 'in progress', description: 'doing stuff' } } }
+
+        before do
+          allow(client).to receive(:fetch_service_instance_last_operation).and_return(in_progress_last_operation_2)
+
+          Timecop.travel(job.polling_interval_seconds + 1.second)
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+        end
+
+        it 'calls the last operation endpoint only' do
+          expect(client).to have_received(:update).once
+          expect(client).to have_received(:fetch_service_instance_last_operation).twice
+        end
+
+        it 'updates the description' do
+          expect(service_instance.last_operation.description).to eq('doing stuff')
+        end
+
+        context 'when there is no description' do
+          let(:in_progress_last_operation_2) { { last_operation: { state: 'in progress' } } }
+
+          it 'leaves the original description' do
+            expect(service_instance.last_operation.description).to eq('abc')
+          end
+        end
+
+        context 'when the description is long (mysql)' do
+          let(:long_description) { '123' * 512 }
+          let(:in_progress_last_operation_2) { { last_operation: { state: 'in progress', description: long_description } } }
+
+          it 'updates the description' do
+            expect(service_instance.last_operation.description).to eq(long_description)
+          end
+        end
+
+        context 'when fetching the last operation from the broker fails' do
+          context 'due to an HttpRequestError' do
+            before do
+              err = HttpRequestError.new('oops', 'uri', 'GET', RuntimeError.new)
+              allow(client).to receive(:fetch_service_instance_last_operation).and_raise(err)
+            end
+
+            it 'should continue' do
+              Timecop.travel(job.polling_interval_seconds + 1.second)
+              execute_all_jobs(expected_successes: 1, expected_failures: 0)
+
+              expect(Delayed::Job.count).to eq 1
+            end
+          end
+
+          context 'due to an HttpResponseError' do
+            before do
+              response = VCAP::Services::ServiceBrokers::V2::HttpResponse.new(code: 412, body: {})
+              err = HttpResponseError.new('oops', 'GET', response)
+              allow(client).to receive(:fetch_service_instance_last_operation).and_raise(err)
+            end
+
+            it 'should continue' do
+              Timecop.travel(job.polling_interval_seconds + 1.second)
+              execute_all_jobs(expected_successes: 1, expected_failures: 0)
+
+              expect(Delayed::Job.count).to eq 1
+            end
+          end
+
+          context 'when saving the last operation to the database fails' do
+            before do
+              allow_any_instance_of(VCAP::CloudController::ManagedServiceInstance).
+                to receive(:save_and_update_operation).and_raise(Sequel::Error.new('foo'))
+            end
+
+            it 'should continue' do
+              Timecop.travel(job.polling_interval_seconds + 1.second)
+              execute_all_jobs(expected_successes: 1, expected_failures: 0)
+
+              expect(Delayed::Job.count).to eq 1
+            end
+          end
+        end
+
+        context 'when saving the last operation to the database fails' do
+          before do
+            allow_any_instance_of(VCAP::CloudController::ManagedServiceInstance).
+              to receive(:save_and_update_operation).and_raise(Sequel::Error.new('foo'))
+          end
+
+          it 'should continue' do
+            Timecop.travel(job.polling_interval_seconds + 1.second)
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+
+            expect(Delayed::Job.count).to eq 1
+          end
+        end
+      end
+
+      context 'timing out' do
+        it 'marks the service instance update as failed' do
+          Timecop.freeze(Time.now + job.maximum_duration_seconds) do
+            execute_all_jobs(expected_successes: 0, expected_failures: 1)
+
+            expect(service_instance.last_operation.type).to eq(operation_type)
+            expect(service_instance.last_operation.state).to eq('failed')
+            expect(service_instance.last_operation.description).to eq("Service Broker failed to #{operation_type_client_method} within the required time.")
+          end
+        end
+
+        context 'when the plan has a maximum duration' do
+          let(:maximum_polling_duration) { 4242 }
+
+          it 'uses it' do
+            Timecop.freeze(Time.now + 4242) do
+              execute_all_jobs(expected_successes: 0, expected_failures: 1)
+
+              expect(service_instance.last_operation.type).to eq('update')
+              expect(service_instance.last_operation.state).to eq('failed')
+              expect(service_instance.last_operation.description).to eq("Service Broker failed to #{operation_type_client_method} within the required time.")
+            end
+          end
+        end
+      end
+    end
+
+    context 'when action has succeeded' do
+      let(:succeeded_last_operation) { { last_operation: { state: 'succeeded', description: '789' } } }
+
+      before do
+        Timecop.travel(job.polling_interval_seconds + 1.second)
+        allow(client).to receive(:fetch_service_instance_last_operation).and_return(succeeded_last_operation)
+        execute_all_jobs(expected_successes: 1, expected_failures: 0)
+      end
+
+      it 'updates the database' do
+        expect(service_instance.last_operation.type).to eq(operation_type)
+        expect(service_instance.last_operation.state).to eq('succeeded')
+        expect(service_instance.last_operation.description).to eq('789')
+
+        pollable_job = VCAP::CloudController::PollableJobModel.last
+        expect(pollable_job.resource_guid).to eq(service_instance.guid)
+        expect(pollable_job.state).to eq(VCAP::CloudController::PollableJobModel::COMPLETE_STATE)
+      end
+
+      it 'creates an audit event' do # changed
+        event = VCAP::CloudController::Event.find(type: "audit.service_instance.#{operation_type_client_method}")
+        expect(event).to be
+        expect(event.actee).to eq(service_instance.guid)
+        expect(event.metadata['request']).to have_key('name')
+        expect(event.metadata['request']).to have_key('parameters')
+        expect(event.metadata['request']).to have_key('tags')
+        expect(event.metadata['request']).to have_key('metadata')
+        expect(event.metadata['request']).to have_key('relationships')
+      end
+    end
+
+    context 'when action has failed' do
+      let(:failed_last_operation) { { last_operation: { state: 'failed', description: 'oops' } } }
+
+      before do
+        Timecop.travel(job.polling_interval_seconds + 1.second)
+        allow(client).to receive(:fetch_service_instance_last_operation).and_return(failed_last_operation)
+        execute_all_jobs(expected_successes: 0, expected_failures: 1)
+      end
+
+      it 'updates the service_instance with last operation' do
+        expect(service_instance.last_operation.type).to eq(operation_type)
+        expect(service_instance.last_operation.state).to eq('failed')
+        expect(service_instance.last_operation.description).to eq('The service broker reported an error during provisioning: oops')
+      end
+
+      it 'updates the job with the api error' do
+        pollable_job = VCAP::CloudController::PollableJobModel.last
+        expect(pollable_job.resource_guid).to eq(service_instance.guid)
+        expect(pollable_job.state).to eq(VCAP::CloudController::PollableJobModel::FAILED_STATE)
+        expect(pollable_job.cf_api_error).not_to be_nil
+        error = YAML.safe_load(pollable_job.cf_api_error)
+        expect(error['errors'].first['code']).to eq(60030)
+        expect(error['errors'].first['detail']).
+          to include('The service broker reported an error during provisioning: oops')
+      end
+
+      it 'does not create an audit event' do
+        event = VCAP::CloudController::Event.find(type: "audit.service_instance.#{operation_type}")
+        expect(event).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/jobs/v3/update_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/update_service_instance_job_spec.rb
@@ -208,23 +208,26 @@ module VCAP
         context 'when the broker client response is asynchronous' do
           let(:broker_request_expect) { -> { expect(client).to have_received(:update).with(
             service_instance,
-            new_service_plan,
-            accepts_incomplete: true,
-            arbitrary_parameters: request_attr,
-            maintenance_info: new_service_plan.maintenance_info.symbolize_keys,
-            previous_values: {
-              plan_id: original_service_plan.broker_provided_id,
-              service_id: service_offering.broker_provided_id,
-              organization_id: org.guid,
-              space_id: space.guid,
-              maintenance_info: original_maintenance_info.stringify_keys,
-            },
-            name: 'new-name',
-          )
+                new_service_plan,
+                accepts_incomplete: true,
+                arbitrary_parameters: request_attr,
+                maintenance_info: new_service_plan.maintenance_info.symbolize_keys,
+                previous_values: {
+                  plan_id: original_service_plan.broker_provided_id,
+                  service_id: service_offering.broker_provided_id,
+                  organization_id: org.guid,
+                  space_id: space.guid,
+                  maintenance_info: original_maintenance_info.stringify_keys,
+                },
+                name: 'new-name',
+              )
                                         }
           }
 
-          it_behaves_like 'service instance last operation polling job', 'update'
+          client_response = ->(broker_response) { [broker_response, nil] }
+          api_error_code = 60031
+
+          it_behaves_like 'service instance last operation polling job', 'update', client_response, api_error_code
 
           context 'when operation is in progress' do
             let(:broker_response) {
@@ -248,7 +251,7 @@ module VCAP
             end
 
             it 'does not update the service instance' do
-              service_instance.reload # TODO: this is not for create
+              service_instance.reload
               expect(service_instance.name).to eq(name)
             end
           end

--- a/spec/unit/jobs/v3/update_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/update_service_instance_job_spec.rb
@@ -150,7 +150,7 @@ module VCAP
             expect(client).to have_received(:update).with(
               service_instance,
               new_service_plan,
-              accepts_incomplete: false,
+              accepts_incomplete: true,
               arbitrary_parameters: request_attr,
               maintenance_info: new_service_plan.maintenance_info.symbolize_keys,
               previous_values: {
@@ -205,7 +205,56 @@ module VCAP
           end
         end
 
-        context 'when the broker client returns an error' do
+        context 'when the broker client response is asynchronous' do
+          let(:broker_request_expect) { -> { expect(client).to have_received(:update).with(
+            service_instance,
+            new_service_plan,
+            accepts_incomplete: true,
+            arbitrary_parameters: request_attr,
+            maintenance_info: new_service_plan.maintenance_info.symbolize_keys,
+            previous_values: {
+              plan_id: original_service_plan.broker_provided_id,
+              service_id: service_offering.broker_provided_id,
+              organization_id: org.guid,
+              space_id: space.guid,
+              maintenance_info: original_maintenance_info.stringify_keys,
+            },
+            name: 'new-name',
+          )
+                                        }
+          }
+
+          it_behaves_like 'service instance last operation polling job', 'update'
+
+          context 'when operation is in progress' do
+            let(:broker_response) {
+              {
+                instance: { dashboard_url: 'example.foo' },
+                last_operation: {
+                  type: :update,
+                  state: 'in progress',
+                  description: 'abc',
+                  broker_provided_operation: 'task1',
+                }
+              }
+            }
+
+            let(:in_progress_last_operation) { { last_operation: { state: 'in progress' } } }
+
+            before do
+              allow(client).to receive(:update).and_return([broker_response, nil])
+              allow(client).to receive(:fetch_service_instance_last_operation).and_return(in_progress_last_operation)
+              run_job(job, jobs_succeeded: 1, jobs_to_execute: 1)
+            end
+
+            it 'does not update the service instance' do
+              service_instance.reload # TODO: this is not for create
+              expect(service_instance.name).to eq(name)
+            end
+          end
+        end
+
+        context 'when the broker client returns an error for update' do
           before do
             allow(client).to receive(:update).and_return([
               {
@@ -397,7 +446,7 @@ module VCAP
                 service_instance,
                 original_service_plan,
                 maintenance_info: plan_maintenance_info,
-                accepts_incomplete: false,
+                accepts_incomplete: true,
                 arbitrary_parameters: {},
                 previous_values: {
                   plan_id: original_service_plan.broker_provided_id,
@@ -428,12 +477,13 @@ module VCAP
                 }
               })
             end
+
             it 'sends a request to the broker' do
               expect(client).to have_received(:update).with(
                 service_instance,
                 new_service_plan,
                 maintenance_info: new_service_plan.maintenance_info.symbolize_keys,
-                accepts_incomplete: false,
+                accepts_incomplete: true,
                 arbitrary_parameters: {},
                 previous_values: {
                   plan_id: original_service_plan.broker_provided_id,
@@ -464,7 +514,7 @@ module VCAP
               expect(client).to have_received(:update).with(
                 service_instance,
                 original_service_plan,
-                accepts_incomplete: false,
+                accepts_incomplete: true,
                 maintenance_info: nil,
                 arbitrary_parameters: { foo: 'bar' },
                 previous_values: {

--- a/spec/unit/jobs/v3/update_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/update_service_instance_job_spec.rb
@@ -225,7 +225,7 @@ module VCAP
           }
 
           client_response = ->(broker_response) { [broker_response, nil] }
-          api_error_code = 60031
+          api_error_code = 10009
 
           it_behaves_like 'service instance last operation polling job', 'update', client_response, api_error_code
 


### PR DESCRIPTION
update MSI when broker response is async.

extracted shared_examples for create/update to take care of last operation polling testing

error scenario when last_operation is 'failed' but success http error code raises a new API error instead of generic one. That does not provide much value but it matches what was done for create.