### PR TITLE
Allow space application supporter to access specific service plan endpoints

### DIFF
--- a/app/controllers/v3/mixins/service_permissions.rb
+++ b/app/controllers/v3/mixins/service_permissions.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
     end
 
     def visible_space_scoped?(space)
-      current_user && space && (space.has_member?(current_user) || space.has_application_supporter?(current_user))
+      current_user && space && (space.has_member?(current_user) || space.has_supporter?(current_user))
     end
 
     def visible_to_current_user?(service: nil, plan: nil)

--- a/app/controllers/v3/mixins/service_permissions.rb
+++ b/app/controllers/v3/mixins/service_permissions.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
     end
 
     def visible_space_scoped?(space)
-      current_user && space && space.has_member?(current_user)
+      current_user && space && (space.has_member?(current_user) || space.has_application_supporter?(current_user))
     end
 
     def visible_to_current_user?(service: nil, plan: nil)

--- a/app/controllers/v3/service_plans_controller.rb
+++ b/app/controllers/v3/service_plans_controller.rb
@@ -55,7 +55,7 @@ class ServicePlansController < ApplicationController
                   message,
                   eager_loaded_associations: Presenters::V3::ServicePlanPresenter.associated_resources,
                   readable_org_guids: permission_queryer.readable_org_guids,
-                  readable_space_guids: permission_queryer.readable_application_supporter_space_scoped_space_guids,
+                  readable_space_guids: permission_queryer.readable_space_supporter_space_scoped_space_guids,
                 )
               end
 

--- a/app/controllers/v3/service_plans_controller.rb
+++ b/app/controllers/v3/service_plans_controller.rb
@@ -55,7 +55,7 @@ class ServicePlansController < ApplicationController
                   message,
                   eager_loaded_associations: Presenters::V3::ServicePlanPresenter.associated_resources,
                   readable_org_guids: permission_queryer.readable_org_guids,
-                  readable_space_guids: permission_queryer.readable_space_scoped_space_guids,
+                  readable_space_guids: permission_queryer.readable_application_supporter_space_scoped_space_guids,
                 )
               end
 

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -234,6 +234,14 @@ class VCAP::CloudController::Permissions
     end
   end
 
+  def readable_application_supporter_space_scoped_space_guids
+    if can_read_globally?
+      VCAP::CloudController::Space.select(:guid).all.map(&:guid)
+    else
+      membership.space_guids_for_roles(SPACE_ROLES_INCLUDING_APPLICATION_SUPPORTERS)
+    end
+  end
+
   def can_read_route?(space_guid, org_guid)
     return true if can_read_globally?
 

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -234,7 +234,7 @@ class VCAP::CloudController::Permissions
     end
   end
 
-  def readable_application_supporter_space_scoped_space_guids
+  def readable_space_supporter_space_scoped_space_guids
     if can_read_globally?
       VCAP::CloudController::Space.select(:guid).all.map(&:guid)
     else

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -238,7 +238,7 @@ class VCAP::CloudController::Permissions
     if can_read_globally?
       VCAP::CloudController::Space.select(:guid).all.map(&:guid)
     else
-      membership.space_guids_for_roles(SPACE_ROLES_INCLUDING_APPLICATION_SUPPORTERS)
+      membership.space_guids_for_roles(SPACE_ROLES_INCLUDING_SUPPORTERS)
     end
   end
 

--- a/spec/request/service_plan_visibility_spec.rb
+++ b/spec/request/service_plan_visibility_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'V3 service plan visibility' do
         )
       }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     context 'for admin-only plans' do
@@ -50,7 +50,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     context 'for space-scoped plans' do
@@ -92,7 +92,7 @@ RSpec.describe 'V3 service plan visibility' do
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     context 'for org-restricted plans' do
@@ -143,7 +143,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
   end
 
