### PR TITLE
Space application supporter can get and list space quotas

### DIFF
--- a/app/controllers/v3/space_quotas_controller.rb
+++ b/app/controllers/v3/space_quotas_controller.rb
@@ -36,7 +36,7 @@ class SpaceQuotasController < ApplicationController
 
     render status: :ok, json: Presenters::V3::SpaceQuotaPresenter.new(
       space_quota,
-      visible_space_guids: readable_space_guids
+      visible_space_guids: readable_application_supporter_space_guids
     )
   end
 
@@ -51,7 +51,7 @@ class SpaceQuotasController < ApplicationController
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
       path: '/v3/space_quotas',
       message: message,
-      extra_presenter_args: { visible_space_guids: readable_space_guids },
+      extra_presenter_args: { visible_space_guids: readable_application_supporter_space_guids },
     )
   end
 
@@ -153,5 +153,9 @@ class SpaceQuotasController < ApplicationController
 
   def readable_space_guids
     permission_queryer.readable_space_guids
+  end
+
+  def readable_application_supporter_space_guids
+    permission_queryer.readable_application_supporter_space_guids
   end
 end

--- a/app/models/runtime/space_quota_definition.rb
+++ b/app/models/runtime/space_quota_definition.rb
@@ -50,6 +50,7 @@ module VCAP::CloudController
       Sequel.or([
         [:organization, user.managed_organizations_dataset],
         [:spaces, user.spaces_dataset],
+        [:spaces, user.application_supported_spaces_dataset],
         [:spaces, user.managed_spaces_dataset],
         [:spaces, user.audited_spaces_dataset]
       ])

--- a/docs/v3/source/includes/resources/space_quotas/_get.md.erb
+++ b/docs/v3/source/includes/resources/space_quotas/_get.md.erb
@@ -32,6 +32,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager | Can only query space quotas owned by affiliated organizations
+Space Application Supporter | Can only query space quotas applied to affiliated spaces
 Space Auditor | Can only query space quotas applied to affiliated spaces
 Space Developer | Can only query space quotas applied to affiliated spaces
 Space Manager | Can only query space quotas applied to affiliated spaces

--- a/spec/request/space_quotas_spec.rb
+++ b/spec/request/space_quotas_spec.rb
@@ -14,10 +14,20 @@ module VCAP::CloudController
 
       context 'when the space quota is applied to the space where the current user has a role' do
         let(:expected_codes_and_responses) do
-          responses_for_space_restricted_single_endpoint(make_space_quota_json(space_quota))
+          h = Hash.new(code: 404)
+          expected_response = make_space_quota_json(space_quota)
+          h['admin'] = { code: 200, response_object: expected_response }
+          h['admin_read_only'] = { code: 200, response_object: expected_response }
+          h['global_auditor'] = { code: 200, response_object: expected_response }
+          h['space_developer'] = { code: 200, response_object: expected_response }
+          h['space_application_supporter'] = { code: 200, response_object: expected_response }
+          h['space_manager'] = { code: 200, response_object: expected_response }
+          h['space_auditor'] = { code: 200, response_object: expected_response }
+          h['org_manager'] = { code: 200, response_object: expected_response }
+          h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the space quota has no associated spaces' do
@@ -33,7 +43,7 @@ module VCAP::CloudController
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the space quota is owned by an org where the current user does not have a role' do
@@ -49,7 +59,7 @@ module VCAP::CloudController
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the space quota does not exist' do
@@ -286,10 +296,11 @@ module VCAP::CloudController
           h['space_manager'] = { code: 200, response_objects: [make_space_quota_json(space_quota)] }
           h['space_auditor'] = { code: 200, response_objects: [make_space_quota_json(space_quota)] }
           h['space_developer'] = { code: 200, response_objects: [make_space_quota_json(space_quota)] }
+          h['space_application_supporter'] = { code: 200, response_objects: [make_space_quota_json(space_quota)] }
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'with filters' do


### PR DESCRIPTION
Allowed access:
GET /v3/space_quotas
GET /v3/space_quotas/:guid

Closes [#2233]

Co-authored-by: Matthew Kocher <mkocher@vmware.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
