### PR TITLE
Allow space application supporter to access specific app POST endpoints

### DIFF
--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -157,9 +157,9 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
   def start
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
     unprocessable_lacking_droplet! unless app.droplet
-    unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
 
     if app.lifecycle_type == DockerLifecycleDataModel::LIFECYCLE_TYPE
       FeatureFlag.raise_unless_enabled!(:diego_docker)
@@ -180,8 +180,8 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
   def stop
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
-    unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
 
     AppStop.stop(app: app, user_audit_info: user_audit_info)
     TelemetryLogger.v3_emit(
@@ -199,9 +199,9 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
   def restart
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
     unprocessable_lacking_droplet! unless app.droplet
-    unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
 
     if app.lifecycle_type == DockerLifecycleDataModel::LIFECYCLE_TYPE
       FeatureFlag.raise_unless_enabled!(:diego_docker)

--- a/docs/v3/source/includes/resources/apps/_restart.md.erb
+++ b/docs/v3/source/includes/resources/apps/_restart.md.erb
@@ -32,7 +32,9 @@ For restarting applications without downtime, see the [deployments](#deployments
 `POST /v3/apps/:guid/actions/restart`
 
 #### Permitted roles
- |
+
+Role | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/apps/_start.md.erb
+++ b/docs/v3/source/includes/resources/apps/_start.md.erb
@@ -25,7 +25,9 @@ Content-Type: application/json
 `POST /v3/apps/:guid/actions/start`
 
 #### Permitted roles
- |
+
+Role | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/apps/_stop.md.erb
+++ b/docs/v3/source/includes/resources/apps/_stop.md.erb
@@ -25,7 +25,9 @@ Content-Type: application/json
 `POST /v3/apps/:guid/actions/stop`
 
 #### Permitted roles
- |
+
+Role | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental |

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -2093,7 +2093,7 @@ RSpec.describe 'Apps' do
     end
   end
 
-  describe 'PUT /v3/apps/:guid/start' do
+  describe 'POST /v3/apps/:guid/actions/start' do
     let(:stack) { VCAP::CloudController::Stack.make(name: 'stack-name') }
     let(:app_model) {
       VCAP::CloudController::AppModel.make(
@@ -2103,319 +2103,6 @@ RSpec.describe 'Apps' do
         desired_state: 'STOPPED',
       )
     }
-
-    before do
-      space.organization.add_user(user)
-      space.add_developer(user)
-    end
-
-    it 'starts the app' do
-      app_model.lifecycle_data.buildpacks = ['http://example.com/git']
-      app_model.lifecycle_data.stack = stack.name
-      app_model.lifecycle_data.save
-
-      droplet = VCAP::CloudController::DropletModel.make(:buildpack, app: app_model, state: VCAP::CloudController::DropletModel::STAGED_STATE)
-      app_model.droplet = droplet
-      app_model.save
-
-      post "/v3/apps/#{app_model.guid}/actions/start", nil, user_header
-      expect(last_response.status).to eq(200)
-
-      parsed_response = MultiJson.load(last_response.body)
-      expect(parsed_response).to be_a_response_like({
-                                                        'name' => 'app-name',
-                                                        'guid' => app_model.guid,
-                                                        'state' => 'STARTED',
-                                                        'created_at' => iso8601,
-                                                        'updated_at' => iso8601,
-                                                        'metadata' => { 'labels' => {}, 'annotations' => {} },
-                                                        'lifecycle' => {
-                                                            'type' => 'buildpack',
-                                                            'data' => {
-                                                                'buildpacks' => ['http://example.com/git'],
-                                                                'stack' => 'stack-name',
-                                                            }
-                                                        },
-                                                        'relationships' => {
-                                                            'space' => {
-                                                                'data' => {
-                                                                    'guid' => space.guid
-                                                                }
-                                                            }
-                                                        },
-                                                        'links' => {
-                                                            'self' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}" },
-                                                            'processes' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/processes" },
-                                                            'packages' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/packages" },
-                                                            'environment_variables' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/environment_variables" },
-                                                            'space' => { 'href' => "#{link_prefix}/v3/spaces/#{space.guid}" },
-                                                            'current_droplet' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets/current" },
-                                                            'droplets' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets" },
-                                                            'tasks' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/tasks" },
-                                                            'start' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/start", 'method' => 'POST' },
-                                                            'stop' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/stop", 'method' => 'POST' },
-                                                            'revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions" },
-                                                            'deployed_revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions/deployed" },
-                                                            'features' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/features" },
-                                                        }
-                                                    })
-
-      event = VCAP::CloudController::Event.last
-      expect(event.values).to include({
-                                          type: 'audit.app.start',
-                                          actee: app_model.guid,
-                                          actee_type: 'app',
-                                          actee_name: 'app-name',
-                                          actor: user.guid,
-                                          actor_type: 'user',
-                                          actor_name: user_email,
-                                          actor_username: user_name,
-                                          space_guid: space.guid,
-                                          organization_guid: space.organization.guid,
-                                      })
-    end
-
-    context 'telemetry' do
-      it 'should log the required fields when the app starts' do
-        app_model.lifecycle_data.buildpacks = ['http://example.com/git']
-        app_model.lifecycle_data.stack = stack.name
-        app_model.lifecycle_data.save
-
-        droplet = VCAP::CloudController::DropletModel.make(:buildpack, app: app_model, state: VCAP::CloudController::DropletModel::STAGED_STATE)
-        app_model.droplet = droplet
-        app_model.save
-
-        Timecop.freeze do
-          expected_json = {
-            'telemetry-source' => 'cloud_controller_ng',
-            'telemetry-time' => Time.now.to_datetime.rfc3339,
-            'start-app' => {
-              'api-version' => 'v3',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
-            }
-          }
-          expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
-          post "/v3/apps/#{app_model.guid}/actions/start", nil, user_header
-
-          expect(last_response.status).to eq(200), last_response.body
-        end
-      end
-    end
-
-    describe 'when there is a new desired droplet and revision feature is turned on' do
-      let(:droplet) {
-        VCAP::CloudController::DropletModel.make(
-          app: app_model,
-          process_types: { web: 'rackup' },
-          state: VCAP::CloudController::DropletModel::STAGED_STATE,
-          package: VCAP::CloudController::PackageModel.make
-        )
-      }
-
-      before do
-        app_model.update(revisions_enabled: true)
-      end
-
-      it 'creates a new revision' do
-        expect {
-          patch "/v3/apps/#{app_model.guid}/relationships/current_droplet", { data: { guid: droplet.guid } }.to_json, user_header
-          expect(last_response.status).to eq(200)
-        }.to change { VCAP::CloudController::RevisionModel.count }.by(0)
-
-        expect {
-          post "/v3/apps/#{app_model.guid}/actions/start", nil, user_header
-          expect(last_response.status).to eq(200), last_response.body
-        }.to change { VCAP::CloudController::RevisionModel.count }.by(1)
-      end
-    end
-
-    context 'when app lifecycle is kpack' do
-      let(:app_model) { VCAP::CloudController::AppModel.make(:kpack, name: 'app-name', droplet: VCAP::CloudController::DropletModel.make(:kpack), space: space) }
-
-      before do
-        VCAP::CloudController::FeatureFlag.make(name: 'diego_docker', enabled: false, error_message: nil)
-      end
-
-      it 'starts the app' do
-        post "/v3/apps/#{app_model.guid}/actions/start", nil, user_header
-        expect(last_response.status).to eq(200)
-
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response).to be_a_response_like({
-          'name' => 'app-name',
-          'guid' => app_model.guid,
-          'state' => 'STARTED',
-          'created_at' => iso8601,
-          'updated_at' => iso8601,
-          'metadata' => { 'labels' => {}, 'annotations' => {} },
-          'lifecycle' => {
-            'type' => 'kpack',
-            'data' => {
-              'buildpacks' => []
-            },
-          },
-          'relationships' => {
-            'space' => {
-              'data' => {
-                'guid' => space.guid
-              }
-            }
-          },
-          'links' => {
-            'self' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}" },
-            'processes' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/processes" },
-            'packages' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/packages" },
-            'environment_variables' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/environment_variables" },
-            'space' => { 'href' => "#{link_prefix}/v3/spaces/#{space.guid}" },
-            'current_droplet' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets/current" },
-            'droplets' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets" },
-            'tasks' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/tasks" },
-            'start' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/start", 'method' => 'POST' },
-            'stop' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/stop", 'method' => 'POST' },
-            'revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions" },
-            'deployed_revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions/deployed" },
-            'features' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/features" },
-          }
-        })
-
-        event = VCAP::CloudController::Event.last
-        expect(event.values).to include({
-          type: 'audit.app.start',
-          actee: app_model.guid,
-          actee_type: 'app',
-          actee_name: 'app-name',
-          actor: user.guid,
-          actor_type: 'user',
-          actor_name: user_email,
-          actor_username: user_name,
-          space_guid: space.guid,
-          organization_guid: space.organization.guid,
-        })
-      end
-    end
-  end
-
-  describe 'POST /v3/apps/:guid/actions/stop' do
-    let(:stack) { VCAP::CloudController::Stack.make(name: 'stack-name') }
-    let(:app_model) { VCAP::CloudController::AppModel.make(
-      :buildpack,
-      name: 'app-name',
-      space: space,
-      desired_state: 'STARTED',
-    )
-    }
-    let!(:droplet) do
-      VCAP::CloudController::DropletModel.make(:buildpack,
-        app: app_model,
-        state: VCAP::CloudController::DropletModel::STAGED_STATE
-      )
-    end
-
-    before do
-      space.organization.add_user(user)
-      space.add_developer(user)
-      app_model.lifecycle_data.buildpacks = ['http://example.com/git']
-      app_model.lifecycle_data.stack = stack.name
-      app_model.lifecycle_data.save
-      app_model.droplet = droplet
-      app_model.save
-    end
-    it 'stops the app' do
-      post "/v3/apps/#{app_model.guid}/actions/stop", nil, user_header
-      expect(last_response.status).to eq(200)
-
-      parsed_response = MultiJson.load(last_response.body)
-      expect(parsed_response).to be_a_response_like(
-        {
-            'name' => 'app-name',
-            'guid' => app_model.guid,
-            'state' => 'STOPPED',
-            'created_at' => iso8601,
-            'updated_at' => iso8601,
-            'metadata' => { 'labels' => {}, 'annotations' => {} },
-            'lifecycle' => {
-                'type' => 'buildpack',
-                'data' => {
-                    'buildpacks' => ['http://example.com/git'],
-                    'stack' => 'stack-name',
-                }
-            },
-            'relationships' => {
-                'space' => {
-                    'data' => {
-                        'guid' => space.guid
-                    }
-                }
-            },
-            'links' => {
-                'self' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}" },
-                'processes' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/processes" },
-                'packages' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/packages" },
-                'environment_variables' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/environment_variables" },
-                'space' => { 'href' => "#{link_prefix}/v3/spaces/#{space.guid}" },
-                'current_droplet' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets/current" },
-                'droplets' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets" },
-                'tasks' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/tasks" },
-                'start' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/start", 'method' => 'POST' },
-                'stop' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/stop", 'method' => 'POST' },
-                'revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions" },
-                'deployed_revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions/deployed" },
-                'features' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/features" },
-            }
-        }
-      )
-      event = VCAP::CloudController::Event.last
-      expect(event.values).to include({
-                                          type: 'audit.app.stop',
-                                          actee: app_model.guid,
-                                          actee_type: 'app',
-                                          actee_name: 'app-name',
-                                          actor: user.guid,
-                                          actor_type: 'user',
-                                          actor_name: user_email,
-                                          actor_username: user_name,
-                                          space_guid: space.guid,
-                                          organization_guid: space.organization.guid,
-                                      })
-    end
-
-    context 'telemetry' do
-      it 'should log the required fields when the app starts' do
-        Timecop.freeze do
-          expected_json = {
-            'telemetry-source' => 'cloud_controller_ng',
-            'telemetry-time' => Time.now.to_datetime.rfc3339,
-            'stop-app' => {
-              'api-version' => 'v3',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
-            }
-          }
-          expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
-
-          post "/v3/apps/#{app_model.guid}/actions/stop", nil, user_header
-
-          expect(last_response.status).to eq(200), last_response.body
-        end
-      end
-    end
-  end
-
-  describe 'POST /v3/apps/:guid/actions/restart' do
-    let(:stack) { VCAP::CloudController::Stack.make(name: 'stack-name') }
-    let(:app_model) { VCAP::CloudController::AppModel.make(
-      :buildpack,
-        name: 'app-name',
-        space: space,
-        desired_state: 'STARTED',
-      )
-    }
-
-    before do
-      space.organization.add_user(user)
-      space.add_developer(user)
-    end
 
     context 'app lifecycle is buildpack' do
       let!(:droplet) do
