### PR TITLE
v3(services): all bindings should have last_operation

### DIFF
--- a/app/presenters/mixins/last_operation_helper.rb
+++ b/app/presenters/mixins/last_operation_helper.rb
@@ -1,0 +1,21 @@
+module VCAP::CloudController::Presenters::Mixins
+  module LastOperationHelper
+    def last_operation(resource)
+      last_operation = resource.try(:last_operation)
+
+      if last_operation
+        last_operation.to_hash
+      else
+        # Bindings created using V2 may not have a last operation, so we make
+        # a best attempt so that the output JSON can be parsed consistently
+        {
+          type: 'create',
+          state: 'succeeded',
+          description: '',
+          created_at: resource.try(:created_at),
+          updated_at: resource.try(:updated_at),
+        }
+      end
+    end
+  end
+end

--- a/app/presenters/v3/service_route_binding_presenter.rb
+++ b/app/presenters/v3/service_route_binding_presenter.rb
@@ -1,10 +1,13 @@
 require_relative 'base_presenter'
+require 'presenters/mixins/last_operation_helper'
 
 module VCAP
   module CloudController
     module Presenters
       module V3
         class ServiceRouteBindingPresenter < BasePresenter
+          include VCAP::CloudController::Presenters::Mixins::LastOperationHelper
+
           def to_hash
             base.merge(decorations)
           end
@@ -17,7 +20,7 @@ module VCAP
               route_service_url: binding.route_service_url,
               created_at: binding.created_at,
               updated_at: binding.updated_at,
-              last_operation: last_operation,
+              last_operation: last_operation(binding),
               relationships: relationships,
               links: links
             }
@@ -29,20 +32,6 @@ module VCAP
 
           def binding
             @resource
-          end
-
-          def last_operation
-            return nil if binding.last_operation.blank?
-
-            last_operation = binding.last_operation
-
-            {
-              type: last_operation.type,
-              state: last_operation.state,
-              description: last_operation.description,
-              created_at: last_operation.created_at,
-              updated_at: last_operation.updated_at
-            }
           end
 
           def links

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1177,7 +1177,7 @@ RSpec.describe 'v3 service credential bindings' do
       created_at: iso8601,
       updated_at: iso8601,
       name: binding.name,
-      last_operation: nil,
+      last_operation: last_operation(binding),
       relationships: {
         service_instance: {
           data: {
@@ -1231,11 +1231,19 @@ RSpec.describe 'v3 service credential bindings' do
   end
 
   def last_operation(binding)
-    if binding.last_operation.present?
+    if binding.try(:last_operation)
       {
         type: binding.last_operation.type,
         state: binding.last_operation.state,
         description: binding.last_operation.description,
+        created_at: iso8601,
+        updated_at: iso8601
+      }
+    else
+      {
+        type: 'create',
+        state: 'succeeded',
+        description: '',
         created_at: iso8601,
         updated_at: iso8601
       }

--- a/spec/unit/presenters/v3/service_credential_binding_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_credential_binding_presenter_spec.rb
@@ -22,7 +22,7 @@ module VCAP
 
         it 'should include the binding fields plus links and relationships' do
           presenter = described_class.new(credential_binding)
-          expect(presenter.to_hash).to match(
+          expect(presenter.to_hash.with_indifferent_access).to match(
             {
               guid: 'some-guid',
               type: 'app',
@@ -78,6 +78,25 @@ module VCAP
             expect(presenter.to_hash[:name]).to be_nil
           end
         end
+
+        context 'no last_operation' do
+          let(:credential_binding) do
+            ServiceBinding.make(name: 'some-name', guid: 'some-guid', app: app, service_instance: instance)
+          end
+
+          it 'still displays the last operation' do
+            presenter = described_class.new(credential_binding)
+            expect(presenter.to_hash[:last_operation]).to match(
+              {
+                type: 'create',
+                state: 'succeeded',
+                description: '',
+                updated_at: credential_binding.updated_at,
+                created_at: credential_binding.created_at
+              }
+            )
+          end
+        end
       end
 
       describe 'key bindings' do
@@ -94,7 +113,13 @@ module VCAP
               name: 'some-name',
               created_at: credential_binding.created_at,
               updated_at: credential_binding.updated_at,
-              last_operation: nil,
+              last_operation: {
+                type: 'create',
+                state: 'succeeded',
+                description: '',
+                updated_at: credential_binding.updated_at,
+                created_at: credential_binding.created_at
+              },
               relationships: {
                 service_instance: {
                   data: {
@@ -118,6 +143,25 @@ module VCAP
               }
             }
           )
+        end
+
+        context 'no last_operation' do
+          let(:credential_binding) do
+            ServiceKey.make(name: 'some-name', guid: 'some-guid', service_instance: instance)
+          end
+
+          it 'still displays the last operation' do
+            presenter = described_class.new(credential_binding)
+            expect(presenter.to_hash[:last_operation]).to match(
+              {
+                type: 'create',
+                state: 'succeeded',
+                description: '',
+                updated_at: credential_binding.updated_at,
+                created_at: credential_binding.created_at
+              }
+            )
+          end
         end
       end
 

--- a/spec/unit/presenters/v3/service_route_binding_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_route_binding_presenter_spec.rb
@@ -27,7 +27,7 @@ module VCAP
 
       it 'presents the correct object' do
         presenter = described_class.new(binding)
-        expect(presenter.to_hash).to match(
+        expect(presenter.to_hash.with_indifferent_access).to match(
           {
             guid: guid,
             created_at: binding.created_at,
@@ -65,6 +65,30 @@ module VCAP
             }
           }
         )
+      end
+
+      context 'no last_operation' do
+        let(:binding) do
+          RouteBinding.make(
+            guid: guid,
+            service_instance: service_instance,
+            route: route,
+            route_service_url: route_service_url,
+          )
+        end
+
+        it 'still displays the last operation' do
+          presenter = described_class.new(binding)
+          expect(presenter.to_hash[:last_operation]).to match(
+            {
+              type: 'create',
+              state: 'succeeded',
+              description: '',
+              updated_at: binding.updated_at,
+              created_at: binding.created_at
+            }
+          )
+        end
       end
 
       describe 'decorators' do


### PR DESCRIPTION
When V3 bindings work is complete all binding types should have a
last_operation. However bindings created in V2 will not have this. To
make the output JSON for V3 GET endpoints consistent, we should patch up
missing last_operation objects, rather than present `null` which can be
harder to parse.

[#171843320](https://www.pivotaltracker.com/story/show/171843320)
