### PR TITLE
v3(services): shared_spaces can include fields

### DIFF
--- a/app/decorators/field_service_instance_organization_decorator.rb
+++ b/app/decorators/field_service_instance_organization_decorator.rb
@@ -12,9 +12,9 @@ module VCAP::CloudController
       @fields = fields[:'space.organization'].to_set.intersection(self.class.allowed)
     end
 
-    def decorate(hash, service_instances)
+    def decorate(hash, resources)
       hash[:included] ||= {}
-      spaces = service_instances.map(&:space).uniq
+      spaces = resources.map { |r| r.try(:space) || r }.uniq
       orgs = spaces.map(&:organization).uniq
 
       hash[:included][:organizations] = orgs.sort_by(&:created_at).map do |org|

--- a/app/decorators/field_service_instance_space_decorator.rb
+++ b/app/decorators/field_service_instance_space_decorator.rb
@@ -12,9 +12,10 @@ module VCAP::CloudController
       @fields = fields[:space].to_set.intersection(self.class.allowed)
     end
 
-    def decorate(hash, service_instances)
+    def decorate(hash, resources)
       hash[:included] ||= {}
-      spaces = service_instances.map(&:space).uniq
+
+      spaces = resources.map { |r| r.try(:space) || r }.uniq
 
       hash[:included][:spaces] = spaces.sort_by(&:created_at).map do |space|
         temp = {}

--- a/app/messages/shared_spaces_show_message.rb
+++ b/app/messages/shared_spaces_show_message.rb
@@ -1,0 +1,18 @@
+module VCAP::CloudController
+  class SharedSpacesShowMessage < BaseMessage
+    register_allowed_keys [:fields]
+
+    validates_with NoAdditionalParamsValidator
+    validates :fields, allow_nil: true, fields: {
+      allowed: {
+        'space' => %w(name guid relationships.organization),
+        'space.organization' => %w(name guid)
+      }
+    }
+
+    def self.from_params(params)
+      instance = super(params, [], fields: %w(fields))
+      instance
+    end
+  end
+end

--- a/app/presenters/v3/to_many_relationship_presenter.rb
+++ b/app/presenters/v3/to_many_relationship_presenter.rb
@@ -4,18 +4,22 @@ module VCAP::CloudController
   module Presenters
     module V3
       class ToManyRelationshipPresenter < BasePresenter
-        def initialize(relation_url, relationships, relationship_path, build_related: true)
+        def initialize(relation_url, relationships, relationship_path, build_related: true, decorators: [])
           @relation_url = relation_url
           @relationships = relationships
           @relationship_path = relationship_path
           @build_related = build_related
+          @decorators = decorators
         end
 
         def to_hash
