### PR TITLE
Use a consistent format for roles table notes in API docs

### DIFF
--- a/docs/v3/source/includes/resources/domains/_get.md.erb
+++ b/docs/v3/source/includes/resources/domains/_get.md.erb
@@ -26,7 +26,7 @@ Content-Type: application/json
 
 #### Permitted roles
 
- Roles | Notes
+ Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/organizations/_get_default_domain.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_get_default_domain.md.erb
@@ -27,7 +27,7 @@ Retrieve the default domain for a given organization.
 `GET /v3/organizations/:guid/domains/default`
 
 #### Permitted roles
- Roles | Notes
+ Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/service_brokers/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_delete.md.erb
@@ -26,8 +26,8 @@ This endpoint creates a job to delete an existing service broker. The `Location`
 `DELETE /v3/service_brokers/:guid`
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
-Space Developer (only space-scoped brokers) |
+Space Developer | Only space-scoped brokers |
 

--- a/docs/v3/source/includes/resources/service_brokers/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_get.md.erb
@@ -27,9 +27,9 @@ This endpoint retrieves the service broker by GUID.
 `GET /v3/service_brokers/:guid`
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
 Global Auditor |
-Space Developer (only space-scoped brokers) |
+Space Developer | Only space-scoped brokers)

--- a/docs/v3/source/includes/resources/service_brokers/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_list.md.erb
@@ -40,9 +40,9 @@ Name | Type | Description
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
 Global Auditor |
-Space Developer (only space-scoped brokers) |
+Space Developer | Only space-scoped brokers

--- a/docs/v3/source/includes/resources/service_brokers/_update.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_update.md.erb
@@ -80,7 +80,7 @@ Name | Type | Description
 <%= yield_content :service_broker_credentials_object %>
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
-Space Developer (only space-scoped brokers) |
+Space Developer | Only space-scoped brokers

--- a/docs/v3/source/includes/resources/service_offerings/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_offerings/_delete.md.erb
@@ -35,7 +35,7 @@ Name | Type | Description
 **purge** | _boolean_ | If `true`, any service plans, instances, and bindings associated with this service offering will also be deleted
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
-Space Developer (only service offerings from space-scoped brokers) |
+Space Developer | Only service offerings from space-scoped brokers

--- a/docs/v3/source/includes/resources/service_offerings/_update.md.erb
+++ b/docs/v3/source/includes/resources/service_offerings/_update.md.erb
@@ -41,8 +41,8 @@ Name | Type | Description
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the service offering
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
-Space Developer (only for service offerings from space-scoped brokers) |
+Space Developer | Only for service offerings from space-scoped brokers
 

--- a/docs/v3/source/includes/resources/service_plans/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_plans/_delete.md.erb
@@ -25,7 +25,7 @@ are no longer provided by the service broker.
 `DELETE /v3/service_plans/:guid`
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
-Space Developer (only service plans from space-scoped brokers) |
+Space Developer | Only service plans from space-scoped brokers

--- a/docs/v3/source/includes/resources/service_plans/_update.md.erb
+++ b/docs/v3/source/includes/resources/service_plans/_update.md.erb
@@ -41,8 +41,8 @@ Name | Type | Description
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the service plan
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
-Space Developer (only for service plans from space-scoped brokers) |
+Space Developer | Only for service plans from space-scoped brokers
 

--- a/docs/v3/source/includes/resources/space_features/_get.md.erb
+++ b/docs/v3/source/includes/resources/space_features/_get.md.erb
@@ -25,7 +25,7 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/features/:name`
 
 #### Permitted roles
-Role | Notes |
+ Roles | Notes
 --- | --- |
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/space_features/_get.md.erb
+++ b/docs/v3/source/includes/resources/space_features/_get.md.erb
@@ -25,7 +25,7 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/features/:name`
 
 #### Permitted roles
- Roles | Notes
+ Role | Notes
 --- | --- |
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/space_features/_list.md.erb
+++ b/docs/v3/source/includes/resources/space_features/_list.md.erb
@@ -27,7 +27,7 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/features`
 
 #### Permitted roles
- Roles | Notes
+ Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/space_features/_list.md.erb
+++ b/docs/v3/source/includes/resources/space_features/_list.md.erb
@@ -27,7 +27,7 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/features`
 
 #### Permitted roles
-Role | Notes |
+ Roles | Notes
 --- | ---
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
@@ -35,7 +35,7 @@ Name | Type | Description
 
 
 #### Permitted roles
- Roles | Notes
+ Role | Notes
 --- | --- |
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
@@ -35,7 +35,7 @@ Name | Type | Description
 
 
 #### Permitted roles
-Role | Notes |
+ Roles | Notes
 --- | --- |
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/spaces/get_assigned_isolation_segment.md.erb
+++ b/docs/v3/source/includes/resources/spaces/get_assigned_isolation_segment.md.erb
@@ -25,7 +25,7 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/relationships/isolation_segment`
 
 #### Permitted roles
-Role | Notes |
+ Roles | Notes
 --- | --- |
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/spaces/get_assigned_isolation_segment.md.erb
+++ b/docs/v3/source/includes/resources/spaces/get_assigned_isolation_segment.md.erb
@@ -25,7 +25,7 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/relationships/isolation_segment`
 
 #### Permitted roles
- Roles | Notes
+ Role | Notes
 --- | --- |
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/users/_get.md.erb
+++ b/docs/v3/source/includes/resources/users/_get.md.erb
@@ -25,7 +25,7 @@ Content-Type: application/json
 `GET /v3/users/:guid`
 
 #### Permitted roles
- Roles | Notes
+ Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |

--- a/docs/v3/source/includes/resources/users/_list.md.erb
+++ b/docs/v3/source/includes/resources/users/_list.md.erb
@@ -41,7 +41,7 @@ Name | Type | Description
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 
 #### Permitted roles
- Roles | Notes
+ Role | Notes
 --- | ---
 Admin Read-Only |
 Admin |


### PR DESCRIPTION
Some tables had notes in the first column, while others had a second 'notes' column that was separate. 

Also adds missing table headers for roles tables that have notes (usually marking a role as 'Experimental') , as the absence of these is currently preventing the second column from rendering altogether.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
