### PR TITLE
Fix broken logging for cc_workers

### DIFF
--- a/lib/cloud_controller/background_job_environment.rb
+++ b/lib/cloud_controller/background_job_environment.rb
@@ -6,11 +6,12 @@ class BackgroundJobEnvironment
   def initialize(config)
     @config = config
     @log_counter = Steno::Sink::Counter.new
-    @logger = Steno.logger('cc.background')
 
     VCAP::CloudController::StenoConfigurer.new(config.get(:logging)).configure do |steno_config_hash|
       steno_config_hash[:sinks] << @log_counter
     end
+
+    @logger = Steno.logger('cc.background')
   end
 
   READINESS_SOCKET_QUEUE_DEPTH = 100


### PR DESCRIPTION
* A short explanation of the proposed change:

We found that our cc_workers do not log db-queries and anymore.
Maybe they do not log anything, we did not go in depth what is logged and what not.

We found that in cloud controller worker environments the logger is set before steno is
initialised.
This leads to cc.background type logs not being emitted as all steno sinks
are missing for the respective logger.
This PR reorders the logger initialisation to be after steno init.
With this we see logs being correctly emitted again.

* An explanation of the use cases your change solves

We need logs 😃 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
