### PR TITLE
Implement get and list methods for tasks in OPI

### DIFF
--- a/lib/cloud_controller/opi/task_client.rb
+++ b/lib/cloud_controller/opi/task_client.rb
@@ -24,7 +24,7 @@ module OPI
     def fetch_task(guid)
       resp = client.get("/tasks/#{guid}")
 
-      return nil if resp.status_code == 404
+      return if resp.status_code == 404
 
       if resp.status_code != 200
         raise CloudController::Errors::ApiError.new_from_details('TaskError', "response status code: #{resp.status_code}")


### PR DESCRIPTION
Implement `fetch_task` and `fetch_tasks` methods in the OPI task client.

Fixes https://github.com/cloudfoundry/cf-for-k8s/issues/412.
Also, related: https://github.com/cloudfoundry-incubator/eirini/issues/107.


[#174335347]

Co-authored-by: Giuseppe Capizzi <gcapizzi@pivotal.io>

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
