### PR TITLE
Support partial Process Stats responses when the stats service (log-cache or metric-proxy) is unavailable

### DIFF
--- a/app/controllers/runtime/stats_controller.rb
+++ b/app/controllers/runtime/stats_controller.rb
@@ -22,7 +22,12 @@ module VCAP::CloudController
       end
 
       begin
-        stats, _ = instances_reporters.stats_for_app(process)
+        stats, warnings = instances_reporters.stats_for_app(process)
+
+        warnings.each do |warning_message|
+          add_warning(warning_message)
+        end
+
         stats.each_value do |stats_hash|
           if stats_hash[:stats]
             stats_hash[:stats].delete_if { |key, _| key == :net_info }

--- a/app/controllers/runtime/stats_controller.rb
+++ b/app/controllers/runtime/stats_controller.rb
@@ -22,7 +22,7 @@ module VCAP::CloudController
       end
 
       begin
-        stats = instances_reporters.stats_for_app(process)
+        stats, _ = instances_reporters.stats_for_app(process)
         stats.each_value do |stats_hash|
           if stats_hash[:stats]
             stats_hash[:stats].delete_if { |key, _| key == :net_info }

--- a/app/controllers/v3/processes_controller.rb
+++ b/app/controllers/v3/processes_controller.rb
@@ -98,7 +98,8 @@ class ProcessesController < ApplicationController
   end
 
   def stats
-    process_stats = instances_reporters.stats_for_app(@process)
+    process_stats, warnings = instances_reporters.stats_for_app(@process)
+    add_warning_headers(warnings)
 
     render status: :ok, json: Presenters::V3::ProcessStatsPresenter.new(@process.type, process_stats)
   end

--- a/app/presenters/v3/process_stats_presenter.rb
+++ b/app/presenters/v3/process_stats_presenter.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
 
         def to_hash
           {
-            resources: present_stats_hash
+            resources: present_stats_hash,
           }
         end
 
@@ -35,12 +35,6 @@ module VCAP::CloudController
             type:       @type,
             index:      index,
             state:      stats[:state],
-            usage:      {
-              time: stats[:stats][:usage][:time],
-              cpu:  stats[:stats][:usage][:cpu],
-              mem:  stats[:stats][:usage][:mem],
-              disk: stats[:stats][:usage][:disk],
-            },
             host:       stats[:stats][:host],
             uptime:     stats[:stats][:uptime],
             mem_quota:  stats[:stats][:mem_quota],
@@ -48,7 +42,10 @@ module VCAP::CloudController
             fds_quota:  stats[:stats][:fds_quota],
             isolation_segment: stats[:isolation_segment],
             details: stats[:details]
-          }.tap { |presented_stats| add_port_info(presented_stats, stats) }
+          }.tap do |presented_stats|
+            add_port_info(presented_stats, stats)
+            add_usage_info(presented_stats, stats)
+          end
         end
 
         def down_instance_stats_hash(index, stats)
@@ -68,6 +65,19 @@ module VCAP::CloudController
           else
             presented_stats[:port] = stats[:stats][:port]
           end
+        end
+
+        def add_usage_info(presented_stats, stats)
+          presented_stats[:usage] = if stats[:stats][:usage].present?
+                                      {
+                                        time: stats[:stats][:usage][:time],
+                                        cpu:  stats[:stats][:usage][:cpu],
+                                        mem:  stats[:stats][:usage][:mem],
+                                        disk: stats[:stats][:usage][:disk],
+                                      }
+                                    else
+                                      {}
+                                    end
         end
 
         def net_info_to_instance_ports(net_info_ports)

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -102,7 +102,6 @@ loggregator:
 logcache:
   host: 'http://doppler.service.cf.internal'
   port: 8080
-  temporary_ignore_server_unavailable_errors: false
 
 logcache_tls:
   key_file: 'spec/fixtures/certs/log_cache.key'

--- a/docs/v3/source/includes/resources/processes/_stats_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats_object.md.erb
@@ -12,6 +12,7 @@ Name | Type | Description
 **type** | _string_ | Process type; a unique identifier for processes belonging to an app
 **index** | _integer_ | The zero-based index of running instances
 **state** | _string_ | The state of the instance; valid values are `RUNNING`, `CRASHED`, `STARTING`, `DOWN`
