### PR TITLE
refactor(services): make offering fetcher like plan fetcher

### DIFF
--- a/app/controllers/v3/service_offerings_controller.rb
+++ b/app/controllers/v3/service_offerings_controller.rb
@@ -21,14 +21,14 @@ class ServiceOfferingsController < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     dataset = if !current_user
-                ServiceOfferingListFetcher.fetch_public(message)
-              elsif permission_queryer.can_read_globally?
                 ServiceOfferingListFetcher.fetch(message)
+              elsif permission_queryer.can_read_globally?
+                ServiceOfferingListFetcher.fetch(message, omniscient: true)
               else
-                ServiceOfferingListFetcher.fetch_visible(
+                ServiceOfferingListFetcher.fetch(
                   message,
-                  permission_queryer.readable_org_guids,
-                  permission_queryer.readable_space_scoped_space_guids,
+                  readable_org_guids: permission_queryer.readable_org_guids,
+                  readable_space_guids: permission_queryer.readable_space_scoped_space_guids,
                 )
               end
 

--- a/app/fetchers/base_service_list_fetcher.rb
+++ b/app/fetchers/base_service_list_fetcher.rb
@@ -1,0 +1,79 @@
+require 'set'
+require 'fetchers/base_list_fetcher'
+require 'fetchers/label_selector_query_generator'
+
+module VCAP::CloudController
+  class BaseServiceListFetcher < BaseListFetcher
+    class << self
+      private
+
+      def select_readable(dataset, omniscient: false, readable_space_guids: [], readable_org_guids: [])
+        if readable_org_guids.any?
+          dataset = dataset.where do
+            (Sequel[:service_plans][:public] =~ true) |
+              (Sequel[:plan_orgs][:guid] =~ readable_org_guids) |
+              (Sequel[:broker_spaces][:guid] =~ readable_space_guids)
+          end
+        elsif !omniscient
+          dataset = dataset.where { Sequel[:service_plans][:public] =~ true }
+        end
+
+        dataset
+      end
+
+      def filter(message, dataset, klass)
+        if message.requested?(:service_broker_guids)
+          dataset = dataset.where { Sequel[:service_brokers][:guid] =~ message.service_broker_guids }
+        end
+
+        if message.requested?(:service_broker_names)
+          dataset = dataset.where { Sequel[:service_brokers][:name] =~ message.service_broker_names }
+        end
+
+        super(message, dataset, klass)
+      end
+
+      def filter_orgs(dataset, organization_guids)
+        dataset.where do
+          (Sequel[:service_plans][:public] =~ true) |
+            (Sequel[:plan_orgs][:guid] =~ organization_guids) |
+            (Sequel[:broker_orgs][:guid] =~ organization_guids)
+        end
+      end
+
+      def filter_spaces(dataset, filtered_space_guids:, readable_space_guids:, omniscient:)
+        space_guids = authorized_space_guids(
+          space_guids: filtered_space_guids,
+          readable_space_guids: readable_space_guids,
+          omniscient: omniscient,
+        )
+
+        dataset.where do
+          (Sequel[:service_plans][:public] =~ true) |
+            (Sequel[:plan_spaces][:guid] =~ space_guids) |
+            (Sequel[:broker_spaces][:guid] =~ space_guids)
+        end
+      end
+
+      def authorized_space_guids(space_guids: [], readable_space_guids: [], omniscient: false)
+        return space_guids if omniscient
+
+        (Set.new(readable_space_guids) & Set.new(space_guids)).to_a
+      end
+
+      def visibility_filter?(message)
+        [:space_guids, :organization_guids].any? { |filter| message.requested?(filter) }
+      end
+
+      def join_all_parent_tables(dataset)
+        dataset.
+          join(:service_brokers, id: Sequel[:services][:service_broker_id]).
+          left_join(Sequel[:spaces].as(:broker_spaces), id: Sequel[:service_brokers][:space_id]).
+          left_join(Sequel[:organizations].as(:broker_orgs), id: Sequel[:broker_spaces][:organization_id]).
+          left_join(:service_plan_visibilities, service_plan_id: Sequel[:service_plans][:id]).
+          left_join(Sequel[:organizations].as(:plan_orgs), id: Sequel[:service_plan_visibilities][:organization_id]).
+          left_join(Sequel[:spaces].as(:plan_spaces), organization_id: Sequel[:plan_orgs][:id])
+      end
+    end
+  end
+end

--- a/app/messages/service_offerings_list_message.rb
+++ b/app/messages/service_offerings_list_message.rb
@@ -46,5 +46,9 @@ module VCAP::CloudController
         end
       end
     end
+
+    def available?
+      requested?(:available) && available == 'true'
+    end
   end
 end

--- a/spec/request/service_offerings_spec.rb
+++ b/spec/request/service_offerings_spec.rb
@@ -216,19 +216,19 @@ RSpec.describe 'V3 service offerings' do
           names: %w(quux quuz),
           space_guids: %w(hoge piyo),
           organization_guids: %w(fuga hogera),
-          per_page:   '10',
+          per_page: '10',
           page: 2,
-          order_by:   'updated_at',
+          order_by: 'updated_at',
           label_selector: 'foo==bar',
           fields: { 'service_broker' => 'name' },
           guids: 'foo,bar',
-          created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
+          created_ats: "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
           updated_ats: { gt: Time.now.utc.iso8601 },
         }
       end
     end
 
-    context 'when there are no service offerings' do
+    context 'no service offerings' do
       it 'returns an empty list' do
         get '/v3/service_offerings', nil, admin_headers
         expect(last_response).to have_status_code(200)
@@ -236,237 +236,75 @@ RSpec.describe 'V3 service offerings' do
       end
     end
 
-    context 'visibility of service offerings' do
-      context 'when there are public service offerings' do
-        let!(:service_offering_1) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
-        let!(:service_offering_2) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
+    describe 'visibility of service offerings' do
+      let!(:public_service_offering) { VCAP::CloudController::ServicePlan.make(public: true, name: 'public').service }
+      let!(:private_service_offering) { VCAP::CloudController::ServicePlan.make(public: false, name: 'private').service }
+      let!(:space_scoped_service_offering) do
+        broker = VCAP::CloudController::ServiceBroker.make(space: space)
+        VCAP::CloudController::Service.make(service_broker: broker)
+      end
+      let!(:org_restricted_service_offering) do
+        service_plan = VCAP::CloudController::ServicePlan.make(public: false)
+        VCAP::CloudController::ServicePlanVisibility.make(organization: org, service_plan: service_plan)
+        service_plan.service
+      end
 
-        let(:expected_codes_and_responses) do
-          Hash.new(
-            code: 200,
-            response_objects: [
-              create_offering_json(service_offering_1),
-              create_offering_json(service_offering_2)
-            ]
-          )
-        end
+      let(:all_offerings_response) do
+        {
+          code: 200,
+          response_objects: [
+            create_offering_json(public_service_offering),
+            create_offering_json(private_service_offering),
+            create_offering_json(space_scoped_service_offering),
+            create_offering_json(org_restricted_service_offering),
+          ]
+        }
+      end
 
-        it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
+      let(:org_offerings_response) do
+        {
+          code: 200,
+          response_objects: [
+            create_offering_json(public_service_offering),
+            create_offering_json(org_restricted_service_offering),
+          ]
+        }
+      end
 
-        context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
-          before do
-            VCAP::CloudController::FeatureFlag.create(name: 'hide_marketplace_from_unauthenticated_users', enabled: true)
-          end
+      let(:space_offerings_response) do
+        {
+          code: 200,
+          response_objects: [
+            create_offering_json(public_service_offering),
+            create_offering_json(space_scoped_service_offering),
+            create_offering_json(org_restricted_service_offering),
+          ]
+        }
+      end
 
