### PR TITLE
services: catalog validation for duplicate plan IDs

### DIFF
--- a/lib/services/service_brokers/v2/catalog_service.rb
+++ b/lib/services/service_brokers/v2/catalog_service.rb
@@ -131,7 +131,7 @@ module VCAP::Services::ServiceBrokers::V2
       duplicate_plans = find_duplicate_plans :broker_provided_id
       if duplicate_plans
         duplicate_plans.each do |plan|
-          errors.add("Plan ids must be unique within a service. Service #{name} already has a plan with id '#{plan}'")
+          errors.add("Plan ids must be unique. Service #{name} already has a plan with id '#{plan}'")
         end
       end
     end

--- a/spec/acceptance/service_broker_spec.rb
+++ b/spec/acceptance/service_broker_spec.rb
@@ -261,6 +261,9 @@ RSpec.describe 'Service Broker' do
           "Service broker catalog is invalid: \n" \
           "Service ids must be unique\n" \
           "Service names must be unique within a broker\n" \
+          "Plan ids must be unique. Unable to register plan with id 'plan-b' (plan name 'large', " \
+          "service name 'service-2') because it uses the same id as another plan in the catalog " \
+          "(plan name 'small', service name 'service-2')\n" \
           "Service dashboard_client id must be unique\n" \
           "Service service-1\n" \
           "  Service id must be a string, but has value 12345\n" \
@@ -275,7 +278,7 @@ RSpec.describe 'Service Broker' do
           "The property '#/properties' of type boolean did not match the following type: object in schema "\
           "http://json-schema.org/draft-04/schema#\n" \
           "Service service-2\n" \
-          "  Plan ids must be unique within a service. Service service-2 already has a plan with id 'plan-b'\n" \
+          "  Plan ids must be unique. Service service-2 already has a plan with id 'plan-b'\n" \
           "  Plan large\n" \
           "    Plan description is required\n" \
           "Service service-3\n" \

--- a/spec/unit/lib/services/service_brokers/v2/catalog_service_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/catalog_service_spec.rb
@@ -267,7 +267,7 @@ module VCAP::Services::ServiceBrokers::V2
         service = CatalogService.new(instance_double(VCAP::CloudController::ServiceBroker), attrs)
         expect(service).not_to be_valid
 
-        expect(service.errors.messages).to include "Plan ids must be unique within a service. Service #{service.name} already has a plan with id 'id-1'"
+        expect(service.errors.messages).to include "Plan ids must be unique. Service #{service.name} already has a plan with id 'id-1'"
       end
 
       it 'validates that the plan names are all unique' do


### PR DESCRIPTION
- For #1911
- Duplicate plan ID within the same catalog cause validation error
- Plan IDs in use for another service of the same broker cause validation error
- Plan IDs in use by another broker do not cause validation errors
because although Plan IDs must be globally unique, enforcing
this now could be problematic for upgrades.

[#175305440](https://www.pivotaltracker.com/story/show/175305440)