### PR TITLE
Re-introduce prevention of unnecessary retrying of fetching stats for stopped OPI instances

### DIFF
--- a/lib/cloud_controller/opi/instances_client.rb
+++ b/lib/cloud_controller/opi/instances_client.rb
@@ -38,7 +38,7 @@ module OPI
     end
 
     def lrp_instances(process)
-      return confirm_stopped(process) if process.stopped?
+      return confirm_not_running(process) if process_has_no_desired_instances?(process)
 
       parsed_response = get_instances(process)
       parsed_response['instances'].map do |instance|
@@ -54,7 +54,11 @@ module OPI
 
     private
 
-    def confirm_stopped(process)
+    def process_has_no_desired_instances?(process)
+      process.stopped? || process.instances == 0
+    end
+
+    def confirm_not_running(process)
       parsed_response = JSON.parse(client.get(instances_path(process)).body)
       raise Error.new("expected no instances for stopped process: #{parsed_response['error']}") unless parsed_response['error'].include?('not found')
 

--- a/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
@@ -171,6 +171,21 @@ RSpec.describe(OPI::InstancesClient) do
         expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(1)
       end
     end
+
+    context 'when the process has 0 desired instances and no actual instances are found' do
+      let(:process) do
+        VCAP::CloudController::ProcessModel.make(state: VCAP::CloudController::ProcessModel::STARTED, instances: 0)
+      end
+      let(:response_body) do
+        { error: 'failed to get instances for app: not found' }.to_json
+      end
+
+      it 'does not error, retry, or wait' do
+        expect(Kernel).not_to receive(:sleep)
+        client.lrp_instances(process)
+        expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(1)
+      end
+    end
   end
 
   context '#desired_lrp_instance' do

--- a/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/instances_client_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe(OPI::InstancesClient) do
         let(:process) { VCAP::CloudController::ProcessModel.make(state: VCAP::CloudController::ProcessModel::STOPPED) }
 
         it 'raises an error' do
-          expect { client.lrp_instances(process) }.to raise_error(OPI::InstancesClient::Error)
+          expect { client.lrp_instances(process) }.to raise_error(OPI::InstancesClient::NotRunningProcessError)
           expect(a_request(:get, "#{opi_url}/apps/#{process.guid}/#{process.version}/instances")).to have_been_made.times(1)
         end
       end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Revert the changes we made to prevent unnecessary retrying of fetching metrics for stopped/0 instances apps and resolve the null-pointer dereferencing error those changes inadvertently introduced

* An explanation of the use cases your change solves
Should mitigate slow response times for the `cf apps` command when there are more than 25+ apps pushed to a standard cf-for-k8s installation

* Links to any other associated PRs
Reverts the reverting of the following:
- #1934
- #2083

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
