### PR TITLE
Allow space application supporter to access specific app feature endpoints and app PATCH endpoints

### DIFF
--- a/app/controllers/v3/app_features_controller.rb
+++ b/app/controllers/v3/app_features_controller.rb
@@ -12,7 +12,7 @@ class AppFeaturesController < ApplicationController
 
   def index
     app, space, org = AppFetcher.new.fetch(hashed_params[:app_guid])
-    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
     resources = presented_app_features(app)
 
     render status: :ok, json: {
@@ -23,7 +23,7 @@ class AppFeaturesController < ApplicationController
 
   def show
     app, space, org = AppFetcher.new.fetch(hashed_params[:app_guid])
-    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
     resource_not_found!(:feature) unless APP_FEATURES.include?(hashed_params[:name])
 
     render status: :ok, json: feature_presenter_for(hashed_params[:name], app)

--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -289,8 +289,8 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
     cannot_remove_droplet! if hashed_params[:body].key?('data') && droplet_guid.nil?
     app, space, org, droplet = AssignCurrentDropletFetcher.new.fetch(app_guid, droplet_guid)
 
-    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
-    unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
     deployment_in_progress! if app.deploying?
 
     AppAssignDroplet.new(user_audit_info).assign(app, droplet)

--- a/docs/v3/source/includes/resources/app_features/_get.md.erb
+++ b/docs/v3/source/includes/resources/app_features/_get.md.erb
@@ -25,7 +25,8 @@ Content-Type: application/json
 `GET /v3/apps/:guid/features/:name` <br>
 
 #### Permitted roles
- |
+
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
@@ -34,3 +35,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Application Supporter | Experimental

--- a/docs/v3/source/includes/resources/app_features/_list.md.erb
+++ b/docs/v3/source/includes/resources/app_features/_list.md.erb
@@ -27,7 +27,8 @@ This endpoint retrieves the list of features for the specified app.
 `GET /v3/apps/:guid/features`
 
 #### Permitted roles
- |
+
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
@@ -36,3 +37,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Application Supporter | Experimental

--- a/docs/v3/source/includes/resources/app_features/_update.md.erb
+++ b/docs/v3/source/includes/resources/app_features/_update.md.erb
@@ -33,7 +33,9 @@ Name | Type | Description
 **enabled** | _boolean_ | Denotes whether or not the app feature should be enabled
 
 #### Permitted roles
- |
+
+Role | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental / Can only update **revisions** feature

--- a/docs/v3/source/includes/resources/apps/_current_droplet.md.erb
+++ b/docs/v3/source/includes/resources/apps/_current_droplet.md.erb
@@ -29,7 +29,9 @@ Set the current droplet for an app. The current droplet is the droplet that the 
 `PATCH /v3/apps/:guid/relationships/current_droplet`
 
 #### Permitted roles
- |
+
+Role | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Application Supporter | Experimental

--- a/spec/request/app_features_spec.rb
+++ b/spec/request/app_features_spec.rb
@@ -1,23 +1,18 @@
 require 'spec_helper'
+require 'request_spec_shared_examples'
 
 RSpec.describe 'App Features' do
   let(:user) { VCAP::CloudController::User.make }
   let(:user_header) { headers_for(user, email: Sham.email, user_name: 'some-username') }
-  let(:space) { VCAP::CloudController::Space.make }
+  let(:admin_header) { admin_headers_for(user) }
+  let(:org) { VCAP::CloudController::Organization.make(created_at: 3.days.ago) }
+  let(:space) { VCAP::CloudController::Space.make(organization: org) }
   let(:app_model) { VCAP::CloudController::AppModel.make(space: space, enable_ssh: true) }
 
-  before do
-    space.organization.add_user(user)
-    space.add_developer(user)
-  end
-
   describe 'GET /v3/apps/:guid/features' do
-    it 'gets a list of available features for the app' do
-      get "/v3/apps/#{app_model.guid}/features", nil, user_header
-      expect(last_response.status).to eq(200)
-
-      parsed_response = MultiJson.load(last_response.body)
-      expect(parsed_response).to be_a_response_like(
+    context 'getting a list of available features for the app' do
+      let(:api_call) { lambda { |user_headers| get "/v3/apps/#{app_model.guid}/features", nil, user_headers } }
+      let(:features_response_object) do
         {
           'resources' => [
             {
@@ -39,42 +34,118 @@ RSpec.describe 'App Features' do
               'last' => { 'href' => "/v3/apps/#{app_model.guid}/features" },
               'next' => nil,
               'previous' => nil,
-          },
+            },
         }
-      )
+      end
+
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 404)
+        %w[admin admin_read_only global_auditor space_developer space_manager space_auditor org_manager
+           space_application_supporter].each do |r|
+          h[r] = {
+            code: 200,
+            response_object: features_response_object
+          }
+        end
+        h.freeze
+      end
+
+      before do
+        space.organization.add_user(user)
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
   end
 
