### PR TITLE
Upgrade fog-aliyun to 0.3.17

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    aliyun-sdk (0.7.3)
+      nokogiri (~> 1.6)
+      rest-client (~> 2.0)
     allowy (2.1.0)
       activesupport (>= 3.2)
       i18n
@@ -155,7 +158,8 @@ GEM
       rake
     fluent-logger (0.7.2)
       msgpack (>= 1.0.0, < 2)
-    fog-aliyun (0.3.10)
+    fog-aliyun (0.3.17)
+      aliyun-sdk (~> 0.7.3)
       fog-core
       fog-json
       ipaddress (~> 0.8)


### PR DESCRIPTION
The fog-aliyun 0.3.17 aims to fix fog-aliyun protential issue, support self-define log file and using alibaba cloud ruby sdk to improve fog-aliyun performance. The related PRs as following:

1. adater oss_sdk_log_path: https://github.com/fog/fog-aliyun/pull/125
2. update ruby sdk to 0.7.3: https://github.com/fog/fog-aliyun/pull/124
3. adapter maxkeys conversion problem: https://github.com/fog/fog-aliyun/pull/123
4. improve put_object_with_body and head_object using sdk do_request: https://github.com/fog/fog-aliyun/pull/131
5. fix max key again: https://github.com/fog/fog-aliyun/pull/128
6. fix downloading object when pushing app twice: https://github.com/fog/fog-aliyun/pull/127
7. fix max key: https://github.com/fog/fog-aliyun/pull/126

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

* [x] I have deploy a whole CF deployment and spring-music app by packing gem fog-aliyun 0.3.17 to Capi-release.