### PR TITLE
Allow space supporter to access specific organizations endpoints

### DIFF
--- a/spec/unit/controllers/v3/organizations_controller_spec.rb
+++ b/spec/unit/controllers/v3/organizations_controller_spec.rb
@@ -4,86 +4,6 @@ require 'permissions_spec_helper'
 ## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
 
 RSpec.describe OrganizationsV3Controller, type: :controller do
-  describe '#show' do
-    let(:user) { set_current_user(VCAP::CloudController::User.make) }
-
-    let!(:org) { VCAP::CloudController::Organization.make(name: 'Eric\'s Farm') }
-    let!(:space) { VCAP::CloudController::Space.make(name: 'Cat', organization: org) }
-
-    describe 'permissions by role' do
-      before do
-        set_current_user(user)
-      end
-
-      role_to_expected_http_response = {
-        'admin' => 200,
-        'space_developer' => 200,
-        'admin_read_only' => 200,
-        'global_auditor' => 200,
-        'space_manager' => 200,
-        'space_auditor' => 200,
-        'org_manager' => 200,
-        'org_auditor' => 200,
-        'org_billing_manager' => 200,
-      }.freeze
-
-      role_to_expected_http_response.each do |role, expected_return_value|
-        context "as an #{role}" do
-          it "returns #{expected_return_value}" do
-            set_current_user_as_role(role: role, org: org, space: space, user: user)
-
-            get :show, params: { guid: org.guid }, as: :json
-
-            expect(response.status).to eq(expected_return_value),
-              "Expected #{expected_return_value}, but got #{response.status}. Response: #{response.body}"
-            if expected_return_value == 200
-              expect(parsed_body['guid']).to eq(org.guid)
-              expect(parsed_body['name']).to eq('Eric\'s Farm')
-              expect(parsed_body['suspended']).to be false
-              expect(parsed_body['created_at']).to match(iso8601)
-              expect(parsed_body['updated_at']).to match(iso8601)
-              expect(parsed_body['links']['self']['href']).to match(%r{/v3/organizations/#{org.guid}$})
-            end
-          end
-        end
-      end
-
-      context 'when the org is suspended' do
-        before do
-          org.update(status: VCAP::CloudController::Organization::SUSPENDED)
-        end
-        role_to_expected_http_response.each do |role, expected_return_value|
-          context "as an #{role}" do
-            it "returns #{expected_return_value}" do
-              set_current_user_as_role(role: role, org: org, space: space, user: user)
-
-              get :show, params: { guid: org.guid }, as: :json
-
-              expect(response.status).to eq(expected_return_value),
-                "Expected #{expected_return_value}, but got #{response.status}. Response: #{response.body}"
-              if expected_return_value == 200
-                expect(parsed_body['guid']).to eq(org.guid)
-                expect(parsed_body['name']).to eq('Eric\'s Farm')
-                expect(parsed_body['suspended']).to be true
-              end
-            end
-          end
-        end
-      end
-    end
-
-    describe 'user with no roles' do
-      before do
-        set_current_user(user)
-      end
-
-      it 'returns an error' do
-        get :show, params: { guid: org.guid }, as: :json
-        expect(response.status).to eq(404), "Got #{response.status}"
-      end
-    end
-  end
-
   describe '#create' do
     let(:user) { VCAP::CloudController::User.make }
     let(:uaa_client) { instance_double(VCAP::CloudController::UaaClient) }
@@ -220,15 +140,6 @@ RSpec.describe OrganizationsV3Controller, type: :controller do
       auditor_org.add_auditor(user)
     end
 
-    it 'returns orgs the user has read access' do
-      get :index
-
-      expect(response.status).to eq(200)
-      expect(parsed_body['resources'].map { |r| r['name'] }).to match_array([
-        member_org.name, manager_org.name, billing_manager_org.name, auditor_org.name
-      ])
-    end
-
     it 'eager loads associated resources that the presenter specifies' do
       expect(VCAP::CloudController::OrgListFetcher).to receive(:fetch).with(
         hash_including(eager_loaded_associations: [:labels, :annotations, :quota_definition])
@@ -307,34 +218,6 @@ RSpec.describe OrganizationsV3Controller, type: :controller do
           expect(response.body).to include('nyan')
           expect(response.body).to include('meow')
         end
-      end
-    end
-
-    context 'when pagination options are specified' do
-      let(:page) { 2 }
-      let(:per_page) { 1 }
-      let(:params) { { 'page' => page, 'per_page' => per_page } }
-
-      it 'paginates the response' do
-        get :index, params: params, as: :json
-
-        parsed_response = parsed_body
-        expect(parsed_response['pagination']['total_results']).to eq(4)
-        expect(parsed_response['resources'].length).to eq(per_page)
-        expect(parsed_response['resources'][0]['name']).to eq('Rat')
-      end
-    end
-
-    context 'when the user has global read access' do
-      before do
-        allow_user_global_read_access(user)
-      end
-
-      it 'returns a 200 and all organizations' do
-        get :index
-
-        expect(response.status).to eq(200)
-        expect(parsed_body['resources'].length).to eq(6)
       end
     end
 


### PR DESCRIPTION
* This was a no-op in the actual code because the org user role will
handle these permissions
* Removed some overlapping controller specs

Resolves #2223

Co-authored-by: Michael Oleske <moleske@pivotal.io>
Co-authored-by: Carson Long <lcarson@vmware.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
