### PR TITLE
Log and save compound errors with V3ErrorHasher in LoggingContextJob

### DIFF
--- a/app/jobs/logging_context_job.rb
+++ b/app/jobs/logging_context_job.rb
@@ -21,7 +21,11 @@ module VCAP::CloudController
       end
 
       def error(job, e)
-        error_presenter = ErrorPresenter.new(e)
+        error_presenter = if e.instance_of?(CloudController::Errors::CompoundError)
+                            ErrorPresenter.new(e, false, V3ErrorHasher.new(e))
+                          else
+                            ErrorPresenter.new(e)
+                          end
         log_error(error_presenter, job)
         save_error(error_presenter, job)
         super(job, e)

--- a/spec/unit/jobs/logging_context_job_spec.rb
+++ b/spec/unit/jobs/logging_context_job_spec.rb
@@ -151,6 +151,25 @@ module VCAP::CloudController
           end
         end
 
+        context 'when the error is a compound error' do
+          let(:error) do
+            CloudController::Errors::CompoundError.new([
+              CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', 'message')
+            ])
+          end
+
+          before do
+            allow(ErrorPresenter).to receive(:new).and_call_original
+          end
+
+          it 'renders the exception in V3 error format' do
+            expect(YAML).to receive(:dump).with(hash_including({
+              'errors' => [hash_including('title' => 'CF-UnprocessableEntity', 'detail' => 'message')]
+            }))
+            logging_context_job.error(job, error)
+          end
+        end
+
         describe 'job priority' do
           context 'when the job priority starts at 0' do
             before do


### PR DESCRIPTION
This PR proposes a fix for #2147.

For compound errors (i.e. `.instance_of?(CloudController::Errors::CompoundError)`), the `V3ErrorHasher` is used that correctly renders the error information before it gets saved into the database.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
