### PR TITLE
v3(services): send ID header with create, update broker

### DIFF
--- a/app/actions/service_broker_create.rb
+++ b/app/actions/service_broker_create.rb
@@ -30,7 +30,7 @@ module VCAP::CloudController
 
           service_event_repository.record_broker_event_with_request(:create, broker, message.audit_hash)
 
-          synchronization_job = SynchronizeBrokerCatalogJob.new(broker.guid)
+          synchronization_job = SynchronizeBrokerCatalogJob.new(broker.guid, user_audit_info: service_event_repository.user_audit_info)
           pollable_job = Jobs::Enqueuer.new(synchronization_job, queue: Jobs::Queues.generic).enqueue_pollable
         end
 

--- a/app/actions/v3/service_broker_update.rb
+++ b/app/actions/v3/service_broker_update.rb
@@ -54,7 +54,12 @@ module VCAP::CloudController
 
           service_event_repository.record_broker_event_with_request(:update, broker, message.audit_hash)
 
-          synchronization_job = UpdateBrokerJob.new(update_request.guid, broker.guid, previous_broker_state)
+          synchronization_job = UpdateBrokerJob.new(
+            update_request.guid,
+            broker.guid,
+            previous_broker_state,
+            user_audit_info: service_event_repository.user_audit_info
+          )
           pollable_job = Jobs::Enqueuer.new(synchronization_job, queue: Jobs::Queues.generic).enqueue_pollable
         end
 

--- a/app/controllers/v3/service_brokers_controller.rb
+++ b/app/controllers/v3/service_brokers_controller.rb
@@ -114,7 +114,7 @@ class ServiceBrokersController < ApplicationController
   private
 
   def service_event_repository
-    VCAP::CloudController::Repositories::ServiceEventRepository::WithUserActor.new(user_audit_info)
+    VCAP::CloudController::Repositories::ServiceEventRepository.new(user_audit_info)
   end
 
   def broker_has_instances!(broker_name)

--- a/app/jobs/v3/services/synchronize_broker_catalog_job.rb
+++ b/app/jobs/v3/services/synchronize_broker_catalog_job.rb
@@ -5,12 +5,13 @@ module VCAP::CloudController
     class SynchronizeBrokerCatalogJob < VCAP::CloudController::Jobs::CCJob
       attr_reader :warnings
 
-      def initialize(broker_guid)
+      def initialize(broker_guid, user_audit_info:)
         @broker_guid = broker_guid
+        @user_audit_info = user_audit_info
       end
 
       def perform
-        @warnings = Perform.new(@broker_guid).perform
+        @warnings = Perform.new(broker_guid, user_audit_info: user_audit_info).perform
       end
 
       def job_name_in_configuration
@@ -35,12 +36,12 @@ module VCAP::CloudController
 
       private
 
-      attr_reader :broker_guid
+      attr_reader :broker_guid, :user_audit_info
 
       class Perform
-        def initialize(broker_guid)
+        def initialize(broker_guid, user_audit_info:)
           @broker = ServiceBroker.find(guid: broker_guid)
-          @catalog_updater = VCAP::CloudController::V3::ServiceBrokerCatalogUpdater.new(@broker)
+          @catalog_updater = VCAP::CloudController::V3::ServiceBrokerCatalogUpdater.new(@broker, user_audit_info: user_audit_info)
         end
 
         def perform

--- a/spec/support/fakes/fake_service_broker_v2_client.rb
+++ b/spec/support/fakes/fake_service_broker_v2_client.rb
@@ -11,7 +11,7 @@ class FakeServiceBrokerV2Client
     @parameters = {}
   end
 
