### PR TITLE
Space application supporter can list service offerings

### DIFF
--- a/app/controllers/v3/service_offerings_controller.rb
+++ b/app/controllers/v3/service_offerings_controller.rb
@@ -35,7 +35,7 @@ class ServiceOfferingsController < ApplicationController
                 ServiceOfferingListFetcher.fetch(
                   message,
                   readable_org_guids: permission_queryer.readable_org_guids,
-                  readable_space_guids: permission_queryer.readable_space_scoped_space_guids,
+                  readable_space_guids: permission_queryer.readable_space_supporter_space_scoped_space_guids,
                   eager_loaded_associations: Presenters::V3::ServiceOfferingPresenter.associated_resources,
                 )
               end

--- a/spec/request/service_offerings_spec.rb
+++ b/spec/request/service_offerings_spec.rb
@@ -3,8 +3,7 @@ require 'request_spec_shared_examples'
 require 'models/services/service_plan'
 require 'hashdiff'
 
-ADDITIONAL_ROLES = %w[unauthenticated].freeze
-COMPLETE_PERMISSIONS = (ALL_PERMISSIONS + ADDITIONAL_ROLES).freeze
+UNAUTHENTICATED = %w[unauthenticated].freeze
 
 RSpec.describe 'V3 service offerings' do
   let(:user) { VCAP::CloudController::User.make }
@@ -28,7 +27,7 @@ RSpec.describe 'V3 service offerings' do
         Hash.new(code: 404)
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     context 'when service plan is not available in any orgs' do
@@ -43,7 +42,7 @@ RSpec.describe 'V3 service offerings' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     context 'when service offering is publicly available' do
@@ -54,7 +53,7 @@ RSpec.describe 'V3 service offerings' do
         Hash.new(successful_response)
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -67,7 +66,7 @@ RSpec.describe 'V3 service offerings' do
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
     end
 
@@ -89,7 +88,7 @@ RSpec.describe 'V3 service offerings' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     context 'when service offering comes from space scoped broker' do
@@ -113,13 +112,14 @@ RSpec.describe 'V3 service offerings' do
               admin_read_only
               global_auditor
               space_developer
+              space_supporter
               space_manager
               space_auditor
             )
           )
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'the user is in a different space to the service broker' do
@@ -135,7 +135,7 @@ RSpec.describe 'V3 service offerings' do
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'the user is a SpaceDeveloper in the space of the broker, but is targeting a different space' do
@@ -154,7 +154,7 @@ RSpec.describe 'V3 service offerings' do
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
     end
 
@@ -295,13 +295,14 @@ RSpec.describe 'V3 service offerings' do
           h['org_manager'] = org_offerings_response
           h['org_billing_manager'] = org_offerings_response
           h['org_auditor'] = org_offerings_response
+          h['space_supporter'] = space_offerings_response
           h['space_developer'] = space_offerings_response
           h['space_manager'] = space_offerings_response
           h['space_auditor'] = space_offerings_response
         end
       end
 
-      it_behaves_like 'permissions for list endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     describe 'pagination' do
@@ -654,7 +655,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     context 'when the service offering exists and has no plans' do
@@ -679,7 +680,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     context 'when the service offering exists and has public plans' do
@@ -693,7 +694,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     context 'when the service offering exists and has org-scoped plans' do
@@ -713,7 +714,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     context 'when the service offering is from a space-scoped service broker' do
@@ -738,12 +739,13 @@ RSpec.describe 'V3 service offerings' do
           h['global_auditor'] = { code: 403 }
           h['space_manager'] = { code: 403 }
           h['space_auditor'] = { code: 403 }
+          h['space_supporter'] = { code: 403 }
           h['space_developer'] = { code: 204 }
           h['unauthenticated'] = { code: 401 }
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', COMPLETE_PERMISSIONS
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
     end
 
     describe 'audit events' do
@@ -863,7 +865,7 @@ RSpec.describe 'V3 service offerings' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'when the service offering exists and has public plans' do
@@ -879,7 +881,7 @@ RSpec.describe 'V3 service offerings' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'when the service offering exists and has org-scoped plans' do
@@ -901,7 +903,7 @@ RSpec.describe 'V3 service offerings' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
 
       context 'when the service offering is from a space-scoped service broker' do
@@ -926,6 +928,7 @@ RSpec.describe 'V3 service offerings' do
             h['global_auditor'] = { code: 403 }
             h['space_manager'] = { code: 403 }
             h['space_auditor'] = { code: 403 }
+            h['space_supporter'] = { code: 403 }
             h['space_developer'] = {
               code: 200,
               response_object: create_offering_json(service_offering, labels: labels, annotations: annotations)
@@ -934,7 +937,7 @@ RSpec.describe 'V3 service offerings' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', COMPLETE_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
       end
     end
   end


### PR DESCRIPTION
* Enable space application supporter to list service offerings
* Add tests to prove the above

Closes #2240 

This PR [assumes](https://github.com/cloudfoundry/cloud_controller_ng/issues/2240#issuecomment-873949705) that, although the endpoint is not mentioned in the user story, the space application supporter is in fact supposed to have limited access to the `/v3/service_offerings/:guid` (on a par with that available to space auditors). If this is a faulty assumption, more changes will be needed.

It was necessary to duplicate changes to [lib/cloud_controller/permissions.rb](https://github.com/sap-contributions/cloud_controller_ng/commit/ea603b10ef491f32f257cd3ab996b432e258f2a8#diff-a291f406c35429c28a43b02ce43619b89c8476c7fe94cc7089a1f75432acd03bR218) and [lib/cloud_controller/permissions/queryer.rb](https://github.com/sap-contributions/cloud_controller_ng/commit/ea603b10ef491f32f257cd3ab996b432e258f2a8#diff-1892e2cb4b2958f0084895dc85b342c1d8aa436cb1abf5a0bd864de8be64e79eR132) that have already been made in the open PR #2349 for service plans. Once both PRs are accepted I think it will be necessary to go back and remove the functions readable_space_scoped_space_guids in both files, as those will no longer be in use.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
