### PR TITLE
v3(services): test order_by for services resources

### DIFF
--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -15,7 +15,7 @@ class ServiceCredentialBindingsController < ApplicationController
 
     presenter = Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::ServiceCredentialBindingPresenter,
-      paginated_result: SequelPaginator.new.get_page(results, pagination_options),
+      paginated_result: SequelPaginator.new.get_page(results, message.try(:pagination_options)),
       path: '/v3' + service_credential_bindings_path,
       message: message,
       decorators: decorators(message)

--- a/app/messages/apps_list_message.rb
+++ b/app/messages/apps_list_message.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
     validates :stacks, array: true, allow_nil: true
 
     def valid_order_by_values
-      super << :name
+      super + [:name]
     end
 
     def self.from_params(params)

--- a/app/messages/isolation_segments_list_message.rb
+++ b/app/messages/isolation_segments_list_message.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
     end
 
     def valid_order_by_values
-      super << :name
+      super + [:name]
     end
   end
 end

--- a/app/messages/orgs_list_message.rb
+++ b/app/messages/orgs_list_message.rb
@@ -22,7 +22,7 @@ module VCAP::CloudController
     end
 
     def valid_order_by_values
-      super << :name
+      super + [:name]
     end
   end
 end

--- a/app/messages/service_brokers_list_message.rb
+++ b/app/messages/service_brokers_list_message.rb
@@ -14,7 +14,7 @@ module VCAP::CloudController
     validates :names, array: true, allow_nil: true
 
     def valid_order_by_values
-      super << :name
+      super + [:name]
     end
 
     def self.from_params(params)

--- a/app/messages/service_credential_bindings_list_message.rb
+++ b/app/messages/service_credential_bindings_list_message.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
     end
 
     def valid_order_by_values
-      super << :name
+      super + [:name]
     end
   end
 end

--- a/app/messages/service_credential_bindings_list_message.rb
+++ b/app/messages/service_credential_bindings_list_message.rb
@@ -24,5 +24,9 @@ module VCAP::CloudController
     def self.from_params(params)
       super(params, ARRAY_KEYS.map(&:to_s))
     end
+
+    def valid_order_by_values
+      super << :name
+    end
   end
 end

--- a/app/messages/service_instances_list_message.rb
+++ b/app/messages/service_instances_list_message.rb
@@ -43,7 +43,7 @@ module VCAP::CloudController
     end
 
     def valid_order_by_values
-      super << :name
+      super + [:name]
     end
   end
 end

--- a/app/messages/service_plans_list_message.rb
+++ b/app/messages/service_plans_list_message.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
     }
 
     def valid_order_by_values
-      super << :name
+      super + [:name]
     end
 
     def self.from_params(params)

--- a/app/messages/service_plans_list_message.rb
+++ b/app/messages/service_plans_list_message.rb
@@ -32,6 +32,10 @@ module VCAP::CloudController
       }
     }
 
+    def valid_order_by_values
+      super << :name
+    end
+
     def self.from_params(params)
       super(params, @array_keys.map(&:to_s), fields: %w(fields))
     end

--- a/app/messages/spaces_list_message.rb
+++ b/app/messages/spaces_list_message.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController
     end
 
     def valid_order_by_values
-      super << :name
+      super + [:name]
     end
   end
 end

--- a/app/messages/stacks_list_message.rb
+++ b/app/messages/stacks_list_message.rb
@@ -15,7 +15,7 @@ module VCAP::CloudController
     end
 
     def valid_order_by_values
-      super << :name
+      super + [:name]
     end
   end
 end

--- a/docs/v3/source/includes/resources/service_plans/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_plans/_list.md.erb
@@ -43,7 +43,7 @@ Name | Type | Description
 **include** | _list of strings_ | Optionally include a list of unique related resources in the response; <br>valid values are `space.organization` and `service_offering`
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
-**order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at` and `updated_at`
+**order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`
 **label_selector** (*experimental*)| _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **fields** (*experimental*)| [_fields parameter_](#fields-parameter) | [_Allowed values_](#service-plans-list-fields)
 

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'V3 service brokers' do
     end
 
     it_behaves_like 'paginated response', '/v3/service_brokers' do
-      let!(:resources) { (0..1).collect { VCAP::CloudController::ServiceBroker.make } }
+      let!(:resources) { Array.new(2) { VCAP::CloudController::ServiceBroker.make } }
     end
 
     it_behaves_like 'request_spec_shared_examples.rb list query endpoint' do

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -20,56 +20,56 @@ RSpec.describe 'V3 service brokers' do
   }
   let(:global_broker_request_body) do
     {
-        name: 'broker name',
-        url: 'http://example.org/broker-url',
-        authentication: {
-            type: 'basic',
-            credentials: {
-                username: 'admin',
-                password: 'welcome',
-            }
-        },
-        metadata: {
-            labels: { potato: 'yam' },
-            annotations: { style: 'mashed' }
+      name: 'broker name',
+      url: 'http://example.org/broker-url',
+      authentication: {
+        type: 'basic',
+        credentials: {
+          username: 'admin',
+          password: 'welcome',
         }
+      },
+      metadata: {
+        labels: { potato: 'yam' },
+        annotations: { style: 'mashed' }
+      }
     }
   end
 
   let(:global_broker_with_identical_name_body) {
     {
-        name: global_broker_request_body[:name],
-        url: 'http://example.org/different-broker-url',
-        authentication: global_broker_request_body[:authentication]
+      name: global_broker_request_body[:name],
+      url: 'http://example.org/different-broker-url',
+      authentication: global_broker_request_body[:authentication]
     }
   }
 
   let(:global_broker_with_identical_url_body) {
     {
-        name: 'different broker name',
-        url: global_broker_request_body[:url],
-        authentication: global_broker_request_body[:authentication]
+      name: 'different broker name',
+      url: global_broker_request_body[:url],
+      authentication: global_broker_request_body[:authentication]
     }
   }
 
   let(:space_scoped_broker_request_body) do
     {
-        name: 'space-scoped broker name',
-        url: 'http://example.org/space-broker-url',
-        authentication: {
-            type: 'basic',
-            credentials: {
-                username: 'admin',
-                password: 'welcome',
-            },
+      name: 'space-scoped broker name',
+      url: 'http://example.org/space-broker-url',
+      authentication: {
+        type: 'basic',
+        credentials: {
+          username: 'admin',
+          password: 'welcome',
         },
-        relationships: {
-            space: {
-                data: {
-                    guid: space.guid
-                },
-            },
+      },
+      relationships: {
+        space: {
+          data: {
+            guid: space.guid
+          },
         },
+      },
     }
   end
 
@@ -106,11 +106,11 @@ RSpec.describe 'V3 service brokers' do
         {
           names: ['foo', 'bar'],
           space_guids: ['foo', 'bar'],
-          per_page:   '10',
+          per_page: '10',
           page: 2,
-          order_by:   'updated_at',
+          order_by: 'updated_at',
           label_selector: 'foo==bar',
-          created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
+          created_ats: "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
           updated_ats: { gt: Time.now.utc.iso8601 },
         }
       end
@@ -132,10 +132,10 @@ RSpec.describe 'V3 service brokers' do
     context 'when there are global service brokers' do
       let(:global_broker_request_body_v2) do
         {
-            name: 'v2 broker name',
-            broker_url: 'http://example.org/broker-url-v2',
-            auth_username: 'admin',
-            auth_password: 'welcome'
+          name: 'v2 broker name',
+          broker_url: 'http://example.org/broker-url-v2',
+          auth_username: 'admin',
+          auth_password: 'welcome'
         }
       end
 
@@ -149,40 +149,40 @@ RSpec.describe 'V3 service brokers' do
 
       let(:broker_created_with_v3_json) do
         {
-            guid: global_service_broker_v3.guid,
-            name: global_service_broker_v3.name,
-            url: global_service_broker_v3.broker_url,
-            created_at: iso8601,
-            updated_at: iso8601,
-            relationships: {},
-            links: {
-              self: {
-                href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{global_service_broker_v3.guid})
-              },
-              service_offerings: {
-                href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{global_service_broker_v3.guid})
-              },
+          guid: global_service_broker_v3.guid,
+          name: global_service_broker_v3.name,
+          url: global_service_broker_v3.broker_url,
+          created_at: iso8601,
+          updated_at: iso8601,
+          relationships: {},
+          links: {
+            self: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{global_service_broker_v3.guid})
             },
-            metadata: { labels: { potato: 'yam' }, annotations: { style: 'mashed' } }
+            service_offerings: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{global_service_broker_v3.guid})
+            },
+          },
+          metadata: { labels: { potato: 'yam' }, annotations: { style: 'mashed' } }
         }
       end
       let(:broker_created_with_v2_json) do
         {
-            guid: global_service_broker_v2.guid,
-            name: global_service_broker_v2.name,
-            url: global_service_broker_v2.broker_url,
-            created_at: iso8601,
-            updated_at: iso8601,
-            relationships: {},
-            links: {
-              self: {
-                href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{global_service_broker_v2.guid})
-              },
-              service_offerings: {
-                href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{global_service_broker_v2.guid})
-              },
+          guid: global_service_broker_v2.guid,
+          name: global_service_broker_v2.name,
+          url: global_service_broker_v2.broker_url,
+          created_at: iso8601,
+          updated_at: iso8601,
+          relationships: {},
+          links: {
+            self: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{global_service_broker_v2.guid})
             },
