### PR TITLE
Pass-thru Docker user from staging completion handler to desire-lrp

### DIFF
--- a/app/models/runtime/droplet_model.rb
+++ b/app/models/runtime/droplet_model.rb
@@ -115,6 +115,19 @@ module VCAP::CloudController
       exposed_ports
     end
 
+    def docker_user
+      if self.execution_metadata.present?
+        begin
+          metadata = JSON.parse(self.execution_metadata)
+          unless metadata['user'].nil?
+            return metadata['user']
+          end
+        rescue JSON::ParserError
+        end
+      end
+      return ''
+    end
+
     def staging?
       self.state == STAGING_STATE
     end

--- a/lib/cloud_controller/opi/apps_client.rb
+++ b/lib/cloud_controller/opi/apps_client.rb
@@ -81,6 +81,7 @@ module OPI
           docker_lifecycle: {
             command: command,
             image: @process.desired_droplet.docker_receipt_image,
+            user: @process.desired_droplet.docker_user,
             registry_username: @process.desired_droplet.docker_receipt_username,
             registry_password: @process.desired_droplet.docker_receipt_password,
           }

--- a/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe(OPI::Client) do
       docker_receipt_password: 'docker-password',
       droplet_hash: 'd_haash',
       guid: 'some-droplet-guid',
+      execution_metadata: { 'user': 2000 }.to_json
     )
     }
     let(:routing_info) {
@@ -373,6 +374,7 @@ RSpec.describe(OPI::Client) do
             expected_body_with_lifecycle = expected_body.merge(lifecycle: {
               docker_lifecycle: {
                 image: 'http://example.org/image1234',
+                user: 2000,
                 registry_username: 'docker-user',
                 registry_password: 'docker-password',
                 command: ['/bin/sh', '-c', 'ls -la']

--- a/spec/unit/models/runtime/droplet_model_spec.rb
+++ b/spec/unit/models/runtime/droplet_model_spec.rb
@@ -181,6 +181,36 @@ module VCAP::CloudController
       end
     end
 
+    describe '#docker_user' do
+      let!(:droplet_model) { DropletModel.make(:docker) }
+
+      describe 'is set to an integer' do
+        before do
+          execution_metadata = {
+              'user' => 2000
+          }
+          droplet_model.execution_metadata = execution_metadata.to_json
+          droplet_model.save
+        end
+        it 'saves the docker_user attribute from execution_metadata ' do
+          expect(droplet_model.docker_user).to eq(2000)
+        end
+      end
+
+      describe 'is set to a string' do
+        before do
+          execution_metadata = {
+              'user' => 'wingdang'
+          }
+          droplet_model.execution_metadata = execution_metadata.to_json
+          droplet_model.save
+        end
+        it 'saves the docker_user attribute from execution_metadata ' do
+          expect(droplet_model.docker_user).to eq('wingdang')
+        end
+      end
+    end
+
     describe '#set_buildpack_receipt' do
       let!(:droplet_model) { DropletModel.make(state: 'STAGED') }
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
`execution_metadata` includes a user string from Eirini `docker_staging` the image and is threaded through to the desire. This is used by Eirini to construct the `PodSecurityContext`.

* An explanation of the use cases your change solves
This will allow images that do not include a numeric UID to run with Eirini.

* Links to any other associated PRs
https://github.com/cloudfoundry-incubator/eirini/pull/121

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
- Still need to run CATS. This PR works in tandem with an Eirini PR. There may be additional changes to be worked out.
