### PR TITLE
v3(services): don't redact in audit logs for empty credentials/params

### DIFF
--- a/app/messages/service_instance_create_user_provided_message.rb
+++ b/app/messages/service_instance_create_user_provided_message.rb
@@ -26,7 +26,11 @@ module VCAP::CloudController
     end
 
     def audit_hash
-      super.tap { |h| h['credentials'] = VCAP::CloudController::Presenters::Censorship::PRIVATE_DATA_HIDDEN }
+      super.tap do |h|
+        if h['credentials'].present?
+          h['credentials'] = VCAP::CloudController::Presenters::Censorship::PRIVATE_DATA_HIDDEN
+        end
+      end
     end
 
     private

--- a/app/repositories/service_event_repository.rb
+++ b/app/repositories/service_event_repository.rb
@@ -196,8 +196,11 @@ module VCAP::CloudController
 
         def with_parameters_redacted(params)
           return params unless params.respond_to? :[]=
+          return params unless params.key?('parameters')
 
-          params.dup.tap { |p| p['parameters'] = Presenters::Censorship::PRIVATE_DATA_HIDDEN }
+          params.dup.tap do |p|
+            p['parameters'] = Presenters::Censorship::PRIVATE_DATA_HIDDEN
+          end
         end
 
         def metadata_for_broker_params(params)

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -951,8 +951,7 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
           'request' => {
             'name'              => instance.name,
             'service_plan_guid' => instance.service_plan.guid,
-            'space_guid'        => instance.space_guid,
-            'parameters'        => '[PRIVATE DATA HIDDEN]'
+            'space_guid'        => instance.space_guid
           }
         }
       }
@@ -976,8 +975,7 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         space_guid: instance.space_guid,
         metadata:   {
           'request' => {
-            'service_plan_guid' => instance.service_plan.guid,
-            'parameters'        => '[PRIVATE DATA HIDDEN]'
+            'service_plan_guid' => instance.service_plan.guid
           }
         }
       }
@@ -998,9 +996,7 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         actee_name: instance.name,
         space_guid: instance.space_guid,
         metadata:   {
-          'request' => {
-            'parameters' => '[PRIVATE DATA HIDDEN]'
-          }
+          'request' => {}
         }
       }
     end
@@ -1024,8 +1020,7 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         space_guid: instance.space_guid,
         metadata:   {
           'request' => {
-            'route_guid' => route.guid,
-            'parameters' => '[PRIVATE DATA HIDDEN]'
+            'route_guid' => route.guid
           }
         }
       }
@@ -1050,8 +1045,7 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
         space_guid: instance.space_guid,
         metadata:   {
           'request' => {
-            'route_guid' => route.guid,
-            'parameters' => '[PRIVATE DATA HIDDEN]'
+            'route_guid' => route.guid
           }
         }
       }

--- a/spec/lightweight_spec_helper.rb
+++ b/spec/lightweight_spec_helper.rb
@@ -1,6 +1,8 @@
 $LOAD_PATH.push(File.expand_path(File.join(__dir__, '..', 'app')))
 $LOAD_PATH.push(File.expand_path(File.join(__dir__, '..', 'lib')))
 
+require 'active_support/all'
+
 # So that specs using this helper don't fail with undefined constant error
 module VCAP
   module CloudController

--- a/spec/unit/messages/service_instance_create_user_provided_message_spec.rb
+++ b/spec/unit/messages/service_instance_create_user_provided_message_spec.rb
@@ -137,9 +137,21 @@ module VCAP::CloudController
     end
 
     describe '.audit_hash' do
-      it 'produces a redacted audit hash' do
-        expected = body.dup.tap { |b| b[:credentials] = '[PRIVATE DATA HIDDEN]' }
-        expect(message.audit_hash).to match(expected.with_indifferent_access)
+      context 'when credentials are provided' do
+        it 'produces a redacted audit hash' do
+          expected = body.dup.tap { |b| b[:credentials] = '[PRIVATE DATA HIDDEN]' }
+          expect(message.audit_hash).to match(expected.with_indifferent_access)
+        end
+      end
+
+      context 'when no credentials are provided' do
+        let(:body_without_credentials) { body.without(:credentials) }
+        let(:message) { described_class.new(body_without_credentials) }
+
+        it 'should not contain a credentials param' do
+          expected = body.without(:credentials)
+          expect(message.audit_hash).to match(expected.with_indifferent_access)
+        end
       end
     end
   end


### PR DESCRIPTION
[#174143941](https://www.pivotaltracker.com/story/show/174143941)
[#174063390](https://www.pivotaltracker.com/story/show/174063390)