### PR TITLE
v3(services): send ID header with CRUD instance

### DIFF
--- a/app/actions/v3/service_instance_delete.rb
+++ b/app/actions/v3/service_instance_delete.rb
@@ -54,7 +54,10 @@ module VCAP::CloudController
       end
 
       def poll
-        result = client.fetch_service_instance_last_operation(service_instance)
+        result = client.fetch_service_instance_last_operation(
+          service_instance,
+          user_guid: service_event_repository.user_audit_info.user_guid
+        )
         case result[:last_operation][:state]
         when 'in progress'
           update_last_operation_with_description(result[:last_operation][:description])
@@ -98,7 +101,11 @@ module VCAP::CloudController
       end
 
       def send_deprovison_to_broker
-        result = client.deprovision(service_instance, accepts_incomplete: true)
+        result = client.deprovision(
+          service_instance,
+          accepts_incomplete: true,
+          user_guid: service_event_repository.user_audit_info.user_guid
+        )
         return DeleteComplete if result[:last_operation][:state] == 'succeeded'
 
         DeleteStarted.call(result[:last_operation][:broker_provided_operation])

--- a/app/jobs/v3/create_service_instance_job.rb
+++ b/app/jobs/v3/create_service_instance_job.rb
@@ -12,6 +12,7 @@ module VCAP::CloudController
         super(service_instance_guid, user_audit_info)
         @request_attr = request_attr
         @arbitrary_parameters = arbitrary_parameters
+        @user_audit_info = user_audit_info
       end
 
       def operation
@@ -26,10 +27,15 @@ module VCAP::CloudController
         client.provision(
           service_instance,
           accepts_incomplete: true,
-          arbitrary_parameters: @arbitrary_parameters,
-          maintenance_info: service_instance.service_plan.maintenance_info
+          arbitrary_parameters: arbitrary_parameters,
+          maintenance_info: service_instance.service_plan.maintenance_info,
+          user_guid: user_audit_info.user_guid
         )
       end
+
+      private
+
+      attr_reader :arbitrary_parameters, :user_audit_info
     end
   end
 end

--- a/app/jobs/v3/service_instance_async_job.rb
+++ b/app/jobs/v3/service_instance_async_job.rb
@@ -94,7 +94,7 @@ module VCAP::CloudController
 
       private
 
-      attr_reader :service_instance_guid
+      attr_reader :service_instance_guid, :user_audit_info
 
       def execute_request(client)
         broker_response = send_broker_request(client)
@@ -132,7 +132,10 @@ module VCAP::CloudController
       end
 
       def fetch_last_operation(client)
-        last_operation_result = client.fetch_service_instance_last_operation(service_instance)
+        last_operation_result = client.fetch_service_instance_last_operation(
+          service_instance,
+          user_guid: user_audit_info.user_guid
+        )
         self.polling_interval_seconds = last_operation_result[:retry_after].to_i if last_operation_result[:retry_after]
 
         operation_failed!(last_operation_result[:last_operation][:description]) if last_operation_result[:http_status_code] == HTTP::Status::BAD_REQUEST

--- a/app/jobs/v3/update_service_instance_job.rb
+++ b/app/jobs/v3/update_service_instance_job.rb
@@ -14,6 +14,7 @@ module VCAP::CloudController
         @message = message
         @update_response = {}
         @request_attr = request_attr
+        @user_audit_info = user_audit_info
       end
 
       def operation
@@ -26,6 +27,8 @@ module VCAP::CloudController
 
       private
 
+      attr_reader :message, :user_audit_info
+
       def send_broker_request(client)
         @update_response, err = client.update(
           service_instance,
@@ -35,6 +38,7 @@ module VCAP::CloudController
           previous_values: previous_values,
           maintenance_info: maintenance_info,
           name: message.requested?(:name) ? message.name : service_instance.name,
+          user_guid: user_audit_info.user_guid
         )
         raise err if err
 
@@ -53,8 +57,6 @@ module VCAP::CloudController
           MetadataUpdate.update(service_instance, message)
         end
       end
-
-      attr_reader :message
 
       def service_plan_gone!
         raise CloudController::Errors::ApiError.new_from_details('ServicePlanNotFound', service_instance_guid)

--- a/spec/support/background_job_helpers.rb
+++ b/spec/support/background_job_helpers.rb
@@ -2,6 +2,13 @@ module BackgroundJobHelpers
   include VCAP::CloudController
 
   def execute_all_jobs(expected_successes:, expected_failures:, jobs_to_execute: 100)