+**usage** | _object_ | Object containing actual usage data for the instance; the value is `{}` when usage data is unavailable
 **usage.time** | _[timestamp](#timestamps)_ | The time when the usage was requested
 **usage.cpu** | _number_ | The current cpu usage of the instance
 **usage.mem** | _integer_ | The current memory usage of the instance
@@ -19,8 +20,8 @@ Name | Type | Description
 **host** | _string_ | The host the instance is running on
 **instance_ports** | _object_ | JSON array of port mappings between the network-exposed port used to communicate with the app (`external`) and port opened to the running process that it can listen on (`internal`)
 **uptime** | _integer_ | The uptime in seconds for the instance
-**mem_quota** | _integer_ | The current maximum memory allocated for the instance
-**disk_quota** | _integer_ | The current maximum disk allocated for the instance
+**mem_quota** | _integer_ | The current maximum memory allocated for the instance; the value is `null` when memory quota data is unavailable
+**disk_quota** | _integer_ | The current maximum disk allocated for the instance; the value is `null` when disk quota data is unavailable
 **fds_quota** | _integer_ | The maximum file descriptors the instance is allowed to use
 **isolation_segment** | _string_ | The current isolation segment that the instance is running on; the value is `null` when the instance is not placed on a particular isolation segment
 **details** | _string_ | Information about errors placing the instance; the value is `null`  if there are no placement errors

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -205,7 +205,6 @@ module VCAP::CloudController
             logcache: {
               host: String,
               port: Integer,
-              temporary_ignore_server_unavailable_errors: bool,
             },
 
             optional(:logcache_tls) => {

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -526,7 +526,6 @@ module CloudController
         client_cert_path: config.get(:logcache_tls, :cert_file),
         client_key_path: config.get(:logcache_tls, :key_file),
         tls_subject_name: config.get(:logcache_tls, :subject_name),
-        temporary_ignore_server_unavailable_errors: config.get(:logcache, :temporary_ignore_server_unavailable_errors)
       )
     end
 

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -20,22 +20,9 @@ module VCAP::CloudController
         logger.debug('stats_for_app.fetching_container_metrics', process_guid: process.guid)
         desired_lrp = bbs_instances_client.desired_lrp_instance(process)
 
-        log_cache_data = envelopes(desired_lrp, process)
-        stats = log_cache_data.
-                map { |e|
-          [
-            e.containerMetric.instanceIndex,
-            converted_container_metrics(e.containerMetric, formatted_current_time),
-          ]
-        }.to_h
-
-        quota_stats = log_cache_data.
-                      map { |e|
-                        [
-                          e.containerMetric.instanceIndex,
-                          e.containerMetric,
-                        ]
-                      }.to_h
+        log_cache_data, log_cache_errors = envelopes(desired_lrp, process)
+        stats = formatted_process_stats(log_cache_data, formatted_current_time)
+        quota_stats = formatted_quota_stats(log_cache_data)
 
         bbs_instances_client.lrp_instances(process).each do |actual_lrp|
           index = actual_lrp.actual_lrp_key.index
@@ -51,25 +38,20 @@ module VCAP::CloudController
               port:       get_default_port(actual_lrp.actual_lrp_net_info),
               net_info:   actual_lrp.actual_lrp_net_info.to_h,
               uptime:     nanoseconds_to_seconds(current_time * 1e9 - actual_lrp.since),
-              mem_quota:  quota_stats[index]&.memoryBytesQuota,
-              disk_quota: quota_stats[index]&.diskBytesQuota,
               fds_quota:  process.file_descriptors,
-              usage:      stats[index] || {
-                time: formatted_current_time,
-                cpu:  0,
-                mem:  0,
-                disk: 0,
-              },
-            }
+            }.merge(metrics_data_for_instance(stats, quota_stats, log_cache_errors, formatted_current_time, index))
           }
           info[:details]                          = actual_lrp.placement_error if actual_lrp.placement_error.present?
           result[actual_lrp.actual_lrp_key.index] = info
         end
 
         fill_unreported_instances_with_down_instances(result, process)
+
+        warnings = [log_cache_errors].compact
+        return result, warnings
       rescue CloudController::Errors::NoRunningInstances => e
         logger.info('stats_for_app.error', error: e.to_s)
-        fill_unreported_instances_with_down_instances({}, process)
+        return fill_unreported_instances_with_down_instances({}, process), []
       rescue StandardError => e
         logger.error('stats_for_app.error', error: e.to_s)
         if e.is_a?(CloudController::Errors::ApiError) && e.name == 'ServiceUnavailable'
@@ -83,6 +65,53 @@ module VCAP::CloudController
 
       private
 
