### PR TITLE
Minor wording fixes to documentation of annotations sent to brokers

### DIFF
--- a/docs/v3/source/includes/concepts/_metadata.md.erb
+++ b/docs/v3/source/includes/concepts/_metadata.md.erb
@@ -30,10 +30,10 @@ Example Resource with Annotations
 
 Annotations are user-specified key-value pairs that are attached to [API resources](#api-resource). They do not affect the operation of Cloud Foundry. Annotations cannot be used in [filters](#filters).
 
-When a service instance is being created, the service broker is sent the annotations of the service instance, and the space and organization in which the service instance reside.
-When a service instance is being updated, the service broker is sent the annotations of the space and organization in which the service instance reside.
+When a service instance is being created, the service broker is sent the annotations of the service instance, and the space and organization in which the service instance resides.
+When a service instance is being updated, the service broker is sent the annotations of the space and organization in which the service instance resides.
 When a service binding is being created, the service broker is sent annotations of any associated app, and the space and organization in which the binding resides.
-Only annotations with a prefix are sent.
+Only annotations with a prefix (e.g. `company.com/contacts`) are sent to service brokers.
 
 Examples may include (but are not limited to):
 


### PR DESCRIPTION
* A short explanation of the proposed change:

Minor typos and clarifications to the documentation of annotations sent to brokers

* Links to any other associated PRs: #2156 #2158

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
