### PR TITLE
Use share mode locking in isolation_segment assign and unassign

### DIFF
--- a/app/actions/isolation_segment_assign.rb
+++ b/app/actions/isolation_segment_assign.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   class IsolationSegmentAssign
     def assign(isolation_segment, organizations)
       isolation_segment.db.transaction do
-        isolation_segment.lock!
+        isolation_segment.lock!(:share)
 
         organizations.sort! { |o1, o2| o1.id <=> o2.id }.each do |org|
           org.lock!

--- a/app/actions/isolation_segment_unassign.rb
+++ b/app/actions/isolation_segment_unassign.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   class IsolationSegmentUnassign
     def unassign(isolation_segment, org)
       isolation_segment.db.transaction do
-        isolation_segment.lock!
+        isolation_segment.lock!(:share)
         org.lock!
 
         org_association_error! if is_default_segment?(isolation_segment, org)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
 Use share mode locking for isolation_segment assign and unassign to allow parallel updates on the join table. This lock still ensures that e.g. deletions will be blocked.

* An explanation of the use cases your change solves
Please check the discussion on slack channel: https://cloudfoundry.slack.com/archives/C07C04W4Q/p1618929622074800?thread_ts=1616571116.025200&cid=C07C04W4Q
* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