@@ -2434,66 +2121,119 @@ RSpec.describe 'Apps' do
         app_model.save
       end
 
-      it 'restarts the app' do
-        post "/v3/apps/#{app_model.guid}/actions/restart", nil, user_header
-        expect(last_response.status).to eq(200)
-
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response).to be_a_response_like(
+      context 'it starts the app' do
+        let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/start", nil, user_headers } }
+        let(:app_start_response_object) do
           {
-              'name' => 'app-name',
-              'guid' => app_model.guid,
-              'state' => 'STARTED',
-              'created_at' => iso8601,
-              'updated_at' => iso8601,
-              'metadata' => { 'labels' => {}, 'annotations' => {} },
-              'lifecycle' => {
-                  'type' => 'buildpack',
-                  'data' => {
-                      'buildpacks' => ['http://example.com/git'],
-                      'stack' => 'stack-name',
-                  }
-              },
-              'relationships' => {
-                  'space' => {
-                      'data' => {
-                          'guid' => space.guid
-                      }
-                  }
-              },
-              'links' => {
-                  'self' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}" },
-                  'processes' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/processes" },
-                  'packages' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/packages" },
-                  'environment_variables' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/environment_variables" },
-                  'space' => { 'href' => "#{link_prefix}/v3/spaces/#{space.guid}" },
-                  'current_droplet' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets/current" },
-                  'droplets' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets" },
-                  'tasks' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/tasks" },
-                  'start' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/start", 'method' => 'POST' },
-                  'stop' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/stop", 'method' => 'POST' },
-                  'revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions" },
-                  'deployed_revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions/deployed" },
-                  'features' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/features" },
+            'name' => 'app-name',
+            'guid' => app_model.guid,
+            'state' => 'STARTED',
+            'created_at' => iso8601,
+            'updated_at' => iso8601,
+            'metadata' => { 'labels' => {}, 'annotations' => {} },
+            'lifecycle' => {
+              'type' => 'buildpack',
+              'data' => {
+                'buildpacks' => ['http://example.com/git'],
+                'stack' => 'stack-name',
               }
+            },
+            'relationships' => {
+              'space' => {
+                'data' => {
+                  'guid' => space.guid
+                }
+              }
+            },
+            'links' => {
+              'self' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}" },
+              'processes' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/processes" },
+              'packages' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/packages" },
+              'environment_variables' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/environment_variables" },
+              'space' => { 'href' => "#{link_prefix}/v3/spaces/#{space.guid}" },
+              'current_droplet' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets/current" },
+              'droplets' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets" },
+              'tasks' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/tasks" },
+              'start' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/start", 'method' => 'POST' },
+              'stop' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/stop", 'method' => 'POST' },
+              'revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions" },
+              'deployed_revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions/deployed" },
+              'features' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/features" },
+            }
           }
