### PR TITLE
services: allow longer service instance names

### DIFF
--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -115,7 +115,7 @@ module VCAP::CloudController
       validates_presence :name
       validates_presence :space
       validates_unique :name, where: name_clashes
-      validates_max_length 50, :name
+      validates_max_length 255, :name
       validates_max_length 10_000, :syslog_drain_url, allow_nil: true
       validate_tags_length
     end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -883,10 +883,10 @@ module VCAP::CloudController
           end
         end
 
-        context 'creating a service instance with a name over 50 characters' do
-          let(:very_long_name) { 's' * 51 }
+        context 'creating a service instance with a name over 255 characters' do
+          let(:very_long_name) { 's' * 256 }
 
-          it 'returns an error if the service instance name is over 50 characters' do
+          it 'returns an error if the service instance name is over 255 characters' do
             req = MultiJson.dump(
               name: very_long_name,
               space_guid: space.guid,
@@ -1770,7 +1770,7 @@ module VCAP::CloudController
 
           context 'when the updated service instance name is too long' do
             it 'fails and returns service instance name too long message correctly' do
-              new_long_instance_name = 'a' * 51
+              new_long_instance_name = 'a' * 256
               put "/v2/service_instances/#{service_instance.guid}",
                 MultiJson.dump({ name: new_long_instance_name })
 
@@ -5256,7 +5256,7 @@ module VCAP::CloudController
 
       it 'returns service plan name too long message correctly' do
         service_instance_params = {
-          name: 'n' * 51,
+          name: 'n' * 256,
           space_guid: space.guid,
           service_plan_guid: free_plan.guid
         }

--- a/spec/unit/controllers/services/user_provided_service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/user_provided_service_instances_controller_spec.rb
@@ -354,10 +354,10 @@ module VCAP::CloudController
         end
       end
 
-      context 'creating a service instance with a name over 50 characters' do
-        let(:very_long_name) { 's' * 51 }
+      context 'creating a service instance with a name over 255 characters' do
+        let(:very_long_name) { 's' * 256 }
 
-        it 'returns an error if the service instance name is over 50 characters' do
+        it 'returns an error if the service instance name is over 255 characters' do
           post '/v2/user_provided_service_instances', {
             name: very_long_name,
             space_guid: space.guid,

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -44,8 +44,8 @@ module VCAP::CloudController
     end
 
     describe 'validations' do
-      context 'when the name is longer than 50 characters' do
-        let(:very_long_name) { 's' * 51 }
+      context 'when the name is longer than 255 characters' do
+        let(:very_long_name) { 's' * 256 }
         it 'refuses to create this service instance' do
           service_instance_attrs[:name] = very_long_name
           expect { service_instance }.to raise_error Sequel::ValidationFailed


### PR DESCRIPTION
Issue #2111 documents a problem with service instance names being
limited to 50 characters and a case to increase that limit.

The original reason for this limit was not documented when it was
introduced in 2013. The best working theory is that there was a service
broker used in Pivotal Web Services (PWS) that was not compatible with
names longer than 50 characters. That is no longer the case. But there
is a risk that this change could cause issues for some service brokers.
We note that OSBAPI does not specify a limit.

The limit has been increased to 255 characters so that it matches the
limit for service binding names.

[#176818363](https://www.pivotaltracker.com/story/show/176818363)

Resolves #2111