-            metadata: { labels: {}, annotations: {} }
+            service_offerings: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{global_service_broker_v2.guid})
+            },
+          },
+          metadata: { labels: {}, annotations: {} }
         }
       end
 
@@ -206,26 +206,26 @@ RSpec.describe 'V3 service brokers' do
       let!(:space_scoped_service_broker) { VCAP::CloudController::ServiceBroker.make(space: space) }
       let(:space_scoped_service_broker_json) do
         {
-            guid: space_scoped_service_broker.guid,
-            name: space_scoped_service_broker.name,
-            url: space_scoped_service_broker.broker_url,
-            created_at: iso8601,
-            updated_at: iso8601,
-            metadata: { labels: {}, annotations: {} },
-            relationships: {
-                space: { data: { guid: space.guid } }
+          guid: space_scoped_service_broker.guid,
+          name: space_scoped_service_broker.name,
+          url: space_scoped_service_broker.broker_url,
+          created_at: iso8601,
+          updated_at: iso8601,
+          metadata: { labels: {}, annotations: {} },
+          relationships: {
+            space: { data: { guid: space.guid } }
+          },
+          links: {
+            self: {
+              href: %r(#{Regexp.escape(link_prefix)}\/v3\/service_brokers\/#{space_scoped_service_broker.guid})
             },
-            links: {
-                self: {
-                    href: %r(#{Regexp.escape(link_prefix)}\/v3\/service_brokers\/#{space_scoped_service_broker.guid})
-                },
-                service_offerings: {
-                  href: %r(#{Regexp.escape(link_prefix)}\/v3\/service_offerings\?service_broker_guids=#{space_scoped_service_broker.guid})
-                },
-                space: {
-                    href: %r(#{Regexp.escape(link_prefix)}\/v3\/spaces\/#{space.guid})
-                }
+            service_offerings: {
+              href: %r(#{Regexp.escape(link_prefix)}\/v3\/service_offerings\?service_broker_guids=#{space_scoped_service_broker.guid})
+            },
+            space: {
+              href: %r(#{Regexp.escape(link_prefix)}\/v3\/spaces\/#{space.guid})
             }
+          }
         }
       end
       let(:expected_codes_and_responses) do
@@ -235,19 +235,19 @@ RSpec.describe 'V3 service brokers' do
         )
 
         h['admin'] = {
-              code: 200,
-              response_objects: [space_scoped_service_broker_json]
+          code: 200,
+          response_objects: [space_scoped_service_broker_json]
         }
         h['admin_read_only'] = {
-              code: 200,
-              response_objects: [space_scoped_service_broker_json]
+          code: 200,
+          response_objects: [space_scoped_service_broker_json]
         }
         h['global_auditor'] = {
-              code: 200,
-              response_objects: [space_scoped_service_broker_json]
+          code: 200,
+          response_objects: [space_scoped_service_broker_json]
         }
         h['space_developer'] = { code: 200,
-              response_objects: [space_scoped_service_broker_json]
+          response_objects: [space_scoped_service_broker_json]
         }
 
         h
@@ -348,21 +348,21 @@ RSpec.describe 'V3 service brokers' do
 
       let(:global_service_broker_v3_json) do
         {
-            guid: global_service_broker_v3.guid,
-            name: global_service_broker_v3.name,
-            url: global_service_broker_v3.broker_url,
-            created_at: iso8601,
-            updated_at: iso8601,
-            metadata: { labels: {}, annotations: {} },
-            relationships: {},
-            links: {
-              self: {
-                href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{global_service_broker_v3.guid})
-              },
-              service_offerings: {
-                href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{global_service_broker_v3.guid})
-              },
-            }
+          guid: global_service_broker_v3.guid,
+          name: global_service_broker_v3.name,
+          url: global_service_broker_v3.broker_url,
+          created_at: iso8601,
+          updated_at: iso8601,
+          metadata: { labels: {}, annotations: {} },
+          relationships: {},
+          links: {
+            self: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{global_service_broker_v3.guid})
+            },
+            service_offerings: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{global_service_broker_v3.guid})
+            },
+          }
         }
       end
 
@@ -370,16 +370,16 @@ RSpec.describe 'V3 service brokers' do
         h = Hash.new(code: 404)
 
         h['admin'] = {
-            code: 200,
-            response_object: global_service_broker_v3_json
+          code: 200,
+          response_object: global_service_broker_v3_json
         }
         h['admin_read_only'] = {
-            code: 200,
-            response_object: global_service_broker_v3_json
+          code: 200,
+          response_object: global_service_broker_v3_json
         }
         h['global_auditor'] = {
-            code: 200,
-            response_object: global_service_broker_v3_json
+          code: 200,
+          response_object: global_service_broker_v3_json
         }
 
         h
@@ -394,46 +394,46 @@ RSpec.describe 'V3 service brokers' do
 
       let(:space_scoped_service_broker_json) do
         {
-            guid: space_scoped_service_broker.guid,
-            name: space_scoped_service_broker.name,
-            url: space_scoped_service_broker.broker_url,
-            created_at: iso8601,
-            updated_at: iso8601,
-            metadata: { labels: {}, annotations: {} },
-            relationships: {
-                space: { data: { guid: space.guid } }
+          guid: space_scoped_service_broker.guid,
+          name: space_scoped_service_broker.name,
+          url: space_scoped_service_broker.broker_url,
+          created_at: iso8601,
+          updated_at: iso8601,
+          metadata: { labels: {}, annotations: {} },
+          relationships: {
+            space: { data: { guid: space.guid } }
+          },
+          links: {
+            self: {
+              href: %r(#{Regexp.escape(link_prefix)}\/v3\/service_brokers\/#{space_scoped_service_broker.guid})
             },
-            links: {
-                self: {
-                    href: %r(#{Regexp.escape(link_prefix)}\/v3\/service_brokers\/#{space_scoped_service_broker.guid})
-                },
-                service_offerings: {
-                  href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{space_scoped_service_broker.guid})
-                },
-               space: {
-                    href: %r(#{Regexp.escape(link_prefix)}\/v3\/spaces\/#{space.guid})
-                }
+            service_offerings: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{space_scoped_service_broker.guid})
+            },
+            space: {
+              href: %r(#{Regexp.escape(link_prefix)}\/v3\/spaces\/#{space.guid})
             }
+          }
         }
       end
       let(:expected_codes_and_responses) do
         h = Hash.new(code: 404)
 
         h['admin'] = {
-            code: 200,
-            response_object: space_scoped_service_broker_json
+          code: 200,
+          response_object: space_scoped_service_broker_json
         }
         h['admin_read_only'] = {
-            code: 200,
-            response_object: space_scoped_service_broker_json
+          code: 200,
+          response_object: space_scoped_service_broker_json
         }
         h['global_auditor'] = {
-            code: 200,
-            response_object: space_scoped_service_broker_json
+          code: 200,
+          response_object: space_scoped_service_broker_json
         }
         h['space_developer'] = {
-            code: 200,
-            response_object: space_scoped_service_broker_json
+          code: 200,
+          response_object: space_scoped_service_broker_json
         }
 
         h
@@ -454,19 +454,19 @@ RSpec.describe 'V3 service brokers' do
 
     let(:update_request_body) {
       {
-          name: 'new-name',
-          url: 'http://example.org/new-broker-url',
-          authentication: {
-              type: 'basic',
-              credentials: {
-                  username: 'new-admin',
-                  password: 'now-welcome',
-              }
-          },
-          metadata: {
-              labels: { potato: 'sweet' },
-              annotations: { style: 'mashed', amount: 'all' }
+        name: 'new-name',
+        url: 'http://example.org/new-broker-url',
+        authentication: {
+          type: 'basic',
+          credentials: {
+            username: 'new-admin',
+            password: 'now-welcome',
           }
+        },
+        metadata: {
+          labels: { potato: 'sweet' },
+          annotations: { style: 'mashed', amount: 'all' }
+        }
       }
     }
 
@@ -611,14 +611,14 @@ RSpec.describe 'V3 service brokers' do
           job_url = last_response['Location']
           get job_url, {}, admin_headers
           expect(parsed_response).to include({
-              'state' => 'COMPLETE',
-              'operation' => 'service_broker.update',
-              'errors' => [],
-              'warnings' => [
-                include({
-                    'detail' => include('Warning: This broker includes configuration for a dashboard client.'),
-                })
-              ],
+            'state' => 'COMPLETE',
+            'operation' => 'service_broker.update',
+            'errors' => [],
+            'warnings' => [
+              include({
+                'detail' => include('Warning: This broker includes configuration for a dashboard client.'),
+              })
+            ],
           })
         end
       end
@@ -656,20 +656,20 @@ RSpec.describe 'V3 service brokers' do
           job_url = last_response['Location']
           get job_url, {}, admin_headers
           expect(parsed_response).to include({
-              'state' => 'COMPLETE',
-              'operation' => 'service_broker.update',
-              'errors' => [],
-              'warnings' => [
-                include({
-                    'detail' => include(
-                      'Warning: Service plans are missing from the broker\'s catalog ' \
+            'state' => 'COMPLETE',
+            'operation' => 'service_broker.update',
+            'errors' => [],
+            'warnings' => [
+              include({
+                'detail' => include(
+                  'Warning: Service plans are missing from the broker\'s catalog ' \
                   '(http://example.org/broker-url/v2/catalog) but can not be removed from Cloud Foundry while instances exist.' \
                   ' The plans have been deactivated to prevent users from attempting to provision new instances of these plans.' \
                   ' The broker should continue to support bind, unbind, and delete for existing instances; if these operations' \
                   " fail contact your broker provider.\n\nService Offering: service_name-1\nPlans deactivated: plan_name-1\n"
-                    ),
-                })
-              ],
+                ),
+              })
+            ],
           })
         end
       end
@@ -702,21 +702,21 @@ RSpec.describe 'V3 service brokers' do
   describe 'POST /v3/service_brokers' do
     let(:global_service_broker) do
       {
-          guid: UUID_REGEX,
-          name: 'broker name',
-          url: 'http://example.org/broker-url',
-          created_at: iso8601,
-          updated_at: iso8601,
-          metadata: { labels: { potato: 'yam' }, annotations: { style: 'mashed' } },
-          relationships: {},
-          links: {
-            self: {
-              href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{UUID_REGEX})
-            },
-            service_offerings: {
-              href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{UUID_REGEX})
-            },
-          }
+        guid: UUID_REGEX,
+        name: 'broker name',
+        url: 'http://example.org/broker-url',
+        created_at: iso8601,
+        updated_at: iso8601,
+        metadata: { labels: { potato: 'yam' }, annotations: { style: 'mashed' } },
+        relationships: {},
+        links: {
+          self: {
+            href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{UUID_REGEX})
+          },
+          service_offerings: {
+            href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{UUID_REGEX})
+          },
+        }
       }
     end
 
@@ -787,17 +787,17 @@ RSpec.describe 'V3 service brokers' do
 
       event = VCAP::CloudController::Event.where({ type: 'audit.service_broker.create', actor_name: admin_headers._generated_email }).first
       expect(event.metadata).to include({
-          'request' => include({
-              'name' => 'broker name',
-              'url' => 'http://example.org/broker-url',
-              'authentication' => {
-                  'type' => 'basic',
-                  'credentials' => {
-                      'username' => 'admin',
-                      'password' => '[PRIVATE DATA HIDDEN]'
-                  }
-              }
-          })
+        'request' => include({
+          'name' => 'broker name',
+          'url' => 'http://example.org/broker-url',
+          'authentication' => {
+            'type' => 'basic',
+            'credentials' => {
+              'username' => 'admin',
+              'password' => '[PRIVATE DATA HIDDEN]'
+            }
+          }
+        })
       })
     end
 
@@ -839,26 +839,26 @@ RSpec.describe 'V3 service brokers' do
     context 'space-scoped service broker' do
       let(:space_scoped_service_broker) do
         {
-            guid: UUID_REGEX,
-            name: 'space-scoped broker name',
-            url: 'http://example.org/space-broker-url',
-            created_at: iso8601,
-            updated_at: iso8601,
-            metadata: { labels: {}, annotations: {} },
-            relationships: {
-                space: { data: { guid: space.guid } }
+          guid: UUID_REGEX,
+          name: 'space-scoped broker name',
+          url: 'http://example.org/space-broker-url',
+          created_at: iso8601,
+          updated_at: iso8601,
+          metadata: { labels: {}, annotations: {} },
+          relationships: {
+            space: { data: { guid: space.guid } }
+          },
+          links: {
+            self: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{UUID_REGEX})
             },
-            links: {
-                self: {
-                    href: %r(#{Regexp.escape(link_prefix)}/v3/service_brokers/#{UUID_REGEX})
-                },
-                service_offerings: {
-                  href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{UUID_REGEX})
-                },
-                space: {
-                    href: %r(#{Regexp.escape(link_prefix)}/v3/spaces/#{space.guid})
-                }
+            service_offerings: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/service_offerings\?service_broker_guids=#{UUID_REGEX})
+            },
+            space: {
+              href: %r(#{Regexp.escape(link_prefix)}/v3/spaces/#{space.guid})
             }
+          }
         }
       end
 
@@ -930,14 +930,14 @@ RSpec.describe 'V3 service brokers' do
           job_url = last_response['Location']
           get job_url, {}, admin_headers
           expect(parsed_response).to include({
-              'state' => 'COMPLETE',
-              'operation' => 'service_broker.catalog.synchronize',
-              'errors' => [],
-              'warnings' => [
-                include({
-                    'detail' => include('Warning: This broker includes configuration for a dashboard client.'),
-                })
-              ],
+            'state' => 'COMPLETE',
+            'operation' => 'service_broker.catalog.synchronize',
+            'errors' => [],
+            'warnings' => [
+              include({
+                'detail' => include('Warning: This broker includes configuration for a dashboard client.'),
+              })
+            ],
           })
         end
       end
@@ -1023,15 +1023,15 @@ RSpec.describe 'V3 service brokers' do
             include(
               'code' => 270012,
               'detail' => "Service broker catalog is invalid: \nService service_name-1\n  Service dashboard client id must be unique\n"
-              )
+            )
           ],
           'links' => {
-              'self' => {
-                  'href' => match(%r(http.+/v3/jobs/#{job.guid}))
-              },
-              'service_brokers' => {
-                  'href' => match(%r(http.+/v3/service_brokers/[^/]+))
-              }
+            'self' => {
+              'href' => match(%r(http.+/v3/jobs/#{job.guid}))
+            },
+            'service_brokers' => {
+              'href' => match(%r(http.+/v3/service_brokers/[^/]+))
+            }
           }
         )
       end
@@ -1040,7 +1040,7 @@ RSpec.describe 'V3 service brokers' do
     context 'when user provides a malformed request' do
       let(:malformed_body) do
         {
-            whatever: 'oopsie'
+          whatever: 'oopsie'
         }
       end
 
@@ -1092,22 +1092,22 @@ RSpec.describe 'V3 service brokers' do
     context 'when a space is provided that the user cannot read' do
       let(:other_space_broker_body) do
         {
-            name: 'space-scoped broker name',
-            url: 'http://example.org/space-broker-url',
-            authentication: {
-                type: 'basic',
-                credentials: {
-                    username: 'admin',
-                    password: 'welcome',
-                },
+          name: 'space-scoped broker name',
+          url: 'http://example.org/space-broker-url',
+          authentication: {
+            type: 'basic',
+            credentials: {
+              username: 'admin',
+              password: 'welcome',
             },
-            relationships: {
-                space: {
-                    data: {
-                        guid: VCAP::CloudController::Space.make.guid
-                    },
-                },
+          },
+          relationships: {
+            space: {
+              data: {
+                guid: VCAP::CloudController::Space.make.guid
+              },
             },
+          },
         }
       end
 
@@ -1240,7 +1240,7 @@ RSpec.describe 'V3 service brokers' do
       end
 
       context 'space-scoped broker' do
-        let(:broker) {  VCAP::CloudController::ServiceBroker.make(space_id: space.id) }
+        let(:broker) { VCAP::CloudController::ServiceBroker.make(space_id: space.id) }
 
         it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
           let(:expected_codes_and_responses) {
@@ -1268,8 +1268,8 @@ RSpec.describe 'V3 service brokers' do
             get job_url, {}, admin_headers
             expect(last_response).to have_status_code(200)
             expect(parsed_response).to include({
-                'state' => 'PROCESSING',
-                'operation' => 'service_broker.delete'
+              'state' => 'PROCESSING',
+              'operation' => 'service_broker.delete'
             })
           end
 
@@ -1294,8 +1294,8 @@ RSpec.describe 'V3 service brokers' do
             get job_url, {}, admin_headers
             expect(last_response).to have_status_code(200)
             expect(parsed_response).to include({
-                'state' => 'COMPLETE',
-                'operation' => 'service_broker.delete'
+              'state' => 'COMPLETE',
+              'operation' => 'service_broker.delete'
             })
           end
 
@@ -1304,19 +1304,19 @@ RSpec.describe 'V3 service brokers' do
             expect(VCAP::CloudController::ServiceDashboardClient.find_client_by_uaa_id(uaa_client_id)).to be_nil
 
             expect(a_request(:post, 'https://uaa.service.cf.internal/oauth/clients/tx/modify').
-                with(
-                  body: [
-                    {
-                          "client_id": uaa_client_id,
-                          "client_secret": nil,
-                          "redirect_uri": nil,
-                          "scope": %w(openid cloud_controller_service_permissions.read),
-                          "authorities": ['uaa.resource'],
-                          "authorized_grant_types": ['authorization_code'],
-                          "action": 'delete'
-                      }
-                  ].to_json
-                )).to have_been_made
+              with(
+                body: [
+                  {
+                    "client_id": uaa_client_id,
+                    "client_secret": nil,
+                    "redirect_uri": nil,
+                    "scope": %w(openid cloud_controller_service_permissions.read),
+                    "authorities": ['uaa.resource'],
+                    "authorized_grant_types": ['authorization_code'],
+                    "action": 'delete'
+                  }
+                ].to_json
+              )).to have_been_made
           end
 
           it 'emits service and plan deletion events, and broker deletion event' do
@@ -1356,9 +1356,9 @@ RSpec.describe 'V3 service brokers' do
           get job_url, {}, admin_headers
           expect(last_response).to have_status_code(200)
           expect(parsed_response).to include({
-              'state' => 'FAILED',
-              'operation' => 'service_broker.delete',
-              'errors' => [include({ 'detail' => include('An unknown error occurred') })]
+            'state' => 'FAILED',
+            'operation' => 'service_broker.delete',
+            'errors' => [include({ 'detail' => include('An unknown error occurred') })]
           })
         end
 
@@ -1435,99 +1435,99 @@ RSpec.describe 'V3 service brokers' do
     stub_request(:get, "https://uaa.service.cf.internal/oauth/clients/#{broker_id}-uaa-id").
       to_return(
         { status: 404, body: {}.to_json, headers: { 'Content-Type' => 'application/json' } },
-            { status: 200, body: { client_id: dashboard_client(broker_id)['id'] }.to_json, headers: { 'Content-Type' => 'application/json' } }
-        )
+        { status: 200, body: { client_id: dashboard_client(broker_id)['id'] }.to_json, headers: { 'Content-Type' => 'application/json' } }
+      )
 
     stub_request(:post, 'https://uaa.service.cf.internal/oauth/clients/tx/modify').
       with(
         body: [
           {
-                "client_id": "#{broker_id}-uaa-id",
-                "client_secret": 'my-dashboard-secret',
-                "redirect_uri": 'http://example.org',
-                "scope": %w(openid cloud_controller_service_permissions.read),
-                "authorities": ['uaa.resource'],
-                "authorized_grant_types": ['authorization_code'],
-                "action": 'add'
-            }
+            "client_id": "#{broker_id}-uaa-id",
+            "client_secret": 'my-dashboard-secret',
+            "redirect_uri": 'http://example.org',
+            "scope": %w(openid cloud_controller_service_permissions.read),
+            "authorities": ['uaa.resource'],
+            "authorized_grant_types": ['authorization_code'],
+            "action": 'add'
+          }
         ].to_json
-        ).
+      ).
       to_return(status: 201, body: {}.to_json, headers: { 'Content-Type' => 'application/json' })
 
     stub_request(:post, 'https://uaa.service.cf.internal/oauth/clients/tx/modify').
       with(
         body: [
           {
-                "client_id": "#{broker_id}-uaa-id",
-                "client_secret": nil,
-                "redirect_uri": nil,
-                "scope": %w(openid cloud_controller_service_permissions.read),
-                "authorities": ['uaa.resource'],
-                "authorized_grant_types": ['authorization_code'],
-                "action": 'delete'
-            }
+            "client_id": "#{broker_id}-uaa-id",
+            "client_secret": nil,
+            "redirect_uri": nil,
+            "scope": %w(openid cloud_controller_service_permissions.read),
+            "authorities": ['uaa.resource'],
+            "authorized_grant_types": ['authorization_code'],
+            "action": 'delete'
+          }
         ].to_json
-        ).
+      ).
       to_return(status: 200, body: {}.to_json, headers: { 'Content-Type' => 'application/json' })
 
     stub_request(:post, 'https://uaa.service.cf.internal/oauth/clients/tx/modify').
       with(
         body: [
           {
-                "client_id": "#{broker_id}-uaa-id",
-                "client_secret": 'my-dashboard-secret',
-                "redirect_uri": 'http://example.org',
-                "scope": %w(openid cloud_controller_service_permissions.read),
-                "authorities": ['uaa.resource'],
-                "authorized_grant_types": ['authorization_code'],
-                "action": 'update,secret'
-            }
+            "client_id": "#{broker_id}-uaa-id",
+            "client_secret": 'my-dashboard-secret',
+            "redirect_uri": 'http://example.org',
+            "scope": %w(openid cloud_controller_service_permissions.read),
+            "authorities": ['uaa.resource'],
+            "authorized_grant_types": ['authorization_code'],
+            "action": 'update,secret'
+          }
         ].to_json
