### PR TITLE
Log incomplete requests when stopping CC

### DIFF
--- a/lib/cloud_controller/logs/request_logs.rb
+++ b/lib/cloud_controller/logs/request_logs.rb
@@ -1,0 +1,63 @@
+require 'ipaddr'
+
+module VCAP::CloudController
+  module Logs
+    class RequestLogs
+      def initialize(logger)
+        @incomplete_requests = {}
+        @logger = logger
+      end
+
+      def start_request(request_id, env)
+        request = ActionDispatch::Request.new(env)
+
+        @logger.info(
+          sprintf('Started %<method>s "%<path>s" for user: %<user>s, ip: %<ip>s with vcap-request-id: %<request_id>s at %<at>s',
+                  method: request.request_method,
+                  path: request.filtered_path,
+                  user: env['cf.user_guid'],
+                  ip: anonymize_ip(request.ip),
+                  request_id: request_id,
+                  at: Time.now.utc)
+        )
+        @incomplete_requests.store(request_id, env)
+      end
+
+      def complete_request(request_id, status)
+        @incomplete_requests.delete(request_id)
+        @logger.info("Completed #{status} vcap-request-id: #{request_id}")
+      end
+
+      def log_incomplete_requests
+        @incomplete_requests.each do |request_id, env|
+          request = ActionDispatch::Request.new(env)
+
+          @logger.error(
+            sprintf('Incomplete request: %<method>s "%<path>s" for user: %<user>s, ip: %<ip>s with vcap-request-id: %<request_id>s',
+                    method: request.request_method,
+                    path: request.filtered_path,
+                    user: env['cf.user_guid'],
+                    ip: anonymize_ip(request.ip),
+                    request_id: request_id)
+          )
+        end
+      end
+
+      private
+
+      def anonymize_ip(request_ip)
+        # Remove last octet of ip if EU GDPR compliance is needed
+        ip = IPAddr.new(request_ip) rescue nil
+        if VCAP::CloudController::Config.config.get(:logging, :anonymize_ips) && ip.nil?.!
+          if ip.ipv4?
+            ip.to_string.split('.')[0...-1].join('.') + '.0'
+          else
+            ip.to_string.split(':')[0...-5].join(':') + ':0000:0000:0000:0000:0000'
+          end
+        else
+          ip.to_string rescue request_ip
+        end
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -11,7 +11,7 @@ require 'zipkin'
 
 module VCAP::CloudController
   class RackAppBuilder
-    def build(config, request_metrics)
+    def build(config, request_metrics, request_logs)
       token_decoder = VCAP::CloudController::UaaTokenDecoder.new(config.get(:uaa))
       configurer = VCAP::CloudController::Security::SecurityContextConfigurer.new(token_decoder)
 
@@ -24,7 +24,7 @@ module VCAP::CloudController
         use CloudFoundry::Middleware::NewRelicCustomAttributes if config.get(:newrelic_enabled)
         use Honeycomb::Rack::Middleware, client: Honeycomb.client if config.get(:honeycomb)
         use CloudFoundry::Middleware::SecurityContextSetter, configurer
