### PR TITLE
Temporarily revert: Retry logic for fetching instance info from Eirini

### DIFF
--- a/lib/cloud_controller/opi/instances_client.rb
+++ b/lib/cloud_controller/opi/instances_client.rb
@@ -1,4 +1,3 @@
-require 'retryable'
 require 'httpclient'
 require 'json'
 require 'cloud_controller/errors/instances_unavailable'
@@ -7,9 +6,6 @@ require 'cloud_controller/opi/base_client'
 
 module OPI
   class InstancesClient < BaseClient
-    class Error < StandardError; end
-
-    LRP_INSTANCES_RETRIES = 5
     ActualLRPKey = Struct.new(:index, :process_guid)
     ActualLRPNetInfo = Struct.new(:address, :ports)
     PortMapping = Struct.new(:container_port, :host_port)
@@ -38,11 +34,20 @@ module OPI
     end
 
     def lrp_instances(process)
-      return confirm_stopped(process) if process.stopped?
-
-      parsed_response = get_instances(process)
-      parsed_response['instances'].map do |instance|
-        ActualLRP.new(instance, parsed_response['process_guid'])
+      path = "/apps/#{process.guid}/#{process.version}/instances"
+      begin
+        retries ||= 0
+        resp = client.get(path)
+        resp_json = JSON.parse(resp.body)
+        handle_error(resp_json)
+      rescue CloudController::Errors::NoRunningInstances => e
+        sleep(1)
+        retry if (retries += 1) < 5
+        raise e
+      end
+      process_guid = resp_json['process_guid']
+      resp_json['instances'].map do |instance|
+        ActualLRP.new(instance, process_guid)
       end
     end
 
@@ -54,45 +59,11 @@ module OPI
 
     private
 
-    def confirm_stopped(process)
-      parsed_response = JSON.parse(client.get(instances_path(process)).body)
-      raise Error.new("expected no instances for stopped process: #{parsed_response['error']}") unless parsed_response['error'].include?('not found')
+    def handle_error(response_body)
+      error = response_body['error']
+      return unless error
 
-      []
-    end
-
-    def get_instances(process)
-      Retryable.retryable(sleep: exponential_backoff_from_500ms, tries: LRP_INSTANCES_RETRIES, log_method: log_method) do
-        parsed_response = JSON.parse(client.get(instances_path(process)).body)
-        raise_error(parsed_response)
-        return parsed_response
-      end
-    end
-
-    def instances_path(process)
-      "/apps/#{process.guid}/#{process.version}/instances"
-    end
-
-    def exponential_backoff_from_500ms
-      lambda { |try| 2**(try - 2) }
-    end
-
-    def log_method
-      lambda do |retries, exception|
-        if retries.zero?
-          logger.error("Failed to fetch instances after #{LRP_INSTANCES_RETRIES} retries, giving up. exception: #{exception}")
-        else
-          logger.info("Failed fetching lrp instances, retrying. exception: #{exception}")
-        end
-      end
-    end
-
-    def raise_error(parsed_response)
-      raise Error.new(parsed_response['error']) if parsed_response['error']
-    end
-
-    def logger
-      Steno.logger('opi.instances_client')
+      raise CloudController::Errors::NoRunningInstances.new('No running instances')
     end
   end
 end

--- a/lib/cloud_controller/opi/instances_client.rb
+++ b/lib/cloud_controller/opi/instances_client.rb
@@ -38,7 +38,7 @@ module OPI
     end
 
     def lrp_instances(process)
-      return confirm_not_running(process) if process_has_no_desired_instances?(process)
+      return confirm_stopped(process) if process.stopped?
 
       parsed_response = get_instances(process)
       parsed_response['instances'].map do |instance|
@@ -54,11 +54,7 @@ module OPI
 
     private
 
-    def process_has_no_desired_instances?(process)
-      process.stopped? || process.instances == 0
-    end
-
-    def confirm_not_running(process)
+    def confirm_stopped(process)
       parsed_response = JSON.parse(client.get(instances_path(process)).body)
       raise Error.new("expected no instances for stopped process: #{parsed_response['error']}") unless parsed_response['error'].include?('not found')
 

--- a/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
@@ -171,21 +171,6 @@ RSpec.describe(OPI::InstancesClient) do
         expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(1)
       end
     end
-
-    context 'when the process has 0 desired instances and no actual instances are found' do
-      let(:process) do
-        VCAP::CloudController::ProcessModel.make(state: VCAP::CloudController::ProcessModel::STARTED, instances: 0)
-      end
-      let(:response_body) do
-        { error: 'failed to get instances for app: not found' }.to_json
-      end
-
-      it 'does not error, retry, or wait' do
-        expect(Kernel).not_to receive(:sleep)
-        client.lrp_instances(process)
-        expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(1)
-      end
-    end
   end
 
   context '#desired_lrp_instance' do

--- a/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
@@ -12,12 +12,7 @@ RSpec.describe(OPI::InstancesClient) do
     )
   end
 
-  let(:process) { VCAP::CloudController::ProcessModel.make(
-    guid: 'my-process-guid',
-    version: 'my-version-guid',
-    state: VCAP::CloudController::ProcessModel::STARTED
-  )
-  }
+  let(:process) { double(guid: 'my-process-guid', version: 'my-version-guid') }
 
   context 'when request executes successfully' do
     subject(:actual_lrps) { client.lrp_instances(process) }
@@ -118,21 +113,20 @@ RSpec.describe(OPI::InstancesClient) do
       end
     end
 
-    context 'when there is an error' do
+    context 'when there are no running instances' do
       let(:response_body) do
-        { error: 'some-error' }.to_json
+        { error: 'no-running-instances' }.to_json
       end
 
-      it 'raises an error' do
-        allow(Kernel).to receive(:sleep)
-        expect { client.lrp_instances(process) }.to raise_error(OPI::InstancesClient::Error)
+      it 'raises NoRunningInstances error' do
+        expect { client.lrp_instances(process) }.to raise_error(CloudController::Errors::NoRunningInstances)
         expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(5)
       end
     end
 
-    context 'when the instances are not initially available' do
+    context 'when the instances are not initially availalbe' do
       let(:error_response_body) do
-        { error: 'errrrrrr' }.to_json
+        { error: 'no-running-instances' }.to_json
       end
 
       before do
@@ -144,31 +138,8 @@ RSpec.describe(OPI::InstancesClient) do
       end
 
       it 'should succeed after several retries' do
-        allow(Kernel).to receive(:sleep)
         client.lrp_instances(process)
         expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(4)
-      end
-
-      context 'when the process is stopped' do
-        let(:process) { VCAP::CloudController::ProcessModel.make(state: VCAP::CloudController::ProcessModel::STOPPED) }
-
-        it 'raises an error' do
-          expect { client.lrp_instances(process) }.to raise_error(OPI::InstancesClient::Error)
-          expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(1)
-        end
-      end
-    end
-
-    context 'when the process is stopped and no instances are found' do
-      let(:process) { VCAP::CloudController::ProcessModel.make(state: VCAP::CloudController::ProcessModel::STOPPED) }
-      let(:response_body) do
-        { error: 'failed to get instances for app: not found' }.to_json
-      end
-
-      it 'does not error, retry, or wait' do
-        expect(Kernel).not_to receive(:sleep)
-        client.lrp_instances(process)
-        expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(1)
       end
     end
   end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Temporarily reverting the changes we introduced in #1934 and #2083 since it's significantly breaking BARAS

* An explanation of the use cases your change solves
Unclear still what CF functionality broke, but a good chunk of it did

* Links to any other associated PRs
#1934, #2083

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
