### PR TITLE
v3(services) Expose parameters in schema object

### DIFF
--- a/app/presenters/v3/service_plan_presenter.rb
+++ b/app/presenters/v3/service_plan_presenter.rb
@@ -90,7 +90,7 @@ module VCAP::CloudController
         end
 
         def parse_schema(schema)
-          return {} unless schema
+          return { parameters: {} } unless schema
 
           { parameters: JSON.parse(schema) }
         rescue JSON::ParserError

--- a/docs/v3/source/includes/api_resources/_service_plans.erb
+++ b/docs/v3/source/includes/api_resources/_service_plans.erb
@@ -44,10 +44,14 @@
           }
         }
       },
-      "update": {}
+      "update": {
+        "parameters": {}
+      }
     },
     "service_binding": {
-      "create": {}
+      "create": {
+        "parameters": {}
+      }
     }
   },
   "relationships": {
@@ -138,10 +142,14 @@
               }
             }
           },
-          "update": {}
+          "update": {
+            "parameters": {}
+          }
         },
         "service_binding": {
-          "create": {}
+          "create": {
+            "parameters": {}
+          }
         }
       },
       "relationships": {
@@ -190,11 +198,17 @@
       },
       "schemas": {
         "service_instance": {
-          "create": {},
-          "update": {}
+          "create": {
+            "parameters": {}
+          },
+          "update": {
+            "parameters": {}
+          }
         },
         "service_binding": {
-          "create": {}
+          "create": {
+            "parameters": {}
+          }
         }
       },
       "relationships": {

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -887,11 +887,17 @@ RSpec.describe 'V3 service plans' do
       },
       schemas: {
         service_instance: {
-          create: {},
-          update: {}
+          create: {
+            parameters: {}
+          },
+          update: {
+            parameters: {}
+          }
         },
         service_binding: {
-          create: {}
+          create: {
+            parameters: {}
+          }
         }
       },
       maintenance_info: maintenance_info,

--- a/spec/unit/presenters/v3/service_plan_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_plan_presenter_spec.rb
@@ -59,11 +59,17 @@ RSpec.describe VCAP::CloudController::Presenters::V3::ServicePlanPresenter do
         },
         schemas: {
           service_instance: {
-            create: {},
-            update: {}
+            create: {
+              parameters: {}
+            },
+            update: {
+              parameters: {}
+            }
           },
           service_binding: {
-            create: {}
+            create: {
+              parameters: {}
+            }
           }
         },
         metadata: {
@@ -380,8 +386,8 @@ RSpec.describe VCAP::CloudController::Presenters::V3::ServicePlanPresenter do
 
         it 'presents the service plan create service_instance with the schema' do
           expect(result[:schemas][:service_instance][:create][:parameters]).to eq(parsed_schema)
-          expect(result[:schemas][:service_instance][:update]).to be_empty
-          expect(result[:schemas][:service_binding][:create]).to be_empty
+          expect(result[:schemas][:service_instance][:update][:parameters]).to be_empty
+          expect(result[:schemas][:service_binding][:create][:parameters]).to be_empty
         end
       end
 
@@ -392,8 +398,8 @@ RSpec.describe VCAP::CloudController::Presenters::V3::ServicePlanPresenter do
 
         it 'presents the service plan update service_instance with the schema' do
           expect(result[:schemas][:service_instance][:update][:parameters]).to eq(parsed_schema)
-          expect(result[:schemas][:service_instance][:create]).to be_empty
-          expect(result[:schemas][:service_binding][:create]).to be_empty
+          expect(result[:schemas][:service_instance][:create][:parameters]).to be_empty
+          expect(result[:schemas][:service_binding][:create][:parameters]).to be_empty
         end
       end
 
@@ -403,8 +409,8 @@ RSpec.describe VCAP::CloudController::Presenters::V3::ServicePlanPresenter do
         end
 
         it 'presents the service plan update service_instance with the schema' do
-          expect(result[:schemas][:service_instance][:update]).to be_empty
-          expect(result[:schemas][:service_instance][:create]).to be_empty
+          expect(result[:schemas][:service_instance][:update][:parameters]).to be_empty
+          expect(result[:schemas][:service_instance][:create][:parameters]).to be_empty
           expect(result[:schemas][:service_binding][:create][:parameters]).to eq(parsed_schema)
         end
       end


### PR DESCRIPTION
Keeping consistency with how we show empty objects.

[#177270692](https://www.pivotaltracker.com/story/show/177270692)
