### PR TITLE
Add cpu_weight_scalar configuration property

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -398,6 +398,7 @@ locket:
   key_file: 'spec/fixtures/certs/bbs_client.key'
 
 threadpool_size: 20
+cpu_weight_scalar: 1.0
 
 default_app_lifecycle: buildpack
 custom_metric_tag_prefix_list: ["metric.tag.cloudfoundry.org"]

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -333,7 +333,6 @@ module VCAP::CloudController
             max_annotations_per_resource: Integer,
 
             internal_route_vip_range: String,
-            cpu_weight_scalar: Float,
 
             default_app_lifecycle: String,
             custom_metric_tag_prefix_list: Array,

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -333,6 +333,7 @@ module VCAP::CloudController
             max_annotations_per_resource: Integer,
 
             internal_route_vip_range: String,
+            cpu_weight_scalar: Float,
 
             default_app_lifecycle: String,
             custom_metric_tag_prefix_list: Array,

--- a/lib/cloud_controller/diego/task_cpu_weight_calculator.rb
+++ b/lib/cloud_controller/diego/task_cpu_weight_calculator.rb
@@ -15,10 +15,10 @@ module VCAP
 
         def calculate
           scalar = config.get(:cpu_weight_scalar)
-          return (100 * scalar) if memory_in_mb > MAX_CPU_PROXY
+          return (100 * scalar).floor if memory_in_mb > MAX_CPU_PROXY
 
           numerator = [MIN_CPU_PROXY, memory_in_mb].max
-          scalar * 100 * numerator / MAX_CPU_PROXY
+          (scalar * 100).floor * numerator / MAX_CPU_PROXY
         end
 
         private

--- a/lib/cloud_controller/diego/task_cpu_weight_calculator.rb
+++ b/lib/cloud_controller/diego/task_cpu_weight_calculator.rb
@@ -9,11 +9,16 @@ module VCAP
           @memory_in_mb = memory_in_mb
         end
 
+        def config
+          @config ||= VCAP::CloudController::Config.config
+        end
+
         def calculate
-          return 100 if memory_in_mb > MAX_CPU_PROXY
+          scalar = config.get(:cpu_weight_scalar)
+          return (100 * scalar) if memory_in_mb > MAX_CPU_PROXY
 
           numerator = [MIN_CPU_PROXY, memory_in_mb].max
-          100 * numerator / MAX_CPU_PROXY
+          scalar * 100 * numerator / MAX_CPU_PROXY
         end
 
         private

--- a/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
@@ -34,6 +34,18 @@ module VCAP::CloudController
             expect(calculator.calculate).to eq(expected_weight)
           end
         end
+
+        context 'when the scalar halves cpu weight' do
+          let(:memory) { (min_cpu_proxy + max_cpu_proxy) / 2 }
+          before do
+            TestConfig.override(cpu_weight_scalar: 0.5)
+          end
+
+          it 'returns half the regular precentage' do
+            expected_weight = 0.5 * (100 * memory) / max_cpu_proxy
+            expect(calculator.calculate).to eq(expected_weight)
+          end
+        end
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
@@ -42,7 +42,7 @@ module VCAP::CloudController
           end
 
           it 'returns half the regular precentage' do
-            expected_weight = 0.5 * (100 * memory) / max_cpu_proxy
+            expected_weight = (0.5 * 100).floor * memory / max_cpu_proxy
             expect(calculator.calculate).to eq(expected_weight)
           end
         end


### PR DESCRIPTION
This configuration property gives operators more control over the CPU weight calculation
and the ability to disable CPU reservations entirely.

Resolves #2107

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Adds a configuration property `cpu_weight_scalar` which allows operators control over how aggressive the CPU reservations are.

* An explanation of the use cases your change solves

Currently we find the CPU calculation to be too aggressive. This allows operators to adjust the weight on a whole deployment until it is possible to specify on a per app basis.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

Unfortunately I had a lot of trouble getting Ruby running locally and have been unable to run acceptance tests