-          let(:expected_codes_and_responses) do
-            h = Hash.new(
-              code: 200,
-              response_objects: [
-                create_offering_json(service_offering_1),
-                create_offering_json(service_offering_2)
-              ]
-            )
-            h['unauthenticated'] = { code: 401 }
-            h
-          end
-
-          it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
+      let(:expected_codes_and_responses) do
+        Hash.new(
+          code: 200,
+          response_objects: [
+            create_offering_json(public_service_offering),
+          ]
+        ).tap do |h|
+          h['admin'] = all_offerings_response
+          h['admin_read_only'] = all_offerings_response
+          h['global_auditor'] = all_offerings_response
+          h['org_manager'] = org_offerings_response
+          h['org_billing_manager'] = org_offerings_response
+          h['org_auditor'] = org_offerings_response
+          h['space_developer'] = space_offerings_response
+          h['space_manager'] = space_offerings_response
+          h['space_auditor'] = space_offerings_response
         end
       end
 
-      context 'when a service offerings is available in some orgs' do
-        let!(:space) { VCAP::CloudController::Space.make }
-        let!(:org_1) { space.organization }
-        let!(:service_plan_1) { VCAP::CloudController::ServicePlan.make(public: false, active: true) }
-        let!(:service_offering_1) { service_plan_1.service }
-        let!(:visibility_1) { VCAP::CloudController::ServicePlanVisibility.make(service_plan: service_plan_1, organization: org_1) }
-
-        let!(:org_2) { VCAP::CloudController::Organization.make }
-        let!(:service_plan_2) { VCAP::CloudController::ServicePlan.make(public: false, active: true) }
-        let!(:service_offering_2) { service_plan_2.service }
-        let!(:visibility_2) { VCAP::CloudController::ServicePlanVisibility.make(service_plan: service_plan_2, organization: org_2) }
-
-        let!(:org_3) { VCAP::CloudController::Organization.make }
-
-        let(:user) { VCAP::CloudController::User.make }
-        let(:org) { org_1 }
-
-        let(:both_offerings_response) do
-          {
-            code: 200,
-            response_objects: [
-              create_offering_json(service_offering_1),
-              create_offering_json(service_offering_2)
-            ]
-          }
-        end
-
-        let(:one_offering_response) do
-          {
-            code: 200,
-            response_objects: [
-              create_offering_json(service_offering_1)
-            ]
-          }
-        end
-
-        let(:no_offerings_response) do
-          {
-            code: 200,
-            response_objects: []
-          }
-        end
-
-        let(:expected_codes_and_responses) do
-          h = {}
-          h['admin'] = both_offerings_response
-          h['admin_read_only'] = both_offerings_response
-          h['global_auditor'] = both_offerings_response
-          h['org_manager'] = one_offering_response
-          h['org_auditor'] = one_offering_response
-          h['org_billing_manager'] = one_offering_response
-          h['space_developer'] = one_offering_response
-          h['space_manager'] = one_offering_response
-          h['space_auditor'] = one_offering_response
-          h['no_role'] = no_offerings_response
-          h['unauthenticated'] = no_offerings_response
-          h
-        end
-
-        it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
-      end
-
-      context 'when there are space-scoped brokers' do
-        let!(:broker_org) { VCAP::CloudController::Organization.make }
-        let!(:broker_space) { VCAP::CloudController::Space.make(organization: broker_org) }
-        let!(:service_broker) { VCAP::CloudController::ServiceBroker.make(space: broker_space) }
-        let!(:service_offering) { VCAP::CloudController::Service.make(service_broker: service_broker) }
-        let!(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service_offering) }
-        let!(:guid) { service_offering.guid }
-
-        context 'the user is in the same space as the service broker' do
-          let(:org) { broker_org }
-          let(:space) { broker_space }
-
-          let(:successful_response) do
-            {
-              code: 200,
-              response_objects: [
-                create_offering_json(service_offering)
-              ]
-            }
-          end
-
-          let(:expected_codes_and_responses) do
-            h = Hash.new({
-              code: 200,
-              response_objects: []
-            })
-            h['admin'] = successful_response
-            h['admin_read_only'] = successful_response
-            h['global_auditor'] = successful_response
-            h['space_developer'] = successful_response
-            h['space_manager'] = successful_response
-            h['space_auditor'] = successful_response
-            h
-          end
-
-          it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
-        end
-
-        context 'the user is in a different space to the service broker' do
-          let(:successful_response) do
-            {
-              code: 200,
-              response_objects: [
-                create_offering_json(service_offering)
-              ]
-            }
-          end
-
-          let(:expected_codes_and_responses) do
-            h = Hash.new({
-              code: 200,
-              response_objects: []
-            })
-            h['admin'] = successful_response
-            h['admin_read_only'] = successful_response
-            h['global_auditor'] = successful_response
-            h
-          end
-
-          it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
-        end
-
-        context 'the user is a SpaceDeveloper in the space of the broker, but is targeting a different space' do
-          let(:user) { VCAP::CloudController::User.make }
-
-          before do
-            broker_org.add_user(user)
-            broker_space.add_developer(user)
-          end
-
-          let(:expected_codes_and_responses) do
-            Hash.new(code: 200,
-              response_objects: [
-                create_offering_json(service_offering)
-              ]
-            )
-          end
-
-          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS # Does not make sense to test 'unauthenticated'
-        end
-      end
-
-      context 'when there is a mixture of service offering types' do
-        # public - can see
-        let!(:service_offering_1) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
-
-        # available in no orgs - cannot see
-        let!(:service_offering_2) { VCAP::CloudController::ServicePlan.make(public: false, active: true).service }
-
-        # visible in org 1 - can see
-        let!(:org_1) { VCAP::CloudController::Organization.make }
-        let!(:org_2) { VCAP::CloudController::Organization.make }
-        let!(:service_plan_1) { VCAP::CloudController::ServicePlan.make(public: false, active: true) }
-        let!(:service_offering_3) { service_plan_1.service }
-        let!(:visibility_1) { VCAP::CloudController::ServicePlanVisibility.make(service_plan: service_plan_1, organization: org_1) }
-
-        # visible in org 3 - cannot see
-        let!(:org_3) { VCAP::CloudController::Organization.make }
-        let!(:service_plan_2) { VCAP::CloudController::ServicePlan.make(public: false, active: true) }
-        let!(:service_offering_4) { service_plan_1.service }
-        let!(:visibility_2) { VCAP::CloudController::ServicePlanVisibility.make(service_plan: service_plan_2, organization: org_3) }
-
-        let!(:space_1) { VCAP::CloudController::Space.make }
-        let!(:space_2) { VCAP::CloudController::Space.make }
-        let!(:space_3) { VCAP::CloudController::Space.make }
-        let!(:service_offering_5) { VCAP::CloudController::ServicePlan.make(public: false, active: true).service }
-        let!(:service_offering_6) { VCAP::CloudController::ServicePlan.make(public: false, active: true).service }
-        before do
-          service_offering_5.service_broker.space = space_1 # visible if member of space 1 - can see
-          service_offering_5.service_broker.save
-          service_offering_6.service_broker.space = space_2 # visible if member of space 2 - cannot see
-          service_offering_6.service_broker.save
-        end
-
-        let(:user) { VCAP::CloudController::User.make }
-
-        it 'can only see the services it is meant to see' do
-          org_1.add_user(user)
-          space_1.organization.add_user(user)
-          space_1.add_developer(user)
-
-          get '/v3/service_offerings', nil, headers_for(user)
-
-          expect(last_response).to have_status_code(200)
-          response_guids = parsed_response['resources'].map { |r| r['guid'] }
-          expect(response_guids).to match_array([service_offering_1.guid, service_offering_3.guid, service_offering_5.guid])
-        end
-      end
+      it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
     end
 
-    context 'pagination' do
+    describe 'pagination' do
       let!(:service_offering_1) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
       let!(:service_offering_2) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
 
@@ -508,8 +346,8 @@ RSpec.describe 'V3 service offerings' do
       end
     end
 
-    context 'filters' do
-      context 'when filtering on the `available` property' do
+    describe 'filters' do
+      describe 'available' do
         let(:api_call) { lambda { |user_headers| get "/v3/service_offerings?available=#{available}", nil, user_headers } }
 
         let!(:service_offering_available) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
