### PR TITLE
Absolute metric for outstanding requests

### DIFF
--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -10,13 +10,13 @@ module VCAP::CloudController
 
       def start_request
         @counter += 1
-        @statsd.gauge('cc.requests.outstanding.total', @counter)
+        @statsd.gauge('cc.requests.outstanding.gauge', @counter)
         @statsd.increment 'cc.requests.outstanding'
       end
 
       def complete_request(status)
         @counter -= 1
-        @statsd.gauge('cc.requests.outstanding.total', @counter)
+        @statsd.gauge('cc.requests.outstanding.gauge', @counter)
         @statsd.batch do |batch|
           batch.decrement 'cc.requests.outstanding'
           batch.increment 'cc.requests.completed'

--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -4,14 +4,19 @@ module VCAP::CloudController
   module Metrics
     class RequestMetrics
       def initialize(statsd=Statsd.new)
+        @counter = 0
         @statsd = statsd
       end
 
       def start_request
+        @counter += 1
+        @statsd.gauge('cc.requests.outstanding.total', @counter)
         @statsd.increment 'cc.requests.outstanding'
       end
 
       def complete_request(status)
+        @counter -= 1
+        @statsd.gauge('cc.requests.outstanding.total', @counter)
         @statsd.batch do |batch|
           batch.decrement 'cc.requests.outstanding'
           batch.increment 'cc.requests.completed'

--- a/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
@@ -9,11 +9,13 @@ module VCAP::CloudController::Metrics
     describe '#start_request' do
       before do
         allow(statsd_client).to receive(:increment)
+        allow(statsd_client).to receive(:gauge)
       end
 
       it 'increments outstanding requests for statsd' do
         request_metrics.start_request
 
+        expect(statsd_client).to have_received(:gauge).with('cc.requests.outstanding.total', 1)
         expect(statsd_client).to have_received(:increment).with('cc.requests.outstanding')
       end
     end
@@ -24,6 +26,7 @@ module VCAP::CloudController::Metrics
 
       before do
         allow(statsd_client).to receive(:batch).and_yield(batch)
+        allow(statsd_client).to receive(:gauge)
         allow(batch).to receive(:increment)
         allow(batch).to receive(:decrement)
       end
@@ -31,6 +34,7 @@ module VCAP::CloudController::Metrics
       it 'increments completed, decrements outstanding, increments status for statsd' do
         request_metrics.complete_request(status)
 
+        expect(statsd_client).to have_received(:gauge).with('cc.requests.outstanding.total', -1)
         expect(batch).to have_received(:decrement).with('cc.requests.outstanding')
         expect(batch).to have_received(:increment).with('cc.requests.completed')
         expect(batch).to have_received(:increment).with('cc.http_status.2XX')

--- a/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
@@ -15,7 +15,7 @@ module VCAP::CloudController::Metrics
       it 'increments outstanding requests for statsd' do
         request_metrics.start_request
 
-        expect(statsd_client).to have_received(:gauge).with('cc.requests.outstanding.total', 1)
+        expect(statsd_client).to have_received(:gauge).with('cc.requests.outstanding.gauge', 1)
         expect(statsd_client).to have_received(:increment).with('cc.requests.outstanding')
       end
     end
@@ -34,7 +34,7 @@ module VCAP::CloudController::Metrics
       it 'increments completed, decrements outstanding, increments status for statsd' do
         request_metrics.complete_request(status)
 
-        expect(statsd_client).to have_received(:gauge).with('cc.requests.outstanding.total', -1)
+        expect(statsd_client).to have_received(:gauge).with('cc.requests.outstanding.gauge', -1)
         expect(batch).to have_received(:decrement).with('cc.requests.outstanding')
         expect(batch).to have_received(:increment).with('cc.requests.completed')
         expect(batch).to have_received(:increment).with('cc.http_status.2XX')


### PR DESCRIPTION
* add a new metric "cc.requests.outstanding.total" and emit as absolute
  gauge value to statsd
* avoids inconsistent metrics when cloud_controller_ng is restarted, but
  the statsd server not
* for more details, see https://github.com/cloudfoundry/cloud_controller_ng/issues/1312

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