@@ -170,13 +170,13 @@ RSpec.describe 'V3 service plan visibility' do
         let(:req_body) { { type: 'admin' } }
         let(:successful_response) { { code: 200, response_object: { type: 'admin' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
 
       context 'and its being updated to "public"' do
         let(:successful_response) { { code: 200, response_object: { type: 'public' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
 
       context 'and its being updated to "organization"' do
@@ -184,7 +184,7 @@ RSpec.describe 'V3 service plan visibility' do
         let(:org_response) { [{ name: org.name, guid: org.guid }, { name: other_org.name, guid: other_org.guid }] }
         let(:successful_response) { { code: 200, response_object: { type: 'organization', organizations: org_response } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
     end
 
@@ -200,14 +200,14 @@ RSpec.describe 'V3 service plan visibility' do
       context 'and its being updated to "public"' do
         let(:successful_response) { { code: 200, response_object: { type: 'public' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
 
       context 'and its being updated to "admin"' do
         let(:req_body) { { type: 'admin' } }
         let(:successful_response) { { code: 200, response_object: { type: 'admin' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
 
       context 'and its being updated to "organization"' do
@@ -215,7 +215,7 @@ RSpec.describe 'V3 service plan visibility' do
         let(:org_response) { [{ name: org.name, guid: org.guid }, { name: other_org.name, guid: other_org.guid }] }
         let(:successful_response) { { code: 200, response_object: { type: 'organization', organizations: org_response } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
     end
 
@@ -259,7 +259,7 @@ RSpec.describe 'V3 service plan visibility' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
           let(:after_request_check) do
             lambda do
               visibilities = VCAP::CloudController::ServicePlanVisibility.where(service_plan: service_plan).all
@@ -289,7 +289,7 @@ RSpec.describe 'V3 service plan visibility' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
           let(:after_request_check) do
             lambda do
               visibilities = VCAP::CloudController::ServicePlanVisibility.where(service_plan: service_plan).all
@@ -551,7 +551,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
 
       it 'returns a 404 for users of other orgs' do
         new_org = VCAP::CloudController::Organization.make
@@ -630,7 +630,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     it 'creates an audit event' do

--- a/spec/request/service_plan_visibility_spec.rb
+++ b/spec/request/service_plan_visibility_spec.rb
@@ -2,9 +2,6 @@ require 'spec_helper'
 require 'request_spec_shared_examples'
 require 'models/services/service_plan'
 
-SPACE_APPLICATION_SUPPORTER = %w[space_application_supporter].freeze
-COMPLETE_PERMISSIONS = (ALL_PERMISSIONS + SPACE_APPLICATION_SUPPORTER).freeze
-
 RSpec.describe 'V3 service plan visibility' do
   let(:user) { VCAP::CloudController::User.make }
   let!(:org) { VCAP::CloudController::Organization.make }
@@ -34,7 +31,7 @@ RSpec.describe 'V3 service plan visibility' do
         )
       }
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'for admin-only plans' do
@@ -53,7 +50,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       }
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'for space-scoped plans' do
@@ -95,7 +92,7 @@ RSpec.describe 'V3 service plan visibility' do
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'for org-restricted plans' do
@@ -146,7 +143,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       }
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
   end
 
@@ -173,13 +170,13 @@ RSpec.describe 'V3 service plan visibility' do
         let(:req_body) { { type: 'admin' } }
         let(:successful_response) { { code: 200, response_object: { type: 'admin' } } }
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'and its being updated to "public"' do
         let(:successful_response) { { code: 200, response_object: { type: 'public' } } }
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'and its being updated to "organization"' do
@@ -187,7 +184,7 @@ RSpec.describe 'V3 service plan visibility' do
         let(:org_response) { [{ name: org.name, guid: org.guid }, { name: other_org.name, guid: other_org.guid }] }
         let(:successful_response) { { code: 200, response_object: { type: 'organization', organizations: org_response } } }
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
     end
 
@@ -203,14 +200,14 @@ RSpec.describe 'V3 service plan visibility' do
       context 'and its being updated to "public"' do
         let(:successful_response) { { code: 200, response_object: { type: 'public' } } }
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'and its being updated to "admin"' do
         let(:req_body) { { type: 'admin' } }
         let(:successful_response) { { code: 200, response_object: { type: 'admin' } } }
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'and its being updated to "organization"' do
@@ -218,7 +215,7 @@ RSpec.describe 'V3 service plan visibility' do
         let(:org_response) { [{ name: org.name, guid: org.guid }, { name: other_org.name, guid: other_org.guid }] }
         let(:successful_response) { { code: 200, response_object: { type: 'organization', organizations: org_response } } }
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
       end
     end
 
@@ -262,7 +259,7 @@ RSpec.describe 'V3 service plan visibility' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
           let(:after_request_check) do
             lambda do
               visibilities = VCAP::CloudController::ServicePlanVisibility.where(service_plan: service_plan).all
@@ -292,7 +289,7 @@ RSpec.describe 'V3 service plan visibility' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
           let(:after_request_check) do
             lambda do
               visibilities = VCAP::CloudController::ServicePlanVisibility.where(service_plan: service_plan).all
@@ -554,7 +551,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
       it 'returns a 404 for users of other orgs' do
         new_org = VCAP::CloudController::Organization.make
@@ -633,7 +630,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     it 'creates an audit event' do

--- a/spec/request/service_plan_visibility_spec.rb
+++ b/spec/request/service_plan_visibility_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'V3 service plan visibility' do
             space_developer
             space_manager
             space_auditor
-            space_application_supporter
+            space_supporter
           )
         )
       end

--- a/spec/request/service_plan_visibility_spec.rb
+++ b/spec/request/service_plan_visibility_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 require 'request_spec_shared_examples'
 require 'models/services/service_plan'
 
+SPACE_APPLICATION_SUPPORTER = %w[space_application_supporter].freeze
+COMPLETE_PERMISSIONS = (ALL_PERMISSIONS + SPACE_APPLICATION_SUPPORTER).freeze
+
 RSpec.describe 'V3 service plan visibility' do
   let(:user) { VCAP::CloudController::User.make }
   let!(:org) { VCAP::CloudController::Organization.make }
@@ -31,7 +34,7 @@ RSpec.describe 'V3 service plan visibility' do
         )
       }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
     end
 
     context 'for admin-only plans' do
@@ -50,7 +53,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
     end
 
     context 'for space-scoped plans' do
@@ -87,11 +90,12 @@ RSpec.describe 'V3 service plan visibility' do
             space_developer
             space_manager
             space_auditor
+            space_application_supporter
           )
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
     end
 
     context 'for org-restricted plans' do
@@ -142,7 +146,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
     end
   end
 
@@ -169,13 +173,13 @@ RSpec.describe 'V3 service plan visibility' do
         let(:req_body) { { type: 'admin' } }
         let(:successful_response) { { code: 200, response_object: { type: 'admin' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
       end
 
       context 'and its being updated to "public"' do
         let(:successful_response) { { code: 200, response_object: { type: 'public' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
       end
 
       context 'and its being updated to "organization"' do
@@ -183,7 +187,7 @@ RSpec.describe 'V3 service plan visibility' do
         let(:org_response) { [{ name: org.name, guid: org.guid }, { name: other_org.name, guid: other_org.guid }] }
         let(:successful_response) { { code: 200, response_object: { type: 'organization', organizations: org_response } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
       end
     end
 
@@ -199,14 +203,14 @@ RSpec.describe 'V3 service plan visibility' do
       context 'and its being updated to "public"' do
         let(:successful_response) { { code: 200, response_object: { type: 'public' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
       end
 
       context 'and its being updated to "admin"' do
         let(:req_body) { { type: 'admin' } }
         let(:successful_response) { { code: 200, response_object: { type: 'admin' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
       end
 
       context 'and its being updated to "organization"' do
@@ -214,7 +218,7 @@ RSpec.describe 'V3 service plan visibility' do
         let(:org_response) { [{ name: org.name, guid: org.guid }, { name: other_org.name, guid: other_org.guid }] }
         let(:successful_response) { { code: 200, response_object: { type: 'organization', organizations: org_response } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
       end
     end
 
@@ -258,7 +262,7 @@ RSpec.describe 'V3 service plan visibility' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS do
           let(:after_request_check) do
             lambda do
               visibilities = VCAP::CloudController::ServicePlanVisibility.where(service_plan: service_plan).all
@@ -288,7 +292,7 @@ RSpec.describe 'V3 service plan visibility' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS do
           let(:after_request_check) do
             lambda do
               visibilities = VCAP::CloudController::ServicePlanVisibility.where(service_plan: service_plan).all
@@ -550,7 +554,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
 
       it 'returns a 404 for users of other orgs' do
         new_org = VCAP::CloudController::Organization.make
@@ -629,7 +633,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
     end
 
     it 'creates an audit event' do

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'V3 service plans' do
         Hash.new(code: 404)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     context 'when there is a public service plan' do
@@ -40,7 +40,7 @@ RSpec.describe 'V3 service plans' do
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -68,7 +68,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'space scoped broker' do
@@ -92,7 +92,7 @@ RSpec.describe 'V3 service plans' do
           )
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
     end
 
@@ -274,11 +274,11 @@ RSpec.describe 'V3 service plans' do
           h['space_developer'] = space_plans_response
           h['space_manager'] = space_plans_response
           h['space_auditor'] = space_plans_response
-          h['space_application_supporter'] = space_plans_response
+          h['space_supporter'] = space_plans_response
         end
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -642,7 +642,7 @@ RSpec.describe 'V3 service plans' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     context 'when the service plan exists and has no service instances' do
@@ -660,7 +660,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'when the plan is public' do
@@ -673,7 +673,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'when the plan is visible only on some orgs' do
@@ -691,7 +691,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'when the plan is from a space-scoped service broker' do
@@ -705,14 +705,14 @@ RSpec.describe 'V3 service plans' do
             h['admin_read_only'] = { code: 403 }
             h['global_auditor'] = { code: 403 }
             h['space_developer'] = { code: 204 }
-            h['space_application_supporter'] = { code: 403 }
+            h['space_supporter'] = { code: 403 }
             h['space_manager'] = { code: 403 }
             h['space_auditor'] = { code: 403 }
             h['unauthenticated'] = { code: 401 }
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
     end
 
@@ -811,7 +811,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'when the plan is public' do
@@ -824,7 +824,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'when the plan is visible only on some orgs' do
@@ -842,7 +842,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'when the plan is from a space-scoped service broker' do
@@ -856,14 +856,14 @@ RSpec.describe 'V3 service plans' do
             h['admin_read_only'] = { code: 403 }
             h['global_auditor'] = { code: 403 }
             h['space_developer'] = { code: 200, response_object: create_plan_json(service_plan, labels: labels, annotations: annotations) }
-            h['space_application_supporter'] = { code: 403 }
+            h['space_supporter'] = { code: 403 }
             h['space_manager'] = { code: 403 }
             h['space_auditor'] = { code: 403 }
             h['unauthenticated'] = { code: 401 }
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
     end
   end

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -4,7 +4,6 @@ require 'models/services/service_plan'
 require 'hashdiff'
 
 UNAUTHENTICATED = %w[unauthenticated].freeze
-COMPLETE_PERMISSIONS = (ALL_PERMISSIONS + UNAUTHENTICATED).freeze
 
 RSpec.describe 'V3 service plans' do
   let(:user) { VCAP::CloudController::User.make }
@@ -21,7 +20,7 @@ RSpec.describe 'V3 service plans' do
         Hash.new(code: 404)
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
     end
 
     context 'when there is a public service plan' do
@@ -41,7 +40,7 @@ RSpec.describe 'V3 service plans' do
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -69,7 +68,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
 
       context 'space scoped broker' do
@@ -93,7 +92,7 @@ RSpec.describe 'V3 service plans' do
           )
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
     end
 
@@ -279,7 +278,7 @@ RSpec.describe 'V3 service plans' do
         end
       end
 
-      it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -643,7 +642,7 @@ RSpec.describe 'V3 service plans' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
     end
 
     context 'when the service plan exists and has no service instances' do
@@ -661,7 +660,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
 
       context 'when the plan is public' do
@@ -674,7 +673,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
 
       context 'when the plan is visible only on some orgs' do
@@ -692,7 +691,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
 
       context 'when the plan is from a space-scoped service broker' do
@@ -713,7 +712,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
     end
 
@@ -812,7 +811,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
 
       context 'when the plan is public' do
@@ -825,7 +824,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
 
       context 'when the plan is visible only on some orgs' do
@@ -843,7 +842,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
 
       context 'when the plan is from a space-scoped service broker' do
@@ -864,7 +863,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_application_supporter']
       end
     end
   end

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'V3 service plans' do
               space_developer
               space_manager
               space_auditor
-              space_application_supporter
+              space_supporter
             )
           )
         end

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -3,9 +3,8 @@ require 'request_spec_shared_examples'
 require 'models/services/service_plan'
 require 'hashdiff'
 
-SPACE_APPLICATION_SUPPORTER = %w[space_application_supporter].freeze
 UNAUTHENTICATED = %w[unauthenticated].freeze
-COMPLETE_PERMISSIONS = (ALL_PERMISSIONS + UNAUTHENTICATED + SPACE_APPLICATION_SUPPORTER).freeze
+COMPLETE_PERMISSIONS = (ALL_PERMISSIONS + UNAUTHENTICATED).freeze
 
 RSpec.describe 'V3 service plans' do
   let(:user) { VCAP::CloudController::User.make }
@@ -22,7 +21,7 @@ RSpec.describe 'V3 service plans' do
         Hash.new(code: 404)
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when there is a public service plan' do
@@ -42,7 +41,7 @@ RSpec.describe 'V3 service plans' do
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -70,7 +69,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'space scoped broker' do
@@ -94,7 +93,7 @@ RSpec.describe 'V3 service plans' do
           )
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
     end
 
@@ -280,7 +279,7 @@ RSpec.describe 'V3 service plans' do
         end
       end
 
-      it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -644,7 +643,7 @@ RSpec.describe 'V3 service plans' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'when the service plan exists and has no service instances' do
@@ -662,7 +661,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the plan is public' do
@@ -675,7 +674,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the plan is visible only on some orgs' do
@@ -693,7 +692,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the plan is from a space-scoped service broker' do
@@ -714,7 +713,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
     end
 
@@ -813,7 +812,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the plan is public' do
@@ -826,7 +825,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the plan is visible only on some orgs' do
@@ -844,7 +843,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
 
       context 'when the plan is from a space-scoped service broker' do
@@ -865,7 +864,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS + ['space_application_supporter']
       end
     end
   end

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -3,8 +3,9 @@ require 'request_spec_shared_examples'
 require 'models/services/service_plan'
 require 'hashdiff'
 
+SPACE_APPLICATION_SUPPORTER = %w[space_application_supporter].freeze
 UNAUTHENTICATED = %w[unauthenticated].freeze
-COMPLETE_PERMISSIONS = (ALL_PERMISSIONS + UNAUTHENTICATED).freeze
+COMPLETE_PERMISSIONS = (ALL_PERMISSIONS + UNAUTHENTICATED + SPACE_APPLICATION_SUPPORTER).freeze
 
 RSpec.describe 'V3 service plans' do
   let(:user) { VCAP::CloudController::User.make }
@@ -88,6 +89,7 @@ RSpec.describe 'V3 service plans' do
               space_developer
               space_manager
               space_auditor
+              space_application_supporter
             )
           )
         end
@@ -274,6 +276,7 @@ RSpec.describe 'V3 service plans' do
           h['space_developer'] = space_plans_response
           h['space_manager'] = space_plans_response
           h['space_auditor'] = space_plans_response
+          h['space_application_supporter'] = space_plans_response
         end
       end
 
@@ -704,6 +707,7 @@ RSpec.describe 'V3 service plans' do
             h['admin_read_only'] = { code: 403 }
             h['global_auditor'] = { code: 403 }
             h['space_developer'] = { code: 204 }
+            h['space_application_supporter'] = { code: 403 }
             h['space_manager'] = { code: 403 }
             h['space_auditor'] = { code: 403 }
             h['unauthenticated'] = { code: 401 }
@@ -854,6 +858,7 @@ RSpec.describe 'V3 service plans' do
             h['admin_read_only'] = { code: 403 }
             h['global_auditor'] = { code: 403 }
             h['space_developer'] = { code: 200, response_object: create_plan_json(service_plan, labels: labels, annotations: annotations) }
+            h['space_application_supporter'] = { code: 403 }
             h['space_manager'] = { code: 403 }
             h['space_auditor'] = { code: 403 }
             h['unauthenticated'] = { code: 401 }


### PR DESCRIPTION
A space application support can access the following endpoints:

GET /v3/service_plans
GET /v3/service_plans/:guid/visibility
GET /v3/service_plans/:guid

Implements #2237

Remark: I'd be glad for feedback on whether I put the role into the right places and whether I added appropriate methods in the correct places. The changes should grant the new role the right permissions and the changes do not interfere with other endpoints which might use methods which were changed, because all unit tests are green. But I don't know whether the coding I added or adjusted fits into the overall picture.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
