### PR TITLE
v3(services): Change 'label' to 'name' in links for

### DIFF
--- a/spec/request/service_offerings_spec.rb
+++ b/spec/request/service_offerings_spec.rb
@@ -762,6 +762,14 @@ RSpec.describe 'V3 service offerings' do
           expect(parsed_response['resources'][2]['name']).to eq('flopsy')
           expect(parsed_response['resources'][3]['name']).to eq('cottontail')
         end
+
+        it 'builds the right links' do
+          get('/v3/service_offerings?order_by=name&per_page=2', nil, admin_headers)
+          expect(last_response).to have_status_code(200)
+          expect(parsed_response['pagination']['first']['href']).to include('order_by=%2Bname')
+          expect(parsed_response['pagination']['last']['href']).to include('order_by=%2Bname')
+          expect(parsed_response['pagination']['next']['href']).to include('order_by=%2Bname')
+        end
       end
 
       it_behaves_like 'list endpoint order_by timestamps', '/v3/service_offerings' do


### PR DESCRIPTION
service_offerings pagination

[#175071777](https://www.pivotaltracker.com/story/show/175071777)

This was done in the same lines than [this story](https://www.pivotaltracker.com/n/projects/2196383/stories/173475906). [Code here](https://github.com/cloudfoundry/cloud_controller_ng/commit/226d9c117f5e69b1334c736a1aa58197127b211a)