### PR TITLE
v3(services): update broker name not sync catalog

### DIFF
--- a/app/jobs/v3/services/update_broker_job.rb
+++ b/app/jobs/v3/services/update_broker_job.rb
@@ -55,7 +55,7 @@ module VCAP::CloudController
           ServiceBroker.db.transaction do
             broker.update(update_params)
 
-            @warnings = @catalog_updater.refresh
+            @warnings = @catalog_updater.refresh unless only_name_change?(update_params)
 
             MetadataUpdate.update(broker, ServiceBrokerUpdateMetadataMessage.new(build_metadata_request_params))
             broker.update(state: ServiceBrokerStateEnum::AVAILABLE)
@@ -91,6 +91,10 @@ module VCAP::CloudController
           end
 
           params
+        end
+
+        def only_name_change?(params)
+          params.keys == [:name]
         end
 
         def build_metadata_request_params

--- a/docs/v3/source/includes/resources/service_brokers/_update.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_update.md.erb
@@ -47,15 +47,21 @@ Content-Type: application/json
 <%= yield_content :single_service_broker %>
 ```
 
-This endpoint updates a service broker. If the parameters include
-`url` or `authentication`, then the endpoint will enqueue a background job to
-synchronize the service offerings and service plans with those in the broker's catalog.
-For updates that consist of only `name` or `metadata`, the update is
-processed immediately, and the service broker's catalog is not synchronized.
+This endpoint updates a service broker. Depending on the parameters specified,
+the endpoint may respond with a background job, and it may synchronize the
+service offerings and service plans with those in the broker's catalog.
 
 When a service broker has a synchronization job in progress, only
-updates with `name` and `metadata` are permitted until the synchronization job
+updates with `metadata` are permitted until the synchronization job
 is complete.
+
+Parameter | Updates Catalog | Responds with job
+--------- | --------------- | -----------------
+**name** | No | Yes
+**url** | Yes | Yes
+**authentication** | Yes | Yes
+**metadata.labels** | No | No
+**metadata.annotations** | No | No
 
 #### Definition
 `PATCH /v3/service_brokers/:guid`


### PR DESCRIPTION
To match V2 behavior, updating a service broker name and nothing else
should not trigger broker catalog synchronization

[#169090128](https://www.pivotaltracker.com/story/show/169090128)
