### PR TITLE
Space application supporter can get, list service instances

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -47,7 +47,7 @@ class ServiceInstancesV3Controller < ApplicationController
                 ServiceInstanceListFetcher.fetch(
                   message,
                   eager_loaded_associations: Presenters::V3::ServiceInstancePresenter.associated_resources,
-                  readable_space_guids: permission_queryer.readable_space_guids,
+                  readable_space_guids: permission_queryer.readable_supporter_space_guids,
                 )
               end
 
@@ -81,7 +81,7 @@ class ServiceInstancesV3Controller < ApplicationController
     message = build_create_message(hashed_params[:body])
 
     space = Space.first(guid: message.space_guid)
-    unprocessable_space! unless space && can_read_space?(space)
+    unprocessable_space! unless space && untrusted_can_read_space?(space)
     unauthorized! unless can_write_space?(space)
 
     case message.type
@@ -170,7 +170,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def relationships_shared_spaces
     service_instance = ServiceInstance.first(guid: hashed_params[:guid])
-    resource_not_found!(:service_instance) unless service_instance && can_read_space?(service_instance.space)
+    resource_not_found!(:service_instance) unless service_instance && untrusted_can_read_space?(service_instance.space)
 
     message = SharedSpacesShowMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?
@@ -359,8 +359,12 @@ class ServiceInstancesV3Controller < ApplicationController
     readable_spaces = service_instance.shared_spaces + [service_instance.space]
 
     readable_spaces.any? do |space|
-      permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
+      permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
     end
+  end
+
+  def untrusted_can_read_space?(space)
+    permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
   end
 
   def can_read_space?(space)

--- a/docs/v3/source/includes/resources/service_instances/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_get.md.erb
@@ -62,8 +62,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
-Space Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |
-
+Space Supporter | Experimental

--- a/docs/v3/source/includes/resources/service_instances/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_get.md.erb
@@ -56,12 +56,13 @@ service_plan.service_offering| `name`, `guid`, `description`, `documentation_url
 service_plan.service_offering.service_broker| `name`, `guid`
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |

--- a/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
@@ -45,7 +45,7 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
-Space Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Supporter | Experimental

--- a/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
@@ -39,12 +39,13 @@ space | `guid`, `name`, `relationships.organization`
 space.organization| `guid`, `name`
 
 #### Permitted roles (in the service instance's originating space)
- |
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
 Global Auditor |
 Org Manager |
+Space Supporter | Experimental
 Space Auditor |
 Space Developer |
 Space Manager |


### PR DESCRIPTION
* Space application supporter can get and list service instances, and list shared spaces relationships of service instances.
* Unit tests to prove the above.

Closes #2238 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
