### PR TITLE
add controller spec deprecation notice

### DIFF
--- a/spec/unit/controllers/internal/app_crashed_controller_spec.rb
+++ b/spec/unit/controllers/internal/app_crashed_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe AppCrashedController do
     describe 'POST /internal/v4/apps/:process_guid/crashed' do

--- a/spec/unit/controllers/internal/download_droplets_controller_spec.rb
+++ b/spec/unit/controllers/internal/download_droplets_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe DownloadDropletsController do
     describe 'GET /internal/v2/droplets/:guid/:droplet_hash/download' do

--- a/spec/unit/controllers/internal/log_access_controller_spec.rb
+++ b/spec/unit/controllers/internal/log_access_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'fetchers/log_access_fetcher'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe LogAccessController do
     let(:app_model) { VCAP::CloudController::AppModel.make(enable_ssh: true) }

--- a/spec/unit/controllers/internal/packages_controller_spec.rb
+++ b/spec/unit/controllers/internal/packages_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   module Internal
     RSpec.describe PackagesController do

--- a/spec/unit/controllers/internal/staging_completion_controller_spec.rb
+++ b/spec/unit/controllers/internal/staging_completion_controller_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'membrane'
 require 'cloud_controller/diego/failure_reason_sanitizer'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe StagingCompletionController do
     let(:buildpack_name) { 'the-pleasant-buildpack' }

--- a/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
+++ b/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe SyslogDrainUrlsInternalController do
     let(:org) { Organization.make(name: 'org-1') }

--- a/spec/unit/controllers/internal/task_completion_controller_spec.rb
+++ b/spec/unit/controllers/internal/task_completion_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'membrane'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe TasksCompletionController do
     describe 'POST /internal/v4/tasks/:task_guid/completed' do

--- a/spec/unit/controllers/runtime/app_bits_download_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_bits_download_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe AppBitsDownloadController do
     describe 'GET /v2/app/:id/download' do

--- a/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe AppBitsUploadController do
     let(:app_event_repository) { Repositories::AppEventRepository.new }

--- a/spec/unit/controllers/runtime/app_events_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_events_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::AppEventsController do
     describe 'Query Parameters' do

--- a/spec/unit/controllers/runtime/app_summaries_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_summaries_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe AppSummariesController do
     before do

--- a/spec/unit/controllers/runtime/app_usage_events_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_usage_events_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe AppUsageEventsController do
     before do

--- a/spec/unit/controllers/runtime/apps_controller_spec.rb
+++ b/spec/unit/controllers/runtime/apps_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::AppsController do
     let(:admin_user) { User.make }

--- a/spec/unit/controllers/runtime/apps_ssh_controller_spec.rb
+++ b/spec/unit/controllers/runtime/apps_ssh_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'cloud_controller/diego/process_guid'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe AppsSSHController do
     let(:diego) { true }

--- a/spec/unit/controllers/runtime/buildpack_bits_controller_spec.rb
+++ b/spec/unit/controllers/runtime/buildpack_bits_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::BuildpackBitsController do
     let(:user) { make_user }

--- a/spec/unit/controllers/runtime/buildpacks_cache_controller_spec.rb
+++ b/spec/unit/controllers/runtime/buildpacks_cache_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe BuildpacksCacheController do
     describe 'DELETE /v2/blobstores/buildpack_cache' do

--- a/spec/unit/controllers/runtime/buildpacks_controller_spec.rb
+++ b/spec/unit/controllers/runtime/buildpacks_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::BuildpacksController do
     def ordered_buildpacks

--- a/spec/unit/controllers/runtime/crashes_controller_spec.rb
+++ b/spec/unit/controllers/runtime/crashes_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::CrashesController do
     describe 'GET /v2/apps/:id/crashes' do

--- a/spec/unit/controllers/runtime/domains_controller_spec.rb
+++ b/spec/unit/controllers/runtime/domains_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::DomainsController do
     describe 'Query Parameters' do

--- a/spec/unit/controllers/runtime/environment_variable_groups_controller_spec.rb
+++ b/spec/unit/controllers/runtime/environment_variable_groups_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe EnvironmentVariableGroupsController do
     describe 'GET /v2/config/environment_variable_groups/:name' do

