### PR TITLE
v3(services): service broker client can take user_guid

### DIFF
--- a/app/actions/service_binding_delete.rb
+++ b/app/actions/service_binding_delete.rb
@@ -72,7 +72,7 @@ module VCAP::CloudController
 
     def remove_from_broker(service_binding)
       client = VCAP::Services::ServiceClientProvider.provide(instance: service_binding.service_instance)
-      client.unbind(service_binding, @user_audit_info.user_guid, @accepts_incomplete)
+      client.unbind(service_binding, user_guid: @user_audit_info.user_guid, accepts_incomplete: @accepts_incomplete)
     rescue => e
       logger.error("Failed unbinding #{service_binding.guid}: #{e.message}")
       raise_wrapped_error(service_binding, e)

--- a/app/actions/services/database_error_service_resource_cleanup.rb
+++ b/app/actions/services/database_error_service_resource_cleanup.rb
@@ -24,7 +24,7 @@ module VCAP::CloudController
     def attempt_unbind(service_binding)
       @logger.info "Attempting synchronous orphan mitigation for service binding #{service_binding.guid}"
       service_instance = service_binding.service_instance
-      client(service_instance).unbind(service_binding, nil, true)
+      client(service_instance).unbind(service_binding, accepts_incomplete: true)
       @logger.info "Success unbinding orphaned service binding #{service_binding.guid}"
     rescue => e
       @logger.error "Unable to delete orphaned service binding #{service_binding.guid}: #{e}"

--- a/app/actions/v3/service_binding_delete.rb
+++ b/app/actions/v3/service_binding_delete.rb
@@ -70,7 +70,7 @@ module VCAP::CloudController
 
       def send_unbind_to_client(binding)
         client = VCAP::Services::ServiceClientProvider.provide(instance: binding.service_instance)
-        details = client.unbind(binding, nil, true)
+        details = client.unbind(binding, accepts_incomplete: true)
         details[:async] ? DeleteStarted.call(details[:operation]) : DeleteComplete
       rescue VCAP::Services::ServiceBrokers::V2::Errors::ConcurrencyError
         broker_concurrency_error!

--- a/app/jobs/v2/services/delete_orphaned_binding.rb
+++ b/app/jobs/v2/services/delete_orphaned_binding.rb
@@ -36,7 +36,7 @@ module VCAP::CloudController
                           " Instance guid: #{binding_info.service_instance_guid}, Binding guid #{binding_info.guid}")
 
           client = VCAP::Services::ServiceBrokers::V2::Client.new(client_attrs)
-          client.unbind(binding_info.to_binding, nil, true)
+          client.unbind(binding_info.to_binding, accepts_incomplete: true)
         end
 
         def job_name_in_configuration

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -1,17 +1,17 @@
 module VCAP::Services::ServiceBrokers::V2
   class Client
     CATALOG_PATH = '/v2/catalog'.freeze
-    PLATFORM     = 'cloudfoundry'.freeze
+    PLATFORM = 'cloudfoundry'.freeze
 
     attr_reader :orphan_mitigator, :attrs
 
     def initialize(attrs)
       http_client_attrs = attrs.slice(:url, :auth_username, :auth_password)
-      @http_client      = VCAP::Services::ServiceBrokers::V2::HttpClient.new(http_client_attrs)
-      @response_parser  = VCAP::Services::ServiceBrokers::V2::ResponseParser.new(@http_client.url)
-      @attrs            = attrs
+      @http_client = VCAP::Services::ServiceBrokers::V2::HttpClient.new(http_client_attrs)
+      @response_parser = VCAP::Services::ServiceBrokers::V2::ResponseParser.new(@http_client.url)
+      @attrs = attrs
       @orphan_mitigator = VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new
-      @config           = VCAP::CloudController::Config.config
+      @config = VCAP::CloudController::Config.config
     end
 
     def catalog
@@ -23,11 +23,11 @@ module VCAP::Services::ServiceBrokers::V2
       path = service_instance_resource_path(instance, accepts_incomplete: accepts_incomplete)
 
       body = {
-        service_id:        instance.service.broker_provided_id,
-        plan_id:           instance.service_plan.broker_provided_id,
+        service_id: instance.service.broker_provided_id,
+        plan_id: instance.service_plan.broker_provided_id,
         organization_guid: instance.organization.guid,
-        space_guid:        instance.space.guid,
-        context:           context_hash_with_instance_name(instance)
+        space_guid: instance.space.guid,
+        context: context_hash_with_instance_name(instance)
       }
 
       body[:parameters] = arbitrary_parameters if arbitrary_parameters.present?
