### PR TITLE
use TCPServer for rake-task readiness checks

### DIFF
--- a/spec/unit/lib/background_job_environment_spec.rb
+++ b/spec/unit/lib/background_job_environment_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe BackgroundJobEnvironment do
   describe '#setup_environment' do
     before do
       allow(VCAP::CloudController::DB).to receive(:load_models)
-      allow(Thread).to receive(:new).and_yield
       allow(EM).to receive(:run).and_yield
       allow(VCAP::CloudController::ResourcePool).to receive(:new)
     end
@@ -55,7 +54,7 @@ RSpec.describe BackgroundJobEnvironment do
         expect {
           background_job_environment.setup_environment(9999)
         }.to change { open_port_count }.by(1)
-        expect { TCPSocket.new('127.0.0.1', 9999).close }.not_to raise_error
+        expect { background_job_environment.readiness_server.close }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
The socket we were opening would pass the readiness probe checks initially, but cause it to fail later with errors like:
```
  ----     ------     ----                  ----                                          -------
  Normal   Scheduled  10m                   default-scheduler                             Successfully assigned cf-system/cf-api-clock-65df859bf7-m2nw5 to gke-tim2-default-pool-e0832f49-cpq3
  Normal   Pulling    10m                   kubelet, gke-tim2-default-pool-e0832f49-cpq3  Pulling image "gcr.io/cf-capi-arya/dev-ccng:kbld-rand-1606256436134787000-1515422298211"
  Normal   Pulled     10m                   kubelet, gke-tim2-default-pool-e0832f49-cpq3  Successfully pulled image "gcr.io/cf-capi-arya/dev-ccng:kbld-rand-1606256436134787000-1515422298211"
  Normal   Created    10m                   kubelet, gke-tim2-default-pool-e0832f49-cpq3  Created container cf-api-clock
  Normal   Started    10m                   kubelet, gke-tim2-default-pool-e0832f49-cpq3  Started container cf-api-clock
  Warning  Unhealthy  9m55s (x3 over 10m)   kubelet, gke-tim2-default-pool-e0832f49-cpq3  Readiness probe failed: dial tcp 10.4.2.195:4446: connect: connection refused
  Warning  Unhealthy  18s (x91 over 4m48s)  kubelet, gke-tim2-default-pool-e0832f49-cpq3  Readiness probe failed: dial tcp 10.4.2.195:4446: i/o timeout
```

This replaces the raw socket with a TCPServer that runs in a background thread that can accept multiple readiness probe connections.

Relates to: https://github.com/cloudfoundry/capi-k8s-release/issues/91

Tracker Story: [#175388005](https://www.pivotaltracker.com/story/show/175388005)