### PR TITLE
App restart action is no longer experimental

### DIFF
--- a/docs/v3/source/includes/experimental_resources/app_restart/_header.md
+++ b/docs/v3/source/includes/experimental_resources/app_restart/_header.md
@@ -1,1 +1,0 @@
-## App Restart

--- a/docs/v3/source/includes/resources/apps/_restart.md.erb
+++ b/docs/v3/source/includes/resources/apps/_restart.md.erb
@@ -6,8 +6,8 @@ Example Request
 
 ```shell
 curl "https://api.example.org/v3/apps/[guid]/actions/restart" \
--X POST \
--H "Authorization: bearer [token]"
+  -X POST \
+  -H "Authorization: bearer [token]"
 ```
 
 ```
@@ -20,6 +20,13 @@ Content-Type: application/json
 
 <%= yield_content :app_with_state, 'STARTED' %>
 ```
+
+This endpoint will synchronously stop and start an application.
+Unlike the [start](#start-an-app) and [stop](#stop-an-app) actions,
+this endpoint will error if the app is not successfully stopped
+in the runtime.
+
+For restarting applications without downtime, see the [deployments](#deployments) resource.
 
 #### Definition
 `POST /v3/apps/:guid/actions/restart`

--- a/docs/v3/source/index.html.md
+++ b/docs/v3/source/index.html.md
@@ -80,6 +80,7 @@ includes:
   - resources/apps/ssh_enabled
   - resources/apps/start
   - resources/apps/stop
+  - resources/apps/restart
   - resources/apps/update_environment_variables
   - resources/app_features/header
   - resources/app_features/object
@@ -342,8 +343,6 @@ includes:
   - resources/users/update
   - resources/users/delete
   - experimental_resources/header
-  - experimental_resources/app_restart/header
-  - experimental_resources/app_restart/create
   - experimental_resources/revisions/header
   - experimental_resources/revisions/object
   - experimental_resources/revisions/get


### PR DESCRIPTION
- Restart action is used by the v7 CLI so it should not be experimental
- Update docs with more details on what the endpoint does