### PR TITLE
v3(services): update the platform broker poll interval while an async…

### DIFF
--- a/app/jobs/reoccurring_job.rb
+++ b/app/jobs/reoccurring_job.rb
@@ -30,7 +30,8 @@ module VCAP::CloudController
       end
 
       def polling_interval_seconds
-        @polling_interval || default_polling_interval_seconds
+        [@polling_interval || 0, default_polling_interval_seconds].max
+
       end
 
       def polling_interval_seconds=(interval)
@@ -51,7 +52,7 @@ module VCAP::CloudController
       end
 
       def default_maximum_duration_seconds
-        VCAP::CloudController::Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
+        Config.config.get(:broker_client_max_async_poll_duration_minutes).minutes
       end
 
       def default_polling_interval_seconds

--- a/app/jobs/reoccurring_job.rb
+++ b/app/jobs/reoccurring_job.rb
@@ -31,7 +31,6 @@ module VCAP::CloudController
 
       def polling_interval_seconds
         [@polling_interval || 0, default_polling_interval_seconds].max
-
       end
 
       def polling_interval_seconds=(interval)

--- a/spec/unit/jobs/reoccurring_job_spec.rb
+++ b/spec/unit/jobs/reoccurring_job_spec.rb
@@ -80,11 +80,11 @@ module VCAP
         Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
         execute_all_jobs(expected_successes: 1, expected_failures: 0)
 
-        Timecop.freeze(94.seconds.after enqueued_time) do
+        Timecop.freeze(94.seconds.after(enqueued_time)) do
           execute_all_jobs(expected_successes: 0, expected_failures: 0)
         end
 
-        Timecop.freeze(96.seconds.after enqueued_time) do
+        Timecop.freeze(96.seconds.after(enqueued_time)) do
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
         end
       end
@@ -99,89 +99,88 @@ module VCAP
       end
 
       context 'updates the polling interval if config changes' do
-          it 'when changed from the job only' do
-            job = FakeJob.new(retry_after: [20, 30])
-            TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
+        it 'when changed from the job only' do
+          job = FakeJob.new(retry_after: [20, 30])
+          TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
 
-            enqueued_time = Time.now
+          enqueued_time = Time.now
 
-            Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
-            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
 
-            Timecop.freeze(19.seconds.after enqueued_time) do
-              execute_all_jobs(expected_successes: 0, expected_failures: 0)
-            end
-
-            Timecop.freeze(22.seconds.after enqueued_time) do
-              enqueued_time = Time.now
-              execute_all_jobs(expected_successes: 1, expected_failures: 0)
-            end
-
-            Timecop.freeze(29.seconds.after enqueued_time) do
-              execute_all_jobs(expected_successes: 0, expected_failures: 0)
-            end
-
-            Timecop.freeze(32.seconds.after enqueued_time) do
-              execute_all_jobs(expected_successes: 1, expected_failures: 0)
-            end
-
+          Timecop.freeze(19.seconds.after(enqueued_time)) do
+            execute_all_jobs(expected_successes: 0, expected_failures: 0)
           end
 
-          it 'when default changed after changing from the job' do
-            job = FakeJob.new(retry_after: [20])
-            TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
-
+          Timecop.freeze(22.seconds.after(enqueued_time)) do
             enqueued_time = Time.now
-
-            Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
             execute_all_jobs(expected_successes: 1, expected_failures: 0)
-
-            Timecop.freeze(19.seconds.after enqueued_time) do
-              execute_all_jobs(expected_successes: 0, expected_failures: 0)
-            end
-
-            Timecop.freeze(21.seconds.after enqueued_time) do
-              TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 30
-              enqueued_time = Time.now
-              execute_all_jobs(expected_successes: 1, expected_failures: 0)
-            end
-
-            Timecop.freeze(29.seconds.after enqueued_time) do
-              execute_all_jobs(expected_successes: 0, expected_failures: 0)
-            end
-
-            Timecop.freeze(31.seconds.after enqueued_time) do
-              execute_all_jobs(expected_successes: 1, expected_failures: 0)
-            end
           end
 
