### PR TITLE
Introduce .editorconfig for ruby files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.rb]
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
* A short explanation of the proposed change:

Many editors and IDEs will leverage an .editorconfig out of the box

This basic configuration for ruby files tells the editor to behave
per how rubocop is configured to handle whitespace

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