-        use CloudFoundry::Middleware::RequestLogs, Steno.logger('cc.api')
+        use CloudFoundry::Middleware::RequestLogs, request_logs
         use CloudFoundry::Middleware::Zipkin
         if config.get(:rate_limiter, :enabled)
           use CloudFoundry::Middleware::RateLimiter, {

--- a/middleware/request_logs.rb
+++ b/middleware/request_logs.rb
@@ -1,43 +1,18 @@
-require 'ipaddr'
-
 module CloudFoundry
   module Middleware
     class RequestLogs
-      def initialize(app, logger)
+      def initialize(app, request_logs)
+        @request_logs = request_logs
         @app = app
-        @logger = logger
-      end
-
-      def anonymize_ip(request_ip)
-        # Remove last octet of ip if EU GDPR compliance is needed
-        ip = IPAddr.new(request_ip) rescue nil
-        if VCAP::CloudController::Config.config.get(:logging, :anonymize_ips) && ip.nil?.!
-          if ip.ipv4?
-            ip.to_string.split('.')[0...-1].join('.') + '.0'
-          else
-            ip.to_string.split(':')[0...-5].join(':') + ':0000:0000:0000:0000:0000'
-          end
-        else
-          ip.to_string rescue request_ip
-        end
       end
 
       def call(env)
-        request = ActionDispatch::Request.new(env)
-
-        @logger.info(
-          sprintf('Started %<method>s "%<path>s" for user: %<user>s, ip: %<ip>s with vcap-request-id: %<request_id>s at %<at>s',
-            method: request.request_method,
-            path: request.filtered_path,
-            user: env['cf.user_guid'],
-            ip: anonymize_ip(request.ip),
-            request_id: env['cf.request_id'],
-            at: Time.now.utc)
-        )
+        request_id = env['cf.request_id']
+        @request_logs.start_request(request_id, env)
 
         status, headers, body = @app.call(env)
 
-        @logger.info("Completed #{status} vcap-request-id: #{env['cf.request_id']}")
+        @request_logs.complete_request(request_id, status)
 
         [status, headers, body]
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -200,7 +200,9 @@ each_run_block = proc do
     rspec_config.after(:each, type: :legacy_api) { add_deprecation_warning }
 
     RspecApiDocumentation.configure do |c|
-      c.app = VCAP::CloudController::RackAppBuilder.new.build(TestConfig.config_instance, VCAP::CloudController::Metrics::RequestMetrics.new)
+      c.app = VCAP::CloudController::RackAppBuilder.new.build(TestConfig.config_instance,
+                                                              VCAP::CloudController::Metrics::RequestMetrics.new,
+                                                              VCAP::CloudController::Logs::RequestLogs.new(Steno.logger('request.logs')))
       c.format = [:html, :json]
       c.api_name = 'Cloud Foundry API'
       c.template_path = 'spec/api/documentation/templates'

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -4,6 +4,7 @@ module RequestSpecHelper
   def app
     test_config     = TestConfig.config_instance
     request_metrics = VCAP::CloudController::Metrics::RequestMetrics.new
-    VCAP::CloudController::RackAppBuilder.new.build test_config, request_metrics
+    request_logs    = VCAP::CloudController::Logs::RequestLogs.new(Steno.logger('request.logs'))
+    VCAP::CloudController::RackAppBuilder.new.build(test_config, request_metrics, request_logs)
   end
 end

--- a/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+require 'cloud_controller/logs/request_logs'
+
+module VCAP::CloudController::Logs
+  RSpec.describe RequestLogs do
+    let(:request_logs) { RequestLogs.new(logger) }
+    let(:logger) { double('logger', info: nil) }
+    let(:fake_request) { double('request', request_method: 'request_method', ip: 'ip', filtered_path: 'filtered_path') }
+    let(:request_id) { 'ID' }
+    let(:env) { { 'cf.user_guid' => 'user-guid' } }
+    let(:status) { 200 }
+
+    describe 'logging' do
+      before do
+        allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+      end
+
+      it 'logs the start of a request' do
+        request_logs.start_request(request_id, env)
+        expect(logger).to have_received(:info).with(/Started.+user: user-guid.+with vcap-request-id: ID/)
+      end
+
+      it 'logs the completion of a request' do
+        request_logs.complete_request(request_id, status)
+        expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/)
+      end
+
+      context 'anonymize_ips flag is true' do
+        before do
+          TestConfig.override(logging: { anonymize_ips: 'true' })
+        end
+
+        it 'logs non ip addresses in ip field unaltered' do
+          request_logs.start_request(request_id, env)
+          expect(logger).to have_received(:info).with(/ip: ip/)
+        end
+      end
+
+      context 'request with ipv4 address' do
+        let(:fake_request) { double('request', request_method: 'request_method', ip: '192.168.1.80', filtered_path: 'filtered_path') }
+
+        context 'anonymize_ips flag is false' do
+          it 'logs full ipv4 addresses' do
+            request_logs.start_request(request_id, env)
+            expect(logger).to have_received(:info).with(/ip: 192.168.1.80/)
+          end
+        end
+
+        context 'anonymize_ips flag is true' do
+          before do
+            TestConfig.override(logging: { anonymize_ips: 'true' })
+          end
+
+          it 'logs anonymized ipv4 addresses' do
+            request_logs.start_request(request_id, env)
+            expect(logger).to have_received(:info).with(/ip: 192.168.1.0/)
+          end
+        end
+      end
+
+      context 'request with ipv6 address' do
+        let(:fake_request) { double('request', request_method: 'request_method', ip: '2001:0db8:85a3:1234:0000:8a2e:0370:7334', filtered_path: 'filtered_path') }
+
+        context 'anonymize_ips flag is false' do
+          it 'logs canonical and unaltered ipv6 addresses' do
+            request_logs.start_request(request_id, env)
+            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:8a2e:0370:7334/)
+          end
+        end
+
+        context 'anonymize_ips flag is true' do
+          before do
+            TestConfig.override(logging: { anonymize_ips: 'true' })
+          end
+
+          it 'logs canonical and anonymized ipv6 addresses' do
+            request_logs.start_request(request_id, env)
+            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/)
+          end
+        end
+      end
+
+      context 'request with non canonical(shortened) ipv6 address' do
+        let(:fake_request) { double('request', request_method: 'request_method', ip: '2001:db8:85a3:1234::370:0', filtered_path: 'filtered_path') }
+
+        context 'anonymize_ips flag is false' do
+          it 'logs canonical and unaltered ipv6 addresses' do
+            request_logs.start_request(request_id, env)
+            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:0000:0370:0000/)
+          end
+        end
+
+        context 'anonymize_ips flag is true' do
+          before do
+            TestConfig.override(logging: { anonymize_ips: 'true' })
+          end
+
+          it 'logs canonical and anonymized ipv6 addresses' do
+            request_logs.start_request(request_id, env)
+            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
@@ -5,11 +5,24 @@ module VCAP::CloudController
     subject(:builder) { RackAppBuilder.new }
 
     describe '#build' do
