### PR TITLE
v2/v3(bindings): allow only one binding per app/SI

### DIFF
--- a/db/migrations/20201013153721_add_service_instance_constraint_to_service_bindings.rb
+++ b/db/migrations/20201013153721_add_service_instance_constraint_to_service_bindings.rb
@@ -2,7 +2,7 @@ Sequel.migration do
   up do
     # We are assuming with this DB migration that the service_bindings table currently
     # has no duplicate rows, according to the unique constraint of 
-    #(service_instance_guid, app_guid). This migration will fail otherwise.
+    # (service_instance_guid, app_guid). This migration will fail otherwise.
     # 
     # Please manually remove duplicate entries from the database if 
     # this migration is failing.

--- a/db/migrations/20201013153721_add_service_instance_constraint_to_service_bindings.rb
+++ b/db/migrations/20201013153721_add_service_instance_constraint_to_service_bindings.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :service_bindings do
+      add_unique_constraint [:service_instance_guid, :app_guid], name: :unique_service_binding_service_instance_guid_app_guid
+    end
+  end
+end

--- a/db/migrations/20201013153721_add_service_instance_constraint_to_service_bindings.rb
+++ b/db/migrations/20201013153721_add_service_instance_constraint_to_service_bindings.rb
@@ -1,7 +1,21 @@
 Sequel.migration do
-  change do
+  up do
+    # We are assuming with this DB migration that the service_bindings table currently
+    # has no duplicate rows, according to the unique constraint of 
+    #(service_instance_guid, app_guid). This migration will fail otherwise.
+    # 
+    # Please manually remove duplicate entries from the database if 
+    # this migration is failing.
+
     alter_table :service_bindings do
       add_unique_constraint [:service_instance_guid, :app_guid], name: :unique_service_binding_service_instance_guid_app_guid
+      add_unique_constraint [:app_id, :route_id, :app_port], name: :apps_routes_app_id_route_id_app_port_key
+    end
+  end
+
+  down do
+    alter_table :service_bindings do
+      drop_constraint :unique_service_binding_service_instance_guid_app_guid
     end
   end
 end


### PR DESCRIPTION
[#175012888](https://www.pivotaltracker.com/story/show/175012888)

When receiving multiple parallel requests to create service bindings, CC will, sometimes, accept more than one request.

This commit adds a DB constraint to stop that from happening

See #1872