### PR TITLE
Fix task completion callback on k8s

### DIFF
--- a/lib/cloud_controller/diego/task_completion_callback_generator.rb
+++ b/lib/cloud_controller/diego/task_completion_callback_generator.rb
@@ -6,10 +6,15 @@ module VCAP::CloudController
       end
 
       def generate(task)
-        schema = 'https'
+        if @config.kubernetes_api_configured?
+          port   = 80
+          schema = 'http'
+        else
+          port   = @config.get(:tls_port)
+          schema = 'https'
+        end
         auth = ''
         host = @config.get(:internal_service_hostname)
-        port = @config.get(:tls_port)
         api_version = 'v4'
 
         path = "/internal/#{api_version}/tasks/#{task.guid}/completed"


### PR DESCRIPTION
When deployed on K8s, Istio handles transparently applying mTLS to network traffic. This means the completion callback should use HTTP and port 80 instead of HTTPS and port 8888. We already had a similar conditional in the `OPI::StagerClient`, this just replicates it the `Diego::TaskCompletionCallbackGenerator`.

We didn't run CATs but we did test this manually using Eirini.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)
* [x] I have viewed, signed, and submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
