### PR TITLE
Space application supporter can get and list security groups

### DIFF
--- a/app/controllers/v3/security_groups_controller.rb
+++ b/app/controllers/v3/security_groups_controller.rb
@@ -83,7 +83,7 @@ class SecurityGroupsController < ApplicationController
 
     render status: :ok, json: Presenters::V3::SecurityGroupPresenter.new(
       security_group,
-      visible_space_guids: permission_queryer.readable_application_supporter_space_guids
+      visible_space_guids: permission_queryer.readable_supporter_space_guids
     )
   end
 
@@ -102,7 +102,7 @@ class SecurityGroupsController < ApplicationController
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
       path: '/v3/security_groups',
       message: message,
-      extra_presenter_args: { visible_space_guids: permission_queryer.readable_application_supporter_space_guids },
+      extra_presenter_args: { visible_space_guids: permission_queryer.readable_supporter_space_guids },
     )
   end
 

--- a/app/controllers/v3/security_groups_controller.rb
+++ b/app/controllers/v3/security_groups_controller.rb
@@ -83,7 +83,7 @@ class SecurityGroupsController < ApplicationController
 
     render status: :ok, json: Presenters::V3::SecurityGroupPresenter.new(
       security_group,
-      visible_space_guids: permission_queryer.readable_space_guids
+      visible_space_guids: permission_queryer.readable_application_supporter_space_guids
     )
   end
 
@@ -102,7 +102,7 @@ class SecurityGroupsController < ApplicationController
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
       path: '/v3/security_groups',
       message: message,
-      extra_presenter_args: { visible_space_guids: permission_queryer.readable_space_guids },
+      extra_presenter_args: { visible_space_guids: permission_queryer.readable_application_supporter_space_guids },
     )
   end
 

--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -96,7 +96,7 @@ class SpacesV3Controller < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     space = SpaceFetcher.new.fetch(hashed_params[:guid])
-    space_not_found! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
+    space_not_found! unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
 
     unfiltered_group_guids = fetch_running_security_group_guids(space)
     dataset = SecurityGroupListFetcher.fetch(message, unfiltered_group_guids)
@@ -115,7 +115,7 @@ class SpacesV3Controller < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     space = SpaceFetcher.new.fetch(hashed_params[:guid])
-    space_not_found! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
+    space_not_found! unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
 
     unfiltered_group_guids = fetch_staging_security_group_guids(space)
     dataset = SecurityGroupListFetcher.fetch(message, unfiltered_group_guids)