+    # SecurityContext is not available for worker threads in production, so we clear it
+    # for testing jobs to avoid false positives
+    saved_user = VCAP::CloudController::SecurityContext.current_user
+    saved_token = VCAP::CloudController::SecurityContext.token
+    saved_auth_token = VCAP::CloudController::SecurityContext.auth_token
+    VCAP::CloudController::SecurityContext.clear
+
     successes, failures = Delayed::Worker.new.work_off(jobs_to_execute)
     failure_message = "Expected #{expected_successes} successful and #{expected_failures} failed jobs, got #{successes} successful and #{failures} failed jobs."
     fail_summaries = Delayed::Job.exclude(failed_at: nil).map { |j| "Handler: #{j.handler}, LastError: #{j.last_error}" }
@@ -9,5 +16,7 @@ module BackgroundJobHelpers
       failure_message += " Failures: \n#{fail_summaries.join("\n")}"
     end
     expect([successes, failures]).to eq([expected_successes, expected_failures]), failure_message
+
+    VCAP::CloudController::SecurityContext.set(saved_user, saved_token, saved_auth_token)
   end
 end

--- a/spec/unit/jobs/v3/create_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/create_service_instance_job_spec.rb
@@ -2,6 +2,7 @@ require 'db_spec_helper'
 require 'support/shared_examples/jobs/delayed_job'
 require 'jobs/v3/create_service_instance_job'
 require 'cloud_controller/errors/api_error'
+require 'cloud_controller/user_audit_info'
 
 module VCAP
   module CloudController
@@ -13,7 +14,8 @@ module VCAP
         let(:params) { { some_data: 'some_value' } }
         let(:plan) { ServicePlan.make(maintenance_info: maintenance_info) }
         let(:service_instance) { ManagedServiceInstance.make(service_plan: plan) }
-        let(:user_info) { instance_double(Object) }
+        let(:user_guid) { Sham.uaa_id }
+        let(:user_info) { instance_double(UserAuditInfo, { user_guid: user_guid }) }
         let(:subject) {
           described_class.new(
             service_instance.guid,
@@ -44,7 +46,8 @@ module VCAP
               service_instance,
               accepts_incomplete: true,
               arbitrary_parameters: params,
-              maintenance_info: maintenance_info
+              maintenance_info: maintenance_info,
+              user_guid: user_guid
             )
           end
 

--- a/spec/unit/jobs/v3/service_instance_async_job_spec.rb
+++ b/spec/unit/jobs/v3/service_instance_async_job_spec.rb
@@ -30,7 +30,8 @@ module VCAP::CloudController
         si.save_with_new_operation({}, { type: operation, state: 'in progress' })
         si.reload
       }
-      let(:audit_info) { UserAuditInfo.new(user_guid: User.make.guid, user_email: 'foo@example.com') }
+      let(:user_guid) { Sham.uaa_id }
+      let(:audit_info) { UserAuditInfo.new(user_guid: user_guid, user_name: Sham.name, user_email: 'foo@example.com') }
       let(:guid) { service_instance.guid }
       let(:job) do
         FakeAsyncOperation.new(guid, audit_info).tap do |j|
@@ -266,7 +267,10 @@ module VCAP::CloudController
 
           it 'fetches the last operation' do
             job.perform
-            expect(client).to have_received(:fetch_service_instance_last_operation).with(service_instance).twice
+            expect(client).to have_received(:fetch_service_instance_last_operation).with(
+              service_instance,
+              user_guid: user_guid
+            ).twice
           end
         end
 

--- a/spec/unit/jobs/v3/update_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/update_service_instance_job_spec.rb
@@ -4,6 +4,8 @@ require 'jobs/v3/update_service_instance_job'
 require 'cloud_controller/errors/api_error'
 require 'cloud_controller/user_audit_info'
 require 'messages/service_instance_update_managed_message'
+require 'support/matchers/have_labels'
+require 'support/matchers/have_annotations'
 
 module VCAP
   module CloudController
@@ -100,6 +102,7 @@ module VCAP
                 maintenance_info: nil,
                 name: service_instance.name,
                 previous_values: previous_values,
+                user_guid: user_audit_info.user_guid,
               )
             end
           end
@@ -121,6 +124,7 @@ module VCAP
                 arbitrary_parameters: {},
                 maintenance_info: nil,
                 previous_values: previous_values,
+                user_guid: user_audit_info.user_guid,
               )
             end
           end
@@ -156,6 +160,7 @@ module VCAP
                 maintenance_info: { version: '2.1.0' },
                 name: service_instance.name,
                 previous_values: previous_values,
+                user_guid: user_audit_info.user_guid,
               )
             end
           end
@@ -178,6 +183,7 @@ module VCAP
                 maintenance_info: { version: '2.2.0' },
                 name: service_instance.name,
                 previous_values: previous_values,
+                user_guid: user_audit_info.user_guid,
               )
             end
           end


### PR DESCRIPTION
The x-broker-api-originating-identity is now sent for Create, Read,
Update and Delete service instance operations for V3 endpoints,
including last operation fetching.

[#176499762](https://www.pivotaltracker.com/story/show/176499762)