### PR TITLE
v3(services) Make sure the LO state is failed when job fails

### DIFF
--- a/app/jobs/v3/create_binding_async_job.rb
+++ b/app/jobs/v3/create_binding_async_job.rb
@@ -7,7 +7,7 @@ require 'jobs/v3/create_service_binding_job_factory'
 module VCAP::CloudController
   module V3
     class CreateBindingAsyncJob < Jobs::ReoccurringJob
-      class BindingGone < CloudController::Errors::ApiError; end
+      class BindingNotFound < CloudController::Errors::ApiError; end
 
       def initialize(type, precursor_guid, parameters:, user_audit_info:, audit_hash:)
         super()
@@ -52,7 +52,7 @@ module VCAP::CloudController
       end
 
       def perform
-        gone! unless resource
+        not_found! unless resource
 
         compute_maximum_duration
 
@@ -72,7 +72,7 @@ module VCAP::CloudController
         if polling_status[:retry_after].present?
           self.polling_interval_seconds = polling_status[:retry_after]
         end
-      rescue BindingGone => e
+      rescue BindingNotFound => e
         raise e
       rescue ServiceBindingCreate::BindingNotRetrievable
         raise CloudController::Errors::ApiError.new_from_details('ServiceBindingInvalid', 'The broker responded asynchronously but does not support fetching binding data')
@@ -92,19 +92,6 @@ module VCAP::CloudController
         )
       end
 
-      def save_failure(error_message)
-        if resource.reload.last_operation.state != 'failed'
-          resource.save_with_attributes_and_new_operation(
-            {},
-            {
-              type: operation_type,
-              state: 'failed',
-              description: error_message,
-            }
-          )
-        end
-      end
-
       private
 
       def resource
@@ -116,8 +103,21 @@ module VCAP::CloudController
         self.maximum_duration_seconds = max_poll_duration_on_plan
       end
 
-      def gone!
-        raise BindingGone.new_from_details('ResourceNotFound', "The binding could not be found: #{@resource_guid}")
+      def not_found!
+        raise BindingNotFound.new_from_details('ResourceNotFound', "The binding could not be found: #{@resource_guid}")
+      end
+
+      def save_failure(error_message)
+        if resource.reload.last_operation.state != 'failed'
+          resource.save_with_attributes_and_new_operation(
+            {},
+            {
+              type: operation_type,
+              state: 'failed',
+              description: error_message,
+            }
+          )
+        end
       end
     end
   end

--- a/app/jobs/v3/create_binding_async_job.rb
+++ b/app/jobs/v3/create_binding_async_job.rb
@@ -7,6 +7,8 @@ require 'jobs/v3/create_service_binding_job_factory'
 module VCAP::CloudController
   module V3
     class CreateBindingAsyncJob < Jobs::ReoccurringJob
+      class BindingGone < CloudController::Errors::ApiError; end
+
       def initialize(type, precursor_guid, parameters:, user_audit_info:, audit_hash:)
         super()
         @type = type
@@ -70,9 +72,12 @@ module VCAP::CloudController
         if polling_status[:retry_after].present?
           self.polling_interval_seconds = polling_status[:retry_after]
         end
+      rescue BindingGone => e
+        raise e
       rescue ServiceBindingCreate::BindingNotRetrievable
         raise CloudController::Errors::ApiError.new_from_details('ServiceBindingInvalid', 'The broker responded asynchronously but does not support fetching binding data')
       rescue => e
+        save_failure(e.message)
         raise CloudController::Errors::ApiError.new_from_details('UnableToPerform', 'bind', e.message)
       end
 
@@ -87,6 +92,19 @@ module VCAP::CloudController
         )
       end
 
+      def save_failure(error_message)
+        if resource.reload.last_operation.state != 'failed'
+          resource.save_with_attributes_and_new_operation(
+            {},
+            {
+              type: operation_type,
+              state: 'failed',
+              description: error_message,
+            }
+          )
+        end
+      end
+
       private
 
       def resource
