### PR TITLE
db_spec_helper for faster db tests

### DIFF
--- a/app/access/base_access.rb
+++ b/app/access/base_access.rb
@@ -1,3 +1,5 @@
+require 'allowy/access_control'
+
 module VCAP::CloudController
   class BaseAccess
     include Allowy::AccessControl

--- a/app/actions/metadata_update.rb
+++ b/app/actions/metadata_update.rb
@@ -1,3 +1,6 @@
+require 'actions/labels_update'
+require 'actions/annotations_update'
+
 module VCAP::CloudController
   class MetadataUpdate
     class << self

--- a/app/actions/v3/service_broker_update.rb
+++ b/app/actions/v3/service_broker_update.rb
@@ -1,4 +1,7 @@
 require 'jobs/v3/services/update_broker_job'
+require 'actions/metadata_update'
+require 'jobs/enqueuer'
+require 'jobs/queues'
 
 module VCAP::CloudController
   module V3

--- a/app/controllers/base/base_controller.rb
+++ b/app/controllers/base/base_controller.rb
@@ -4,6 +4,7 @@ require 'cloud_controller/rest_controller/routes'
 require 'cloud_controller/security/access_context'
 require 'cloud_controller/basic_auth/basic_auth_authenticator'
 require 'vcap/json_message'
+require 'vcap/rest_api'
 
 module VCAP::CloudController::RestController
   # The base class for all api endpoints.

--- a/app/controllers/base/front_controller.rb
+++ b/app/controllers/base/front_controller.rb
@@ -1,4 +1,6 @@
 require 'cloud_controller/security/security_context_configurer'
+require 'vcap/rest_api'
+require 'sinatra/vcap'
 
 module VCAP::CloudController
   include VCAP::RestAPI

--- a/app/controllers/base/model_controller.rb
+++ b/app/controllers/base/model_controller.rb
@@ -1,4 +1,6 @@
 require 'presenters/api/job_presenter'
+require 'controllers/base/base_controller'
+require 'cloud_controller/rest_controller/controller_dsl'
 
 module VCAP::CloudController::RestController
   # Wraps models and presents collection and per object rest end points

--- a/app/fetchers/service_broker_list_fetcher.rb
+++ b/app/fetchers/service_broker_list_fetcher.rb
@@ -1,4 +1,5 @@
 require 'fetchers/base_list_fetcher'
+require 'fetchers/label_selector_query_generator'
 
 module VCAP::CloudController
   class ServiceBrokerListFetcher < BaseListFetcher

--- a/app/fetchers/service_credential_binding_fetcher.rb
+++ b/app/fetchers/service_credential_binding_fetcher.rb
@@ -1,3 +1,5 @@
+require 'fetchers/service_credential_binding_list_fetcher'
+
 module VCAP
   module CloudController
     class ServiceCredentialBindingFetcher

--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -1,4 +1,5 @@
 require 'fetchers/base_list_fetcher'
+require 'fetchers/label_selector_query_generator'
 
 module VCAP::CloudController
   class ServiceInstanceListFetcher < BaseListFetcher

--- a/app/fetchers/service_offering_list_fetcher.rb
+++ b/app/fetchers/service_offering_list_fetcher.rb
@@ -1,4 +1,5 @@
 require 'fetchers/base_list_fetcher'
+require 'fetchers/label_selector_query_generator'
 
 module VCAP::CloudController
   class ServiceOfferingListFetcher < BaseListFetcher

--- a/app/fetchers/service_plan_list_fetcher.rb
+++ b/app/fetchers/service_plan_list_fetcher.rb
@@ -1,5 +1,6 @@
 require 'set'
 require 'fetchers/base_list_fetcher'
+require 'fetchers/label_selector_query_generator'
 
 module VCAP::CloudController
   class ServicePlanListFetcher < BaseListFetcher

--- a/app/fetchers/service_usage_event_list_fetcher.rb
+++ b/app/fetchers/service_usage_event_list_fetcher.rb
@@ -1,4 +1,5 @@
 require 'fetchers/base_list_fetcher'
+require 'cloud_controller/errors/api_error'
 
 module VCAP::CloudController
   class ServiceUsageEventListFetcher < BaseListFetcher

