### PR TITLE
v3(services): synchronous broker name and metadata updates

### DIFF
--- a/docs/v3/source/includes/resources/service_brokers/_update.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_update.md.erb
@@ -27,7 +27,7 @@ curl "https://api.example.org/v3/service_brokers/[guid]" \
 ```
 
 ```
-Example Response
+Example Response with job
 ```
 
 ```http
@@ -36,10 +36,26 @@ Content-Type: application/json
 Location: https://api.example.org/v3/jobs/af5c57f6-8769-41fa-a499-2c84ed896788
 ```
 
-This endpoint updates a broker and creates a job to synchronize the service offerings and service plans with those in the broker's catalog.
-The `Location` header refers to the created job which syncs the broker with the catalog. See [_Service broker jobs_](#service-broker-jobs) for more information and limitations.
+```
+Example Response without job
+```
 
-Service brokers that are in the process of being synchronized or deleted cannot be updated.
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+<%= yield_content :single_service_broker %>
+```
+
+This endpoint updates a service broker. If the parameters include
+`url` or `authentication`, then the endpoint will enqueue a background job to
+synchronize the service offerings and service plans with those in the broker's catalog.
+For updates that consist of only `name` or `metadata`, the update is
+processed immediately, and the service broker's catalog is not synchronized.
+
+When a service broker has a synchronization job in progress, only
+updates with `name` and `metadata` are permitted until the synchronization job
+is complete.
 
 #### Definition
 `PATCH /v3/service_brokers/:guid`
@@ -62,4 +78,3 @@ Name | Type | Description
 --- | ---
 Admin |
 Space Developer (only space-scoped brokers) |
-

--- a/spec/unit/actions/v3/service_broker_update_spec.rb
+++ b/spec/unit/actions/v3/service_broker_update_spec.rb
@@ -4,9 +4,12 @@ require 'messages/service_broker_update_message'
 
 module VCAP
   module CloudController
-    RSpec.describe 'ServiceBrokerUpdate' do
-      let(:state) { ServiceBrokerStateEnum::AVAILABLE }
+    RSpec.describe ServiceBrokerUpdate do
+      subject(:action) { V3::ServiceBrokerUpdate.new(existing_service_broker, message, event_repository) }
 
