### PR TITLE
services: do not expose broker URL in binding errors

### DIFF
--- a/lib/services/service_brokers/v2/errors/http_client_timeout.rb
+++ b/lib/services/service_brokers/v2/errors/http_client_timeout.rb
@@ -7,7 +7,7 @@ module VCAP::Services
         class HttpClientTimeout < HttpRequestError
           def initialize(uri, method, source)
             super(
-              "The request to the service broker timed out: #{uri}",
+              'The request to the service broker timed out',
               uri,
               method,
               source

--- a/lib/services/service_brokers/v2/errors/service_broker_api_timeout.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_api_timeout.rb
@@ -7,7 +7,7 @@ module VCAP::Services
         class ServiceBrokerApiTimeout < HttpRequestError
           def initialize(uri, method, source)
             super(
-              "The request to the service broker timed out: #{uri}",
+              'The request to the service broker timed out',
               uri,
               method,
               source

--- a/lib/services/service_brokers/v2/errors/service_broker_api_unreachable.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_api_unreachable.rb
@@ -7,7 +7,7 @@ module VCAP::Services
         class ServiceBrokerApiUnreachable < HttpRequestError
           def initialize(uri, method, source)
             super(
-              "The service broker could not be reached: #{uri}",
+              'The service broker could not be reached',
               uri,
               method,
               source

--- a/lib/services/service_brokers/v2/errors/service_broker_conflict.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_conflict.rb
@@ -12,7 +12,7 @@ module VCAP::Services
             end
 
             super(
-              error_message || "Resource conflict: #{uri}",
+              error_message || 'Resource conflict',
               method,
               response
             )

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -3391,8 +3391,7 @@ module VCAP::CloudController
 
               response_description = [
                 "Service instance #{service_instance.name}:",
-                ' The request to the service broker timed out:',
-                " #{service.service_broker.broker_url}/v2/service_instances/#{service_instance.guid}"
+                ' The request to the service broker timed out'
               ].join
               expect(decoded_response['description']).to eq(response_description)
             end

--- a/spec/unit/lib/services/service_brokers/v2/errors/service_broker_api_timeout_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/service_broker_api_timeout_spec.rb
@@ -11,7 +11,7 @@ module VCAP::Services
 
           it 'initializes the base class correctly' do
             exception = ServiceBrokerApiTimeout.new(uri, method, error)
-            expect(exception.message).to eq("The request to the service broker timed out: #{uri}")
+            expect(exception.message).to eq('The request to the service broker timed out')
             expect(exception.uri).to eq(uri)
             expect(exception.method).to eq(method)
             expect(exception.source).to be(error)

--- a/spec/unit/lib/services/service_brokers/v2/errors/service_broker_api_unreachable_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/service_broker_api_unreachable_spec.rb
@@ -17,7 +17,7 @@ module VCAP::Services
             exception.set_backtrace(['/generatedexception:3', '/backtrace:4'])
 
             expect(exception.to_h).to eq({
-              'description' => "The service broker could not be reached: #{uri}",
+              'description' => 'The service broker could not be reached',
               'backtrace' => ['/generatedexception:3', '/backtrace:4'],
               'http' => {
                 'uri' => uri,

--- a/spec/unit/lib/services/service_brokers/v2/errors/service_broker_conflict_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/errors/service_broker_conflict_spec.rb
@@ -30,7 +30,7 @@ module VCAP::Services
 
             it 'initializes the base class correctly' do
               exception = ServiceBrokerConflict.new(uri, method, response)
-              expect(exception.message).to eq("Resource conflict: #{uri}")
+              expect(exception.message).to eq('Resource conflict')
               expect(exception.method).to eq(method)
               expect(exception.source).to eq(MultiJson.load(response.body))
             end
@@ -41,7 +41,7 @@ module VCAP::Services
 
             it 'initializes the base class correctly' do
               exception = ServiceBrokerConflict.new(uri, method, response)
-              expect(exception.message).to eq("Resource conflict: #{uri}")
+              expect(exception.message).to eq('Resource conflict')
               expect(exception.method).to eq(method)
               expect(exception.source).to eq(response.body)
             end

--- a/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
@@ -491,7 +491,7 @@ module VCAP::Services
         end
 
         def self.broker_timeout_error(uri)
-          "The request to the service broker timed out: #{uri}"
+          'The request to the service broker timed out'
         end
 
         def self.with_valid_volume_mounts


### PR DESCRIPTION
The URL of brokers can sometime leak to users in an error message.
This has been fixed for four error classes.

[#176053272](https://www.pivotaltracker.com/story/show/176053272)