### PR TITLE
Create a droplet in the kpack stager

### DIFF
--- a/app/actions/build_update.rb
+++ b/app/actions/build_update.rb
@@ -15,7 +15,7 @@ module VCAP::CloudController
         if message.state == VCAP::CloudController::BuildModel::FAILED_STATE
           build.fail_to_stage!('StagerError', message.error)
         elsif message.state == VCAP::CloudController::BuildModel::STAGED_STATE
-          droplet = VCAP::CloudController::DropletCreate.new.create_docker_droplet(build)
+          droplet = build.droplet
           droplet.lock!
           droplet.docker_receipt_image = message.lifecycle.dig(:data, :image)
           droplet.process_types = message.lifecycle.dig(:data, :processTypes)

--- a/app/actions/droplet_update.rb
+++ b/app/actions/droplet_update.rb
@@ -1,11 +1,19 @@
 module VCAP::CloudController
   class DropletUpdate
-    class Error < ::StandardError
-    end
+    class Error < ::StandardError; end
+    class InvalidDroplet < StandardError; end
 
     def update(droplet, message)
       droplet.db.transaction do
         droplet.lock!
+
+        if message.requested?(:image)
+          raise InvalidDroplet.new('Droplet image cannot be updated during staging') if droplet.staging?
+          raise InvalidDroplet.new('Images can only be updated for docker droplets') unless droplet.docker?
+
+          droplet.docker_receipt_image = message.image
+        end
+
         LabelsUpdate.update(droplet, message.labels, DropletLabelModel)
         AnnotationsUpdate.update(droplet, message.annotations, DropletAnnotationModel)
         droplet.save

--- a/app/messages/droplet_update_message.rb
+++ b/app/messages/droplet_update_message.rb
@@ -2,8 +2,9 @@ require 'messages/metadata_base_message'
 
 module VCAP::CloudController
   class DropletUpdateMessage < MetadataBaseMessage
-    register_allowed_keys []
+    register_allowed_keys [:image]
 
+    validates :image, string: true, allow_nil: true
     validates_with NoAdditionalKeysValidator
   end
 end

--- a/spec/request/builds_spec.rb
+++ b/spec/request/builds_spec.rb
@@ -583,7 +583,9 @@ RSpec.describe 'Builds' do
       end
 
       context 'updating state' do