@@ -519,36 +357,22 @@ RSpec.describe 'V3 service offerings' do
           offering
         end
 
-        context 'filtering for available offerings' do
-          let(:available) { true }
-          let(:expected_codes_and_responses) do
-            Hash.new(
-              code: 200,
-              response_objects: [
-                create_offering_json(service_offering_available),
-              ]
-            )
-          end
-
-          it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
+        it 'filters for available offerings' do
+          expect_filtered_service_offerings(
+            'available=true',
+            [service_offering_available],
+          )
         end
 
-        context 'filtering for unavailable offerings' do
-          let(:available) { false }
-          let(:expected_codes_and_responses) do
-            Hash.new(
-              code: 200,
-              response_objects: [
-                create_offering_json(service_offering_unavailable),
-              ]
-            )
-          end
-
-          it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
+        it 'filters for unavailable offerings' do
+          expect_filtered_service_offerings(
+            'available=false',
+            [service_offering_unavailable],
+          )
         end
       end
 
-      context 'when filtering by GUID' do
+      describe 'guids' do
         let!(:service_broker_1) { VCAP::CloudController::ServiceBroker.make(space: space) }
         let!(:service_offering_1) { VCAP::CloudController::Service.make(service_broker: service_broker_1) }
 
@@ -573,7 +397,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      context 'when filtering by space GUID' do
+      describe 'space_guids' do
         let!(:service_broker_1) { VCAP::CloudController::ServiceBroker.make(space: space) }
         let!(:service_offering_1) { VCAP::CloudController::Service.make(service_broker: service_broker_1) }
 
@@ -598,7 +422,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      context 'when filtering by org GUID' do
+      describe 'organization_guids' do
         let!(:service_broker_1) { VCAP::CloudController::ServiceBroker.make(space: space) }
         let!(:service_offering_1) { VCAP::CloudController::Service.make(service_broker: service_broker_1) }
 
@@ -625,7 +449,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      context 'when filtering on the service broker GUID' do
+      describe 'service_broker_guids' do
         let!(:service_broker) { VCAP::CloudController::ServiceBroker.make }
         let!(:service_offering_1) do
           offering = VCAP::CloudController::Service.make(service_broker: service_broker)
@@ -639,39 +463,21 @@ RSpec.describe 'V3 service offerings' do
         end
         let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make.service }
         let!(:service_offering_4) { VCAP::CloudController::ServicePlan.make.service }
-
-        let(:api_call) { lambda { |user_headers| get "/v3/service_offerings?service_broker_guids=#{service_broker_guids.join(',')}", nil, user_headers } }
         let(:service_broker_guids) { [service_broker.guid, service_offering_3.service_broker.guid] }
 
-        let(:expected_codes_and_responses) do
-          Hash.new(
-            code: 200,
-            response_objects: [
-              create_offering_json(service_offering_1),
-              create_offering_json(service_offering_2),
-              create_offering_json(service_offering_3),
-            ]
+        it 'filters by broker guid' do
+          expect_filtered_service_offerings(
+            "service_broker_guids=#{service_broker_guids.join(',')}",
+            [
+              service_offering_1,
+              service_offering_2,
+              service_offering_3,
+            ],
           )
         end
-
-        it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
       end
 
-      context 'when filtering on the service broker name' do
-        let(:api_call) { lambda { |user_headers| get "/v3/service_offerings?service_broker_names=#{service_broker_names.join(',')}", nil, user_headers } }
-        let(:service_broker_names) { [service_broker.name, service_offering_4.service_broker.name] }
-
-        let(:expected_codes_and_responses) do
-          Hash.new(
-            code: 200,
-            response_objects: [
-              create_offering_json(service_offering_1),
-              create_offering_json(service_offering_2),
-              create_offering_json(service_offering_4),
-            ]
-          )
-        end
-
+      describe 'service_broker_names' do
         let!(:service_broker) { VCAP::CloudController::ServiceBroker.make }
         let!(:service_offering_1) do
           offering = VCAP::CloudController::Service.make(service_broker: service_broker)
@@ -685,35 +491,39 @@ RSpec.describe 'V3 service offerings' do
         end
         let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make.service }
         let!(:service_offering_4) { VCAP::CloudController::ServicePlan.make.service }
+        let(:service_broker_names) { [service_broker.name, service_offering_4.service_broker.name] }
 
-        it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
-      end
-
-      context 'when filtering on the name' do
-        let(:api_call) { lambda { |user_headers| get "/v3/service_offerings?names=#{service_offering_names.join(',')}", nil, user_headers } }
-        let(:service_offering_names) { [service_offering_1.name, service_offering_4.name] }
-
-        let(:expected_codes_and_responses) do
-          Hash.new(
-            code: 200,
-            response_objects: [
-              create_offering_json(service_offering_1),
-              create_offering_json(service_offering_4),
-            ]
+        it 'filters by broker name' do
+          expect_filtered_service_offerings(
+            "service_broker_names=#{service_broker_names.join(',')}",
+            [
+              service_offering_1,
+              service_offering_2,
+              service_offering_4,
+            ],
           )
         end
+      end
 
+      describe 'names' do
         let!(:service_offering_1) { VCAP::CloudController::ServicePlan.make(public: true).service }
         let!(:service_offering_2) { VCAP::CloudController::ServicePlan.make(public: true).service }
         let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make(public: true).service }
         let!(:service_offering_4) { VCAP::CloudController::ServicePlan.make(public: true).service }
+        let(:service_offering_names) { [service_offering_1.name, service_offering_4.name] }
 
-        it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
+        it 'filters by name' do
+          expect_filtered_service_offerings(
+            "names=#{service_offering_names.join(',')}",
+            [
+              service_offering_1,
+              service_offering_4,
+            ],
+          )
+        end
       end
 
-      context 'when filtering on labels' do
-        let(:api_call) { lambda { |user_headers| get '/v3/service_offerings?label_selector=flavor=orange', nil, user_headers } }
-
+      describe 'label_selector' do
         let!(:service_offering_1) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
         let!(:service_offering_2) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
         let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
@@ -724,17 +534,15 @@ RSpec.describe 'V3 service offerings' do
           VCAP::CloudController::ServiceOfferingLabelModel.make(resource_guid: service_offering_3.guid, key_name: 'flavor', value: 'apple')
         end
 
