### PR TITLE
v3(services): Only update expected binding fields when creating a

### DIFF
--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -17,6 +17,8 @@ module VCAP::CloudController
         @audit_hash = audit_hash
       end
 
+      PERMITTED_BINDING_ATTRIBUTES = [:credentials, :syslog_drain_url, :volume_mounts].freeze
+
       def precursor(service_instance, app: nil, name: nil, volume_mount_services_enabled: false)
         validate!(service_instance, app, volume_mount_services_enabled)
 
@@ -45,7 +47,7 @@ module VCAP::CloudController
 
       def complete_binding_and_save(binding, binding_details, last_operation)
         binding.save_with_attributes_and_new_operation(
-          binding_details,
+          binding_details.symbolize_keys().slice(*PERMITTED_BINDING_ATTRIBUTES),
           {
             type: 'create',
             state: last_operation[:state],

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1383,17 +1383,8 @@ RSpec.describe 'v3 service credential bindings' do
                   syslog_drain_url: syslog_drain_url,
                   credentials: credentials,
                   parameters: parameters,
-                  service_id:'extra-field-service_id',
-                  plan_id:'extra-field-plan_id',
-                  name: 'extra-field-name',
-                  bind_resource:{
-                    app_guid:'extra-field',
-                    space_guid:'extra-field'
-                  },
-                  context:
-                    {
-                      platform:'extra-field',
-                    }
+                  service_id:'extra-field-service_id-should-ignore',
+                  name: 'extra-field-name-should-not-update',
                 }
               end
 

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1382,7 +1382,18 @@ RSpec.describe 'v3 service credential bindings' do
                 {
                   syslog_drain_url: syslog_drain_url,
                   credentials: credentials,
-                  parameters: parameters
+                  parameters: parameters,
+                  service_id:'extra-field-service_id',
+                  plan_id:'extra-field-plan_id',
+                  name: 'extra-field-name',
+                  bind_resource:{
+                    app_guid:'extra-field',
+                    space_guid:'extra-field'
+                  },
+                  context:
+                    {
+                      platform:'extra-field',
+                    }
                 }
               end
 
@@ -1409,11 +1420,12 @@ RSpec.describe 'v3 service credential bindings' do
                 expect(job.state).to eq(VCAP::CloudController::PollableJobModel::COMPLETE_STATE)
               end
 
-              it 'updates the binding details with the fetch binding response' do
+              it 'updates the binding details with the fetch binding response ignoring extra fields' do
                 execute_all_jobs(expected_successes: 1, expected_failures: 0)
 
                 expect(binding.reload.syslog_drain_url).to eq(syslog_drain_url)
                 expect(binding.credentials).to eq(credentials.with_indifferent_access)
+                expect(binding.name).to eq('some-name')
               end
 
               context 'fetching binding fails ' do


### PR DESCRIPTION
binding

OSBAPI spec outlines the broker expected response for a create binding
and indicates that any other field return by brokers should be ignored.
v2 has this behaviour but was missing in v3 and was causing failures
when the broker response includes attributes that are not part of the CC
DB. This is so we don't try to update any other fields.

[#175662475](https://www.pivotaltracker.com/story/show/175662475)