+      attr_reader :bbs_instances_client
+
+      def metrics_data_for_instance(stats, quota_stats, log_cache_errors, formatted_current_time, index)
+        if log_cache_errors.blank?
+          {
+            mem_quota:  quota_stats[index]&.memoryBytesQuota,
+            disk_quota: quota_stats[index]&.diskBytesQuota,
+            usage:      stats[index] || missing_process_stats(formatted_current_time)
+          }
+        else
+          {
+            mem_quota: nil,
+            disk_quota: nil,
+            usage: {}
+          }
+        end
+      end
+
+      def missing_process_stats(formatted_current_time)
+        {
+          time: formatted_current_time,
+          cpu:  0,
+          mem:  0,
+          disk: 0,
+        }
+      end
+
+      def formatted_process_stats(log_cache_data, formatted_current_time)
+        log_cache_data.
+          map { |e|
+            [
+              e.containerMetric.instanceIndex,
+              converted_container_metrics(e.containerMetric, formatted_current_time),
+            ]
+          }.to_h
+      end
+
+      def formatted_quota_stats(log_cache_data)
+        log_cache_data.
+          map { |e|
+            [
+              e.containerMetric.instanceIndex,
+              e.containerMetric,
+            ]
+          }.to_h
+      end
+
       def envelopes(desired_lrp, process)
         if desired_lrp.metric_tags['process_id']
           filter = ->(envelope) { envelope.tags.any? { |key, value| key == 'process_id' && value == process.guid } }
@@ -92,14 +121,15 @@ module VCAP::CloudController
           source_guid = process.guid
         end
 
-        @logstats_client.container_metrics(
+        return @logstats_client.container_metrics(
           source_guid: source_guid,
           auth_token: VCAP::CloudController::SecurityContext.auth_token,
           logcache_filter: filter
-        )
+        ), nil
+      rescue GRPC::BadStatus, CloudController::Errors::ApiError => e
+        logger.error('stats_for_app.error', error: e.message, backtrace: e.backtrace.join("\n"))
+        return [], 'Stats server temporarily unavailable.'
       end
-
-      attr_reader :bbs_instances_client
 
       def logger
         @logger ||= Steno.logger('cc.diego.instances_reporter')
@@ -111,12 +141,7 @@ module VCAP::CloudController
         disk = container_metrics.diskBytes
 
         if cpu.nil? || mem.nil? || disk.nil?
-          {
-            time: formatted_current_time,
-            cpu: 0,
-            mem: 0,
-            disk: 0
-          }
+          missing_process_stats(formatted_current_time)
         else
           {
             time: formatted_current_time,

--- a/lib/logcache/client.rb
+++ b/lib/logcache/client.rb
@@ -6,7 +6,7 @@ module Logcache
     MAX_LIMIT = 1000
     DEFAULT_LIMIT = 100
 
-    def initialize(host:, port:, client_ca_path:, client_cert_path:, client_key_path:, tls_subject_name:, temporary_ignore_server_unavailable_errors:)
+    def initialize(host:, port:, client_ca_path:, client_cert_path:, client_key_path:, tls_subject_name:)
       if client_ca_path
         client_ca = IO.read(client_ca_path)
         client_key = IO.read(client_key_path)
@@ -25,8 +25,6 @@ module Logcache
           timeout: 250
         )
       end
-
-      @temporary_ignore_server_unavailable_errors = temporary_ignore_server_unavailable_errors
     end
 
     def container_metrics(source_guid:, envelope_limit: DEFAULT_LIMIT, start_time:, end_time:)

--- a/lib/logcache/client.rb
+++ b/lib/logcache/client.rb
@@ -59,12 +59,6 @@ module Logcache
         retry
       end
 
-      if @temporary_ignore_server_unavailable_errors && e.is_a?(GRPC::BadStatus) && e.to_status.code == 14
-        logger.warn("rescuing GRPC Unavailable error: #{e.to_status}")
-
-        return EmptyEnvelope.new(source_guid)
-      end
-
       raise e
     end
 

--- a/spec/api/documentation/apps_api_spec.rb
+++ b/spec/api/documentation/apps_api_spec.rb
@@ -374,7 +374,7 @@ RSpec.resource 'Apps', type: [:api, :legacy_api] do
 
       instances_reporters = double(:instances_reporters)
       allow(CloudController::DependencyLocator.instance).to receive(:instances_reporters).and_return(instances_reporters)
-      allow(instances_reporters).to receive(:stats_for_app).and_return(stats)
+      allow(instances_reporters).to receive(:stats_for_app).and_return([stats, []])
 
       client.get "/v2/apps/#{process.guid}/stats", {}, headers
       expect(status).to eq(200)