-        )
+      )
   end
 
-  def catalog(id=global_broker_id)
+  def catalog(id = global_broker_id)
     {
-        'services' => [
-          {
-              'id' => "#{id}-1",
-              'name' => 'service_name-1',
-              'description' => 'some description 1',
-              'bindable' => true,
-              'plans' => [
-                {
-                      'id' => 'fake_plan_id-1',
-                      'name' => 'plan_name-1',
-                      'description' => 'fake_plan_description 1',
-                      'schemas' => nil
-                  }
-              ],
-              'dashboard_client' => dashboard_client(id)
-          },
-          {
-              'id' => "#{id}-2",
-              'name' => 'route_volume_service_name-2',
-              'requires' => ['volume_mount', 'route_forwarding'],
-              'description' => 'some description 2',
-              'bindable' => true,
-              'plans' => [
-                {
-                    'id' => 'fake_plan_id-2',
-                    'name' => 'plan_name-2',
-                    'description' => 'fake_plan_description 2',
-                    'schemas' => nil
-                }
-              ]
-          },
-        ]
+      'services' => [
+        {
+          'id' => "#{id}-1",
+          'name' => 'service_name-1',
+          'description' => 'some description 1',
+          'bindable' => true,
+          'plans' => [
+            {
+              'id' => 'fake_plan_id-1',
+              'name' => 'plan_name-1',
+              'description' => 'fake_plan_description 1',
+              'schemas' => nil
+            }
+          ],
+          'dashboard_client' => dashboard_client(id)
+        },
+        {
+          'id' => "#{id}-2",
+          'name' => 'route_volume_service_name-2',
+          'requires' => ['volume_mount', 'route_forwarding'],
+          'description' => 'some description 2',
+          'bindable' => true,
+          'plans' => [
+            {
+              'id' => 'fake_plan_id-2',
+              'name' => 'plan_name-2',
+              'description' => 'fake_plan_description 2',
+              'schemas' => nil
+            }
+          ]
+        },
+      ]
     }
   end
 
