### PR TITLE
Add basic Zipkin instrumentation

### DIFF
--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -7,6 +7,7 @@ require 'cef_logs'
 require 'security_context_setter'
 require 'rate_limiter'
 require 'new_relic_custom_attributes'
+require 'zipkin'
 
 module VCAP::CloudController
   class RackAppBuilder
@@ -24,6 +25,7 @@ module VCAP::CloudController
         use Honeycomb::Rack::Middleware, client: Honeycomb.client if config.get(:honeycomb)
         use CloudFoundry::Middleware::SecurityContextSetter, configurer
         use CloudFoundry::Middleware::RequestLogs, Steno.logger('cc.api')
+        use CloudFoundry::Middleware::Zipkin
         if config.get(:rate_limiter, :enabled)
           use CloudFoundry::Middleware::RateLimiter, {
             logger: Steno.logger('cc.rate_limiter'),

--- a/lib/services/service_brokers/v2/http_client.rb
+++ b/lib/services/service_brokers/v2/http_client.rb
@@ -64,6 +64,9 @@ module VCAP::Services
         user_guid = user_guid(options)
         opts[:header][VCAP::Request::HEADER_BROKER_API_ORIGINATING_IDENTITY] = IdentityEncoder.encode(user_guid) if user_guid
 
+        opts[:header][VCAP::Request::HEADER_ZIPKIN_B3_TRACEID] = VCAP::Request.b3_trace_id if VCAP::Request.b3_trace_id
+        opts[:header][VCAP::Request::HEADER_ZIPKIN_B3_SPANID] = VCAP::Request.b3_span_id if VCAP::Request.b3_span_id
+
         headers = client.default_header.merge(opts[:header])
 
         logger.debug "Sending #{method} to #{uri}, BODY: #{body.inspect}, HEADERS: #{headers}"

--- a/lib/vcap/request.rb
+++ b/lib/vcap/request.rb
@@ -5,6 +5,8 @@ module VCAP
     HEADER_API_INFO_LOCATION = 'X-Api-Info-Location'.freeze
     HEADER_BROKER_API_ORIGINATING_IDENTITY = 'X-Broker-Api-Originating-Identity'.freeze
     HEADER_BROKER_API_REQUEST_IDENTITY = 'X-Broker-API-Request-Identity'.freeze
+    HEADER_ZIPKIN_B3_TRACEID = 'X-B3-TraceId'.freeze
+    HEADER_ZIPKIN_B3_SPANID = 'X-B3-SpanId'.freeze
 
     class << self
       def current_id=(request_id)
@@ -18,6 +20,32 @@ module VCAP
 
       def current_id
         Thread.current[:vcap_request_id]
+      end
+
+      def b3_trace_id=(trace_id)
+        Thread.current[:b3_trace_id] = trace_id
+        if trace_id.nil?
+          Steno.config.context.data.delete('b3_trace_id')
+        else
+          Steno.config.context.data['b3_trace_id'] = trace_id
+        end
+      end
+
+      def b3_trace_id
+        Thread.current[:b3_trace_id]
+      end
+
+      def b3_span_id=(span_id)
+        Thread.current[:b3_span_id] = span_id
+        if span_id.nil?
+          Steno.config.context.data.delete('b3_span_id')
+        else
+          Steno.config.context.data['b3_span_id'] = span_id
+        end
+      end
+
+      def b3_span_id
+        Thread.current[:b3_span_id]
       end
     end
   end

--- a/middleware/zipkin.rb
+++ b/middleware/zipkin.rb
@@ -1,0 +1,41 @@
+module CloudFoundry
+  module Middleware
+    class Zipkin
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        return call_app(env) if !(env['HTTP_X_B3_TRACEID'] && env['HTTP_X_B3_SPANID'])
+
+        env['b3.trace_id'], env['b3.span_id'] = external_b3_ids(env)
+
+        ::VCAP::Request.b3_trace_id = env['b3.trace_id']
+        ::VCAP::Request.b3_span_id = env['b3.span_id']
+
+        zipkin_headers = {
+          'X-B3-TraceId' => env['HTTP_X_B3_TRACEID'],
+          'X-B3-SpanId'  => env['HTTP_X_B3_SPANID']
+        }
+
+        status, headers, body = @app.call(env)
+
+        ::VCAP::Request.b3_trace_id = nil
+        ::VCAP::Request.b3_span_id = nil
+
+        [status, headers.merge(zipkin_headers), body]
+      end
+
+      def call_app(env)
+        @app.call(env)
+      end
+
+      def external_b3_ids(env)
+        trace_id = env['HTTP_X_B3_TRACEID']
+        span_id = env ['HTTP_X_B3_SPANID']
+
+        [trace_id, span_id]
+      end
+    end
+  end
+end

--- a/spec/unit/lib/vcap/request_spec.rb
+++ b/spec/unit/lib/vcap/request_spec.rb
@@ -22,6 +22,18 @@ module VCAP
       end
     end
 
+    describe '::HEADER_ZIPKIN_B3_TRACEID' do
+      it 'constant is expected header name' do
+        expect(Request::HEADER_ZIPKIN_B3_TRACEID).to eq 'X-B3-TraceId'
+      end
+    end
+
+    describe '::HEADER_ZIPKIN_B3_SPANID' do
+      it 'constant is expected header name' do
+        expect(Request::HEADER_ZIPKIN_B3_SPANID).to eq 'X-B3-SpanId'
+      end
+    end
+
     describe '.current_id' do
       after do
         Request.current_id = nil
@@ -52,6 +64,46 @@ module VCAP
         Request.current_id = request_id
 
         expect(Thread.current[:vcap_request_id]).to eq(request_id)
+      end
+    end
+
+    describe '.b3_trace_id' do
+      after do
+        Request.b3_trace_id = nil
+      end
+
+      let(:trace_id) { SecureRandom.hex(8) }
+
+      it 'sets the new b3_trace_id value' do
+        Request.b3_trace_id = trace_id
+
+        expect(Request.b3_trace_id).to eq trace_id
+      end
+
+      it 'uses the :b3_trace_id thread local' do
+        Request.b3_trace_id = trace_id
+
+        expect(Thread.current[:b3_trace_id]).to eq(trace_id)
+      end
+    end
+
+    describe '.b3_span_id' do
+      after do
+        Request.b3_span_id = nil
+      end
+
+      let(:span_id) { SecureRandom.hex(8) }
+
+      it 'sets the new b3_span_id value' do
+        Request.b3_span_id = span_id
+
+        expect(Request.b3_span_id).to eq span_id
+      end
+
+      it 'uses the :b3_span_id thread local' do
+        Request.b3_span_id = span_id
+
+        expect(Thread.current[:b3_span_id]).to eq(span_id)
       end
     end
   end

--- a/spec/unit/middleware/zipkin_spec.rb
+++ b/spec/unit/middleware/zipkin_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+require 'zipkin'
+require 'securerandom'
+
+module CloudFoundry
+  module Middleware
+    RSpec.describe Zipkin do
+      let(:middleware) { Zipkin.new(app) }
+      let(:app) { FakeApp.new }
+
+      class FakeApp
+        attr_accessor :last_trace_id, :last_span_id, :last_env_input
+
+        def call(env)
+          @last_trace_id = ::VCAP::Request.b3_trace_id
+          @last_span_id = ::VCAP::Request.b3_span_id
+          @last_env_input = env
+          [200, {}, 'a body']
+        end
+      end
+
+      describe 'handling the request' do
+        let(:trace_id) { SecureRandom.hex(8) }
+        let(:span_id) { SecureRandom.hex(8) }
+        let(:request_headers) do
+          {
+            'HTTP_X_B3_TRACEID' => trace_id,
+            'HTTP_X_B3_SPANID'  => span_id
+          }
+        end
+
+        context 'setting the trace headers in the logger' do
+          it 'has assigned it before passing the request' do
+            middleware.call(request_headers)
+            expect(app.last_trace_id).to eq trace_id
+            expect(app.last_span_id).to eq span_id
+          end
+
+          it 'nils it out after the request has been processed' do
+            middleware.call(request_headers)
+            expect(::VCAP::Request.b3_trace_id).to eq(nil)
+            expect(::VCAP::Request.b3_span_id).to eq(nil)
+          end
+        end
+
+        context 'when the Zipkin (B3) headers are passed in from outside' do
+          it 'includes it in b3.trace_id and b3.span_id' do
+            middleware.call(request_headers)
+            expect(app.last_env_input['b3.trace_id']).to eq trace_id
+            expect(app.last_env_input['b3.span_id']).to eq span_id
+          end
+        end
+
+        context 'when the Zipkin (B3) headers are NOT passed in from outside' do
+          it 'does not include b3.trace_id and b3.span_id' do
+            middleware.call({})
+            expect(app.last_env_input['b3.trace_id']).to be_nil
+            expect(app.last_env_input['b3.span_id']).to be_nil
+          end
+        end
+      end
+
+      describe 'the response' do
+        let(:trace_id) { SecureRandom.hex(8) }
+        let(:span_id) { SecureRandom.hex(8) }
+
+        context 'when the Zipkin (B3) headers are passed in' do
+          let(:request_headers) do
+            {
+              'HTTP_X_B3_TRACEID' => trace_id,
+              'HTTP_X_B3_SPANID'  => span_id
+            }
+          end
+
+          it 'is returned in the response' do
+            _, headers, _ = middleware.call(request_headers)
+
+            expect(headers['X-B3-TraceId']).to eq trace_id
+            expect(headers['X-B3-SpanId']).to eq span_id
+          end
+        end
+
+        context 'when the Zipkin (B3) headers are NOT passed in' do
+          it 'does not return any Zipkin (B3) headers' do
+            _, headers, _ = middleware.call({})
+
+            expect(headers['X-B3-TraceId']).to be_nil
+            expect(headers['X-B3-SpanId']).to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## A short explanation of the proposed change

Currently, the Zipkin (B3) tracing headers are not passed to the service brokers when they are set by the client/gorouter. With this change the [B3 protocol headers](https://github.com/openzipkin/b3-propagation) (`X-B3-TraceId` and `X-B3-SpanId`) will be passed along to service brokers.

## An explanation of the use cases your change solves

We want to implement distributed tracing between the external services used for applications deployment, and service brokers. Currently, in case of the failure, we need to manually find corresponding logs/errors. This change will help us have a more complete picture about the deployment process. Also B3 protocol headers are widely adopted by various tracing solutions, e.g. [Opentracing](https://github.com/opentracing/specification/blob/master/rfc/trace_identifiers.md#b3-http-headers) and [Datadog](https://docs.datadoghq.com/tracing/setup_overview/custom_instrumentation/go/#b3-headers-extraction-and-injection), as well as [Gorouter](https://docs.cloudfoundry.org/concepts/http-routing.html).

## Tests

In addition to unit tests, I also performed a simple manual test.

1. Execute service instance operation with B3 headers set:

    ```console
    ❯ cf curl /v2/service_instances -H "X-B3-TraceId: 37e14e49ddc5f909" -H "X-B3-SpanId: 37e14e49ddc5f909" -d '{"space_guid":"9b6cce17-20b1-407e-af3b-69d14476605c", "name":"my-awesome-service", "service_plan_guid":"05c3b2e3-6c80-4549-9402-16f2f03caeeb"}' -X POST
    ```

1. Observe the same values in the service broker logs:

    ```console
    ❯ 2021-03-17T17:12:22.32+0100 [RTR/1] OUT my-broker.domain.net - [2021-03-17T16:12:22.019948167Z] "PUT /v2/service_instances/0f8ccc92-4c34-42c9-8635-6a8c2d6e9026 HTTP/1.1" 201 461 3 "-" "HTTPClient/1.0 (2.8.3, ruby 2.5.5 (2019-03-15))" "x.x.x.x:25601" "10.10.136.16:61002" x_forwarded_for:"x.x.x.x" x_forwarded_proto:"https" vcap_request_id:"74bcd293-c1d0-4508-6a69-c3db60b29508" response_time:0.303627 gorouter_time:0.000173 app_id:"cc4c2400-152c-41e7-9d22-7a2212c65fd7" app_index:"1" x_cf_routererror:"-" x_b3_traceid:"37e14e49ddc5f909" x_b3_spanid:"37e14e49ddc5f909" x_b3_parentspanid:"-" b3:"37e14e49ddc5f909-37e14e49ddc5f909"
    ``` 

## Additional context

- https://cloudfoundry.slack.com/archives/C07C04W4Q/p1607623144301100

---

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Signed-off-by: Andrei Krasnitski <a.krasnitski@outlook.com>