### PR TITLE
Eirini LRP instances client can handle processes with 0 instances

### DIFF
--- a/lib/cloud_controller/opi/instances_client.rb
+++ b/lib/cloud_controller/opi/instances_client.rb
@@ -38,7 +38,7 @@ module OPI
     end
 
     def lrp_instances(process)
-      return confirm_stopped(process) if process.stopped?
+      return confirm_not_running(process) if process_has_no_desired_instances?(process)
 
       parsed_response = get_instances(process)
       parsed_response['instances'].map do |instance|
@@ -54,7 +54,11 @@ module OPI
 
     private
 
-    def confirm_stopped(process)
+    def process_has_no_desired_instances?(process)
+      process.stopped? || process.instances == 0
+    end
+
+    def confirm_not_running(process)
       parsed_response = JSON.parse(client.get(instances_path(process)).body)
       raise Error.new("expected no instances for stopped process: #{parsed_response['error']}") unless parsed_response['error'].include?('not found')
 

--- a/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
@@ -171,6 +171,21 @@ RSpec.describe(OPI::InstancesClient) do
         expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(1)
       end
     end
+
+    context 'when the process has 0 desired instances and no actual instances are found' do
+      let(:process) do
+        VCAP::CloudController::ProcessModel.make(state: VCAP::CloudController::ProcessModel::STARTED, instances: 0)
+      end
+      let(:response_body) do
+        { error: 'failed to get instances for app: not found' }.to_json
+      end
+
+      it 'does not error, retry, or wait' do
+        expect(Kernel).not_to receive(:sleep)
+        client.lrp_instances(process)
+        expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(1)
+      end
+    end
   end
 
   context '#desired_lrp_instance' do


### PR DESCRIPTION
https://github.com/cloudfoundry/cloud_controller_ng/pull/1934 updated this code to handle `STOPPED` processes, but did not account for `STARTED` processes that had 0 desired running instances. Processes with 0 instances do not have a
StatefulSet backing them on Kubernetes which caused the instance stats check to raise an exception.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) -- nope 🙂

cc @Birdrock @davewalter @acosta11