-        )
+        end
+
+        let(:expected_codes_and_responses) do
+          h = Hash.new(code: 403)
+          h['no_role'] = { code: 404 }
+          h['org_auditor'] = { code: 404 }
+          h['org_billing_manager'] = { code: 404 }
+          h['admin'] = {
+            code: 200,
+            response_object: app_start_response_object
+          }
+          h['space_application_supporter'] = {
+            code: 200,
+            response_object: app_start_response_object
+          }
+          h['space_developer'] = {
+            code: 200,
+            response_object: app_start_response_object
+          }
+          h.freeze
+        end
+
+        before do
+          space.organization.add_user(user)
+        end
+
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
+
+      context 'events' do
+        before do
+          space.organization.add_user(user)
+          space.add_developer(user)
+        end
+
+        it 'should issue the required events when the app starts' do
+          post "/v3/apps/#{app_model.guid}/actions/start", nil, user_header
+
+          event = VCAP::CloudController::Event.last
+          expect(event.values).to include({
+            type: 'audit.app.start',
+            actee: app_model.guid,
+            actee_type: 'app',
+            actee_name: 'app-name',
+            actor: user.guid,
+            actor_type: 'user',
+            actor_name: user_email,
+            actor_username: user_name,
+            space_guid: space.guid,
+            organization_guid: space.organization.guid,
+          })
+        end
+      end
+
       context 'telemetry' do
