### PR TITLE
Do not set VCAP_APPLICATION env var during kpack staging

### DIFF
--- a/lib/cloud_controller/kpack/stager.rb
+++ b/lib/cloud_controller/kpack/stager.rb
@@ -101,7 +101,7 @@ module Kpack
 
     def get_environment_variables(staging_details)
       staging_details.environment_variables.
-        except('VCAP_SERVICES').
+        except('VCAP_SERVICES', 'VCAP_APPLICATION').
         map { |key, value| { name: key, value: value.to_s } }
     end
 

--- a/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
+++ b/spec/unit/lib/cloud_controller/kpack/stager_spec.rb
@@ -13,7 +13,14 @@ module Kpack
     )
     }
     let(:package) { VCAP::CloudController::PackageModel.make }
-    let(:environment_variables) { { 'BP_JAVA_VERSION' => '8.*', 'BPL_HEAD_ROOM' => 0, 'VCAP_SERVICES' => { postgres: [] } } }
+    let(:environment_variables) {
+      {
+        'BP_JAVA_VERSION' => '8.*',
+        'BPL_HEAD_ROOM' => 0,
+        'VCAP_SERVICES' => { postgres: [] },
+        'VCAP_APPLICATION' => { limits: { fds: 16384, mem: 1024, disk: 4096 } }
+      }
+    }
     let(:staging_memory_in_mb) { 1024 }
     let(:staging_disk_in_mb) { 1024 }
     let(:blobstore_url_generator) do


### PR DESCRIPTION
* A short explanation of the proposed change:

We have noticed that during kpack staging, VCAP_APPLICATION is set to a Hash#to_s string. It should be a json string, although in diego staging, VCAP_APPLICATION is not set at all.

This PR excludes VCAP_APPLICATION from the environment in the same way that VCAP_SERVICES is already excluded.

* An explanation of the use cases your change solves

When deploying postfacto, for example, the rails-assets precompilation triggers `bundle exec rails assets:precompile` which ends up trying to [deserialise VCAP_APPLICATION from json](https://github.com/pivotal/postfacto/blob/89d4d5e07b9399e99fa963b6020547fba04d358b/api/lib/configurations/action_cable_host_provider.rb#L37). This fails as it gets the ruby hash string. In CF on VMs, VCAP_APPLICATION is not set and the staging succeeds.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
