### PR TITLE
Set additional header with user guid

### DIFF
--- a/middleware/security_context_setter.rb
+++ b/middleware/security_context_setter.rb
@@ -23,6 +23,8 @@ module CloudFoundry
           return invalid_token!(env, headers)
         end
 
+        headers['X-USER-GUID'] = env['cf.user_guid'] if env['cf.user_guid']
+
         return [status, headers, body]
       rescue VCAP::CloudController::UaaUnavailable => e
         logger.error("Failed communicating with UAA: #{e.message}")

--- a/spec/unit/middleware/security_context_setter_spec.rb
+++ b/spec/unit/middleware/security_context_setter_spec.rb
@@ -29,9 +29,9 @@ module CloudFoundry
           expect(VCAP::CloudController::SecurityContext.auth_token).to eq('auth-token')
         end
 
-        it 'sets the X-USER-GUID header' do
+        it 'adds the X-USER-GUID header' do
           _, header, _ = middleware.call(env)
-          expect(header).to include({ 'X-USER-GUID' => 'user-id-1' })
+          expect(header).to eq({ 'X-USER-GUID' => 'user-id-1' })
         end
 
         context 'when given a UAA user token' do

--- a/spec/unit/middleware/security_context_setter_spec.rb
+++ b/spec/unit/middleware/security_context_setter_spec.rb
@@ -29,6 +29,11 @@ module CloudFoundry
           expect(VCAP::CloudController::SecurityContext.auth_token).to eq('auth-token')
         end
 
+        it 'sets the X-USER-GUID header' do
+          _, header, _ = middleware.call(env)
+          expect(header).to include({ 'X-USER-GUID' => 'user-id-1' })
+        end
+
         context 'when given a UAA user token' do
           it 'sets user name and guid on the env' do
             middleware.call(env)
@@ -53,6 +58,17 @@ module CloudFoundry
           end
         end
 
+        context 'when there is no token (unauthenticated)' do
+          before do
+            allow(token_decoder).to receive(:decode_token)
+          end
+
+          it 'does not set the X-USER-GUID header' do
+            _, header, _ = middleware.call({})
+            expect(header).not_to include('X-USER-GUID')
+          end
+        end
+
         context 'when the rate limiter returns 429' do
           let(:app) { double(:app, call: [429, { 'X-RateLimit-Remaining' => '0' }, 'a body']) }
 
@@ -64,7 +80,7 @@ module CloudFoundry
             it 'forwards the response from the rate limiter' do
               status, headers, body = middleware.call(env)
               expect(status).to eq(429)
-              expect(headers).to eq({ 'X-RateLimit-Remaining' => '0' })
+              expect(headers).to include({ 'X-RateLimit-Remaining' => '0' })
               expect(body).to eq('a body')
             end
           end


### PR DESCRIPTION
* A short explanation of the proposed change:
  Set user guid as additional header. This can be used for example in the nginx access logs.
  There will be a related capi PR which ensures that the guid is not forwarded to the client/user

* Links to any other associated PRs
  * https://github.com/cloudfoundry/capi-release/pull/191 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
