### PR TITLE
V3: Improve error messages in packages_controller

### DIFF
--- a/app/controllers/v3/packages_controller.rb
+++ b/app/controllers/v3/packages_controller.rb
@@ -148,8 +148,8 @@ class PackagesController < ApplicationController
 
     app = AppModel.where(guid: message.app_guid).eager(:space, :organization).first
     unprocessable_app! unless app &&
-      permission_queryer.can_read_from_space?(app.space.guid, app.organization.guid) &&
-      permission_queryer.can_write_to_space?(app.space.guid)
+      permission_queryer.can_read_from_space?(app.space.guid, app.organization.guid)
+    unauthorized! unless permission_queryer.can_write_to_space?(app.space.guid)
 
     if message.type != PackageModel::DOCKER_TYPE && app.docker?
       unprocessable_non_docker_package!
@@ -166,13 +166,13 @@ class PackagesController < ApplicationController
     app_guid = JSON.parse(request.body).deep_symbolize_keys.dig(:relationships, :app, :data, :guid)
     destination_app = AppModel.where(guid: app_guid).eager(:space, :organization).first
     unprocessable_app! unless destination_app &&
-      permission_queryer.can_read_from_space?(destination_app.space.guid, destination_app.organization.guid) &&
-      permission_queryer.can_write_to_space?(destination_app.space.guid)
+      permission_queryer.can_read_from_space?(destination_app.space.guid, destination_app.organization.guid)
+    unauthorized! unless permission_queryer.can_write_to_space?(destination_app.space.guid)
 
     source_package = PackageModel.where(guid: hashed_params[:source_guid]).eager(:app, :space, space: :organization).first
     unprocessable_source_package! unless source_package &&
-      permission_queryer.can_read_from_space?(source_package.space.guid, source_package.space.organization.guid) &&
-      permission_queryer.can_write_to_space?(source_package.space.guid)
+      permission_queryer.can_read_from_space?(source_package.space.guid, source_package.space.organization.guid)
+    unauthorized! unless permission_queryer.can_write_to_space?(source_package.space.guid)
 
     PackageCopy.new.copy(
       destination_app_guid: app_guid,

--- a/spec/unit/controllers/v3/packages_controller_spec.rb
+++ b/spec/unit/controllers/v3/packages_controller_spec.rb
@@ -1384,11 +1384,11 @@ RSpec.describe PackagesController, type: :controller do
             disallow_user_write_access(user, space: source_space)
           end
 
-          it 'returns a 422 UnprocessableEntity error' do
+          it 'returns a 403 Unauthorized error' do
             post :create, params: { source_guid: original_package.guid }.merge(relationship_request_body), as: :json
 
-            expect(response.status).to eq 422
-            expect(response.body).to include 'UnprocessableEntity'
+            expect(response.status).to eq 403
+            expect(response.body).to include 'NotAuthorized'
           end
         end
 
@@ -1411,11 +1411,11 @@ RSpec.describe PackagesController, type: :controller do
             disallow_user_write_access(user, space: destination_space)
           end
 
-          it 'returns a 422 UnprocessableEntity error' do
+          it 'returns a 403 Unauthorized error' do
             post :create, params: { source_guid: original_package.guid }.merge(relationship_request_body), as: :json
 
-            expect(response.status).to eq 422
-            expect(response.body).to include 'UnprocessableEntity'
+            expect(response.status).to eq 403
+            expect(response.body).to include 'NotAuthorized'
           end
         end
       end


### PR DESCRIPTION
Previously these endpoints returned an error implying that the user did
not have read access to the the app even if they have read access but
not write access.

[Finishes #177486351]

Co-authored-by: Carson Long <lcarson@vmware.com>
Co-authored-by: Merric de Launey <mdelauney@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Split up permission check for read and and write access to create more fine grained errors that follow the [v3 style guide](https://github.com/cloudfoundry/cc-api-v3-style-guide#client-errors).

* An explanation of the use cases your change solves
If a space auditor will get a more accurate error message if they attempt to hit POST v3/packages or  POST v3/packages?source_guid=:guid endpoints. 

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
