### PR TITLE
Add ability to disable staging through `PUT /v2/apps/:guid`

### DIFF
--- a/app/actions/v2/app_update.rb
+++ b/app/actions/v2/app_update.rb
@@ -110,6 +110,10 @@ module VCAP::CloudController
       end
 
       def prepare_to_stage(app)
+        if v2_api_staging_disabled?
+          raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', 'Staging through the v2 API is disabled')
+        end
+
         app.update(droplet_guid: nil)
       end
 
@@ -172,6 +176,10 @@ module VCAP::CloudController
 
       def staging_necessary?(process, request_attrs)
         request_attrs.key?('state') && process.needs_staging?
+      end
+
+      def v2_api_staging_disabled?
+        !!VCAP::CloudController::Config.config.get(:temporary_disable_v2_staging)
       end
     end
   end

--- a/app/models/runtime/process_model.rb
+++ b/app/models/runtime/process_model.rb
@@ -184,7 +184,7 @@ module VCAP::CloudController
       return nil if package.nil?
 
       if package.bits?
-        package.package_hash
+        package.checksum_info[:value]
       elsif package.docker?
         package.image
       end
@@ -485,7 +485,7 @@ module VCAP::CloudController
     end
 
     def needs_staging?
-      package_hash && !staged? && started?
+      package_hash.present? && !staged? && started?
     end
 
     def staged?

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -11,6 +11,7 @@ module VCAP::CloudController
           external_domain: String,
           temporary_disable_deployments: bool,
           temporary_use_logcache: bool,
+          optional(:temporary_disable_v2_staging) => bool,
           tls_port: Integer,
           external_protocol: String,
           internal_service_hostname: String,

--- a/spec/unit/actions/app_start_spec.rb
+++ b/spec/unit/actions/app_start_spec.rb
@@ -89,17 +89,24 @@ module VCAP::CloudController
               state:   DropletModel::STAGED_STATE,
             )
           end
-          let(:package) { PackageModel.make(app: app, package_hash: 'some-awesome-thing', state: PackageModel::READY_STATE) }
+          let(:package) do
+            PackageModel.make(
+              app: app,
+              package_hash: 'some-sha1',
+              sha256_checksum: 'some-sha256',
+              state: PackageModel::READY_STATE
+            )
+          end
 
-          it 'sets the package hash correctly on the process' do
+          it 'the package_hash for each process refers to the latest package' do
             AppStart.start(app: app, user_audit_info: user_audit_info)
 
             process1.reload
-            expect(process1.package_hash).to eq(package.package_hash)
+            expect(process1.package_hash).to eq(package.sha256_checksum)
             expect(process1.package_state).to eq('STAGED')
 
             process2.reload
-            expect(process2.package_hash).to eq(package.package_hash)
+            expect(process2.package_hash).to eq(package.sha256_checksum)
             expect(process2.package_state).to eq('STAGED')
           end
         end

--- a/spec/unit/actions/v2/app_update_spec.rb
+++ b/spec/unit/actions/v2/app_update_spec.rb
@@ -379,13 +379,13 @@ module VCAP::CloudController
 
           it 'does not mark the app for staging' do
             expect(process.staged?).to be_falsey
-            expect(process.needs_staging?).to be_nil
+            expect(process.needs_staging?).to be false
 
             app_update.update(app, process, request_attrs)
             process.reload
 
             expect(process.staged?).to be_falsey
-            expect(process.needs_staging?).to be_nil
+            expect(process.needs_staging?).to be false
           end
         end
       end

--- a/spec/unit/actions/v2/app_update_spec.rb
+++ b/spec/unit/actions/v2/app_update_spec.rb
@@ -568,6 +568,18 @@ module VCAP::CloudController
               app_update.update(app, process, request_attrs)
               expect(process.reload.desired_droplet).to be_nil
             end
+
+            context 'when temporary_disable_v2_staging is true' do
+              before do
+                TestConfig.override(temporary_disable_v2_staging: true)
+              end
+
+              it 'raises an error' do
+                expect {
+                  app_update.update(app, process, request_attrs)
+                }.to raise_error(/Staging through the v2 API is disabled/)
+              end
+            end
           end
 
           context 'when the app does not need staging' do
@@ -581,6 +593,18 @@ module VCAP::CloudController
               expect(process.desired_droplet).not_to be_nil
               app_update.update(app, process, request_attrs)
               expect(process.reload.desired_droplet).not_to be_nil
+            end
+
+            context 'when temporary_disable_v2_staging is true' do
+              before do
+                TestConfig.override(temporary_disable_v2_staging: true)
+              end
+
+              it 'does not raise an error' do
+                expect {
+                  app_update.update(app, process, request_attrs)
+                }.not_to raise_error
+              end
             end
           end
         end

--- a/spec/unit/controllers/runtime/apps_controller_spec.rb
+++ b/spec/unit/controllers/runtime/apps_controller_spec.rb
@@ -973,14 +973,14 @@ module VCAP::CloudController
 
           it 'does not mark the app for staging' do
             expect(process.staged?).to be_falsey
-            expect(process.needs_staging?).to be_nil
+            expect(process.needs_staging?).to be false
 
             put "/v2/apps/#{process.app.guid}", MultiJson.dump({ stack_guid: new_stack.guid })
             expect(last_response.status).to eq(201)
             process.reload
 
             expect(process.staged?).to be_falsey
-            expect(process.needs_staging?).to be_nil
+            expect(process.needs_staging?).to be false
           end
         end
       end

--- a/spec/unit/lib/cloud_controller/backends/stagers_spec.rb
+++ b/spec/unit/lib/cloud_controller/backends/stagers_spec.rb
@@ -16,7 +16,7 @@ module VCAP::CloudController
       end
 
       context 'when the app package hash is blank' do
-        before { PackageModel.make(package_hash: nil, app: process_model) }
+        before { PackageModel.make(package_hash: nil, sha256_checksum: '', app: process_model) }
 
         it 'raises' do
           expect {

--- a/spec/unit/models/runtime/process_model_spec.rb
+++ b/spec/unit/models/runtime/process_model_spec.rb
@@ -1066,8 +1066,8 @@ module VCAP::CloudController
           process.update(state: 'STARTED', instances: 1)
         end
 
-        it 'should return false if the package_hash is nil' do
-          process.latest_package.update(package_hash: nil)
+        it 'should return false if the latest package has not been uploaded (indicated by blank checksums)' do
+          process.latest_package.update(package_hash: nil, sha256_checksum: '')
           expect(process.needs_staging?).to be_falsey
         end
 


### PR DESCRIPTION
This PR introduces a new, temporary config property called `temporary_disable_v2_staging` that can be used to disable package staging through the v2 APIs. The property will be removed once the [v2 APIs are fully disabled](https://docs.google.com/document/d/1KFZogeeexOqFf13oKHloe2QAorLh9OqwQHp8JvBl9lY/edit), hence the `temporary_` prefix.

In `capi-k8s-release` this property will default to `true`. We do not validate that the v2 APIs work in `cf-for-k8s` so disabling this can help reinforce their lack of support and encourage users to move over to clients that use the v3 APIs.

Additionally, this fixes an issue where the `PUT /v2/apps/:guid` API would not detect that a package uploaded to the package registry needed staging. This resulted in `cf push` commands that used the `/v2/apps/:guid` endpoint to hang until staging timed out.

CAKE Story: [#175157530](https://www.pivotaltracker.com/story/show/175157530)