-      let(:request_metrics) { nil }
+      let(:request_metrics) { double }
+      let(:request_logs) { double }
+
+      before do
+        allow(CloudFoundry::Middleware::RequestMetrics).to receive(:new)
+        allow(CloudFoundry::Middleware::RequestLogs).to receive(:new)
+      end
 
       it 'returns a Rack application' do
-        expect(builder.build(TestConfig.config_instance, request_metrics)).to be_a(Rack::Builder)
-        expect(builder.build(TestConfig.config_instance, request_metrics)).to respond_to(:call)
+        expect(builder.build(TestConfig.config_instance, request_metrics, request_logs)).to be_a(Rack::Builder)
+        expect(builder.build(TestConfig.config_instance, request_metrics, request_logs)).to respond_to(:call)
+      end
+
+      it 'uses RequestMetrics and RequestLogs middleware' do
+        builder.build(TestConfig.config_instance, request_metrics, request_logs).to_app
+
+        expect(CloudFoundry::Middleware::RequestMetrics).to have_received(:new).with(anything, request_metrics)
+        expect(CloudFoundry::Middleware::RequestLogs).to have_received(:new).with(anything, request_logs)
       end
 
       describe 'Rack::CommonLogger' do
@@ -18,13 +31,13 @@ module VCAP::CloudController
         end
 
         it 'uses Rack::CommonLogger when nginx is disabled' do
-          builder.build(TestConfig.override(nginx: { use_nginx: false }), request_metrics).to_app
+          builder.build(TestConfig.override(nginx: { use_nginx: false }), request_metrics, request_logs).to_app
 
           expect(Rack::CommonLogger).to have_received(:new).with(anything, instance_of(File))
         end
 
         it 'does not use Rack::CommonLogger when nginx is enabled' do
-          builder.build(TestConfig.override(nginx: { use_nginx: true }), request_metrics).to_app
+          builder.build(TestConfig.override(nginx: { use_nginx: true }), request_metrics, request_logs).to_app
 
           expect(Rack::CommonLogger).to_not have_received(:new)
         end
