### PR TITLE
Space supporter can access correct org quotas endpoints

### DIFF
--- a/docs/v3/source/includes/resources/organization_quotas/_get.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_get.md.erb
@@ -40,4 +40,4 @@ Org Billing Manager | Response will only include guids of billing-managed organi
 Space Auditor | Response will only include guids of parent organizations
 Space Developer | Response will only include guids of parent organizations
 Space Manager | Response will only include guids of parent organizations
-Space Supporter | Response will only include guids of parent organizations
+Space Supporter | Experimental / Response will only include guids of parent organizations

--- a/docs/v3/source/includes/resources/organization_quotas/_get.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_get.md.erb
@@ -40,3 +40,4 @@ Org Billing Manager | Response will only include guids of billing-managed organi
 Space Auditor | Response will only include guids of parent organizations
 Space Developer | Response will only include guids of parent organizations
 Space Manager | Response will only include guids of parent organizations
+Space Supporter | Response will only include guids of parent organizations

--- a/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
@@ -52,3 +52,4 @@ Org Billing Manager | Response will only include guids of billing-managed organi
 Space Auditor | Response will only include guids of parent organizations
 Space Developer | Response will only include guids of parent organizations
 Space Manager | Response will only include guids of parent organizations
+Space Supporter | Response will only include guids of parent organizations

--- a/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
@@ -52,4 +52,4 @@ Org Billing Manager | Response will only include guids of billing-managed organi
 Space Auditor | Response will only include guids of parent organizations
 Space Developer | Response will only include guids of parent organizations
 Space Manager | Response will only include guids of parent organizations
-Space Supporter | Response will only include guids of parent organizations
+Space Supporter | Experimental / Response will only include guids of parent organizations

--- a/spec/request/organization_quotas_spec.rb
+++ b/spec/request/organization_quotas_spec.rb
@@ -80,7 +80,7 @@ module VCAP::CloudController
           }.by 1
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
 
       context 'using provided params' do
@@ -210,7 +210,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
 
         it_behaves_like 'list_endpoint_with_common_filters' do
           let(:resource_klass) { VCAP::CloudController::QuotaDefinition }
@@ -277,7 +277,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
 
       context 'when the organization_quota had no associated organizations' do
@@ -382,7 +382,7 @@ module VCAP::CloudController
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
 
       context 'when the organization_quota does not exist' do
         it 'returns a 404 with a helpful message' do
@@ -487,7 +487,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
 
       context 'when an org guid does not exist' do
@@ -541,7 +541,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
       end
 
       context 'when the user is not logged in' do


### PR DESCRIPTION
* Update tests to prove space supporters can get and list org quotas, but cannot access other endpoints.

Closes #2387

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