-  def dashboard_client(id=global_broker_id)
+  def dashboard_client(id = global_broker_id)
     {
-        'id' => "#{id}-uaa-id",
-        'secret' => 'my-dashboard-secret',
-        'redirect_uri' => 'http://example.org'
+      'id' => "#{id}-uaa-id",
+      'secret' => 'my-dashboard-secret',
+      'redirect_uri' => 'http://example.org'
     }
   end
 
@@ -1538,9 +1538,9 @@ RSpec.describe 'V3 service brokers' do
     plan.save
 
     request_body = {
-        name: 'my-service-instance',
-        space_guid: space.guid,
-        service_plan_guid: plan.guid
+      name: 'my-service-instance',
+      space_guid: space.guid,
+      service_plan_guid: plan.guid
     }
     # TODO: replace this with v3 once it's implemented
     post('/v2/service_instances', request_body.to_json, with)

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe 'V3 service instances' do
     end
 
     describe 'pagination' do
-      let!(:resources) { (0..2).collect { VCAP::CloudController::ServiceInstance.make } }
+      let!(:resources) { Array.new(2) { VCAP::CloudController::ServiceInstance.make } }
 
       it_behaves_like 'paginated response', '/v3/service_instances'
 

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe 'V3 service instances' do
           service_plan_guids: ['guid-1', 'guid-2'],
           service_plan_names: ['plan-1', 'plan-2'],
           fields: { 'space.organization' => 'name' },
