### PR TITLE
v3(services): deny subsequent delete binding request

### DIFF
--- a/app/actions/v3/service_binding_delete.rb
+++ b/app/actions/v3/service_binding_delete.rb
@@ -16,8 +16,12 @@ module VCAP::CloudController
       PollingFinished = PollingStatus.new(true, nil).freeze
       ContinuePolling = ->(retry_after) { PollingStatus.new(false, retry_after) }
 
+      def blocking_operation_in_progress?(binding)
+        binding.operation_in_progress? && binding.last_operation.type != 'create'
+      end
+
       def delete(binding)
-        operation_in_progress! if binding.operation_in_progress? && binding.last_operation.type != 'create'
+        operation_in_progress! if blocking_operation_in_progress?(binding)
 
         result = send_unbind_to_client(binding)
         if result[:finished]

--- a/app/actions/v3/service_binding_delete.rb
+++ b/app/actions/v3/service_binding_delete.rb
@@ -98,12 +98,12 @@ module VCAP::CloudController
       end
 
       def operation_in_progress!
-        raise ConcurrencyError.new('The delete request was rejected due to an operation being in progress for the binding')
+        raise ConcurrencyError.new('The delete request was rejected due to an operation being in progress for the service binding.')
       end
 
       def broker_concurrency_error!
         raise ConcurrencyError.new(
-          'The service broker rejected the request due to an operation being in progress for the binding'
+          'The service broker rejected the request due to an operation being in progress for the service binding.'
         )
       end
     end

--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -308,7 +308,7 @@ class ServiceCredentialBindingsController < ApplicationController
   end
 
   def binding_operation_in_progress!
-    unprocessable!('There is an operation in progress for the service credential binding.')
+    unprocessable!('There is an operation in progress for the service binding.')
   end
 
   def not_found!

--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -64,14 +64,16 @@ class ServiceRouteBindingsController < ApplicationController
 
   def destroy
     route_binding_not_found! unless @route_binding && can_read_space?(@route_binding.route.space)
-    operation_in_progress! if @route_binding.service_instance.operation_in_progress?
+
+    action = V3::ServiceRouteBindingDelete.new(user_audit_info)
+    binding_operation_in_progress! if action.blocking_operation_in_progress?(@route_binding)
+    instance_operation_in_progress! if @route_binding.service_instance.operation_in_progress?
 
     case @route_binding.service_instance
     when ManagedServiceInstance
       pollable_job_guid = enqueue_unbind_job(@route_binding.guid)
       head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job_guid}")
     when UserProvidedServiceInstance
-      action = V3::ServiceRouteBindingDelete.new(user_audit_info)
       action.delete(@route_binding)
       head :no_content
     end
@@ -238,8 +240,12 @@ class ServiceRouteBindingsController < ApplicationController
     raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceAlreadyBoundToSameRoute').with_response_code(422)
   end
 
-  def operation_in_progress!
+  def instance_operation_in_progress!
     unprocessable!('There is an operation in progress for the service instance.')
+  end
+
+  def binding_operation_in_progress!
+    unprocessable!('There is an operation in progress for the service binding.')
   end
 
   def set_route_binding

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1457,6 +1457,20 @@ RSpec.describe 'v3 service credential bindings' do
         end
       end
 
+      context 'when the service credential binding has a delete in progress' do
+        it 'responds with 422' do
+          binding.save_with_attributes_and_new_operation({}, { type: 'delete', state: 'in progress' })
+
+          api_call.call admin_headers
+          expect(last_response).to have_status_code(422)
+          expect(parsed_response['errors']).to include(include({
+            'detail' => include('There is an operation in progress for the service credential binding.'),
+            'title' => 'CF-UnprocessableEntity',
+            'code' => 10008,
+          }))
+        end
+      end
+
       context 'when the service credential binding is still creating' do
         before do
           binding.save_with_attributes_and_new_operation(

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1464,7 +1464,7 @@ RSpec.describe 'v3 service credential bindings' do
           api_call.call admin_headers
           expect(last_response).to have_status_code(422)
           expect(parsed_response['errors']).to include(include({
-            'detail' => include('There is an operation in progress for the service credential binding.'),
+            'detail' => include('There is an operation in progress for the service binding.'),
             'title' => 'CF-UnprocessableEntity',
             'code' => 10008,
           }))

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -1383,6 +1383,20 @@ RSpec.describe 'v3 service route bindings' do
           end
         end
 
+        context 'when the route binding has a delete in progress' do
+          it 'responds with 422' do
+            binding.save_with_new_operation({}, { type: 'delete', state: 'in progress' })
+
+            api_call.call admin_headers
+            expect(last_response).to have_status_code(422)
+            expect(parsed_response['errors']).to include(include({
+              'detail' => include('There is an operation in progress for the service binding.'),
+              'title' => 'CF-UnprocessableEntity',
+              'code' => 10008,
+            }))
+          end
+        end
+
         context 'when the route binding is still creating' do
           before do
             binding.save_with_new_operation(

--- a/spec/support/shared_examples/v3_service_binding_delete.rb
+++ b/spec/support/shared_examples/v3_service_binding_delete.rb
@@ -79,7 +79,7 @@ RSpec.shared_examples 'service binding deletion' do |binding_model|
             action.delete(binding)
           }.to raise_error(
             described_class::ConcurrencyError,
-            'The service broker rejected the request due to an operation being in progress for the binding',
+            'The service broker rejected the request due to an operation being in progress for the service binding.',
           )
 
           binding.reload
@@ -103,7 +103,7 @@ RSpec.shared_examples 'service binding deletion' do |binding_model|
           action.delete(binding)
         }.to raise_error(
           described_class::ConcurrencyError,
-          'The delete request was rejected due to an operation being in progress for the binding',
+          'The delete request was rejected due to an operation being in progress for the service binding.',
         )
 
         binding.reload


### PR DESCRIPTION
If a binding deletion is already in progress, then a subsequent attempt to
delete the same binding should fail

[#176116284](https://www.pivotaltracker.com/story/show/176116284)

Co-Authored-By: George Blue <blgm@users.noreply.github.com>