@@ -42,7 +55,7 @@ module VCAP::CloudController
               reset_interval_in_minutes: 60,
               general_limit: 123,
               unauthenticated_limit: 1,
-            }), request_metrics).to_app
+            }), request_metrics, request_logs).to_app
           end
 
           it 'enables the RateLimiter middleware' do
@@ -63,7 +76,7 @@ module VCAP::CloudController
               reset_interval_in_minutes: 60,
               general_limit: 123,
               unauthenticated_limit: 1
-            }), request_metrics).to_app
+            }), request_metrics, request_logs).to_app
           end
 
           it 'does not enable the RateLimiter middleware' do
@@ -79,7 +92,7 @@ module VCAP::CloudController
 
         context 'when new relic is enabled' do
           before do
-            builder.build(TestConfig.override(newrelic_enabled: true), request_metrics).to_app
+            builder.build(TestConfig.override(newrelic_enabled: true), request_metrics, request_logs).to_app
           end
 
           it 'enables the New Relic custom attribute middleware' do
@@ -89,7 +102,7 @@ module VCAP::CloudController
 
         context 'when new relic is NOT enabled' do
           before do
-            builder.build(TestConfig.override(newrelic_enabled: false), request_metrics).to_app
+            builder.build(TestConfig.override(newrelic_enabled: false), request_metrics, request_logs).to_app
           end
 
           it 'does NOT enable the New Relic custom attribute middleware' do
@@ -104,7 +117,7 @@ module VCAP::CloudController
         end
 
         it 'does not include Cef Middleware when security_event_logging is disabled' do
-          builder.build(TestConfig.override(security_event_logging: { enabled: false }), request_metrics).to_app
+          builder.build(TestConfig.override(security_event_logging: { enabled: false }), request_metrics, request_logs).to_app
 
           expect(CloudFoundry::Middleware::CefLogs).not_to have_received(:new)
         end
@@ -113,7 +126,7 @@ module VCAP::CloudController
           fake_logger = instance_double(Logger)
           allow(Logger).to receive(:new).with(TestConfig.config_instance.get(:security_event_logging, :file)).and_return(fake_logger)
           enabled_config = TestConfig.config_instance.get(:security_event_logging).merge(enabled: true)
-          builder.build(TestConfig.override(security_event_logging: enabled_config), request_metrics).to_app
+          builder.build(TestConfig.override(security_event_logging: enabled_config), request_metrics, request_logs).to_app
 
           expect(CloudFoundry::Middleware::CefLogs).to have_received(:new).with(anything, fake_logger, TestConfig.config_instance.get(:local_route))
         end

--- a/spec/unit/middleware/request_logs_spec.rb
+++ b/spec/unit/middleware/request_logs_spec.rb
@@ -4,106 +4,24 @@ require 'request_logs'
 module CloudFoundry
   module Middleware
     RSpec.describe RequestLogs do
-      let(:middleware) { RequestLogs.new(app, logger) }
+      let(:middleware) { RequestLogs.new(app, request_logs) }
       let(:app) { double(:app, call: [200, {}, 'a body']) }
-      let(:logger) { double('logger', info: nil) }
-      let(:fake_request) { double('request', request_method: 'request_method', ip: 'ip', filtered_path: 'filtered_path') }
-      let(:env) { { 'cf.request_id' => 'ID', 'cf.user_guid' => 'user-guid' } }
+      let(:request_logs) { instance_double(VCAP::CloudController::Logs::RequestLogs, start_request: nil, complete_request: nil) }
+      let(:env) { { 'cf.request_id' => 'ID' } }
 
-      describe 'logging' do
-        before do
-          allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+      describe 'handling the request' do
+        it 'calls start request on request logs before the request' do
+          middleware.call(env)
+          expect(request_logs).to have_received(:start_request).with('ID', env)
         end
 
         it 'returns the app response unaltered' do
           expect(middleware.call(env)).to eq([200, {}, 'a body'])
         end
 
-        it 'logs before calling the app' do
+        it 'calls complete request on request logs after the request' do
           middleware.call(env)