-          created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
+          created_ats: "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
           updated_ats: { gt: Time.now.utc.iso8601 },
         }
       end
@@ -3581,10 +3581,10 @@ RSpec.describe 'V3 service instances' do
       it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:expected_response) do
           {
-             data: [{ guid: other_space.guid }],
-             links: {
-               self: { href: "#{link_prefix}/v3/service_instances/#{instance.guid}/relationships/shared_spaces" },
-             }
+            data: [{ guid: other_space.guid }],
+            links: {
+              self: { href: "#{link_prefix}/v3/service_instances/#{instance.guid}/relationships/shared_spaces" },
+            }
           }
         end
 

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -163,17 +163,7 @@ RSpec.describe 'V3 service instances' do
   describe 'GET /v3/service_instances' do
     let(:api_call) { lambda { |user_headers| get '/v3/service_instances', nil, user_headers } }
 
-    let!(:msi_1) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
-    let!(:msi_2) { VCAP::CloudController::ManagedServiceInstance.make(space: another_space) }
-    let!(:upsi_1) { VCAP::CloudController::UserProvidedServiceInstance.make(space: space) }
-    let!(:upsi_2) { VCAP::CloudController::UserProvidedServiceInstance.make(space: another_space) }
-    let!(:ssi) { VCAP::CloudController::ManagedServiceInstance.make(space: another_space) }
-
-    before do
-      ssi.add_shared_space(space)
-    end
-
-    describe 'list query parameters' do
+    it_behaves_like 'request_spec_shared_examples.rb list query endpoint' do
       let(:user_header) { admin_headers }
       let(:request) { 'v3/service_instances' }
       let(:message) { VCAP::CloudController::ServiceInstancesListMessage }
