### PR TITLE
Support expiring of DB connections

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -89,6 +89,8 @@ module VCAP::CloudController
               log_level: String, # debug, info, etc.
               log_db_queries: bool,
               connection_validation_timeout: Integer,
+              optional(:connection_expiration_timeout) => Integer,
+              optional(:connection_expiration_random_delay) => Integer,
               optional(:ssl_verify_hostname) => bool,
               optional(:ca_cert_path) => String,
             },

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -30,6 +30,7 @@ module VCAP::CloudController
         db.sql_log_level = opts[:log_level]
       end
       db.default_collate = 'utf8_bin' if db.database_type == :mysql
+      add_connection_expiration_extension(db, opts)
       add_connection_validator_extension(db, opts)
       db
     end
@@ -46,6 +47,16 @@ module VCAP::CloudController
     def self.add_connection_validator_extension(db, opts)
       db.extension(:connection_validator)
       db.pool.connection_validation_timeout = opts[:connection_validation_timeout] if opts[:connection_validation_timeout]
+    end
+
+    def self.add_connection_expiration_extension(db, opts)
+      if opts[:connection_expiration_timeout]
+        db.extension(:connection_expiration)
+        db.pool.connection_expiration_timeout = opts[:connection_expiration_timeout] if opts[:connection_expiration_timeout]
+        db.pool.connection_expiration_random_delay = opts[:connection_expiration_random_delay] if opts[:connection_expiration_random_delay]
+        # So that there are no existing connections without an expiration timestamp
+        db.disconnect
+      end
     end
 
     def self.load_models(db_config, logger)


### PR DESCRIPTION
## A short explanation of the proposed change:
Support DB connections being expired after a certain time period (with a random delay)

## An explanation of the use cases your change solves
We have long running CC processes and connections appear to be consuming and not freeing a lot of Postgres resources. We are hoping that by expiring connections after a certain (configurable) time limit, we can free up these resources before we see more damaging effects on the DB

It uses a builtin extension to Sequel which should hopefully be well understood and tested and just exposes some configuration parameters. Additionally, the extension should only end up being enabled for users who opt-in by specifying the timeout and optionally a random delay

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
