### PR TITLE
Space application supporter can access environment variable groups

### DIFF
--- a/spec/request/environment_variable_groups_spec.rb
+++ b/spec/request/environment_variable_groups_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe 'Environment group variables' do
         expect(last_response.status).to eq(401)
       end
     end
+
+    context 'permissions' do
+      let(:org) { VCAP::CloudController::Organization.make }
+      let(:space) { VCAP::CloudController::Space.make(organization: org) }
+      let(:api_call) { lambda { |user_headers| get '/v3/environment_variable_groups/running', nil, user_headers } }
+      let(:expected_codes_and_responses) { Hash.new(code: 200).freeze }
+
+      before do
+        space.organization.add_user(user)
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+    end
   end
 
   describe 'PATCH /v3/environment_variable_groups/:name' do
@@ -239,6 +252,28 @@ RSpec.describe 'Environment group variables' do
 
         expect(last_response.status).to eq(401)
       end
+    end
+
+    context 'permissions' do
+      let(:org) { VCAP::CloudController::Organization.make }
+      let(:space) { VCAP::CloudController::Space.make(organization: org) }
+      let(:api_call) { lambda { |user_headers| patch '/v3/environment_variable_groups/running', params.to_json, user_headers } }
+      let(:expected_codes_and_responses) do
+        h = Hash.new(
+          code: 403
+        )
+        h['admin'] = {
+          code: 200
+        }
+
+        h.freeze
+      end
+
+      before do
+        space.organization.add_user(user)
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
   end
 end

--- a/spec/request/environment_variable_groups_spec.rb
+++ b/spec/request/environment_variable_groups_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Environment group variables' do
       end
     end
 
-    context 'permissions' do
+    context 'when the user is logged in' do
       let(:org) { VCAP::CloudController::Organization.make }
       let(:space) { VCAP::CloudController::Space.make(organization: org) }
       let(:api_call) { lambda { |user_headers| get '/v3/environment_variable_groups/running', nil, user_headers } }
@@ -197,7 +197,7 @@ RSpec.describe 'Environment group variables' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when request input message is invalid' do
@@ -252,28 +252,6 @@ RSpec.describe 'Environment group variables' do
 
         expect(last_response.status).to eq(401)
       end
-    end
-
-    context 'permissions' do
-      let(:org) { VCAP::CloudController::Organization.make }
-      let(:space) { VCAP::CloudController::Space.make(organization: org) }
-      let(:api_call) { lambda { |user_headers| patch '/v3/environment_variable_groups/running', params.to_json, user_headers } }
-      let(:expected_codes_and_responses) do
-        h = Hash.new(
-          code: 403
-        )
-        h['admin'] = {
-          code: 200
-        }
-
-        h.freeze
-      end
-
-      before do
-        space.organization.add_user(user)
-      end
-
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
   end
 end


### PR DESCRIPTION
* Add unit tests to prove that all roles can _get_ access environment variable groups and that only the admin role can _update_ environment variable groups (as documented [here](https://v3-apidocs.cloudfoundry.org/version/3.101.0/index.html#get-an-environment-variable-group) and [here](https://v3-apidocs.cloudfoundry.org/version/3.101.0/index.html#update-environment-variable-group))

Closes #2221

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
