### PR TITLE
Space application supporter can get and list packages

### DIFF
--- a/app/controllers/v3/packages_controller.rb
+++ b/app/controllers/v3/packages_controller.rb
@@ -22,12 +22,12 @@ class PackagesController < ApplicationController
 
     if app_nested?
       app, dataset = PackageListFetcher.fetch_for_app(message: message)
-      app_not_found! unless app && permission_queryer.can_read_from_space?(app.space.guid, app.organization.guid)
+      app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(app.space.guid, app.organization.guid)
     else
       dataset = if permission_queryer.can_read_globally?
                   PackageListFetcher.fetch_all(message: message)
                 else
-                  PackageListFetcher.fetch_for_spaces(message: message, space_guids: permission_queryer.readable_space_guids)
+                  PackageListFetcher.fetch_for_spaces(message: message, space_guids: permission_queryer.readable_application_supporter_space_guids)
                 end
     end
 
@@ -102,7 +102,7 @@ class PackagesController < ApplicationController
 
   def show
     package = PackageModel.where(guid: hashed_params[:guid]).eager(:space, space: :organization).first
-    package_not_found! unless package && permission_queryer.can_read_from_space?(package.space.guid, package.space.organization.guid)
+    package_not_found! unless package && permission_queryer.untrusted_can_read_from_space?(package.space.guid, package.space.organization.guid)
 
     render status: :ok, json: Presenters::V3::PackagePresenter.new(package, show_bits_service_upload_link: permission_queryer.can_write_to_space?(package.space.guid))
   end

--- a/docs/v3/source/includes/resources/packages/_get.md.erb
+++ b/docs/v3/source/includes/resources/packages/_get.md.erb
@@ -25,7 +25,7 @@ Content-Type: application/json
 `GET /v3/packages/:guid`
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
@@ -34,3 +34,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Application Supporter | Experimental

--- a/docs/v3/source/includes/resources/packages/_get.md.erb
+++ b/docs/v3/source/includes/resources/packages/_get.md.erb
@@ -31,7 +31,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Application Supporter | Experimental

--- a/docs/v3/source/includes/resources/packages/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/packages/_list_for_app.md.erb
@@ -40,7 +40,7 @@ Name | Type | Description
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
@@ -49,3 +49,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Application Supporter | Experimental

--- a/docs/v3/source/includes/resources/packages/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/packages/_list_for_app.md.erb
@@ -46,7 +46,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Application Supporter | Experimental

--- a/spec/request/packages_spec.rb
+++ b/spec/request/packages_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe 'Packages' do
     end
 
     context 'when listing all packages' do
-      let(:api_call) { lambda { |user_headers| get "/v3/packages", { per_page: per_page }, user_headers } }
+      let(:api_call) { lambda { |user_headers| get '/v3/packages', { per_page: per_page }, user_headers } }
       let(:message) { VCAP::CloudController::PackagesListMessage }
       let(:request) { '/v3/packages' }
       let(:excluded_params) {

--- a/spec/request/packages_spec.rb
+++ b/spec/request/packages_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe 'Packages' do
       }
 
       it 'gets all the packages' do
-        bits_package = VCAP::CloudController::PackageModel.make(type: bits_type, app_guid: app_model.guid)
+        VCAP::CloudController::PackageModel.make(type: bits_type, app_guid: app_model.guid)
 
         get request, nil, user_header
         expect(last_response.status).to eq(200), JSON.parse(last_response.body)['errors'].try(:first).try(:[], 'detail')
@@ -422,7 +422,6 @@ RSpec.describe 'Packages' do
             :app_guid
           ]
         }
-  
       end
 
       it_behaves_like 'list_endpoint_with_common_filters' do

--- a/spec/support/model_creation.rb
+++ b/spec/support/model_creation.rb
@@ -26,6 +26,12 @@ module ModelCreation
     user
   end
 
+  def make_application_supporter_for_space(space)
+    user = make_user_for_org space.organization
+    space.add_application_supporter user
+    user
+  end
+
   def make_auditor_for_space(space)
     user = make_user_for_org(space.organization)
     space.add_auditor(user)

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -276,6 +276,7 @@ module UserHelpers
 
   def stub_readable_space_guids_for(user, spaces)
     allow(permissions_double(user)).to receive(:readable_space_guids).and_return(spaces.map(&:guid))
+    allow(permissions_double(user)).to receive(:readable_application_supporter_space_guids).and_return(spaces.map(&:guid))
   end
 
   def stub_readable_org_guids_for(user, orgs)


### PR DESCRIPTION
* Enable space application supporter to get and list packages (including [listing them as a subresource of apps](https://v3-apidocs.cloudfoundry.org/version/3.101.0/index.html#list-packages-for-an-app)).
* Add unit tests to prove the above

Closes #2225 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
