### PR TITLE
Space application supporter can get, create and delete service route bindings

### DIFF
--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -64,7 +64,7 @@ class ServiceRouteBindingsController < ApplicationController
 
   def destroy
     route_binding_not_found! unless @route_binding && untrusted_can_read_space?(@route_binding.route.space)
-    unauthorized! unless can_write_space?(@route_binding.route.space)
+    unauthorized! unless untrusted_can_write_space?(@route_binding.route.space)
 
     action = V3::ServiceRouteBindingDelete.new(user_audit_info)
     binding_operation_in_progress! if action.blocking_operation_in_progress?(@route_binding)

--- a/docs/v3/source/includes/resources/service_route_bindings/_create.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_create.md.erb
@@ -87,7 +87,8 @@ Name | Type | Description |
 
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Supporter | Experimental

--- a/docs/v3/source/includes/resources/service_route_bindings/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_delete.md.erb
@@ -37,7 +37,8 @@ responds with a job which can be used to track the progress of the delete operat
 `DELETE /v3/service_route_bindings/:guid`
 
 #### Permitted Roles
- |
+Role | Notes
 --- | ---
 Admin |
 Space Developer |
+Space Supporter | Experimental

--- a/docs/v3/source/includes/resources/service_route_bindings/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_get.md.erb
@@ -33,7 +33,7 @@ Name | Type | Description
 **include** | _list of strings_ | Optionally include a list of unique related resources in the response. Valid values are: `route`, `service_instance`
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
@@ -42,3 +42,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Supporter | Experimental

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'v3 service route bindings' do
         Hash.new(code: 200, response_objects: [])
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     describe 'a mix of bindings' do
@@ -120,7 +120,7 @@ RSpec.describe 'v3 service route bindings' do
         VCAP::CloudController::AnnotationsUpdate.update(route_binding_2, route_binding_2_metadata[:annotations], VCAP::CloudController::RouteBindingAnnotationModel)
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     describe 'filtering' do
@@ -290,7 +290,10 @@ RSpec.describe 'v3 service route bindings' do
       )
     end
     let(:expected_codes_and_responses) do
-      responses_for_space_restricted_single_endpoint(expected_body)
+      responses_for_space_restricted_single_endpoint(
+        expected_body,
+        permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_application_supporter']
+      )
     end
 
     context 'user-provided service instance' do
@@ -301,7 +304,7 @@ RSpec.describe 'v3 service route bindings' do
         VCAP::CloudController::AnnotationsUpdate.update(route_binding, metadata[:annotations], VCAP::CloudController::RouteBindingAnnotationModel)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'managed service instance' do
@@ -314,7 +317,7 @@ RSpec.describe 'v3 service route bindings' do
         VCAP::CloudController::AnnotationsUpdate.update(route_binding, metadata[:annotations], VCAP::CloudController::RouteBindingAnnotationModel)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
     end
 
     context 'does not exist' do
@@ -895,10 +898,11 @@ RSpec.describe 'v3 service route bindings' do
       end
 
       describe 'permissions' do
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
           let(:expected_codes_and_responses) do
             Hash.new(code: 403).tap do |h|
               h['admin'] = { code: 202 }
+              h['space_application_supporter'] = { code: 202 }
               h['space_developer'] = { code: 202 }
 
               h['no_role'] = { code: 422 }
@@ -994,10 +998,11 @@ RSpec.describe 'v3 service route bindings' do
       it_behaves_like 'create route binding'
 
       context 'permissions' do
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
           let(:expected_codes_and_responses) do
             Hash.new(code: 403).tap do |h|
               h['admin'] = { code: 201 }
+              h['space_application_supporter'] = { code: 201 }
               h['space_developer'] = { code: 201 }
 
               h['no_role'] = { code: 422 }
@@ -1147,7 +1152,7 @@ RSpec.describe 'v3 service route bindings' do
           end
         }
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
         it 'creates an audit log' do
           api_call.call(admin_headers)
@@ -1193,7 +1198,7 @@ RSpec.describe 'v3 service route bindings' do
           }
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
         it 'responds with a job resource' do
           api_call.call(space_dev_headers)
@@ -1561,7 +1566,7 @@ RSpec.describe 'v3 service route bindings' do
           to_return(status: broker_status_code, body: broker_response.to_json, headers: {})
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
       it 'calls the broker with the identity header' do
         api_call.call(space_dev_headers)
@@ -1631,7 +1636,7 @@ RSpec.describe 'v3 service route bindings' do
         end
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
 
       it 'returns the appropriate error' do
         api_call.call(admin_headers)