@@ -195,57 +185,11 @@ RSpec.describe 'V3 service instances' do
           updated_ats: { gt: Time.now.utc.iso8601 },
         }
       end
-
-      it_behaves_like 'request_spec_shared_examples.rb list query endpoint'
-    end
-
-    describe 'permissions' do
-      let(:all_instances) do
-        {
-          code: 200,
-          response_objects: [
-            create_managed_json(msi_1),
-            create_managed_json(msi_2),
-            create_user_provided_json(upsi_1),
-            create_user_provided_json(upsi_2),
-            create_managed_json(ssi),
-          ]
-        }
-      end
-
-      let(:space_instances) do
-        {
-          code: 200,
-          response_objects: [
-            create_managed_json(msi_1),
-            create_user_provided_json(upsi_1),
-            create_managed_json(ssi),
-          ]
-        }
-      end
-
-      let(:expected_codes_and_responses) do
-        h = Hash.new(
-          code: 200,
-          response_objects: []
-        )
-
-        h['admin'] = all_instances
-        h['admin_read_only'] = all_instances
-        h['global_auditor'] = all_instances
-        h['space_developer'] = space_instances
-        h['space_manager'] = space_instances
-        h['space_auditor'] = space_instances
-        h['org_manager'] = space_instances
-
-        h
-      end
-
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     describe 'pagination' do
-      let(:resources) { [msi_1, msi_2, upsi_1, upsi_2, ssi] }
+      let!(:resources) { (0..2).collect { VCAP::CloudController::ServiceInstance.make } }
+
       it_behaves_like 'paginated response', '/v3/service_instances'
 
       it_behaves_like 'paginated fields response', '/v3/service_instances', 'space', 'guid,name,relationships.organization'
@@ -253,226 +197,293 @@ RSpec.describe 'V3 service instances' do
       it_behaves_like 'paginated fields response', '/v3/service_instances', 'space.organization', 'name,guid'
     end
 
-    describe 'filters' do
-      it 'filters by name' do
-        get "/v3/service_instances?names=#{msi_1.name}", nil, admin_headers
-        check_filtered_instances(create_managed_json(msi_1))
+    describe 'order_by' do
+      it_behaves_like 'list endpoint order_by name', '/v3/service_instances' do
+        let(:resource_klass) { VCAP::CloudController::ServiceInstance }
       end
 
-      it 'filters by space guid' do
-        get "/v3/service_instances?space_guids=#{another_space.guid}", nil, admin_headers
-        check_filtered_instances(
-          create_managed_json(msi_2),
-          create_user_provided_json(upsi_2),
-          create_managed_json(ssi),
-        )
-      end
-
-      it 'filters by organization guids' do
-        get "/v3/service_instances?organization_guids=#{another_space.organization.guid}", nil, admin_headers
-        check_filtered_instances(
-          create_managed_json(msi_2),
-          create_user_provided_json(upsi_2),
-          create_managed_json(ssi),
-        )
-      end
-
-      it 'filters by label' do
-        VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'strawberry', service_instance: msi_1)
-        VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'raspberry', service_instance: msi_2)
-        VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'strawberry', service_instance: ssi)
-        VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'strawberry', service_instance: upsi_2)
-
-        get '/v3/service_instances?label_selector=fruit=strawberry', nil, admin_headers
-
-        check_filtered_instances(
-          create_managed_json(msi_1, labels: { fruit: 'strawberry' }),
-          create_user_provided_json(upsi_2, labels: { fruit: 'strawberry' }),
-          create_managed_json(ssi, labels: { fruit: 'strawberry' }),
-        )
-      end
-
-      it 'filters by type' do
-        get '/v3/service_instances?type=managed', nil, admin_headers
-        check_filtered_instances(
-          create_managed_json(msi_1),
-          create_managed_json(msi_2),
-          create_managed_json(ssi),
-        )
-      end
-
-      it 'filters by service_plan_guids' do
-        get "/v3/service_instances?service_plan_guids=#{msi_1.service_plan.guid},#{msi_2.service_plan.guid}", nil, admin_headers
-        check_filtered_instances(
-          create_managed_json(msi_1),
-          create_managed_json(msi_2)
-        )
-      end
-
-      it 'filters by service_plan_names' do
-        get "/v3/service_instances?service_plan_names=#{msi_1.service_plan.name},#{msi_2.service_plan.name}", nil, admin_headers
-        check_filtered_instances(
-          create_managed_json(msi_1),
-          create_managed_json(msi_2)
-        )
-      end
-
-      def check_filtered_instances(*instances)
-        expect(last_response).to have_status_code(200)
-        expect(parsed_response['resources'].length).to be(instances.length)
-        expect({ resources: parsed_response['resources'] }).to match_json_response(
-          { resources: instances }
-        )
+      it_behaves_like 'list endpoint order_by timestamps', '/v3/service_instances' do
+        let(:resource_klass) { VCAP::CloudController::ServiceInstance }
       end
     end
 
-    context 'fields' do
-      it 'can include the space and organization name and guid fields' do
-        get '/v3/service_instances?fields[space]=guid,name,relationships.organization&fields[space.organization]=name,guid', nil, admin_headers
-        expect(last_response).to have_status_code(200)
+    context 'given a mixture of managed, user-provided and shared service instances' do
+      let!(:msi_1) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
+      let!(:msi_2) { VCAP::CloudController::ManagedServiceInstance.make(space: another_space) }
+      let!(:upsi_1) { VCAP::CloudController::UserProvidedServiceInstance.make(space: space) }
+      let!(:upsi_2) { VCAP::CloudController::UserProvidedServiceInstance.make(space: another_space) }
+      let!(:ssi) { VCAP::CloudController::ManagedServiceInstance.make(space: another_space) }
 
-        included = {
-          spaces: [
-            {
-              guid: space.guid,
-              name: space.name,
-              relationships: {
-                organization: {
-                  data: {
-                    guid: space.organization.guid
-                  }
-                }
-              }
-            },
-            {
-              guid: another_space.guid,
-              name: another_space.name,
-              relationships: {
-                organization: {
-                  data: {
-                    guid: another_space.organization.guid
-                  }
-                }
-              }
-            }
-          ],
-          organizations: [
-            {
-              name: space.organization.name,
-              guid: space.organization.guid
-            },
-            {
-              name: another_space.organization.name,
-              guid: another_space.organization.guid
-            }
-          ]
-        }
-
-        expect({ included: parsed_response['included'] }).to match_json_response({ included: included })
+      before do
+        ssi.add_shared_space(space)
       end
 
