### PR TITLE
Log when DB queries return large numbers of rows

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -88,6 +88,7 @@ module VCAP::CloudController
               pool_timeout: Integer, # timeout before raising an error when connection can't be established to the db
               log_level: String, # debug, info, etc.
               log_db_queries: bool,
+              optional(:query_size_log_threshold) => Integer,
               connection_validation_timeout: Integer,
               optional(:connection_expiration_timeout) => Integer,
               optional(:connection_expiration_random_delay) => Integer,

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -116,6 +116,20 @@ class Sequel::Model
   end
 end
 
+class Sequel::Dataset
+  def post_load(all_records)
+    num_records = all_records.length
+    num_associations = all_records.map do |record|
+                         associations = record.instance_variable_get(:@associations)
+                         next 0 if associations.nil?
+                         associations.values.map { |value| value.respond_to?(:length) ? value.length : 1 }.reduce(:+)
+                       end.reduce(:+)
+
+    table_name = self.instance_variable_get(:@opts)[:model].instance_variable_get(:@simple_table)
+    self.instance_variable_get(:@db).log_info("Loaded #{num_records} records from table #{table_name} with #{num_associations} associations")
+  end
+end
+
 # Helper to create migrations.  This was added because
 # I wanted to add an index to all the Timestamps so that
 # we can enumerate by :created_at.

--- a/spec/unit/lib/cloud_controller/db_dataset_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_dataset_spec.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
         it 'logs the number of returned rows over threshold' do
           10.times { Space.make }
           Space.all
-          expect(logs.string).to match 'Loaded 10 records for query SELECT \* FROM "spaces"'
+          expect(logs.string).to match 'Loaded 10 records for query SELECT \* FROM [`"]spaces[`"]'
         end
 
         it 'does not log the number of returned rows under threshold' do

--- a/spec/unit/lib/cloud_controller/db_dataset_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_dataset_spec.rb
@@ -5,17 +5,18 @@ module VCAP::CloudController
     describe '#post_load', type: :model do
       let(:logs) { StringIO.new }
       let(:logger) { Logger.new(logs) }
+      let(:db) { Route.db }
 
       before do
-        Route.db.loggers << logger
+        db.opts.merge!({ log_db_queries: true, query_size_log_threshold: 1 })
+        db.loggers << logger
       end
 
       it 'log the number of returned rows' do
-
-        space=Space.make
+        space = Space.make
         Route.make(space: space)
         Route.dataset.eager(:space).all
-        expect(logs.string).to match "Loaded 1 records from table \"routes\" with 1 associations"
+        expect(logs.string).to match 'Loaded 1 records for query SELECT \* FROM "routes"'
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/db_dataset_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_dataset_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  RSpec.describe Sequel::Dataset do
+    describe '#post_load', type: :model do
+      let(:logs) { StringIO.new }
+      let(:logger) { Logger.new(logs) }
+
+      before do
+        Route.db.loggers << logger
+      end
+
+      it 'log the number of returned rows' do
+
+        space=Space.make
+        Route.make(space: space)
+        Route.dataset.eager(:space).all
+        expect(logs.string).to match "Loaded 1 records from table \"routes\" with 1 associations"
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cloud_controller/db_dataset_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_dataset_spec.rb
@@ -5,18 +5,52 @@ module VCAP::CloudController
     describe '#post_load', type: :model do
       let(:logs) { StringIO.new }
       let(:logger) { Logger.new(logs) }
-      let(:db) { Route.db }
+      let(:db) { Space.db }
 
       before do
-        db.opts.merge!({ log_db_queries: true, query_size_log_threshold: 1 })
         db.loggers << logger
       end
 
-      it 'log the number of returned rows' do
-        space = Space.make
-        Route.make(space: space)
-        Route.dataset.eager(:space).all
-        expect(logs.string).to match 'Loaded 1 records for query SELECT \* FROM "routes"'
+      describe 'with logging enabled' do
+        before do
+          db.opts.merge!({ log_db_queries: true, query_size_log_threshold: 5 })
+        end
+
+        it 'logs the number of returned rows over threshold' do
+          10.times { Space.make }
+          Space.all
+          expect(logs.string).to match 'Loaded 10 records for query SELECT \* FROM "spaces"'
+        end
+
+        it 'does not log the number of returned rows under threshold' do
+          2.times { Space.make }
+          Space.all
+          expect(logs.string).to_not match 'Loaded'
+        end
+      end
+
+      describe 'with no threshold set' do
+        before do
+          db.opts.merge!({ log_db_queries: true, query_size_log_threshold: nil })
+        end
+
+        it 'does not log' do
+          2.times { Space.make }
+          Space.all
+          expect(logs.string).to_not match 'Loaded'
+        end
+      end
+
+      describe 'with db query logging not enabled' do
+        before do
+          db.opts.merge!({ log_db_queries: false, query_size_log_threshold: 1 })
+        end
+
+        it 'does not log the number of returned rows under threshold' do
+          2.times { Space.make }
+          Space.all
+          expect(logs.string).to_not match 'Loaded'
+        end
       end
     end
   end


### PR DESCRIPTION
## A short explanation of the proposed change
Add some extra logging for when DB queries return a large number of rows including a configuration flag which can both toggle the feature off as well as set a threshold for when to log.

## An explanation of the use cases your change solves
We've seen [some DB queries](https://github.com/cloudfoundry/cloud_controller_ng/pull/2215) return large numbers of rows which CC then has to parse/marshal which can be particularly slow. By adding some additional logging when queries return lots of data we can hopefully identify specific requests that cause large numbers or rows to be handled.

We've also looked at using pg_stat_statments but by using the existing Steno logger in CC we can identify a specific request as our users submit error reports about slow endpoints including the VCAP request ID.

## Links to any other associated PRs
Slow service plan visibilities caused by large numbers of returned rows - https://github.com/cloudfoundry/cloud_controller_ng/pull/2215

## Checks
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
