### PR TITLE
v3(services): optimize service plan presenter

### DIFF
--- a/app/presenters/v3/service_plan_presenter.rb
+++ b/app/presenters/v3/service_plan_presenter.rb
@@ -83,12 +83,16 @@ module VCAP::CloudController
         end
 
         def parse_schema(schema)
+          return {} unless schema
+
           { parameters: JSON.parse(schema) }
         rescue JSON::ParserError
           {}
         end
 
         def parse(json)
+          return {} unless json
+
           JSON.parse(json).deep_symbolize_keys
         rescue JSON::ParserError
           {}


### PR DESCRIPTION
By skipping the parsing of empty JSON, the /v3/service_plans endpoint is
around 10% faster

[#175872162](https://www.pivotaltracker.com/story/show/175872162)
