### PR TITLE
Log caller and query length for sql queries

### DIFF
--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -2,6 +2,7 @@ require 'sequel'
 require 'cloud_controller/db_migrator'
 require 'cloud_controller/db_connection/options_factory'
 require 'cloud_controller/db_connection/finalizer'
+require 'sequel/extensions/query_length_logging'
 
 module VCAP::CloudController
   class DB
@@ -29,10 +30,12 @@ module VCAP::CloudController
         db.logger = logger
         db.sql_log_level = opts[:log_level]
         db.extension :caller_logging
-        db.caller_logging_ignore = /sequel_paginator/
+        db.caller_logging_ignore = /sequel_paginator|query_length_logging/
         db.caller_logging_formatter = lambda do |caller|
           "(#{caller.sub(%r{^.*/cloud_controller_ng/}, '')})"
         end
+
+        db.extension(:query_length_logging)
       end
       db.default_collate = 'utf8_bin' if db.database_type == :mysql
       add_connection_validator_extension(db, opts)

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -28,6 +28,11 @@ module VCAP::CloudController
       if opts[:log_db_queries]
         db.logger = logger
         db.sql_log_level = opts[:log_level]
+        db.extension :caller_logging
+        db.caller_logging_ignore = /sequel_paginator/
+        db.caller_logging_formatter = lambda do |caller|
+          "(#{caller.sub(%r{^.*/cloud_controller_ng/}, '')})"
+        end
       end
       db.default_collate = 'utf8_bin' if db.database_type == :mysql
       add_connection_validator_extension(db, opts)

--- a/lib/sequel/extensions/query_length_logging.rb
+++ b/lib/sequel/extensions/query_length_logging.rb
@@ -1,0 +1,13 @@
+# frozen-string-literal: true
+
+module Sequel::QueryLengthLogging
+  # Include SQL query length when logging query.
+  def log_connection_yield(sql, conn, args=nil)
+    unless @loggers.empty?
+      sql = "(query_length=#{sql.length}) #{sql}"
+    end
+    super
+  end
+end
+
+Sequel::Database.register_extension(:query_length_logging, Sequel::QueryLengthLogging)

--- a/spec/unit/lib/sequel/extensions/query_length_logging_spec.rb
+++ b/spec/unit/lib/sequel/extensions/query_length_logging_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe Sequel::QueryLengthLogging do
+  describe 'log_connection_yield' do
+    let(:db) { DbConfig.new.connection }
+    let(:logs) { StringIO.new }
+    let(:logger) { Logger.new(logs) }
+
+    before do
+      db.loggers << logger
+      db.sql_log_level = :info
+      db.extension(:query_length_logging)
+    end
+
+    it 'add the query length parameter' do
+      query = 'SELECT * FROM some_table WHERE condition > 1'
+      db.log_connection_yield(query, nil) {}
+      expect(logs.string).to match /.*\(query_length=44\) SELECT \* FROM some_table WHERE condition > 1/
+    end
+  end
+end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
  For better analyzing load pattern we want to log the caller and length of db queries. This is related to the slow requests we found recently (e.g. `security_groups`) 
  Log example:
  ```
  <14>1 2021-06-10T14:55:09.157985Z 10.0.129.64 cloud_controller_ng rs2 - [instance@47450 director="bosh" deployment="cf" group="api" id="bosh-id"] {"timestamp":"2021-06-10T14:55:08.266616342Z","message":"(0.045727s) (app/controllers/v3/domains_controller.rb:26:in `index') (query_length=443579) SELECT \"domains\".* FROM \"domains\" WHERE (((\"domains\".\"owning_organization_id\" IS NULL) OR (\"domains\".\"owning_organization_id\" IN (SELECT \"id\" FROM \"organizations\" WHERE (\"guid\" IN ...
  ```


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
