### PR TITLE
Allow application supporters to use route endpoints

### DIFF
--- a/app/controllers/v3/domains_controller.rb
+++ b/app/controllers/v3/domains_controller.rb
@@ -56,7 +56,7 @@ class DomainsController < ApplicationController
     message = DomainShowMessage.new({ guid: hashed_params['guid'] })
     unprocessable!(message.errors.full_messages) unless message.valid?
 
-    domain = find_domain(message)
+    domain = find_domain(message, include_application_supporters: true)
     domain_not_found! unless domain
 
     check_route_params = to_route_list_params(query_params, domain)
@@ -161,8 +161,8 @@ class DomainsController < ApplicationController
     check_route_params
   end
 
-  def find_domain(message)
-    readable_org_guids = permission_queryer.readable_org_guids_for_domains
+  def find_domain(message, include_application_supporters: false)
+    readable_org_guids = permission_queryer.readable_org_guids_for_domains(include_application_supporters: include_application_supporters)
     domain = DomainFetcher.fetch(
       message,
       readable_org_guids

--- a/app/controllers/v3/routes_controller.rb
+++ b/app/controllers/v3/routes_controller.rb
@@ -46,7 +46,7 @@ class RoutesController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     route = Route.find(guid: message.guid)
-    route_not_found! unless route && permission_queryer.can_read_route?(route.space.guid, route.organization.guid)
+    route_not_found! unless route && permission_queryer.untrusted_can_read_route?(route.space.guid, route.organization.guid)
 
     decorators = []
     decorators << IncludeRouteDomainDecorator if IncludeRouteDomainDecorator.match?(message.include)
@@ -70,7 +70,7 @@ class RoutesController < ApplicationController
 
     unprocessable_space! unless space
     unprocessable_domain! unless domain
-    unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
     unprocessable_wildcard! if domain.shared? && message.wildcard? && !permission_queryer.can_write_globally?
 
     route = RouteCreate.new(user_audit_info).create(message: message, space: space, domain: domain)
@@ -93,8 +93,8 @@ class RoutesController < ApplicationController
     message = RouteUpdateMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
 
-    route_not_found! unless route && permission_queryer.can_read_route?(route.space.guid, route.organization.guid)
-    unauthorized! unless permission_queryer.can_write_to_space?(route.space.guid)
+    route_not_found! unless route && permission_queryer.untrusted_can_read_route?(route.space.guid, route.organization.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(route.space.guid)
 
     route = VCAP::CloudController::RouteUpdate.new.update(route: route, message: message)
 
@@ -106,8 +106,8 @@ class RoutesController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     route = Route.find(guid: message.guid)
-    route_not_found! unless route && permission_queryer.can_read_route?(route.space.guid, route.organization.guid)
-    unauthorized! unless permission_queryer.can_write_to_space?(route.space.guid)
+    route_not_found! unless route && permission_queryer.untrusted_can_read_route?(route.space.guid, route.organization.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(route.space.guid)
 
     delete_action = RouteDeleteAction.new(user_audit_info)
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Route, route.guid, delete_action)
@@ -121,7 +121,7 @@ class RoutesController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     route = Route.find(guid: message.guid)
-    route_not_found! unless route && permission_queryer.can_read_route?(route.space.guid, route.organization.guid)
+    route_not_found! unless route && permission_queryer.untrusted_can_read_route?(route.space.guid, route.organization.guid)
 
     destinations_message = RouteDestinationsListMessage.from_params(query_params)
     unprocessable!(destinations_message.errors.full_messages) unless destinations_message.valid?
@@ -135,9 +135,9 @@ class RoutesController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     route = Route.find(guid: hashed_params[:guid])
-    route_not_found! unless route && permission_queryer.can_read_route?(route.space.guid, route.organization.guid)
+    route_not_found! unless route && permission_queryer.untrusted_can_read_route?(route.space.guid, route.organization.guid)
 
-    unauthorized! unless permission_queryer.can_write_to_space?(route.space.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(route.space.guid)
 
     desired_app_guids = message.destinations.map { |dst| HashUtils.dig(dst, :app, :guid) }.compact
 
@@ -157,9 +157,9 @@ class RoutesController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     route = Route.find(guid: hashed_params[:guid])
-    route_not_found! unless route && permission_queryer.can_read_route?(route.space.guid, route.organization.guid)
+    route_not_found! unless route && permission_queryer.untrusted_can_read_route?(route.space.guid, route.organization.guid)
 
-    unauthorized! unless permission_queryer.can_write_to_space?(route.space.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(route.space.guid)
 
     desired_app_guids = message.destinations.map { |dst| HashUtils.dig(dst, :app, :guid) }.compact
 
@@ -176,8 +176,8 @@ class RoutesController < ApplicationController
 
   def destroy_destination
     route = Route.find(guid: hashed_params[:guid])
-    route_not_found! unless route && permission_queryer.can_read_route?(route.space.guid, route.organization.guid)
-    unauthorized! unless permission_queryer.can_write_to_space?(route.space.guid)
+    route_not_found! unless route && permission_queryer.untrusted_can_read_route?(route.space.guid, route.organization.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(route.space.guid)
 
     destination = RouteMappingModel.find(guid: hashed_params[:destination_guid])
     unprocessable_destination! unless destination
@@ -194,7 +194,7 @@ class RoutesController < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     app, space, org = AppFetcher.new.fetch(hashed_params['guid'])
-    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
 
     dataset = RouteFetcher.fetch(
       message,

--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -134,9 +134,9 @@ class SpacesV3Controller < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     space = fetch_space(hashed_params[:guid])
-    space_not_found! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
+    space_not_found! unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
 
-    unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
 
     deletion_job = VCAP::CloudController::Jobs::V3::SpaceDeleteUnmappedRoutesJob.new(space)
     pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable

--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -128,6 +128,7 @@ module VCAP::CloudController
       space_guids = Space.join(:spaces_developers, space_id: :id, user_id: user.id).select(:spaces__guid).
                     union(Space.join(:spaces_managers, space_id: :id, user_id: user.id).select(:spaces__guid)).
                     union(Space.join(:spaces_auditors, space_id: :id, user_id: user.id).select(:spaces__guid)).
+                    union(Space.join(:spaces_application_supporters, space_id: :id, user_id: user.id).select(:spaces__guid)).
                     union(Space.join(:organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__guid))
       {
         apps__guid: AppModel.where(space: space_guids.all).select(:guid)

--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -166,6 +166,8 @@ module VCAP::CloudController
            ).union(
              Space.dataset.join_table(:inner, :spaces_auditors, space_id: :id, user_id: user.id).select(:spaces__id)
            ).union(
+             Space.dataset.join_table(:inner, :spaces_application_supporters, space_id: :id, user_id: user.id).select(:spaces__id)
+           ).union(
              Space.dataset.join_table(:inner, :organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__id)
            ).union(
              Space.dataset.join_table(:inner, :organizations_auditors, organization_id: :organization_id, user_id: user.id).select(:spaces__id)

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -30,6 +30,7 @@ module VCAP::CloudController
     define_user_group :developers, reciprocal: :spaces, before_add: :validate_developer
     define_user_group :managers, reciprocal: :managed_spaces, before_add: :validate_manager
     define_user_group :auditors, reciprocal: :audited_spaces, before_add: :validate_auditor
+    define_user_group :application_supporters, reciprocal: :application_supporter_spaces, before_add: :validate_application_supporter
 
     many_to_one :organization, before_set: :validate_change_organization
 
@@ -155,7 +156,7 @@ module VCAP::CloudController
     export_attributes :name, :organization_guid, :space_quota_definition_guid, :allow_ssh
 
     import_attributes :name, :organization_guid, :developer_guids, :allow_ssh, :isolation_segment_guid,
-      :manager_guids, :auditor_guids, :security_group_guids, :space_quota_definition_guid
+      :manager_guids, :auditor_guids, :application_supporter_guids, :security_group_guids, :space_quota_definition_guid
 
     strip_attributes :name
 
@@ -192,6 +193,10 @@ module VCAP::CloudController
 
     def has_developer?(user)
       user.present? && developers_dataset.where(user_id: user.id).present?
+    end
+
+    def has_application_supporter?(user)
+      user.present? && application_supporters_dataset.where(user_id: user.id).present?
     end
 
     def has_member?(user)

--- a/docs/v3/source/includes/resources/routes/_check_route_reservations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_check_route_reservations.md.erb
@@ -48,3 +48,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_create.md.erb
+++ b/docs/v3/source/includes/resources/routes/_create.md.erb
@@ -65,4 +65,5 @@ Role  | Notes
 ----- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental |
 

--- a/docs/v3/source/includes/resources/routes/_delete.md.erb
+++ b/docs/v3/source/includes/resources/routes/_delete.md.erb
@@ -28,4 +28,5 @@ Role  | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental |
 

--- a/docs/v3/source/includes/resources/routes/_delete_unmapped.md.erb
+++ b/docs/v3/source/includes/resources/routes/_delete_unmapped.md.erb
@@ -30,5 +30,6 @@ Role  | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental |
 
 **Note**: `unmapped=true` is a required query parameter; always include it.

--- a/docs/v3/source/includes/resources/routes/_get.md.erb
+++ b/docs/v3/source/includes/resources/routes/_get.md.erb
@@ -42,4 +42,5 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Application Supporter | Experimental |
 

--- a/docs/v3/source/includes/resources/routes/_insert_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_insert_destinations.md.erb
@@ -56,7 +56,8 @@ replace all destinations for a route at once using the [replace destinations end
 
 #### Permitted roles
 
-| Role            |
-| --------------- |
+| Role            | Notes |
+| --------------- | --- |
 | Admin           |
 | Space Developer |
+| Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_list_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_destinations.md.erb
@@ -45,3 +45,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
@@ -42,7 +42,7 @@ Name | Type | Description
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
- |
+Role  | Notes
 --- | ---
 Admin |
 Admin Read-Only |
@@ -51,3 +51,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_remove_destination.md.erb
+++ b/docs/v3/source/includes/resources/routes/_remove_destination.md.erb
@@ -29,3 +29,4 @@ Role  | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_replace_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_replace_destinations.md.erb
@@ -91,7 +91,8 @@ and unweighted destinations for a route is not allowed.
 
 #### Permitted roles
 
-| Role            |
-| --------------- |
+| Role            | Notes |
+| --------------- | --- |
 | Admin           |
 | Space Developer |
+| Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_update.md.erb
+++ b/docs/v3/source/includes/resources/routes/_update.md.erb
@@ -44,3 +44,4 @@ Role | Notes
 ----- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental |

--- a/lib/cloud_controller/permissions/queryer.rb
+++ b/lib/cloud_controller/permissions/queryer.rb
@@ -69,10 +69,10 @@ class VCAP::CloudController::Permissions::Queryer
     end
   end
 
-  def readable_org_guids_for_domains
+  def readable_org_guids_for_domains(include_application_supporters: false)
     science 'readable_org_guids_for_domains' do |e|
       e.use do
-        db_permissions.readable_org_guids_for_domains
+        db_permissions.readable_org_guids_for_domains(include_application_supporters: include_application_supporters)
       end
       e.try do
         perm_permissions.readable_org_guids_for_domains
@@ -174,6 +174,10 @@ class VCAP::CloudController::Permissions::Queryer
     end
   end
 
+  def untrusted_can_write_to_space?(space_guid)
+    db_permissions.untrusted_can_write_to_space?(space_guid)
+  end
+
   def can_update_space?(space_guid, org_guid)
     science 'can_update_space' do |e|
       e.context(space_guid: space_guid, org_guid: org_guid)
@@ -217,6 +221,10 @@ class VCAP::CloudController::Permissions::Queryer
 
       e.run_if { !db_permissions.can_read_globally? }
     end
+  end
+
+  def untrusted_can_read_route?(space_guid, org_guid)
+    db_permissions.untrusted_can_read_route?(space_guid, org_guid)
   end
 
   def readable_app_guids

--- a/spec/request/domains_spec.rb
+++ b/spec/request/domains_spec.rb
@@ -650,7 +650,7 @@ RSpec.describe 'Domains Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'there are route matches' do
@@ -678,7 +678,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when querying with only host' do
@@ -705,7 +705,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when querying with only port' do
@@ -741,7 +741,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
         context 'when querying a TCP route without filtering the port' do
           it 'returns no matching routes' do

--- a/spec/request/route_destinations_spec.rb
+++ b/spec/request/route_destinations_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe 'Route Destinations Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when the route does not exist' do
@@ -291,12 +291,13 @@ RSpec.describe 'Route Destinations Request' do
 
         h['admin'] = { code: 200, response_object: response_json }
         h['space_developer'] = { code: 200, response_object: response_json }
+        h['space_application_supporter'] = { code: 200, response_object: response_json }
         h['org_billing_manager'] = { code: 404 }
         h['no_role'] = { code: 404 }
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
         let(:expected_event_hash) do
           new_destination = parsed_response['destinations'].detect { |dst| dst['guid'] != existing_destination.guid }
 
@@ -696,12 +697,13 @@ RSpec.describe 'Route Destinations Request' do
 
         h['admin'] = { code: 200, response_object: response_json }
         h['space_developer'] = { code: 200, response_object: response_json }
+        h['space_application_supporter'] = { code: 200, response_object: response_json }
         h['org_billing_manager'] = { code: 404 }
         h['no_role'] = { code: 404 }
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
       context 'when the user is not logged in' do
         it 'returns 401 for Unauthenticated requests' do
@@ -1100,12 +1102,13 @@ RSpec.describe 'Route Destinations Request' do
 
         h['admin'] = { code: 204 }
         h['space_developer'] = { code: 204 }
+        h['space_application_supporter'] = { code: 204 }
         h['org_billing_manager'] = { code: 404 }
         h['no_role'] = { code: 404 }
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
         let(:expected_event_hash) do
           {
             type: 'audit.app.unmap-route',

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     describe 'includes' do
@@ -950,7 +950,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     describe 'when the user is not logged in' do
@@ -1167,10 +1167,14 @@ RSpec.describe 'Routes Request' do
               code: 201,
               response_object: route_json
             }
+            h['space_application_supporter'] = {
+              code: 201,
+              response_object: route_json
+            }
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
         end
       end
 
@@ -1239,6 +1243,10 @@ RSpec.describe 'Routes Request' do
                 response_object: route_json
               }
               h['space_developer'] = {
+                code: 201,
+                response_object: route_json
+              }
+              h['space_application_supporter'] = {
                 code: 201,
                 response_object: route_json
               }
@@ -1322,10 +1330,14 @@ RSpec.describe 'Routes Request' do
               code: 201,
               response_object: route_json
             }
+            h['space_application_supporter'] = {
+              code: 201,
+              response_object: route_json
+            }
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
         end
       end
     end
@@ -1416,10 +1428,14 @@ RSpec.describe 'Routes Request' do
               code: 201,
               response_object: route_json
             }
+            h['space_application_supporter'] = {
+              code: 201,
+              response_object: route_json
+            }
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
         end
       end
 
@@ -1483,12 +1499,14 @@ RSpec.describe 'Routes Request' do
             }
             h['space_developer'] = {
               code: 422,
-              response_object: { fasd: 'afsd' }
+            }
+            h['space_application_supporter'] = {
+              code: 422,
             }
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
         end
       end
 
@@ -1568,11 +1586,15 @@ RSpec.describe 'Routes Request' do
             code: 201,
             response_object: route_json
           }
+          h['space_application_supporter'] = {
+            code: 201,
+            response_object: route_json
+          }
           h.freeze
         end
 
         context 'and the user provides a valid port' do
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
           context 'and a route with the domain and port already exist' do
             let!(:duplicate_route) { VCAP::CloudController::Route.make(host: '', space: space, domain: domain, port: 123) }
@@ -1610,7 +1632,7 @@ RSpec.describe 'Routes Request' do
             }
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
           context 'and randomly selected port is already in use' do
             let(:existing_route) { VCAP::CloudController::Route.make(host: '', space: space, domain: domain, port: 123) }
@@ -1703,15 +1725,10 @@ RSpec.describe 'Routes Request' do
             code: 201,
             response_object: route_json
           }
-          h['space_developer'] = {
-            code: 403,
-            # code: 422,
-            # response_object: { tater: 'tots' }
-          }
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
     end
 
@@ -1825,10 +1842,14 @@ RSpec.describe 'Routes Request' do
               code: 201,
               response_object: route_json
             }
