### PR TITLE
Ensure that space application supporter can access GET /v3/jobs/:guid

### DIFF
--- a/docs/v3/source/includes/resources/jobs/_get.md.erb
+++ b/docs/v3/source/includes/resources/jobs/_get.md.erb
@@ -38,10 +38,4 @@ Content-Type: application/json
 #### Permitted roles
  |
 --- | ---
-Admin |
-Admin Read-Only |
-Global Auditor |
-Org Manager |
-Space Auditor |
-Space Developer |
-Space Manager |
+All Roles |


### PR DESCRIPTION
- Add tests that check permissions.
- Adjust documentation; "All Roles" are permitted.

Closes #2224.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
