### PR TITLE
Allow space application supporter to access specific sidecar endpoints

### DIFF
--- a/app/controllers/v3/sidecars_controller.rb
+++ b/app/controllers/v3/sidecars_controller.rb
@@ -16,7 +16,7 @@ class SidecarsController < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     app, dataset = SidecarListFetcher.fetch_for_app(message, hashed_params[:app_guid])
-    resource_not_found!(:app) unless app && permission_queryer.can_read_from_space?(app.space.guid, app.organization.guid)
+    resource_not_found!(:app) unless app && permission_queryer.untrusted_can_read_from_space?(app.space.guid, app.organization.guid)
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::SidecarPresenter,
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
@@ -29,7 +29,7 @@ class SidecarsController < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     process, dataset = SidecarListFetcher.fetch_for_process(message, hashed_params[:process_guid])
-    resource_not_found!(:process) unless process && permission_queryer.can_read_from_space?(process.space.guid, process.organization.guid)
+    resource_not_found!(:process) unless process && permission_queryer.untrusted_can_read_from_space?(process.space.guid, process.organization.guid)
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::SidecarPresenter,
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
@@ -41,7 +41,7 @@ class SidecarsController < ApplicationController
     sidecar = SidecarModel.find(guid: hashed_params[:guid])
     resource_not_found!(:sidecar) unless sidecar
     app = sidecar.app
-    resource_not_found!(:sidecar) unless permission_queryer.can_read_from_space?(app.space.guid, app.space.organization.guid)
+    resource_not_found!(:sidecar) unless permission_queryer.untrusted_can_read_from_space?(app.space.guid, app.space.organization.guid)
 
     render status: 200, json: Presenters::V3::SidecarPresenter.new(sidecar)
   end

--- a/docs/v3/source/includes/experimental_resources/sidecars/_get.md.erb
+++ b/docs/v3/source/includes/experimental_resources/sidecars/_get.md.erb
@@ -31,6 +31,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |

--- a/docs/v3/source/includes/experimental_resources/sidecars/_list_for_app.md.erb
+++ b/docs/v3/source/includes/experimental_resources/sidecars/_list_for_app.md.erb
@@ -43,6 +43,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |

--- a/docs/v3/source/includes/experimental_resources/sidecars/_list_for_process.md.erb
+++ b/docs/v3/source/includes/experimental_resources/sidecars/_list_for_process.md.erb
@@ -43,6 +43,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Application Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |

--- a/spec/request/sidecars_spec.rb
+++ b/spec/request/sidecars_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe 'Sidecars' do
     let!(:sidecar_spider) { VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar, type: 'spider') }
     let!(:sidecar_web) { VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar, type: 'web') }
 
-    context 'as a space developer' do
+    context 'as a permitted user' do
       before do
         app_model.space.organization.add_user(user)
         app_model.space.add_developer(user)
@@ -337,30 +337,15 @@ RSpec.describe 'Sidecars' do
       let(:space) { app_model.space }
 
       let(:expected_codes_and_responses) do