+            h['space_application_supporter'] = {
+              code: 201,
+              response_object: route_json
+            }
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
         end
       end
     end
@@ -2051,6 +2072,10 @@ RSpec.describe 'Routes Request' do
           code: 201,
           response_object: route_json
         }
+        h['space_application_supporter'] = {
+          code: 201,
+          response_object: route_json
+        }
         h.freeze
       end
 
@@ -2058,7 +2083,7 @@ RSpec.describe 'Routes Request' do
         VCAP::CloudController::Config.config.set(:system_domain, domain.name)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     describe 'quotas' do
@@ -2360,10 +2385,11 @@ RSpec.describe 'Routes Request' do
         h['no_role'] = { code: 404 }
         h['org_billing_manager'] = { code: 404 }
         h['space_developer'] = { code: 200, response_object: route_json }
+        h['space_application_supporter'] = { code: 200, response_object: route_json }
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when the user is not a member in the routes org' do
@@ -2423,7 +2449,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when route does not exist' do
@@ -2509,10 +2535,11 @@ RSpec.describe 'Routes Request' do
 
         h['admin'] = { code: 202 }
         h['space_developer'] = { code: 202 }
+        h['space_application_supporter'] = { code: 202 }
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
         let(:expected_event_hash) do
           {
             type: 'audit.route.delete-request',
@@ -2645,7 +2672,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'ports filter' do

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -1023,10 +1023,11 @@ RSpec.describe 'Spaces' do
 
         h['admin'] = { code: 202 }
         h['space_developer'] = { code: 202 }
+        h['space_application_supporter'] = { code: 202 }
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when user does not specify unmapped query param' do

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -212,6 +212,7 @@ module UserHelpers
 
   def allow_user_write_access(user, space:)
     allow(permissions_double(user)).to receive(:can_write_to_space?).with(space.guid).and_return(true)
+    allow(permissions_double(user)).to receive(:untrusted_can_write_to_space?).with(space.guid).and_return(true)
   end
 
   def allow_user_read_access_for(user, orgs: [], spaces: [])
@@ -266,6 +267,7 @@ module UserHelpers
 
   def disallow_user_write_access(user, space:)
     allow(permissions_double(user)).to receive(:can_write_to_space?).with(space.guid).and_return(false)
+    allow(permissions_double(user)).to receive(:untrusted_can_write_to_space?).with(space.guid).and_return(true)
   end
 
   def stub_readable_space_guids_for(user, spaces)

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -157,25 +157,38 @@ module VCAP::CloudController
 
     describe '#readable_org_guids_for_domains' do
       context 'when user has valid membership' do
-        it 'combines readable orgs for both org-scoped and space-scoped roles' do
-          first_org_guid = double(:first_org_guid)
-          second_org_guid = double(:second_org_guid)
-          space_guid = double(:space_guid)
+        let(:membership) { instance_double(Membership) }
+        let(:space_guid) { double(:space_guid) }
+        let(:first_org_guid) { double(:first_org_guid) }
+        let(:second_org_guid) { double(:second_org_guid) }
+
+        before do
           organization = double(:organization, guid: second_org_guid)
           space = double(:space, organization: organization)
 
-          membership = instance_double(Membership)
           allow(membership).to receive(:org_guids_for_roles).
             with(Permissions::ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS).
             and_return([first_org_guid])
-          allow(membership).to receive(:space_guids_for_roles).
-            with(Permissions::SPACE_ROLES).
-            and_return([space_guid])
           allow(Membership).to receive(:new).with(user).and_return(membership)
           allow(Space).to receive(:find).with(guid: space_guid).
             and_return(space)
+        end
+
+        it 'combines readable orgs for both org-scoped and space-scoped roles' do
+          allow(membership).to receive(:space_guids_for_roles).
+            with(Permissions::SPACE_ROLES).
+            and_return([space_guid])
 
           expect(permissions.readable_org_guids_for_domains).
+            to contain_exactly(first_org_guid, second_org_guid)
+        end
+
+        it 'combines readable orgs for both org-scoped and space-scoped roles including application supporters' do
+          allow(membership).to receive(:space_guids_for_roles).
+            with(Permissions::SPACE_ROLES_INCLUDING_APPLICATION_SUPPORTERS).
+            and_return([space_guid])
+
+          expect(permissions.readable_org_guids_for_domains(include_application_supporters: true)).
             to contain_exactly(first_org_guid, second_org_guid)
         end
       end
@@ -715,6 +728,85 @@ module VCAP::CloudController
       end
     end
 
+    describe '#untrusted_can_write_to_space?' do
+      context 'user has no membership' do
+        context 'and user is an admin' do
+          it 'returns true' do
+            set_current_user(user, { admin: true })
+            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be true
+          end
+        end
+
+        context 'and user is admin_read_only' do
+          it 'return false' do
+            set_current_user_as_admin_read_only
+            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+          end
+        end
+
+        context 'and user is global auditor' do
+          it 'return false' do
+            set_current_user_as_global_auditor
+            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+          end
+        end
+
+        context 'and user is not an admin' do
+          it 'return false' do
+            set_current_user(user)
+            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+          end
+        end
+      end
+
+      context 'user has valid membership' do
+        it 'returns true for space developer' do
+          org.add_user(user)
+          space.add_developer(user)
+          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be true
+        end
+
+        it 'returns true for space application supporter' do
+          org.add_user(user)
+          space.add_application_supporter(user)
+          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be true
+        end
+
+        context "and the space's org is suspended" do
+          it 'returns false for the space developer' do
+            org.add_user(user)
+            space.add_developer(user)
+            org.update(status: Organization::SUSPENDED)
+            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be_falsey
+          end
+
+          it 'returns false for the space application supporter' do
+            org.add_user(user)
+            space.add_application_supporter(user)
+            org.update(status: Organization::SUSPENDED)
+            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be_falsey
+          end
+        end
+
+        it 'returns false for space manager' do
+          org.add_user(user)
+          space.add_manager(user)
+          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+        end
+
+        it 'returns false for space auditor' do
+          org.add_user(user)
+          space.add_auditor(user)
+          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+        end
+
+        it 'returns false for org manager' do
+          org.add_manager(user)
+          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+        end
+      end
+    end
+
     describe '#can_update_space?' do
       context 'user has no membership' do
         context 'and user is an admin' do
@@ -1068,6 +1160,13 @@ module VCAP::CloudController
         expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
+      it 'returns false for space application supporter' do
+        org.add_user(user)
+        space.add_application_supporter(user)
+
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be false
+      end
+
       it 'returns false for org billing manager' do
         org.add_user(user)
         org.add_billing_manager(user)
@@ -1083,6 +1182,82 @@ module VCAP::CloudController
 
       it 'returns false for other user' do
         expect(permissions.can_read_route?(space_guid, org_guid)).to be false
+      end
+    end
+
+    describe '#untrusted_can_read_route?' do
+      it 'returns true if user is an admin' do
+        set_current_user(user, { admin: true })
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+      end
+
+      it 'returns true if user is a read-only admin' do
+        set_current_user(user, { admin_read_only: true })
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+      end
+
+      it 'returns true if user is a global auditor' do
+        set_current_user_as_global_auditor
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+      end
+
+      it 'returns true for space developer' do
+        org.add_user(user)
+        space.add_developer(user)
+
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+      end
+
+      it 'returns true for space manager' do
+        org.add_user(user)
+        space.add_manager(user)
+
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+      end
+
+      it 'returns true for space auditor' do
+        org.add_user(user)
+        space.add_auditor(user)
+
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+      end
+
+      it 'returns true for space application supporter' do
+        org.add_user(user)
+        space.add_application_supporter(user)
+
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+      end
+
+      it 'returns true for org manager' do
+        org.add_user(user)
+        org.add_manager(user)
+
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+      end
+
+      it 'returns true for org auditor' do
+        org.add_user(user)
+        org.add_auditor(user)
+
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+      end
+
+      it 'returns false for org billing manager' do
+        org.add_user(user)
+        org.add_billing_manager(user)
+
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be false
+      end
+
+      it 'returns false for regular org user' do
+        org.add_user(user)
+
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be false
+      end
+
+      it 'returns false for other user' do
+        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be false
       end
     end
 


### PR DESCRIPTION
The readable_org_guids_for_domains function takes a flag for now about
whether to include application supporters. All usages of this function
will eventually set this flag to true at which point it can be removed.

As some controllers start using the untrusted_* functions, the
user_helpers spec file needs to return the correct value for whichever
of these functions has been called. The tests that use this helper do
not need to know which of the two functions was called, only that the
permission will or will not be granted.

Added a has_application_supporter? public function to the space object
so that we can use untrusted_can_read_route? as the can_read_route?
function is used by v2 endpoints which we don't want to grant access to
for application supporters

Co-authored-by: Philipp Thun <philipp.thun@sap.com>

Closes #2229 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