--- a/spec/unit/controllers/runtime/events_controller_spec.rb
+++ b/spec/unit/controllers/runtime/events_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe EventsController do
     describe 'Query Parameters' do

--- a/spec/unit/controllers/runtime/feature_flags_controller_spec.rb
+++ b/spec/unit/controllers/runtime/feature_flags_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe FeatureFlagsController do
     before { set_current_user_as_admin }

--- a/spec/unit/controllers/runtime/helpers/blob_dispatcher_spec.rb
+++ b/spec/unit/controllers/runtime/helpers/blob_dispatcher_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe BlobDispatcher do
     subject(:dispatcher) { BlobDispatcher.new(blobstore: blobstore, controller: controller) }

--- a/spec/unit/controllers/runtime/info_controller_spec.rb
+++ b/spec/unit/controllers/runtime/info_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::InfoController do
     describe 'GET /v2/info' do

--- a/spec/unit/controllers/runtime/instances_controller_spec.rb
+++ b/spec/unit/controllers/runtime/instances_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::InstancesController do
     let(:instances_reporters) { double(:instances_reporters) }

--- a/spec/unit/controllers/runtime/jobs_controller_spec.rb
+++ b/spec/unit/controllers/runtime/jobs_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::JobsController do
     let(:job) { Delayed::Job.enqueue double(perform: nil) }

--- a/spec/unit/controllers/runtime/legacy_api_base_spec.rb
+++ b/spec/unit/controllers/runtime/legacy_api_base_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::LegacyApiBase do
     let(:user) { User.make(admin: true, active: true) }

--- a/spec/unit/controllers/runtime/legacy_info_spec.rb
+++ b/spec/unit/controllers/runtime/legacy_info_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   # port of the legacy cc info spec, minus legacy token support. i.e. this is jwt
   # tokens only.

--- a/spec/unit/controllers/runtime/organization_summaries_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organization_summaries_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::OrganizationSummariesController do
     num_spaces = 2

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::OrganizationsController do
     let(:org) { Organization.make }

--- a/spec/unit/controllers/runtime/private_domains_controller_spec.rb
+++ b/spec/unit/controllers/runtime/private_domains_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe PrivateDomainsController do
     describe 'Query Parameters' do

--- a/spec/unit/controllers/runtime/quota_definitions_controller_spec.rb
+++ b/spec/unit/controllers/runtime/quota_definitions_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::QuotaDefinitionsController do
     describe 'Query Parameters' do

--- a/spec/unit/controllers/runtime/resource_matches_controller_spec.rb
+++ b/spec/unit/controllers/runtime/resource_matches_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::ResourceMatchesController do
     include_context 'resource pool'

--- a/spec/unit/controllers/runtime/restages_controller_spec.rb
+++ b/spec/unit/controllers/runtime/restages_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe RestagesController do
     let(:app_event_repository) { Repositories::AppEventRepository.new }

--- a/spec/unit/controllers/runtime/root_controller_spec.rb
+++ b/spec/unit/controllers/runtime/root_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::RootController do
     describe 'GET /' do

--- a/spec/unit/controllers/runtime/route_mappings_controller_spec.rb
+++ b/spec/unit/controllers/runtime/route_mappings_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::RouteMappingsController do
     before do

--- a/spec/unit/controllers/runtime/routes_controller_spec.rb
+++ b/spec/unit/controllers/runtime/routes_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::RoutesController do
     let(:routing_api_client) { double('routing_api_client', enabled?: true) }

--- a/spec/unit/controllers/runtime/security_group_running_defaults_controller_spec.rb
+++ b/spec/unit/controllers/runtime/security_group_running_defaults_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe SecurityGroupRunningDefaultsController do
     before { set_current_user(User.make) }

--- a/spec/unit/controllers/runtime/security_group_staging_defaults_controller_spec.rb
+++ b/spec/unit/controllers/runtime/security_group_staging_defaults_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe SecurityGroupStagingDefaultsController do
     before { set_current_user(User.make) }

