### PR TITLE
Log service broker requests at info level

### DIFF
--- a/lib/services/service_brokers/v2/http_client.rb
+++ b/lib/services/service_brokers/v2/http_client.rb
@@ -69,9 +69,11 @@ module VCAP::Services
 
         headers = client.default_header.merge(opts[:header])
 
+        logger.info 'request', method: method, url: uri.to_s
         logger.debug "Sending #{method} to #{uri}, BODY: #{body.inspect}, HEADERS: #{headers}"
 
         response = client.request(method, uri, opts)
+        logger.info 'response', status: response.code
         logger.debug "Response from request to #{uri}: STATUS #{response.code}, BODY: #{redact_credentials(response)}, HEADERS: #{response.headers.inspect}"
 
         HttpResponse.from_http_client_response(response)


### PR DESCRIPTION
Service brokers represent complex external systems that can easily fail
so adding some logging at info level should allow operators to debug
failing brokers more easily. Both request and response log lines include
a request_guid (which is the VCAP request ID) from the Steno context for
tracking requests from both the CC and broker sides

Resolves #2292 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
