### PR TITLE
v3(services): refactor delete for service instance

### DIFF
--- a/spec/unit/actions/v3/service_instance_delete_spec.rb
+++ b/spec/unit/actions/v3/service_instance_delete_spec.rb
@@ -55,20 +55,16 @@ module VCAP
               with(:delete, instance_of(UserProvidedServiceInstance))
           end
 
-          it 'returns nothing' do
-            expect(subject.delete(service_instance)).to be_nil
+          it 'returns true' do
+            expect(subject.delete(service_instance)).to be_truthy
           end
         end
 
         context 'managed service instances' do
           let!(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make }
 
-          it 'enqueues a job and returns the job guid' do
-            job_guid = subject.delete(service_instance)
-            job = VCAP::CloudController::PollableJobModel.last
-
-            expect(job.guid).to eq(job_guid)
-            expect(job.resource_guid).to eq(service_instance.guid)
+          it 'returns false' do
+            expect(subject.delete(service_instance)).to be_falsey
           end
         end
 


### PR DESCRIPTION
We have moved to a pattern where a controller either uses an action to
do something, or schedules a job to do something, and the job uses an
action under the hood. The services instances delete endpoint was using
an action to schedule a job, which could be confusing as it's different
to other endpoints.

[#171728591](https://www.pivotaltracker.com/story/show/171728591)