-  def catalog
+  def catalog(user_guid: nil)
     {
       'services' => [{
         'id'          => 'service_id',
@@ -94,7 +94,7 @@ class FakeServiceBrokerV2Client
   end
 
   class WithConflictingUAAClient < FakeServiceBrokerV2Client
-    def catalog
+    def catalog(user_guid: nil)
       {
         'services' => [{
           'id'          => 'service_id',

--- a/spec/unit/actions/service_broker_create_spec.rb
+++ b/spec/unit/actions/service_broker_create_spec.rb
@@ -6,9 +6,11 @@ module VCAP
   module CloudController
     RSpec.describe 'ServiceBrokerCreate' do
       let(:dummy) { double('dummy').as_null_object }
+      let(:user_audit_info) { instance_double(UserAuditInfo, { user_guid: Sham.guid }) }
       let(:event_repository) do
         dbl = double(Repositories::ServiceEventRepository::WithUserActor)
         allow(dbl).to receive(:record_broker_event_with_request)
+        allow(dbl).to receive(:user_audit_info).and_return(user_audit_info)
         dbl
       end
 

--- a/spec/unit/actions/v3/service_broker_update_spec.rb
+++ b/spec/unit/actions/v3/service_broker_update_spec.rb
@@ -20,9 +20,11 @@ module VCAP
         )
       end
 
+      let(:user_audit_info) { instance_double(UserAuditInfo, { user_guid: Sham.guid }) }
       let(:event_repository) do
         dbl = double(Repositories::ServiceEventRepository::WithUserActor)
         allow(dbl).to receive(:record_broker_event_with_request)
+        allow(dbl).to receive(:user_audit_info).and_return(user_audit_info)
         dbl
       end
 
@@ -159,7 +161,8 @@ module VCAP
           expect(VCAP::CloudController::V3::UpdateBrokerJob).to have_received(:new).with(
             service_broker_update_request.guid,
             existing_service_broker.guid,
-            previous_state
+            previous_state,
+            user_audit_info: user_audit_info
           ).once
         end
 
@@ -257,7 +260,8 @@ module VCAP
             expect(VCAP::CloudController::V3::UpdateBrokerJob).to have_received(:new).with(
               service_broker_update_request.guid,
               existing_service_broker.guid,
-              ''
+              '',
+              user_audit_info: user_audit_info
             ).once
           end
         end

--- a/spec/unit/jobs/pollable_job_wrapper_spec.rb
+++ b/spec/unit/jobs/pollable_job_wrapper_spec.rb
@@ -120,7 +120,8 @@ module VCAP::CloudController::Jobs
         )
       }
 
-      let(:job) { VCAP::CloudController::V3::SynchronizeBrokerCatalogJob.new(broker.guid) }
+      let(:user_audit_info) { instance_double(VCAP::CloudController::UserAuditInfo, { user_guid: Sham.guid }) }
+      let(:job) { VCAP::CloudController::V3::SynchronizeBrokerCatalogJob.new(broker.guid, user_audit_info: user_audit_info) }
 
       before do
         allow_any_instance_of(VCAP::CloudController::V3::SynchronizeBrokerCatalogJob).

--- a/spec/unit/jobs/v3/services/synchronize_broker_catalog_job_spec.rb
+++ b/spec/unit/jobs/v3/services/synchronize_broker_catalog_job_spec.rb
@@ -18,9 +18,10 @@ module VCAP
             )
           end
           let(:service_manager_factory) { Services::ServiceBrokers::ServiceManager }
+          let(:user_audit_info) { instance_double(UserAuditInfo, { user_guid: Sham.guid }) }
 
           subject(:job) do
-            SynchronizeBrokerCatalogJob.new(broker.guid)
+            SynchronizeBrokerCatalogJob.new(broker.guid, user_audit_info: user_audit_info)
           end
 
           let(:broker_client) { FakeServiceBrokerV2Client.new }

--- a/spec/unit/jobs/v3/services/update_broker_job_spec.rb
+++ b/spec/unit/jobs/v3/services/update_broker_job_spec.rb
@@ -63,8 +63,10 @@ module VCAP
 
           let(:previous_state) { ServiceBrokerStateEnum::AVAILABLE }
 
+          let(:user_audit_info) { instance_double(UserAuditInfo, { user_guid: Sham.guid }) }
+
           subject(:job) do
-            UpdateBrokerJob.new(update_broker_request.guid, broker.guid, previous_state)
+            UpdateBrokerJob.new(update_broker_request.guid, broker.guid, previous_state, user_audit_info: user_audit_info)
           end
 
           let(:broker_client) { FakeServiceBrokerV2Client.new }
@@ -127,7 +129,7 @@ module VCAP
 
             it 'updates the name without refreshing the catalog' do
               update_broker_request = ServiceBrokerUpdateRequest.create(name: 'new-name', service_broker_id: broker.id)
-              job = UpdateBrokerJob.new(update_broker_request.guid, broker.guid, previous_state)
+              job = UpdateBrokerJob.new(update_broker_request.guid, broker.guid, previous_state, user_audit_info: user_audit_info)
 
               job.perform
 
@@ -145,7 +147,7 @@ module VCAP
                 broker_url: 'http://example.org/new-broker-url',
                 service_broker_id: broker.id
               )
-              job = UpdateBrokerJob.new(update_broker_request.guid, broker.guid, previous_state)
+              job = UpdateBrokerJob.new(update_broker_request.guid, broker.guid, previous_state, user_audit_info: user_audit_info)
 
               job.perform
 
@@ -163,7 +165,7 @@ module VCAP
                 authentication: '{"credentials":{"username":"new-admin","password":"welcome"}}',
                 service_broker_id: broker.id
               )
-              job = UpdateBrokerJob.new(update_broker_request.guid, broker.guid, previous_state)
+              job = UpdateBrokerJob.new(update_broker_request.guid, broker.guid, previous_state, user_audit_info: user_audit_info)
 
               job.perform
 


### PR DESCRIPTION
Sets x-broker-api-originating-identity header when getting broker
catalog from service broker

[#176499762](https://www.pivotaltracker.com/story/show/176499762)