-      it 'can include the service plan, offering and broker fields' do
-        get '/v3/service_instances?fields[service_plan]=guid,name,relationships.service_offering&' \
+      describe 'permissions' do
+        let(:all_instances) do
+          {
+            code: 200,
+            response_objects: [
+              create_managed_json(msi_1),
+              create_managed_json(msi_2),
+              create_user_provided_json(upsi_1),
+              create_user_provided_json(upsi_2),
+              create_managed_json(ssi),
+            ]
+          }
+        end
+
+        let(:space_instances) do
+          {
+            code: 200,
+            response_objects: [
+              create_managed_json(msi_1),
+              create_user_provided_json(upsi_1),
+              create_managed_json(ssi),
+            ]
+          }
+        end
+
+        let(:expected_codes_and_responses) do
+          h = Hash.new(
+            code: 200,
+            response_objects: []
+          )
+
+          h['admin'] = all_instances
+          h['admin_read_only'] = all_instances
+          h['global_auditor'] = all_instances
+          h['space_developer'] = space_instances
+          h['space_manager'] = space_instances
+          h['space_auditor'] = space_instances
+          h['org_manager'] = space_instances
+
+          h
+        end
+
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+      end
+
+      describe 'filters' do
+        it 'filters by name' do
+          get "/v3/service_instances?names=#{msi_1.name}", nil, admin_headers
+          check_filtered_instances(create_managed_json(msi_1))
+        end
+
+        it 'filters by space guid' do
+          get "/v3/service_instances?space_guids=#{another_space.guid}", nil, admin_headers
+          check_filtered_instances(
+            create_managed_json(msi_2),
+            create_user_provided_json(upsi_2),
+            create_managed_json(ssi),
+          )
+        end
+
+        it 'filters by organization guids' do
+          get "/v3/service_instances?organization_guids=#{another_space.organization.guid}", nil, admin_headers
+          check_filtered_instances(
+            create_managed_json(msi_2),
+            create_user_provided_json(upsi_2),
+            create_managed_json(ssi),
+          )
+        end
+
+        it 'filters by label' do
+          VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'strawberry', service_instance: msi_1)
+          VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'raspberry', service_instance: msi_2)
+          VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'strawberry', service_instance: ssi)
+          VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'strawberry', service_instance: upsi_2)
+
+          get '/v3/service_instances?label_selector=fruit=strawberry', nil, admin_headers
+
+          check_filtered_instances(
+            create_managed_json(msi_1, labels: { fruit: 'strawberry' }),
+            create_user_provided_json(upsi_2, labels: { fruit: 'strawberry' }),
+            create_managed_json(ssi, labels: { fruit: 'strawberry' }),
+          )
+        end
+
+        it 'filters by type' do
+          get '/v3/service_instances?type=managed', nil, admin_headers
+          check_filtered_instances(
+            create_managed_json(msi_1),
+            create_managed_json(msi_2),
+            create_managed_json(ssi),
+          )
+        end
+
+        it 'filters by service_plan_guids' do
+          get "/v3/service_instances?service_plan_guids=#{msi_1.service_plan.guid},#{msi_2.service_plan.guid}", nil, admin_headers
+          check_filtered_instances(
+            create_managed_json(msi_1),
+            create_managed_json(msi_2)
+          )
+        end
+
+        it 'filters by service_plan_names' do
+          get "/v3/service_instances?service_plan_names=#{msi_1.service_plan.name},#{msi_2.service_plan.name}", nil, admin_headers
+          check_filtered_instances(
+            create_managed_json(msi_1),
+            create_managed_json(msi_2)
+          )
+        end
+
+        def check_filtered_instances(*instances)
+          expect(last_response).to have_status_code(200)
+          expect(parsed_response['resources'].length).to be(instances.length)
+          expect({ resources: parsed_response['resources'] }).to match_json_response(
+            { resources: instances }
+          )
+        end
+      end
+
+      context 'fields' do
+        it 'can include the space and organization name and guid fields' do
+          get '/v3/service_instances?fields[space]=guid,name,relationships.organization&fields[space.organization]=name,guid', nil, admin_headers
+          expect(last_response).to have_status_code(200)
+
+          included = {
+            spaces: [
+              {
+                guid: space.guid,
+                name: space.name,
+                relationships: {
+                  organization: {
+                    data: {
+                      guid: space.organization.guid
+                    }
+                  }
+                }
+              },
+              {
+                guid: another_space.guid,
+                name: another_space.name,
+                relationships: {
+                  organization: {
+                    data: {
+                      guid: another_space.organization.guid
+                    }
+                  }
+                }
+              }
+            ],
+            organizations: [
+              {
+                name: space.organization.name,
+                guid: space.organization.guid
+              },
+              {
+                name: another_space.organization.name,
+                guid: another_space.organization.guid
+              }
+            ]
+          }
+
+          expect({ included: parsed_response['included'] }).to match_json_response({ included: included })
+        end
+
+        it 'can include the service plan, offering and broker fields' do
+          get '/v3/service_instances?fields[service_plan]=guid,name,relationships.service_offering&' \
                 'fields[service_plan.service_offering]=name,guid,description,documentation_url,relationships.service_broker&' \
                 'fields[service_plan.service_offering.service_broker]=name,guid', nil, admin_headers
 
-        expect(last_response).to have_status_code(200)
+          expect(last_response).to have_status_code(200)
 
