### PR TITLE
Remove `unmunged_body` method and references

### DIFF
--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -80,10 +80,6 @@ class ApplicationController < ActionController::Base
     request.query_parameters.with_indifferent_access
   end
 
-  def unmunged_body
-    JSON.parse(request.body.string)
-  end
-
   def parsed_yaml
     return @parsed_yaml if @parsed_yaml
 

--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -116,7 +116,7 @@ class OrganizationsV3Controller < ApplicationController
   end
 
   def update_default_isolation_segment
-    message = OrgDefaultIsoSegUpdateMessage.new(unmunged_body)
+    message = OrgDefaultIsoSegUpdateMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     org = fetch_editable_org(hashed_params[:guid])

--- a/app/controllers/v3/processes_controller.rb
+++ b/app/controllers/v3/processes_controller.rb
@@ -53,7 +53,7 @@ class ProcessesController < ApplicationController
   end
 
   def update
-    message = ProcessUpdateMessage.new(unmunged_body)
+    message = ProcessUpdateMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     ProcessUpdate.new(user_audit_info).update(@process, message, NonManifestStrategy)


### PR DESCRIPTION
Hello CAPI team,

This is a small change to remove some cruft in the cloud controller database, as part of the national movement to Make CCNG Less Crusty. Please be assured that I (a complete stranger) have taken the proper precautions when making this change. Except running CATS.

Best,
Belinda

**The change**: This method was introduced in 2016 to allow empty arrays in a request
body (see https://www.pivotaltracker.com/n/projects/966314/stories/117658779). However, the controllers that still use this method no longer involve arrays in the request body. 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
