### PR TITLE
Strictly validate page and per_page pagination options

### DIFF
--- a/app/messages/list_message.rb
+++ b/app/messages/list_message.rb
@@ -52,6 +52,7 @@ module VCAP::CloudController
 
         validate_page(page, record) if !page.nil?
         validate_per_page(per_page, record) if !per_page.nil?
+        validate_maximum_result(page, per_page, record) if !page.nil? || !per_page.nil?
       end
 
       def validate_page(value, record)
@@ -63,6 +64,12 @@ module VCAP::CloudController
           record.errors.add(:per_page, 'must be between 1 and 5000') unless value.to_i <= 5000
         else
           record.errors.add(:per_page, 'must be a positive integer')
+        end
+      end
+
+      def validate_maximum_result(page, per_page, record)
+        if (page || PaginationOptions::PAGE_DEFAULT).to_i * (per_page || PaginationOptions::PER_PAGE_DEFAULT).to_i > 9223372036854775807
+          record.errors.add(:maximum_result, '(page * per_page) must be less than 9223372036854775807')
         end
       end
     end

--- a/spec/unit/messages/list_message_spec.rb
+++ b/spec/unit/messages/list_message_spec.rb
@@ -65,6 +65,35 @@ module VCAP::CloudController
       end
     end
 
+    describe 'maximum_result' do
+      it 'is valid if page and per_page is nil' do
+        message = ListMessage.from_params({ page: nil, per_page: nil }, [])
+        expect(message).to be_valid
+      end
+
+      it 'is valid when using default page' do
+        message = ListMessage.from_params({ page: nil, per_page: 5000 }, [])
+        expect(message).to be_valid
+      end
+
+      it 'is valid when using default per_page' do
+        message = ListMessage.from_params({ page: 20, per_page: nil }, [])
+        expect(message).to be_valid
+      end
+
+      it 'is invalid when page * default per_page exceeds DB limits' do
+        message = ListMessage.from_params({ page: 184467440737095517, per_page: nil }, [])
+        expect(message).to be_invalid
+        expect(message.errors[:maximum_result]).to include('(page * per_page) must be less than 9223372036854775807')
+      end
+
+      it 'is invalid when page * per_page exceeds DB limits' do
+        message = ListMessage.from_params({ page: 9223372036854775807, per_page: 2 }, [])
+        expect(message).to be_invalid
+        expect(message.errors[:maximum_result]).to include('(page * per_page) must be less than 9223372036854775807')
+      end
+    end
+
     describe 'order validations' do
       context 'when order_by is present' do
         it 'validates when order_by is `created_at`' do


### PR DESCRIPTION
Existing validation just compared the value of the input `.to_i` against
the limits. This method means that floats and strings such as `1.abcd`
get treated as valid integers and so are accepted by the API. By using
the Rails validation methods we can get stricter controls over what
is allowable and save writing custom validation functions

Fixes #2194 

A short explanation of the proposed change:
* Use Rails builtin validation for v3 pagination query params

An explanation of the use cases your change solves
* Users submitting non-integer `page` parameters should get 400 errors rather than fuzzy integer casts


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