-        included = {
-          service_plans: [
-            {
-              guid: msi_1.service_plan.guid,
-              name: msi_1.service_plan.name,
-              relationships: {
-                service_offering: {
-                  data: {
-                    guid: msi_1.service_plan.service.guid
+          included = {
+            service_plans: [
+              {
+                guid: msi_1.service_plan.guid,
+                name: msi_1.service_plan.name,
+                relationships: {
+                  service_offering: {
+                    data: {
+                      guid: msi_1.service_plan.service.guid
+                    }
+                  }
+                }
+              },
+              {
+                guid: msi_2.service_plan.guid,
+                name: msi_2.service_plan.name,
+                relationships: {
+                  service_offering: {
+                    data: {
+                      guid: msi_2.service_plan.service.guid
+                    }
+                  }
+                }
+              },
+              {
+                guid: ssi.service_plan.guid,
+                name: ssi.service_plan.name,
+                relationships: {
+                  service_offering: {
+                    data: {
+                      guid: ssi.service_plan.service.guid
+                    }
                   }
                 }
               }
-            },
-            {
-              guid: msi_2.service_plan.guid,
-              name: msi_2.service_plan.name,
-              relationships: {
-                service_offering: {
-                  data: {
-                    guid: msi_2.service_plan.service.guid
+            ],
+            service_offerings: [
+              {
+                name: msi_1.service_plan.service.name,
+                guid: msi_1.service_plan.service.guid,
+                description: msi_1.service_plan.service.description,
+                documentation_url: 'https://some.url.for.docs/',
+                relationships: {
+                  service_broker: {
+                    data: {
+                      guid: msi_1.service_plan.service.service_broker.guid
+                    }
+                  }
+                }
+              },
+              {
+                name: msi_2.service_plan.service.name,
+                guid: msi_2.service_plan.service.guid,
+                description: msi_2.service_plan.service.description,
+                documentation_url: 'https://some.url.for.docs/',
+                relationships: {
+                  service_broker: {
+                    data: {
+                      guid: msi_2.service_plan.service.service_broker.guid
+                    }
+                  }
+                }
+              },
+              {
+                name: ssi.service_plan.service.name,
+                guid: ssi.service_plan.service.guid,
+                description: ssi.service_plan.service.description,
+                documentation_url: 'https://some.url.for.docs/',
+                relationships: {
+                  service_broker: {
+                    data: {
+                      guid: ssi.service_plan.service.service_broker.guid
+                    }
                   }
                 }
               }
-            },
-            {
-              guid: ssi.service_plan.guid,
-              name: ssi.service_plan.name,
-              relationships: {
-                service_offering: {
-                  data: {
-                    guid: ssi.service_plan.service.guid
-                  }
-                }
+            ],
+            service_brokers: [
+              {
+                name: msi_1.service_plan.service.service_broker.name,
+                guid: msi_1.service_plan.service.service_broker.guid
+              },
+              {
+                name: msi_2.service_plan.service.service_broker.name,
+                guid: msi_2.service_plan.service.service_broker.guid
+              },
+              {
+                name: ssi.service_plan.service.service_broker.name,
+                guid: ssi.service_plan.service.service_broker.guid
               }
-            }
-          ],
-          service_offerings: [
-            {
-              name: msi_1.service_plan.service.name,
-              guid: msi_1.service_plan.service.guid,
-              description: msi_1.service_plan.service.description,
-              documentation_url: 'https://some.url.for.docs/',
-              relationships: {
-                service_broker: {
-                  data: {
-                    guid: msi_1.service_plan.service.service_broker.guid
-                  }
-                }
-              }
-            },
-            {
-              name: msi_2.service_plan.service.name,
-              guid: msi_2.service_plan.service.guid,
-              description: msi_2.service_plan.service.description,
-              documentation_url: 'https://some.url.for.docs/',
-              relationships: {
-                service_broker: {
-                  data: {
-                    guid: msi_2.service_plan.service.service_broker.guid
-                  }
-                }
-              }
-            },
-            {
-              name: ssi.service_plan.service.name,
-              guid: ssi.service_plan.service.guid,
-              description: ssi.service_plan.service.description,
-              documentation_url: 'https://some.url.for.docs/',
-              relationships: {
-                service_broker: {
-                  data: {
-                    guid: ssi.service_plan.service.service_broker.guid
-                  }
-                }
-              }
-            }
-          ],
-          service_brokers: [
-            {
-              name: msi_1.service_plan.service.service_broker.name,
-              guid: msi_1.service_plan.service.service_broker.guid
-            },
-            {
-              name: msi_2.service_plan.service.service_broker.name,
-              guid: msi_2.service_plan.service.service_broker.guid
-            },
-            {
-              name: ssi.service_plan.service.service_broker.name,
-              guid: ssi.service_plan.service.service_broker.guid
-            }
 
-          ]
-        }
+            ]
+          }
 
-        expect({ included: parsed_response['included'] }).to match_json_response({ included: included })
+          expect({ included: parsed_response['included'] }).to match_json_response({ included: included })
+        end
       end
     end
   end

--- a/spec/request/service_offerings_spec.rb
+++ b/spec/request/service_offerings_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe 'V3 service offerings' do
       end
     end
 
-    context 'filters and sorting' do
+    context 'filters' do
       context 'when filtering on the `available` property' do
         let(:api_call) { lambda { |user_headers| get "/v3/service_offerings?available=#{available}", nil, user_headers } }
 
@@ -706,6 +706,12 @@ RSpec.describe 'V3 service offerings' do
         end
 
         it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
+      end
+    end
+
+    describe 'order_by' do
+      it_behaves_like 'list endpoint order_by timestamps', '/v3/service_offerings' do
+        let(:resource_klass) { VCAP::CloudController::Service }
       end
     end
 

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -196,13 +196,13 @@ RSpec.describe 'V3 service plans' do
           order_by: 'updated_at',
           label_selector: 'foo==bar',
           fields: { 'service_offering.service_broker' => 'name' },
-          created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
+          created_ats: "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
           updated_ats: { gt: Time.now.utc.iso8601 },
         }
       end
     end
 
-    context 'when there are no service plans' do
+    context 'no service plans' do
       it 'returns an empty list' do
         get '/v3/service_plans', nil, admin_headers
         expect(last_response).to have_status_code(200)
@@ -486,6 +486,16 @@ RSpec.describe 'V3 service plans' do
           get '/v3/service_plans?available=false', {}, admin_headers
           check_filtered_plans(alternate_plan)
         end
+      end
+    end
+
+    describe 'order_by' do
+      it_behaves_like 'list endpoint order_by name', '/v3/service_plans' do
+        let(:resource_klass) { VCAP::CloudController::ServicePlan }
+      end
+
+      it_behaves_like 'list endpoint order_by timestamps', '/v3/service_plans' do
+        let(:resource_klass) { VCAP::CloudController::ServicePlan }
       end
     end
 

--- a/spec/support/shared_examples/request/service_brokers.rb
+++ b/spec/support/shared_examples/request/service_brokers.rb
@@ -30,19 +30,19 @@ RSpec.shared_examples 'a successful broker delete' do
     expect(VCAP::CloudController::ServiceDashboardClient.find_client_by_uaa_id(uaa_client_id)).to be_nil
 
     expect(a_request(:post, 'https://uaa.service.cf.internal/oauth/clients/tx/modify').
-        with(
-          body: [
-            {
-                  "client_id": uaa_client_id,
-                  "client_secret": nil,
-                  "redirect_uri": nil,
-                  "scope": %w(openid cloud_controller_service_permissions.read),
-                  "authorities": ['uaa.resource'],
-                  "authorized_grant_types": ['authorization_code'],
-                  "action": 'delete'
-              }
-          ].to_json
-        )).to have_been_made
+      with(
+        body: [
+          {
+            "client_id": uaa_client_id,
+            "client_secret": nil,
+            "redirect_uri": nil,
+            "scope": %w(openid cloud_controller_service_permissions.read),
+            "authorities": ['uaa.resource'],
+            "authorized_grant_types": ['authorization_code'],
+            "action": 'delete'
+          }
+        ].to_json
+      )).to have_been_made
   end
 
   def clear_events

--- a/spec/unit/messages/service_credential_bindings_list_message_spec.rb
+++ b/spec/unit/messages/service_credential_bindings_list_message_spec.rb
@@ -7,9 +7,9 @@ module VCAP::CloudController
 
     let(:params) do
       {
-        'page'      => 1,
-        'per_page'  => 5,
-        'order_by'  => 'created_at',
+        'page' => 1,
+        'per_page' => 5,
+        'order_by' => 'created_at',
         'service_instance_guids' => 'service-instance-1-guid, service-instance-2-guid, service-instance-3-guid',
         'service_instance_names' => 'service-instance-1-name, service-instance-2-name, service-instance-3-name',
         'names' => 'name1, name2',

--- a/spec/unit/messages/service_credential_bindings_list_message_spec.rb
+++ b/spec/unit/messages/service_credential_bindings_list_message_spec.rb
@@ -92,5 +92,12 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe 'order_by' do
+      it 'allows name' do
+        message = described_class.from_params(order_by: 'name')
+        expect(message).to be_valid
+      end
+    end
   end
 end

--- a/spec/unit/messages/service_instances_list_message_spec.rb
+++ b/spec/unit/messages/service_instances_list_message_spec.rb
@@ -113,5 +113,12 @@ module VCAP::CloudController
 
       it_behaves_like 'fields to_param_hash', 'space.organization', 'name'
     end
+
+    describe 'order_by' do
+      it 'allows name' do
+        message = described_class.from_params(order_by: 'name')
+        expect(message).to be_valid
+      end
+    end
   end
 end

--- a/spec/unit/messages/service_plans_list_message_spec.rb
+++ b/spec/unit/messages/service_plans_list_message_spec.rb
@@ -120,5 +120,12 @@ module VCAP::CloudController
 
       it_behaves_like 'fields to_param_hash', 'service_offering.service_broker', 'guid,name'
     end
+
+    describe 'order_by' do
+      it 'allows name' do
+        message = described_class.from_params(order_by: 'name')
+        expect(message).to be_valid
+      end
+    end
   end
 end


### PR DESCRIPTION
- implemented order_by name where it was not implemented already except
for service offerings where it is complex due to the DB column being
called `label` rather than `name`
- improved the pagination shared example to check links
