### PR TITLE
fix docker app deletion when using a package registry

### DIFF
--- a/app/actions/package_delete.rb
+++ b/app/actions/package_delete.rb
@@ -8,12 +8,8 @@ module VCAP::CloudController
       packages = Array(packages)
 
       packages.each do |package|
-        package_delete = if VCAP::CloudController::Config.config.package_image_registry_configured?
-                           Jobs::Kubernetes::RegistryDelete.new(package.bits_image_reference)
-                         else
-                           Jobs::Runtime::BlobstoreDelete.new(package.guid, :package_blobstore)
-                         end
-        Jobs::Enqueuer.new(package_delete, queue: Jobs::Queues.generic).enqueue
+        package_src_delete_job = create_package_source_deletion_job(package)
+        Jobs::Enqueuer.new(package_src_delete_job, queue: Jobs::Queues.generic).enqueue if package_src_delete_job
         package.destroy
 
         Repositories::PackageEventRepository.record_app_package_delete(
@@ -22,6 +18,18 @@ module VCAP::CloudController
       end
 
       []
+    end
+
+    private
+
+    def create_package_source_deletion_job(package)
+      return Jobs::Runtime::BlobstoreDelete.new(package.guid, :package_blobstore) unless package_registry_configured?
+
+      package.bits? ? Jobs::Kubernetes::RegistryDelete.new(package.bits_image_reference) : nil
+    end
+
+    def package_registry_configured?
+      VCAP::CloudController::Config.config.package_image_registry_configured?
     end
   end
 end

--- a/spec/unit/actions/package_delete_spec.rb
+++ b/spec/unit/actions/package_delete_spec.rb
@@ -24,18 +24,32 @@ module VCAP::CloudController
             TestConfig.override(packages: { image_registry: { base_path: 'hub.example.com/user' } })
           end
 
-          it 'schedules a job to the delete the blobstore item' do
-            expect {
-              package_delete.delete(package)
-            }.to change {
-              Delayed::Job.count
-            }.by(1)
+          context 'when the package type is bits' do
+            it 'schedules a job to the delete the package from the container registry' do
+              expect {
+                package_delete.delete(package)
+              }.to change {
+                Delayed::Job.count
+              }.by(1)
 
-            job = Delayed::Job.last
-            expect(job.handler).to include('VCAP::CloudController::Jobs::Kubernetes::RegistryDelete')
-            expect(job.handler).to include(package.bits_image_reference(digest: false))
-            expect(job.queue).to eq(Jobs::Queues.generic)
-            expect(job.guid).not_to be_nil
+              job = Delayed::Job.last
+              expect(job.handler).to include('VCAP::CloudController::Jobs::Kubernetes::RegistryDelete')
+              expect(job.handler).to include(package.bits_image_reference(digest: false))
+              expect(job.queue).to eq(Jobs::Queues.generic)
+              expect(job.guid).not_to be_nil
+            end
+          end
+
+          context 'when the package type is docker' do
+            let!(:package) { PackageModel.make(type: PackageModel::DOCKER_TYPE) }
+
+            it 'does not schedule a deletion job since there was no source code uploaded' do
+              expect {
+                package_delete.delete(package)
+              }.to change {
+                Delayed::Job.count
+              }.by(0)
+            end
           end
         end
 


### PR DESCRIPTION
- the package.bits_image_reference method returns an error when the
package type is 'docker'
- there is no need to clean up the package registry for a docker app so
we can skip it

fixes https://github.com/cloudfoundry/capi-k8s-release/issues/84
[#175295965](https://www.pivotaltracker.com/story/show/175295965)
