### PR TITLE
V3 route binding last operation polling 174398276

### DIFF
--- a/app/actions/service_route_binding_create.rb
+++ b/app/actions/service_route_binding_create.rb
@@ -47,7 +47,10 @@ module VCAP::CloudController
 
       def poll(binding)
         client = VCAP::Services::ServiceClientProvider.provide(instance: binding.service_instance)
-        details = client.fetch_service_binding_last_operation(binding)
+
+        details = fetch_last_operation(client, binding)
+        return PollingNotComplete.new unless details
+
         attributes = {}
 
         complete = details[:last_operation][:state] == 'succeeded'
@@ -75,23 +78,12 @@ module VCAP::CloudController
         else
           PollingNotComplete.new(details[:retry_after])
         end
-      rescue VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerBadResponse,
-             VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerResponseMalformed => e
-
-        binding.save_with_new_operation({}, {
-          type: 'create',
-          state: 'failed',
-          description: e.message,
-        })
-
-        raise e
       rescue => e
         binding.save_with_new_operation({}, {
           type: 'create',
           state: 'failed',
           description: e.message,
         })
-
         return PollingComplete.new
       end
 
@@ -107,6 +99,19 @@ module VCAP::CloudController
       private
 
       attr_reader :service_event_repository
+
+      def fetch_last_operation(client, binding)
+        client.fetch_service_binding_last_operation(binding)
+      rescue VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerBadResponse,
+             VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerRequestRejected => e
+        binding.save_with_new_operation({}, {
+          type: 'create',
+          state: 'in progress',
+          description: e.message,
+        })
+
+        return nil
+      end
 
       def save_incomplete_binding(precursor, operation)
         precursor.save_with_new_operation({},

--- a/app/models/runtime/pollable_job_model.rb
+++ b/app/models/runtime/pollable_job_model.rb
@@ -24,6 +24,8 @@ module VCAP::CloudController
                 QuotaDefinition
               when 'space_quota'
                 SpaceQuotaDefinition
+              when 'service_route_binding'
+                RouteBinding
               else
                 Sequel::Model(ActiveSupport::Inflector.pluralize(resource_type).to_sym)
               end

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -214,6 +214,11 @@ RSpec.describe 'v3 service route bindings' do
         expect(job.operation).to eq('service_route_bindings.create')
         expect(job.resource_guid).to eq(binding.guid)
         expect(job.resource_type).to eq('service_route_binding')
+
+        get "/v3/jobs/#{job.guid}", nil, space_dev_headers
+
+        expect(last_response).to have_status_code(200)
+        expect(parsed_response['guid']). to eq(job.guid)
       end
 
       describe 'the pollable job' do

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe 'v3 service route bindings' do
             end
           end
 
-          it_behaves_like 'last operation response handling'
+          it_behaves_like 'create binding last operation response handling'
 
           context 'binding not retrievable' do
             let(:offering) { VCAP::CloudController::Service.make(bindings_retrievable: false, requires: ['route_forwarding']) }

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -386,65 +386,7 @@ RSpec.describe 'v3 service route bindings' do
             end
           end
 
-          context 'last operation response is 200 OK and indicates failure' do
-            let(:state) { 'failed' }
-
-            it 'updates the binding and job' do
-              execute_all_jobs(expected_successes: 1, expected_failures: 0)
-
-              expect(binding.last_operation.type).to eq('create')
-              expect(binding.last_operation.state).to eq(state)
-              expect(binding.last_operation.description).to eq(description)
-
-              expect(job.state).to eq(VCAP::CloudController::PollableJobModel::COMPLETE_STATE)
-            end
-          end
-
-          context 'last operation response is 400 Bad Request' do
-            let(:last_operation_status_code) { 400 }
-            let(:state) { 'failed' }
-            let(:description) { 'a helpful description' }
-
-            it 'updates the binding and job' do
-              execute_all_jobs(expected_successes: 1, expected_failures: 0)
-
-              expect(binding.last_operation.type).to eq('create')
-              expect(binding.last_operation.state).to eq(state)
-              expect(binding.last_operation.description).to eq(description)
-
-              expect(job.state).to eq(VCAP::CloudController::PollableJobModel::COMPLETE_STATE)
-            end
-          end
-
-          context 'last operation response is 404 Not Found' do
-            let(:last_operation_status_code) { 404 }
-            let(:last_operation_body) { 'cannot see it' }
-
-            it 'updates the binding and job' do
-              execute_all_jobs(expected_successes: 1, expected_failures: 0)
-
-              expect(binding.last_operation.type).to eq('create')
-              expect(binding.last_operation.state).to eq('failed')
-              expect(binding.last_operation.description).to eq('The service broker rejected the request. Status Code: 404 Not Found, Body: "cannot see it"')
-
-              expect(job.state).to eq(VCAP::CloudController::PollableJobModel::COMPLETE_STATE)
-            end
-          end
-
-          context 'last operation response is 500 Internal Server Error' do
-            let(:last_operation_status_code) { 500 }
-            let(:last_operation_body) { 'something awful' }
-
-            it 'updates the binding and job' do
-              execute_all_jobs(expected_successes: 0, expected_failures: 1)
-
-              expect(binding.last_operation.type).to eq('create')
-              expect(binding.last_operation.state).to eq('failed')
-              expect(binding.last_operation.description).to eq('The service broker returned an invalid response. Status Code: 500 Internal Server Error, Body: "something awful"')
-
-              expect(job.state).to eq(VCAP::CloudController::PollableJobModel::FAILED_STATE)
-            end
-          end
+          it_behaves_like 'last operation response handling'
 
           context 'binding not retrievable' do
             let(:offering) { VCAP::CloudController::Service.make(bindings_retrievable: false, requires: ['route_forwarding']) }

--- a/spec/support/shared_examples/request/last_operation_response_handling.rb
+++ b/spec/support/shared_examples/request/last_operation_response_handling.rb
@@ -1,0 +1,44 @@
+RSpec.shared_examples 'last operation response handling' do
+  context 'valid http codes' do
+    valid_responses = [
+      { code: 400, body: { description: 'helpful message' }, expected_description: 'helpful message' },
+      { code: 200, body: { state: 'failed', description: 'something went wrong' }, expected_description: 'something went wrong' }
+    ]
+    valid_responses.each do |response|
+      context "last operation response is #{response[:code]}" do
+        let(:state) { response[:state] }
+        let(:last_operation_status_code) { response[:code] }
+        let(:last_operation_body) { response[:body] }
+
+        it 'updates the binding and job' do
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+
+          expect(binding.last_operation.type).to eq('create')
+          expect(binding.last_operation.state).to eq('failed')
+          expect(binding.last_operation.description).to eq(response[:body][:description])
+
+          expect(job.state).to eq(VCAP::CloudController::PollableJobModel::COMPLETE_STATE)
+        end
+      end
+    end
+  end
+
+  context 'invalid http codes' do
+    [404, 410, 500].each do |code|
+      context "last operation response is #{code}" do
+        let(:last_operation_status_code) { code }
+        let(:last_operation_body) { 'something awful' }
+
+        it 'continues polling' do
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+
+          expect(binding.last_operation.type).to eq('create')
+          expect(binding.last_operation.state).to eq('in progress')
+          expect(binding.last_operation.description).to include("Status Code: #{code}") unless code == 410
+
+          expect(job.state).to eq(VCAP::CloudController::PollableJobModel::POLLING_STATE)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/request/last_operation_response_handling.rb
+++ b/spec/support/shared_examples/request/last_operation_response_handling.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'last operation response handling' do
+RSpec.shared_examples 'create binding last operation response handling' do
   context 'valid http codes' do
     valid_responses = [
       { code: 400, body: { description: 'helpful message' }, expected_description: 'helpful message' },

--- a/spec/unit/models/runtime/pollable_job_model_spec.rb
+++ b/spec/unit/models/runtime/pollable_job_model_spec.rb
@@ -84,6 +84,18 @@ module VCAP::CloudController
           job = PollableJobModel.make(resource_type: 'role', resource_guid: 'not-a-real-guid')
           expect(job.resource_exists?).to be(false)
         end
+
+        it 'returns true if the resource exists' do
+          route_binding = RouteBinding.make
+          job = PollableJobModel.make(resource_type: 'service_route_binding', resource_guid: route_binding.guid)
+          expect(job.resource_exists?).to be(true)
+        end
+
+        it 'returns false if the resource does NOT exist' do
+          job = PollableJobModel.make(resource_type: 'service_route_binding', resource_guid: 'not-a-real-guid')
+          expect(job.resource_exists?).to be(false)
+        end
+
       end
     end
 

--- a/spec/unit/models/runtime/pollable_job_model_spec.rb
+++ b/spec/unit/models/runtime/pollable_job_model_spec.rb
@@ -95,7 +95,6 @@ module VCAP::CloudController
           job = PollableJobModel.make(resource_type: 'service_route_binding', resource_guid: 'not-a-real-guid')
           expect(job.resource_exists?).to be(false)
         end
-
       end
     end
 


### PR DESCRIPTION
[#174398276](https://www.pivotaltracker.com/story/show/174398276)

Fixes 

1. Fix job endpoint to look up for correct table for route_bindings, GET v3/jobs/<route-binding-job-guid> now works. I added a special case although it could have also been fixed by changing the value of resource_type in the job class. I chose this path so as to keep consistency and store always the resource name as we do with the rest.

2. Fix error codes handling according to osbapi spec, only 200 and 400 are valid responses from last operation for a create request