### PR TITLE
v3(services): eager load for instances endpoint

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -36,9 +36,17 @@ class ServiceInstancesV3Controller < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     dataset = if permission_queryer.can_read_globally?
-                ServiceInstanceListFetcher.fetch(message, omniscient: true)
+                ServiceInstanceListFetcher.fetch(
+                  message,
+                  eager_loaded_associations: Presenters::V3::ServiceInstancePresenter.associated_resources,
+                  omniscient: true,
+                )
               else
-                ServiceInstanceListFetcher.fetch(message, readable_space_guids: permission_queryer.readable_space_guids)
+                ServiceInstanceListFetcher.fetch(
+                  message,
+                  eager_loaded_associations: Presenters::V3::ServiceInstancePresenter.associated_resources,
+                  readable_space_guids: permission_queryer.readable_space_guids,
+                )
               end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(

--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -4,8 +4,8 @@ require 'fetchers/label_selector_query_generator'
 module VCAP::CloudController
   class ServiceInstanceListFetcher < BaseListFetcher
     class << self
-      def fetch(message, omniscient: false, readable_space_guids: [])
-        dataset = ServiceInstance.dataset.
+      def fetch(message, omniscient: false, readable_space_guids: [], eager_loaded_associations: [])
+        dataset = ServiceInstance.dataset.eager(eager_loaded_associations).
                   join(:spaces, id: Sequel[:service_instances][:space_id]).
                   left_join(:service_instance_shares, service_instance_guid: Sequel[:service_instances][:guid])
 

--- a/app/presenters/v3/service_instance_presenter.rb
+++ b/app/presenters/v3/service_instance_presenter.rb
@@ -18,7 +18,6 @@ module VCAP::CloudController
           end
         end
 
-
         def to_hash
           hash = correct_order(
             hash_common.deep_merge(

--- a/app/presenters/v3/service_instance_presenter.rb
+++ b/app/presenters/v3/service_instance_presenter.rb
@@ -7,6 +7,18 @@ module VCAP::CloudController
       class ServiceInstancePresenter < BasePresenter
         include VCAP::CloudController::Presenters::Mixins::MetadataPresentationHelpers
 
+        class << self
+          # :labels and :annotations come from MetadataPresentationHelpers
+          def associated_resources
+            super + [
+              :space,
+              :service_instance_operation,
+              :service_plan_sti_eager_load,
+            ]
+          end
+        end
+
+
         def to_hash
           hash = correct_order(
             hash_common.deep_merge(

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -479,7 +479,7 @@ RSpec.describe 'V3 service instances' do
           hash_including(eager_loaded_associations: [:labels, :annotations, :space, :service_instance_operation, :service_plan_sti_eager_load])
         ).and_call_original
 
-        get "/v3/service_instances", nil, admin_headers
+        get '/v3/service_instances', nil, admin_headers
         expect(last_response).to have_status_code(200)
       end
     end

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -472,6 +472,18 @@ RSpec.describe 'V3 service instances' do
       end
     end
 
+    describe 'eager loading' do
+      it 'eager loads associated resources that the presenter specifies' do
+        expect(VCAP::CloudController::ServiceInstanceListFetcher).to receive(:fetch).with(
+          an_instance_of(VCAP::CloudController::ServiceInstancesListMessage),
+          hash_including(eager_loaded_associations: [:labels, :annotations, :space, :service_instance_operation, :service_plan_sti_eager_load])
+        ).and_call_original
+
+        get "/v3/service_instances", nil, admin_headers
+        expect(last_response).to have_status_code(200)
+      end
+    end
+
     it_behaves_like 'list_endpoint_with_common_filters' do
       let(:resource_klass) { VCAP::CloudController::ServiceInstance }
       let(:api_call) do

--- a/spec/unit/fetchers/service_instance_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_instance_list_fetcher_spec.rb
@@ -40,6 +40,13 @@ module VCAP::CloudController
         expect(dataset.all).to contain_exactly(msi_2, ssi)
       end
 
+      it 'eager loads the specified resources for the processes' do
+        dataset = fetcher.fetch(message, omniscient: true, eager_loaded_associations: [:labels])
+
+        expect(dataset.all.first.associations.key?(:labels)).to be true
+        expect(dataset.all.first.associations.key?(:annotations)).to be false
+      end
+
       context 'filtering' do
         context 'by names' do
           let(:filters) { { names: [msi_1.name, ssi.name, 'no-such-name'] } }


### PR DESCRIPTION
Increases performance by about 20% for the following test:
```ruby
context 'given many instances' do
  let!(:instances) { Array.new(1000) { VCAP::CloudController::ManagedServiceInstance.make } }

  it 'does it fast' do
    start = Time.now
    get '/v3/service_instances?per_page=5000', nil, admin_headers
    expect(last_response).to have_status_code(200)
    p "duration: #{Time.now - start}"
  end
end
```

[#175715881](https://www.pivotaltracker.com/story/show/175715881)