-        h = Hash.new(code: 404)
-        h['admin'] = {
-          code: 200,
+        h = Hash.new(code: 200, response_guid: sidecar.guid)
+        h['no_role'] = {
+          code: 404,
         }
-        h['admin_read_only'] = {
-          code: 200,
+        h['org_auditor'] = {
+          code: 404,
         }
-        h['space_developer'] = {
-          code: 200,
-        }
-        h['space_application_supporter'] = {
-          code: 200,
-        }
-        h['global_auditor'] = {
-          code: 200,
-        }
-        h['space_manager'] = {
-          code: 200,
-        }
-        h['space_auditor'] = {
-          code: 200,
-        }
-        h['org_manager'] = {
-          code: 200,
+        h['org_billing_manager'] = {
+          code: 404,
         }
         h
       end

--- a/spec/request/sidecars_spec.rb
+++ b/spec/request/sidecars_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe 'Sidecars' do
   let(:user) { VCAP::CloudController::User.make }
   let(:user_header) { headers_for(user) }
 
-  before do
-    app_model.space.organization.add_user(user)
-    app_model.space.add_developer(user)
-  end
-
   describe 'POST /v3/apps/:guid/sidecars' do
+    before do
+      app_model.space.organization.add_user(user)
+      app_model.space.add_developer(user)
+    end
+
     let(:sidecar_params) {
       {
           name: 'sidecar_one',
@@ -130,6 +130,11 @@ RSpec.describe 'Sidecars' do
   end
 
   describe 'PATCH /v3/apps/:guid/sidecars' do
+    before do
+      app_model.space.organization.add_user(user)
+      app_model.space.add_developer(user)
+    end
+
     let!(:sidecar) { VCAP::CloudController::SidecarModel.make(name: 'My sidecar', command: 'rackdown', app: app_model, memory: 400) }
     let!(:sidecar_process_type) do
       VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar, type: 'other_worker', app_guid: app_model.guid)
@@ -293,30 +298,74 @@ RSpec.describe 'Sidecars' do
     let!(:sidecar_spider) { VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar, type: 'spider') }
     let!(:sidecar_web) { VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar, type: 'web') }
 
-    it 'gets the sidecar' do
-      get "/v3/sidecars/#{sidecar.guid}", nil, user_header
+    context 'as a space developer' do
+      before do
+        app_model.space.organization.add_user(user)
+        app_model.space.add_developer(user)
+      end
 
-      expected_response = {
-        'guid' => sidecar.guid,
-        'name' => 'sidecar',
-        'command' => 'smarch',
-        'process_types' => ['spider', 'web'],
-        'memory_in_mb' => 300,
-        'origin' => 'user',
-        'created_at' => iso8601,
-        'updated_at' => iso8601,
-        'relationships' => {
-          'app' => {
-            'data' => {
-              'guid' => app_model.guid
+      it 'gets the sidecar in the expected format' do
+        get "/v3/sidecars/#{sidecar.guid}", nil, user_header
+
+        expected_response = {
+          'guid' => sidecar.guid,
+          'name' => 'sidecar',
+          'command' => 'smarch',
+          'process_types' => ['spider', 'web'],
+          'memory_in_mb' => 300,
+          'origin' => 'user',
+          'created_at' => iso8601,
+          'updated_at' => iso8601,
+          'relationships' => {
+            'app' => {
+              'data' => {
+                'guid' => app_model.guid
+              }
             }
           }
         }
-      }
 
-      expect(last_response.status).to eq(200), last_response.body
-      parsed_response = MultiJson.load(last_response.body)
-      expect(parsed_response).to be_a_response_like(expected_response)
+        expect(last_response.status).to eq(200), last_response.body
+        parsed_response = MultiJson.load(last_response.body)
+        expect(parsed_response).to be_a_response_like(expected_response)
+      end
+    end
+
+    context 'permissions' do
+      let(:api_call) { lambda { |user_headers| get "/v3/sidecars/#{sidecar.guid}", nil, user_headers } }
+      let(:org) { app_model.organization }
+      let(:space) { app_model.space }
+
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 404)
+        h['admin'] = {
+          code: 200,
+        }
+        h['admin_read_only'] = {
+          code: 200,
+        }
+        h['space_developer'] = {
+          code: 200,
+        }
+        h['space_application_supporter'] = {
+          code: 200,
+        }
+        h['global_auditor'] = {
+          code: 200,
+        }
+        h['space_manager'] = {
+          code: 200,
+        }
+        h['space_auditor'] = {
+          code: 200,
+        }
+        h['org_manager'] = {
+          code: 200,
+        }
+        h
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
   end
 
@@ -357,98 +406,141 @@ RSpec.describe 'Sidecars' do
     )
     }
 
-    it_behaves_like 'list query endpoint' do
-      let(:request) { "/v3/processes/#{process1.guid}/sidecars" }
-      let(:message) { VCAP::CloudController::SidecarsListMessage }
-
-      let(:params) do
-        {
-          page:   '2',
-          per_page:   '10',
-          order_by:   'updated_at',
-          guids: "#{process1.guid},bogus",
-          created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
-          updated_ats: { gt: Time.now.utc.iso8601 },
-        }
+    context 'as a space developer' do
+      before do
+        app_model.space.organization.add_user(user)
+        app_model.space.add_developer(user)
       end
-    end
 
-    it "retrieves the process' sidecars" do
-      get "/v3/processes/#{process1.guid}/sidecars?per_page=2", nil, user_header
+      it_behaves_like 'list query endpoint' do
+        let(:request) { "/v3/processes/#{process1.guid}/sidecars" }
+        let(:message) { VCAP::CloudController::SidecarsListMessage }
 
-      expected_response = {
-        'pagination' => {
-          'total_results' => 3,
-          'total_pages'   => 2,
-          'first'         => { 'href' => "#{link_prefix}/v3/processes/#{process1.guid}/sidecars?page=1&per_page=2" },
-          'last'          => { 'href' => "#{link_prefix}/v3/processes/#{process1.guid}/sidecars?page=2&per_page=2" },
-          'next'          => { 'href' => "#{link_prefix}/v3/processes/#{process1.guid}/sidecars?page=2&per_page=2" },
-          'previous'      => nil,
-        },
-        'resources' => [
+        let(:params) do
           {
-            'guid' => sidecar1a.guid,
-            'name' => 'sidecar1a',
-            'command' => 'missile1a',
-            'process_types' => ['web', 'worker'],
-            'memory_in_mb' => nil,
-            'origin' => 'user',
-            'relationships' => {
-              'app' => {
-                'data' => {
-                  'guid' => app_model.guid,
-                },
-              },
-            },
-            'created_at' => iso8601,
-            'updated_at' => iso8601,
-          },
-          {
-            'guid' => sidecar1b.guid,
-            'name' => 'sidecar1b',
-            'command' => 'missile1b',
-            'process_types' => ['web', 'worker'],
-            'memory_in_mb' => nil,
-            'origin' => 'user',
-            'relationships' => {
-              'app' => {
-                'data' => {
-                  'guid' => app_model.guid,
-                },
-              },
-            },
-            'created_at' => iso8601,
-            'updated_at' => iso8601,
-          },
-        ]
-      }
-
-      expect(last_response.status).to eq(200), last_response.body
-      parsed_response = MultiJson.load(last_response.body)
-      expect(parsed_response).to be_a_response_like(expected_response)
-    end
-
-    context 'filtering on created_ats and updated_ats' do
-      let(:app_model3) { VCAP::CloudController::AppModel.make }
-      let!(:process3) { VCAP::CloudController::ProcessModel.make(
-        :process,
-        app:        app_model3,
-        type:       'web',
-        command:    'rackup',
-      )
-      }
-
-      it_behaves_like 'list_endpoint_with_common_filters' do
-        let(:resource_klass) { VCAP::CloudController::SidecarModel }
-        let(:additional_resource_params) { { app: app_model3 } }
-        let(:headers) { admin_headers }
-        let(:api_call) do
-          app_model3.sidecars_dataset.each do |sidecar|
-            VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar, type: 'web')
-          end
-          lambda { |headers, filters| get "/v3/processes/#{process3.guid}/sidecars?#{filters}", nil, headers }
+            page:   '2',
+            per_page:   '10',
+            order_by:   'updated_at',
+            guids: "#{process1.guid},bogus",
+            created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
+            updated_ats: { gt: Time.now.utc.iso8601 },
+          }
         end
       end