--- a/spec/unit/controllers/runtime/security_groups_controller_spec.rb
+++ b/spec/unit/controllers/runtime/security_groups_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe SecurityGroupsController do
     let(:group) { SecurityGroup.make }

--- a/spec/unit/controllers/runtime/shared_domains_controller_spec.rb
+++ b/spec/unit/controllers/runtime/shared_domains_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe SharedDomainsController do
     describe 'Query Parameters' do

--- a/spec/unit/controllers/runtime/space_quota_definitions_controller_spec.rb
+++ b/spec/unit/controllers/runtime/space_quota_definitions_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::SpaceQuotaDefinitionsController do
     before { set_current_user_as_admin }

--- a/spec/unit/controllers/runtime/space_summaries_controller_spec.rb
+++ b/spec/unit/controllers/runtime/space_summaries_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe SpaceSummariesController do
     let(:space) { Space.make }

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::SpacesController do
     let(:organization_one) { Organization.make }

--- a/spec/unit/controllers/runtime/stacks_controller_spec.rb
+++ b/spec/unit/controllers/runtime/stacks_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::StacksController do
     let(:user) { User.make }

--- a/spec/unit/controllers/runtime/stagings_controller_spec.rb
+++ b/spec/unit/controllers/runtime/stagings_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.shared_examples 'droplet staging error handling' do
     context 'when a content-md5 is specified' do

--- a/spec/unit/controllers/runtime/stats_controller_spec.rb
+++ b/spec/unit/controllers/runtime/stats_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::StatsController do
     let(:user) { make_user_for_space(process.space) }

--- a/spec/unit/controllers/runtime/user_summaries_controller_spec.rb
+++ b/spec/unit/controllers/runtime/user_summaries_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe UserSummariesController do
     describe 'GET /users/:guid/summary' do

--- a/spec/unit/controllers/runtime/users_controller_spec.rb
+++ b/spec/unit/controllers/runtime/users_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::UsersController do
     let(:uaa_client) { instance_double(UaaClient) }

--- a/spec/unit/controllers/services/lifecycle/service_instance_binding_manager_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_instance_binding_manager_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServiceInstanceBindingManager do
     let(:manager) { ServiceInstanceBindingManager.new(access_validator, logger) }

--- a/spec/unit/controllers/services/lifecycle/service_instance_deprovisioner_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_instance_deprovisioner_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServiceInstanceDeprovisioner do
     let(:event_repository) { Repositories::ServiceEventRepository.new(UserAuditInfo.new(user_guid: User.make.guid, user_email: 'email')) }

--- a/spec/unit/controllers/services/lifecycle/service_instance_purger_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_instance_purger_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::ServiceInstancePurger do
     let(:event_repository) { VCAP::CloudController::Repositories::ServiceEventRepository.new(UserAuditInfo.new(user_guid: User.make.guid, user_email: 'email')) }

--- a/spec/unit/controllers/services/lifecycle/service_key_manager_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_key_manager_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServiceKeyManager do
     let(:guid_pattern) { '[[:alnum:]-]+' }

--- a/spec/unit/controllers/services/managed_service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/managed_service_instances_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ManagedServiceInstancesController, :services do
     describe 'GET', '/v2/managed_service_instances' do

--- a/spec/unit/controllers/services/service_bindings_controller_spec.rb
+++ b/spec/unit/controllers/services/service_bindings_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServiceBindingsController do
     describe 'Query Parameters' do