-        let(:expected_codes_and_responses) do
-          Hash.new(
-            code: 200,
-            response_objects: [
-              create_offering_json(service_offering_1, labels: { flavor: 'orange' }),
-              create_offering_json(service_offering_2, labels: { flavor: 'orange' }),
-            ]
+        it 'filters by label' do
+          expect_filtered_service_offerings(
+            'label_selector=flavor=orange',
+            [
+              service_offering_1,
+              service_offering_2,
+            ],
           )
         end
-
-        it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
       end
     end
 

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -338,35 +338,54 @@ RSpec.describe 'V3 service plans' do
       describe 'organization_guids' do
         let(:org_1) { VCAP::CloudController::Organization.make }
         let(:org_2) { VCAP::CloudController::Organization.make }
-        let(:plan_1) { VCAP::CloudController::ServicePlan.make(public: false) }
-        let(:plan_2) { VCAP::CloudController::ServicePlan.make(public: false) }
+        let!(:org_plan_1) { VCAP::CloudController::ServicePlan.make(public: false) }
+        let!(:org_plan_2) { VCAP::CloudController::ServicePlan.make(public: false) }
+
+        let(:space_1){VCAP::CloudController::Space.make(organization: org_1)}
+        let(:space_2){VCAP::CloudController::Space.make(organization: org_2)}
+        let!(:space_plan_1) {generate_space_scoped_plan(space_1)}
+        let!(:space_plan_2) {generate_space_scoped_plan(space_2)}
+
+        let!(:public_plan){VCAP::CloudController::ServicePlan.make(public: true)}
 
         before do
-          VCAP::CloudController::ServicePlanVisibility.make(service_plan: plan_1, organization: org_1)
-          VCAP::CloudController::ServicePlanVisibility.make(service_plan: plan_2, organization: org_2)
+          VCAP::CloudController::ServicePlanVisibility.make(service_plan: org_plan_1, organization: org_1)
+          VCAP::CloudController::ServicePlanVisibility.make(service_plan: org_plan_2, organization: org_2)
         end
 
-        it 'selects on org guid' do
+        it 'selects on org plans, space plans and public plans' do
           get "/v3/service_plans?organization_guids=#{org_1.guid}", {}, admin_headers
-          check_filtered_plans(plan_1)
+          check_filtered_plans(org_plan_1, space_plan_1, public_plan)
+
+          get "/v3/service_plans?organization_guids=#{org_1.guid},#{org_2.guid}", {}, admin_headers
+          check_filtered_plans(org_plan_1, org_plan_2, space_plan_1,  space_plan_2, public_plan)
         end
       end
 
       describe 'space_guids' do
         let(:org_1) { VCAP::CloudController::Organization.make }
         let(:org_2) { VCAP::CloudController::Organization.make }
-        let(:plan_1) { VCAP::CloudController::ServicePlan.make(public: false) }
-        let(:plan_2) { VCAP::CloudController::ServicePlan.make(public: false) }
-        let(:space_1) { VCAP::CloudController::Space.make(organization: org_1) }
+        let!(:org_plan_1) { VCAP::CloudController::ServicePlan.make(public: false) }
+        let!(:org_plan_2) { VCAP::CloudController::ServicePlan.make(public: false) }
+
+        let(:space_1){VCAP::CloudController::Space.make(organization: org_1)}
+        let(:space_2){VCAP::CloudController::Space.make(organization: org_2)}
+        let!(:space_plan_1) {generate_space_scoped_plan(space_1)}
+        let!(:space_plan_2) {generate_space_scoped_plan(space_2)}
+
+        let!(:public_plan){VCAP::CloudController::ServicePlan.make(public: true)}
 
         before do
-          VCAP::CloudController::ServicePlanVisibility.make(service_plan: plan_1, organization: org_1)
-          VCAP::CloudController::ServicePlanVisibility.make(service_plan: plan_2, organization: org_2)
+          VCAP::CloudController::ServicePlanVisibility.make(service_plan: org_plan_1, organization: org_1)
+          VCAP::CloudController::ServicePlanVisibility.make(service_plan: org_plan_2, organization: org_2)
         end
 
-        it 'selects on org guid' do
+        it 'selects on org plans, space plans and public plans' do
           get "/v3/service_plans?space_guids=#{space_1.guid}", {}, admin_headers
-          check_filtered_plans(plan_1)
+          check_filtered_plans(org_plan_1, space_plan_1, public_plan)
+
+          get "/v3/service_plans?space_guids=#{space_1.guid},#{space_2.guid}", {}, admin_headers
+          check_filtered_plans(org_plan_1, org_plan_2, space_plan_1,  space_plan_2, public_plan)
         end
       end
 

--- a/spec/unit/fetchers/service_offering_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_offering_list_fetcher_spec.rb
@@ -3,417 +3,440 @@ require 'fetchers/service_offering_list_fetcher'
 require 'messages/service_offerings_list_message'
 
 module VCAP::CloudController
-  RSpec.shared_examples 'filtered service offering fetcher' do |current_method|
-    describe 'the `available` filter' do
-      let!(:service_offering_available) { ServicePlan.make(public: true, active: true).service }
-      let!(:service_offering_unavailable) do
-        offering = Service.make(active: false)
-        ServicePlan.make(public: true, active: true, service: offering)
-        offering
-      end
-
-      context 'filtering available offerings' do
-        let(:message) { ServiceOfferingsListMessage.from_params({ available: 'true' }.with_indifferent_access) }
-
-        it 'filters the available offerings' do
-          expect(service_offerings).to contain_exactly(service_offering_available)
-        end
-      end
-
-      context 'filtering unavailable offerings' do
-        let(:message) { ServiceOfferingsListMessage.from_params({ available: 'false' }.with_indifferent_access) }
-
-        it 'filters the available offerings' do
-          expect(service_offerings).to contain_exactly(service_offering_unavailable)
-        end
-      end
-    end
-
-    describe 'the `service_broker_guids` filter' do
-      let!(:service_broker) { VCAP::CloudController::ServiceBroker.make }
-      let!(:service_offering_1) do
-        offering = VCAP::CloudController::Service.make(service_broker: service_broker)
-        VCAP::CloudController::ServicePlan.make(public: true, service: offering)
-        offering
-      end
-      let!(:service_offering_2) do
-        offering = VCAP::CloudController::Service.make(service_broker: service_broker)
-        VCAP::CloudController::ServicePlan.make(public: true, service: offering)
-        offering
-      end
-      let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make.service }
-      let!(:service_offering_4) { VCAP::CloudController::ServicePlan.make.service }
-
-      let(:service_broker_guids) { [service_broker.guid, service_offering_3.service_broker.guid] }
-      let(:message) { ServiceOfferingsListMessage.from_params({ service_broker_guids: service_broker_guids.join(',') }.with_indifferent_access) }
-
-      it 'filters the service offerings with matching service broker GUIDs' do
-        expect(service_offerings).to contain_exactly(
-          service_offering_1,
-          service_offering_2,
-          service_offering_3,
-        )
-      end
-    end
-
-    describe 'the `service_broker_names` filter' do
-      let!(:service_broker) { VCAP::CloudController::ServiceBroker.make }
-      let!(:service_offering_1) do
-        offering = VCAP::CloudController::Service.make(service_broker: service_broker)
-        VCAP::CloudController::ServicePlan.make(public: true, service: offering)
-        offering
-      end
-      let!(:service_offering_2) do
-        offering = VCAP::CloudController::Service.make(service_broker: service_broker)
-        VCAP::CloudController::ServicePlan.make(public: true, service: offering)
-        offering
-      end
-      let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make.service }
-      let!(:service_offering_4) { VCAP::CloudController::ServicePlan.make.service }
-
-      let(:service_broker_names) { [service_broker.name, service_offering_4.service_broker.name] }
-      let(:message) { ServiceOfferingsListMessage.from_params({ service_broker_names: service_broker_names.join(',') }.with_indifferent_access) }
-
-      it 'filters the service offerings with matching service broker names' do
-        expect(service_offerings).to contain_exactly(
-          service_offering_1,
-          service_offering_2,
-          service_offering_4,
-        )
-      end
-    end
-
-    describe 'the `names` filter' do
-      let!(:service_offering_1) { VCAP::CloudController::ServicePlan.make(public: true).service }
-      let!(:service_offering_2) { VCAP::CloudController::ServicePlan.make(public: true).service }
-      let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make(public: true).service }
-      let!(:service_offering_4) { VCAP::CloudController::ServicePlan.make(public: true).service }
-
-      let(:service_offering_names) { [service_offering_1.name, service_offering_3.name] }
-      let(:message) { ServiceOfferingsListMessage.from_params({ names: service_offering_names.join(',') }.with_indifferent_access) }
-
-      it 'filters the service offerings with matching names' do
-        expect(service_offerings).to contain_exactly(
-          service_offering_1,
-          service_offering_3,
-        )
-      end
-    end
-
-    describe 'the `label_selector` filter' do
-      let!(:service_offering_1) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
-      let!(:service_offering_2) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
-      let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
-      let(:message) { ServiceOfferingsListMessage.from_params({ label_selector: 'flavor=orange' }.with_indifferent_access) }
-
-      before do
-        VCAP::CloudController::ServiceOfferingLabelModel.make(resource_guid: service_offering_1.guid, key_name: 'flavor', value: 'orange')
-        VCAP::CloudController::ServiceOfferingLabelModel.make(resource_guid: service_offering_2.guid, key_name: 'flavor', value: 'orange')
-        VCAP::CloudController::ServiceOfferingLabelModel.make(resource_guid: service_offering_3.guid, key_name: 'flavor', value: 'apple')
-      end
-
-      it 'filters the matching service offerings' do
-        expect(service_offerings).to contain_exactly(service_offering_1, service_offering_2)
-      end
-    end
-
-    describe 'the `space_guids` filter' do
-      let(:space_1) { VCAP::CloudController::Space.make }
-      let!(:service_broker_1) { VCAP::CloudController::ServiceBroker.make(space: space_1) }
-      let!(:service_offering_1) { VCAP::CloudController::Service.make(service_broker: service_broker_1) }
-
-      let(:space_2) { VCAP::CloudController::Space.make }
-      let(:service_broker_2) { VCAP::CloudController::ServiceBroker.make(space: space_2) }
-      let!(:service_offering_2) { VCAP::CloudController::Service.make(service_broker: service_broker_2) }
-
-      let(:space_3) { VCAP::CloudController::Space.make }
-      let(:service_broker_3) { VCAP::CloudController::ServiceBroker.make(space: space_3) }
-      let!(:service_offering_3) { VCAP::CloudController::Service.make(service_broker: service_broker_3) }
-
-      let!(:public_plan) { VCAP::CloudController::ServicePlan.make(public: true) }
-      let!(:public_service_offering) { public_plan.service }
-
-      let(:filter_space_guids) { [space_1.guid, space_2.guid] }
-      let(:space_guids) { [space_1.guid] }
-      let(:message) { ServiceOfferingsListMessage.from_params({ space_guids: filter_space_guids.join(',') }.with_indifferent_access) }
-
-      it 'filters the matching service offerings' do
-        case current_method
-        when :fetch
-          expect(service_offerings).to contain_exactly(service_offering_1, service_offering_2, public_service_offering)
-        when :fetch_public
-          expect(service_offerings).to contain_exactly(public_service_offering)
-        when :fetch_visible
-          expect(service_offerings).to contain_exactly(service_offering_1, public_service_offering)
-        else
-          fail('unexpected method')
-        end
-      end
-    end
-
-    describe 'the `organization_guids` filter' do
-      let!(:org_1) { VCAP::CloudController::Organization.make }
-      let!(:service_broker_1) { VCAP::CloudController::ServiceBroker.make }
-      let!(:service_offering_1) { VCAP::CloudController::Service.make(service_broker: service_broker_1) }
-      let!(:service_plan_1) { VCAP::CloudController::ServicePlan.make(public: false, service: service_offering_1) }
-      let!(:visibility_1) { VCAP::CloudController::ServicePlanVisibility.make(service_plan: service_plan_1, organization: org_1) }
-
-      let!(:org_2) { VCAP::CloudController::Organization.make }
-      let!(:service_broker_2) { VCAP::CloudController::ServiceBroker.make }
-      let!(:service_offering_2) { VCAP::CloudController::Service.make(service_broker: service_broker_2) }
-      let!(:service_plan_2) { VCAP::CloudController::ServicePlan.make(public: false, service: service_offering_2) }
-      let!(:visibility_2) { VCAP::CloudController::ServicePlanVisibility.make(service_plan: service_plan_2, organization: org_2) }
-
-      let(:space_3) { VCAP::CloudController::Space.make }
-      let(:service_broker_3) { VCAP::CloudController::ServiceBroker.make(space: space_3) }
-      let!(:service_offering_3) { VCAP::CloudController::Service.make(service_broker: service_broker_3) }
-
-      let!(:public_plan) { VCAP::CloudController::ServicePlan.make(public: true) }
-      let!(:public_service_offering) { public_plan.service }
-
-      let(:filter_org_guids) { [org_1.guid, org_2.guid] }
-      let(:org_guids) { [org_1.guid] }
-      let(:message) { ServiceOfferingsListMessage.from_params({ organization_guids: filter_org_guids.join(',') }.with_indifferent_access) }
-
-      it 'filters the matching service offerings' do
-        case current_method
-        when :fetch
-          expect(service_offerings).to contain_exactly(service_offering_1, service_offering_2, public_service_offering)
-        when :fetch_public
-          expect(service_offerings).to contain_exactly(public_service_offering)
-        when :fetch_visible
-          expect(service_offerings.size).to eq(2)
-          expect(service_offerings).to contain_exactly(service_offering_1, public_service_offering)
-        else
-          fail('unexpected method')
-        end
-      end
-    end
-  end
-
   RSpec.describe ServiceOfferingListFetcher do
     let(:message) { ServiceOfferingsListMessage.from_params({}) }
 
     describe '#fetch' do
