### PR TITLE
make credential_client_id optional when creating service keys

### DIFF
--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -361,11 +361,10 @@ module VCAP::CloudController
               registry_tag_base: String,
             }
           },
+          optional(:cc_service_key_client_name) => String,
+          optional(:cc_service_key_client_secret) => String,
 
           **VCAP::Config::Dsl.omit_on_k8s(
-            cc_service_key_client_name: String,
-            cc_service_key_client_secret: String,
-
             diego: {
               bbs: {
                 url: String,


### PR DESCRIPTION
- makes the `cc_service_key_client_name` and
`cc_service_key_client_secret` config properties optional to accomodate
environments that do not have a platform CredHub deployed
- updates the services api client to only send the optional
`credential_client_id` bind_resource param when those config properties
are present
- see: https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#bind-resource-object

Addresses https://github.com/cloudfoundry/capi-k8s-release/issues/101

Tracker Story: [#175562836](https://www.pivotaltracker.com/story/show/175562836)