### PR TITLE
Add link to the `get default domain` endpoint

### DIFF
--- a/docs/v3/source/includes/resources/domains/_list_domains_for_an_org.md.erb
+++ b/docs/v3/source/includes/resources/domains/_list_domains_for_an_org.md.erb
@@ -25,6 +25,8 @@ Retrieve all domains available in an organization for the current user. This wil
 (those without an owning organization), domains that are scoped to the given organization (owned by the given
 organization), and domains that have been shared with the organization.
 
+To retrieve the default domain for an organization, use the [get default domain](#get-default-domain) endpoint.
+
 #### Definition
 `GET /v3/organizations/:guid/domains`
 


### PR DESCRIPTION
* A short explanation of the proposed change:

Add a link from the [list domains for an organization](https://v3-apidocs.cloudfoundry.org/version/3.88.0/index.html#list-domains-for-an-organization) endpoint to the [get default domain](https://v3-apidocs.cloudfoundry.org/version/3.88.0/index.html#get-default-domain) endpoint api documentation

* An explanation of the use cases your change solves

People search for a possibility to retrieve the default domain on the `Domains` ressources.
This PR helps to guide them to the correct ressouce `Organization`
Related Github issue #1454 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
