### PR TITLE
Revert "build(deps-dev): bump rubocop from 1.16.1 to 1.17.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ group :test do
   gem 'rspec-rails', '~> 5.0.1'
   gem 'rspec-wait'
   gem 'rspec_api_documentation', '>= 6.1.0'
-  gem 'rubocop', '~> 1.17.0'
+  gem 'rubocop', '~> 1.16.1'
   gem 'timecop'
   gem 'webmock', '> 2.3.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,7 +409,7 @@ GEM
       activesupport (>= 3.0.0)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0)
-    rubocop (1.17.0)
+    rubocop (1.16.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -582,7 +582,7 @@ DEPENDENCIES
   rspec-rails (~> 5.0.1)
   rspec-wait
   rspec_api_documentation (>= 6.1.0)
-  rubocop (~> 1.17.0)
+  rubocop (~> 1.16.1)
   ruby-debug-ide (>= 0.7.0.beta4)
   rubyzip (>= 1.3.0)
   scientist (~> 1.1.0)


### PR DESCRIPTION
Reverts cloudfoundry/cloud_controller_ng#2339