-          expect(logger).to have_received(:info).with(/Started.+user: user-guid.+with vcap-request-id: ID/)
-        end
-
-        it 'logs after calling the app' do
-          middleware.call(env)
-          expect(logger).to have_received(:info).with(/Completed.+vcap-request-id: ID/)
-        end
-
-        context 'anonymize_ips flag is true' do
-          before do
-            TestConfig.override(logging: { anonymize_ips: 'true' })
-          end
-
-          it 'logs non ip adresses in ip field unaltered' do
-            middleware.call(env)
-            expect(logger).to have_received(:info).with(/ip: ip/)
-          end
-        end
-
-        context 'request with ipv4 adress' do
-          let(:fake_request) { double('request', request_method: 'request_method', ip: '192.168.1.80', filtered_path: 'filtered_path') }
-
-          context 'anonymize_ips flag is false' do
-            it 'logs full ipv4 adresses' do
-              middleware.call(env)
-              expect(logger).to have_received(:info).with(/ip: 192.168.1.80/)
-            end
-          end
-
-          context 'anonymize_ips flag is true' do
-            before do
-              TestConfig.override(logging: { anonymize_ips: 'true' })
-            end
-
-            it 'logs anonymized ipv4 adresses' do
-              middleware.call(env)
-              expect(logger).to have_received(:info).with(/ip: 192.168.1.0/)
-            end
-          end
-        end
-
-        context 'request with ipv6 adress' do
-          let(:fake_request) { double('request', request_method: 'request_method', ip: '2001:0db8:85a3:1234:0000:8a2e:0370:7334', filtered_path: 'filtered_path') }
-
-          context 'anonymize_ips flag is false' do
-            it 'logs canonical and unaltered ipv6 adresses' do
-              middleware.call(env)
-              expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:8a2e:0370:7334/)
-            end
-          end
-
-          context 'anonymize_ips flag is true' do
-            before do
-              TestConfig.override(logging: { anonymize_ips: 'true' })
-            end
-
-            it 'logs canonical and anonymized ipv6 adresses' do
-              middleware.call(env)
-              expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/)
-            end
-          end
-        end
-
-        context 'request with non canonical(shortened) ipv6 adress' do
-          let(:fake_request) { double('request', request_method: 'request_method', ip: '2001:db8:85a3:1234::370:0', filtered_path: 'filtered_path') }
-
-          context 'anonymize_ips flag is false' do
-            it 'logs canonical and unaltered ipv6 adresses' do
-              middleware.call(env)
-              expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:0000:0370:0000/)
-            end
-          end
-
-          context 'anonymize_ips flag is true' do
-            before do
-              TestConfig.override(logging: { anonymize_ips: 'true' })
-            end
-
-            it 'logs canonical and anonymized ipv6 adresses' do
-              middleware.call(env)
-              expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/)
-            end
-          end
+          expect(request_logs).to have_received(:complete_request).with('ID', 200)
         end
       end
     end

--- a/spec/unit/middleware/request_metrics_spec.rb
+++ b/spec/unit/middleware/request_metrics_spec.rb
@@ -14,6 +14,10 @@ module CloudFoundry
           expect(request_metrics).to have_received(:start_request)
         end
 
+        it 'returns the app response unaltered' do
+          expect(middleware.call({})).to eq([200, {}, 'a body'])
+        end
+
         it 'calls complete request on request metrics after the request' do
           middleware.call({})
           expect(request_metrics).to have_received(:complete_request).with(200)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
When CC receives the signal to stop execution, it simply aborts outstanding requests. With this change, all incomplete requests will be written into the log file when (after) the Thin server is stopped.

  The request logging code has been restructured similar to `Metrics::RequestMetrics`.

* An explanation of the use cases your change solves
This change enables operators to identify requests that have not been completed due to a restart of Cloud Controller. Without this change it was required to search through the logs and compare the `Started ...` and `Completed ...` messages in order to identify which requests were still processed when CC stopped. This helps analyzing potentially blocking and/or slow requests that need to be improved.

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
