### PR TITLE
Modified kpack lifecycle run commands.

### DIFF
--- a/lib/cloud_controller/opi/apps_client.rb
+++ b/lib/cloud_controller/opi/apps_client.rb
@@ -113,7 +113,7 @@ module OPI
 
       def to_hash
         command = if @process.started_command.presence
-                    ['/bin/sh', '-c', "#{CNB_LAUNCHER_PATH} #{@process.started_command}"]
+                    [CNB_LAUNCHER_PATH.to_s, @process.started_command.to_s]
                   else
                     []
                   end

--- a/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/apps_client_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe(OPI::Client) do
               expected_body_with_lifecycle = expected_body.merge(lifecycle: {
                 docker_lifecycle: {
                   image: 'http://example.org/image1234',
-                  command: ['/bin/sh', '-c', '/cnb/lifecycle/launcher ls -la']
+                  command: ['/cnb/lifecycle/launcher', 'ls -la']
                 }
               })
               actual_body == expected_body_with_lifecycle
@@ -435,7 +435,7 @@ RSpec.describe(OPI::Client) do
               expected_body_with_lifecycle = expected_body.merge(lifecycle: {
                 docker_lifecycle: {
                   image: 'http://example.org/image1234',
-                  command: ['/bin/sh', '-c', '/cnb/lifecycle/launcher $HOME/boot.sh']
+                  command: ['/cnb/lifecycle/launcher', '$HOME/boot.sh']
                 }
               })
               actual_body == expected_body_with_lifecycle


### PR DESCRIPTION
- Command string wasn't inheriting all of environ
- Caused applications to ignore some arguments.

[cf-for-k8s issue #603](https://github.com/cloudfoundry/cf-for-k8s/issues/603)

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This modifies the Kpack lifecycle start command. The command has been a flagged string instead of a direct execution. This causes some of the environ not to be inherited. Specifically, this manifested in cf-for-k8s user reports that `spring.profiles.active` was not being respected on cnb Java applications. https://github.com/cloudfoundry/cf-for-k8s/issues/603

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`
