### PR TITLE
Space application supporter /v3/spaces endpoint permissions

### DIFF
--- a/app/controllers/v3/space_features_controller.rb
+++ b/app/controllers/v3/space_features_controller.rb
@@ -6,7 +6,7 @@ class SpaceFeaturesController < ApplicationController
 
   def index
     space = Space.find(guid: hashed_params[:guid])
-    resource_not_found!(:space) unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
+    resource_not_found!(:space) unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
 
     render status: :ok, json: {
       resources: [Presenters::V3::SpaceSshFeaturePresenter.new(space)],
@@ -15,7 +15,7 @@ class SpaceFeaturesController < ApplicationController
 
   def show
     space = SpaceFetcher.new.fetch(hashed_params[:guid])
-    resource_not_found!(:space) unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
+    resource_not_found!(:space) unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
     resource_not_found!(:feature) unless SPACE_FEATURE == hashed_params[:name]
 
     render status: :ok, json: Presenters::V3::SpaceSshFeaturePresenter.new(space)

--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -173,7 +173,7 @@ class SpacesV3Controller < ApplicationController
     space_not_found! unless space
 
     org = space.organization
-    space_not_found! unless permission_queryer.can_read_from_space?(space.guid, org.guid)
+    space_not_found! unless permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
 
     isolation_segment = fetch_isolation_segment(space.isolation_segment_guid)
     render status: :ok, json: Presenters::V3::ToOneRelationshipPresenter.new(

--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -37,7 +37,7 @@ class SpacesV3Controller < ApplicationController
     space = SpaceFetcher.new.fetch(hashed_params[:guid])
     message = SpaceShowMessage.from_params(query_params)
 
-    space_not_found! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
+    space_not_found! unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     decorators = []

--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -226,7 +226,7 @@ class SpacesV3Controller < ApplicationController
         SpaceListFetcher.fetch_all(message: message, eager_loaded_associations: Presenters::V3::SpacePresenter.associated_resources)
       end
     else
-      readable_space_guids = permission_queryer.readable_space_guids
+      readable_space_guids = permission_queryer.readable_application_supporter_space_guids
       filtered_readable_guids = message.requested?(:guids) ? readable_space_guids & message.guids : readable_space_guids
       SpaceListFetcher.fetch(message: message, guids: filtered_readable_guids, eager_loaded_associations: Presenters::V3::SpacePresenter.associated_resources)
     end

--- a/docs/v3/package-lock.json
+++ b/docs/v3/package-lock.json
@@ -719,6 +719,7 @@
         "dom-serializer": "~0.1.0",
         "entities": "~1.1.1",
         "htmlparser2": "~3.8.1",
+        "jsdom": "^7.0.2",
         "lodash": "^4.1.0"
       },
       "engines": {
@@ -932,6 +933,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -4815,9 +4817,13 @@
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
         "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
-        "safer-buffer": "^2.0.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/docs/v3/source/includes/resources/audit_events/_list.md.erb
+++ b/docs/v3/source/includes/resources/audit_events/_list.md.erb
@@ -43,8 +43,8 @@ Name | Type | Description
 #### Permitted roles
  |
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Auditor |
 Org Manager |

--- a/docs/v3/source/includes/resources/deployments/_list.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_list.md.erb
@@ -44,8 +44,8 @@ Name | Type | Description
 #### Permitted roles
  |
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Auditor |
 Org Manager |

--- a/docs/v3/source/includes/resources/domains/_get.md.erb
+++ b/docs/v3/source/includes/resources/domains/_get.md.erb
@@ -28,8 +28,8 @@ Content-Type: application/json
 
  Roles | Notes
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Auditor |
 Org Billing Manager | Can only view domains without an organization relationship

--- a/docs/v3/source/includes/resources/domains/_get.md.erb
+++ b/docs/v3/source/includes/resources/domains/_get.md.erb
@@ -34,7 +34,7 @@ Global Auditor |
 Org Auditor |
 Org Billing Manager | Can only view domains without an organization relationship
 Org Manager |
+Space Application Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Application Supporter | Experimental

--- a/docs/v3/source/includes/resources/organizations/_get_default_domain.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_get_default_domain.md.erb
@@ -29,13 +29,13 @@ Retrieve the default domain for a given organization.
 #### Permitted roles
  Roles | Notes
 --- | ---
+Admin Read-Only |
+Admin |
+Global Auditor |
+Org Auditor |
+Org Billing Manager | Can only view domains without an organization relationship
+Org Manager |
+Space Application Supporter | Experimental
+Space Auditor |
 Space Developer |
 Space Manager |
-Space Auditor |
-Org Auditor |
-Org Manager |
-Org Billing Manager | Can only view domains without an organization relationship
-Admin |
-Admin Read-Only |
-Global Auditor |
-Space Application Supporter | Experimental

--- a/docs/v3/source/includes/resources/organizations/_get_default_domain.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_get_default_domain.md.erb
@@ -29,8 +29,8 @@ Retrieve the default domain for a given organization.
 #### Permitted roles
  Roles | Notes
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Auditor |
 Org Billing Manager | Can only view domains without an organization relationship

--- a/docs/v3/source/includes/resources/routes/_check_route_reservations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_check_route_reservations.md.erb
@@ -39,8 +39,8 @@ Name | Type | Description
 
 Role  | Notes
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Auditor |
 Org Billing Manager | Can only check if routes exist for a domain without an organization relationship

--- a/docs/v3/source/includes/resources/routes/_check_route_reservations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_check_route_reservations.md.erb
@@ -39,13 +39,13 @@ Name | Type | Description
 
 Role  | Notes
 --- | ---
-Admin |
 Admin Read-Only |
+Admin |
 Global Auditor |
 Org Auditor |
 Org Billing Manager | Can only check if routes exist for a domain without an organization relationship
 Org Manager |
+Space Application Supporter | Experimental |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_create.md.erb
+++ b/docs/v3/source/includes/resources/routes/_create.md.erb
@@ -64,6 +64,6 @@ Content-Type: application/json
 Role  | Notes
 ----- | ---
 Admin |
-Space Developer |
 Space Application Supporter | Experimental |
+Space Developer |
 

--- a/docs/v3/source/includes/resources/routes/_delete.md.erb
+++ b/docs/v3/source/includes/resources/routes/_delete.md.erb
@@ -27,6 +27,5 @@ Location: https://api.example.org/v3/jobs/[guid]
 Role  | Notes
 --- | ---
 Admin |
-Space Developer |
 Space Application Supporter | Experimental |
-
+Space Developer |

--- a/docs/v3/source/includes/resources/routes/_delete_unmapped.md.erb
+++ b/docs/v3/source/includes/resources/routes/_delete_unmapped.md.erb
@@ -29,7 +29,7 @@ Deletes all routes in a space that are not mapped to any applications and not bo
 Role  | Notes
 --- | ---
 Admin |
-Space Developer |
 Space Application Supporter | Experimental |
+Space Developer |
 
 **Note**: `unmapped=true` is a required query parameter; always include it.

--- a/docs/v3/source/includes/resources/routes/_get.md.erb
+++ b/docs/v3/source/includes/resources/routes/_get.md.erb
@@ -39,8 +39,7 @@ Admin |
 Global Auditor |
 Org Auditor |
 Org Manager |
+Space Application Supporter | Experimental |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Application Supporter | Experimental |
-

--- a/docs/v3/source/includes/resources/routes/_get.md.erb
+++ b/docs/v3/source/includes/resources/routes/_get.md.erb
@@ -34,8 +34,8 @@ Name | Type | Description
 
 Role  | Notes
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Auditor |
 Org Manager |

--- a/docs/v3/source/includes/resources/routes/_insert_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_insert_destinations.md.erb
@@ -59,5 +59,5 @@ replace all destinations for a route at once using the [replace destinations end
 | Role            | Notes |
 | --------------- | --- |
 | Admin           |
-| Space Developer |
 | Space Application Supporter | Experimental |
+| Space Developer |

--- a/docs/v3/source/includes/resources/routes/_list_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_destinations.md.erb
@@ -42,7 +42,7 @@ Admin |
 Global Auditor |
 Org Auditor |
 Org Manager |
+Space Application Supporter | Experimental |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_list_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_destinations.md.erb
@@ -37,8 +37,8 @@ Name | Type | Description
 
 Role  | Notes
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Auditor |
 Org Manager |

--- a/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
@@ -44,11 +44,11 @@ Name | Type | Description
 #### Permitted roles
 Role  | Notes
 --- | ---
-Admin |
 Admin Read-Only |
+Admin |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
@@ -44,8 +44,8 @@ Name | Type | Description
 #### Permitted roles
 Role  | Notes
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Manager |
 Space Application Supporter | Experimental |

--- a/docs/v3/source/includes/resources/routes/_remove_destination.md.erb
+++ b/docs/v3/source/includes/resources/routes/_remove_destination.md.erb
@@ -28,5 +28,5 @@ Remove a destination from a route.
 Role  | Notes
 --- | ---
 Admin |
-Space Developer |
 Space Application Supporter | Experimental |
+Space Developer |

--- a/docs/v3/source/includes/resources/routes/_replace_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_replace_destinations.md.erb
@@ -94,5 +94,5 @@ and unweighted destinations for a route is not allowed.
 | Role            | Notes |
 | --------------- | --- |
 | Admin           |
-| Space Developer |
 | Space Application Supporter | Experimental |
+| Space Developer |

--- a/docs/v3/source/includes/resources/routes/_update.md.erb
+++ b/docs/v3/source/includes/resources/routes/_update.md.erb
@@ -43,5 +43,5 @@ Content-Type: application/json
 Role | Notes
 ----- | ---
 Admin |
-Space Developer |
 Space Application Supporter | Experimental |
+Space Developer |

--- a/docs/v3/source/includes/resources/space_features/_get.md.erb
+++ b/docs/v3/source/includes/resources/space_features/_get.md.erb
@@ -25,12 +25,13 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/features/:name`
 
 #### Permitted roles
- |
---- | ---
+Role | Notes |
+--- | --- |
 Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental |
 Space Auditor |
 Space Developer |
 Space Manager |

--- a/docs/v3/source/includes/resources/space_features/_list.md.erb
+++ b/docs/v3/source/includes/resources/space_features/_list.md.erb
@@ -27,12 +27,13 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/features`
 
 #### Permitted roles
- |
+Role | Notes |
 --- | ---
 Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental |
 Space Auditor |
 Space Developer |
 Space Manager |

--- a/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
@@ -35,12 +35,13 @@ Name | Type | Description
 
 
 #### Permitted roles
- |
---- | ---
+Role | Notes |
+--- | --- |
 Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental |
 Space Auditor |
 Space Developer |
 Space Manager |

--- a/docs/v3/source/includes/resources/spaces/get_assigned_isolation_segment.md.erb
+++ b/docs/v3/source/includes/resources/spaces/get_assigned_isolation_segment.md.erb
@@ -25,12 +25,13 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/relationships/isolation_segment`
 
 #### Permitted roles
- |
---- | ---
+Role | Notes |
+--- | --- |
 Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental |
 Space Auditor |
 Space Developer |
 Space Manager |

--- a/docs/v3/source/includes/resources/tasks/_get.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_get.md.erb
@@ -30,8 +30,8 @@ in the response based on the user's role.
 #### Permitted roles
  |
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Manager |
 Space Auditor |

--- a/docs/v3/source/includes/resources/tasks/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_list_for_app.md.erb
@@ -45,8 +45,8 @@ Name | Type | Description
 #### Permitted roles
  |
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Manager |
 Space Auditor |

--- a/docs/v3/source/includes/resources/users/_get.md.erb
+++ b/docs/v3/source/includes/resources/users/_get.md.erb
@@ -27,8 +27,8 @@ Content-Type: application/json
 #### Permitted roles
  Roles | Notes
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Auditor | Can only view users affiliated with their org
 Org Billing Manager | Can only view users affiliated with their org

--- a/spec/request/space_features_spec.rb
+++ b/spec/request/space_features_spec.rb
@@ -26,10 +26,13 @@ RSpec.describe 'Space Features' do
     end
 
     let(:expected_codes_and_responses) do
-      responses_for_space_restricted_single_endpoint(space_features_json)
+      responses_for_space_restricted_single_endpoint(
+        space_features_json,
+        permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_application_supporter']
+      )
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
   end
 
   describe 'GET /v3/spaces/:guid/features/:name' do
@@ -46,10 +49,13 @@ RSpec.describe 'Space Features' do
     end
 
     let(:expected_codes_and_responses) do
-      responses_for_space_restricted_single_endpoint(space_ssh_feature_json)
+      responses_for_space_restricted_single_endpoint(
+        space_ssh_feature_json,
+        permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_application_supporter']
+      )
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
   end
 
   describe 'PATCH /v3/spaces/:guid/features/:name' do

--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -69,7 +69,8 @@ RSpec.shared_examples 'permissions for list endpoint' do |roles|
         expect(last_response).to have_status_code(expected_response_code)
 
         expected_response_objects = expected_codes_and_responses[role][:response_objects]
-        if expected_response_objects
+
+        if (200...300).cover?(expected_response_code) && expected_response_objects
           expect({ resources: parsed_response['resources'] }).to match_json_response({ resources: expected_response_objects })
 
           expect(parsed_response['pagination']).to match_json_response({
@@ -116,14 +117,14 @@ RSpec.shared_examples 'permissions for single object endpoint' do |roles|
         expected_response_code = expected_codes_and_responses[role][:code]
         expect(last_response).to have_status_code(expected_response_code)
 
-        if expected_response_code == 202
-          job_location = last_response.headers['Location']
-          expect(job_location).to match(%r(http.+/v3/jobs/[a-fA-F0-9-]+))
-        end
+        if (200...300).cover? expected_response_code
+          if expected_response_code == 202
+            job_location = last_response.headers['Location']
+            expect(job_location).to match(%r(http.+/v3/jobs/[a-fA-F0-9-]+))
+          end
 
-        expected_response_object = expected_codes_and_responses[role][:response_object]
+          expected_response_object = expected_codes_and_responses[role][:response_object]
 
-        if expected_response_object
           expect(parsed_response).to match_json_response(expected_response_object) unless expected_response_object.nil?
 
           after_request_check.call
@@ -143,9 +144,10 @@ RSpec.shared_examples 'permissions for single object endpoint' do |roles|
             expect(expected_events.call(email)).to be_reported_as_events
           end
         end
+
         expected_response_guid = expected_codes_and_responses[role][:response_guid]
         if expected_response_guid
-          expect(parsed_response['guid'] ).to eq(expected_response_guid)
+          expect(parsed_response['guid']).to eq(expected_response_guid)
         end
       end
     end

--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -68,8 +68,8 @@ RSpec.shared_examples 'permissions for list endpoint' do |roles|
         expected_response_code = expected_codes_and_responses[role][:code]
         expect(last_response).to have_status_code(expected_response_code)
 
-        if (200...300).cover? expected_response_code
-          expected_response_objects = expected_codes_and_responses[role][:response_objects]
+        expected_response_objects = expected_codes_and_responses[role][:response_objects]
+        if expected_response_objects
           expect({ resources: parsed_response['resources'] }).to match_json_response({ resources: expected_response_objects })
 
           expect(parsed_response['pagination']).to match_json_response({
@@ -80,6 +80,11 @@ RSpec.shared_examples 'permissions for list endpoint' do |roles|
             next: anything,
             previous: anything
           })
+        end
+
+        expected_response_guids = expected_codes_and_responses[role][:response_guids]
+        if expected_response_guids
+          expect(parsed_response['resources'].map { |space| space['guid'] }).to match_array(expected_response_guids)
         end
       end
     end

--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -116,13 +116,14 @@ RSpec.shared_examples 'permissions for single object endpoint' do |roles|
         expected_response_code = expected_codes_and_responses[role][:code]
         expect(last_response).to have_status_code(expected_response_code)
 
-        if (200...300).cover? expected_response_code
-          if expected_response_code == 202
-            job_location = last_response.headers['Location']
-            expect(job_location).to match(%r(http.+/v3/jobs/[a-fA-F0-9-]+))
-          end
+        if expected_response_code == 202
+          job_location = last_response.headers['Location']
+          expect(job_location).to match(%r(http.+/v3/jobs/[a-fA-F0-9-]+))
+        end
 
-          expected_response_object = expected_codes_and_responses[role][:response_object]
+        expected_response_object = expected_codes_and_responses[role][:response_object]
+
+        if expected_response_object
           expect(parsed_response).to match_json_response(expected_response_object) unless expected_response_object.nil?
 
           after_request_check.call
@@ -141,6 +142,10 @@ RSpec.shared_examples 'permissions for single object endpoint' do |roles|
           if expected_events
             expect(expected_events.call(email)).to be_reported_as_events
           end
+        end
+        expected_response_guid = expected_codes_and_responses[role][:response_guid]
+        if expected_response_guid
+          expect(parsed_response['guid'] ).to eq(expected_response_guid)
         end
       end
     end

--- a/spec/unit/controllers/v3/spaces_controller_spec.rb
+++ b/spec/unit/controllers/v3/spaces_controller_spec.rb
@@ -946,41 +946,6 @@ RSpec.describe SpacesV3Controller, type: :controller do
     let!(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }
     let(:assigner) { VCAP::CloudController::IsolationSegmentAssign.new }
 
-    context 'when the user has permissions to read from the space' do
-      before do
-        allow_user_read_access_for(user, orgs: [org], spaces: [space])
-        assigner.assign(isolation_segment_model, [org])
-        space.update(isolation_segment_guid: isolation_segment_model.guid)
-      end
-
-      it 'returns a 200 and the isolation segment associated with the space' do
-        get :show_isolation_segment, params: { guid: space.guid }
-
-        expect(response.status).to eq(200)
-        expect(parsed_body['data']['guid']).to eq(isolation_segment_model.guid)
-      end
-
-      context 'when the space does not exist' do
-        it 'returns a 404' do
-          get :show_isolation_segment, params: { guid: 'potato' }
-
-          expect(response.status).to eq(404)
-          expect(response.body).to include('Space not found')
-        end
-      end
-
-      context 'when the space is not associated with an isolation segment' do
-        before { space.update(isolation_segment_guid: nil) }
-
-        it 'returns a 200' do
-          get :show_isolation_segment, params: { guid: space.guid }
-
-          expect(response.status).to eq(200)
-          expect(parsed_body['data']).to eq(nil)
-        end
-      end
-    end
-
     context 'when the user does not have permissions to read from the space' do
       before { allow_user_read_access_for(user, orgs: [], spaces: []) }
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: let space application supporters access some /v3/spaces endpoints.

* An explanation of the use cases your change solves: space application supporters can get and list spaces as well as get the isolation segment

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

closes #2226 