### PR TITLE
Add audit events for Apps#show_env and Revisions#show_environment_variables

### DIFF
--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -261,6 +261,8 @@ class AppsV3Controller < ApplicationController
 
     FeatureFlag.raise_unless_enabled!(:space_developer_env_var_visibility)
 
+    Repositories::AppEventRepository.new.record_app_show_environment_variables(app, user_audit_info)
+
     render status: :ok, json: Presenters::V3::AppEnvironmentVariablesPresenter.new(app)
   end
 

--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -32,6 +32,7 @@ require 'fetchers/app_builds_list_fetcher'
 require 'fetchers/app_fetcher'
 require 'fetchers/app_delete_fetcher'
 require 'fetchers/assign_current_droplet_fetcher'
+require 'repositories/app_event_repository'
 
 class AppsV3Controller < ApplicationController
   def index
@@ -244,6 +245,8 @@ class AppsV3Controller < ApplicationController
     unauthorized! unless permission_queryer.can_read_secrets_in_space?(space.guid, org.guid)
 
     FeatureFlag.raise_unless_enabled!(:space_developer_env_var_visibility)
+
+    Repositories::AppEventRepository.new.record_app_show_env(app, user_audit_info)
 
     render status: :ok, json: Presenters::V3::AppEnvPresenter.new(app)
   end

--- a/app/controllers/v3/revisions_controller.rb
+++ b/app/controllers/v3/revisions_controller.rb
@@ -2,6 +2,7 @@ require 'messages/revisions_update_message'
 require 'actions/revisions_update'
 require 'presenters/v3/revision_presenter'
 require 'presenters/v3/revision_environment_variables_presenter'
+require 'repositories/revision_event_repository'
 
 class RevisionsController < ApplicationController
   def show
@@ -22,6 +23,7 @@ class RevisionsController < ApplicationController
 
   def show_environment_variables
     revision = fetch_revision(hashed_params[:revision_guid], needs_secrets_read_permission: true)
+    Repositories::RevisionEventRepository.record_show_environment_variables(revision, revision.app, user_audit_info)
     render status: :ok, json: Presenters::V3::RevisionEnvironmentVariablesPresenter.new(revision)
   end
 

--- a/app/repositories/app_event_repository.rb
+++ b/app/repositories/app_event_repository.rb
@@ -160,6 +160,11 @@ module VCAP::CloudController
         create_app_audit_event('audit.app.environment.show', app, app.space, actor_hash, {})
       end
 
+      def record_app_show_environment_variables(app, user_audit_info)
+        actor_hash = { name: user_audit_info.user_email, guid: user_audit_info.user_guid, user_name: user_audit_info.user_name, type: 'user' }
+        create_app_audit_event('audit.app.environment_variables.show', app, app.space, actor_hash, {})
+      end
+
       private
 
       def create_app_audit_event(type, app, space, actor, metadata)

--- a/app/repositories/app_event_repository.rb
+++ b/app/repositories/app_event_repository.rb
@@ -155,6 +155,11 @@ module VCAP::CloudController
         create_app_audit_event('audit.app.ssh-authorized', app, app.space, actor_hash, { index: index })
       end
 
+      def record_app_show_env(app, user_audit_info)
+        actor_hash = { name: user_audit_info.user_email, guid: user_audit_info.user_guid, user_name: user_audit_info.user_name, type: 'user' }
+        create_app_audit_event('audit.app.environment.show', app, app.space, actor_hash, {})
+      end
+
       private
 
       def create_app_audit_event(type, app, space, actor, metadata)

--- a/app/repositories/revision_event_repository.rb
+++ b/app/repositories/revision_event_repository.rb
@@ -22,6 +22,26 @@ module VCAP::CloudController
           organization_guid: app.space.organization_guid,
         )
       end
+
+      def self.record_show_environment_variables(revision, app, user_audit_info)
+        Event.create(
+          type:              'audit.app.revision.environment_variables.show',
+          actor:             user_audit_info.user_guid,
+          actor_type:        'user',
+          actor_name:        user_audit_info.user_email,
+          actor_username:    user_audit_info.user_name,
+          actee:             app.guid,
+          actee_type:        'app',
+          actee_name:        app.name,
+          timestamp:         Sequel::CURRENT_TIMESTAMP,
+          metadata:          {
+            revision_guid: revision.guid,
+            revision_version: revision.version
+          },
+          space_guid:        app.space_guid,
+          organization_guid: app.space.organization_guid,
+        )
+      end
     end
   end
 end

--- a/spec/unit/controllers/v3/apps_controller_spec.rb
+++ b/spec/unit/controllers/v3/apps_controller_spec.rb
@@ -1718,7 +1718,7 @@ RSpec.describe AppsV3Controller, type: :controller do
     let(:user) { VCAP::CloudController::User.make }
 
     before do
-      set_current_user(user)
+      set_current_user(user, email: 'mona@example.com')
       allow_user_read_access_for(user, spaces: [space])
       allow_user_write_access(user, space: space)
       allow_user_secret_access(user, space: space)
@@ -1730,6 +1730,25 @@ RSpec.describe AppsV3Controller, type: :controller do
 
       expect(response.status).to eq 200
       expect(parsed_body['environment_variables']).to eq(app_model.environment_variables)
+    end
+
+    it 'records an audit event' do
+      expect {
+        get :show_env, params: { guid: app_model.guid }
+      }.to change { VCAP::CloudController::Event.count }.by(1)
+
+      event = VCAP::CloudController::Event.find(type: 'audit.app.environment.show')
+      expect(event).not_to be_nil
+      expect(event.actor).to eq(user.guid)
+      expect(event.actor_type).to eq('user')
+      expect(event.actor_name).to eq('mona@example.com')
+      expect(event.actee).to eq(app_model.guid)
+      expect(event.actee_type).to eq('app')
+      expect(event.actee_name).to eq(app_model.name)
+      expect(event.timestamp).to be
+      expect(event.space_guid).to eq(app_model.space_guid)
+      expect(event.organization_guid).to eq(app_model.space.organization.guid)
+      expect(event.metadata).to eq({})
     end
 
     context 'permissions' do


### PR DESCRIPTION
### A short explanation of the proposed change:

Add two audit events:
- `audit.app.show-env`
- `audit.app.revision.show-environment-variables`

Environment variables frequently contain sensitive information, and so we should audit access, even when viewing.

### An explanation of the use cases your change solves

As a security analyst,
I want to audit when developers access environment variables,
so that I can hold them to account

As an operator,
I want to record access to environment variables,
so my users can hold me to account

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
