### PR TITLE
space application supporter can access specific "process" GET endpoints.

### DIFF
--- a/app/controllers/v3/processes_controller.rb
+++ b/app/controllers/v3/processes_controller.rb
@@ -26,14 +26,14 @@ class ProcessesController < ApplicationController
 
     if app_nested?
       app, dataset = ProcessListFetcher.fetch_for_app(message, eager_loaded_associations: Presenters::V3::ProcessPresenter.associated_resources)
-      app_not_found! unless app && permission_queryer.can_read_from_space?(app.space.guid, app.organization.guid)
+      app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(app.space.guid, app.organization.guid)
     else
       dataset = if permission_queryer.can_read_globally?
                   ProcessListFetcher.fetch_all(message, eager_loaded_associations: Presenters::V3::ProcessPresenter.associated_resources)
                 else
                   ProcessListFetcher.fetch_for_spaces(
                     message,
-                    space_guids: permission_queryer.readable_space_guids,
+                    space_guids: permission_queryer.readable_application_supporter_space_guids,
                     eager_loaded_associations: Presenters::V3::ProcessPresenter.associated_resources
                   )
                 end
@@ -109,11 +109,11 @@ class ProcessesController < ApplicationController
   def find_process_and_space
     if app_nested?
       @process, app, @space, org = ProcessFetcher.fetch_for_app_by_type(app_guid: hashed_params[:app_guid], process_type: hashed_params[:type])
-      app_not_found! unless app && permission_queryer.can_read_from_space?(@space.guid, org.guid)
+      app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(@space.guid, org.guid)
       process_not_found! unless @process
     else
       @process, @space, org = ProcessFetcher.fetch(process_guid: hashed_params[:process_guid])
-      process_not_found! unless @process && permission_queryer.can_read_from_space?(@space.guid, org.guid)
+      process_not_found! unless @process && permission_queryer.untrusted_can_read_from_space?(@space.guid, org.guid)
     end
   end
 

--- a/docs/v3/source/includes/resources/processes/_get.md.erb
+++ b/docs/v3/source/includes/resources/processes/_get.md.erb
@@ -26,12 +26,13 @@ Content-Type: application/json
 `GET /v3/apps/:guid/processes/:type`
 
 #### Permitted roles
- |
+Role | Notes |
 --- | ---
 Admin |
 Admin Read-Only |
-Global Auditor |
-Org Manager |
-Space Auditor |
+Global Auditor | Some fields are redacted
+Org Manager | Some fields are redacted
+Space Application Supporter | Some fields are redacted. Experimental |
+Space Auditor | Some fields are redacted
 Space Developer |
-Space Manager |
+Space Manager | Some fields are redacted

--- a/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
@@ -40,7 +40,7 @@ Name | Type | Description
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 
 #### Permitted roles
- |
+Roles | Notes |
 --- | ---
 Admin |
 Admin Read-Only |
@@ -48,4 +48,5 @@ Global Auditor |
 Org Manager |
 Space Auditor |
 Space Developer |
+Space Application Developer | Experimental
 Space Manager |

--- a/docs/v3/source/includes/resources/processes/_stats.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats.md.erb
@@ -26,12 +26,13 @@ Content-Type: application/json
 `GET /v3/apps/:guid/processes/:type/stats`
 
 #### Permitted roles
- |
+Role | Notes |
 --- | ---
 Admin |
 Admin Read-Only |
-Global Auditor |
-Org Manager |
-Space Auditor |
+Global Auditor | Some fields are redacted
+Org Manager | Some fields are redacted
+Space Application Supporter | Some fields are redacted. Experimental |
+Space Auditor | Some fields are redacted
 Space Developer |
-Space Manager |
+Space Manager | Some fields are redacted

--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -85,7 +85,7 @@ RSpec.shared_examples 'permissions for list endpoint' do |roles|
 
         expected_response_guids = expected_codes_and_responses[role][:response_guids]
         if expected_response_guids
-          expect(parsed_response['resources'].map { |space| space['guid'] }).to match_array(expected_response_guids)
+          expect(parsed_response['resources'].map { |resource| resource['guid'] }).to match_array(expected_response_guids)
         end
       end
     end

--- a/spec/unit/controllers/v3/processes_controller_spec.rb
+++ b/spec/unit/controllers/v3/processes_controller_spec.rb
@@ -11,31 +11,7 @@ RSpec.describe ProcessesController, type: :controller do
       allow_user_read_access_for(user, spaces: [space])
     end
 
-    it 'returns 200 and lists the processes' do
-      process1 = VCAP::CloudController::ProcessModel.make(:process, app: app)
-      process2 = VCAP::CloudController::ProcessModel.make(:process, app: app)
-      VCAP::CloudController::ProcessModel.make
-
-      get :index
-
-      response_guids = parsed_body['resources'].map { |r| r['guid'] }
-      expect(response.status).to eq(200)
-      expect(response_guids).to match_array([process1.guid, process2.guid])
-    end
-
     context 'when accessed as an app subresource' do
-      it 'uses the app as a filter' do
-        process1 = VCAP::CloudController::ProcessModel.make(:process, app: app)
-        process2 = VCAP::CloudController::ProcessModel.make(:process, app: app)
-        VCAP::CloudController::ProcessModel.make(:process)
-
-        get :index, params: { app_guid: app.guid }
-
-        expect(response.status).to eq(200)
-        response_guids = parsed_body['resources'].map { |r| r['guid'] }
-        expect(response_guids).to match_array([process1.guid, process2.guid])
-      end
-
       it 'eager loads associated resources that the presenter specifies' do
         expect(VCAP::CloudController::ProcessListFetcher).to receive(:fetch_for_app).with(
           an_instance_of(VCAP::CloudController::ProcessesListMessage),


### PR DESCRIPTION
We also added documentation to reflect fields being redacted.

`GET` endpoints for #2211

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
