### PR TITLE
space supporter receives a 403 when accessing PATCH /v3/tasks/:guid

### DIFF
--- a/app/controllers/v3/tasks_controller.rb
+++ b/app/controllers/v3/tasks_controller.rb
@@ -83,7 +83,7 @@ class TasksController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     task, space, org = TaskFetcher.new.fetch(task_guid: hashed_params[:task_guid])
-    task_not_found! unless task && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    task_not_found! unless task && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
     unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
 
     task = TaskUpdate.new.update(task, message)

--- a/spec/request/tasks_spec.rb
+++ b/spec/request/tasks_spec.rb
@@ -561,6 +561,27 @@ RSpec.describe 'Tasks' do
       }
       expect(parsed_response).to be_a_response_like(expected_response)
     end
+
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      before do
+        space.remove_developer(user)
+      end
+
+      let(:api_call) { lambda { |headers| patch "/v3/tasks/#{task_guid}", request_body, headers } }
+
+      let(:expected_codes_and_responses) {
+        h = Hash.new(code: 404)
+        h['space_supporter'] = { code: 403 }
+        h['space_manager'] = { code: 403 }
+        h['org_manager'] = { code: 403 }
+        h['global_auditor'] = { code: 403 }
+        h['space_auditor'] = { code: 403 }
+        h['admin_read_only'] = { code: 403 }
+        h['space_developer'] = { code: 200 }
+        h['admin'] = { code: 200 }
+        h
+      }
+    end
   end
 
   describe 'POST /v3/tasks/:guid/actions/cancel' do


### PR DESCRIPTION
like it says in the subject. Just making this consistent with the style guide.

Co-authored-by: Matthew Kocher <mkocher@pivotal.io>
Co-authored-by: Galen Hammond <galenh@vmware.com>

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