-      context 'when there are no service offerings' do
+      context 'when there are no offerings' do
         it 'is empty' do
-          service_offerings = ServiceOfferingListFetcher.fetch(message).all
-
+          service_offerings = ServiceOfferingListFetcher.fetch(message, omniscient: true).all
           expect(service_offerings).to be_empty
         end
       end
 
-      context 'when there are public, non-public and space-scoped service offerings' do
-        let!(:public_service_offering) { ServicePlan.make(public: true, active: true).service }
+      describe 'visibility of offerings' do
+        let!(:public_offering_1) { make_public_offering }
+        let!(:public_offering_2) { make_public_offering }
 
-        let!(:non_public_service_offering) { Service.make(active: true) }
+        let!(:private_offering_1) { make_private_offering }
+        let!(:private_offering_2) { make_private_offering }
 
-        let!(:space_scoped_service_broker) { ServiceBroker.make(space: Space.make) }
-        let!(:space_scoped_service_offering) { Service.make(service_broker: space_scoped_service_broker) }
+        let(:org_1) { Organization.make }
+        let(:org_2) { Organization.make }
+        let(:org_3) { Organization.make }
+        let!(:org_restricted_offering_1) { make_org_restricted_offering(org_1) }
+        let!(:org_restricted_offering_2) { make_org_restricted_offering(org_2) }
+        let!(:org_restricted_offering_3) { make_org_restricted_offering(org_3) }
+        let!(:org_restricted_offering_4) { make_org_restricted_offering(org_3) }
 
-        it 'lists them all' do
-          service_offerings = ServiceOfferingListFetcher.fetch(message).all
-          expect(service_offerings).to contain_exactly(public_service_offering, non_public_service_offering, space_scoped_service_offering)
+        let(:space_1) { Space.make(organization: org_1) }
+        let(:space_2) { Space.make(organization: org_2) }
+        let(:space_3) { Space.make(organization: org_3) }
+        let!(:space_scoped_offering_1) { make_space_scoped_offering(space_1) }
+        let!(:space_scoped_offering_2) { make_space_scoped_offering(space_2) }
+        let!(:space_scoped_offering_3) { make_space_scoped_offering(space_3) }
+        let!(:space_scoped_offering_4) { make_space_scoped_offering(space_3) }
+
+        context 'when no authorization is specified' do
+          it 'only fetches public plans' do
+            service_offerings = described_class.fetch(message).all
+            expect(service_offerings).to contain_exactly(public_offering_1, public_offering_2)
+          end
+        end
+
+        context 'when the `omniscient` flag is true' do
+          it 'fetches all plans' do
+            service_offerings = described_class.fetch(message, omniscient: true).all
+            expect(service_offerings).to contain_exactly(
+              public_offering_1,
+              public_offering_2,
+              private_offering_1,
+              private_offering_2,
+              space_scoped_offering_1,
+              space_scoped_offering_2,
+              space_scoped_offering_3,
+              space_scoped_offering_4,
+              org_restricted_offering_1,
+              org_restricted_offering_2,
+              org_restricted_offering_3,
+              org_restricted_offering_4,
+            )
+          end
+        end
+
+        context 'when `readable_org_guids` are specified' do
+          it 'includes public plans and ones for those orgs' do
+            service_offerings = described_class.fetch(
+              message,
+              readable_org_guids: [org_1.guid, org_3.guid],
+              readable_space_guids: [],
+            ).all
+
+            expect(service_offerings).to contain_exactly(
+              public_offering_1,
+              public_offering_2,
+              org_restricted_offering_1,
+              org_restricted_offering_3,
+              org_restricted_offering_4,
+            )
+          end
+        end
+
+        context 'when both `readable_space_guids` and `readable_org_guids` are specified' do
+          it 'includes public plans, ones for those spaces and ones for those orgs' do
+            service_offerings = described_class.fetch(
+              message,
+              readable_space_guids: [space_3.guid],
+              readable_org_guids: [org_3.guid],
+            ).all
+
+            expect(service_offerings).to contain_exactly(
+              public_offering_1,
+              public_offering_2,
+              space_scoped_offering_3,
+              space_scoped_offering_4,
+              org_restricted_offering_3,
+              org_restricted_offering_4,
+            )
+          end
         end
       end
 