-        it 'should log the required fields when the app is restarted' do
+        before do
+          space.organization.add_user(user)
+          space.add_developer(user)
+        end
+
+        it 'should log the required fields when the app starts' do
           Timecop.freeze do
             expected_json = {
               'telemetry-source' => 'cloud_controller_ng',
               'telemetry-time' => Time.now.to_datetime.rfc3339,
-              'restart-app' => {
+              'start-app' => {
                 'api-version' => 'v3',
                 'app-id' => Digest::SHA256.hexdigest(app_model.guid),
                 'user-id' => Digest::SHA256.hexdigest(user.guid),
               }
             }
             expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
-
-            post "/v3/apps/#{app_model.guid}/actions/restart", nil, user_header
+            post "/v3/apps/#{app_model.guid}/actions/start", nil, user_header
 
             expect(last_response.status).to eq(200), last_response.body
           end
@@ -2501,25 +2241,45 @@ RSpec.describe 'Apps' do
       end
     end
 
-    context 'app lifecycle is kpack' do
-      let(:app_model) {
-        VCAP::CloudController::AppModel.make(:kpack,
-          name: 'app-name',
-          droplet: VCAP::CloudController::DropletModel.make(:kpack),
-          space: space,
-          desired_state: 'STARTED')
+    describe 'when there is a new desired droplet and revision feature is turned on' do
+      let(:droplet) {
+        VCAP::CloudController::DropletModel.make(
+          app: app_model,
+          process_types: { web: 'rackup' },
+          state: VCAP::CloudController::DropletModel::STAGED_STATE,
+          package: VCAP::CloudController::PackageModel.make
+        )
       }
+
+      before do
+        space.organization.add_user(user)
+        space.add_developer(user)
+        app_model.update(revisions_enabled: true)
+      end
+
+      it 'creates a new revision' do
+        expect {
+          patch "/v3/apps/#{app_model.guid}/relationships/current_droplet", { data: { guid: droplet.guid } }.to_json, user_header
+          expect(last_response.status).to eq(200)
+        }.to change { VCAP::CloudController::RevisionModel.count }.by(0)
+
+        expect {
+          post "/v3/apps/#{app_model.guid}/actions/start", nil, user_header
+          expect(last_response.status).to eq(200), last_response.body
+        }.to change { VCAP::CloudController::RevisionModel.count }.by(1)
+      end
+    end
+
+    context 'app lifecycle is kpack' do
+      let(:app_model) { VCAP::CloudController::AppModel.make(:kpack, name: 'app-name', droplet: VCAP::CloudController::DropletModel.make(:kpack), space: space) }
 
       before do
         VCAP::CloudController::FeatureFlag.make(name: 'diego_docker', enabled: false, error_message: nil)
       end
 
-      it 'restarts the app' do
-        post "/v3/apps/#{app_model.guid}/actions/restart", nil, user_header
-        expect(last_response.status).to eq(200)
-
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response).to be_a_response_like(
+      context 'it starts the app' do
+        let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/start", nil, user_headers } }
+        let(:app_start_response_object) do
           {
             'name' => 'app-name',
             'guid' => app_model.guid,
@@ -2556,7 +2316,384 @@ RSpec.describe 'Apps' do
               'features' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/features" },
             }
           }
+        end
+
+        let(:expected_codes_and_responses) do
+          h = Hash.new(code: 403)
+          h['no_role'] = { code: 404 }
+          h['org_auditor'] = { code: 404 }
+          h['org_billing_manager'] = { code: 404 }
+          h['admin'] = {
+            code: 200,
+            response_object: app_start_response_object
+          }
+          h['space_application_supporter'] = {
+            code: 200,
+            response_object: app_start_response_object
+          }
+          h['space_developer'] = {
+            code: 200,
+            response_object: app_start_response_object
+          }
+          h.freeze
+        end
+
+        before do
+          space.organization.add_user(user)
+        end
+
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      end
+    end
+  end
+
+  describe 'POST /v3/apps/:guid/actions/stop' do
+    let(:stack) { VCAP::CloudController::Stack.make(name: 'stack-name') }
+    let(:app_model) { VCAP::CloudController::AppModel.make(
+      :buildpack,
+      name: 'app-name',
+      space: space,
+      desired_state: 'STARTED',
+    )
+    }
+    let!(:droplet) do
+      VCAP::CloudController::DropletModel.make(:buildpack,
+        app: app_model,
+        state: VCAP::CloudController::DropletModel::STAGED_STATE
+      )
+    end
+
+    before do
+      app_model.lifecycle_data.buildpacks = ['http://example.com/git']
+      app_model.lifecycle_data.stack = stack.name
+      app_model.lifecycle_data.save
+      app_model.droplet = droplet
+      app_model.save
+    end
+
+    context 'it stops the app' do
+      let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/stop", nil, user_headers } }
+      let(:app_stop_response_object) do
+        {
+          'name' => 'app-name',
+          'guid' => app_model.guid,
+          'state' => 'STOPPED',
+          'created_at' => iso8601,
+          'updated_at' => iso8601,
+          'metadata' => { 'labels' => {}, 'annotations' => {} },
+          'lifecycle' => {
+            'type' => 'buildpack',
+            'data' => {
+              'buildpacks' => ['http://example.com/git'],
+              'stack' => 'stack-name',
+            }
+          },
+          'relationships' => {
+            'space' => {
+              'data' => {
+                'guid' => space.guid
+              }
+            }
+          },
+          'links' => {
+            'self' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}" },
+            'processes' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/processes" },
+            'packages' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/packages" },
+            'environment_variables' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/environment_variables" },
+            'space' => { 'href' => "#{link_prefix}/v3/spaces/#{space.guid}" },
+            'current_droplet' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets/current" },
+            'droplets' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets" },
+            'tasks' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/tasks" },
+            'start' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/start", 'method' => 'POST' },
+            'stop' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/stop", 'method' => 'POST' },
+            'revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions" },
+            'deployed_revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions/deployed" },
+            'features' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/features" },
+          }
+        }
+      end
+
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 403)
+        h['no_role'] = { code: 404 }
+        h['org_auditor'] = { code: 404 }
+        h['org_billing_manager'] = { code: 404 }
+        h['admin'] = {
+          code: 200,
+          response_object: app_stop_response_object
+        }
+        h['space_application_supporter'] = {
+          code: 200,
+          response_object: app_stop_response_object
+        }
+        h['space_developer'] = {
+          code: 200,
+          response_object: app_stop_response_object
+        }
+        h.freeze
+      end
+
+      before do
+        space.organization.add_user(user)
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+    end
+
+    context 'events' do
+      before do
+        space.organization.add_user(user)
+        space.add_developer(user)
+      end
+
+      it 'should issue the required events when the app stops' do
+        post "/v3/apps/#{app_model.guid}/actions/stop", nil, user_header
+
+        event = VCAP::CloudController::Event.last
+        expect(event.values).to include({
+          type: 'audit.app.stop',
+          actee: app_model.guid,
+          actee_type: 'app',
+          actee_name: 'app-name',
+          actor: user.guid,
+          actor_type: 'user',
+          actor_name: user_email,
+          actor_username: user_name,
+          space_guid: space.guid,
+          organization_guid: space.organization.guid,
+        })
+      end
+    end
+
+    context 'telemetry' do
+      before do
+        space.organization.add_user(user)
+        space.add_developer(user)
+      end
+
+      it 'should log the required fields when the app stops' do
+        Timecop.freeze do
+          expected_json = {
+            'telemetry-source' => 'cloud_controller_ng',
+            'telemetry-time' => Time.now.to_datetime.rfc3339,
+            'stop-app' => {
+              'api-version' => 'v3',
+              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
+              'user-id' => Digest::SHA256.hexdigest(user.guid),
+            }
+          }
+          expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
+
+          post "/v3/apps/#{app_model.guid}/actions/stop", nil, user_header
+
+          expect(last_response.status).to eq(200), last_response.body
+        end
+      end
+    end
+  end
+
+  describe 'POST /v3/apps/:guid/actions/restart' do
+    let(:stack) { VCAP::CloudController::Stack.make(name: 'stack-name') }
+    let(:app_model) { VCAP::CloudController::AppModel.make(
+      :buildpack,
+        name: 'app-name',
+        space: space,
+        desired_state: 'STARTED',
+      )
+    }
+
+    context 'app lifecycle is buildpack' do
+      let!(:droplet) do
+        VCAP::CloudController::DropletModel.make(
+          :buildpack,
+          app: app_model,
+          state: VCAP::CloudController::DropletModel::STAGED_STATE
         )
