### PR TITLE
Staging no longer requires process types

### DIFF
--- a/spec/unit/controllers/internal/staging_completion_controller_spec.rb
+++ b/spec/unit/controllers/internal/staging_completion_controller_spec.rb
@@ -318,8 +318,6 @@ module VCAP::CloudController
         end
 
         it 'adds the buildpack info to the droplet' do
-          # expect_any_instance_of(Diego::Stager).to receive(:staging_complete).with(instance_of(BuildModel), { result: staging_result }, false)
-
           allow_any_instance_of(BuildModel).to receive(:in_final_state?).and_return(false)
           post url, MultiJson.dump(staging_response)
           expect(last_response.status).to eq(200)

--- a/spec/unit/lib/cloud_controller/diego/docker/staging_completion_handler_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/staging_completion_handler_spec.rb
@@ -73,7 +73,7 @@ module VCAP::CloudController
                 expect(droplet.process_types).to eq(data)
               end
 
-              context 'when process_types is empty' do
+              context 'when process_types is empty and the process has no command' do
                 before do
                   payload[:result][:process_types] = nil
                 end
@@ -87,7 +87,7 @@ module VCAP::CloudController
                 it 'logs an error for the CF user' do
                   handler.staging_complete(payload)
 
-                  expect(VCAP::AppLogEmitter).to have_received(:emit_error).with(build.app_guid, /No process types returned from stager/)
+                  expect(VCAP::AppLogEmitter).to have_received(:emit_error).with(build.app_guid, /Start command not specified/)
                 end
               end
 


### PR DESCRIPTION
- Staging will no longer fail if no process types are returned from the
buildpack as long as the latest web process already has a start command.
- The `with_start` argument is used in the v2 staging flow and bypassed
the requirement for process types, as long as the process already has a
start command.
- Some buildpacks (for example the python buildpack) do not return
process types unless a Procfile is provided. The previous logic meant
that staging would always fail without a Procfile in the v3 staging flow.
- Requiring a Procfile in the base case is an upgrade barrier for the v3
API. Instead, we can use the same default command as the v2 staging
flow. As a side effect, the process_types/start command logic no longer
depend on `with_start`
- Change the `app.processes.first.command.blank?` check to use
`app.newest_web_process` instead, since that is the process that will be
started (either later in `staging_completion_handler` in the `with_start`
flow or when assigning the droplet/starting the app in the v3 staging
flow).

[#1922]

Authored-by: Greg Cobb <gcobb@pivotal.io>

Related BARAs PR: cloudfoundry/capi-bara-tests#5