### PR TITLE
Make logcache tls optional

### DIFF
--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -213,7 +213,7 @@ module VCAP::CloudController
             temporary_ignore_server_unavailable_errors: bool,
           },
 
-          logcache_tls: {
+          optional(:logcache_tls) => {
             key_file: String,
             cert_file: String,
             ca_file: String,

--- a/spec/logcache/client_spec.rb
+++ b/spec/logcache/client_spec.rb
@@ -10,133 +10,172 @@ module Logcache
 
     let(:host) { 'doppler.service.cf.internal' }
     let(:port) { '8080' }
-    let(:tls_subject_name) { 'my-logcache' }
-    let(:client_ca_path) { File.join(Paths::FIXTURES, 'certs/log_cache_ca.crt') }
-    let(:client_cert_path) { File.join(Paths::FIXTURES, 'certs/log_cache.crt') }
-    let(:client_key_path) { File.join(Paths::FIXTURES, 'certs/log_cache.key') }
-    let(:credentials) { instance_double(GRPC::Core::ChannelCredentials) }
-    let(:channel_arg_hash) do
-      {
-          channel_args: { GRPC::Core::Channel::SSL_TARGET => tls_subject_name }
-      }
-    end
-    let(:client) do
-      Logcache::Client.new(host: host, port: port, client_ca_path: client_ca_path,
-                           client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name,
-                           temporary_ignore_server_unavailable_errors: false)
-    end
     let(:expected_request_options) { { 'headers' => { 'Authorization' => 'bearer oauth-token' } } }
-    let(:client_ca) { File.open(client_ca_path).read }
-    let(:client_key) { File.open(client_key_path).read }
-    let(:client_cert) { File.open(client_cert_path).read }
 
-    describe '#container_metrics' do
-      let(:instance_count) { 2 }
-      let!(:process) { VCAP::CloudController::ProcessModel.make(instances: instance_count) }
-
-      before do
-        expect(GRPC::Core::ChannelCredentials).to receive(:new).
-          with(client_ca, client_key, client_cert).
-          and_return(credentials)
-        expect(Logcache::V1::Egress::Stub).to receive(:new).
-          with("#{host}:#{port}", credentials, channel_arg_hash).
-          and_return(logcache_service)
-        allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
+    describe 'with TLS' do
+      let(:tls_subject_name) { 'my-logcache' }
+      let(:client_ca_path) { File.join(Paths::FIXTURES, 'certs/log_cache_ca.crt') }
+      let(:client_cert_path) { File.join(Paths::FIXTURES, 'certs/log_cache.crt') }
+      let(:client_key_path) { File.join(Paths::FIXTURES, 'certs/log_cache.key') }
+      let(:credentials) { instance_double(GRPC::Core::ChannelCredentials) }
+      let(:channel_arg_hash) do
+        {
+            channel_args: { GRPC::Core::Channel::SSL_TARGET => tls_subject_name }
+        }
       end
-
-      it 'calls Logcache with the correct parameters and returns envelopes' do
-        expect(
-          client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
-        ).to eq([:fake_envelope_1, :fake_envelope_2])
-
-        expect(Logcache::V1::ReadRequest).to have_received(:new).with(
-          source_id: process.guid,
-          limit: 1000,
-          descending: true,
-          start_time: 100,
-          end_time: 101,
-          envelope_types: [:GAUGE]
-        )
-        expect(logcache_service).to have_received(:read).with(logcache_request)
+      let(:client) do
+        Logcache::Client.new(host: host, port: port, client_ca_path: client_ca_path,
+                             client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name,
+                             temporary_ignore_server_unavailable_errors: false)
       end
-    end
+      let(:client_ca) { File.open(client_ca_path).read }
+      let(:client_key) { File.open(client_key_path).read }
+      let(:client_cert) { File.open(client_cert_path).read }
 
-    describe 'when logcache is unavailable' do
-      let(:instance_count) { 0 }
-      let(:bad_status) { GRPC::BadStatus.new(14) }
-      let!(:process) { VCAP::CloudController::ProcessModel.make(instances: instance_count) }
+      describe '#container_metrics' do
+        let(:instance_count) { 2 }
+        let!(:process) { VCAP::CloudController::ProcessModel.make(instances: instance_count) }
 
-      before do
-        expect(GRPC::Core::ChannelCredentials).to receive(:new).
-          with(client_ca, client_key, client_cert).
-          and_return(credentials)
-        expect(Logcache::V1::Egress::Stub).to receive(:new).
-          with("#{host}:#{port}", credentials, channel_arg_hash).
-          and_return(logcache_service)
-        allow(client).to receive(:sleep)
-        allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
-        allow(logcache_service).to receive(:read).and_raise(bad_status)
-      end
-
-      context 'and operator has enabled temporary_ignore_server_unavailable_errors' do
-        let(:client) do
-          Logcache::Client.new(host: host, port: port, client_ca_path: client_ca_path,
-                               client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name,
-                               temporary_ignore_server_unavailable_errors: true)
+        before do
+          expect(GRPC::Core::ChannelCredentials).to receive(:new).
+            with(client_ca, client_key, client_cert).
+            and_return(credentials)
+          expect(Logcache::V1::Egress::Stub).to receive(:new).
+            with("#{host}:#{port}", credentials, channel_arg_hash).
+            and_return(logcache_service)
+          allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
         end
 
-        it 'returns an empty envelope' do
+        it 'calls Logcache with the correct parameters and returns envelopes' do
           expect(
             client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
-          ).to be_a(Logcache::EmptyEnvelope)
-        end
+          ).to eq([:fake_envelope_1, :fake_envelope_2])
 
-        # TODO: fix calling the function under test separately
-        it 'retries the request three times' do
-          client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
-
-          expect(logcache_service).to have_received(:read).with(logcache_request).exactly(3).times
+          expect(Logcache::V1::ReadRequest).to have_received(:new).with(
+            source_id: process.guid,
+            limit: 1000,
+            descending: true,
+            start_time: 100,
+            end_time: 101,
+            envelope_types: [:GAUGE]
+          )
+          expect(logcache_service).to have_received(:read).with(logcache_request)
         end
       end
 
-      context 'and operator has disabled temporary_ignore_server_unavailable_errors' do
-        let(:client) do
-          Logcache::Client.new(host: host, port: port, client_ca_path: client_ca_path,
-                               client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name,
-                               temporary_ignore_server_unavailable_errors: false)
+      describe 'when logcache is unavailable' do
+        let(:instance_count) { 0 }
+        let(:bad_status) { GRPC::BadStatus.new(14) }
+        let!(:process) { VCAP::CloudController::ProcessModel.make(instances: instance_count) }
+
+        before do
+          expect(GRPC::Core::ChannelCredentials).to receive(:new).
+            with(client_ca, client_key, client_cert).
+            and_return(credentials)
+          expect(Logcache::V1::Egress::Stub).to receive(:new).
+            with("#{host}:#{port}", credentials, channel_arg_hash).
+            and_return(logcache_service)
+          allow(client).to receive(:sleep)
+          allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
+          allow(logcache_service).to receive(:read).and_raise(bad_status)
         end
 
-        it 'retries the request three times and raises an exception' do
+        context 'and operator has enabled temporary_ignore_server_unavailable_errors' do
+          let(:client) do
+            Logcache::Client.new(host: host, port: port, client_ca_path: client_ca_path,
+                                 client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name,
+                                 temporary_ignore_server_unavailable_errors: true)
+          end
+
+          it 'returns an empty envelope' do
+            expect(
+              client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
+            ).to be_a(Logcache::EmptyEnvelope)
+          end
+
+          # TODO: fix calling the function under test separately
+          it 'retries the request three times' do
+            client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
+
+            expect(logcache_service).to have_received(:read).with(logcache_request).exactly(3).times
+          end
+        end
+
+        context 'and operator has disabled temporary_ignore_server_unavailable_errors' do
+          let(:client) do
+            Logcache::Client.new(host: host, port: port, client_ca_path: client_ca_path,
+                                 client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name,
+                                 temporary_ignore_server_unavailable_errors: false)
+          end
+
+          it 'retries the request three times and raises an exception' do
+            expect {
+              client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
+            }.to raise_error(bad_status)
+
+            expect(logcache_service).to have_received(:read).with(logcache_request).exactly(3).times
+          end
+        end
+      end
+
+      describe 'when the logcache service has any other error' do
+        let(:bad_status) { GRPC::BadStatus.new(13) }
+        let!(:process) { VCAP::CloudController::ProcessModel.make(instances: instance_count) }
+        let(:instance_count) { 2 }
+
+        before do
+          expect(GRPC::Core::ChannelCredentials).to receive(:new).
+            with(client_ca, client_key, client_cert).
+            and_return(credentials)
+          expect(Logcache::V1::Egress::Stub).to receive(:new).
+            with("#{host}:#{port}", credentials, channel_arg_hash).
+            and_return(logcache_service)
+          allow(client).to receive(:sleep)
+          allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
+          allow(logcache_service).to receive(:read).and_raise(bad_status)
+        end
+
+        it 'raises the exception' do
           expect {
             client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
           }.to raise_error(bad_status)
-
-          expect(logcache_service).to have_received(:read).with(logcache_request).exactly(3).times
         end
       end
     end
 
-    describe 'when the logcache service has any other error' do
-      let(:bad_status) { GRPC::BadStatus.new(13) }
-      let!(:process) { VCAP::CloudController::ProcessModel.make(instances: instance_count) }
-      let(:instance_count) { 2 }
-
-      before do
-        expect(GRPC::Core::ChannelCredentials).to receive(:new).
-          with(client_ca, client_key, client_cert).
-          and_return(credentials)
-        expect(Logcache::V1::Egress::Stub).to receive(:new).
-          with("#{host}:#{port}", credentials, channel_arg_hash).
-          and_return(logcache_service)
-        allow(client).to receive(:sleep)
-        allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
-        allow(logcache_service).to receive(:read).and_raise(bad_status)
+    describe 'without TLS' do
+      let(:client) do
+        Logcache::Client.new(host: host, port: port, temporary_ignore_server_unavailable_errors: false,
+                            client_ca_path: nil, client_cert_path: nil, client_key_path: nil, tls_subject_name: nil)
       end
 
-      it 'raises the exception' do
-        expect {
-          client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
-        }.to raise_error(bad_status)
+      describe '#container_metrics' do
+        let(:instance_count) { 2 }
+        let!(:process) { VCAP::CloudController::ProcessModel.make(instances: instance_count) }
+
+        before do
+          expect(GRPC::Core::ChannelCredentials).not_to receive(:new)
+          expect(Logcache::V1::Egress::Stub).to receive(:new).
+            with("#{host}:#{port}", :this_channel_is_insecure).
+            and_return(logcache_service)
+          allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
+        end
+
+        it 'calls Logcache with the correct parameters and returns envelopes' do
+          expect(
+            client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
+          ).to eq([:fake_envelope_1, :fake_envelope_2])
+
+          expect(Logcache::V1::ReadRequest).to have_received(:new).with(
+            source_id: process.guid,
+            limit: 1000,
+            descending: true,
+            start_time: 100,
+            end_time: 101,
+            envelope_types: [:GAUGE]
+          )
+          expect(logcache_service).to have_received(:read).with(logcache_request)
+        end
       end
     end
   end


### PR DESCRIPTION
* This is to allow cf-for-k8s to use Istio for tls instead

[#173597144]

cc/ @dtimm @louis-brann 

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This makes talking to logcache over TLS to get container metrics optional. 

* An explanation of the use cases your change solves
This allows CAPI to keep talking over TLS in bosh while deferring TLS to istio in cf-for-k8s.

* Links to any other associated PRs
* https://github.com/cloudfoundry/capi-k8s-release/pull/51

Tracker: https://www.pivotaltracker.com/story/show/173597144

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
