### PR TITLE
Allow space application supporter to access specific droplet endpoints

### DIFF
--- a/docs/v3/source/includes/resources/droplets/_get.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_get.md.erb
@@ -25,12 +25,13 @@ Content-Type: application/json
 `GET /v3/droplets/:guid`
 
 #### Permitted roles
- |
+Role | Notes |
 --- | ---
 Admin |
 Admin Read-Only |
-Global Auditor |
-Org Manager |
-Space Auditor |
+Global Auditor | Some fields are redacted
+Org Manager | Some fields are redacted
+Space Application Supporter | Some fields are redacted. Experimental |
+Space Auditor | Some fields are redacted
 Space Developer |
-Space Manager |
+Space Manager | Some fields are redacted

--- a/docs/v3/source/includes/resources/droplets/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_list_for_app.md.erb
@@ -39,12 +39,13 @@ Name | Type | Description
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
- |
---- | ---
+Role | Notes |
+--- | --- |
 Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
 Space Auditor |
+Space Application Supporter | Experimental |
 Space Developer |
 Space Manager |

--- a/docs/v3/source/includes/resources/droplets/_list_for_package.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_list_for_package.md.erb
@@ -38,12 +38,13 @@ Name | Type | Description
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
- |
---- | ---
+Role | Notes |
+--- | --- |
 Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
 Space Auditor |
+Space Application Supporter | Experimental |
 Space Developer |
 Space Manager |


### PR DESCRIPTION
We added documentation to reflect fields being redacted, and deleted duplicate controller specs.

Closes out #2220 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