--- a/app/jobs/enqueuer.rb
+++ b/app/jobs/enqueuer.rb
@@ -1,5 +1,8 @@
 require 'clockwork'
 require 'cloud_controller/clock/job_timeout_calculator'
+require 'jobs/pollable_job_wrapper'
+require 'jobs/logging_context_job'
+require 'jobs/timeout_job'
 
 module VCAP::CloudController
   module Jobs

--- a/app/jobs/pollable_job_wrapper.rb
+++ b/app/jobs/pollable_job_wrapper.rb
@@ -1,4 +1,5 @@
 require 'presenters/error_presenter'
+require 'jobs/wrapping_job'
 
 module VCAP::CloudController
   module Jobs

--- a/app/jobs/v3/create_route_binding_job.rb
+++ b/app/jobs/v3/create_route_binding_job.rb
@@ -1,4 +1,6 @@
 require 'jobs/reoccurring_job'
+require 'actions/service_route_binding_create'
+require 'cloud_controller/errors/api_error'
 
 module VCAP::CloudController
   module V3

--- a/app/jobs/v3/delete_service_instance_job.rb
+++ b/app/jobs/v3/delete_service_instance_job.rb
@@ -1,4 +1,5 @@
 require 'jobs/v3/service_instance_async_job'
+require 'services/service_brokers/v2/errors/service_broker_bad_response'
 
 module VCAP::CloudController
   module V3

--- a/app/jobs/v3/service_instance_async_job.rb
+++ b/app/jobs/v3/service_instance_async_job.rb
@@ -1,4 +1,5 @@
 require 'jobs/reoccurring_job'
+require 'services/service_brokers/service_client_provider'
 
 module VCAP::CloudController
   module V3

--- a/app/jobs/v3/services/update_broker_job.rb
+++ b/app/jobs/v3/services/update_broker_job.rb
@@ -1,4 +1,5 @@
 require 'presenters/mixins/metadata_presentation_helpers'
+require 'jobs/cc_job'
 
 module VCAP::CloudController
   module V3

--- a/app/jobs/v3/update_service_instance_job.rb
+++ b/app/jobs/v3/update_service_instance_job.rb
@@ -1,4 +1,5 @@
 require 'jobs/v3/service_instance_async_job'
+require 'actions/metadata_update'
 
 module VCAP::CloudController
   module V3

--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -1,4 +1,5 @@
 require 'cloud_controller/database_uri_generator'
+require 'cloud_controller/serializer'
 require 'models/helpers/process_types'
 require 'hashdiff'
 

--- a/app/models/runtime/environment_variable_group.rb
+++ b/app/models/runtime/environment_variable_group.rb
@@ -1,3 +1,5 @@
+require 'messages/validators'
+
 module VCAP::CloudController
   class EnvironmentVariableGroup < Sequel::Model(:env_groups)
     import_attributes :environment_json

--- a/app/models/runtime/process_model.rb
+++ b/app/models/runtime/process_model.rb
@@ -7,6 +7,8 @@ require 'utils/uri_utils'
 require 'models/runtime/helpers/package_state_calculator.rb'
 require 'models/helpers/process_types'
 require 'models/helpers/health_check_types'
+require 'cloud_controller/serializer'
+require 'cloud_controller/integer_array_serializer'
 
 require_relative 'buildpack'
 

--- a/app/models/runtime/role.rb
+++ b/app/models/runtime/role.rb
@@ -1,3 +1,5 @@
+require 'models/helpers/role_types'
+
 module VCAP::CloudController
   SPACE_OR_ORGANIZATION_NOT_SPECIFIED = -1
 

--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -1,5 +1,7 @@
 require 'utils/uri_utils'
 require 'models/helpers/process_types'
+require 'cloud_controller/routing_api/disabled_routing_api_client'
+require 'cloud_controller/route_validator'
 
 module VCAP::CloudController
   class Route < Sequel::Model

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -1,4 +1,5 @@
 require 'models/helpers/process_types'
+require 'cloud_controller/errors/invalid_relation'
 
 module VCAP::CloudController
   class Space < Sequel::Model

--- a/app/presenters/v3/service_plan_presenter.rb
+++ b/app/presenters/v3/service_plan_presenter.rb
@@ -1,3 +1,5 @@
+require 'json'
+require 'json-schema'
 require 'presenters/v3/base_presenter'
 require 'presenters/mixins/metadata_presentation_helpers'
 

