### PR TITLE
Revert "Implement get and list methods for tasks in OPI"

### DIFF
--- a/lib/cloud_controller/opi/task_client.rb
+++ b/lib/cloud_controller/opi/task_client.rb
@@ -21,33 +21,12 @@ module OPI
       end
     end
 
-    def fetch_task(guid)
-      resp = client.get("/tasks/#{guid}")
-
-      return if resp.status_code == 404
-
-      if resp.status_code != 200
-        raise CloudController::Errors::ApiError.new_from_details('TaskError', "response status code: #{resp.status_code}")
-      end
-
-      task = JSON.parse(resp.body)
-      task[:task_guid] = task.delete('guid')
-      OPI.recursive_ostruct(task)
+    def fetch_task(_)
+      Diego::Bbs::Models::Task.new
     end
 
     def fetch_tasks
-      resp = client.get('/tasks')
-
-      if resp.status_code != 200
-        raise CloudController::Errors::ApiError.new_from_details('TaskError', "response status code: #{resp.status_code}")
-      end
-
-      tasks = JSON.parse(resp.body)
-      tasks.each do |task|
-        task['task_guid'] = task.delete('guid')
-      end
-
-      tasks.map { |t| OPI.recursive_ostruct(t) }
+      []
     end
 
     def cancel_task(guid)

--- a/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
@@ -138,80 +138,24 @@ RSpec.describe(OPI::TaskClient) do
   end
 
   describe 'can fetch a task' do
-    let(:expected_body) {
-      { 'guid': 'foo' }.to_json
-    }
-
-    before(:each) do
-      stub_request(:get, "#{opi_url}/tasks/some-task-guid").
-        to_return(status: 200, body: expected_body)
+    it 'should return a empty dummy task' do
+      task = client.fetch_task('some-guid')
+      expect(task).to eq(Diego::Bbs::Models::Task.new)
     end
 
-    it 'should return a parsed task' do
-      task = client.fetch_task('some-task-guid')
-
-      expect(WebMock).to have_requested(:get, "#{opi_url}/tasks/some-task-guid")
-
-      expect(task).to eq(OpenStruct.new(task_guid: 'foo'))
-    end
-
-    context 'when the task is not found' do
-      before(:each) do
-        stub_request(:get, "#{opi_url}/tasks/some-task-guid").
-          to_return(status: 404)
-      end
-
-      it 'should return nil' do
-        expect(client.fetch_task('some-task-guid')).to be_nil
-      end
-    end
-
-    context 'when fetching the task fails' do
-      before(:each) do
-        stub_request(:get, "#{opi_url}/tasks/some-task-guid").
-          to_return(status: 500)
-      end
-
-      it 'should raise an ApiError' do
-        expect { client.fetch_task('some-task-guid') }.to raise_error(CloudController::Errors::ApiError, /response status code: 500/) do |e|
-          expect(e.name).to eq('TaskError')
-        end
-      end
+    it 'should not send any request to opi' do
+      expect(a_request(:any, opi_url)).not_to have_been_made
     end
   end
 
   describe 'can fetch all tasks' do
-    let(:expected_body) {
-      [{ 'guid': 'foo' }, { 'guid': 'bar' }].to_json
-    }
-
-    before(:each) do
-      stub_request(:get, "#{opi_url}/tasks").
-        to_return(status: 200, body: expected_body)
-    end
-
-    it 'should return a parsed list of tasks' do
+    it 'should return an empty list' do
       tasks = client.fetch_tasks
-
-      expect(WebMock).to have_requested(:get, "#{opi_url}/tasks")
-
-      expect(tasks).to match_array([
-        OpenStruct.new(task_guid: 'foo'),
-        OpenStruct.new(task_guid: 'bar'),
-      ])
+      expect(tasks).to be_empty
     end
 
-    context 'when fetching the tasks fails' do
-      before(:each) do
-        stub_request(:get, "#{opi_url}/tasks").
-          to_return(status: 500)
-      end
-
-      it 'should raise an ApiError' do
-        expect { client.fetch_tasks }.to raise_error(CloudController::Errors::ApiError, /response status code: 500/) do |e|
-          expect(e.name).to eq('TaskError')
-        end
-      end
+    it 'should not send any request to opi' do
+      expect(a_request(:any, opi_url)).not_to have_been_made
     end
   end
 


### PR DESCRIPTION
Reverts cloudfoundry/cloud_controller_ng#1892

The Eirini version that implements these endpoints hasn't been released yet. We should hold off on merging this until it is released and consumed in `cf-for-k8s`, otherwise the clock will fail to sync tasks and crash.

I logged a chore to figure out a Kubernetes alternative to our [sync-integration-tests](https://github.com/cloudfoundry/sync-integration-tests) as well: https://www.pivotaltracker.com/story/show/175566065