### PR TITLE
v3(services): use original name as target when auditing update si events

### DIFF
--- a/app/actions/service_instance_update_managed.rb
+++ b/app/actions/service_instance_update_managed.rb
@@ -28,8 +28,9 @@ module VCAP::CloudController
           lock.asynchronous_unlock!
           return nil, job
         else
+          original_service_instance = service_instance.dup
           si = updater.update_sync
-          service_event_repository.record_service_instance_event(:update, service_instance, message.audit_hash)
+          service_event_repository.record_service_instance_event(:update, original_service_instance, message.audit_hash)
           lock.synchronous_unlock!
           return si, nil
         end

--- a/app/actions/service_instance_update_user_provided.rb
+++ b/app/actions/service_instance_update_user_provided.rb
@@ -22,9 +22,10 @@ module VCAP::CloudController
       updates[:tags] = message.tags if message.requested?(:tags)
 
       service_instance.db.transaction do
+        original_service_instance = service_instance.dup
         service_instance.update(updates)
         MetadataUpdate.update(service_instance, message)
-        service_event_repository.record_user_provided_service_instance_event(:update, service_instance, message.audit_hash)
+        service_event_repository.record_user_provided_service_instance_event(:update, original_service_instance, message.audit_hash)
       end
       logger.info("Finished updating user-provided service_instance #{service_instance.guid}")
       service_instance

--- a/app/jobs/v3/service_instance_async_job.rb
+++ b/app/jobs/v3/service_instance_async_job.rb
@@ -126,7 +126,8 @@ module VCAP::CloudController
       end
 
       def operation_completed?
-        service_instance.last_operation.state == 'succeeded' && service_instance.last_operation.type == operation_type
+        last_operation = service_instance.last_operation
+        last_operation.state == 'succeeded' && last_operation.type == operation_type
       end
 
       def fetch_last_operation(client)

--- a/app/jobs/v3/update_service_instance_job.rb
+++ b/app/jobs/v3/update_service_instance_job.rb
@@ -23,6 +23,8 @@ module VCAP::CloudController
         'update'
       end
 
+      private
+
       def send_broker_request(client)
         @update_response, err = client.update(
           service_instance,
@@ -50,8 +52,6 @@ module VCAP::CloudController
           MetadataUpdate.update(service_instance, message)
         end
       end
-
-      private
 
       attr_reader :message
 

--- a/spec/unit/actions/service_instance_update_managed_spec.rb
+++ b/spec/unit/actions/service_instance_update_managed_spec.rb
@@ -18,10 +18,11 @@ module VCAP::CloudController
       let(:service_offering) { Service.make(plan_updateable: true) }
       let(:original_maintenance_info) { { version: '2.1.0', description: 'original version' } }
       let(:service_plan) { ServicePlan.make(service: service_offering, maintenance_info: original_maintenance_info) }
+      let(:original_name) { 'foo' }
       let!(:service_instance) do
         si = VCAP::CloudController::ManagedServiceInstance.make(
           service_plan: service_plan,
-          name: 'foo',
+          name: original_name,
           tags: %w(accounting mongodb),
           space: space,
           maintenance_info: original_maintenance_info
@@ -95,7 +96,11 @@ module VCAP::CloudController
           expect(event_repository).
             to have_received(:record_service_instance_event).with(
               :update,
-              instance_of(ManagedServiceInstance),
+              have_attributes(
+                name: original_name,
+                guid: service_instance.guid,
+                space: service_instance.space
+              ),
               body.with_indifferent_access
             )
         end


### PR DESCRIPTION
[#174144038](https://www.pivotaltracker.com/story/show/174144038)