### PR TITLE
Allows space supporter to access GET v3/service_route_bindings

### DIFF
--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -182,7 +182,7 @@ class ServiceRouteBindingsController < ApplicationController
   end
 
   def space_guids
-    permission_queryer.readable_space_guids
+    permission_queryer.readable_supporter_space_guids
   end
 
   def parse_create_request

--- a/docs/v3/source/includes/resources/service_route_bindings/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_list.md.erb
@@ -53,4 +53,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter |
+Space Supporter | Experimental

--- a/docs/v3/source/includes/resources/service_route_bindings/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_list.md.erb
@@ -53,3 +53,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Supporter |

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe 'v3 service route bindings' do
           h['admin_read_only'] = bindings_response_body
           h['global_auditor'] = bindings_response_body
           h['space_developer'] = bindings_response_body
+          h['space_supporter'] = bindings_response_body
           h['space_manager'] = bindings_response_body
           h['space_auditor'] = bindings_response_body
           h['org_manager'] = bindings_response_body


### PR DESCRIPTION
Allows space supporter access to service route binding list endpoint

Closes #2422

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