--- a/spec/logcache/client_spec.rb
+++ b/spec/logcache/client_spec.rb
@@ -21,8 +21,7 @@ module Logcache
       let(:channel_arg_hash) { { GRPC::Core::Channel::SSL_TARGET => tls_subject_name } }
       let(:client) do
         Logcache::Client.new(host: host, port: port, client_ca_path: client_ca_path,
-                             client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name,
-                             temporary_ignore_server_unavailable_errors: false)
+                             client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name)
       end
       let(:client_ca) { File.open(client_ca_path).read }
       let(:client_key) { File.open(client_key_path).read }
@@ -78,8 +77,7 @@ module Logcache
 
         let(:client) do
           Logcache::Client.new(host: host, port: port, client_ca_path: client_ca_path,
-                               client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name,
-                               temporary_ignore_server_unavailable_errors: false)
+                               client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name)
         end
 
         it 'retries the request three times and raises an exception' do
@@ -110,8 +108,7 @@ module Logcache
 
         let(:client) do
           Logcache::Client.new(host: host, port: port, client_ca_path: client_ca_path,
-                               client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name,
-                               temporary_ignore_server_unavailable_errors: false)
+                               client_cert_path: client_cert_path, client_key_path: client_key_path, tls_subject_name: tls_subject_name)
         end
 
         it 'raises an exception' do
@@ -150,8 +147,14 @@ module Logcache
 
     describe 'without TLS' do
       let(:client) do
-        Logcache::Client.new(host: host, port: port, temporary_ignore_server_unavailable_errors: false,
-                            client_ca_path: nil, client_cert_path: nil, client_key_path: nil, tls_subject_name: nil)
+        Logcache::Client.new(
+          host: host,
+          port: port,
+          client_ca_path: nil,
+          client_cert_path: nil,
+          client_key_path: nil,
+          tls_subject_name: nil
+        )
       end
 
       describe '#container_metrics' do

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -480,44 +480,44 @@ RSpec.describe 'Processes' do
 
     let(:expected_response) do
       {
-      'resources' => [{
-        'type'           => 'worker',
-        'index'          => 0,
-        'state'          => 'RUNNING',
-        'isolation_segment' => 'very-isolated',
-        'details' => 'some-details',
-        'usage' => {
-          'time' => usage_time,
-          'cpu'  => 80,
-          'mem'  => 128,
-          'disk' => 1024,
-        },
-        'host'           => 'toast',
-        'instance_ports' => [
-          {
-            'external' => 8080,
-            'internal' => 1234,
-            'external_tls_proxy_port' => 61002,
-            'internal_tls_proxy_port' => 61003
+        'resources' => [{
+          'type'           => 'worker',
+          'index'          => 0,
+          'state'          => 'RUNNING',
+          'isolation_segment' => 'very-isolated',
+          'details' => 'some-details',
+          'usage' => {
+            'time' => usage_time,
+            'cpu'  => 80,
+            'mem'  => 128,
+            'disk' => 1024,
           },
-          {
-            'external' => 3000,
-            'internal' => 4000,
-            'external_tls_proxy_port' => 61006,
-            'internal_tls_proxy_port' => 61007
-          }
-        ],
-        'uptime'         => 12345,
-        'mem_quota'      => 1073741824,
-        'disk_quota'     => 1073741824,
-        'fds_quota'      => 16384
-      }]
+          'host'           => 'toast',
+          'instance_ports' => [
+            {
+              'external' => 8080,
+              'internal' => 1234,
+              'external_tls_proxy_port' => 61002,
+              'internal_tls_proxy_port' => 61003
+            },
+            {
+              'external' => 3000,
+              'internal' => 4000,
+              'external_tls_proxy_port' => 61006,
+              'internal_tls_proxy_port' => 61007
+            }
+          ],
+          'uptime'         => 12345,
+          'mem_quota'      => 1073741824,
+          'disk_quota'     => 1073741824,
+          'fds_quota'      => 16384
+        }]
     }
     end
 
     before do
       CloudController::DependencyLocator.instance.register(:instances_reporters, instances_reporters)
-      allow(instances_reporters).to receive(:stats_for_app).and_return(stats_for_process)
+      allow(instances_reporters).to receive(:stats_for_app).and_return([stats_for_process, []])
     end
 
     describe 'GET /v3/processes/:guid/stats' do

--- a/spec/request/v2/apps_spec.rb
+++ b/spec/request/v2/apps_spec.rb
@@ -1365,7 +1365,7 @@ RSpec.describe 'Apps' do
 
     before do
       allow(CloudController::DependencyLocator.instance).to receive(:instances_reporters).and_return(instances_reporters)
-      allow(instances_reporters).to receive(:stats_for_app).and_return(instances_reporter_response)
+      allow(instances_reporters).to receive(:stats_for_app).and_return([instances_reporter_response, []])
     end
 
     it 'displays the stats' do

--- a/spec/unit/controllers/runtime/stats_controller_spec.rb
+++ b/spec/unit/controllers/runtime/stats_controller_spec.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
 
         before do
           CloudController::DependencyLocator.instance.register(:instances_reporters, instances_reporters)
-          allow(instances_reporters).to receive(:stats_for_app).and_return(stats)
+          allow(instances_reporters).to receive(:stats_for_app).and_return([stats, []])
         end
 
         context 'because they are a developer' do

--- a/spec/unit/controllers/runtime/stats_controller_spec.rb
+++ b/spec/unit/controllers/runtime/stats_controller_spec.rb
@@ -22,11 +22,12 @@ module VCAP::CloudController
             }
           }
         end
