### PR TITLE
Ensure that space application supporter can access user GET endpoints

### DIFF
--- a/docs/v3/source/includes/resources/users/_get.md.erb
+++ b/docs/v3/source/includes/resources/users/_get.md.erb
@@ -36,5 +36,6 @@ Org Manager | Can only view users affiliated with their org
 Space Auditor | Can only view users affiliated with their org
 Space Developer | Can only view users affiliated with their org
 Space Manager | Can only view users affiliated with their org
+Space Application Supporter | Experimental / Can only view users affiliated with their org
 
 **Note:** A user can always see themselves with this endpoint, regardless of role.

--- a/docs/v3/source/includes/resources/users/_list.md.erb
+++ b/docs/v3/source/includes/resources/users/_list.md.erb
@@ -52,3 +52,4 @@ Org Manager | Can only view users affiliated with their org
 Space Auditor | Can only view users affiliated with their org
 Space Developer | Can only view users affiliated with their org
 Space Manager | Can only view users affiliated with their org
+Space Application Supporter | Experimental / Can only view users affiliated with their org

--- a/spec/request/users_spec.rb
+++ b/spec/request/users_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'Users Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the actee has an org or space role' do
@@ -213,7 +213,7 @@ RSpec.describe 'Users Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
     end
 
@@ -232,7 +232,7 @@ RSpec.describe 'Users Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when filtering by usernames and origins' do
@@ -280,7 +280,7 @@ RSpec.describe 'Users Request' do
           )
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when filtering by usernames' do
@@ -305,7 +305,7 @@ RSpec.describe 'Users Request' do
           )
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
         context 'when UAA is disabled' do
           before do
@@ -452,7 +452,7 @@ RSpec.describe 'Users Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when the actee has an org or space role' do
@@ -472,7 +472,7 @@ RSpec.describe 'Users Request' do
         org.add_user(actee)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when the user is not logged in' do
@@ -484,10 +484,6 @@ RSpec.describe 'Users Request' do
 
     context 'when the user is logged in' do
       let(:user_header) { headers_for(user, scopes: %w(cloud_controller.read)) }
-
-      before do
-        set_current_user_as_role(role: 'space_developer', org: org, space: space, user: user)
-      end
 
       it 'returns 200 when showing current user' do
         get "/v3/users/#{user.guid}", nil, user_header


### PR DESCRIPTION
- Add `space_application_supporter` to permission tests.
- Remove `set_current_user_as_role` from "when the user is logged in" context; for this test only the scope (`cloud_controller.read`) is important.

Closes #2236.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