-  describe 'ssh feature' do
-    describe 'GET /v3/apps/:guid/features/ssh' do
-      it 'gets a specific app feature' do
-        get "/v3/apps/#{app_model.guid}/features/ssh", nil, user_header
-        expect(last_response.status).to eq(200)
-
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response).to be_a_response_like(
-          {
-            'name' => 'ssh',
-            'description' => 'Enable SSHing into the app.',
-            'enabled' => true
-          }
-        )
+  describe 'GET /v3/apps/:guid/features/:name' do
+    let(:expected_codes_and_responses) do
+      h = Hash.new(code: 404)
+      %w[admin admin_read_only global_auditor space_developer space_manager space_auditor org_manager
+         space_application_supporter].each do |r|
+        h[r] = {
+          code: 200,
+          response_object: feature_response_object
+        }
       end
+      h.freeze
     end
 
-    describe 'PATCH /v3/apps/:guid/features/ssh' do
-      it 'enables/disables the specific app feature' do
-        request_body = { body: { enabled: false } }
-        patch "/v3/apps/#{app_model.guid}/features/ssh", request_body.to_json, user_header
+    before do
+      space.organization.add_user(user)
+    end
 
-        expect(last_response.status).to eq(200)
-        parsed_response = MultiJson.load(last_response.body)
-        expect(parsed_response).to be_a_response_like({
+    context 'ssh app feature' do
+      let(:api_call) { lambda { |user_headers| get "/v3/apps/#{app_model.guid}/features/ssh", nil, user_headers } }
+      let(:feature_response_object) do
+        {
+          'name' => 'ssh',
+          'description' => 'Enable SSHing into the app.',
+          'enabled' => true
+        }
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+    end
+
+    context 'revisions app feature' do
+      let(:api_call) { lambda { |user_headers| get "/v3/apps/#{app_model.guid}/features/revisions", nil, user_headers } }
+      let(:feature_response_object) do
+        {
+          'name' => 'revisions',
+          'description' => 'Enable versioning of an application',
+          'enabled' => true
+        }
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+    end
+  end
+
+  describe 'PATCH /v3/apps/:guid/features/:name' do
+    let(:request_body) { { body: { enabled: false } } }
+    let(:expected_codes_and_responses) do
+      h = Hash.new(code: 403)
+      %w[no_role org_auditor org_billing_manager].each do |r|
+        h[r] = { code: 404 }
+      end
+      %w[admin space_developer].each do |r|
+        h[r] = {
+          code: 200,
+          response_object: feature_response_object
+        }
+      end
+      h.freeze
+    end
+
+    before do
+      space.organization.add_user(user)
+    end
+
+    context 'ssh app feature' do
+      let(:api_call) { lambda { |user_headers| patch "/v3/apps/#{app_model.guid}/features/ssh", request_body.to_json, user_headers } }
+      let(:feature_response_object) do
+        {
           'name' => 'ssh',
           'description' => 'Enable SSHing into the app.',
           'enabled' => false
-        })
+        }
       end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+    end