+        let(:warnings) { [] }
         let(:instances_reporters) { double(:instances_reporters) }
 
         before do
           CloudController::DependencyLocator.instance.register(:instances_reporters, instances_reporters)
-          allow(instances_reporters).to receive(:stats_for_app).and_return([stats, []])
+          allow(instances_reporters).to receive(:stats_for_app).and_return([stats, warnings])
         end
 
         context 'because they are a developer' do
@@ -55,6 +56,7 @@ module VCAP::CloudController
 
             expect(last_response.status).to eq(200)
             expect(MultiJson.load(last_response.body)).to eq(expected)
+            expect(last_response.headers['X-Cf-Warnings']).to be_nil
             expect(instances_reporters).to have_received(:stats_for_app).with(
               satisfy { |requested_app| requested_app.guid == process.app.guid })
           end
@@ -86,6 +88,40 @@ module VCAP::CloudController
 
             expect(last_response.status).to eq(200)
             expect(MultiJson.load(last_response.body)).to eq(expected)
+            expect(instances_reporters).to have_received(:stats_for_app).with(
+              satisfy { |requested_app| requested_app.guid == process.app.guid })
+          end
+        end
+
+        context 'when the instances reporter returns warnings' do
+          let(:warnings) { ['s0mjgnbha', 'full_moon_with_s0mjgnbha'] }
+
+          it 'should return the stats with an X-Cf-Warnings header' do
+            set_current_user(developer)
+
+            process.state     = 'STARTED'
+            process.instances = 1
+            process.save
+
+            process.refresh
+
+            expected = {
+              '0' => {
+                'state' => 'RUNNING',
+                'stats' => {},
+              },
+              '1' => {
+                'state'   => 'DOWN',
+                'details' => 'start-me',
+                'since'   => 1,
+              }
+            }
+
+            get "/v2/apps/#{process.app.guid}/stats"
+
+            expect(last_response.status).to eq(200)
+            expect(MultiJson.load(last_response.body)).to eq(expected)
+            expect(last_response.headers['X-Cf-Warnings']).to eq('s0mjgnbha,full_moon_with_s0mjgnbha')
             expect(instances_reporters).to have_received(:stats_for_app).with(
               satisfy { |requested_app| requested_app.guid == process.app.guid })
           end

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -503,7 +503,6 @@ RSpec.describe CloudController::DependencyLocator do
         client_cert_path: nil,
         client_key_path: nil,
         tls_subject_name: nil,
-        temporary_ignore_server_unavailable_errors: false
       )
     end
 
@@ -513,7 +512,6 @@ RSpec.describe CloudController::DependencyLocator do
           logcache: {
             host: 'some-logcache-host',
             port: 1234,
-            temporary_ignore_server_unavailable_errors: false,
           },
           logcache_tls: {
             ca_file: 'logcache-ca',
@@ -531,7 +529,6 @@ RSpec.describe CloudController::DependencyLocator do
         client_cert_path: 'logcache-client-ca',
         client_key_path: 'logcache-client-key',
         tls_subject_name: 'some-tls-cert-san',
-        temporary_ignore_server_unavailable_errors: false
       )
     end
   end


### PR DESCRIPTION
This change rescues errors from log-cache and metric-proxy and passes them up as warnings to callers instead of exceptions so that the stats endpoint can continue to function on a best-effort basis. On /v3/processes/:guid/stats these warnings are included in a new "warnings" key on the response, on v2 they are ignored. Alternatively/additionally we could add these to the `'X-Cf-Warnings'` header as @sethboyles [mentioned on the issue](https://github.com/cloudfoundry/cloud_controller_ng/issues/2227#issuecomment-828039303).

The related issue has more information: https://github.com/cloudfoundry/cloud_controller_ng/issues/2227

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