-          {
-            data: build_relations,
+          relations = build_relations
+          h = {
+            data: relations,
             links: build_links
           }
+
+          @decorators.reduce(h) { |memo, d| d.decorate(memo, @relationships) }
         end
 
         private

--- a/docs/v3/source/includes/concepts/_fields.md.erb
+++ b/docs/v3/source/includes/concepts/_fields.md.erb
@@ -30,6 +30,7 @@ For information on `fields` support for each resource refer to its documentation
 Resource |  Endpoint
 -------- | --------------
 **Service Instances** | [v3/service_instances](#list-service-instances), [v3/service_instances/:guid](/#get-a-service-instance)
+**Shared Spaces** | [/v3/service_instances/:guid/relationships/shared_spaces](#list-shared-spaces-relationship)
 **Service Offerings** | [v3/service_offerings](#list-service-offerings), [v3/service_offerings/:guid](/#get-a-service-offering)
 **Service Plans** | [v3/service_plans](#list-service-plans), [v3/service_plans/:guid](/#get-a-service-plan)
 

--- a/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
@@ -25,6 +25,19 @@ This endpoint lists the spaces that the service instance has been shared to.
 #### Definition
 `GET /v3/service_instances/:guid/relationships/shared_spaces`
 
+#### Query parameters
+
+Name | Type | Description
+---- | ---- | ------------
+**fields** (*experimental*)| [_fields parameter_](#fields-parameter) | [_Allowed values_](#shared-spaces-fields)
+
+##### Shared Spaces List Fields
+
+Resource            | Allowed Keys
+------------------- | ----
+space | `guid`, `name`, `relationships.organization`
+space.organization| `guid`, `name`
+
 #### Permitted roles (in the service instance's originating space)
  |
 --- | ---

--- a/spec/unit/decorators/field_service_instance_organization_decorator_spec.rb
+++ b/spec/unit/decorators/field_service_instance_organization_decorator_spec.rb
@@ -68,6 +68,27 @@ module VCAP::CloudController
           expect(hash[:included][:organizations]).to have(1).element
         end
       end
+
+      context 'decorating relationships' do
+        it 'includes the related resource correctly' do
+          decorator = described_class.new({ 'space.organization': ['name', 'guid'] })
+          undecorated_hash = { foo: 'bar', included: { monkeys: %w(zach greg) } }
+          relationship = [space1, space2, space1]
+
+          hash = decorator.decorate(undecorated_hash, relationship)
+
+          expect(hash).to match({
+            foo: 'bar',
+            included: {
+              monkeys: %w(zach greg),
+              organizations: [
+                { name: org1.name, guid: org1.guid },
+                { name: org2.name, guid: org2.guid }
+              ]
+            }
+          })
+        end
+      end
     end
 
     describe '.match?' do

--- a/spec/unit/decorators/field_service_instance_space_decorator_spec.rb
+++ b/spec/unit/decorators/field_service_instance_space_decorator_spec.rb
@@ -144,6 +144,31 @@ module VCAP::CloudController
           expect(hash[:included][:spaces]).to have(1).element
         end
       end
+
+      context 'decorating relationships' do
+        it 'includes the related resource correctly' do
+          decorator = described_class.new({ 'space': ['guid'] })
+          undecorated_hash = { foo: 'bar', included: { monkeys: %w(zach greg) } }
+          relationship = [space1, space2, space1]
+
+          hash = decorator.decorate(undecorated_hash, relationship)
+
+          expect(hash).to match({
+            foo: 'bar',
+            included: {
+              monkeys: %w(zach greg),
+              spaces: [
+                {
+                  guid: space1.guid,
+                },
+                {
+                  guid: space2.guid,
+                }
+              ]
+            }
+          })
+        end
+      end
     end
 
     describe '.match?' do

--- a/spec/unit/messages/shared_spaces_show_message_spec.rb
+++ b/spec/unit/messages/shared_spaces_show_message_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'messages/shared_spaces_show_message'
+require 'field_message_spec_shared_examples'
+
+module VCAP::CloudController
+  RSpec.describe SharedSpacesShowMessage do
+    it_behaves_like 'field query parameter', 'space', 'name,guid,relationships.organization'
+
+    it_behaves_like 'field query parameter', 'space.organization', 'name,guid'
+
+    it_behaves_like 'fields query hash'
+  end
+end

--- a/spec/unit/presenters/v3/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_instance_presenter_spec.rb
@@ -208,19 +208,20 @@ module VCAP::CloudController::Presenters::V3
     end
 
     context 'when a decorator is provided' do
-      class FakeDecorator
-        def self.decorate(hash, resources)
-          hash[:included] = { resource: { guid: resources[0].guid } }
-          hash
+      let(:fake_decorator) { double }
+      let(:impl) do
+        ->(hash, resources) do
+          hash.tap { |h| h[:included] = { resource: { guid: "included #{resources[0].guid}" } } }
         end
       end
+      before { allow(fake_decorator).to receive(:decorate, &impl) }
 
-      let(:presenter) { described_class.new(service_instance, decorators: [FakeDecorator]) }
+      let(:presenter) { described_class.new(service_instance, decorators: [fake_decorator]) }
 
       let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make }
 
       it 'uses the decorator' do
-        expect(result[:included]).to match({ resource: { guid: service_instance.guid } })
+        expect(result[:included]).to match({ resource: { guid: "included #{service_instance.guid}" } })
       end
     end
   end


### PR DESCRIPTION
Valid fields are:
* space: name, guid, relationships.organization
* space.organization: name, guid

[#171954418](https://www.pivotaltracker.com/story/show/171954418)
