### PR TITLE
Space application supporter roles permissions

### DIFF
--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -261,6 +261,7 @@ module VCAP::CloudController
         spaces__id: dataset.join_table(:inner, :spaces_developers, space_id: :id, user_id: user.id).select(:spaces__id).
           union(dataset.join_table(:inner, :spaces_managers, space_id: :id, user_id: user.id).select(:spaces__id)).
           union(dataset.join_table(:inner, :spaces_auditors, space_id: :id, user_id: user.id).select(:spaces__id)).
+          union(dataset.join_table(:inner, :spaces_application_supporters, space_id: :id, user_id: user.id).select(:spaces__id)).
           union(dataset.join_table(:inner, :organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__id)).
           select(:id)
       }

--- a/docs/v3/source/includes/resources/roles/_get.md.erb
+++ b/docs/v3/source/includes/resources/roles/_get.md.erb
@@ -44,5 +44,6 @@ Org Manager | Can see roles in managed organizations or spaces in those organiza
 Org Auditor | Can only see organization roles in audited organizations
 Org Billing Manager | Can only see organization roles in billing-managed organizations
 Space Auditor | Can see roles in audited spaces or parent organizations
+[Space Application Supporter](#valid-role-types) (*under development*) | Can see roles in supported spaces or parent organizations
 Space Developer | Can see roles in developed spaces or parent organizations
 Space Manager | Can see roles in managed spaces or parent organizations

--- a/spec/request/roles_spec.rb
+++ b/spec/request/roles_spec.rb
@@ -1024,11 +1024,21 @@ RSpec.describe 'Roles Request' do
           )
         }
 
+        h['space_application_supporter'] = {
+          code: 200,
+          response_objects: contain_exactly(
+            space_auditor_response_object,
+            org_auditor_response_object,
+            make_org_role_for_current_user('organization_user'),
+            make_space_role_for_current_user('space_application_supporter')
+          )
+        }
+
         h['no_role'] = { code: 200, response_objects: [] }
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
       context 'when the user is not logged in' do
         it 'returns 401 for Unauthenticated requests' do
@@ -1342,14 +1352,18 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
       end
 
       let(:expected_codes_and_responses) do
-        responses_for_space_restricted_single_endpoint(expected_response)
+        h = Hash.new(code: 200, response_object: expected_response)
+        h['org_auditor'] = { code: 404 }
+        h['org_billing_manager'] = { code: 404 }
+        h['no_role'] = { code: 404 }
+        h
       end
 
       before do
         org.add_user(user_with_role)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when getting a org role' do
@@ -1386,7 +1400,7 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when the role does not exist' do


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Allow space application_supporters to list and get roles

* An explanation of the use cases your change solves

Adresses #2228

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
