### PR TITLE
Truncate large process crash events

### DIFF
--- a/app/repositories/app_event_repository.rb
+++ b/app/repositories/app_event_repository.rb
@@ -1,11 +1,11 @@
 require 'repositories/mixins/app_manifest_event_mixins'
+require 'repositories/mixins/truncation_mixin'
 
 module VCAP::CloudController
   module Repositories
     class AppEventRepository
       include AppManifestEventMixins
-      TRUNCATED_SUFFIX = ' (truncated)'.freeze
-      TRUNCATE_THRESHOLD = 10000
+      include TruncationMixin
 
       CENSORED_FIELDS   = [:encrypted_environment_json,
                            :command,
@@ -19,7 +19,7 @@ module VCAP::CloudController
 
         actor    = { name: app.name, guid: app.guid, type: 'app' }
         metadata = droplet_exited_payload.slice('instance', 'index', 'cell_id', 'exit_status', 'exit_description', 'reason')
-        metadata['exit_description'] = metadata['exit_description'].truncate(TRUNCATE_THRESHOLD, omission: TRUNCATED_SUFFIX)
+        metadata['exit_description'] = truncate(metadata['exit_description'])
 
         create_app_audit_event('app.crash', app, app.space, actor, metadata)
       end

--- a/app/repositories/mixins/truncation_mixin.rb
+++ b/app/repositories/mixins/truncation_mixin.rb
@@ -1,0 +1,10 @@
+module VCAP::CloudController
+  module TruncationMixin
+    TRUNCATED_SUFFIX = ' (truncated)'.freeze
+    TRUNCATE_THRESHOLD = 10000
+
+    def truncate(message)
+      message.truncate(TRUNCATE_THRESHOLD, omission: TRUNCATED_SUFFIX)
+    end
+  end
+end

--- a/app/repositories/process_event_repository.rb
+++ b/app/repositories/process_event_repository.rb
@@ -1,9 +1,11 @@
 require 'repositories/mixins/app_manifest_event_mixins'
+require 'repositories/mixins/truncation_mixin'
 
 module VCAP::CloudController
   module Repositories
     class ProcessEventRepository
       extend AppManifestEventMixins
+      extend TruncationMixin
 
       def self.record_create(process, user_audit_info, manifest_triggered: false)
         VCAP::AppLogEmitter.emit(process.app.guid, "Added process: \"#{process.type}\"")
@@ -98,6 +100,7 @@ module VCAP::CloudController
 
       def self.record_crash(process, crash_payload)
         VCAP::AppLogEmitter.emit(process.app.guid, "Process has crashed with type: \"#{process.type}\"")
+        crash_payload['exit_description'] = truncate(crash_payload['exit_description'])
 
         create_event(
           process:    process,


### PR DESCRIPTION
## A short explanation of the proposed change
Truncate large process crash events

## An explanation of the use cases your change solves
Large crash events (e.g. with a stacktrace in the `exit_description`) can be multiple MBs in size which is then saved in a DB row. This has a performance impact on both the CC having to handle such requests/DB queries and the DB having to store/search such large data. A while back, the `app.crash` event had the `exit_description` field truncated to avoid this issue, this PR brings the `audit.app.process.crash` event in line with that.

## Links to any other associated PRs
App crash event fix - https://github.com/cloudfoundry/cloud_controller_ng/commit/0c199d4773c357e933db6a1e2a3eb86d0dc8aade

Fixes #1820 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