+      let(:message) { ServiceBrokerUpdateMessage.new(request) }
+
+      let(:state) { ServiceBrokerStateEnum::AVAILABLE }
       let!(:existing_service_broker) do
         ServiceBroker.make(
           name: 'old-name',
@@ -23,155 +26,125 @@ module VCAP
         dbl
       end
 
-      subject(:action) {
-        V3::ServiceBrokerUpdate.new(existing_service_broker, event_repository)
-      }
+      describe '#update_broker_needed?' do
+        context 'name' do
+          let(:request) { { name: 'new-name' } }
 
-      let(:message) do
-        ServiceBrokerUpdateMessage.new(
-          name: 'new-name',
-          url: 'http://example.org/new-broker-url',
-          authentication: {
-            credentials: {
-              username: 'new-admin',
-              password: 'welcome'
-            }
-          },
-          metadata: {
-              labels: { potato: 'yam' },
-              annotations: { style: 'mashed' }
-          }
-        )
-      end
+          it 'is false' do
+            expect(action.update_broker_needed?).to be_falsey
+          end
+        end
 
-      let(:service_broker_update_request) {
-        ServiceBrokerUpdateRequest.find(service_broker_id: existing_service_broker.id)
-      }
-
-      it 'does not update the broker in the DB' do
-        action.update(message)
-
-        expect(existing_service_broker.name).to eq('old-name')
-        expect(existing_service_broker.broker_url).to eq('http://example.org/old-broker-url')
-        expect(existing_service_broker.auth_username).to eq('old-admin')
-        expect(existing_service_broker.auth_password).to eq('not-welcome')
-      end
-
-      it 'creates an entry for the update request in the DB' do
-        action.update(message)
-
-        service_broker_update_request = ServiceBrokerUpdateRequest.find(service_broker_id: existing_service_broker.id)
-
-        expect(service_broker_update_request.name).to eq('new-name')
-        expect(service_broker_update_request.broker_url).to eq('http://example.org/new-broker-url')
-        expect(service_broker_update_request.authentication).to eq('{"credentials":{"username":"new-admin","password":"welcome"}}')
-        expect(service_broker_update_request.labels[0][:key_name]).to eq('potato')
-        expect(service_broker_update_request.labels[0][:value]).to eq('yam')
-        expect(service_broker_update_request.annotations[0][:key]).to eq('style')
-        expect(service_broker_update_request.annotations[0][:value]).to eq('mashed')
-      end
-
-      it 'creates and returns a update job' do
-        job = action.update(message)[:pollable_job]
-
-        expect(job).to be_a PollableJobModel
-        expect(job.operation).to eq('service_broker.update')
-        expect(job.resource_guid).to eq(existing_service_broker.guid)
-        expect(job.resource_type).to eq('service_brokers')
-      end
-
-      it 'creates an update job with the right arguments' do
-        allow(VCAP::CloudController::V3::UpdateBrokerJob).to receive(:new).and_return(spy(VCAP::CloudController::V3::UpdateBrokerJob))
-        previous_state = existing_service_broker.state
-
-        action.update(message)
-
-        expect(VCAP::CloudController::V3::UpdateBrokerJob).to have_received(:new).with(
-          service_broker_update_request.guid,
-            existing_service_broker.guid,
-            previous_state
-        ).once
-      end
-
-      it 'sets the state to SYNCHRONIZING' do
-        action.update(message)
-
-        expect(existing_service_broker.state).to eq(ServiceBrokerStateEnum::SYNCHRONIZING)
-      end
-
-      it 'creates an audit event' do
-        action.update(message)
-
-        expect(event_repository).
-          to have_received(:record_broker_event_with_request).with(
-            :update,
-            instance_of(ServiceBroker),
+        context 'metadata' do
+          let(:request) do
             {
-              name: 'new-name',
-              url: 'http://example.org/new-broker-url',
+              metadata: {
+                labels: { potato: 'yam' },
+                annotations: { style: 'mashed' }
+              }
+            }
+          end
+
+          it 'is false' do
+            expect(action.update_broker_needed?).to be_falsey
+          end
+        end
+
+        context 'url' do
+          let(:request) { { url: 'new-url' } }
+
+          it 'is true' do
+            expect(action.update_broker_needed?).to be_truthy
+          end
+        end
+
+        context 'authentication' do
+          let(:request) do
+            {
               authentication: {
                 credentials: {
                   username: 'new-admin',
-                  password: '[PRIVATE DATA HIDDEN]'
+                  password: 'welcome'
                 }
-              },
-              metadata: {
-                  labels: { potato: 'yam' },
-                  annotations: { style: 'mashed' }
               }
-            }.with_indifferent_access
-          )
-      end
-
-      context 'If broker is in transitional state' do
-        let(:expected_error_message) { 'Cannot update a broker when other operation is already in progress' }
-
-        context 'If broker is in SYNCHRONIZING state' do
-          let(:state) { ServiceBrokerStateEnum::SYNCHRONIZING }
-
-          it 'raises an InvalidServiceBroker error' do
-            expect { action.update(message) }.to raise_error(V3::ServiceBrokerUpdate::InvalidServiceBroker, expected_error_message)
+            }
           end
-        end
 
-        context 'If broker is in DELETE_IN_PROGRESS state' do
-          let(:state) { ServiceBrokerStateEnum::DELETE_IN_PROGRESS }
-
-          it 'raises an InvalidServiceBroker error' do
-            expect { action.update(message) }.to raise_error(V3::ServiceBrokerUpdate::InvalidServiceBroker, expected_error_message)
+          it 'is true' do
+            expect(action.update_broker_needed?).to be_truthy
           end
         end
       end
 