+      end
+
+      before do
+        app_model.lifecycle_data.buildpacks = ['http://example.com/git']
+        app_model.lifecycle_data.stack = stack.name
+        app_model.lifecycle_data.save
+        app_model.droplet = droplet
+        app_model.save
+      end
+
+      context 'it restarts the app' do
+        let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/restart", nil, user_headers } }
+        let(:app_restart_response_object) do
+          {
+            'name' => 'app-name',
+            'guid' => app_model.guid,
+            'state' => 'STARTED',
+            'created_at' => iso8601,
+            'updated_at' => iso8601,
+            'metadata' => { 'labels' => {}, 'annotations' => {} },
+            'lifecycle' => {
+              'type' => 'buildpack',
+              'data' => {
+                'buildpacks' => ['http://example.com/git'],
+                'stack' => 'stack-name',
+              }
+            },
+            'relationships' => {
+              'space' => {
+                'data' => {
+                  'guid' => space.guid
+                }
+              }
+            },
+            'links' => {
+              'self' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}" },
+              'processes' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/processes" },
+              'packages' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/packages" },
+              'environment_variables' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/environment_variables" },
+              'space' => { 'href' => "#{link_prefix}/v3/spaces/#{space.guid}" },
+              'current_droplet' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets/current" },
+              'droplets' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets" },
+              'tasks' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/tasks" },
+              'start' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/start", 'method' => 'POST' },
+              'stop' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/stop", 'method' => 'POST' },
+              'revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions" },
+              'deployed_revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions/deployed" },
+              'features' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/features" },
+            }
+          }
+        end
+
+        let(:expected_codes_and_responses) do
+          h = Hash.new(code: 403)
+          h['no_role'] = { code: 404 }
+          h['org_auditor'] = { code: 404 }
+          h['org_billing_manager'] = { code: 404 }
+          h['admin'] = {
+            code: 200,
+            response_object: app_restart_response_object
+          }
+          h['space_application_supporter'] = {
+            code: 200,
+            response_object: app_restart_response_object
+          }
+          h['space_developer'] = {
+            code: 200,
+            response_object: app_restart_response_object
+          }
+          h.freeze
+        end
+
+        before do
+          space.organization.add_user(user)
+        end
+
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      end
+
+      context 'telemetry' do
+        before do
+          space.organization.add_user(user)
+          space.add_developer(user)
+        end
+
+        it 'should log the required fields when the app is restarted' do
+          Timecop.freeze do
+            expected_json = {
+              'telemetry-source' => 'cloud_controller_ng',
+              'telemetry-time' => Time.now.to_datetime.rfc3339,
+              'restart-app' => {
+                'api-version' => 'v3',
+                'app-id' => Digest::SHA256.hexdigest(app_model.guid),
+                'user-id' => Digest::SHA256.hexdigest(user.guid),
+              }
+            }
+            expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
+
+            post "/v3/apps/#{app_model.guid}/actions/restart", nil, user_header
+
+            expect(last_response.status).to eq(200), last_response.body
+          end
+        end
+      end
+    end
+
+    context 'app lifecycle is kpack' do
+      let(:app_model) {
+        VCAP::CloudController::AppModel.make(:kpack,
+          name: 'app-name',
+          droplet: VCAP::CloudController::DropletModel.make(:kpack),
+          space: space,
+          desired_state: 'STARTED')
+      }
+
+      before do
+        VCAP::CloudController::FeatureFlag.make(name: 'diego_docker', enabled: false, error_message: nil)
+      end
+
+      context 'it restarts the app' do
+        let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/restart", nil, user_headers } }
+        let(:app_restart_response_object) do
+          {
+            'name' => 'app-name',
+            'guid' => app_model.guid,
+            'state' => 'STARTED',
+            'created_at' => iso8601,
+            'updated_at' => iso8601,
+            'metadata' => { 'labels' => {}, 'annotations' => {} },
+            'lifecycle' => {
+              'type' => 'kpack',
+              'data' => {
+                'buildpacks' => []
+              },
+            },
+            'relationships' => {
+              'space' => {
+                'data' => {
+                  'guid' => space.guid
+                }
+              }
+            },
+            'links' => {
+              'self' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}" },
+              'processes' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/processes" },
+              'packages' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/packages" },
+              'environment_variables' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/environment_variables" },
+              'space' => { 'href' => "#{link_prefix}/v3/spaces/#{space.guid}" },
+              'current_droplet' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets/current" },
+              'droplets' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/droplets" },
+              'tasks' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/tasks" },
+              'start' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/start", 'method' => 'POST' },
+              'stop' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/actions/stop", 'method' => 'POST' },
+              'revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions" },
+              'deployed_revisions' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/revisions/deployed" },
+              'features' => { 'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/features" },
+            }
+          }
+        end
+
+        let(:expected_codes_and_responses) do
+          h = Hash.new(code: 403)
+          h['no_role'] = { code: 404 }
+          h['org_auditor'] = { code: 404 }
+          h['org_billing_manager'] = { code: 404 }
+          h['admin'] = {
+            code: 200,
+            response_object: app_restart_response_object
+          }
+          h['space_application_supporter'] = {
+            code: 200,
+            response_object: app_restart_response_object
+          }
+          h['space_developer'] = {
+            code: 200,
+            response_object: app_restart_response_object
+          }
+          h.freeze
+        end
+
+        before do
+          space.organization.add_user(user)
+        end
+
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
     end
   end

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -2121,7 +2121,7 @@ RSpec.describe 'Apps' do
         app_model.save
       end
 