@@ -40,21 +40,21 @@ module VCAP::Services::ServiceBrokers::V2
         raise e
       end
 
-      parsed_response     = @response_parser.parse_provision(path, response)
+      parsed_response = @response_parser.parse_provision(path, response)
       last_operation_hash = parsed_response['last_operation'] || {}
-      return_values       = {
-        instance:       {
-          credentials:   {},
+      return_values = {
+        instance: {
+          credentials: {},
           dashboard_url: parsed_response['dashboard_url']
         },
         last_operation: {
-          type:                      'create',
-          description:               last_operation_hash['description'] || '',
+          type: 'create',
+          description: last_operation_hash['description'] || '',
           broker_provided_operation: async_response?(response) ? parsed_response['operation'] : nil
         }
       }
 
-      state                                  = last_operation_hash['state']
+      state = last_operation_hash['state']
       return_values[:last_operation][:state] = state || 'succeeded'
 
       return_values
@@ -67,12 +67,12 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     def create_service_key(key, arbitrary_parameters: {})
-      path              = service_binding_resource_path(key.guid, key.service_instance.guid)
-      body              = {
-        service_id:    key.service.broker_provided_id,
-        plan_id:       key.service_plan.broker_provided_id,
+      path = service_binding_resource_path(key.guid, key.service_instance.guid)
+      body = {
+        service_id: key.service.broker_provided_id,
+        plan_id: key.service_plan.broker_provided_id,
         bind_resource: {},
-        context:       context_hash(key.service_instance),
+        context: context_hash(key.service_instance),
       }
 
       body[:bind_resource][:credential_client_id] = @config.get(:cc_service_key_client_name) if @config.get(:cc_service_key_client_name).present?
@@ -97,11 +97,11 @@ module VCAP::Services::ServiceBrokers::V2
     def bind(binding, arbitrary_parameters: {}, accepts_incomplete: false)
       path = service_binding_resource_path(binding.guid, binding.service_instance.guid, accepts_incomplete: accepts_incomplete)
       body = {
-        service_id:    binding.service.broker_provided_id,
-        plan_id:       binding.service_plan.broker_provided_id,
-        app_guid:      binding.try(:app_guid),
+        service_id: binding.service.broker_provided_id,
+        plan_id: binding.service_plan.broker_provided_id,
+        app_guid: binding.try(:app_guid),
         bind_resource: binding_required_parameters(binding),
-        context:       context_hash(binding.service_instance)
+        context: context_hash(binding.service_instance)
       }
       body = body.compact
       body[:parameters] = arbitrary_parameters if arbitrary_parameters.present?
@@ -152,7 +152,7 @@ module VCAP::Services::ServiceBrokers::V2
 
       body = {
         service_id: service_binding.service.broker_provided_id,
-        plan_id:    service_binding.service_plan.broker_provided_id,
+        plan_id: service_binding.service_plan.broker_provided_id,
       }
       body[:accepts_incomplete] = true if accepts_incomplete
       response = @http_client.delete(path, body, user_guid)
@@ -175,25 +175,25 @@ module VCAP::Services::ServiceBrokers::V2
       path = service_instance_resource_path(instance, accepts_incomplete: accepts_incomplete)
 
       body = {
-        service_id:      instance.service.broker_provided_id,
-        plan_id:         plan.broker_provided_id,
+        service_id: instance.service.broker_provided_id,
+        plan_id: plan.broker_provided_id,
         previous_values: previous_values,
-        context:         context_hash_with_instance_name(instance, name: name)
+        context: context_hash_with_instance_name(instance, name: name)
       }
-      body[:parameters]       = arbitrary_parameters if arbitrary_parameters
+      body[:parameters] = arbitrary_parameters if arbitrary_parameters
       body[:maintenance_info] = maintenance_info if maintenance_info
-      response                = @http_client.patch(path, body)
+      response = @http_client.patch(path, body)
 
-      parsed_response     = @response_parser.parse_update(path, response)
+      parsed_response = @response_parser.parse_update(path, response)
       last_operation_hash = parsed_response['last_operation'] || {}
-      state               = last_operation_hash['state'] || 'succeeded'
-      dashboard_url       = parsed_response['dashboard_url']
+      state = last_operation_hash['state'] || 'succeeded'
+      dashboard_url = parsed_response['dashboard_url']
 
       attributes = {
         last_operation: {
-          type:                      'update',
-          state:                     state,
-          description:               last_operation_hash['description'] || '',
+          type: 'update',
+          state: state,
+          description: last_operation_hash['description'] || '',
           broker_provided_operation: async_response?(response) ? parsed_response['operation'] : nil
         },
       }
@@ -217,8 +217,8 @@ module VCAP::Services::ServiceBrokers::V2
 
       attributes = {
         last_operation: {
-          state:       'failed',
-          type:        'update',
+          state: 'failed',
+          type: 'update',
           description: e.message
         }
       }
@@ -230,22 +230,22 @@ module VCAP::Services::ServiceBrokers::V2
 
       body = {
         service_id: instance.service.broker_provided_id,
-        plan_id:    instance.service_plan.broker_provided_id,
+        plan_id: instance.service_plan.broker_provided_id,
       }
       body[:accepts_incomplete] = true if accepts_incomplete
-      response                  = @http_client.delete(path, body)
+      response = @http_client.delete(path, body)
 
-      parsed_response     = @response_parser.parse_deprovision(path, response) || {}
+      parsed_response = @response_parser.parse_deprovision(path, response) || {}
       last_operation_hash = parsed_response['last_operation'] || {}
-      state               = last_operation_hash['state']
+      state = last_operation_hash['state']
 
       {
         last_operation: {
-                          type:                      'delete',
-                          description:               last_operation_hash['description'] || '',
-                          state:                     state || 'succeeded',
-                          broker_provided_operation: async_response?(response) ? parsed_response['operation'] : nil
-                        }.compact
+          type: 'delete',
+          description: last_operation_hash['description'] || '',
+          state: state || 'succeeded',
+          broker_provided_operation: async_response?(response) ? parsed_response['operation'] : nil
+        }.compact
       }
     rescue VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerConflict => e
       raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceDeprovisionFailed', e.message)
@@ -256,9 +256,9 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     def fetch_service_instance_last_operation(instance)
-      path                = service_instance_last_operation_path(instance)
-      response            = @http_client.get(path)
-      parsed_response     = @response_parser.parse_fetch_state(path, response)
+      path = service_instance_last_operation_path(instance)
+      response = @http_client.get(path)
+      parsed_response = @response_parser.parse_fetch_state(path, response)
       last_operation_hash = parsed_response.delete('last_operation') || {}
 
       result = {
@@ -333,11 +333,11 @@ module VCAP::Services::ServiceBrokers::V2
 
     def context_hash(service_instance)
       {
-        platform:          PLATFORM,
+        platform: PLATFORM,
         organization_guid: service_instance.organization.guid,
-        space_guid:        service_instance.space.guid,
+        space_guid: service_instance.space.guid,
         organization_name: service_instance.organization.name,
-        space_name:        service_instance.space.name
+        space_name: service_instance.space.name
       }
     end
 
@@ -357,9 +357,9 @@ module VCAP::Services::ServiceBrokers::V2
 
     def service_instance_last_operation_path(instance)
       query_params = {}.tap do |q|
-        q['plan_id']    = instance.service_plan.broker_provided_id
+        q['plan_id'] = instance.service_plan.broker_provided_id
         q['service_id'] = instance.service.broker_provided_id
-        q['operation']  = instance.last_operation.broker_provided_operation if instance.last_operation.broker_provided_operation
+        q['operation'] = instance.last_operation.broker_provided_operation if instance.last_operation.broker_provided_operation
       end
 
       "#{service_instance_resource_path(instance)}/last_operation?#{query_params.to_query}"
@@ -375,8 +375,8 @@ module VCAP::Services::ServiceBrokers::V2
 
     def service_binding_last_operation_path(service_binding)
       query_params = {
-       'service_id' => service_binding.service_instance.service.broker_provided_id,
-       'plan_id' => service_binding.service_instance.service_plan.broker_provided_id
+        'service_id' => service_binding.service_instance.service.broker_provided_id,
+        'plan_id' => service_binding.service_instance.service_plan.broker_provided_id
       }
 
       if service_binding.last_operation.broker_provided_operation

--- a/lib/services/service_brokers/v2/http_client.rb
+++ b/lib/services/service_brokers/v2/http_client.rb
@@ -19,19 +19,19 @@ module VCAP::Services
         @logger = logger || Steno.logger('cc.service_broker.v2.http_client')
       end
 
-      def get(path)
-        make_request(:get, uri_for(path))
+      def get(path, user_guid: nil)
+        make_request(:get, uri_for(path), nil, user_guid: user_guid)
       end
 
-      def put(path, message)
-        make_request(:put, uri_for(path), message.to_json, content_type: 'application/json')
+      def put(path, message, user_guid: nil)
+        make_request(:put, uri_for(path), message.to_json, content_type: 'application/json', user_guid: user_guid)
       end
 
-      def patch(path, message)
-        make_request(:patch, uri_for(path), message.to_json, content_type: 'application/json')
+      def patch(path, message, user_guid: nil)
+        make_request(:patch, uri_for(path), message.to_json, content_type: 'application/json', user_guid: user_guid)
       end
 
-      def delete(path, message, user_guid=nil)
+      def delete(path, message, user_guid: nil)
         uri = uri_for(path)
         uri.query = message.to_query
 

--- a/spec/support/shared_examples/v3_service_binding_delete.rb
+++ b/spec/support/shared_examples/v3_service_binding_delete.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples 'service binding deletion' do |binding_model|
     it 'makes the right call to the broker client' do
       action.delete(binding)
 
-      expect(broker_client).to have_received(:unbind).with(binding, nil, true)
+      expect(broker_client).to have_received(:unbind).with(binding, { accepts_incomplete: true })
     end
 
     context 'unbind fails with generic error' do

--- a/spec/unit/actions/app_delete_spec.rb
+++ b/spec/unit/actions/app_delete_spec.rb
@@ -276,7 +276,7 @@ module VCAP::CloudController
               let!(:binding1) { ServiceBinding.make(app: app, service_instance: ManagedServiceInstance.make(space: app.space)) }
 
               it 'should always call the broker with accepts_incomplete true' do
-                expect(client).to receive(:unbind).with(binding1, user_audit_info.user_guid, true)
+                expect(client).to receive(:unbind).with(binding1, user_guid: user_audit_info.user_guid, accepts_incomplete: true)
 
                 expect { app_delete.delete(app_dataset) }.to raise_error(AppDelete::SubResourceError)
               end

--- a/spec/unit/actions/service_binding_delete_spec.rb
+++ b/spec/unit/actions/service_binding_delete_spec.rb
@@ -39,7 +39,7 @@ module VCAP::CloudController
       end
 
       it 'asks the broker to unbind the instance' do
-        expect(client).to receive(:unbind).with(service_binding, user_guid, false)
+        expect(client).to receive(:unbind).with(service_binding, user_guid: user_guid, accepts_incomplete: false)
         service_binding_delete.foreground_delete_request(service_binding)
       end
 
@@ -131,7 +131,7 @@ module VCAP::CloudController
         let(:accepts_incomplete) { true }
 
         it 'asks the broker to unbind the instance async' do
-          expect(client).to receive(:unbind).with(service_binding, user_guid, true)
+          expect(client).to receive(:unbind).with(service_binding, user_guid: user_guid, accepts_incomplete: true)
           service_binding_delete.delete(service_binding)
         end
 
@@ -219,7 +219,7 @@ module VCAP::CloudController
         let(:accepts_incomplete) { false }
 
         it 'asks the broker to unbind the instance sync' do
-          expect(client).to receive(:unbind).with(service_binding, user_guid, false)
+          expect(client).to receive(:unbind).with(service_binding, user_guid: user_guid, accepts_incomplete: false)
           service_binding_delete.delete(service_binding)
         end
 
@@ -270,7 +270,7 @@ module VCAP::CloudController
         let(:service_binding_delete) { ServiceBindingDelete.new(UserAuditInfo.new(user_guid: user_guid, user_email: user_email)) }
 
         it 'defaults to false and asks the broker to unbind the instance sync' do
-          expect(client).to receive(:unbind).with(service_binding, user_guid, false)
+          expect(client).to receive(:unbind).with(service_binding, user_guid: user_guid, accepts_incomplete: false)
           service_binding_delete.delete(service_binding)
         end
       end

--- a/spec/unit/actions/services/database_error_service_resource_cleanup_spec.rb
+++ b/spec/unit/actions/services/database_error_service_resource_cleanup_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'DatabaseErrorServiceResourceCleanup' do
     it 'attempts to unbind the binding' do
       subject.attempt_unbind(service_binding)
 
-      expect(client).to have_received(:unbind).with(service_binding, nil, true)
+      expect(client).to have_received(:unbind).with(service_binding, { accepts_incomplete: true })
     end
 
     it 'logs that it is attempting to orphan mitigate' do

--- a/spec/unit/jobs/services/delete_orphaned_binding_spec.rb
+++ b/spec/unit/jobs/services/delete_orphaned_binding_spec.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
 
       describe '#perform' do
         before do
-          allow(client).to receive(:unbind).with(binding_info.to_binding, nil, true)
+          allow(client).to receive(:unbind).with(binding_info.to_binding, accepts_incomplete: true)
           allow(VCAP::Services::ServiceBrokers::V2::Client).to receive(:new).and_return(client)
         end
 

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -6,7 +6,7 @@ module VCAP::Services::ServiceBrokers::V2
 
     let(:client_attrs) {
       {
-        url:           service_broker.broker_url,
+        url: service_broker.broker_url,
         auth_username: service_broker.auth_username,
         auth_password: service_broker.auth_password,
       }
@@ -48,13 +48,13 @@ module VCAP::Services::ServiceBrokers::V2
         {
           'services' => [
             {
-              'id'          => service_id,
-              'name'        => service_name,
+              'id' => service_id,
+              'name' => service_name,
               'description' => service_description,
-              'plans'       => [
+              'plans' => [
                 {
-                  'id'          => plan_id,
-                  'name'        => plan_name,
+                  'id' => plan_id,
+                  'name' => plan_name,
                   'description' => plan_description
                 }
               ]
@@ -85,8 +85,8 @@ module VCAP::Services::ServiceBrokers::V2
       let(:instance) do
         VCAP::CloudController::ManagedServiceInstance.make(
           service_plan: plan,
-          space:        space,
-          name:     'instance-007'
+          space: space,
+          name: 'instance-007'
         )
       end
 
@@ -134,17 +134,17 @@ module VCAP::Services::ServiceBrokers::V2
 
         expect(http_client).to have_received(:put).with(
           anything,
-          service_id:        instance.service.broker_provided_id,
-          plan_id:           instance.service_plan.broker_provided_id,
+          service_id: instance.service.broker_provided_id,
+          plan_id: instance.service_plan.broker_provided_id,
           organization_guid: instance.organization.guid,
-          space_guid:        instance.space.guid,
-          context:           {
-            platform:          'cloudfoundry',
+          space_guid: instance.space.guid,
+          context: {
+            platform: 'cloudfoundry',
             organization_guid: instance.organization.guid,
-            space_guid:        instance.space_guid,
-            instance_name:     instance.name,
+            space_guid: instance.space_guid,
+            instance_name: instance.name,
             organization_name: instance.organization.name,
-            space_name:        instance.space.name
+            space_name: instance.space.name
           }
         )
       end
@@ -217,7 +217,7 @@ module VCAP::Services::ServiceBrokers::V2
           let(:message) { 'Accepted' }
 
           it 'return immediately with the operation from the broker response' do
-            client        = Client.new(client_attrs)
+            client = Client.new(client_attrs)
             attributes, _ = client.provision(instance, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to eq('a_broker_operation_identifier')
@@ -227,7 +227,7 @@ module VCAP::Services::ServiceBrokers::V2
         context 'and the response is 200' do
           let(:code) { 200 }
           it 'ignores the operation' do
-            client        = Client.new(client_attrs)
+            client = Client.new(client_attrs)
             attributes, _ = client.provision(instance, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to be_nil
@@ -243,7 +243,7 @@ module VCAP::Services::ServiceBrokers::V2
         end
 
         it 'return immediately with the broker response' do
-          client        = Client.new(client_attrs)
+          client = Client.new(client_attrs)
           attributes, _ = client.provision(instance, accepts_incomplete: true)
 
           expect(attributes[:instance][:broker_provided_operation]).to be_nil
@@ -366,13 +366,13 @@ module VCAP::Services::ServiceBrokers::V2
       let(:instance) do
         VCAP::CloudController::ManagedServiceInstance.make(
           service_plan: plan,
-          space:        space
+          space: space
         )
       end
 
       let(:response_data) do
         {
-          'state'       => 'succeeded',
+          'state' => 'succeeded',
           'description' => '100% created'
         }
       end
@@ -416,7 +416,7 @@ module VCAP::Services::ServiceBrokers::V2
       end
 
       it 'returns the attributes to update the service instance model' do
-        attrs          = client.fetch_service_instance_last_operation(instance)
+        attrs = client.fetch_service_instance_last_operation(instance)
         expected_attrs = { last_operation: response_data.symbolize_keys }
         expect(attrs).to eq(expected_attrs)
       end
@@ -424,9 +424,9 @@ module VCAP::Services::ServiceBrokers::V2
       context 'when the broker provides other fields' do
         let(:response_data) do
           {
-            'state'       => 'succeeded',
+            'state' => 'succeeded',
             'description' => '100% created',
-            'foo'         => 'bar'
+            'foo' => 'bar'
           }
         end
 
@@ -536,7 +536,7 @@ module VCAP::Services::ServiceBrokers::V2
         let(:response) { HttpResponse.new(code: code, message: message, body: response_body, headers: { 'Retry-After' => 10 }) }
 
         it 'returns the retry after header in the result' do
-          attrs          = client.fetch_service_instance_last_operation(instance)
+          attrs = client.fetch_service_instance_last_operation(instance)
           expected_attrs = { retry_after: 10, last_operation: response_data.symbolize_keys }
           expect(attrs).to eq(expected_attrs)
         end
@@ -550,7 +550,7 @@ module VCAP::Services::ServiceBrokers::V2
       let(:space) { VCAP::CloudController::Space.make }
       let(:last_operation) do
         VCAP::CloudController::ServiceInstanceOperation.make(
-          type:  'create',
+          type: 'create',
           state: 'succeeded'
         )
       end
@@ -558,8 +558,8 @@ module VCAP::Services::ServiceBrokers::V2
       let(:instance) do
         VCAP::CloudController::ManagedServiceInstance.make(
           service_plan: old_plan,
-          space:        space,
-          name:         'instance-007'
+          space: space,
+          name: 'instance-007'
         )
       end
 
@@ -593,12 +593,12 @@ module VCAP::Services::ServiceBrokers::V2
         expect(http_client).to have_received(:patch).with(anything,
           hash_including({
             context: {
-              platform:          'cloudfoundry',
+              platform: 'cloudfoundry',
               organization_guid: instance.organization.guid,
-              space_guid:        instance.space_guid,
-              instance_name:     'fake_name',
+              space_guid: instance.space_guid,
+              instance_name: 'fake_name',
               organization_name: instance.organization.name,
-              space_name:        instance.space.name
+              space_name: instance.space.name
             }
           })
         )
@@ -610,12 +610,12 @@ module VCAP::Services::ServiceBrokers::V2
         expect(http_client).to have_received(:patch).with(anything,
           hash_including({
             context: {
-              platform:          'cloudfoundry',
+              platform: 'cloudfoundry',
               organization_guid: instance.organization.guid,
-              space_guid:        instance.space_guid,
-              instance_name:     instance.name,
+              space_guid: instance.space_guid,
+              instance_name: instance.name,
               organization_name: instance.organization.name,
-              space_name:        instance.space.name
+              space_name: instance.space.name
             }
           })
         )
@@ -633,7 +633,7 @@ module VCAP::Services::ServiceBrokers::V2
           expect(http_client).to have_received(:patch).with(
             anything,
             hash_including({
-              plan_id:         new_plan.broker_provided_id,
+              plan_id: new_plan.broker_provided_id,
               previous_values: {
                 plan_id: '1234'
               }
@@ -649,7 +649,7 @@ module VCAP::Services::ServiceBrokers::V2
           expect(http_client).to have_received(:patch).with(
             anything,
             hash_including({
-              parameters:      { myParam: 'some-value' },
+              parameters: { myParam: 'some-value' },
               previous_values: {}
             })
           )
@@ -679,7 +679,7 @@ module VCAP::Services::ServiceBrokers::V2
           end
 
           it 'returns maintenance_info as a proposed changed' do
-            client           = Client.new(client_attrs.merge(accepts_incomplete: true))
+            client = Client.new(client_attrs.merge(accepts_incomplete: true))
             attributes, _, _ = client.update(instance, old_plan, maintenance_info: maintenance_info, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:proposed_changes]).to eq({ service_plan_guid: old_plan.guid, maintenance_info: maintenance_info })
@@ -721,7 +721,7 @@ module VCAP::Services::ServiceBrokers::V2
           end
 
           it 'return immediately with the broker response' do
-            client               = Client.new(client_attrs.merge(accepts_incomplete: true))
+            client = Client.new(client_attrs.merge(accepts_incomplete: true))
             attributes, _, error = client.update(instance, new_plan, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:type]).to eq('update')
@@ -758,7 +758,7 @@ module VCAP::Services::ServiceBrokers::V2
           let(:message) { 'Accepted' }
 
           it 'return immediately with the operation from the broker response' do
-            client        = Client.new(client_attrs)
+            client = Client.new(client_attrs)
             attributes, _ = client.update(instance, new_plan, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to eq('a_broker_operation_identifier')
@@ -768,7 +768,7 @@ module VCAP::Services::ServiceBrokers::V2
         context 'and the response is 200' do
           let(:code) { 200 }
           it 'ignores the operation' do
-            client        = Client.new(client_attrs)
+            client = Client.new(client_attrs)
             attributes, _ = client.update(instance, new_plan, accepts_incomplete: true)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to be_nil
@@ -826,8 +826,8 @@ module VCAP::Services::ServiceBrokers::V2
             expect(err).to eq error
             expect(attrs).to eq({
               last_operation: {
-                state:       'failed',
-                type:        'update',
+                state: 'failed',
+                type: 'update',
                 description: error.message,
               }
             })
@@ -847,8 +847,8 @@ module VCAP::Services::ServiceBrokers::V2
             expect(err).to eq error
             expect(attrs).to eq({
               last_operation: {
-                state:       'failed',
-                type:        'update',
+                state: 'failed',
+                type: 'update',
                 description: error.message,
               }
             })
@@ -868,8 +868,8 @@ module VCAP::Services::ServiceBrokers::V2
             expect(err).to eq error
             expect(attrs).to eq({
               last_operation: {
-                state:       'failed',
-                type:        'update',
+                state: 'failed',
+                type: 'update',
                 description: error.message,
               }
             })
@@ -889,8 +889,8 @@ module VCAP::Services::ServiceBrokers::V2
             expect(err).to eq error
             expect(attrs).to eq({
               last_operation: {
-                state:       'failed',
-                type:        'update',
+                state: 'failed',
+                type: 'update',
                 description: error.message,
               }
             })
@@ -910,8 +910,8 @@ module VCAP::Services::ServiceBrokers::V2
             expect(err).to eq error
             expect(attrs).to eq({
               last_operation: {
-                state:       'failed',
-                type:        'update',
+                state: 'failed',
+                type: 'update',
                 description: error.message,
               }
             })
@@ -924,7 +924,7 @@ module VCAP::Services::ServiceBrokers::V2
       let(:instance) { VCAP::CloudController::ManagedServiceInstance.make }
       let(:key) do
         VCAP::CloudController::ServiceKey.new(
-          name:             'fake-service_key',
+          name: 'fake-service_key',
           service_instance: instance
         )
       end
@@ -961,14 +961,14 @@ module VCAP::Services::ServiceBrokers::V2
 
         expect(http_client).to have_received(:put).
           with(anything,
-            plan_id:    key.service_plan.broker_provided_id,
+            plan_id: key.service_plan.broker_provided_id,
             service_id: key.service.broker_provided_id,
-            context:    {
-              platform:          'cloudfoundry',
+            context: {
+              platform: 'cloudfoundry',
               organization_guid: key.service_instance.organization.guid,
-              space_guid:        key.service_instance.space.guid,
+              space_guid: key.service_instance.space.guid,
               organization_name: key.service_instance.organization.name,
-              space_name:        key.service_instance.space.name
+              space_name: key.service_instance.space.name
             },
             bind_resource: {
               credential_client_id: cc_service_key_client_name,
@@ -1112,8 +1112,8 @@ module VCAP::Services::ServiceBrokers::V2
       let(:binding) do
         VCAP::CloudController::ServiceBinding.new(
           service_instance: instance,
-          app:              app,
-          type:             'app'
+          app: app,
+          type: 'app'
         )
       end
       let(:arbitrary_parameters) { {} }
@@ -1149,16 +1149,16 @@ module VCAP::Services::ServiceBrokers::V2
 
         expect(http_client).to have_received(:put).
           with(anything,
-            plan_id:       binding.service_plan.broker_provided_id,
-            service_id:    binding.service.broker_provided_id,
-            app_guid:      binding.app_guid,
+            plan_id: binding.service_plan.broker_provided_id,
+            service_id: binding.service.broker_provided_id,
+            app_guid: binding.app_guid,
             bind_resource: binding.required_parameters,
-            context:       {
-              platform:          'cloudfoundry',
+            context: {
+              platform: 'cloudfoundry',
               organization_guid: instance.organization.guid,
-              space_guid:        instance.space_guid,
+              space_guid: instance.space_guid,
               organization_name: instance.organization.name,
-              space_name:        instance.space.name
+              space_name: instance.space.name
             }
           )
       end
@@ -1293,7 +1293,7 @@ module VCAP::Services::ServiceBrokers::V2
 
         let(:response_data) do
           {
-            'credentials'      => {},
+            'credentials' => {},
             'syslog_drain_url' => 'syslog://example.com:514'
           }
         end
@@ -1517,7 +1517,7 @@ module VCAP::Services::ServiceBrokers::V2
         expect(http_client).to have_received(:delete).
           with(anything,
             {
-              plan_id:    binding.service_plan.broker_provided_id,
+              plan_id: binding.service_plan.broker_provided_id,
               service_id: binding.service.broker_provided_id,
             },
             nil
@@ -1667,7 +1667,7 @@ module VCAP::Services::ServiceBrokers::V2
           anything,
           {
             service_id: instance.service.broker_provided_id,
-            plan_id:    instance.service_plan.broker_provided_id
+            plan_id: instance.service_plan.broker_provided_id
           }
         )
       end
@@ -1677,8 +1677,8 @@ module VCAP::Services::ServiceBrokers::V2
           attrs, _ = client.deprovision(instance)
           expect(attrs).to eq({
             last_operation: {
-              type:        'delete',
-              state:       'succeeded',
+              type: 'delete',
+              state: 'succeeded',
               description: ''
             }
           })
@@ -1700,8 +1700,8 @@ module VCAP::Services::ServiceBrokers::V2
             attrs, _ = client.deprovision(instance, accepts_incomplete: true)
             expect(attrs).to eq({
               last_operation: {
-                type:        'delete',
-                state:       'in progress',
+                type: 'delete',
+                state: 'in progress',
                 description: ''
               }
             })
@@ -1717,9 +1717,9 @@ module VCAP::Services::ServiceBrokers::V2
 
               expect(attributes).to eq({
                 last_operation: {
-                  type:                      'delete',
-                  state:                     'in progress',
-                  description:               '',
+                  type: 'delete',
+                  state: 'in progress',
+                  description: '',
                   broker_provided_operation: 'a_broker_operation_identifier'
                 }
               })
@@ -1734,8 +1734,8 @@ module VCAP::Services::ServiceBrokers::V2
             attrs, _ = client.deprovision(instance, accepts_incomplete: true)
             expect(attrs).to eq({
               last_operation: {
-                type:        'delete',
-                state:       'succeeded',
+                type: 'delete',
+                state: 'succeeded',
                 description: ''
               }
             })
@@ -1781,7 +1781,7 @@ module VCAP::Services::ServiceBrokers::V2
           let(:message) { 'Accepted' }
 
           it 'return immediately with the operation from the broker response' do
-            client     = Client.new(client_attrs)
+            client = Client.new(client_attrs)
             attributes = client.deprovision(instance)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to eq('a_broker_operation_identifier')
@@ -1791,7 +1791,7 @@ module VCAP::Services::ServiceBrokers::V2
         context 'and the response is 200' do
           let(:code) { 200 }
           it 'ignores the operation' do
-            client     = Client.new(client_attrs)
+            client = Client.new(client_attrs)
             attributes = client.deprovision(instance)
 
             expect(attributes[:last_operation][:broker_provided_operation]).to be_nil
@@ -1806,8 +1806,8 @@ module VCAP::Services::ServiceBrokers::V2
       let(:binding) do
         VCAP::CloudController::ServiceBinding.new(
           service_instance: instance,
-          app:              app,
-          type:             'app'
+          app: app,
+          type: 'app'
         )
       end
 
@@ -1852,7 +1852,7 @@ module VCAP::Services::ServiceBrokers::V2
     describe '#fetch_service_binding_last_operation' do
       let(:response_data) do
         {
-          'state'       => 'in progress',
+          'state' => 'in progress',
           'description' => '10%'
         }
       end
@@ -1950,7 +1950,7 @@ module VCAP::Services::ServiceBrokers::V2
     describe '#fetch_service_binding_create_last_operation' do
       let(:response_data) do
         {
-          'state'       => 'in progress',
+          'state' => 'in progress',
           'description' => '10%'
         }
       end

--- a/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
@@ -182,9 +182,9 @@ module VCAP::Services::ServiceBrokers::V2
           make_request
 
           expect(a_request(http_method, full_url).
-                 with(basic_auth: basic_auth).
-                 with(query: hash_including({})).
-                 with(headers: { 'X-Broker-API-Request-Identity' => /[[:alnum:]-]+/ })).
+            with(basic_auth: basic_auth).
+            with(query: hash_including({})).
+            with(headers: { 'X-Broker-API-Request-Identity' => /[[:alnum:]-]+/ })).
             to have_been_made
         end
       end


### PR DESCRIPTION
The service broker client reads the user_guid from the SecurityContext
when run from a controller. When run in a job, the SecurityContext is
not present. The client API now will now consistently accept an optional
user_guid parameter which will default to previous behaviour when not
specified.

[#176499762](https://www.pivotaltracker.com/story/show/176499762)