-      context 'If broker is in a failed state' do
-        context 'If broker is in SYNCHRONIZATION_FAILED state' do
-          let(:state) { ServiceBrokerStateEnum::SYNCHRONIZATION_FAILED }
-
-          it 'does not raise an error' do
-            expect { action.update(message) }.not_to raise_error
-          end
+      describe '#update_sync' do
+        let(:request) do
+          {
+            name: 'new-name',
+            metadata: {
+              labels: { potato: 'yam' },
+              annotations: { style: 'mashed' }
+            }
+          }
         end
 
-        context 'If broker is in DELETE_FAILED state' do
-          let(:state) { ServiceBrokerStateEnum::DELETE_FAILED }
+        before do
+          action.update_sync
+        end
 
-          it 'does not raise an error' do
-            expect { action.update(message) }.not_to raise_error
-          end
+        it 'updates name and metadata' do
+          expect(existing_service_broker.name).to eq('new-name')
+          expect(existing_service_broker).to have_labels({ key: 'potato', value: 'yam' })
+          expect(existing_service_broker).to have_annotations({ key: 'style', value: 'mashed' })
         end
       end
 
-      context 'legacy service brokers' do
-        let!(:state) { '' } # broker creating from V2 endpoint will not have a state
-
-        it 'sets the state to SYNCHRONIZING' do
-          action.update(message)
-
-          expect(existing_service_broker.reload.state).to eq(ServiceBrokerStateEnum::SYNCHRONIZING)
+      describe '#enqueue_update' do
+        let(:request) do
+          {
+            name: 'new-name',
+            url: 'http://example.org/new-broker-url',
+            authentication: {
+              credentials: {
+                username: 'new-admin',
+                password: 'welcome'
+              }
+            },
+            metadata: {
+              labels: { potato: 'yam' },
+              annotations: { style: 'mashed' }
+            }
+          }
         end
 
-        it 'creates and returns a synchronization job' do
-          job = action.update(message)[:pollable_job]
+        let(:service_broker_update_request) {
+          ServiceBrokerUpdateRequest.find(service_broker_id: existing_service_broker.id)
+        }
+
+        it 'does not update the broker in the DB' do
+          action.enqueue_update
+
+          expect(existing_service_broker.name).to eq('old-name')
+          expect(existing_service_broker.broker_url).to eq('http://example.org/old-broker-url')
+          expect(existing_service_broker.auth_username).to eq('old-admin')
+          expect(existing_service_broker.auth_password).to eq('not-welcome')
+        end
+
+        it 'creates an entry for the update request in the DB' do
+          action.enqueue_update
+
+          service_broker_update_request = ServiceBrokerUpdateRequest.find(service_broker_id: existing_service_broker.id)
+
+          expect(service_broker_update_request.name).to eq('new-name')
+          expect(service_broker_update_request.broker_url).to eq('http://example.org/new-broker-url')
+          expect(service_broker_update_request.authentication).to eq('{"credentials":{"username":"new-admin","password":"welcome"}}')
+          expect(service_broker_update_request.labels[0][:key_name]).to eq('potato')
+          expect(service_broker_update_request.labels[0][:value]).to eq('yam')
+          expect(service_broker_update_request.annotations[0][:key]).to eq('style')
+          expect(service_broker_update_request.annotations[0][:value]).to eq('mashed')
+        end
+
+        it 'creates and returns a update job' do
+          job = action.enqueue_update
 
           expect(job).to be_a PollableJobModel
           expect(job.operation).to eq('service_broker.update')
@@ -181,14 +154,114 @@ module VCAP
 
         it 'creates an update job with the right arguments' do
           allow(VCAP::CloudController::V3::UpdateBrokerJob).to receive(:new).and_return(spy(VCAP::CloudController::V3::UpdateBrokerJob))
+          previous_state = existing_service_broker.state
 
