### PR TITLE
ISSUE-2393 Catch exceptions and decrease outstanding requests metric

### DIFF
--- a/middleware/request_metrics.rb
+++ b/middleware/request_metrics.rb
@@ -11,9 +11,13 @@ module CloudFoundry
 
         status, headers, body = @app.call(env)
 
-        @request_metrics.complete_request(status)
-
         [status, headers, body]
+      # in case of e.g. DB exceptions which are not being caught, make sure the metric is being decreased
+      rescue => e
+        status = 500
+        raise e
+      ensure
+        @request_metrics.complete_request(status)
       end
     end
   end

--- a/spec/unit/middleware/request_metrics_spec.rb
+++ b/spec/unit/middleware/request_metrics_spec.rb
@@ -22,6 +22,21 @@ module CloudFoundry
           middleware.call({})
           expect(request_metrics).to have_received(:complete_request).with(200)
         end
+
+        context 'when an unexpected error occurs' do
+          let(:middleware) { RequestMetrics.new(app, request_metrics) }
+          let(:app) { double(:app) }
+
+          before do
+            allow(app).to receive(:call).and_raise('Unexpected')
+          end
+
+          it 'catches the exception and calls complete request on request metrics' do
+            expect { middleware.call({}) }.to raise_error do
+              expect(request_metrics).to have_received(:complete_request).with(500)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Catch all exceptions in the `request_metrics` middleware and decrease the outstanding requests metric.

* An explanation of the use cases your change solves

This PR solves the issue described in #2393 

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
