### PR TITLE
Space supporter receives a 403 for v3/deployments/:guid

### DIFF
--- a/app/controllers/v3/deployments_controller.rb
+++ b/app/controllers/v3/deployments_controller.rb
@@ -58,7 +58,7 @@ class DeploymentsController < ApplicationController
   def update
     deployment = DeploymentModel.find(guid: hashed_params[:guid])
     resource_not_found!(:deployment) unless deployment &&
-      permission_queryer.can_read_from_space?(deployment.app.space.guid, deployment.app.space.organization.guid)
+      permission_queryer.untrusted_can_read_from_space?(deployment.app.space.guid, deployment.app.space.organization.guid)
     unauthorized! unless permission_queryer.can_write_to_space?(deployment.app.space.guid)
 
     message = VCAP::CloudController::DeploymentUpdateMessage.new(hashed_params[:body])

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -793,7 +793,7 @@ RSpec.describe 'Deployments' do
     end
   end
 
-  describe 'PATCH /v3/deployments' do
+  describe 'PATCH /v3/deployments/:guid' do
     let(:user) { make_developer_for_space(space) }
     let(:deployment) {
       VCAP::CloudController::DeploymentModel.make(
@@ -863,6 +863,27 @@ RSpec.describe 'Deployments' do
           }
         }
       })
+    end
+
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      before do
+        space.remove_developer(user)
+      end
+
+      let(:api_call) { lambda { |user_headers| patch "/v3/deployments/#{deployment.guid}", update_request, user_headers } }
+
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 404)
+        h['admin'] = { code: 200 }
+        h['space_developer'] = { code: 200 }
+        h['global_auditor'] = { code: 403 }
+        h['admin_read_only'] = { code: 403 }
+        h['space_manager'] = { code: 403 }
+        h['org_manager'] = { code: 403 }
+        h['space_auditor'] = { code: 403 }
+        h['space_supporter'] = { code: 403 }
+        h
+      end
     end
   end
 


### PR DESCRIPTION
This PR allows space supporters to receive a 403 instead of a 404 when submitting PATCH requests to the v3/deployments/:guid endpoint.

Closes #2399

Co-authored-by: Matthew Kocher <mkocher@pivotal.io>
Co-authored-by: Galen Hammond <galenh@vmware.com>


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
