### PR TITLE
v3(services): send ID header with CRD for bindings

### DIFF
--- a/app/actions/v3/service_binding_delete.rb
+++ b/app/actions/v3/service_binding_delete.rb
@@ -43,7 +43,7 @@ module VCAP::CloudController
 
       def poll(binding)
         client = VCAP::Services::ServiceClientProvider.provide(instance: binding.service_instance)
-        details = client.fetch_and_handle_service_binding_last_operation(binding)
+        details = client.fetch_and_handle_service_binding_last_operation(binding, user_guid: @user_audit_info.user_guid)
 
         case details[:last_operation][:state]
         when 'in progress'
@@ -70,7 +70,11 @@ module VCAP::CloudController
 
       def send_unbind_to_client(binding)
         client = VCAP::Services::ServiceClientProvider.provide(instance: binding.service_instance)
-        details = client.unbind(binding, accepts_incomplete: true)
+        details = client.unbind(
+          binding,
+          accepts_incomplete: true,
+          user_guid: @user_audit_info.user_guid
+        )
         details[:async] ? DeleteStarted.call(details[:operation]) : DeleteComplete
       rescue VCAP::Services::ServiceBrokers::V2::Errors::ConcurrencyError
         broker_concurrency_error!

--- a/lib/services/service_brokers/user_provided/client.rb
+++ b/lib/services/service_brokers/user_provided/client.rb
@@ -4,7 +4,7 @@ module VCAP::Services
       class Client
         def provision(_); end
 
-        def bind(binding, arbitrary_parameters: nil, accepts_incomplete: nil)
+        def bind(binding, arbitrary_parameters: nil, accepts_incomplete: nil, user_guid: nil)
           if binding.class.name.demodulize == 'RouteBinding'
             {
               async: false,

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -855,9 +855,22 @@ RSpec.describe 'v3 service credential bindings' do
           end
         end
 
-        context 'when the broker returns params' do
+        context 'when the broker will returns params' do
           before do
             stub_param_broker_request_for_binding(binding, binding_params)
+          end
+
+          it 'sends a request to the broker including the identity header' do
+            api_call.call(headers_for(user, scopes: %w(cloud_controller.admin)))
+
+            broker_binding_url = "#{instance.service_broker.broker_url}/v2/service_instances/#{instance.guid}/service_bindings/#{binding.guid}"
+            encoded_user_guid = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+            expect(
+              a_request(:get, broker_binding_url).
+                with(
+                  headers: { 'X-Broker-Api-Originating-Identity' => "cloudfoundry #{encoded_user_guid}" },
+                )
+            ).to have_been_made.once
           end
 
           it 'returns the params in the response body' do
@@ -888,19 +901,27 @@ RSpec.describe 'v3 service credential bindings' do
       context 'when the service allows bindings to be fetched' do
         before do
           instance.service.update(bindings_retrievable: true)
+          stub_param_broker_request_for_binding(binding, binding_params)
         end
 
-        context 'when the broker returns params' do
-          before do
-            stub_param_broker_request_for_binding(binding, binding_params)
-          end
+        it 'sends a request to the broker including the identity header' do
+          api_call.call(headers_for(user, scopes: %w(cloud_controller.admin)))
 
-          it 'returns the params in the response body' do
-            api_call.call(admin_headers)
+          broker_binding_url = "#{instance.service_broker.broker_url}/v2/service_instances/#{instance.guid}/service_bindings/#{binding.guid}"
+          encoded_user_guid = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
+          expect(
+            a_request(:get, broker_binding_url).
+              with(
+                headers: { 'X-Broker-Api-Originating-Identity' => "cloudfoundry #{encoded_user_guid}" },
+              )
+          ).to have_been_made.once
+        end
 
-            expect(last_response).to have_status_code(200)
-            expect(parsed_response).to eq(binding_params)
-          end
+        it 'returns the params in the response body' do
+          api_call.call(admin_headers)
+
+          expect(last_response).to have_status_code(200)
+          expect(parsed_response).to eq(binding_params)
         end
       end
     end
@@ -1683,10 +1704,12 @@ RSpec.describe 'v3 service credential bindings' do
         it 'sends an unbind request with the right arguments to the service broker' do
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
 
+          encoded_user_guid = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
           expect(
             a_request(:delete, broker_unbind_url).
               with(
                 query: query,
+                headers: { 'X-Broker-Api-Originating-Identity' => "cloudfoundry #{encoded_user_guid}" },
               )
           ).to have_been_made.once
         end
@@ -1748,13 +1771,17 @@ RSpec.describe 'v3 service credential bindings' do
           it 'polls the last operation endpoint' do
             execute_all_jobs(expected_successes: 1, expected_failures: 0)
 
+            encoded_user_guid = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
             expect(
               a_request(:get, broker_binding_last_operation_url).
-                with(query: {
+                with(
+                  query: {
                   operation: operation,
                   service_id: service_instance.service_plan.service.unique_id,
                   plan_id: service_instance.service_plan.unique_id,
-                })
+                },
+                  headers: { 'X-Broker-Api-Originating-Identity' => "cloudfoundry #{encoded_user_guid}" },
+                )
             ).to have_been_made.once
           end
 
@@ -1796,13 +1823,17 @@ RSpec.describe 'v3 service credential bindings' do
             Timecop.travel(Time.now + 1.minute)
             execute_all_jobs(expected_successes: 1, expected_failures: 0)
 
+            encoded_user_guid = Base64.strict_encode64("{\"user_id\":\"#{user.guid}\"}")
             expect(
               a_request(:get, broker_binding_last_operation_url).
-                with(query: {
+                with(
+                  query: {
                   operation: operation,
                   service_id: service_instance.service_plan.service.unique_id,
                   plan_id: service_instance.service_plan.unique_id,
-                })
+                },
+                  headers: { 'X-Broker-Api-Originating-Identity' => "cloudfoundry #{encoded_user_guid}" },
+                )
             ).to have_been_made.twice
           end
 

--- a/spec/support/shared_examples/v3_service_binding_create.rb
+++ b/spec/support/shared_examples/v3_service_binding_create.rb
@@ -58,6 +58,7 @@ RSpec.shared_examples 'service binding creation' do |binding_model|
             precursor,
             arbitrary_parameters: { foo: 'bar' },
             accepts_incomplete: false,
+            user_guid: user_guid
           )
         end
       end