+
+    context 'revisions app feature' do
+      let(:api_call) { lambda { |user_headers| patch "/v3/apps/#{app_model.guid}/features/revisions", request_body.to_json, user_headers } }
+      let(:feature_response_object) do
+        {
+          'name' => 'revisions',
+          'description' => 'Enable versioning of an application',
+          'enabled' => false
+        }
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 end

--- a/spec/request/app_features_spec.rb
+++ b/spec/request/app_features_spec.rb
@@ -104,19 +104,6 @@ RSpec.describe 'App Features' do
 
   describe 'PATCH /v3/apps/:guid/features/:name' do
     let(:request_body) { { body: { enabled: false } } }
-    let(:expected_codes_and_responses) do
-      h = Hash.new(code: 403)
-      %w[no_role org_auditor org_billing_manager].each do |r|
-        h[r] = { code: 404 }
-      end
-      %w[admin space_developer].each do |r|
-        h[r] = {
-          code: 200,
-          response_object: feature_response_object
-        }
-      end
-      h.freeze
-    end
 
     before do
       space.organization.add_user(user)
@@ -132,7 +119,21 @@ RSpec.describe 'App Features' do
         }
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 403)
+        %w[no_role org_auditor org_billing_manager].each do |r|
+          h[r] = { code: 404 }
+        end
+        %w[admin space_developer].each do |r|
+          h[r] = {
+            code: 200,
+            response_object: feature_response_object
+          }
+        end
+        h.freeze
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'revisions app feature' do
@@ -145,7 +146,21 @@ RSpec.describe 'App Features' do
         }
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 403)
+        %w[no_role org_auditor org_billing_manager].each do |r|
+          h[r] = { code: 404 }
+        end
+        %w[admin space_developer space_application_supporter].each do |r|
+          h[r] = {
+            code: 200,
+            response_object: feature_response_object
+          }
+        end
+        h.freeze
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
   end
 end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -223,8 +223,10 @@ module UserHelpers
     stub_readable_org_guids_for(user, orgs)
 
     allow(permissions_double(user)).to receive(:can_read_from_space?).and_return(false)
+    allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).and_return(false)
     spaces.each do |space|
       allow(permissions_double(user)).to receive(:can_read_from_space?).with(space.guid, space.organization_guid).and_return(true)
+      allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).with(space.guid, space.organization_guid).and_return(true)
     end
     stub_readable_space_guids_for(user, spaces)
   end
@@ -255,6 +257,7 @@ module UserHelpers
 
   def disallow_user_read_access(user, space:)
     allow(permissions_double(user)).to receive(:can_read_from_space?).with(space.guid, space.organization_guid).and_return(false)
+    allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).with(space.guid, space.organization_guid).and_return(false)
   end
 
   def disallow_user_build_update_access(user)
@@ -267,7 +270,7 @@ module UserHelpers
 
   def disallow_user_write_access(user, space:)
     allow(permissions_double(user)).to receive(:can_write_to_space?).with(space.guid).and_return(false)
-    allow(permissions_double(user)).to receive(:untrusted_can_write_to_space?).with(space.guid).and_return(true)
+    allow(permissions_double(user)).to receive(:untrusted_can_write_to_space?).with(space.guid).and_return(false)
   end
 
   def stub_readable_space_guids_for(user, spaces)


### PR DESCRIPTION
- Space Application Supporter can assign current droplet
  - Addition of permission checks for changed endpoint.
    - Move droplet creation to parent context (describe) for reuse.
    - Move event emission test into own context (grouped with similar test).
  - Group sidecar tests in context.

- Space Application Supporter can update the revisions feature
  - Ensure that space application supporter cannot update the ssh feature.

- Space Application Supporter can access specific app feature endpoints
  - Addition of permission checks for all /apps/:guid/features endpoints.
  - Addition of tests for the revisions app feature.

Closes #2272
Partly implements #2280

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