--- a/app/repositories/service_event_repository.rb
+++ b/app/repositories/service_event_repository.rb
@@ -1,3 +1,5 @@
+require 'presenters/helpers/censorship'
+
 module VCAP::CloudController
   module Repositories
     class ServiceEventRepository

--- a/config/initializers/json.rb
+++ b/config/initializers/json.rb
@@ -1,3 +1,5 @@
+require 'active_support/json/encoding'
+
 module CCInitializers
   def self.json(_cc_config)
     ActiveSupport.json_encoder = Class.new do

--- a/db/migrations/20200727211409_add_kpack_encrypted_buildpack_infos_column.rb
+++ b/db/migrations/20200727211409_add_kpack_encrypted_buildpack_infos_column.rb
@@ -1,3 +1,5 @@
+require 'multi_json'
+
 Sequel.migration do
   change do
     alter_table :kpack_lifecycle_data do

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -12,6 +12,8 @@ require 'cloud_controller/config_schemas/route_syncer_schema'
 require 'cloud_controller/config_schemas/worker_schema'
 require 'cloud_controller/config_schemas/deployment_updater_schema'
 require 'cloud_controller/config_schemas/rotatate_database_key_schema'
+require 'utils/hash_utils'
+require 'cloud_controller/internal_api'
 
 module VCAP::CloudController
   class Config

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -1,4 +1,5 @@
 require 'vcap/config'
+require 'cloud_controller/resource_pool'
 
 module VCAP::CloudController
   module ConfigSchemas

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -1,3 +1,4 @@
+require 'sequel'
 require 'cloud_controller/db_migrator'
 require 'cloud_controller/db_connection/options_factory'
 require 'cloud_controller/db_connection/finalizer'

--- a/lib/cloud_controller/errors/api_error.rb
+++ b/lib/cloud_controller/errors/api_error.rb
@@ -1,3 +1,5 @@
+require 'cloud_controller/errors/details'
+
 module CloudController
   module Errors
     class ApiError < StandardError

--- a/lib/cloud_controller/http_response_error.rb
+++ b/lib/cloud_controller/http_response_error.rb
@@ -1,3 +1,5 @@
+require 'cloud_controller/structured_error'
+
 class HttpResponseError < StructuredError
   attr_reader :uri, :method, :status
 

--- a/lib/cloud_controller/rest_controller/routes.rb
+++ b/lib/cloud_controller/rest_controller/routes.rb
@@ -1,3 +1,5 @@
+require 'controllers/base/front_controller'
+
 module VCAP::CloudController::RestController
   module Routes
     def self.included(base)

--- a/lib/cloud_controller/security/access_context.rb
+++ b/lib/cloud_controller/security/access_context.rb
@@ -1,3 +1,5 @@
+require 'allowy/context'
+
 module VCAP::CloudController
   module Security
     class AccessContext

--- a/lib/cloud_controller/steno_configurer.rb
+++ b/lib/cloud_controller/steno_configurer.rb
@@ -1,4 +1,8 @@
+require 'steno'
 require 'steno/codec_rfc3339'
+require 'steno/config'
+require 'steno/context'
+
 module VCAP::CloudController
   class StenoConfigurer
     def initialize(logging_config)

--- a/lib/services/service_brokers/v2/errors/service_broker_bad_response.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_bad_response.rb
@@ -1,3 +1,5 @@
+require 'cloud_controller/http_response_error'
+
 module VCAP::Services
   module ServiceBrokers
     module V2

--- a/spec/db_spec_helper.rb
+++ b/spec/db_spec_helper.rb
@@ -4,17 +4,27 @@ require 'rspec/collection_matchers'
 
 require 'rails'
 require 'support/bootstrap/spec_bootstrap'
+require 'support/database_isolation'
 require 'sequel_plugins/sequel_plugins'
 
 require 'machinist/sequel'
 require 'machinist/object'
 
-VCAP::CloudController::SpecBootstrap.init
+VCAP::CloudController::SpecBootstrap.init(recreate_tables: false)
 
 require 'support/fakes/blueprints'
 
 RSpec.configure do |rspec_config|
   rspec_config.before :suite do
     VCAP::CloudController::SpecBootstrap.seed