@@ -75,6 +76,7 @@ RSpec.shared_examples 'service binding creation' do |binding_model|
           precursor,
           arbitrary_parameters: {},
           accepts_incomplete: true,
+          user_guid: user_guid
         )
 
         binding = precursor.reload
@@ -133,7 +135,7 @@ RSpec.shared_examples 'polling service binding creation' do
     it 'fetches the last operation' do
       action.poll(binding)
 
-      expect(broker_client).to have_received(:fetch_and_handle_service_binding_last_operation).with(binding)
+      expect(broker_client).to have_received(:fetch_and_handle_service_binding_last_operation).with(binding, user_guid: user_guid)
     end
 
     context 'last operation state is complete' do
@@ -157,7 +159,7 @@ RSpec.shared_examples 'polling service binding creation' do
       it 'fetches the service binding' do
         action.poll(binding)
 
-        expect(broker_client).to have_received(:fetch_service_binding).with(binding)
+        expect(broker_client).to have_received(:fetch_service_binding).with(binding, user_guid: user_guid)
       end
 
       context 'fails while fetching binding' do
@@ -299,7 +301,7 @@ RSpec.shared_examples 'polling service credential binding creation' do
         it 'fetches the service binding and updates only the credentials, volume_mounts and syslog_drain_url' do
           action.poll(binding)
 
-          expect(broker_client).to have_received(:fetch_service_binding).with(binding)
+          expect(broker_client).to have_received(:fetch_service_binding).with(binding, user_guid: user_guid)
 
           binding.reload
           expect(binding.credentials).to eq(credentials)

--- a/spec/support/shared_examples/v3_service_binding_delete.rb
+++ b/spec/support/shared_examples/v3_service_binding_delete.rb
@@ -18,7 +18,11 @@ RSpec.shared_examples 'service binding deletion' do |binding_model|
     it 'makes the right call to the broker client' do
       action.delete(binding)
 