-          action.update(message)
+          action.enqueue_update
 
           expect(VCAP::CloudController::V3::UpdateBrokerJob).to have_received(:new).with(
             service_broker_update_request.guid,
+            existing_service_broker.guid,
+            previous_state
+          ).once
+        end
+
+        it 'sets the state to SYNCHRONIZING' do
+          action.enqueue_update
+
+          expect(existing_service_broker.state).to eq(ServiceBrokerStateEnum::SYNCHRONIZING)
+        end
+
+        it 'creates an audit event' do
+          action.enqueue_update
+
+          expect(event_repository).
+            to have_received(:record_broker_event_with_request).with(
+              :update,
+              instance_of(ServiceBroker),
+              {
+                name: 'new-name',
+                url: 'http://example.org/new-broker-url',
+                authentication: {
+                  credentials: {
+                    username: 'new-admin',
+                    password: '[PRIVATE DATA HIDDEN]'
+                  }
+                },
+                metadata: {
+                  labels: { potato: 'yam' },
+                  annotations: { style: 'mashed' }
+                }
+              }.with_indifferent_access
+            )
+        end
+
+        context 'If broker is in transitional state' do
+          let(:expected_error_message) { 'Cannot update a broker when other operation is already in progress' }
+
+          context 'If broker is in SYNCHRONIZING state' do
+            let(:state) { ServiceBrokerStateEnum::SYNCHRONIZING }
+
+            it 'raises an InvalidServiceBroker error' do
+              expect { action.enqueue_update }.to raise_error(V3::ServiceBrokerUpdate::InvalidServiceBroker, expected_error_message)
+            end
+          end
+
+          context 'If broker is in DELETE_IN_PROGRESS state' do
+            let(:state) { ServiceBrokerStateEnum::DELETE_IN_PROGRESS }
+
+            it 'raises an InvalidServiceBroker error' do
+              expect { action.enqueue_update }.to raise_error(V3::ServiceBrokerUpdate::InvalidServiceBroker, expected_error_message)
+            end
+          end
+        end
+
+        context 'If broker is in a failed state' do
+          context 'If broker is in SYNCHRONIZATION_FAILED state' do
+            let(:state) { ServiceBrokerStateEnum::SYNCHRONIZATION_FAILED }
+
+            it 'does not raise an error' do
+              expect { action.enqueue_update }.not_to raise_error
+            end
+          end
+
+          context 'If broker is in DELETE_FAILED state' do
+            let(:state) { ServiceBrokerStateEnum::DELETE_FAILED }
+
+            it 'does not raise an error' do
+              expect { action.enqueue_update }.not_to raise_error
+            end
+          end
+        end
+
+        context 'legacy service brokers' do
+          let!(:state) { '' } # broker creating from V2 endpoint will not have a state
+
+          it 'sets the state to SYNCHRONIZING' do
+            action.enqueue_update
+
+            expect(existing_service_broker.reload.state).to eq(ServiceBrokerStateEnum::SYNCHRONIZING)
+          end
+
+          it 'creates and returns a synchronization job' do
+            job = action.enqueue_update
+
+            expect(job).to be_a PollableJobModel
+            expect(job.operation).to eq('service_broker.update')
+            expect(job.resource_guid).to eq(existing_service_broker.guid)
+            expect(job.resource_type).to eq('service_brokers')
+          end
+
+          it 'creates an update job with the right arguments' do
+            allow(VCAP::CloudController::V3::UpdateBrokerJob).to receive(:new).and_return(spy(VCAP::CloudController::V3::UpdateBrokerJob))
+
+            action.enqueue_update
+
+            expect(VCAP::CloudController::V3::UpdateBrokerJob).to have_received(:new).with(
+              service_broker_update_request.guid,
               existing_service_broker.guid,
               ''
-          ).once
+            ).once
+          end
         end
       end
     end


### PR DESCRIPTION
- auth and url changes should trigger catalog synchronization
- name and metadata changes are only DB updates so can be synchronous
- sync updates should be permitted when a job is in progress

[#175479368](https://www.pivotaltracker.com/story/show/175479368)
[#169090128](https://www.pivotaltracker.com/story/show/169090128)

Co-authored-by: George Blue <gblue@pivotal.io>
Co-authored-by: Marcela Campo <mcampo@pivotal.io>