### PR TITLE
v3(services): perf: many orgs slows POST /v3/service_plan/:guid/visib…

### DIFF
--- a/app/presenters/v3/service_plan_visibility_presenter.rb
+++ b/app/presenters/v3/service_plan_visibility_presenter.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
             }
           end
 
-          if visibility[:type] == VCAP::CloudController::ServicePlanVisibilityTypes::ORGANIZATION
+          if visibility[:type] == VCAP::CloudController::ServicePlanVisibilityTypes::ORGANIZATION && !@visible_in_orgs.nil?
             visibility[:organizations] = @visible_in_orgs.map { |org| { guid: org.guid, name: org.name } }
           end
 

--- a/docs/v3/source/includes/api_resources/_service_plan_visibility.erb
+++ b/docs/v3/source/includes/api_resources/_service_plan_visibility.erb
@@ -38,18 +38,8 @@
 }
 <% end %>
 
-<% content_for :service_plan_visibility_with_new_org do | metadata={} | %>
+<% content_for :service_plan_visibility_response do | metadata={} | %>
 {
-  "type": "organization",
-  "organizations": [
-    {
-      "guid": "bf7eb420-11e5-11ea-b7db-4b5d5e7976a9",
-      "name": "my_org"
-    },
-    {
-      "guid": "0fc1ad4f-e1d7-4436-8e23-6b20f03c6482",
-      "name": "other_org"
-    }
-  ]
+  "type": "organization"
 }
 <% end %>

--- a/docs/v3/source/includes/resources/service_plan_visibility/_apply.md.erb
+++ b/docs/v3/source/includes/resources/service_plan_visibility/_apply.md.erb
@@ -25,7 +25,7 @@ Example Response
 HTTP/1.1 200 OK
 Content-Type: application/json
 
-<%= yield_content :service_plan_visibility_with_new_org %>
+<%= yield_content :service_plan_visibility_response %>
 ```
 
 This endpoint applies a service plan visibility. It behaves similar to the [PATCH service plan visibility endpoint](#update-a-service-plan-visibility) but this endpoint will append to the existing list of organizations when the service plan is `organization` visible.

--- a/spec/request/service_plan_visibility_spec.rb
+++ b/spec/request/service_plan_visibility_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe 'V3 service plan visibility' do
         post api_url, body.to_json, admin_headers
         expect(last_response).to have_status_code(200)
         expect(parsed_response['type']).to eq 'organization'
-        expect(parsed_response['organizations']).to match_array(expected_orgs)
+        expect(parsed_response).not_to have_key('organizations')
 
         get api_url, {}, admin_headers
         expect(parsed_response['type']).to eq 'organization'
@@ -433,7 +433,7 @@ RSpec.describe 'V3 service plan visibility' do
         post api_url, body, admin_headers
         expect(last_response).to have_status_code(200)
         expect(parsed_response['type']).to eq 'organization'
-        expect(parsed_response['organizations']).to match_array(expected_orgs)
+        expect(parsed_response).not_to have_key('organizations')
 
         get api_url, {}, admin_headers
         expect(parsed_response['type']).to eq 'organization'
@@ -457,7 +457,7 @@ RSpec.describe 'V3 service plan visibility' do
           post api_url, body.to_json, admin_headers
 
           expect(parsed_response['type']).to eq 'organization'
-          expect(parsed_response['organizations']).to contain_exactly({ 'guid' => org.guid, 'name' => org.name })
+          expect(parsed_response).not_to have_key('organizations')
         end
 
         it 'creates an audit event' do
@@ -541,13 +541,7 @@ RSpec.describe 'V3 service plan visibility' do
 
     context 'permissions' do
       let(:req_body) { { type: 'organization', organizations: [{ guid: third_org.guid }] } }
-      let(:org_response) { [
-        { name: org.name, guid: org.guid },
-        { name: other_org.name, guid: other_org.guid },
-        { name: third_org.name, guid: third_org.guid }
-      ]
-      }
-      let(:successful_response) { { code: 200, response_object: { type: 'organization', organizations: org_response } } }
+      let(:successful_response) { { code: 200, response_object: { type: 'organization' } } }
       let(:expected_codes_and_responses) do
         Hash.new(code: 403).tap do |h|
           h['admin'] = successful_response

--- a/spec/unit/presenters/v3/service_plan_visibility_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_plan_visibility_presenter_spec.rb
@@ -3,7 +3,8 @@ require 'presenters/v3/service_plan_visibility_presenter'
 
 RSpec.describe VCAP::CloudController::Presenters::V3::ServicePlanVisibilityPresenter do
   describe '#to_hash' do
-    let(:result) { described_class.new(service_plan, []).to_hash.deep_symbolize_keys }
+    let(:visible_in_orgs) { [] }
+    let(:result) { described_class.new(service_plan, visible_in_orgs).to_hash.deep_symbolize_keys }
 
     context 'when service plan is public' do
       let(:service_plan) do
@@ -53,27 +54,51 @@ RSpec.describe VCAP::CloudController::Presenters::V3::ServicePlanVisibilityPrese
 
     context 'when service plan is visible for a set of orgs only' do
       let(:service_plan) do
-        plan = VCAP::CloudController::ServicePlan.make(public: false)
-        VCAP::CloudController::ServicePlanVisibility.make(service_plan: plan, organization: org)
-        plan
+        VCAP::CloudController::ServicePlan.make(public: false) do |plan|
+          VCAP::CloudController::ServicePlanVisibility.make(service_plan: plan, organization: org_1)
+          VCAP::CloudController::ServicePlanVisibility.make(service_plan: plan, organization: org_2)
+        end
       end
 
-      let(:org) do
-        VCAP::CloudController::Organization.make
-      end
-
-      let(:result) { described_class.new(service_plan, [org]).to_hash.deep_symbolize_keys }
+      let(:org_1) { VCAP::CloudController::Organization.make }
+      let(:org_2) { VCAP::CloudController::Organization.make }
+      let(:visible_in_orgs) { [org_1, org_2] }
 
       it 'should return type organization' do
         expect(result).to eq({
           type: 'organization',
           organizations: [
             {
-              guid: org.guid,
-              name: org.name
+              guid: org_1.guid,
+              name: org_1.name
+            },
+            {
+              guid: org_2.guid,
+              name: org_2.name
             }
           ]
         })
+      end
+
+      context 'when the list of orgs is empty' do
+        let(:visible_in_orgs) { [] }
+
+        it 'should return an empty list' do
+          expect(result).to eq({
+            type: 'organization',
+            organizations: []
+          })
+        end
+      end
+
+      context 'when the list of orgs is omitted' do
+        let(:visible_in_orgs) { nil }
+
+        it 'should return the type and omit the list' do
+          expect(result).to eq({
+            type: 'organization'
+          })
+        end
       end
     end
   end


### PR DESCRIPTION
When a plan is visible in many (tens of thousand) of orgs, adding a new
org to the list is slow.
- the list of organizations in the response has been removed because we
are not aware of a client that needs it, and it's computationally
expensive
- the algorithm for adding/replacing orgs has been changed so that it no
longer loads all the organization visibilities. This optimizes it for
the case that you want to add a small number of organizations to an
existing long list.

On a test environment with ~70000 orgs and an service offering with two
plans with org visibility in all of the orgs, the time taken to run `cf
enable-service-access <name> -org <new org>` went down from 2 minutes, to 5
seconds.

[#176901816](https://www.pivotaltracker.com/story/show/176901816)