### PR TITLE
Space supporter process write permissions

### DIFF
--- a/app/controllers/v3/processes_controller.rb
+++ b/app/controllers/v3/processes_controller.rb
@@ -118,7 +118,7 @@ class ProcessesController < ApplicationController
   end
 
   def ensure_can_write
-    unauthorized! unless permission_queryer.can_write_to_space?(@space.guid)
+    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(@space.guid)
   end
 
   def process_not_found!

--- a/app/controllers/v3/processes_controller.rb
+++ b/app/controllers/v3/processes_controller.rb
@@ -26,14 +26,14 @@ class ProcessesController < ApplicationController
 
     if app_nested?
       app, dataset = ProcessListFetcher.fetch_for_app(message, eager_loaded_associations: Presenters::V3::ProcessPresenter.associated_resources)
-      app_not_found! unless app && permission_queryer.can_read_from_space?(app.space.guid, app.organization.guid)
+      app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(app.space.guid, app.organization.guid)
     else
       dataset = if permission_queryer.can_read_globally?
                   ProcessListFetcher.fetch_all(message, eager_loaded_associations: Presenters::V3::ProcessPresenter.associated_resources)
                 else
                   ProcessListFetcher.fetch_for_spaces(
                     message,
-                    space_guids: permission_queryer.readable_space_guids,
+                    space_guids: permission_queryer.readable_application_supporter_space_guids,
                     eager_loaded_associations: Presenters::V3::ProcessPresenter.associated_resources
                   )
                 end
@@ -109,11 +109,11 @@ class ProcessesController < ApplicationController
   def find_process_and_space
     if app_nested?
       @process, app, @space, org = ProcessFetcher.fetch_for_app_by_type(app_guid: hashed_params[:app_guid], process_type: hashed_params[:type])
-      app_not_found! unless app && permission_queryer.can_read_from_space?(@space.guid, org.guid)
+      app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(@space.guid, org.guid)
       process_not_found! unless @process
     else
       @process, @space, org = ProcessFetcher.fetch(process_guid: hashed_params[:process_guid])
-      process_not_found! unless @process && permission_queryer.can_read_from_space?(@space.guid, org.guid)
+      process_not_found! unless @process && permission_queryer.untrusted_can_read_from_space?(@space.guid, org.guid)
     end
   end
 

--- a/docs/v3/source/includes/resources/processes/_get.md.erb
+++ b/docs/v3/source/includes/resources/processes/_get.md.erb
@@ -26,12 +26,13 @@ Content-Type: application/json
 `GET /v3/apps/:guid/processes/:type`
 
 #### Permitted roles
- |
+Role | Notes |
 --- | ---
 Admin |
 Admin Read-Only |
-Global Auditor |
-Org Manager |
-Space Auditor |
+Global Auditor | Some fields are redacted
+Org Manager | Some fields are redacted
+Space Application Supporter | Some fields are redacted. Experimental |
+Space Auditor | Some fields are redacted
 Space Developer |
-Space Manager |
+Space Manager | Some fields are redacted

--- a/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
@@ -48,5 +48,5 @@ Global Auditor |
 Org Manager |
 Space Auditor |
 Space Developer |
-Space Application Developer | Experimental
 Space Manager |
+Space Supporter |

--- a/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
@@ -40,7 +40,7 @@ Name | Type | Description
 **updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
 
 #### Permitted roles
- |
+Roles | Notes |
 --- | ---
 Admin |
 Admin Read-Only |
@@ -48,4 +48,5 @@ Global Auditor |
 Org Manager |
 Space Auditor |
 Space Developer |
+Space Application Developer | Experimental
 Space Manager |

--- a/docs/v3/source/includes/resources/processes/_scale.md.erb
+++ b/docs/v3/source/includes/resources/processes/_scale.md.erb
@@ -44,3 +44,4 @@ Name | Type | Description
 --- | ---
 Admin |
 Space Developer |
+Space Supporter |

--- a/docs/v3/source/includes/resources/processes/_stats.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats.md.erb
@@ -26,12 +26,13 @@ Content-Type: application/json
 `GET /v3/apps/:guid/processes/:type/stats`
 
 #### Permitted roles
- |
+Role | Notes |
 --- | ---
 Admin |
 Admin Read-Only |
-Global Auditor |
-Org Manager |
-Space Auditor |
+Global Auditor | Some fields are redacted
+Org Manager | Some fields are redacted
+Space Application Supporter | Some fields are redacted. Experimental |
+Space Auditor | Some fields are redacted
 Space Developer |
-Space Manager |
+Space Manager | Some fields are redacted

--- a/docs/v3/source/includes/resources/processes/_terminate_instance.md
+++ b/docs/v3/source/includes/resources/processes/_terminate_instance.md
@@ -31,3 +31,4 @@ This allows a user to stop a single misbehaving instance of a process.
 --- | ---
 Admin |
 Space Developer |
+Space Supporter |

--- a/docs/v3/source/includes/resources/processes/_update.md.erb
+++ b/docs/v3/source/includes/resources/processes/_update.md.erb
@@ -50,3 +50,4 @@ Name | Type | Description
 --- | ---
 Admin |
 Space Developer |
+Space Supporter |

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -816,9 +816,11 @@ RSpec.describe 'Processes' do
     end
 
     context 'when the user is assigned the space_supporter role' do
-      before do
+      let(:space_supporter) do
+        user = VCAP::CloudController::User.make
         org.add_user(user)
         space.add_application_supporter(user)
+        user
       end
 
       it 'can scale a process' do