-        let(:build_model) { VCAP::CloudController::BuildModel.make(package: package_model, state: VCAP::CloudController::BuildModel::STAGING_STATE) }
+        let(:build_model) { VCAP::CloudController::BuildModel.make(:kpack, package: package_model,
+          state: VCAP::CloudController::BuildModel::STAGING_STATE)
+        }
         let(:request) do
           {
             state: 'STAGED',

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -129,6 +129,8 @@ module VCAP::CloudController
     guid { Sham.guid }
     droplet_hash { nil }
     sha256_checksum { nil }
+    docker_receipt_image { nil }
+    app { AppModel.make(:kpack, droplet_guid: guid) }
     state { VCAP::CloudController::DropletModel::STAGED_STATE }
     buildpack_lifecycle_data { nil.tap { |_| object.save } }
   end

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -78,9 +78,10 @@ module VCAP::CloudController
   BuildModel.blueprint(:kpack) do
     guid     { Sham.guid }
     state    { VCAP::CloudController::DropletModel::STAGING_STATE }
-    app { AppModel.make }
+    app { AppModel.make(droplet_guid: guid) }
     kpack_lifecycle_data { KpackLifecycleDataModel.make(build: object.save) }
     package { PackageModel.make(app: app) }
+    droplet { DropletModel.make(:docker, build: object.save) }
   end
 
   BuildModel.blueprint(:buildpack) do

--- a/spec/unit/actions/build_update_spec.rb
+++ b/spec/unit/actions/build_update_spec.rb
@@ -133,6 +133,7 @@ module VCAP::CloudController
 
       context 'when updating state' do
         let(:build) { BuildModel.make(:kpack) }
+
         context 'when a build was successfully completed' do
           let(:body) do
             {
@@ -154,6 +155,7 @@ module VCAP::CloudController
             build_update.update(build, message)
 
             expect(build.state).to eq('STAGED')
+            expect(build.droplet.state).to eq('STAGED')
             expect(build.droplet.docker_receipt_image).to eq('some-fake-image:tag')
             expect(build.droplet.process_types).to eq({ 'foo' => 'foo start', 'bar' => 'bar start' })
           end

--- a/spec/unit/actions/droplet_update_spec.rb
+++ b/spec/unit/actions/droplet_update_spec.rb
@@ -10,49 +10,102 @@ module VCAP::CloudController
     subject(:droplet_update) { DropletUpdate.new }
 
     describe '#update' do
-      let!(:droplet) { DropletModel.make }
+      context 'buildpack droplet update' do
+        let!(:droplet) { DropletModel.make }
+        let!(:label) do
+          VCAP::CloudController::DropletLabelModel.make(
+            key_prefix: 'indiana.edu',
+            key_name: 'state',
+            value: 'Indiana',
+            resource_guid: droplet.guid
+          )
+        end
 
-      let!(:label) do
-        VCAP::CloudController::DropletLabelModel.make(
-          key_prefix: 'indiana.edu',
-          key_name: 'state',
-          value: 'Indiana',
-          resource_guid: droplet.guid
-        )
-      end
+        let!(:annotation) do
+          VCAP::CloudController::DropletAnnotationModel.make(
+            key: 'University',
+            value: 'Toronto',
+            resource_guid: droplet.guid
+          )
+        end
 
-      let!(:annotation) do
-        VCAP::CloudController::DropletAnnotationModel.make(
-          key: 'University',
-          value: 'Toronto',
-          resource_guid: droplet.guid
-        )
-      end
-
-      let(:message) do
-        VCAP::CloudController::DropletUpdateMessage.new({
-          metadata: {
-            labels: {
-              freaky: 'wednesday',
-              'indiana.edu/state' => nil,
+        let(:message) do
+          VCAP::CloudController::DropletUpdateMessage.new({
+            metadata: {
+              labels: {
+                freaky: 'wednesday',
+                'indiana.edu/state' => nil,
+              },
+              annotations: {
+                reason: 'add some more annotations',
+              },
             },
-            annotations: {
-              reason: 'add some more annotations',
-            },
-          },
-        })
+          })
+        end
+
+        it 'update the droplet record' do
+          expect(message).to be_valid
+          updated_droplet = droplet_update.update(droplet, message)
+
+          expect(updated_droplet.labels.first.key_name).to eq 'freaky'
+          expect(updated_droplet.labels.first.value).to eq 'wednesday'
+          expect(updated_droplet.labels.size).to eq 1
+          expect(updated_droplet.annotations.size).to eq(2)
+          expect(Hash[updated_droplet.annotations.map { |a| [a.key, a.value] }]).
+            to eq({ 'University' => 'Toronto', 'reason' => 'add some more annotations' })
+        end
+        context 'trying to update a buildpack droplet image' do
+          let(:message) do
+            VCAP::CloudController::DropletUpdateMessage.new({
+              image: 'some-image-reference',
+              metadata: {
+                labels: {
+                  freaky: 'wednesday',
+                  'indiana.edu/state' => nil,
+                },
+                annotations: {
+                  reason: 'add some more annotations',
+                },
+              },
+            })
+          end
+          it 'returns an error saying that a buildpack droplet image cannot be updated' do
+            expect(message).to be_valid
+            expect { droplet_update.update(droplet, message)
+            }.to raise_error(DropletUpdate::InvalidDroplet, 'Images can only be updated for docker droplets')
+          end
+        end
       end
+      context 'docker droplet update' do
+        let!(:docker_droplet) do
+          VCAP::CloudController::DropletModel.make(:kpack)
+        end
 
-      it 'update the droplet record' do
-        expect(message).to be_valid
-        updated_droplet = droplet_update.update(droplet, message)
-
-        expect(updated_droplet.labels.first.key_name).to eq 'freaky'
-        expect(updated_droplet.labels.first.value).to eq 'wednesday'
-        expect(updated_droplet.labels.size).to eq 1
-        expect(updated_droplet.annotations.size).to eq(2)
-        expect(Hash[updated_droplet.annotations.map { |a| [a.key, a.value] }]).
-          to eq({ 'University' => 'Toronto', 'reason' => 'add some more annotations' })
+        let(:message) do
+          VCAP::CloudController::DropletUpdateMessage.new({
+            image: 'new-image-reference'
+          })
+        end
+        context 'the image of a staged docker droplet is requested to be updated' do
+          before do
+            docker_droplet.update(docker_receipt_image: 'some-image-reference')
+          end
+          it 'updates the droplet record with new image reference' do
+            expect(message).to be_valid
+            updated_droplet = droplet_update.update(docker_droplet, message)
+            expect(updated_droplet.docker_receipt_image).to eq 'new-image-reference'
+          end
+        end
+        context 'the image of a staging docker droplet is requested to be updated' do
+          before do
+            docker_droplet.update(state: VCAP::CloudController::DropletModel::STAGING_STATE)
+          end
+          it 'returns an error saying that a droplet update cannot occur during staging' do
+            expect(message).to be_valid
+            expect { droplet_update.update(docker_droplet, message)
+            }.to raise_error(DropletUpdate::InvalidDroplet, 'Droplet image cannot be updated during staging')
+          end
+        end
       end
     end
   end

--- a/spec/unit/messages/droplet_update_message_spec.rb
+++ b/spec/unit/messages/droplet_update_message_spec.rb
@@ -5,6 +5,7 @@ module VCAP::CloudController
   RSpec.describe DropletUpdateMessage do
     let(:body) do
       {
+        'image' => 'some-image-reference',
         'metadata' => {
           'labels' => {
             'potatoes' => 'taterTots'
@@ -17,6 +18,7 @@ module VCAP::CloudController
       it 'can parse labels and annotations' do
         params =
           {
+            "image": 'new-image-reference',
             "metadata": {
               "labels": {
                 "potato": 'mashed'
@@ -30,6 +32,7 @@ module VCAP::CloudController
         expect(message).to be_valid
         expect(message.labels).to include("potato": 'mashed')
         expect(message.annotations).to include("eating": 'potatoes')
+        expect(message.image).to eq('new-image-reference')
       end
 
       it 'validates both bad labels and bad annotations' do
@@ -42,6 +45,15 @@ module VCAP::CloudController
         message = DropletUpdateMessage.new(params)
         expect(message).not_to be_valid
         expect(message.errors_on(:metadata)).to match_array(["'annotations' is not an object", "'labels' is not an object"])
+      end
+
+      it 'validates bad image references' do
+        params = {
+          "image": { 'blah': 34234 }
+        }
+        message = DropletUpdateMessage.new(params)
+        expect(message).not_to be_valid
+        expect(message.errors_on(:image)).to match_array(['must be a string'])
       end
     end
   end


### PR DESCRIPTION
- Previously for kpack apps, the droplet was created when the build
controller would send a patch request to CAPI after a successful OCI
Image build. We wanted to create the droplet when the Image CR is
created so that the Image CR would have a droplet guid label that could
be used by the image controller to know which droplet to update after a
stack update.
- Removed droplet creation from the BuildUpdate action
- Non-kpack lifecycle app staging workflows should not have been changed or
impacted by this change.

[172542372]

Co-authored-by: Piyali Banerjee <pbanerjee@pivotal.io>
Co-authored-by: Nat Bennett <nbennett@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
