### PR TITLE
Introduce "kpack" Droplets and Support Custom Start Commands

### DIFF
--- a/app/actions/droplet_create.rb
+++ b/app/actions/droplet_create.rb
@@ -63,6 +63,20 @@ module VCAP::CloudController
       droplet
     end
 
+    def create_kpack_droplet(build)
+      droplet = droplet_from_build(build)
+
+      DropletModel.db.transaction do
+        droplet.save
+        droplet.kpack_lifecycle_data = build.kpack_lifecycle_data
+      end
+
+      droplet.reload
+      Steno.logger('build_completed').info("droplet created: #{droplet.guid}")
+      record_audit_event(droplet, build.package, user_audit_info_from_build(build))
+      droplet
+    end
+
     private
 
     def droplet_from_build(build)

--- a/app/actions/droplet_update.rb
+++ b/app/actions/droplet_update.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
 
         if message.requested?(:image)
           raise InvalidDroplet.new('Droplet image can only be updated on staged droplets') unless droplet.staged?
-          raise InvalidDroplet.new('Images can only be updated for docker droplets') unless droplet.docker?
+          raise InvalidDroplet.new('Images can only be updated for docker droplets') unless droplet.has_docker_image?
 
           droplet.docker_receipt_image = message.image
         end

--- a/app/presenters/v3/droplet_presenter.rb
+++ b/app/presenters/v3/droplet_presenter.rb
@@ -47,7 +47,7 @@ module VCAP::CloudController
           }.tap do |links|
             links[:package] = { href: url_builder.build_url(path: "/v3/packages/#{droplet.package_guid}") } if droplet.package_guid.present?
             links[:upload] = { href: url_builder.build_url(path: "/v3/droplets/#{droplet.guid}/upload"), method: 'POST' } if droplet.state == DropletModel::AWAITING_UPLOAD_STATE
-            if droplet.state == DropletModel::STAGED_STATE && !droplet.docker?
+            if droplet.state == DropletModel::STAGED_STATE && droplet.buildpack?
               links[:download] = { href: url_builder.build_url(path: "/v3/droplets/#{droplet.guid}/download") }
             end
           end

--- a/db/migrations/20201020204056_index_kpack_lifecycle_data_droplet_guid.rb
+++ b/db/migrations/20201020204056_index_kpack_lifecycle_data_droplet_guid.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :kpack_lifecycle_data do
+      add_index :droplet_guid, name: :kpack_lifecycle_droplet_guid_index
+    end
+  end
+
+  down do
+    alter_table :kpack_lifecycle_data do
+      drop_index :droplet_guid, name: :kpack_lifecycle_droplet_guid_index
+    end
+  end
+end

--- a/lib/cloud_controller/kpack/stager.rb
+++ b/lib/cloud_controller/kpack/stager.rb
@@ -180,7 +180,7 @@ module Kpack
 
     def create_droplet_and_get_guid(staging_details)
       build = VCAP::CloudController::BuildModel.find(guid: staging_details.staging_guid)
-      droplet = VCAP::CloudController::DropletCreate.new.create_docker_droplet(build)
+      droplet = VCAP::CloudController::DropletCreate.new.create_kpack_droplet(build)
       droplet.guid
     end
   end

--- a/lib/cloud_controller/opi/apps_client.rb
+++ b/lib/cloud_controller/opi/apps_client.rb
@@ -112,8 +112,8 @@ module OPI
       end
 
       def to_hash
-        command = if @process.command.presence
-                    ['/bin/sh', '-c', "#{CNB_LAUNCHER_PATH} #{@process.command}"]
+        command = if @process.started_command.presence
+                    ['/bin/sh', '-c', "#{CNB_LAUNCHER_PATH} #{@process.started_command}"]
                   else
                     []
                   end

--- a/lib/cloud_controller/opi/apps_client.rb
+++ b/lib/cloud_controller/opi/apps_client.rb
@@ -104,10 +104,35 @@ module OPI
       end
     end
 
+    class KpackLifecycle
+      CNB_LAUNCHER_PATH = '/cnb/lifecycle/launcher'.freeze
+
+      def initialize(process)
+        @process = process
+      end
+
+      def to_hash
+        command = if @process.command.presence
+                    ['/bin/sh', '-c', "#{CNB_LAUNCHER_PATH} #{@process.command}"]
+                  else
+                    []
+                  end
+        {
+          docker_lifecycle: {
+            command: command,
+            image: @process.desired_droplet.docker_receipt_image,
+          }
+        }
+      end
+    end
+
     def lifecycle_for(process)
