### PR TITLE
Allow space supporter to access specific isolation segment endpoints

### DIFF
--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -149,7 +149,7 @@ class SpacesV3Controller < ApplicationController
     space_not_found! unless space
     org = space.organization
     org_not_found! unless org
-    space_not_found! unless permission_queryer.can_read_from_space?(space.guid, org.guid)
+    space_not_found! unless permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
     unauthorized! unless roles.admin? || space.organization.managers.include?(current_user)
 
     message = SpaceUpdateIsolationSegmentMessage.new(hashed_params[:body])

--- a/docs/v3/source/includes/resources/isolation_segments/_get.md.erb
+++ b/docs/v3/source/includes/resources/isolation_segments/_get.md.erb
@@ -27,10 +27,5 @@ Content-Type: application/json
 #### Permitted roles
  |
 --- | ---
-Admin |
-Admin Read-Only |
-Global Auditor |
-Org Manager |
-Space Auditor |
-Space Developer |
-Space Manager |
+All Roles |
+

--- a/docs/v3/source/includes/resources/isolation_segments/_list_spaces.md.erb
+++ b/docs/v3/source/includes/resources/isolation_segments/_list_spaces.md.erb
@@ -29,10 +29,4 @@ This endpoint lists the spaces to which the isolation segment is assigned.  For 
 #### Permitted roles
  |
 --- | ---
-Admin |
-Admin Read-Only |
-Global Auditor |
-Org Manager |
-Space Auditor |
-Space Developer |
-Space Manager |
+All Roles |

--- a/spec/request/isolation_segments_spec.rb
+++ b/spec/request/isolation_segments_spec.rb
@@ -75,6 +75,24 @@ RSpec.describe 'IsolationSegmentModels' do
       expect(parsed_response['data']).to include(expected_response['data'][1])
       expect(parsed_response.except('data')).to be_a_response_like(expected_response.except('data'))
     end
+
+    context 'permissions' do
+      before do
+        assigner.assign(isolation_segment_model, [space.organization])
+        space.update(isolation_segment_guid: isolation_segment_model.guid)
+      end
+
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        let(:api_call) { lambda { |user_headers| get "/v3/isolation_segments/#{isolation_segment_model.guid}/relationships/organizations", nil, user_headers } }
+        let(:org) { space.organization }
+        let(:user) { VCAP::CloudController::User.make }
+        let(:expected_codes_and_responses) do
+          h = Hash.new(code: 200)
+          h['no_role'] = { code: 404 }
+          h
+        end
+      end
+    end
   end
 
   describe 'GET /v3/isolation_segments/:guid/relationships/spaces' do
@@ -100,6 +118,20 @@ RSpec.describe 'IsolationSegmentModels' do
       expect(parsed_response['links']).to eq({
         'self' => { 'href' => "#{link_prefix}/v3/isolation_segments/#{isolation_segment_model.guid}/relationships/spaces" },
       })
+    end
+
+    context 'permissions' do
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        let(:api_call) { lambda { |user_headers| get "/v3/isolation_segments/#{isolation_segment_model.guid}/relationships/spaces", nil, user_headers } }
+        let(:org) { space1.organization }
+        let(:space) { space1 }
+        let(:user) { VCAP::CloudController::User.make }
+        let(:expected_codes_and_responses) do
+          h = Hash.new(code: 200)
+          h['no_role'] = { code: 404 }
+          h
+        end
+      end
     end
   end
 
@@ -214,6 +246,24 @@ RSpec.describe 'IsolationSegmentModels' do
         }
 
         expect(parsed_response).to be_a_response_like(expected_response)
+      end
+    end
+
+    context 'permissions' do
+      before do
+        assigner.assign(isolation_segment_model, [space.organization])
+        space.update(isolation_segment_guid: isolation_segment_model.guid)
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        let(:api_call) { lambda { |user_headers| get "/v3/isolation_segments/#{isolation_segment_model.guid}", nil, user_headers } }
+        let(:org) { space.organization }
+        let(:user) { VCAP::CloudController::User.make }
+        let(:expected_codes_and_responses) do
+          h = Hash.new(code: 200)
+          h['no_role'] = { code: 404 }
+          h
+        end
       end
     end
   end
@@ -435,6 +485,18 @@ RSpec.describe 'IsolationSegmentModels' do
 
         parsed_response = MultiJson.load(last_response.body)
         expect(parsed_response['resources'].map { |r| r['guid'] }).to contain_exactly(iso_segB.guid, iso_segC.guid)
+      end
+    end
+
+    context 'permissions' do
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        let(:api_call) { lambda { |user_headers| get '/v3/isolation_segments', nil, user_headers } }
+        let(:org) { space.organization }
+        let(:user) { VCAP::CloudController::User.make }
+        let(:expected_codes_and_responses) do
+          h = Hash.new(code: 200)
+          h
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #2222  

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
