### PR TITLE
Correct documentation to properly reflect allowed roles.

### DIFF
--- a/docs/v3/source/includes/resources/droplets/_update.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_update.md.erb
@@ -37,6 +37,4 @@ Name | Type | Description
  |
 --- | ---
 Admin |
-Org Manager |
 Space Developer |
-Space Manager |


### PR DESCRIPTION
We noticed a noticed a disparity in the documented behavior vs our code.
It seems like this story (https://www.pivotaltracker.com/story/show/162360247)
implies that the code was correct in only
allowing the space developer and admin to use PATCH /v3/droplets/guid.

Co-authored-by: Galen Hammond <galenh@vmware.com>
Co-authored-by: Merric de Launey <mdelauney@pivotal.io>

