### PR TITLE
v3(services): only redact credentials when updating upsi when actually provided

### DIFF
--- a/app/messages/metadata_base_message.rb
+++ b/app/messages/metadata_base_message.rb
@@ -1,5 +1,6 @@
 require 'messages/base_message'
 require 'messages/validators/metadata_validator'
+require 'utils/hash_utils'
 
 module VCAP::CloudController
   class MetadataBaseMessage < BaseMessage

--- a/app/messages/service_instance_create_message.rb
+++ b/app/messages/service_instance_create_message.rb
@@ -1,9 +1,9 @@
-require 'messages/metadata_base_message'
+require 'messages/service_instance_message'
 require 'presenters/helpers/censorship'
 require 'utils/hash_utils'
 
 module VCAP::CloudController
-  class ServiceInstanceCreateMessage < MetadataBaseMessage
+  class ServiceInstanceCreateMessage < ServiceInstanceMessage
     register_allowed_keys [
       :type,
       :relationships,

--- a/app/messages/service_instance_create_user_provided_message.rb
+++ b/app/messages/service_instance_create_user_provided_message.rb
@@ -25,14 +25,6 @@ module VCAP::CloudController
       @relationships_message ||= Relationships.new(relationships&.deep_symbolize_keys)
     end
 
-    def audit_hash
-      super.tap do |h|
-        if h['credentials'].present?
-          h['credentials'] = VCAP::CloudController::Presenters::Censorship::PRIVATE_DATA_HIDDEN
-        end
-      end
-    end
-
     private
 
     def route_service_url_must_be_https

--- a/app/messages/service_instance_message.rb
+++ b/app/messages/service_instance_message.rb
@@ -1,0 +1,16 @@
+require 'messages/metadata_base_message'
+require 'presenters/helpers/censorship'
+
+module VCAP
+  module CloudController
+    class ServiceInstanceMessage < MetadataBaseMessage
+      def audit_hash
+        super.tap do |h|
+          if h['credentials'].present?
+            h['credentials'] = VCAP::CloudController::Presenters::Censorship::PRIVATE_DATA_HIDDEN
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/messages/service_instance_update_user_provided_message.rb
+++ b/app/messages/service_instance_update_user_provided_message.rb
@@ -1,7 +1,7 @@
-require 'messages/metadata_base_message'
+require 'messages/service_instance_message'
 
 module VCAP::CloudController
-  class ServiceInstanceUpdateUserProvidedMessage < MetadataBaseMessage
+  class ServiceInstanceUpdateUserProvidedMessage < ServiceInstanceMessage
     register_allowed_keys [
       :name,
       :tags,
@@ -20,10 +20,6 @@ module VCAP::CloudController
 
     validate :tags_must_be_strings
     validate :route_service_url_must_be_https
-
-    def audit_hash
-      super.tap { |h| h['credentials'] = VCAP::CloudController::Presenters::Censorship::PRIVATE_DATA_HIDDEN }
-    end
 
     private
 

--- a/spec/unit/messages/service_instance_update_user_provided_message_spec.rb
+++ b/spec/unit/messages/service_instance_update_user_provided_message_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'lightweight_spec_helper'
 require 'messages/service_instance_update_user_provided_message'
 
 module VCAP::CloudController
@@ -99,9 +99,21 @@ module VCAP::CloudController
     end
 
     describe '.audit_hash' do
-      it 'produces a redacted audit hash' do
-        expected = body.dup.tap { |b| b[:credentials] = '[PRIVATE DATA HIDDEN]' }
-        expect(message.audit_hash).to match(expected.with_indifferent_access)
+      context 'when credentials are passed in' do
+        it 'produces a redacted audit hash' do
+          expected = body.dup.tap { |b| b[:credentials] = '[PRIVATE DATA HIDDEN]' }
+          expect(message.audit_hash).to match(expected.with_indifferent_access)
+        end
+      end
+
+      context 'when no credentials are passed in' do
+        let(:body_without_credentials) { body.without(:credentials) }
+        let(:message) { described_class.new(body_without_credentials) }
+
+        it 'does not add a redacted credentials key' do
+          expected = body.without(:credentials)
+          expect(message.audit_hash).to match(expected.with_indifferent_access)
+        end
       end
     end
   end


### PR DESCRIPTION
[#174144371](https://www.pivotaltracker.com/story/show/174144371)
