### PR TITLE
docs: update service instance list intro

### DIFF
--- a/docs/v3/source/includes/resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list.md.erb
@@ -20,9 +20,7 @@ Content-Type: application/json
 
 <%= yield_content :paginated_list_of_service_instances %>
 ```
-This endpoint retrieves the service instances the user has access to. At the moment, this endpoint only returns managed service instances. This may change in the future.
-
-This includes access granted by service instance sharing.
+This endpoint retrieves the service instances the user has access to, including access granted by service instance sharing.
 
 #### Definition
 `GET /v3/service_instances`


### PR DESCRIPTION
* A short explanation of the proposed change
As of https://github.com/cloudfoundry/cloud_controller_ng/commit/f444b95067b7937df9642257258b54b67503e6e9, the `/v3/service_instances` endpoint returns all types (managed and user provided) of service instances. This PR updates the docs accordingly.


* An explanation of the use cases your change solves
User reading the docs and getting confused on what's returned by the endpoint

* Links to any other associated PRs
N/A

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Given it's only a docs change, I haven't run the tests