@@ -99,7 +117,7 @@ module VCAP::CloudController
       end
 
       def gone!
-        raise CloudController::Errors::ApiError.new_from_details('ResourceNotFound', "The binding could not be found: #{@resource_guid}")
+        raise BindingGone.new_from_details('ResourceNotFound', "The binding could not be found: #{@resource_guid}")
       end
     end
   end

--- a/spec/support/shared_examples/jobs/create_binding_job.rb
+++ b/spec/support/shared_examples/jobs/create_binding_job.rb
@@ -180,7 +180,7 @@ RSpec.shared_examples 'create binding job' do |binding_type|
         binding.destroy
 
         expect { subject.perform }.to raise_error(
-          VCAP::CloudController::V3::CreateBindingAsyncJob::BindingGone,
+          VCAP::CloudController::V3::CreateBindingAsyncJob::BindingNotFound,
           /The binding could not be found/,
         )
       end

--- a/spec/support/shared_examples/jobs/create_binding_job.rb
+++ b/spec/support/shared_examples/jobs/create_binding_job.rb
@@ -180,7 +180,7 @@ RSpec.shared_examples 'create binding job' do |binding_type|
         binding.destroy
 
         expect { subject.perform }.to raise_error(
-          CloudController::Errors::ApiError,
+          VCAP::CloudController::V3::CreateBindingAsyncJob::BindingGone,
           /The binding could not be found/,
         )
       end
@@ -194,6 +194,10 @@ RSpec.shared_examples 'create binding job' do |binding_type|
           CloudController::Errors::ApiError,
           'bind could not be completed: StandardError',
         )
+
+        binding.reload
+        expect(binding.last_operation.type).to eq('create')
+        expect(binding.last_operation.state).to eq('failed')
       end
     end
 
@@ -205,6 +209,10 @@ RSpec.shared_examples 'create binding job' do |binding_type|
           CloudController::Errors::ApiError,
           'bind could not be completed: StandardError',
         )
+
+        binding.reload
+        expect(binding.last_operation.type).to eq('create')
+        expect(binding.last_operation.state).to eq('failed')
       end
     end
   end
@@ -212,6 +220,7 @@ RSpec.shared_examples 'create binding job' do |binding_type|
   describe '#handle_timeout' do
     it 'updates the last operation to failed' do
       subject.handle_timeout
+
       binding.reload
       expect(binding.last_operation.type).to eq('create')
       expect(binding.last_operation.state).to eq('failed')

--- a/spec/unit/jobs/v3/service_instance_async_job_spec.rb
+++ b/spec/unit/jobs/v3/service_instance_async_job_spec.rb
@@ -68,10 +68,10 @@ module VCAP::CloudController
 
         it 'returns if gone! is defined' do
           service_instance.destroy
-          allow(job).to receive(:not_found!).and_return(true)
+          allow(job).to receive(:gone!).and_return(true)
 
           expect { job.perform }.not_to raise_error
-          expect(job).to have_received(:not_found!)
+          expect(job).to have_received(:gone!)
         end
 
         context 'when there is another operation in progress' do

--- a/spec/unit/jobs/v3/service_instance_async_job_spec.rb
+++ b/spec/unit/jobs/v3/service_instance_async_job_spec.rb
@@ -68,10 +68,10 @@ module VCAP::CloudController
 
         it 'returns if gone! is defined' do
           service_instance.destroy
-          allow(job).to receive(:gone!).and_return(true)
+          allow(job).to receive(:not_found!).and_return(true)
 
           expect { job.perform }.not_to raise_error
-          expect(job).to have_received(:gone!)
+          expect(job).to have_received(:not_found!)
         end
 
         context 'when there is another operation in progress' do


### PR DESCRIPTION
Sometimes the Job can fail for unexpected reasons. In any failure we should make sure to leave the LO state as 'failed'

[#175264299](https://www.pivotaltracker.com/story/show/175264299)