+  end
+
+  rspec_config.around :each do |example|
+    # DatabaseIsolation requires the api config context
+    TestConfig.context = :api
+    TestConfig.reset
+
+    isolation = DatabaseIsolation.choose(example.metadata[:isolation], TestConfig.config_instance, DbConfig.new.connection)
+    isolation.cleanly { example.run }
   end
 end

--- a/spec/db_spec_helper.rb
+++ b/spec/db_spec_helper.rb
@@ -1,0 +1,20 @@
+require 'lightweight_spec_helper'
+
+require 'rspec/collection_matchers'
+
+require 'rails'
+require 'support/bootstrap/spec_bootstrap'
+require 'sequel_plugins/sequel_plugins'
+
+require 'machinist/sequel'
+require 'machinist/object'
+
+VCAP::CloudController::SpecBootstrap.init
+
+require 'support/fakes/blueprints'
+
+RSpec.configure do |rspec_config|
+  rspec_config.before :suite do
+    VCAP::CloudController::SpecBootstrap.seed
+  end
+end

--- a/spec/lightweight_spec_helper.rb
+++ b/spec/lightweight_spec_helper.rb
@@ -30,3 +30,7 @@ class StubConfig
 
   attr_reader :data
 end
+
+RSpec.configure do |rspec_config|
+  rspec_config.expose_dsl_globally = false
+end

--- a/spec/support/bootstrap/db_config.rb
+++ b/spec/support/bootstrap/db_config.rb
@@ -1,3 +1,6 @@
+require 'cloud_controller/db'
+require 'cloud_controller/database_parts_parser'
+
 class DbConfig
   def initialize(connection_string: ENV['DB_CONNECTION_STRING'], db_type: ENV['DB'])
     @connection_string = connection_string || default_connection_string(db_type || 'postgres')

--- a/spec/support/bootstrap/spec_bootstrap.rb
+++ b/spec/support/bootstrap/spec_bootstrap.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
   module SpecBootstrap
     @initialized = false
 
-    def self.init
+    def self.init(recreate_tables: true)
       return if @initialized
 
       @initialized = true
@@ -29,8 +29,10 @@ module VCAP::CloudController
 
       db_config = DbConfig.new
 
-      db_resetter = TableRecreator.new(db_config.connection)
-      db_resetter.recreate_tables
+      if recreate_tables
+        db_resetter = TableRecreator.new(db_config.connection)
+        db_resetter.recreate_tables
+      end
 
       DB.load_models(db_config.config, db_config.db_logger)
     end

--- a/spec/support/bootstrap/spec_bootstrap.rb
+++ b/spec/support/bootstrap/spec_bootstrap.rb
@@ -1,10 +1,17 @@
 require 'support/bootstrap/test_config'
 require 'support/bootstrap/table_recreator'
 require 'cloud_controller/seeds'
+require 'cloud_controller/telemetry_logger'
+require 'cloud_controller/steno_configurer'
 
 module VCAP::CloudController
   module SpecBootstrap
+    @initialized = false
+
     def self.init
+      return if @initialized
+
+      @initialized = true
       ENV['CC_TEST'] = 'true'
       FileUtils.mkdir_p(Paths::ARTIFACTS)
 

--- a/spec/support/bootstrap/test_config.rb
+++ b/spec/support/bootstrap/test_config.rb
@@ -1,6 +1,8 @@
 require 'support/bootstrap/db_config'
 require 'support/paths'
 require 'cloud_controller/config'
+require 'fog/core/mock'
+require 'cloud_controller/dependency_locator'
 
 module TestConfig
   class << self

--- a/spec/support/test_models.rb
+++ b/spec/support/test_models.rb
@@ -1,3 +1,6 @@
+require 'access/base_access'
+require 'controllers/base/model_controller'
+
 module VCAP::CloudController
   class TestModelDestroyDep < Sequel::Model; end
   class TestModelNullifyDep < Sequel::Model; end

--- a/spec/unit/actions/v3/service_broker_update_spec.rb
+++ b/spec/unit/actions/v3/service_broker_update_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'actions/v3/service_broker_update'
+require 'messages/service_broker_update_message'
 
 module VCAP
   module CloudController