+
+      it "retrieves the process' sidecars" do
+        get "/v3/processes/#{process1.guid}/sidecars?per_page=2", nil, user_header
+
+        expected_response = {
+          'pagination' => {
+            'total_results' => 3,
+            'total_pages'   => 2,
+            'first'         => { 'href' => "#{link_prefix}/v3/processes/#{process1.guid}/sidecars?page=1&per_page=2" },
+            'last'          => { 'href' => "#{link_prefix}/v3/processes/#{process1.guid}/sidecars?page=2&per_page=2" },
+            'next'          => { 'href' => "#{link_prefix}/v3/processes/#{process1.guid}/sidecars?page=2&per_page=2" },
+            'previous'      => nil,
+          },
+          'resources' => [
+            {
+              'guid' => sidecar1a.guid,
+              'name' => 'sidecar1a',
+              'command' => 'missile1a',
+              'process_types' => ['web', 'worker'],
+              'memory_in_mb' => nil,
+              'origin' => 'user',
+              'relationships' => {
+                'app' => {
+                  'data' => {
+                    'guid' => app_model.guid,
+                  },
+                },
+              },
+              'created_at' => iso8601,
+              'updated_at' => iso8601,
+            },
+            {
+              'guid' => sidecar1b.guid,
+              'name' => 'sidecar1b',
+              'command' => 'missile1b',
+              'process_types' => ['web', 'worker'],
+              'memory_in_mb' => nil,
+              'origin' => 'user',
+              'relationships' => {
+                'app' => {
+                  'data' => {
+                    'guid' => app_model.guid,
+                  },
+                },
+              },
+              'created_at' => iso8601,
+              'updated_at' => iso8601,
+            },
+          ]
+        }
+
+        expect(last_response.status).to eq(200), last_response.body
+        parsed_response = MultiJson.load(last_response.body)
+        expect(parsed_response).to be_a_response_like(expected_response)
+      end
+
+      context 'filtering on created_ats and updated_ats' do
+        let(:app_model3) { VCAP::CloudController::AppModel.make }
+        let!(:process3) { VCAP::CloudController::ProcessModel.make(
+          :process,
+          app:        app_model3,
+          type:       'web',
+          command:    'rackup',
+        )
+        }
+
+        it_behaves_like 'list_endpoint_with_common_filters' do
+          let(:resource_klass) { VCAP::CloudController::SidecarModel }
+          let(:additional_resource_params) { { app: app_model3 } }
+          let(:headers) { admin_headers }
+          let(:api_call) do
+            app_model3.sidecars_dataset.each do |sidecar|
+              VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar, type: 'web')
+            end
+            lambda { |headers, filters| get "/v3/processes/#{process3.guid}/sidecars?#{filters}", nil, headers }
+          end
+        end
+      end
+    end
+    describe 'permissions' do
+      let(:api_call) { lambda { |user_headers| get "/v3/processes/#{process1.guid}/sidecars", nil, user_headers } }
+      let(:org) { app_model.organization }
+      let(:space) { app_model.space }
+
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 404)
+        h['admin'] = {
+          code: 200,
+        }
+        h['admin_read_only'] = {
+          code: 200,
+        }
+        h['space_developer'] = {
+          code: 200,
+        }
+        h['space_application_supporter'] = {
+          code: 200,
+        }
+        h['global_auditor'] = {
+          code: 200,
+        }
+        h['space_manager'] = {
+          code: 200,
+        }
+        h['space_auditor'] = {
+          code: 200,
+        }
+        h['org_manager'] = {
+          code: 200,
+        }
+        h
+      end
+
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
   end
 