-      expect(broker_client).to have_received(:unbind).with(binding, { accepts_incomplete: true })
+      expect(broker_client).to have_received(:unbind).with(
+        binding,
+        accepts_incomplete: true,
+        user_guid: user_guid
+      )
     end
 
     context 'unbind fails with generic error' do
@@ -189,7 +193,7 @@ RSpec.shared_examples 'polling service binding deletion' do
     it 'fetches the last operation' do
       action.poll(binding)
 
-      expect(broker_client).to have_received(:fetch_and_handle_service_binding_last_operation).with(binding)
+      expect(broker_client).to have_received(:fetch_and_handle_service_binding_last_operation).with(binding, user_guid: user_guid)
     end
 
     context 'last operation state is complete' do

--- a/spec/unit/actions/service_credential_binding_app_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_app_create_spec.rb
@@ -14,7 +14,8 @@ module VCAP::CloudController
       let(:space) { Space.make }
       let(:app) { AppModel.make(space: space) }
       let(:binding_details) {}
-      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: '100_000') }
+      let(:user_guid) { Sham.uaa_id }
+      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: user_guid) }
       let(:binding_event_repo) { instance_double(Repositories::ServiceGenericBindingEventRepository) }
       let(:name) { 'foo' }
       let(:message) {

--- a/spec/unit/actions/service_credential_binding_delete_spec.rb
+++ b/spec/unit/actions/service_credential_binding_delete_spec.rb
@@ -5,7 +5,8 @@ require 'support/shared_examples/v3_service_binding_delete'
 module VCAP::CloudController
   module V3
     RSpec.describe V3::ServiceCredentialBindingDelete do
-      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: '100_000') }
+      let(:user_guid) { Sham.uaa_id }
+      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: user_guid) }
       let(:action) { described_class.new(type, user_audit_info) }
       let(:binding_event_repo) { instance_double(Repositories::ServiceGenericBindingEventRepository) }
       let(:space) { Space.make }

--- a/spec/unit/actions/service_credential_binding_key_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_key_create_spec.rb
@@ -8,7 +8,8 @@ module VCAP::CloudController
       subject(:action) { described_class.new(user_audit_info, audit_hash) }
 
       let(:audit_hash) { { some_info: 'some_value' } }
-      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: '100_000') }
+      let(:user_guid) { Sham.uaa_id }
+      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: user_guid) }
       let(:org) { Organization.make }
       let(:space) { Space.make(organization: org) }
       let(:binding_details) {}

--- a/spec/unit/actions/service_route_binding_create_spec.rb
+++ b/spec/unit/actions/service_route_binding_create_spec.rb
@@ -22,7 +22,8 @@ module VCAP::CloudController
       }
 
       let(:audit_hash) { { some_info: 'some_value' } }
-      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: '100_000') }
+      let(:user_guid) { Sham.uaa_id }
+      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: user_guid) }
       let(:binding_event_repo) { instance_double(Repositories::ServiceGenericBindingEventRepository) }
 
       before do
@@ -311,7 +312,7 @@ module VCAP::CloudController
             it 'fetches the service binding and updates the route_services_url' do
               action.poll(binding)
 
-              expect(broker_client).to have_received(:fetch_service_binding).with(binding)
+              expect(broker_client).to have_received(:fetch_service_binding).with(binding, user_guid: user_guid)
 
               binding.reload
               expect(binding.route_service_url).to eq(route_service_url)

--- a/spec/unit/actions/service_route_binding_delete_spec.rb
+++ b/spec/unit/actions/service_route_binding_delete_spec.rb
@@ -58,7 +58,8 @@ module VCAP::CloudController
           { type: last_operation_type, state: last_operation_state }
         )
       end
-      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: '100_000') }
+      let(:user_guid) { Sham.uaa_id }
+      let(:user_audit_info) { UserAuditInfo.new(user_email: 'run@lola.run', user_guid: user_guid) }
       let(:binding_event_repo) { instance_double(Repositories::ServiceGenericBindingEventRepository) }
 
       let(:messenger) { instance_double(Diego::Messenger, send_desire_request: nil) }


### PR DESCRIPTION
The x-broker-api-originating-identity is now sent for Create, Read,
and Delete service binding operations for V3 endpoints,
including last operation fetching.

[#176499762](https://www.pivotaltracker.com/story/show/176499762)