--- a/app/models/runtime/security_group.rb
+++ b/app/models/runtime/security_group.rb
@@ -37,10 +37,12 @@ module VCAP::CloudController
 
       Sequel.or([
         [:spaces, user.spaces_dataset],
+        [:spaces, user.application_supported_spaces_dataset],
         [:spaces, user.managed_spaces_dataset],
         [:spaces, user.audited_spaces_dataset],
         [:spaces, managed_organizations_spaces_dataset],
         [:staging_spaces, user.spaces_dataset],
+        [:staging_spaces, user.application_supported_spaces_dataset],
         [:staging_spaces, user.managed_spaces_dataset],
         [:staging_spaces, user.audited_spaces_dataset],
         [:staging_spaces, managed_organizations_spaces_dataset],

--- a/docs/v3/source/includes/experimental_resources/sidecars/_get.md.erb
+++ b/docs/v3/source/includes/experimental_resources/sidecars/_get.md.erb
@@ -31,7 +31,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
-Space Application Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Supporter | Experimental

--- a/docs/v3/source/includes/experimental_resources/sidecars/_list_for_app.md.erb
+++ b/docs/v3/source/includes/experimental_resources/sidecars/_list_for_app.md.erb
@@ -43,7 +43,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
-Space Application Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Supporter | Experimental

--- a/docs/v3/source/includes/experimental_resources/sidecars/_list_for_process.md.erb
+++ b/docs/v3/source/includes/experimental_resources/sidecars/_list_for_process.md.erb
@@ -43,7 +43,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
-Space Application Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Supporter | Experimental

--- a/docs/v3/source/includes/resources/security_groups/_get.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_get.md.erb
@@ -33,6 +33,7 @@ Global Auditor | Can see all security groups
 Org Auditor | Can see globally enabled security groups
 Org Billing Manager | Can see globally enabled security groups
 Org Manager | Can see globally enabled security groups or groups associated with a space they can see
+Space Application Supporter | Can see globally enabled security groups or groups associated with a space they can see
 Space Auditor | Can see globally enabled security groups or groups associated with a space they can see
 Space Developer | Can see globally enabled security groups or groups associated with a space they can see
 Space Manager | Can see globally enabled security groups or groups associated with a space they can see

--- a/docs/v3/source/includes/resources/security_groups/_get.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_get.md.erb
@@ -33,8 +33,8 @@ Global Auditor | Can see all security groups
 Org Auditor | Can see globally enabled security groups
 Org Billing Manager | Can see globally enabled security groups
 Org Manager | Can see globally enabled security groups or groups associated with a space they can see
-Space Application Supporter | Can see globally enabled security groups or groups associated with a space they can see
 Space Auditor | Can see globally enabled security groups or groups associated with a space they can see
 Space Developer | Can see globally enabled security groups or groups associated with a space they can see
 Space Manager | Can see globally enabled security groups or groups associated with a space they can see
+Space Supporter | Experimental. Can see globally enabled security groups or groups associated with a space they can see
 

--- a/docs/v3/source/includes/resources/security_groups/_list.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list.md.erb
@@ -49,7 +49,7 @@ Global Auditor | Can see all security groups
 Org Auditor | Can see globally–enabled security groups
 Org Billing Manager | Can see globally–enabled security groups
 Org Manager | Can see globally–enabled security groups or groups associated with a space they can see
-Space Application Supporter | Can see globally–enabled security groups or groups associated with a space they can see
 Space Auditor | Can see globally–enabled security groups or groups associated with a space they can see
 Space Developer | Can see globally–enabled security groups or groups associated with a space they can see
 Space Manager | Can see globally–enabled security groups or groups associated with a space they can see
+Space Supporter | Experimental. Can see globally–enabled security groups or groups associated with a space they can see

--- a/docs/v3/source/includes/resources/security_groups/_list.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list.md.erb
@@ -49,6 +49,7 @@ Global Auditor | Can see all security groups
 Org Auditor | Can see globally–enabled security groups
 Org Billing Manager | Can see globally–enabled security groups
 Org Manager | Can see globally–enabled security groups or groups associated with a space they can see
+Space Application Supporter | Can see globally–enabled security groups or groups associated with a space they can see
 Space Auditor | Can see globally–enabled security groups or groups associated with a space they can see
 Space Developer | Can see globally–enabled security groups or groups associated with a space they can see
 Space Manager | Can see globally–enabled security groups or groups associated with a space they can see

--- a/docs/v3/source/includes/resources/security_groups/_list_running_security_groups.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list_running_security_groups.md.erb
@@ -44,7 +44,7 @@ Admin | Can see all security groups
 Admin Read-Only | Can see all security groups
 Global Auditor | Can see all security groups
 Org Manager | Can see globally-enabled security groups and groups associated with spaces in their managed organizations
-Space Application Supporter | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Auditor | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Developer | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Manager | Can see globally-enabled security groups and groups associated with spaces where they have this role
+Space Supporter | Experimental. Can see globally-enabled security groups and groups associated with spaces where they have this role

--- a/docs/v3/source/includes/resources/security_groups/_list_running_security_groups.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list_running_security_groups.md.erb
@@ -44,6 +44,7 @@ Admin | Can see all security groups
 Admin Read-Only | Can see all security groups
 Global Auditor | Can see all security groups
 Org Manager | Can see globally-enabled security groups and groups associated with spaces in their managed organizations
+Space Application Supporter | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Auditor | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Developer | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Manager | Can see globally-enabled security groups and groups associated with spaces where they have this role

--- a/docs/v3/source/includes/resources/security_groups/_list_staging_security_groups.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list_staging_security_groups.md.erb
@@ -44,7 +44,7 @@ Admin | Can see all security groups
 Admin Read-Only | Can see all security groups
 Global Auditor | Can see all security groups
 Org Manager | Can see globally-enabled security groups and groups associated with spaces in their managed organizations
-Space Application Supporter | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Auditor | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Developer | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Manager | Can see globally-enabled security groups and groups associated with spaces where they have this role
+Space Supporter | Experimental. Can see globally-enabled security groups and groups associated with spaces where they have this role

--- a/docs/v3/source/includes/resources/security_groups/_list_staging_security_groups.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list_staging_security_groups.md.erb
@@ -44,6 +44,7 @@ Admin | Can see all security groups
 Admin Read-Only | Can see all security groups
 Global Auditor | Can see all security groups
 Org Manager | Can see globally-enabled security groups and groups associated with spaces in their managed organizations
+Space Application Supporter | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Auditor | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Developer | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Manager | Can see globally-enabled security groups and groups associated with spaces where they have this role

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -819,7 +819,7 @@ RSpec.describe 'Processes' do
       let(:space_supporter) do
         user = VCAP::CloudController::User.make
         org.add_user(user)
-        space.add_application_supporter(user)
+        space.add_supporter(user)
         user
       end
 
@@ -1459,7 +1459,7 @@ RSpec.describe 'Processes' do
       let(:space_supporter) do
         user = VCAP::CloudController::User.make
         org.add_user(user)
-        space.add_application_supporter(user)
+        space.add_supporter(user)
         user
       end
 

--- a/spec/request/security_groups_spec.rb
+++ b/spec/request/security_groups_spec.rb
@@ -665,6 +665,10 @@ RSpec.describe 'Security_Groups Request' do
           code: 200,
           response_objects: [expected_response_2, expected_response_3]
         }
+        h['space_application_supporter'] = {
+          code: 200,
+          response_objects: [expected_response_2, expected_response_3]
+        }
         h['space_manager'] = {
           code: 200,
           response_objects: [expected_response_2, expected_response_3]
@@ -692,7 +696,7 @@ RSpec.describe 'Security_Groups Request' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'filtering security groups' do
@@ -816,7 +820,7 @@ RSpec.describe 'Security_Groups Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'getting a security group NOT globally enabled, associated with spaces' do
@@ -869,6 +873,10 @@ RSpec.describe 'Security_Groups Request' do
           code: 200,
           response_object: expected_response
         }
+        h['space_application_supporter'] = {
+          code: 200,
+          response_object: expected_response
+        }
         h['space_manager'] = {
           code: 200,
           response_object: expected_response
@@ -884,7 +892,7 @@ RSpec.describe 'Security_Groups Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'getting a security group globally enabled' do
@@ -919,7 +927,7 @@ RSpec.describe 'Security_Groups Request' do
         Hash.new(code: 200, response_object: expected_response)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'security group does not exist' do

--- a/spec/request/security_groups_spec.rb
+++ b/spec/request/security_groups_spec.rb
@@ -665,7 +665,7 @@ RSpec.describe 'Security_Groups Request' do
           code: 200,
           response_objects: [expected_response_2, expected_response_3]
         }
-        h['space_application_supporter'] = {
+        h['space_supporter'] = {
           code: 200,
           response_objects: [expected_response_2, expected_response_3]
         }
@@ -696,7 +696,7 @@ RSpec.describe 'Security_Groups Request' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     context 'filtering security groups' do
@@ -820,7 +820,7 @@ RSpec.describe 'Security_Groups Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     context 'getting a security group NOT globally enabled, associated with spaces' do
@@ -873,7 +873,7 @@ RSpec.describe 'Security_Groups Request' do
           code: 200,
           response_object: expected_response
         }
-        h['space_application_supporter'] = {
+        h['space_supporter'] = {
           code: 200,
           response_object: expected_response
         }
@@ -892,7 +892,7 @@ RSpec.describe 'Security_Groups Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     context 'getting a security group globally enabled' do
@@ -927,7 +927,7 @@ RSpec.describe 'Security_Groups Request' do
         Hash.new(code: 200, response_object: expected_response)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     context 'security group does not exist' do

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -615,6 +615,7 @@ RSpec.describe 'Spaces' do
         h['space_manager'] = { code: 200, response_objects: response_object }
         h['space_auditor'] = { code: 200, response_objects: response_object }
         h['space_developer'] = { code: 200, response_objects: response_object }
+        h['space_application_supporter'] = { code: 200, response_objects: response_object }
         h.freeze
       end
 
@@ -766,6 +767,7 @@ RSpec.describe 'Spaces' do
         h['space_manager'] = { code: 200, response_objects: response_object }
         h['space_auditor'] = { code: 200, response_objects: response_object }
         h['space_developer'] = { code: 200, response_objects: response_object }
+        h['space_application_supporter'] = { code: 200, response_objects: response_object }
         h.freeze
       end
 

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -615,7 +615,7 @@ RSpec.describe 'Spaces' do
         h['space_manager'] = { code: 200, response_objects: response_object }
         h['space_auditor'] = { code: 200, response_objects: response_object }
         h['space_developer'] = { code: 200, response_objects: response_object }
-        h['space_application_supporter'] = { code: 200, response_objects: response_object }
+        h['space_supporter'] = { code: 200, response_objects: response_object }
         h.freeze
       end
 
@@ -767,7 +767,7 @@ RSpec.describe 'Spaces' do
         h['space_manager'] = { code: 200, response_objects: response_object }
         h['space_auditor'] = { code: 200, response_objects: response_object }
         h['space_developer'] = { code: 200, response_objects: response_object }
-        h['space_application_supporter'] = { code: 200, response_objects: response_object }
+        h['space_supporter'] = { code: 200, response_objects: response_object }
         h.freeze
       end
 


### PR DESCRIPTION
Allowed access:
* GET /v3/security_groups/:guid - Can see globally–enabled security
groups or groups associated with a space they can see
* GET /v3/security_groups - Can see globally–enabled security groups or
groups associated with a space they can see
* GET /v3/spaces/:guid/running_security_groups
* GET /v3/spaces/:guid/staging_security_groups

Closes [#2230](https://github.com/cloudfoundry/cloud_controller_ng/issues/2230)

Co-authored-by: Matthew Kocher <mkocher@vmware.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
