### PR TITLE
v3(services): Retry-After header type conversion

### DIFF
--- a/app/jobs/v3/create_route_binding_job.rb
+++ b/app/jobs/v3/create_route_binding_job.rb
@@ -54,7 +54,7 @@ module VCAP::CloudController
           finish
         when ServiceRouteBindingCreate::PollingNotComplete
           unless polling_status.retry_after.nil?
-            self.polling_interval_seconds = polling_status.retry_after
+            self.polling_interval_seconds = polling_status.retry_after.to_i
           end
         end
       rescue ServiceRouteBindingCreate::BindingNotRetrievable

--- a/app/jobs/v3/service_instance_async_job.rb
+++ b/app/jobs/v3/service_instance_async_job.rb
@@ -132,7 +132,7 @@ module VCAP::CloudController
 
       def fetch_last_operation(client)
         last_operation_result = client.fetch_service_instance_last_operation(service_instance)
-        self.polling_interval_seconds = last_operation_result[:retry_after] if last_operation_result[:retry_after]
+        self.polling_interval_seconds = last_operation_result[:retry_after].to_i if last_operation_result[:retry_after]
 
         operation_failed!(last_operation_result.dig(:last_operation)[:description]) if last_operation_result[:http_status_code] == HTTP::Status::BAD_REQUEST
 

--- a/spec/unit/jobs/v3/create_route_binding_job_spec.rb
+++ b/spec/unit/jobs/v3/create_route_binding_job_spec.rb
@@ -132,7 +132,7 @@ module VCAP::CloudController
 
         context 'retry interval' do
           def test_retry_after(value, expected)
-            allow(action).to receive(:poll).and_return(ServiceRouteBindingCreate::PollingNotComplete.new(value))
+            allow(action).to receive(:poll).and_return(ServiceRouteBindingCreate::PollingNotComplete.new(value.to_s))
             subject.perform
             expect(subject.polling_interval_seconds).to eq(expected)
           end

--- a/spec/unit/jobs/v3/service_instance_async_job_spec.rb
+++ b/spec/unit/jobs/v3/service_instance_async_job_spec.rb
@@ -458,11 +458,11 @@ module VCAP::CloudController
               [
                 {
                   last_operation: { state: 'in progress', type: operation },
-                  retry_after: 95
+                  retry_after: '95'
                 },
                 {
                   last_operation: { state: 'in progress', type: operation },
-                  retry_after: 180
+                  retry_after: '180'
                 },
               ]
             }


### PR DESCRIPTION
The Retry-After header is always a string, so we should convert it to a
number

[#174398274](https://www.pivotaltracker.com/story/show/174398274)