### PR TITLE
ISSUE-2161 Pass service binding parameters to service broker

### DIFF
--- a/app/actions/app_apply_manifest.rb
+++ b/app/actions/app_apply_manifest.rb
@@ -156,7 +156,7 @@ module VCAP::CloudController
             message: binding_message)
 
           begin
-            result = action.bind(binding)
+            result = action.bind(binding, parameters: binding_message.parameters)
             if result[:async]
               raise ServiceBrokerRespondedAsyncWhenNotAllowed
             end

--- a/spec/unit/actions/app_apply_manifest_spec.rb
+++ b/spec/unit/actions/app_apply_manifest_spec.rb
@@ -733,7 +733,9 @@ module VCAP::CloudController
               allow(service_cred_binding_create).to receive(:bind).and_return({ async: false })
               allow(service_cred_binding_create).to receive(:precursor).and_return(ServiceBinding.make)
               allow(service_binding_create_message_1).to receive(:audit_hash).and_return({ foo: 'bar-1' })
+              allow(service_binding_create_message_1).to receive(:parameters)
               allow(service_binding_create_message_2).to receive(:audit_hash).and_return({ foo: 'bar-2' })
+              allow(service_binding_create_message_2).to receive(:parameters).and_return({ 'foo' => 'bar' })
             end
 
             it 'creates an action with the right arguments' do
@@ -799,8 +801,8 @@ module VCAP::CloudController
 
               app_apply_manifest.apply(app.guid, message)
 
-              expect(service_cred_binding_create).to have_received(:bind).with(service_binding_1)
-              expect(service_cred_binding_create).to have_received(:bind).with(service_binding_2)
+              expect(service_cred_binding_create).to have_received(:bind).with(service_binding_1, parameters: nil)
+              expect(service_cred_binding_create).to have_received(:bind).with(service_binding_2, parameters: { 'foo' => 'bar' })
             end
 
             it 'wraps the error when precursor errors' do


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Pass service binding parameters, which were provided in an app manifest, to the service broker.
* An explanation of the use cases your change solves
This PR is a suggestion for solving #2161 
* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