-      context 'it starts the app' do
+      context 'starting an app' do
         let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/start", nil, user_headers } }
         let(:app_start_response_object) do
           {
@@ -2277,7 +2277,7 @@ RSpec.describe 'Apps' do
         VCAP::CloudController::FeatureFlag.make(name: 'diego_docker', enabled: false, error_message: nil)
       end
 
-      context 'it starts the app' do
+      context 'starting an app' do
         let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/start", nil, user_headers } }
         let(:app_start_response_object) do
           {
@@ -2371,7 +2371,7 @@ RSpec.describe 'Apps' do
       app_model.save
     end
 
-    context 'it stops the app' do
+    context 'stopping an app' do
       let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/stop", nil, user_headers } }
       let(:app_stop_response_object) do
         {
@@ -2519,7 +2519,7 @@ RSpec.describe 'Apps' do
         app_model.save
       end
 
-      context 'it restarts the app' do
+      context 'restarting an app' do
         let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/restart", nil, user_headers } }
         let(:app_restart_response_object) do
           {
@@ -2628,7 +2628,7 @@ RSpec.describe 'Apps' do
         VCAP::CloudController::FeatureFlag.make(name: 'diego_docker', enabled: false, error_message: nil)
       end
 
-      context 'it restarts the app' do
+      context 'restarting an app' do
         let(:api_call) { lambda { |user_headers| post "/v3/apps/#{app_model.guid}/actions/restart", nil, user_headers } }
         let(:app_restart_response_object) do
           {

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -223,8 +223,10 @@ module UserHelpers
     stub_readable_org_guids_for(user, orgs)
 
     allow(permissions_double(user)).to receive(:can_read_from_space?).and_return(false)
+    allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).and_return(false)
     spaces.each do |space|
       allow(permissions_double(user)).to receive(:can_read_from_space?).with(space.guid, space.organization_guid).and_return(true)
+      allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).with(space.guid, space.organization_guid).and_return(true)
     end
     stub_readable_space_guids_for(user, spaces)
   end
@@ -255,6 +257,7 @@ module UserHelpers
 
   def disallow_user_read_access(user, space:)
     allow(permissions_double(user)).to receive(:can_read_from_space?).with(space.guid, space.organization_guid).and_return(false)
+    allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).with(space.guid, space.organization_guid).and_return(false)
   end
 
   def disallow_user_build_update_access(user)
@@ -267,7 +270,7 @@ module UserHelpers
 
   def disallow_user_write_access(user, space:)
     allow(permissions_double(user)).to receive(:can_write_to_space?).with(space.guid).and_return(false)
-    allow(permissions_double(user)).to receive(:untrusted_can_write_to_space?).with(space.guid).and_return(true)
+    allow(permissions_double(user)).to receive(:untrusted_can_write_to_space?).with(space.guid).and_return(false)
   end
 
   def stub_readable_space_guids_for(user, spaces)


### PR DESCRIPTION
Space application supporters can start, stop and restart applications.

Enhance apps request tests to check permissions for all roles.

Partly implements #2280 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
