### PR TITLE
Add connection expiration to deployment_updater_schema

### DIFF
--- a/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
@@ -28,6 +28,8 @@ module VCAP::CloudController
               ssl_verify_hostname: bool,
               connection_validation_timeout: Integer,
               optional(:ca_cert_path) => String,
+              optional(:connection_expiration_timeout) => Integer,
+              optional(:connection_expiration_random_delay) => Integer,
             },
 
             index: Integer, # Component index (cc-0, cc-1, etc)

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -60,7 +60,7 @@ module VCAP::CloudController
     def self.add_connection_expiration_extension(db, opts)
       if opts[:connection_expiration_timeout]
         db.extension(:connection_expiration)
-        db.pool.connection_expiration_timeout = opts[:connection_expiration_timeout] if opts[:connection_expiration_timeout]
+        db.pool.connection_expiration_timeout = opts[:connection_expiration_timeout]
         db.pool.connection_expiration_random_delay = opts[:connection_expiration_random_delay] if opts[:connection_expiration_random_delay]
         # So that there are no existing connections without an expiration timestamp
         db.disconnect


### PR DESCRIPTION
## A short explanation of the proposed change:
Add connection expiration to the deployment updater schema so that it can be configured correctly.

## An explanation of the use cases your change solves
The deployment updater uses the same DB setup classes as the main application and is deployed as a long running process so may well benefit from expiring connections

## Links to any other associated PRs
#2351 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