-      context 'when filters are provided' do
-        let(:service_offerings) { ServiceOfferingListFetcher.fetch(message).all }
+      describe 'filtering by organization_guids and space_guids' do
+        let(:org_1) { Organization.make }
+        let(:org_2) { Organization.make }
+        let(:org_3) { Organization.make }
+        let(:space_1) { Space.make(organization: org_1) }
+        let(:space_2) { Space.make(organization: org_2) }
+        let(:space_3) { Space.make(organization: org_3) }
 
-        it_behaves_like 'filtered service offering fetcher', :fetch
+        let!(:public_offering) { make_public_offering }
 
-        context 'uniqueness of service offerings' do
-          let!(:service_broker) { VCAP::CloudController::ServiceBroker.make }
-          let!(:service_offering) do
-            offering = VCAP::CloudController::Service.make(service_broker: service_broker)
-            VCAP::CloudController::ServicePlan.make(public: true, service: offering)
-            VCAP::CloudController::ServicePlan.make(public: true, service: offering)
-            VCAP::CloudController::ServicePlan.make(public: true, service: offering)
+        let!(:org_restricted_offering_1) { make_org_restricted_offering(org_1) }
+        let!(:org_restricted_offering_2) { make_org_restricted_offering(org_2) }
+        let!(:org_restricted_offering_3) { make_org_restricted_offering(org_3) }
+
+        let!(:space_scoped_offering_1) { make_space_scoped_offering(space_1) }
+        let!(:space_scoped_offering_2) { make_space_scoped_offering(space_2) }
+        let!(:space_scoped_offering_3) { make_space_scoped_offering(space_3) }
+
+        describe 'organization_guids' do
+          context 'omniscient' do
+            it 'can filter plans by organization guids' do
+              message = ServiceOfferingsListMessage.from_params({
+                organization_guids: [org_1.guid, org_2.guid].join(',')
+              }.with_indifferent_access)
+
+              service_offerings = ServiceOfferingListFetcher.fetch(message, omniscient: true).all
+
+              expect(service_offerings).to contain_exactly(org_restricted_offering_1, org_restricted_offering_2, public_offering, space_scoped_offering_1, space_scoped_offering_2)
+            end
+
+            it 'only shows public plans when there are no matches' do
+              message = ServiceOfferingsListMessage.from_params({
+                organization_guids: 'non-matching-guid',
+              }.with_indifferent_access)
+
+              service_offerings = ServiceOfferingListFetcher.fetch(message, omniscient: true).all
+
+              expect(service_offerings).to contain_exactly(public_offering)
+            end
+          end
+
+          context 'only some orgs are readable (ORG_AUDITOR etc)' do
+            it 'shows only readable plans' do
+              message = ServiceOfferingsListMessage.from_params({
+                organization_guids: [org_1.guid, org_2.guid].join(',')
+              }.with_indifferent_access)
+
+              service_offerings = ServiceOfferingListFetcher.fetch(
+                message,
+                readable_org_guids: [org_1.guid],
+                readable_space_guids: [],
+              ).all
+
+              expect(service_offerings).to contain_exactly(org_restricted_offering_1, public_offering)
+            end
+          end
+
+          context 'no orgs are readable' do
+            it 'shows only public plans' do
+              message = ServiceOfferingsListMessage.from_params({
+                organization_guids: [org_1.guid, org_2.guid].join(',')
+              }.with_indifferent_access)
+
+              service_offerings = ServiceOfferingListFetcher.fetch(
+                message,
+                readable_org_guids: [],
+                readable_space_guids: [],
+              ).all
+
+              expect(service_offerings).to contain_exactly(public_offering)
+            end
+          end
+
+          context 'when the user only has access to some spaces in an org' do
+            let(:space_1a) { Space.make(organization: org_1) }
+            let!(:space_scoped_offering_1a) { make_space_scoped_offering(space_1a) }
+
+            it 'only shows space-scoped plans for the readable spaces' do
+              message = ServiceOfferingsListMessage.from_params({
+                organization_guids: [org_1.guid].join(',')
+              }.with_indifferent_access)
+
+              service_offerings = ServiceOfferingListFetcher.fetch(
+                message,
+                readable_org_guids: [org_1.guid],
+                readable_space_guids: [space_1.guid],
+              ).all
+
+              expect(service_offerings).to contain_exactly(public_offering, org_restricted_offering_1, space_scoped_offering_1)
+            end
+          end
+        end
+
+        describe 'space_guids' do
+          context 'omniscient' do
+            it 'can filter by space guids' do
+              message = ServiceOfferingsListMessage.from_params({
+                space_guids: [space_1.guid, space_2.guid].join(',')
+              }.with_indifferent_access)
+              service_offerings = ServiceOfferingListFetcher.fetch(message, omniscient: true).all
+              expect(service_offerings).to contain_exactly(space_scoped_offering_1, org_restricted_offering_1, space_scoped_offering_2, org_restricted_offering_2, public_offering)
+            end
+
+            it 'only shows public plans when there are no matches' do
+              message = ServiceOfferingsListMessage.from_params({
+                space_guids: 'non-matching-guid'
+              }.with_indifferent_access)
+              service_offerings = ServiceOfferingListFetcher.fetch(message, omniscient: true).all
+              expect(service_offerings).to contain_exactly(public_offering)
+            end
+          end
+
+          context 'only some spaces are readable (SPACE_DEVELOPER, SPACE_AUDITOR etc)' do
+            it 'shows only plans for readable spaces and orgs' do
+              message = ServiceOfferingsListMessage.from_params({
+                space_guids: [space_1.guid, space_2.guid].join(',')
+              }.with_indifferent_access)
+              service_offerings = ServiceOfferingListFetcher.fetch(
+                message,
+                readable_org_guids: [org_1.guid],
+                readable_space_guids: [space_1.guid],
+              ).all
+              expect(service_offerings).to contain_exactly(space_scoped_offering_1, org_restricted_offering_1, public_offering)
+            end
+          end
+
+          context 'when a filter contains a space guid that the user cannot access' do
+            it 'ignores the unauthorized space guid' do
+              message = ServiceOfferingsListMessage.from_params({
+                space_guids: [space_1.guid, space_2.guid].join(',')
+              }.with_indifferent_access)
+              service_offerings = ServiceOfferingListFetcher.fetch(
+                message,
+                readable_org_guids: [org_1.guid, org_2.guid],
+                readable_space_guids: [space_1.guid],
+              ).all
+              expect(service_offerings).to contain_exactly(space_scoped_offering_1, org_restricted_offering_1, public_offering)
+            end
+          end
+
+          context 'no spaces are readable' do
+            it 'shows only public plans' do
+              message = ServiceOfferingsListMessage.from_params({
+                space_guids: [space_1.guid, space_2.guid].join(',')
+              }.with_indifferent_access)
+
+              service_offerings = ServiceOfferingListFetcher.fetch(
+                message,
+                readable_org_guids: [],
+                readable_space_guids: [],
+              ).all
+
+              expect(service_offerings).to contain_exactly(public_offering)
+            end
+          end
+        end
+
+        describe 'organization_guids and space_guids together' do
+          context 'omniscient' do
+            it 'results in the overlap' do
+              message = ServiceOfferingsListMessage.from_params({
+                space_guids: [space_1.guid, space_2.guid].join(','),
+                organization_guids: [org_2.guid, org_3.guid].join(',')
+              }.with_indifferent_access)
+              service_offerings = ServiceOfferingListFetcher.fetch(message, omniscient: true).all
+              expect(service_offerings).to contain_exactly(space_scoped_offering_2, org_restricted_offering_2, public_offering)
+            end
+
+            it 'only shows public plans when there are no matches' do
+              message = ServiceOfferingsListMessage.from_params({
+                space_guids: [space_1.guid].join(','),
+                organization_guids: [org_3.guid].join(',')
+              }.with_indifferent_access)
+              service_offerings = ServiceOfferingListFetcher.fetch(message, omniscient: true).all
+              expect(service_offerings).to contain_exactly(public_offering)
+            end
+          end
+
+          context 'when only some spaces and orgs are visible' do
+            it 'excludes plans that do not meet all the filter conditions' do
+              message = ServiceOfferingsListMessage.from_params({
+                space_guids: [space_1.guid, space_2.guid].join(','),
+                organization_guids: [org_2.guid, org_3.guid].join(',')
+              }.with_indifferent_access)
+              service_offerings = ServiceOfferingListFetcher.fetch(
+                message,
+                readable_org_guids: [org_1.guid, org_2.guid],
+                readable_space_guids: [space_1.guid],
+              ).all
+              expect(service_offerings).to contain_exactly(public_offering)
+            end
+          end
+        end
+      end
+
+      describe 'other filters' do
+        let(:service_offerings) { ServiceOfferingListFetcher.fetch(message, omniscient: true).all }
+
+        describe 'the `available` filter' do
+          let!(:service_offering_available) { ServicePlan.make(public: true, active: true).service }
+          let!(:service_offering_unavailable) do
+            offering = Service.make(active: false)
+            ServicePlan.make(public: true, active: true, service: offering)
             offering
           end
 