--- a/spec/unit/decorators/include_binding_route_decorator_spec.rb
+++ b/spec/unit/decorators/include_binding_route_decorator_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'decorators/include_binding_route_decorator'
 
 module VCAP

--- a/spec/unit/decorators/include_binding_service_instance_decorator_spec.rb
+++ b/spec/unit/decorators/include_binding_service_instance_decorator_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'decorators/include_binding_service_instance_decorator'
 
 module VCAP

--- a/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_broker_list_fetcher'
 require 'messages/service_brokers_list_message'
 

--- a/spec/unit/fetchers/service_credential_binding_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_credential_binding_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_credential_binding_fetcher'
 
 module VCAP

--- a/spec/unit/fetchers/service_credential_binding_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_credential_binding_list_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_credential_binding_list_fetcher'
 require 'messages/service_credential_binding_list_message'
 

--- a/spec/unit/fetchers/service_instance_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_instance_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_instance_fetcher'
 
 module VCAP::CloudController

--- a/spec/unit/fetchers/service_instance_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_instance_list_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_instance_list_fetcher'
 require 'messages/service_instances_list_message'
 

--- a/spec/unit/fetchers/service_offering_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_offering_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_offering_fetcher'
 
 module VCAP::CloudController

--- a/spec/unit/fetchers/service_offering_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_offering_list_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_offering_list_fetcher'
 require 'messages/service_offerings_list_message'
 

--- a/spec/unit/fetchers/service_plan_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_plan_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_plan_fetcher'
 
 module VCAP::CloudController

--- a/spec/unit/fetchers/service_plan_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_plan_list_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_plan_list_fetcher'
 require 'messages/service_plans_list_message'
 

--- a/spec/unit/fetchers/service_plan_visibility_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_plan_visibility_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'fetchers/service_plan_visibility_fetcher'
 
 module VCAP::CloudController

--- a/spec/unit/fetchers/service_usage_event_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_usage_event_list_fetcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'messages/service_usage_events_list_message'
 require 'fetchers/service_usage_event_list_fetcher'
 

--- a/spec/unit/jobs/v3/create_route_binding_job_spec.rb
+++ b/spec/unit/jobs/v3/create_route_binding_job_spec.rb
@@ -1,4 +1,5 @@
-require 'spec_helper'
+require 'db_spec_helper'
+require 'support/shared_examples/jobs/delayed_job'
 require 'jobs/v3/create_route_binding_job'
 
 module VCAP::CloudController

--- a/spec/unit/jobs/v3/create_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/create_service_instance_job_spec.rb
@@ -1,4 +1,5 @@
-require 'spec_helper'
+require 'db_spec_helper'
+require 'support/shared_examples/jobs/delayed_job'
 require 'jobs/v3/create_service_instance_job'
 require 'cloud_controller/errors/api_error'
 

--- a/spec/unit/jobs/v3/delete_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/delete_service_instance_job_spec.rb
@@ -1,6 +1,9 @@
-require 'spec_helper'
-require 'jobs/v3/create_service_instance_job'
+require 'db_spec_helper'
+require 'support/shared_examples/jobs/delayed_job'
+require 'jobs/v3/delete_service_instance_job'
 require 'cloud_controller/errors/api_error'
+require 'cloud_controller/user_audit_info'
+require 'services/service_brokers/v2/http_response'
 
 module VCAP::CloudController
   module V3

--- a/spec/unit/jobs/v3/update_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/update_service_instance_job_spec.rb
@@ -1,6 +1,9 @@
-require 'spec_helper'
+require 'db_spec_helper'
+require 'support/shared_examples/jobs/delayed_job'
 require 'jobs/v3/update_service_instance_job'
 require 'cloud_controller/errors/api_error'
+require 'cloud_controller/user_audit_info'
+require 'messages/service_instance_update_managed_message'
 
 module VCAP
   module CloudController

--- a/spec/unit/messages/service_credential_binding_list_message_spec.rb
+++ b/spec/unit/messages/service_credential_binding_list_message_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'lightweight_spec_helper'
 require 'messages/service_credential_binding_list_message'
 
 module VCAP::CloudController