@@ -1670,7 +1675,7 @@ RSpec.describe 'v3 service route bindings' do
 
     it_behaves_like 'metadata update for service binding', 'service_route_binding'
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
       let(:response_object) {
         expected_json(
           binding_guid: binding.guid,
@@ -1694,6 +1699,7 @@ RSpec.describe 'v3 service route bindings' do
           h['no_role'] = { code: 404 }
           h['org_auditor'] = { code: 404 }
           h['org_billing_manager'] = { code: 404 }
+          h['space_application_supporter'] = { code: 404 }
         end
       end
     end

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'v3 service route bindings' do
         Hash.new(code: 200, response_objects: [])
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     describe 'a mix of bindings' do
@@ -120,7 +120,7 @@ RSpec.describe 'v3 service route bindings' do
         VCAP::CloudController::AnnotationsUpdate.update(route_binding_2, route_binding_2_metadata[:annotations], VCAP::CloudController::RouteBindingAnnotationModel)
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     describe 'filtering' do
@@ -292,7 +292,7 @@ RSpec.describe 'v3 service route bindings' do
     let(:expected_codes_and_responses) do
       responses_for_space_restricted_single_endpoint(
         expected_body,
-        permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_application_supporter']
+        permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_supporter']
       )
     end
 
@@ -304,7 +304,7 @@ RSpec.describe 'v3 service route bindings' do
         VCAP::CloudController::AnnotationsUpdate.update(route_binding, metadata[:annotations], VCAP::CloudController::RouteBindingAnnotationModel)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     context 'managed service instance' do
@@ -317,7 +317,7 @@ RSpec.describe 'v3 service route bindings' do
         VCAP::CloudController::AnnotationsUpdate.update(route_binding, metadata[:annotations], VCAP::CloudController::RouteBindingAnnotationModel)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
     end
 
     context 'does not exist' do
@@ -898,11 +898,11 @@ RSpec.describe 'v3 service route bindings' do
       end
 
       describe 'permissions' do
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
           let(:expected_codes_and_responses) do
             Hash.new(code: 403).tap do |h|
               h['admin'] = { code: 202 }
-              h['space_application_supporter'] = { code: 202 }
+              h['space_supporter'] = { code: 202 }
               h['space_developer'] = { code: 202 }
 
               h['no_role'] = { code: 422 }
@@ -998,11 +998,11 @@ RSpec.describe 'v3 service route bindings' do
       it_behaves_like 'create route binding'
 
       context 'permissions' do
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
           let(:expected_codes_and_responses) do
             Hash.new(code: 403).tap do |h|
               h['admin'] = { code: 201 }
-              h['space_application_supporter'] = { code: 201 }
+              h['space_supporter'] = { code: 201 }
               h['space_developer'] = { code: 201 }
 
               h['no_role'] = { code: 422 }
@@ -1144,7 +1144,7 @@ RSpec.describe 'v3 service route bindings' do
         let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make(space: space, route_service_url: route_service_url) }
 
         let(:expected_codes_and_responses) { responses_for_space_restricted_delete_endpoint(
-          permitted_roles: SpaceRestrictedResponseGenerators.default_write_permitted_roles + ['space_application_supporter']
+          permitted_roles: SpaceRestrictedResponseGenerators.default_write_permitted_roles + ['space_supporter']
         )
         }
         let(:db_check) {
@@ -1155,7 +1155,7 @@ RSpec.describe 'v3 service route bindings' do
           end
         }
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
 
         it 'creates an audit log' do
           api_call.call(admin_headers)
@@ -1186,7 +1186,7 @@ RSpec.describe 'v3 service route bindings' do
         let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan) }
 
         let(:expected_codes_and_responses) { responses_for_space_restricted_async_delete_endpoint(
-          permitted_roles: SpaceRestrictedResponseGenerators.default_write_permitted_roles + ['space_application_supporter']
+          permitted_roles: SpaceRestrictedResponseGenerators.default_write_permitted_roles + ['space_supporter']
         )
         }
         let(:db_check) { lambda {} }
@@ -1204,7 +1204,7 @@ RSpec.describe 'v3 service route bindings' do
           }
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
 
         it 'responds with a job resource' do
           api_call.call(space_dev_headers)
@@ -1572,7 +1572,7 @@ RSpec.describe 'v3 service route bindings' do
           to_return(status: broker_status_code, body: broker_response.to_json, headers: {})
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
 
       it 'calls the broker with the identity header' do
         api_call.call(space_dev_headers)
@@ -1642,7 +1642,7 @@ RSpec.describe 'v3 service route bindings' do
         end
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
 
       it 'returns the appropriate error' do
         api_call.call(admin_headers)
@@ -1681,7 +1681,7 @@ RSpec.describe 'v3 service route bindings' do
 
     it_behaves_like 'metadata update for service binding', 'service_route_binding'
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_application_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
       let(:response_object) {
         expected_json(
           binding_guid: binding.guid,
@@ -1705,7 +1705,7 @@ RSpec.describe 'v3 service route bindings' do
           h['no_role'] = { code: 404 }
           h['org_auditor'] = { code: 404 }
           h['org_billing_manager'] = { code: 404 }
-          h['space_application_supporter'] = { code: 404 }
+          h['space_supporter'] = { code: 404 }
         end
       end
     end

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -1143,7 +1143,10 @@ RSpec.describe 'v3 service route bindings' do
       context 'user-provided service instance' do
         let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make(space: space, route_service_url: route_service_url) }
 
-        let(:expected_codes_and_responses) { responses_for_space_restricted_delete_endpoint }
+        let(:expected_codes_and_responses) { responses_for_space_restricted_delete_endpoint(
+          permitted_roles: SpaceRestrictedResponseGenerators.default_write_permitted_roles + ['space_application_supporter']
+        )
+        }
         let(:db_check) {
           lambda do
             expect(VCAP::CloudController::RouteBinding.all).to be_empty
@@ -1182,7 +1185,10 @@ RSpec.describe 'v3 service route bindings' do
         let(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service_offering) }
         let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan) }
 
-        let(:expected_codes_and_responses) { responses_for_space_restricted_async_delete_endpoint }
+        let(:expected_codes_and_responses) { responses_for_space_restricted_async_delete_endpoint(
+          permitted_roles: SpaceRestrictedResponseGenerators.default_write_permitted_roles + ['space_application_supporter']
+        )
+        }
         let(:db_check) { lambda {} }
         let(:job) { VCAP::CloudController::PollableJobModel.last }
         let(:broker_base_url) { service_instance.service_broker.broker_url }


### PR DESCRIPTION
* Enable space application supporter to get, create and delete service route bindings
* Add unit tests to prove the above

Note that the user story related to this PR did not ask for the DELETE endpoint to be implemented, but [I have assumed](https://github.com/cloudfoundry/cloud_controller_ng/issues/2242#issuecomment-874092400) that this was a mistake. If that turns out to be incorrect, I can reverse that part of the changes.

Closes #2242 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