-      if process.app.droplet.lifecycle_type == VCAP::CloudController::Lifecycles::DOCKER
+      case process.app.droplet.lifecycle_type
+      when VCAP::CloudController::Lifecycles::DOCKER
         DockerLifecycle.new(process)
-      elsif process.app.droplet.lifecycle_type == VCAP::CloudController::Lifecycles::BUILDPACK
+      when VCAP::CloudController::Lifecycles::KPACK
+        KpackLifecycle.new(process)
+      when VCAP::CloudController::Lifecycles::BUILDPACK
         BuildpackLifecycle.new(process)
       else
         raise("lifecycle type `#{process.app.lifecycle_type}` is invalid")

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -121,9 +121,10 @@ module VCAP::CloudController
     guid { Sham.guid }
     droplet_hash { nil }
     sha256_checksum { nil }
-    state { VCAP::CloudController::DropletModel::STAGING_STATE }
+    state { VCAP::CloudController::DropletModel::STAGED_STATE }
     app { AppModel.make(droplet_guid: guid) }
     buildpack_lifecycle_data { nil.tap { |_| object.save } }
+    kpack_lifecycle_data { nil.tap { |_| object.save } }
   end
 
   DropletModel.blueprint(:kpack) do
@@ -134,6 +135,7 @@ module VCAP::CloudController
     app { AppModel.make(:kpack, droplet_guid: guid) }
     state { VCAP::CloudController::DropletModel::STAGED_STATE }
     buildpack_lifecycle_data { nil.tap { |_| object.save } }
+    kpack_lifecycle_data { KpackLifecycleDataModel.make(droplet: object.save) }
   end
 
   DeploymentModel.blueprint do

--- a/spec/unit/actions/droplet_create_spec.rb
+++ b/spec/unit/actions/droplet_create_spec.rb
@@ -220,5 +220,72 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe '#create_kpack_droplet' do
+      let!(:kpack_lifecycle_data) { KpackLifecycleDataModel.make(build: build) }
+
+      it 'sets it on the droplet' do
+        expect {
+          droplet_create.create_kpack_droplet(build)
+        }.to change { [DropletModel.count, Event.count] }.by([1, 1])
+
+        droplet = DropletModel.last
+
+        expect(droplet.state).to eq(DropletModel::STAGING_STATE)
+        expect(droplet.app).to eq(app)
+        expect(droplet.package).to eq(package)
+        expect(droplet.build).to eq(build)
+        expect(droplet.kpack?).to be true
+
+        kpack_lifecycle_data.reload
+        expect(kpack_lifecycle_data.droplet).to eq(droplet)
+
+        event = Event.last
+        expect(event.type).to eq('audit.app.droplet.create')
+        expect(event.actor).to eq('schneider')
+        expect(event.actor_type).to eq('user')
+        expect(event.actor_name).to eq('bob@loblaw.com')
+        expect(event.actor_username).to eq('bobert')
+        expect(event.actee).to eq(app.guid)
+        expect(event.actee_type).to eq('app')
+        expect(event.actee_name).to eq(app.name)
+        expect(event.timestamp).to be
+        expect(event.space_guid).to eq(app.space_guid)
+        expect(event.organization_guid).to eq(app.space.organization.guid)
+        expect(event.metadata).to eq({
+          'droplet_guid' => droplet.guid,
+          'package_guid' => package.guid,
+        })
+      end
+
+      context 'when the build does not contain created_by fields' do
+        let(:build) do
+          BuildModel.make(
+            app: app,
+            package: package,
+          )
+        end
+
+        it 'sets the actor to UNKNOWN' do
+          expect {
+            droplet_create.create_kpack_droplet(build)
+          }.to change { [DropletModel.count, Event.count] }.by([1, 1])
+
+          droplet = DropletModel.last
+          expect(droplet.build).to eq(build)
+
+          event = Event.last
+          expect(event.type).to eq('audit.app.droplet.create')
+          expect(event.actor_type).to eq('user')
+          expect(event.actor).to eq('UNKNOWN')
+          expect(event.actor_name).to eq('')
+          expect(event.actor_username).to eq('')
+          expect(event.metadata).to eq({
+            'droplet_guid' => droplet.guid,
+            'package_guid' => package.guid,
+          })
+        end
+      end
+    end
   end
 end

--- a/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
+++ b/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
@@ -98,10 +98,10 @@ module Kpack
       end
 
       let!(:build) { VCAP::CloudController::BuildModel.make(:kpack) }
