### PR TITLE
Allow Space Application Supporter access to specific Audit Events endpoints

### DIFF
--- a/app/controllers/v3/events_controller.rb
+++ b/app/controllers/v3/events_controller.rb
@@ -7,7 +7,7 @@ class EventsController < ApplicationController
     message = EventsListMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?
 
-    dataset = EventListFetcher.fetch_all(message, readable_event_dataset)
+    dataset = EventListFetcher.fetch_all(message, permission_queryer.readable_event_dataset)
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::EventPresenter,
@@ -18,7 +18,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    event = readable_event_dataset.first(guid: hashed_params[:guid])
+    event = permission_queryer.readable_event_dataset.first(guid: hashed_params[:guid])
     event_not_found! unless event
 
     render status: :ok, json: Presenters::V3::EventPresenter.new(event)
@@ -28,9 +28,5 @@ class EventsController < ApplicationController
 
   def event_not_found!
     resource_not_found!(:event)
-  end
-
-  def readable_event_dataset
-    Event.user_visible(current_user, permission_queryer.can_read_globally?)
   end
 end

--- a/docs/v3/source/includes/resources/audit_events/_get.md.erb
+++ b/docs/v3/source/includes/resources/audit_events/_get.md.erb
@@ -31,6 +31,7 @@ Role | Notes
 Admin |
 Admin Read-Only |
 Global Auditor |
+Space Application Supporter | Experimental; Cannot see events which occurred in spaces that the user does not belong to
 Space Auditor | Cannot see events which occurred in spaces that the user does not belong to
 Space Developer | Cannot see events which occurred in spaces that the user does not belong to
 Org Auditor | Cannot see events which occurred in orgs that the user does not belong to

--- a/docs/v3/source/includes/resources/audit_events/_list.md.erb
+++ b/docs/v3/source/includes/resources/audit_events/_list.md.erb
@@ -41,13 +41,14 @@ Name | Type | Description
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
 Global Auditor |
 Org Auditor |
 Org Manager |
+Space Application Supporter | Experimental |
 Space Auditor |
 Space Developer |
 Space Manager |

--- a/docs/v3/source/includes/resources/users/_list.md.erb
+++ b/docs/v3/source/includes/resources/users/_list.md.erb
@@ -43,8 +43,8 @@ Name | Type | Description
 #### Permitted roles
  Roles | Notes
 --- | ---
-Admin Read-Only |
 Admin |
+Admin Read-Only |
 Global Auditor |
 Org Auditor | Can only view users affiliated with their org
 Org Billing Manager | Can only view users affiliated with their org

--- a/lib/cloud_controller/permissions/queryer.rb
+++ b/lib/cloud_controller/permissions/queryer.rb
@@ -318,6 +318,17 @@ class VCAP::CloudController::Permissions::Queryer
     end
   end
 
+  def readable_event_dataset
+    science 'readable_security_group_guids' do |e|
+      e.use { db_permissions.readable_event_dataset }
+      e.try { perm_permissions.readable_event_dataset }
+
+      e.compare { |a, b| compare_arrays(a, b) }
+
+      e.run_if { !db_permissions.can_read_globally? }
+    end
+  end
+
   def can_update_build_state?
     db_permissions.can_update_build_state?
   end

--- a/spec/request/events_spec.rb
+++ b/spec/request/events_spec.rb
@@ -115,13 +115,14 @@ RSpec.describe 'Events' do
 
         h['space_auditor'] = { code: 200, response_objects: [space_scoped_event_json] }
         h['space_developer'] = { code: 200, response_objects: [space_scoped_event_json] }
+        h['space_application_supporter'] = { code: 200, response_objects: [space_scoped_event_json] }
 
         h['org_auditor'] = { code: 200, response_objects: [org_scoped_event_json, space_scoped_event_json] }
 
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'filtering by type' do
@@ -271,11 +272,12 @@ RSpec.describe 'Events' do
               org_auditor
               space_auditor
               space_developer
+              space_application_supporter
             )
           )
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
         context 'and the space has been deleted' do
           before do
@@ -355,6 +357,10 @@ RSpec.describe 'Events' do
             code: 404,
             response_object: []
           }
+          h['space_application_supporter'] = {
+            code: 404,
+            response_object: []
+          }
           h['space_manager'] = {
             code: 404,
             response_object: []
@@ -374,7 +380,7 @@ RSpec.describe 'Events' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
         context 'and the org has been deleted' do
           before do
@@ -452,7 +458,7 @@ RSpec.describe 'Events' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
     end
 


### PR DESCRIPTION
Also refactored v3 Events permissions checks to be in the permissions queryer because we believe that to be the desired pattern + it seems easier to follow. We also updated the documentation.

Closes #2216

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
