### PR TITLE
Make nginx timeout configurable

### DIFF
--- a/lib/cloud_controller/drain.rb
+++ b/lib/cloud_controller/drain.rb
@@ -12,8 +12,8 @@ module VCAP
         log_info("Drain invoked with #{args.map(&:inspect).join(' ')}")
       end
 
-      def shutdown_nginx(pid_path)
-        nginx_timeout = 30
+      def shutdown_nginx(pid_path, timeout=30)
+        nginx_timeout = timeout
         nginx_interval = 3
         send_signal(pid_path, 'QUIT', 'Nginx') # request nginx graceful shutdown
         wait_for_pid(pid_path, nginx_timeout, nginx_interval) # wait until nginx is shut down

--- a/spec/unit/lib/cloud_controller/drain_spec.rb
+++ b/spec/unit/lib/cloud_controller/drain_spec.rb
@@ -67,6 +67,20 @@ module VCAP::CloudController
           expect(log).to match(/\w+ not running/)
         end
       end
+
+      it 'times out after 10 * 3s = 30s (default)' do
+        allow(File).to receive(:exist?).with(pid_path).and_return(true)
+        expect(drain).to receive(:sleep).with(3).exactly(10).times
+
+        drain.shutdown_nginx(pid_path)
+      end
+
+      it 'times out after 20 * 3s = 60s if timeout parameter is set to 60' do
+        allow(File).to receive(:exist?).with(pid_path).and_return(true)
+        expect(drain).to receive(:sleep).with(3).exactly(20).times
+
+        drain.shutdown_nginx(pid_path, 60)
+      end
     end
 
     describe '#shutdown_cc' do


### PR DESCRIPTION

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
  Currently the nginx timeout for graceful shutdown is hard coded to 30 secs. If requests take longer than this (e.g. `v2/services` on big foundries) they'll be terminated. Making this configurable will allow operators to prevent (too many) failed requests during monit restarts. 

* Links to any other associated PRs
  PR for capi-release: https://github.com/cloudfoundry/capi-release/pull/188

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
