### PR TITLE
v3(services): service_plan_visibility performance improvement

### DIFF
--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -169,7 +169,7 @@ module VCAP::CloudController
 
       return ServicePlanVisibilityTypes::SPACE if broker_space_scoped?
 
-      return ServicePlanVisibilityTypes::ORGANIZATION if service_plan_visibilities.any?
+      return ServicePlanVisibilityTypes::ORGANIZATION unless service_plan_visibilities_dataset.empty?
 
       return ServicePlanVisibilityTypes::ADMIN
     end


### PR DESCRIPTION
model was making a service_plan_visibilities.any? when figuring out
visibility type for the plan. That would load all the results. Instead,
using the dataset empty? method makes only an exists query to the
database making those queries faster.