-          it 'de-duplicates service offerings' do
-            service_offerings = ServiceOfferingListFetcher.fetch(message).all
-            expect(service_offerings).to contain_exactly(service_offering)
+          context 'filtering available offerings' do
+            let(:message) { ServiceOfferingsListMessage.from_params({ available: 'true' }.with_indifferent_access) }
+
+            it 'filters the available offerings' do
+              expect(service_offerings).to contain_exactly(service_offering_available)
+            end
+          end
+
+          context 'filtering unavailable offerings' do
+            let(:message) { ServiceOfferingsListMessage.from_params({ available: 'false' }.with_indifferent_access) }
+
+            it 'filters the available offerings' do
+              expect(service_offerings).to contain_exactly(service_offering_unavailable)
+            end
+          end
+        end
+
+        describe 'the `service_broker_guids` filter' do
+          let!(:service_broker) { VCAP::CloudController::ServiceBroker.make }
+          let!(:service_offering_1) do
+            offering = VCAP::CloudController::Service.make(service_broker: service_broker)
+            VCAP::CloudController::ServicePlan.make(public: true, service: offering)
+            offering
+          end
+          let!(:service_offering_2) do
+            offering = VCAP::CloudController::Service.make(service_broker: service_broker)
+            VCAP::CloudController::ServicePlan.make(public: true, service: offering)
+            offering
+          end
+          let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make.service }
+          let!(:service_offering_4) { VCAP::CloudController::ServicePlan.make.service }
+
+          let(:service_broker_guids) { [service_broker.guid, service_offering_3.service_broker.guid] }
+          let(:message) { ServiceOfferingsListMessage.from_params({ service_broker_guids: service_broker_guids.join(',') }.with_indifferent_access) }
+
+          it 'filters the service offerings with matching service broker GUIDs' do
+            expect(service_offerings).to contain_exactly(
+              service_offering_1,
+              service_offering_2,
+              service_offering_3,
+            )
+          end
+        end
+
+        describe 'the `service_broker_names` filter' do
+          let!(:service_broker) { VCAP::CloudController::ServiceBroker.make }
+          let!(:service_offering_1) do
+            offering = VCAP::CloudController::Service.make(service_broker: service_broker)
+            VCAP::CloudController::ServicePlan.make(public: true, service: offering)
+            offering
+          end
+          let!(:service_offering_2) do
+            offering = VCAP::CloudController::Service.make(service_broker: service_broker)
+            VCAP::CloudController::ServicePlan.make(public: true, service: offering)
+            offering
+          end
+          let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make.service }
+          let!(:service_offering_4) { VCAP::CloudController::ServicePlan.make.service }
+
+          let(:service_broker_names) { [service_broker.name, service_offering_4.service_broker.name] }
+          let(:message) { ServiceOfferingsListMessage.from_params({ service_broker_names: service_broker_names.join(',') }.with_indifferent_access) }
+
+          it 'filters the service offerings with matching service broker names' do
+            expect(service_offerings).to contain_exactly(
+              service_offering_1,
+              service_offering_2,
+              service_offering_4,
+            )
+          end
+        end
+
+        describe 'the `names` filter' do
+          let!(:service_offering_1) { VCAP::CloudController::ServicePlan.make(public: true).service }
+          let!(:service_offering_2) { VCAP::CloudController::ServicePlan.make(public: true).service }
+          let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make(public: true).service }
+          let!(:service_offering_4) { VCAP::CloudController::ServicePlan.make(public: true).service }
+
+          let(:service_offering_names) { [service_offering_1.name, service_offering_3.name] }
+          let(:message) { ServiceOfferingsListMessage.from_params({ names: service_offering_names.join(',') }.with_indifferent_access) }
+
+          it 'filters the service offerings with matching names' do
+            expect(service_offerings).to contain_exactly(
+              service_offering_1,
+              service_offering_3,
+            )
+          end
+        end
+
+        describe 'the `label_selector` filter' do
+          let!(:service_offering_1) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
+          let!(:service_offering_2) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
+          let!(:service_offering_3) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
+          let(:message) { ServiceOfferingsListMessage.from_params({ label_selector: 'flavor=orange' }.with_indifferent_access) }
+
+          before do
+            VCAP::CloudController::ServiceOfferingLabelModel.make(resource_guid: service_offering_1.guid, key_name: 'flavor', value: 'orange')
+            VCAP::CloudController::ServiceOfferingLabelModel.make(resource_guid: service_offering_2.guid, key_name: 'flavor', value: 'orange')
+            VCAP::CloudController::ServiceOfferingLabelModel.make(resource_guid: service_offering_3.guid, key_name: 'flavor', value: 'apple')
+          end
+
+          it 'filters the matching service offerings' do
+            expect(service_offerings).to contain_exactly(service_offering_1, service_offering_2)
           end
         end
       end
     end
 
-    describe '#fetch_public' do
-      context 'when there are no public service offerings' do
-        let!(:service_offering_1) { ServicePlan.make(public: false, active: true).service }
-        let!(:service_offering_2) { ServicePlan.make(public: false, active: true).service }
-
-        it 'is empty' do
-          service_offerings = ServiceOfferingListFetcher.fetch_public(message).all
-
-          expect(service_offerings).to be_empty
-        end
-      end
-
-      context 'when there are public service offerings' do
-        let!(:service_offering_1) { ServicePlan.make(public: true, active: true).service }
-        let!(:service_offering_2) { ServicePlan.make(public: true, active: true).service }
-
-        it 'lists them all' do
-          service_offerings = ServiceOfferingListFetcher.fetch_public(message).all
-
-          expect(service_offerings).to contain_exactly(service_offering_1, service_offering_2)
-        end
-      end
-
-      context 'uniqueness of service offerings' do
-        let(:service_offering) { Service.make }
-
-        before do
-          2.times { ServicePlan.make(service: service_offering, public: true, active: true) }
-        end
-
-        it 'de-duplicates service offerings' do
-          service_offerings = ServiceOfferingListFetcher.fetch_public(message).all
-
-          expect(service_offerings).to contain_exactly(service_offering)
-        end
-      end
-
-      context 'when filters are provided' do
-        let(:service_offerings) { ServiceOfferingListFetcher.fetch_public(message).all }
-
-        it_behaves_like 'filtered service offering fetcher', :fetch_public
-      end
+    def make_public_offering
+      service_offering = Service.make(label: "public-#{Sham.name}")
+      ServicePlan.make(public: true, active: true, service: service_offering)
+      service_offering
     end
 