--- a/spec/unit/messages/service_credential_binding_show_message_spec.rb
+++ b/spec/unit/messages/service_credential_binding_show_message_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'lightweight_spec_helper'
 require 'messages/service_credential_binding_show_message'
 
 module VCAP::CloudController

--- a/spec/unit/messages/service_plan_visibility_update_message_spec.rb
+++ b/spec/unit/messages/service_plan_visibility_update_message_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'lightweight_spec_helper'
 require 'messages/service_plan_visibility_update_message'
 
 module VCAP::CloudController

--- a/spec/unit/messages/service_plans_list_message_spec.rb
+++ b/spec/unit/messages/service_plans_list_message_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'lightweight_spec_helper'
 require 'messages/service_plans_list_message'
 require 'field_message_spec_shared_examples'
 

--- a/spec/unit/presenters/v3/service_binding_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_binding_presenter_spec.rb
@@ -1,8 +1,11 @@
-require 'spec_helper'
+require 'db_spec_helper'
+require 'support/link_helpers'
 require 'presenters/v3/service_binding_presenter'
 
 module VCAP::CloudController::Presenters::V3
   RSpec.describe ServiceBindingPresenter do
+    include LinkHelpers
+
     let(:presenter) { ServiceBindingPresenter.new(service_binding) }
     let(:credentials) { { 'very-secret' => 'password' }.to_json }
     let(:volume_mounts) { [{ 'container_dir' => '/a/reasonable/path', 'device' => { 'very-secret' => 'password' } }] }

--- a/spec/unit/presenters/v3/service_credential_binding_details_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_credential_binding_details_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'presenters/v3/service_credential_binding_details_presenter'
 
 module VCAP

--- a/spec/unit/presenters/v3/service_credential_binding_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_credential_binding_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'presenters/v3/service_credential_binding_presenter'
 
 module VCAP

--- a/spec/unit/presenters/v3/service_instance_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_instance_presenter_spec.rb
@@ -1,8 +1,11 @@
-require 'spec_helper'
+require 'db_spec_helper'
+require 'support/link_helpers'
 require 'presenters/v3/service_instance_presenter'
 
 module VCAP::CloudController::Presenters::V3
   RSpec.describe ServiceInstancePresenter do
+    include LinkHelpers
+
     let(:presenter) { described_class.new(service_instance) }
     let(:result) { presenter.to_hash.deep_symbolize_keys }
 

--- a/spec/unit/presenters/v3/service_offering_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_offering_presenter_spec.rb
@@ -3,6 +3,8 @@ require 'support/link_helpers'
 require 'presenters/v3/service_offering_presenter'
 
 RSpec.describe VCAP::CloudController::Presenters::V3::ServiceOfferingPresenter do
+  include LinkHelpers
+
   let(:guid) { 'some-offering-guid' }
   let(:name) { 'some-offering-name' }
   let(:description) { 'some offering description' }

--- a/spec/unit/presenters/v3/service_plan_visibility_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_plan_visibility_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'presenters/v3/service_plan_visibility_presenter'
 
 RSpec.describe VCAP::CloudController::Presenters::V3::ServicePlanVisibilityPresenter do

--- a/spec/unit/presenters/v3/service_route_binding_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_route_binding_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'db_spec_helper'
 require 'presenters/v3/service_route_binding_presenter'
 
 module VCAP

--- a/spec/unit/presenters/v3/service_usage_event_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_usage_event_presenter_spec.rb
@@ -1,7 +1,10 @@
-require 'spec_helper'
+require 'db_spec_helper'
+require 'support/link_helpers'
 require 'presenters/v3/service_usage_event_presenter'
 
 RSpec.describe VCAP::CloudController::Presenters::V3::ServiceUsageEventPresenter do
+  include LinkHelpers
+
   let(:usage_event) { VCAP::CloudController::ServiceUsageEvent.make }
 
   describe '#to_hash' do


### PR DESCRIPTION
This includes a `db_spec_helper` file which loads far less files than the normal `spec_helper`.  Additionally it does not automatically rerun migrations from scratch.  This makes running individual tests much quicker.  Additionally, as many files are not automatically included, running a test with this spec helper will highlight code that is relying on `require`s in other files.  This forces files to more explicitly `require` the files specifically needed, which in turn creates more consistency in the code so that everything isn't relying on the side effects of everything else.