--- a/spec/unit/controllers/services/service_brokers_controller_spec.rb
+++ b/spec/unit/controllers/services/service_brokers_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServiceBrokersController, :services do
     let(:broker) { ServiceBroker.make }

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::ServiceInstancesController, :services do
     let(:service_broker_url_regex) { %r{http://example.com/v2/service_instances/(.*)} }

--- a/spec/unit/controllers/services/service_keys_controller_spec.rb
+++ b/spec/unit/controllers/services/service_keys_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServiceKeysController do
     describe 'Attributes' do

--- a/spec/unit/controllers/services/service_plan_visibilities_controller_spec.rb
+++ b/spec/unit/controllers/services/service_plan_visibilities_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServicePlanVisibilitiesController, :services do
     let(:user) { User.make }

--- a/spec/unit/controllers/services/service_plans_controller_spec.rb
+++ b/spec/unit/controllers/services/service_plans_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServicePlansController, :services do
     shared_examples 'enumerate and read plan only' do |perm_name|

--- a/spec/unit/controllers/services/service_usage_events_controller_spec.rb
+++ b/spec/unit/controllers/services/service_usage_events_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServiceUsageEventsController do
     let(:event_guid1) { SecureRandom.uuid }

--- a/spec/unit/controllers/services/services_controller_spec.rb
+++ b/spec/unit/controllers/services/services_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe ServicesController, :services do
     shared_examples 'enumerate and read service only' do |perm_name|

--- a/spec/unit/controllers/services/user_provided_service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/user_provided_service_instances_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe UserProvidedServiceInstancesController, :services do
     describe 'Query Parameters' do

--- a/spec/unit/controllers/services/validators/service_update_validator_spec.rb
+++ b/spec/unit/controllers/services/validators/service_update_validator_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::ServiceUpdateValidator, :services do
     describe '#validate_service_instance' do

--- a/spec/unit/controllers/v3/app_features_controller_spec.rb
+++ b/spec/unit/controllers/v3/app_features_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe AppFeaturesController, type: :controller do
   let(:app_model) { VCAP::CloudController::AppModel.make(enable_ssh: true) }
   let(:space) { app_model.space }

--- a/spec/unit/controllers/v3/app_manifests_controller_spec.rb
+++ b/spec/unit/controllers/v3/app_manifests_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe AppManifestsController, type: :controller do
   describe '#show' do
     let(:app_model) { VCAP::CloudController::AppModel.make }

--- a/spec/unit/controllers/v3/app_revisions_controller_spec.rb
+++ b/spec/unit/controllers/v3/app_revisions_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe AppRevisionsController, type: :controller do
   let!(:space) { app_model.space }
   let(:user) { VCAP::CloudController::User.make }

--- a/spec/unit/controllers/v3/application_controller_spec.rb
+++ b/spec/unit/controllers/v3/application_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'rails_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe ApplicationController, type: :controller do
   RSpec::Matchers.define_negated_matcher :not_change, :change
 

--- a/spec/unit/controllers/v3/apps_controller_spec.rb
+++ b/spec/unit/controllers/v3/apps_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe AppsV3Controller, type: :controller do
   describe '#index' do
     let(:app_model_1) { VCAP::CloudController::AppModel.make }

--- a/spec/unit/controllers/v3/buildpacks_controller_spec.rb
+++ b/spec/unit/controllers/v3/buildpacks_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require 'messages/buildpack_create_message'
 require 'models/runtime/buildpack'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe BuildpacksController, type: :controller do
   before do
     TestConfig.override(kubernetes: {})

--- a/spec/unit/controllers/v3/builds_controller_spec.rb
+++ b/spec/unit/controllers/v3/builds_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe BuildsController, type: :controller do
   describe '#index' do
     let(:user) { set_current_user(VCAP::CloudController::User.make) }

--- a/spec/unit/controllers/v3/deployments_controller_spec.rb
+++ b/spec/unit/controllers/v3/deployments_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require 'permissions_spec_helper'
 require 'messages/deployment_create_message'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe DeploymentsController, type: :controller do
   let(:user) { VCAP::CloudController::User.make }
   let(:app) { VCAP::CloudController::AppModel.make(desired_state: VCAP::CloudController::ProcessModel::STARTED) }

--- a/spec/unit/controllers/v3/droplets_controller_spec.rb
+++ b/spec/unit/controllers/v3/droplets_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe DropletsController, type: :controller do
   describe '#create' do
     let(:app_model) { VCAP::CloudController::AppModel.make }

--- a/spec/unit/controllers/v3/errors_controller_spec.rb
+++ b/spec/unit/controllers/v3/errors_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe ErrorsController, type: :controller do
   describe '#not_found' do
     it 'returns an error' do

--- a/spec/unit/controllers/v3/feature_flags_controller_spec.rb
+++ b/spec/unit/controllers/v3/feature_flags_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe FeatureFlagsController, type: :controller do
   describe '#index' do
     let(:user) { VCAP::CloudController::User.make }

--- a/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
+++ b/spec/unit/controllers/v3/isolation_segments_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'isolation_segment_assign'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe IsolationSegmentsController, type: :controller do
   let(:user) { set_current_user(VCAP::CloudController::User.make) }
   let(:isolation_segment_model) { VCAP::CloudController::IsolationSegmentModel.make }

--- a/spec/unit/controllers/v3/jobs_controller_spec.rb
+++ b/spec/unit/controllers/v3/jobs_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe V3::JobsController, type: :controller do
   describe '#show' do
     let!(:job) { VCAP::CloudController::PollableJobModel.make(resource_type: 'app') }

--- a/spec/unit/controllers/v3/organizations_controller_spec.rb
+++ b/spec/unit/controllers/v3/organizations_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe OrganizationsV3Controller, type: :controller do
   describe '#show' do
     let(:user) { set_current_user(VCAP::CloudController::User.make) }

--- a/spec/unit/controllers/v3/packages_controller_spec.rb
+++ b/spec/unit/controllers/v3/packages_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe PackagesController, type: :controller do
   describe '#upload' do
     let(:package) { VCAP::CloudController::PackageModel.make }

--- a/spec/unit/controllers/v3/processes_controller_spec.rb
+++ b/spec/unit/controllers/v3/processes_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe ProcessesController, type: :controller do
   let(:space) { VCAP::CloudController::Space.make }
   let(:app) { VCAP::CloudController::AppModel.make(space: space) }

--- a/spec/unit/controllers/v3/resource_matches_controller_spec.rb
+++ b/spec/unit/controllers/v3/resource_matches_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'rails_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe ResourceMatchesController, type: :controller do
   describe '#create' do
     include_context 'resource pool'

--- a/spec/unit/controllers/v3/revisions_controller_spec.rb
+++ b/spec/unit/controllers/v3/revisions_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe RevisionsController, type: :controller do
   describe '#show' do
     let!(:droplet) { VCAP::CloudController::DropletModel.make }

--- a/spec/unit/controllers/v3/sidecars_controller_spec.rb
+++ b/spec/unit/controllers/v3/sidecars_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe SidecarsController, type: :controller do
   let!(:app_model) { VCAP::CloudController::AppModel.make(space: space) }
   let(:user) { VCAP::CloudController::User.make }

--- a/spec/unit/controllers/v3/space_manifests_controller_spec.rb
+++ b/spec/unit/controllers/v3/space_manifests_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe SpaceManifestsController, type: :controller do
   describe '#apply_manifest' do
     let(:app_model) { VCAP::CloudController::AppModel.make(name: 'blah') }

--- a/spec/unit/controllers/v3/spaces_controller_spec.rb
+++ b/spec/unit/controllers/v3/spaces_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe SpacesV3Controller, type: :controller do
   describe '#show' do
     let(:user) { set_current_user(VCAP::CloudController::User.make) }

--- a/spec/unit/controllers/v3/stacks_controller_spec.rb
+++ b/spec/unit/controllers/v3/stacks_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require 'actions/stack_create'
 require 'permissions_spec_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe StacksController, type: :controller do
   describe '#index' do
     before { VCAP::CloudController::Stack.dataset.destroy }

--- a/spec/unit/controllers/v3/tasks_controller_spec.rb
+++ b/spec/unit/controllers/v3/tasks_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
 RSpec.describe TasksController, type: :controller do
   let(:client) { instance_double(VCAP::CloudController::Diego::BbsTaskClient, desire_task: nil) }
   let(:tasks_enabled) { true }


### PR DESCRIPTION
controller specs are deprecated by adr #0003. Adding a notice so the ADR
is more discoverable. Skipped the base specs as those files are meta
enough to perhaps justify controller specs.

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:


* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