-          it 'when changing default only' do
-            job = FakeJob.new
-            TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
-
-            enqueued_time = Time.now
-
-            Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
-            execute_all_jobs(expected_successes: 1, expected_failures: 0)
-
-            Timecop.freeze(9.seconds.after enqueued_time) do
-              execute_all_jobs(expected_successes: 0, expected_failures: 0)
-            end
-
-            Timecop.freeze(11.seconds.after enqueued_time) do
-              TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 30
-              enqueued_time = Time.now
-              execute_all_jobs(expected_successes: 1, expected_failures: 0)
-            end
-
-            Timecop.freeze(29.seconds.after enqueued_time) do
-              execute_all_jobs(expected_successes: 0, expected_failures: 0)
-            end
-
-            Timecop.freeze(31.seconds.after enqueued_time) do
-              execute_all_jobs(expected_successes: 1, expected_failures: 0)
-            end
+          Timecop.freeze(29.seconds.after(enqueued_time)) do
+            execute_all_jobs(expected_successes: 0, expected_failures: 0)
           end
+
+          Timecop.freeze(32.seconds.after(enqueued_time)) do
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          end
+        end
+
+        it 'when default changed after changing from the job' do
+          job = FakeJob.new(retry_after: [20])
+          TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
+
+          enqueued_time = Time.now
+
+          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+
+          Timecop.freeze(19.seconds.after(enqueued_time)) do
+            execute_all_jobs(expected_successes: 0, expected_failures: 0)
+          end
+
+          Timecop.freeze(21.seconds.after(enqueued_time)) do
+            TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 30
+            enqueued_time = Time.now
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          end
+
+          Timecop.freeze(29.seconds.after(enqueued_time)) do
+            execute_all_jobs(expected_successes: 0, expected_failures: 0)
+          end
+
+          Timecop.freeze(31.seconds.after(enqueued_time)) do
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          end
+        end
+
+        it 'when changing default only' do
+          job = FakeJob.new
+          TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
+
+          enqueued_time = Time.now
+
+          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+
+          Timecop.freeze(9.seconds.after(enqueued_time)) do
+            execute_all_jobs(expected_successes: 0, expected_failures: 0)
+          end
+
+          Timecop.freeze(11.seconds.after(enqueued_time)) do
+            TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 30
+            enqueued_time = Time.now
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          end
+
+          Timecop.freeze(29.seconds.after(enqueued_time)) do
+            execute_all_jobs(expected_successes: 0, expected_failures: 0)
+          end
+
+          Timecop.freeze(31.seconds.after(enqueued_time)) do
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          end
+        end
       end
 
       it 'continues to run until finished' do
@@ -208,7 +207,7 @@ module VCAP
           execute_all_jobs(expected_successes: 0, expected_failures: 1)
           expect(PollableJobModel.first.state).to eq('FAILED')
 
-          Timecop.freeze(61.seconds.after Time.now) do
+          Timecop.freeze(61.seconds.after(Time.now)) do
             execute_all_jobs(expected_successes: 0, expected_failures: 0)
           end
         end
@@ -251,7 +250,7 @@ module VCAP
 
           Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
 
-          Timecop.freeze(61.seconds.after Time.now) do
+          Timecop.freeze(61.seconds.after(Time.now)) do
             execute_all_jobs(expected_successes: 0, expected_failures: 1, jobs_to_execute: 1)
             expect(PollableJobModel.first.state).to eq('FAILED')
           end


### PR DESCRIPTION
… job is enqueued

[#174398272](https://www.pivotaltracker.com/story/show/174398272)

This just improves testing overall by making sure the updated interval is actually being used at runtime.

It also allows for platform default value to be updated in the unlikely scenario that we changed the platform value right after changing the polling interval from code. At the moment this scenario is very unlikely because it's the small interval between getting the response from the broker with a retry-after and re-scheduling the job, so I would be okay rolling back that change if we think it makes the code more complicated, but it makes for a more predictable behaviour.