### PR TITLE
Fix buildpack delete race condition

### DIFF
--- a/app/actions/buildpack_delete.rb
+++ b/app/actions/buildpack_delete.rb
@@ -4,13 +4,11 @@ module VCAP::CloudController
       buildpacks.each do |buildpack|
         Buildpack.db.transaction do
           Locking[name: 'buildpacks'].lock!
-
-          if buildpack.key
-            blobstore_delete = Jobs::Runtime::BlobstoreDelete.new(buildpack.key, :buildpack_blobstore)
-            Jobs::Enqueuer.new(blobstore_delete, queue: Jobs::Queues.generic).enqueue
-          end
-
           buildpack.destroy
+        end
+        if buildpack.key
+          blobstore_delete = Jobs::Runtime::BlobstoreDelete.new(buildpack.key, :buildpack_blobstore)
+          Jobs::Enqueuer.new(blobstore_delete, queue: Jobs::Queues.generic).enqueue
         end
       end
 

--- a/spec/unit/actions/buildpack_delete_spec.rb
+++ b/spec/unit/actions/buildpack_delete_spec.rb
@@ -38,7 +38,7 @@ module VCAP::CloudController
         it 'first deletes the database record and afterwards the blob' do
           expect(buildpack).to receive(:destroy).ordered
           expect(Jobs::Runtime::BlobstoreDelete).to receive(:new).ordered
-          enqueue_job_dbl = double("Jobs::Enqueuer")
+          enqueue_job_dbl = double('Jobs::Enqueuer')
           expect(Jobs::Enqueuer).to receive(:new).and_return(enqueue_job_dbl).ordered
           expect(enqueue_job_dbl).to receive(:enqueue).ordered
 

--- a/spec/unit/actions/buildpack_delete_spec.rb
+++ b/spec/unit/actions/buildpack_delete_spec.rb
@@ -34,6 +34,16 @@ module VCAP::CloudController
           expect(job.queue).to eq(Jobs::Queues.generic)
           expect(job.guid).not_to be_nil
         end
+
+        it 'first deletes the database record and afterwards the blob' do
+          expect(buildpack).to receive(:destroy).ordered
+          expect(Jobs::Runtime::BlobstoreDelete).to receive(:new).ordered
+          enqueue_job_dbl = double("Jobs::Enqueuer")
+          expect(Jobs::Enqueuer).to receive(:new).and_return(enqueue_job_dbl).ordered
+          expect(enqueue_job_dbl).to receive(:enqueue).ordered
+
+          buildpack_delete.delete([buildpack])
+        end
       end
 
       context 'when the buildpack has associated metadata' do


### PR DESCRIPTION
Fix for https://github.com/cloudfoundry/cloud_controller_ng/issues/2010

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

This PR fixes the race condition explained in https://github.com/cloudfoundry/cloud_controller_ng/issues/2010

* An explanation of the use cases your change solves

If a CF buildpack is deleted the blobstore object is deleted before the database record. In scenarios with heavy load and slower procession of delayed background jobs, it can happen that a simultaneously executed "cf push" fails with:
```
Staging app and tracing logs...
Staging error: Missing blob for <buildpack name>. Specify a different buildpack with the -b flag or contact your operator.
```
The fix first deletes the database record and cleans up the blobstore afterwards. Should the blobstore deletion fail, the OrphanedBlobsCleanup class would clean up the orphaned buildpack blob.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