@@ -460,74 +552,118 @@ RSpec.describe 'Sidecars' do
     let!(:sidecar3) { VCAP::CloudController::SidecarModel.make(name: 'sidecar3', app: app_model) }
     let!(:sidecar3_processes) { VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar3, type: 'three') }
 
-    it 'lists the sidecars for an app' do
-      get "/v3/apps/#{app_model.guid}/sidecars?per_page=2", nil, user_header
-      expect(last_response.status).to eq(200), last_response.body
+    context 'with a user in the space' do
+      before do
+        app_model.space.organization.add_user(user)
+        app_model.space.add_developer(user)
+      end
 
-      expect(parsed_response).to be_a_response_like(
-        {
-          'pagination' => {
-            'total_results' => 3,
-            'total_pages' => 2,
-            'first' => {
-              'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/sidecars?page=1&per_page=2"
+      it 'lists the sidecars for an app' do
+        get "/v3/apps/#{app_model.guid}/sidecars?per_page=2", nil, user_header
+        expect(last_response.status).to eq(200), last_response.body
+
+        expect(parsed_response).to be_a_response_like(
+          {
+            'pagination' => {
+              'total_results' => 3,
+              'total_pages' => 2,
+              'first' => {
+                'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/sidecars?page=1&per_page=2"
+              },
+              'last' => {
+                'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/sidecars?page=2&per_page=2"
+              },
+              'next' => {
+                'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/sidecars?page=2&per_page=2"
+              },
+              'previous' => nil
             },
-            'last' => {
-              'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/sidecars?page=2&per_page=2"
-            },
-            'next' => {
-              'href' => "#{link_prefix}/v3/apps/#{app_model.guid}/sidecars?page=2&per_page=2"
-            },
-            'previous' => nil
-          },
-          'resources' => [
-            {
-              'guid' => sidecar1.guid,
-              'name' => 'sidecar1',
-              'command' => 'bundle exec rackup',
-              'process_types' => ['one'],
-              'memory_in_mb' => nil,
-              'origin' => 'user',
-              'created_at' => iso8601,
-              'updated_at' => iso8601,
-              'relationships' => {
-                'app' => {
-                  'data' => {
-                    'guid' => app_model.guid
+            'resources' => [
+              {
+                'guid' => sidecar1.guid,
+                'name' => 'sidecar1',
+                'command' => 'bundle exec rackup',
+                'process_types' => ['one'],
+                'memory_in_mb' => nil,
+                'origin' => 'user',
+                'created_at' => iso8601,
+                'updated_at' => iso8601,
+                'relationships' => {
+                  'app' => {
+                    'data' => {
+                      'guid' => app_model.guid
+                    }
                   }
                 }
-              }
-            },
-            {
-              'guid' => sidecar2.guid,
-              'name' => 'sidecar2',
-              'command' => 'bundle exec rackup',
-              'process_types' => ['two'],
-              'memory_in_mb' => nil,
-              'origin' => 'user',
-              'created_at' => iso8601,
-              'updated_at' => iso8601,
-              'relationships' => {
-                'app' => {
-                  'data' => {
-                    'guid' => app_model.guid
+              },
+              {
+                'guid' => sidecar2.guid,
+                'name' => 'sidecar2',
+                'command' => 'bundle exec rackup',
+                'process_types' => ['two'],
+                'memory_in_mb' => nil,
+                'origin' => 'user',
+                'created_at' => iso8601,
+                'updated_at' => iso8601,
+                'relationships' => {
+                  'app' => {
+                    'data' => {
+                      'guid' => app_model.guid
+                    }
                   }
                 }
-              }
-            },
-          ]
-        }
-    )
+              },
+            ]
+          }
+      )
+      end
+
+      it_behaves_like 'list_endpoint_with_common_filters' do
+        let(:resource_klass) { VCAP::CloudController::SidecarModel }
+        let(:app_model2) { VCAP::CloudController::AppModel.make }
+        let(:additional_resource_params) { { app: app_model2 } }
+        let(:headers) { admin_headers }
+        let(:api_call) do
+          lambda { |headers, filters| get "/v3/apps/#{app_model2.guid}/sidecars?#{filters}", nil, headers }
+        end
+      end
     end
 
-    it_behaves_like 'list_endpoint_with_common_filters' do
-      let(:resource_klass) { VCAP::CloudController::SidecarModel }
-      let(:app_model2) { VCAP::CloudController::AppModel.make }
-      let(:additional_resource_params) { { app: app_model2 } }
-      let(:headers) { admin_headers }
-      let(:api_call) do
-        lambda { |headers, filters| get "/v3/apps/#{app_model2.guid}/sidecars?#{filters}", nil, headers }
+    context 'permissions' do
+      let(:api_call) { lambda { |user_headers| get "/v3/apps/#{app_model.guid}/sidecars", nil, user_headers } }
+      let(:org) { app_model.organization }
+      let(:space) { app_model.space }
+
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 404)
+        h['admin'] = {
+          code: 200,
+        }
+        h['admin_read_only'] = {
+          code: 200,
+        }
+        h['space_developer'] = {
+          code: 200,
+        }
+        h['space_application_supporter'] = {
+          code: 200,
+        }
+        h['global_auditor'] = {
+          code: 200,
+        }
+        h['space_manager'] = {
+          code: 200,
+        }
+        h['space_auditor'] = {
+          code: 200,
+        }
+        h['org_manager'] = {
+          code: 200,
+        }
+        h
       end
+
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
   end
 
@@ -535,6 +671,11 @@ RSpec.describe 'Sidecars' do
     let(:sidecar) { VCAP::CloudController::SidecarModel.make(app: app_model, name: 'sidecar', command: 'smarch') }
     let!(:sidecar_spider) { VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar, type: 'spider') }
     let!(:sidecar_web) { VCAP::CloudController::SidecarProcessTypeModel.make(sidecar: sidecar, type: 'web') }
+
+    before do
+      app_model.space.organization.add_user(user)
+      app_model.space.add_developer(user)
+    end
 
     it 'deletes the sidecar' do
       delete "/v3/sidecars/#{sidecar.guid}", nil, user_header


### PR DESCRIPTION
allows access to:
GET /v3/sidecars/:guid
GET /v3/processes/:process_guid/sidecars
GET /v3/apps/:app_guid/sidecars

Finishes #2231

Co-authored-by: Maria Shaldybin <mariash@vmware.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