@@ -828,7 +830,7 @@ RSpec.describe 'Processes' do
           disk_in_mb:   20,
         }
 
-        post "/v3/processes/#{process.guid}/actions/scale", scale_request.to_json, developer_headers
+        post "/v3/processes/#{process.guid}/actions/scale", scale_request.to_json, headers_for(space_supporter)
 
         expect(last_response.status).to eq(202)
         expect(parsed_response).to be_a_response_like(expected_response)
@@ -840,7 +842,7 @@ RSpec.describe 'Processes' do
       end
     end
 
-    it 'returns a helpful error when the meemory is too large' do
+    it 'returns a helpful error when the memory is too large' do
       scale_request = {
         memory_in_mb: 100000000000,
       }
@@ -1454,13 +1456,15 @@ RSpec.describe 'Processes' do
     end
 
     context 'when the user is assigned the space_supporter role' do
-      before do
+      let(:space_supporter) do
+        user = VCAP::CloudController::User.make
         org.add_user(user)
         space.add_application_supporter(user)
+        user
       end
 
       it 'can scale a process' do
-        post "/v3/apps/#{app_model.guid}/processes/web/actions/scale", scale_request.to_json, developer_headers
+        post "/v3/apps/#{app_model.guid}/processes/web/actions/scale", scale_request.to_json, headers_for(space_supporter)
 
         expect(last_response.status).to eq(202)
         expect(parsed_response).to be_a_response_like(expected_response)

--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -85,7 +85,7 @@ RSpec.shared_examples 'permissions for list endpoint' do |roles|
 
         expected_response_guids = expected_codes_and_responses[role][:response_guids]
         if expected_response_guids
-          expect(parsed_response['resources'].map { |space| space['guid'] }).to match_array(expected_response_guids)
+          expect(parsed_response['resources'].map { |resource| resource['guid'] }).to match_array(expected_response_guids)
         end
       end
     end

--- a/spec/unit/controllers/v3/processes_controller_spec.rb
+++ b/spec/unit/controllers/v3/processes_controller_spec.rb
@@ -11,31 +11,7 @@ RSpec.describe ProcessesController, type: :controller do
       allow_user_read_access_for(user, spaces: [space])
     end
 
-    it 'returns 200 and lists the processes' do
-      process1 = VCAP::CloudController::ProcessModel.make(:process, app: app)
-      process2 = VCAP::CloudController::ProcessModel.make(:process, app: app)
-      VCAP::CloudController::ProcessModel.make
-
-      get :index
-
-      response_guids = parsed_body['resources'].map { |r| r['guid'] }
-      expect(response.status).to eq(200)
-      expect(response_guids).to match_array([process1.guid, process2.guid])
-    end
-
     context 'when accessed as an app subresource' do
-      it 'uses the app as a filter' do
-        process1 = VCAP::CloudController::ProcessModel.make(:process, app: app)
-        process2 = VCAP::CloudController::ProcessModel.make(:process, app: app)
-        VCAP::CloudController::ProcessModel.make(:process)
-
-        get :index, params: { app_guid: app.guid }
-
-        expect(response.status).to eq(200)
-        response_guids = parsed_body['resources'].map { |r| r['guid'] }
-        expect(response_guids).to match_array([process1.guid, process2.guid])
-      end
-
       it 'eager loads associated resources that the presenter specifies' do
         expect(VCAP::CloudController::ProcessListFetcher).to receive(:fetch_for_app).with(
           an_instance_of(VCAP::CloudController::ProcessesListMessage),

--- a/spec/unit/controllers/v3/processes_controller_spec.rb
+++ b/spec/unit/controllers/v3/processes_controller_spec.rb
@@ -389,46 +389,6 @@ RSpec.describe ProcessesController, type: :controller do
         expect(response.body).to include('Cannot update this process while a deployment is in flight.')
       end
     end
-
-    context 'permissions' do
-      context 'when the user cannot read the process' do
-        before do
-          disallow_user_read_access(user, space: space)
-        end
-
-        it 'raises 404' do
-          patch :update, params: { process_guid: process_type.guid }.merge(request_body), as: :json
-
-          expect(response.status).to eq(404)
-          expect(response.body).to include('ResourceNotFound')
-        end
-      end
-
-      context 'when the user can read but not write to the process due to membership' do
-        before do
-          allow_user_read_access_for(user, spaces: [space])
-          disallow_user_write_access(user, space: space)
-        end
-
-        it 'raises an ApiError with a 403 code' do
-          patch :update, params: { process_guid: process_type.guid }.merge(request_body), as: :json
-
-          expect(response.status).to eq 403
-          expect(response.body).to include('NotAuthorized')
-        end
-      end
-
-      context 'when the user does not have write permissions' do
-        before { set_current_user(VCAP::CloudController::User.make, scopes: ['cloud_controller.read']) }
-
-        it 'raises an ApiError with a 403 code' do
-          patch :update, params: { process_guid: process_type.guid }.merge(request_body), as: :json
-
-          expect(response.body).to include('NotAuthorized')
-          expect(response.status).to eq(403)
-        end
-      end
-    end
   end
 
   describe '#terminate' do


### PR DESCRIPTION
Hello CAPI team,

This is a PR to allow the `space supporter` role to access POST, PATCH, and DELETE actions on process endpoints. This addresses [this issue](https://github.com/cloudfoundry/cloud_controller_ng/issues/2211) and is part of the larger track of work to add the `space supporter` role to CCNG.
Please let us know if you have any feedback.

Thanks,
@galenhammond && @belinda-liu 

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