-    describe '#fetch_visible' do
-      context 'when there are no service offerings' do
-        it 'is empty' do
-          service_offerings = ServiceOfferingListFetcher.fetch_visible(message, [], []).all
+    def make_private_offering
+      service_offering = Service.make(label: "private-#{Sham.name}")
+      ServicePlan.make(public: false, active: true, service: service_offering)
+      service_offering
+    end
 
-          expect(service_offerings).to be_empty
-        end
-      end
+    def make_space_scoped_offering(space)
+      service_broker = ServiceBroker.make(space: space)
+      Service.make(service_broker: service_broker, label: "space-scoped-#{Sham.name}")
+    end
 
-      context 'when there are public service offerings' do
-        let!(:service_offering_1) { ServicePlan.make(public: true, active: true).service }
-        let!(:service_offering_2) { ServicePlan.make(public: true, active: true).service }
-
-        it 'lists them all' do
-          service_offerings = ServiceOfferingListFetcher.fetch_visible(message, [], []).all
-
-          expect(service_offerings).to contain_exactly(service_offering_1, service_offering_2)
-        end
-      end
-
-      context 'when there are service offerings that are only visible in certain orgs' do
-        let!(:organization_1) { Organization.make }
-        let!(:organization_2) { Organization.make }
-        let!(:service_plan_1) { ServicePlan.make(public: false, active: true) }
-        let!(:service_plan_2) { ServicePlan.make(public: false, active: true) }
-        let!(:service_plan_3) { ServicePlan.make(public: false, active: true) }
-        let!(:service_plan_4) { ServicePlan.make(public: false, active: true) }
-        let!(:service_offering_1) { service_plan_1.service }
-        let!(:service_offering_2) { service_plan_2.service }
-        let!(:service_offering_3) { service_plan_3.service }
-        let!(:service_offering_4) { service_plan_4.service }
-        let!(:visibility_2) { ServicePlanVisibility.make(service_plan: service_plan_2, organization: organization_1) }
-        let!(:visibility_3) { ServicePlanVisibility.make(service_plan: service_plan_3, organization: organization_2) }
-        let!(:visibility_4) { ServicePlanVisibility.make(service_plan: service_plan_4, organization: organization_1) }
-
-        it 'lists the ones that are visible in the specified orgs' do
-          service_offerings_1 = ServiceOfferingListFetcher.fetch_visible(message, [organization_1.guid], []).all
-          expect(service_offerings_1).to contain_exactly(service_offering_2, service_offering_4)
-
-          service_offerings_2 = ServiceOfferingListFetcher.fetch_visible(message, [organization_1.guid, organization_2.guid], []).all
-          expect(service_offerings_2).to contain_exactly(service_offering_2, service_offering_3, service_offering_4)
-        end
-      end
-
-      context 'when there are service offerings from a space-scoped broker' do
-        let!(:space_1) { Space.make }
-        let!(:space_2) { Space.make }
-
-        let!(:service_offering_1) { Service.make(active: true) }
-        let!(:service_offering_2) { Service.make(active: true) }
-        let!(:service_offering_3) { Service.make(active: true) }
-        let!(:service_offering_4) { Service.make(active: true) }
-
-        before do
-          service_offering_1.service_broker.space = space_1
-          service_offering_1.service_broker.save
-          service_offering_2.service_broker.space = space_1
-          service_offering_2.service_broker.save
-          service_offering_3.service_broker.space = space_2
-          service_offering_3.service_broker.save
-        end
-
-        it 'lists the ones visible in the specified spaces' do
-          service_offerings_1 = ServiceOfferingListFetcher.fetch_visible(message, [], [space_1.guid]).all
-          expect(service_offerings_1).to contain_exactly(service_offering_1, service_offering_2)
-
-          service_offerings_2 = ServiceOfferingListFetcher.fetch_visible(message, [], [space_1.guid, space_2.guid]).all
-          expect(service_offerings_2).to contain_exactly(service_offering_1, service_offering_2, service_offering_3)
-        end
-      end
-
-      context 'when there is a mixture of service offerings' do
-        # public - can see
-        let!(:service_offering_1) { ServicePlan.make(public: true, active: true).service }
-
-        # non public - cannot see
-        let!(:service_offering_2) { ServicePlan.make(public: false, active: true).service }
-
-        # visible in org 1 - can see
-        let!(:org_1) { Organization.make }
-        let!(:org_2) { Organization.make }
-        let!(:service_plan_1) { ServicePlan.make(public: false, active: true) }
-        let!(:service_offering_3) { service_plan_1.service }
-        let!(:visibility_1) { ServicePlanVisibility.make(service_plan: service_plan_1, organization: org_1) }
-
-        # visbible in org 3 - cannot see
-        let!(:org_3) { Organization.make }
-        let!(:service_plan_2) { ServicePlan.make(public: false, active: true) }
-        let!(:service_offering_4) { service_plan_1.service }
-        let!(:visibility_2) { ServicePlanVisibility.make(service_plan: service_plan_2, organization: org_3) }
-
-        let!(:space_1) { Space.make }
-        let!(:space_2) { Space.make }
-        let!(:space_3) { Space.make }
-        let!(:service_offering_5) { ServicePlan.make(public: false, active: true).service }
-        let!(:service_offering_6) { ServicePlan.make(public: false, active: true).service }
-        before do
-          service_offering_5.service_broker.space = space_1 # visible if member of space 1 - can see
-          service_offering_5.service_broker.save
-          service_offering_6.service_broker.space = space_2 # visible if member of space 2 - cannot see
-          service_offering_6.service_broker.save
-        end
-
-        it 'lists the visible ones' do
-          service_offerings = ServiceOfferingListFetcher.fetch_visible(message, [org_1.guid, org_2.guid], [space_1.guid, space_3.guid]).all
-          expect(service_offerings).to contain_exactly(service_offering_1, service_offering_3, service_offering_5)
-        end
-      end
-
-      context 'uniqueness of service offerings' do
-        let!(:organization_1) { Organization.make }
-        let!(:organization_2) { Organization.make }
-        let!(:service_plan) { ServicePlan.make(public: false, active: true) }
-        let!(:service_offering) { service_plan.service }
-        let!(:visibility_1) { ServicePlanVisibility.make(service_plan: service_plan, organization: organization_1) }
-        let!(:visibility_2) { ServicePlanVisibility.make(service_plan: service_plan, organization: organization_2) }
-
-        it 'de-duplicates service offerings' do
-          service_offerings = ServiceOfferingListFetcher.fetch_visible(message, [organization_1.guid, organization_2.guid], []).all
-          expect(service_offerings).to contain_exactly(service_offering)
-        end
-      end
-
-      context 'when filters are provided' do
-        let(:org_guids) { [] }
-        let(:space_guids) { [] }
-        let(:service_offerings) { ServiceOfferingListFetcher.fetch_visible(message, org_guids, space_guids).all }
-
-        it_behaves_like 'filtered service offering fetcher', :fetch_visible
-      end
+    def make_org_restricted_offering(org)
+      service_offering = Service.make(label: "org-restricted-#{Sham.name}")
+      service_plan = ServicePlan.make(public: false, service: service_offering)
+      ServicePlanVisibility.make(organization: org, service_plan: service_plan)
+      service_offering
     end
   end
 end


### PR DESCRIPTION
We wrote the service offering fetcher before the service plan fetcher,
and learnt some lessons while doing it which we applied to the service
plan fetcher. This change applies those lessons to the service offering
fetcher, pulling common code into a new base class.

[#171435755](https://www.pivotaltracker.com/story/show/171435755)