-      let!(:droplet) { VCAP::CloudController::DropletModel.make(:docker, app: package.app) }
+      let!(:droplet) { VCAP::CloudController::DropletModel.make(:kpack, app: package.app) }
 
       before do
-        allow_any_instance_of(VCAP::CloudController::DropletCreate).to receive(:create_docker_droplet).with(build).and_return(droplet)
+        allow_any_instance_of(VCAP::CloudController::DropletCreate).to receive(:create_kpack_droplet).with(build).and_return(droplet)
       end
 
       it 'checks if the image exists' do

--- a/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe(OPI::Client) do
         end
       end
 
-      context 'when droplet belongs to buildpack lifecycle' do
+      context 'when droplet has a buildpack lifecycle' do
         let(:lifecycle_type) { :buildpack }
         let(:buildpack_lifecycle) {
           {
@@ -362,7 +362,7 @@ RSpec.describe(OPI::Client) do
         end
       end
 
-      context 'when droplet belongs to docker lifecycle' do
+      context 'when droplet has a docker lifecycle' do
         let(:lifecycle_type) { :docker }
         it 'sends a PUT request' do
           response = client.desire_app(lrp)
@@ -376,6 +376,25 @@ RSpec.describe(OPI::Client) do
                 registry_username: 'docker-user',
                 registry_password: 'docker-password',
                 command: ['/bin/sh', '-c', 'ls -la']
+              }
+            })
+            actual_body == expected_body_with_lifecycle
+          }
+        end
+      end
+
+      context 'when droplet has a kpack lifecycle' do
+        let(:lifecycle_type) { :kpack }
+        it 'sends a PUT request' do
+          response = client.desire_app(lrp)
+
+          expect(response.status_code).to equal(201)
+          expect(WebMock).to have_requested(:put, "#{opi_url}/apps/process-guid-#{lrp.version}").with { |request|
+            actual_body = MultiJson.load(request.body, symbolize_keys: true)
+            expected_body_with_lifecycle = expected_body.merge(lifecycle: {
+              docker_lifecycle: {
+                image: 'http://example.org/image1234',
+                command: ['/bin/sh', '-c', '/cnb/lifecycle/launcher ls -la']
               }
             })
             actual_body == expected_body_with_lifecycle

--- a/spec/unit/presenters/v3/droplet_presenter_spec.rb
+++ b/spec/unit/presenters/v3/droplet_presenter_spec.rb
@@ -232,6 +232,36 @@ module VCAP::CloudController::Presenters::V3
         end
       end
 
+      context 'kpack lifecycle' do
+        let(:droplet) do
+          VCAP::CloudController::DropletModel.make(
+            :kpack,
+            state: VCAP::CloudController::DropletModel::STAGED_STATE
+          )
+        end
+
+        before do
+          droplet.docker_receipt_image = 'test-image'
+          droplet.save
+        end
+
+        it 'presents the docker image and lifecycle data' do
+          expect(result[:image]).to eq('test-image')
+          expect(result[:lifecycle][:type]).to eq('kpack')
+          expect(result[:lifecycle][:data]).to eq({})
+          expect(result[:links][:download]).to be_nil
+        end
+
+        context 'when show_secrets is false' do
+          let(:result) { DropletPresenter.new(droplet, show_secrets: false).to_hash }
+
+          it 'redacts the process_types and execution_metadata' do
+            expect(result[:process_types]).to eq({ 'redacted_message' => '[PRIVATE DATA HIDDEN]' })
+            expect(result[:execution_metadata]).to eq('[PRIVATE DATA HIDDEN]')
+          end
+        end
+      end
+
       context 'when there are labels and annotations for the droplet' do
         let!(:release_label) do
           VCAP::CloudController::DropletLabelModel.make(


### PR DESCRIPTION
This PR introduces the concept of "kpack" droplets by associating the existing `kpack_lifecycle_data` for a build with its droplet instead of creating "docker" droplets. It allows us to distinguish kpack-built droplets from regular "docker" droplets and means we can now support custom start commands by invoking them with the CNB launcer: `/cnb/lifecycle/launcher`.

Additionally it includes a migration to convert existing kpack-built "docker" droplets into "kpack" droplets by associating their `kpack_lifecycle_data` with the "docker" droplet.

This change addresses the following issues:
* https://github.com/cloudfoundry/capi-k8s-release/issues/72
* https://github.com/cloudfoundry/cf-for-k8s/issues/502

CAKE Story: https://www.pivotaltracker.com/story/show/175081086