### PR TITLE
v3(services): binding metadata update audit events

### DIFF
--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -106,6 +106,15 @@ class ServiceRouteBindingsController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     updated_route_binding = TransactionalMetadataUpdate.update(@route_binding, message)
+
+    Repositories::ServiceGenericBindingEventRepository.
+      new(Repositories::ServiceGenericBindingEventRepository::SERVICE_ROUTE_BINDING).
+      record_update(
+        @route_binding,
+        user_audit_info,
+        message.audit_hash
+      )
+
     render status: :ok, json: Presenters::V3::ServiceRouteBindingPresenter.new(updated_route_binding)
   end
 

--- a/app/repositories/service_generic_binding_event_repository.rb
+++ b/app/repositories/service_generic_binding_event_repository.rb
@@ -35,6 +35,17 @@ module VCAP::CloudController
         )
       end
 
+      def record_update(service_binding, user_audit_info, request, manifest_triggered: false)
+        attrs = censor_request_attributes(request)
+
+        record_event(
+          type:            "audit.#{@actee_name}.update",
+          service_binding: service_binding,
+          user_audit_info: user_audit_info,
+          metadata:        add_manifest_triggered(manifest_triggered, { request: attrs })
+        )
+      end
+
       def record_start_delete(service_binding, user_audit_info)
         record_event(
           type: "audit.#{@actee_name}.start_delete",

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1553,8 +1553,9 @@ RSpec.describe 'v3 service credential bindings' do
       let(:binding) do
         VCAP::CloudController::ServiceKey.make(service_instance: instance) { |binding| operate_on(binding) }
       end
+      let(:binding_name) { binding.name }
 
-      it_behaves_like 'metadata update for service binding'
+      it_behaves_like 'metadata update for service binding', 'service_key'
 
       it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
@@ -1564,8 +1565,9 @@ RSpec.describe 'v3 service credential bindings' do
       let(:binding) do
         VCAP::CloudController::ServiceBinding.make(service_instance: instance, app: app_to_bind_to) { |binding| operate_on(binding) }
       end
+      let(:binding_name) { '' }
 
-      it_behaves_like 'metadata update for service binding'
+      it_behaves_like 'metadata update for service binding', 'service_binding'
 
       it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -1599,8 +1599,9 @@ RSpec.describe 'v3 service route bindings' do
         }
       }
     }
+    let(:binding_name) { '' }
 
-    it_behaves_like 'metadata update for service binding'
+    it_behaves_like 'metadata update for service binding', 'service_route_binding'
 
     it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:response_object) {


### PR DESCRIPTION
Service Binding, Keys and Route Binding metadata updates will record
audit events.

[#176513662](https://www.pivotaltracker.com/story/show/176513662)