### PR TITLE
v3(services): revert synchronous broker name updates

### DIFF
--- a/spec/unit/actions/v3/service_broker_update_spec.rb
+++ b/spec/unit/actions/v3/service_broker_update_spec.rb
@@ -30,8 +30,8 @@ module VCAP
         context 'name' do
           let(:request) { { name: 'new-name' } }
 
-          it 'is false' do
-            expect(action.update_broker_needed?).to be_falsey
+          it 'is true' do
+            expect(action.update_broker_needed?).to be_truthy
           end
         end
 
@@ -79,7 +79,6 @@ module VCAP
       describe '#update_sync' do
         let(:request) do
           {
-            name: 'new-name',
             metadata: {
               labels: { potato: 'yam' },
               annotations: { style: 'mashed' }
@@ -91,8 +90,7 @@ module VCAP
           action.update_sync
         end
 
-        it 'updates name and metadata' do
-          expect(existing_service_broker.name).to eq('new-name')
+        it 'updates metadata' do
           expect(existing_service_broker).to have_labels({ key: 'potato', value: 'yam' })
           expect(existing_service_broker).to have_annotations({ key: 'style', value: 'mashed' })
         end


### PR DESCRIPTION
- the CF CLI always expects a job from a service broker rename
- we therefore should always return a job, rather than HTTP 200
- it's ok to return HTTP 200 without a job for metadata updates
as the CF CLI (cf set-label) will handle this

[#169090128](https://www.pivotaltracker.com/story/show/169090128)