### PR TITLE
Replace readable_org_guids_for_domains with query

### DIFF
--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -123,18 +123,9 @@ class VCAP::CloudController::Permissions
 
   def readable_org_guids_for_domains
     if can_read_globally?
-      VCAP::CloudController::Organization.select(:guid).all.map(&:guid)
+      VCAP::CloudController::Organization.select(:guid)
     else
-      # Getting readable orgs for org-scoped roles
-      org_guids = membership.org_guids_for_roles(ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS)
-
-      # Getting readable orgs for space-scoped roles
-      space_guids = membership.space_guids_for_roles(SPACE_ROLES_INCLUDING_SUPPORTERS)
-      org_guids_from_space_guids = space_guids.filter_map do |guid|
-        VCAP::CloudController::Space.find(guid: guid)&.organization&.guid
-      end
-
-      (org_guids + org_guids_from_space_guids).uniq
+      membership.org_guids_for_roles_subquery(ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + SPACE_ROLES_INCLUDING_SUPPORTERS)
     end
   end
 

--- a/spec/unit/fetchers/domain_fetcher_spec.rb
+++ b/spec/unit/fetchers/domain_fetcher_spec.rb
@@ -55,8 +55,9 @@ module VCAP::CloudController
           )
         end
 
-        it 'returns readable domains for multiple orgs' do
-          domains = DomainFetcher.fetch_all_for_orgs([org2.guid, org3.guid])
+        it 'returns readable domains for multiple orgs filtered using sequel subquery' do
+          org_guids = Organization.where(guid: [org2.guid, org3.guid]).select(:guid)
+          domains = DomainFetcher.fetch_all_for_orgs(org_guids)
           expect(domains.map(&:guid)).to contain_exactly(
             'shared_domain1', 'shared_domain2',
             'private_domain1', 'private_domain3'

--- a/spec/unit/lib/cloud_controller/membership_spec.rb
+++ b/spec/unit/lib/cloud_controller/membership_spec.rb
@@ -404,6 +404,38 @@ module VCAP::CloudController
           end
         end
 
+        context 'for space managers' do
+          it 'returns all orgs for spaces in which the user is a space manager' do
+            SpaceManager.create(user: user, space: space)
+            guids = membership.org_guids_for_roles(Membership::SPACE_MANAGER)
+            expect(guids).to eq([organization.guid])
+          end
+        end
+
+        context 'for space developers' do
+          it 'returns all orgs for spaces in which the user is a space developer' do
+            SpaceDeveloper.create(user: user, space: space)
+            guids = membership.org_guids_for_roles(Membership::SPACE_DEVELOPER)
+            expect(guids).to eq([organization.guid])
+          end
+        end
+
+        context 'for space supporters' do
+          it 'returns all orgs for spaces in which the user is a space supporters' do
+            SpaceSupporter.create(user: user, space: space)
+            guids = membership.org_guids_for_roles(Membership::SPACE_SUPPORTER)
+            expect(guids).to eq([organization.guid])
+          end
+        end
+
+        context 'for space auditors' do
+          it 'returns all orgs for spaces in which the user is a space auditor' do
+            SpaceAuditor.create(user: user, space: space)
+            guids = membership.org_guids_for_roles(Membership::SPACE_AUDITOR)
+            expect(guids).to eq([organization.guid])
+          end
+        end
+
         context 'when the user has multiple roles' do
           it 'does not return duplicate org guids' do
             organization.add_auditor(user)

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -159,19 +159,15 @@ module VCAP::CloudController
       context 'when user has valid membership' do
         let(:membership) { instance_double(Membership) }
         let(:space_guid) { double(:space_guid) }
+        let(:subquery) { instance_double(Sequel::Dataset) }
         let(:first_org_guid) { double(:first_org_guid) }
         let(:second_org_guid) { double(:second_org_guid) }
 
         before do
-          organization = double(:organization, guid: second_org_guid)
-          space = double(:space, organization: organization)
-
-          allow(membership).to receive(:org_guids_for_roles).
-            with(Permissions::ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS).
-            and_return([first_org_guid])
+          allow(membership).to receive(:org_guids_for_roles_subquery).
+            with(Permissions::ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + Permissions::SPACE_ROLES_INCLUDING_SUPPORTERS).
+            and_return(subquery)
           allow(Membership).to receive(:new).with(user).and_return(membership)
-          allow(Space).to receive(:find).with(guid: space_guid).
-            and_return(space)
         end
 
         it 'combines readable orgs for both org-scoped and space-scoped roles' do
@@ -180,7 +176,7 @@ module VCAP::CloudController
             and_return([space_guid])
 
           expect(permissions.readable_org_guids_for_domains).
-            to contain_exactly(first_org_guid, second_org_guid)
+            to be(subquery)
         end
       end
     end


### PR DESCRIPTION
## A short explanation of the proposed change:
Replace the `readable_org_guids_for_domains` function with one that returns a SQL subquery as a filter rather than an actual Ruby array.

## An explanation of the use cases your change solves
We have seen extremely large query strings when an admin or a power-user in many orgs requests domains as the entire list of (sometimes >100k) guids is turned into a giant `WHERE IN ('abc', 'def' etc.)` SQL query.
This is expensive for Ruby to turn into the query, expensive to send over the network and expensive for the DB to process.

Databases are very very good at working out the most efficient way to run a query so even though the subqueries produced by this look pretty complex (due to each role being a separate table and space roles needing a join to the orgs table), the actual runtime is much better this way.

## Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/2255 - similar problem of huge query strings that may actually be better addressed by this approach

## Comparison with performance tests
Using the tests at https://github.com/cloudfoundry-incubator/cf-performance-tests I ran (locally) a comparison of the /v3/domains endpoint with:
* 50,000 orgs
* 100,000 spaces
* 20,000 domains

The results seem pretty clear cut:
![BEFORE](https://user-images.githubusercontent.com/14118619/123313894-da6ac700-d521-11eb-91a8-c5f0b9cab073.png)
![AFTER](https://user-images.githubusercontent.com/14118619/123313901-dccd2100-d521-11eb-8829-ece17bbaaee8.png)


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
