### PR TITLE
Fix typo in service_credential_bindings docs

### DIFF
--- a/docs/v3/source/includes/resources/service_credential_bindings/_details.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_details.md.erb
@@ -24,7 +24,7 @@ Content-Type: application/json
 This endpoint retrieves the service credential binding details.
 
 #### Definition
-`GET /v3/service_service_credential_bindings/:guid/details`
+`GET /v3/service_credential_bindings/:guid/details`
 
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/service_credential_bindings/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_get.md.erb
@@ -36,7 +36,7 @@ Content-Type: application/json
 This endpoint retrieves the service credential binding by GUID.
 
 #### Definition
-`GET /v3/service_service_credential_bindings/:guid`
+`GET /v3/service_credential_bindings/:guid`
 
 #### Query parameters
 


### PR DESCRIPTION
Spotted a small typo

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
