### PR TITLE
Allow space supporter to get ssh_enabled app feature and to access apps in the stack

### DIFF
--- a/app/controllers/v3/app_features_controller.rb
+++ b/app/controllers/v3/app_features_controller.rb
@@ -57,7 +57,7 @@ class AppFeaturesController < ApplicationController
   def ssh_enabled
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
 
-    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
 
     render status: :ok, json: Presenters::V3::AppSshStatusPresenter.new(app, Config.config.get(:allow_app_ssh_access))
   end

--- a/app/controllers/v3/stacks_controller.rb
+++ b/app/controllers/v3/stacks_controller.rb
@@ -67,7 +67,7 @@ class StacksController < ApplicationController
     dataset = if permission_queryer.can_read_globally?
                 AppListFetcher.fetch_all(message)
               else
-                AppListFetcher.fetch(message, permission_queryer.readable_space_guids)
+                AppListFetcher.fetch(message, permission_queryer.readable_supporter_space_guids)
               end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(

--- a/docs/v3/source/includes/resources/apps/_ssh_enabled.md.erb
+++ b/docs/v3/source/includes/resources/apps/_ssh_enabled.md.erb
@@ -39,3 +39,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_ssh_enabled.md.erb
+++ b/docs/v3/source/includes/resources/apps/_ssh_enabled.md.erb
@@ -30,7 +30,7 @@ whether it is disabled globally, at the space level, or at the app level.
 `GET /v3/apps/:guid/ssh_enabled` <br>
 
 #### Permitted roles
- |
+Role | Notes
 --- | ---
 Admin |
 Admin Read-Only |
@@ -39,4 +39,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter |
+Space Supporter | Experimental

--- a/docs/v3/source/includes/resources/stacks/_apps.md.erb
+++ b/docs/v3/source/includes/resources/stacks/_apps.md.erb
@@ -21,10 +21,10 @@ Content-Type: application/json
 <%= yield_content :paginated_list_of_apps, '/v3/stacks/[guid]/apps' %>
 ```
 
-Retrieve all stacks.
+Retrieve all apps using a given stack.
 
 #### Definition
-`GET /v3/stacks`
+`GET /v3/stacks/:guid/apps`
 
 #### Query parameters
 

--- a/docs/v3/source/includes/resources/stacks/_apps.md.erb
+++ b/docs/v3/source/includes/resources/stacks/_apps.md.erb
@@ -1,0 +1,43 @@
+### List apps on a stack
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/stacks/[guid]/apps" \
+  -X GET \
+  -H "Authorization: bearer [token]"
+```
+
+```
+Example Response
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+<%= yield_content :paginated_list_of_apps, '/v3/stacks/[guid]/apps' %>
+```
+
+Retrieve all stacks.
+
+#### Definition
+`GET /v3/stacks`
+
+#### Query parameters
+
+Name | Type | Description
+---- | ---- | ------------
+**page** | _integer_ | Page to display; valid values are integers >= 1
+**per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
+**order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`, and `name`
+**label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
+**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+
+#### Permitted roles
+|
+--- | ---
+All Roles |

--- a/docs/v3/source/index.html.md
+++ b/docs/v3/source/index.html.md
@@ -348,6 +348,7 @@ includes:
   - resources/stacks/create
   - resources/stacks/get
   - resources/stacks/list
+  - resources/stacks/apps
   - resources/stacks/update
   - resources/stacks/delete
   - resources/tasks/header

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -1873,6 +1873,33 @@ RSpec.describe 'Apps' do
     end
   end
 
+  describe 'GET /v3/apps/:guid/ssh_enabled' do
+    before do
+      space.organization.add_user(user)
+    end
+
+    context 'when getting an apps ssh_enabled value' do
+      let(:api_call) { lambda { |user_headers| get "/v3/apps/#{app_model.guid}/ssh_enabled", nil, user_headers } }
+      let!(:app_model) { VCAP::CloudController::AppModel.make(
+        :buildpack,
+        name: 'my_app',
+        guid: 'app1_guid',
+        space: space,
+      )
+      }
+
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 200)
+        h['org_auditor'] = { code: 404 }
+        h['org_billing_manager'] = { code: 404 }
+        h['no_role'] = { code: 404 }
+        h
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    end
+  end
+
   describe 'DELETE /v3/apps/guid' do
     let!(:app_model) { VCAP::CloudController::AppModel.make(name: 'app_name', space: space) }
     let!(:package) { VCAP::CloudController::PackageModel.make(app: app_model) }

--- a/spec/request/stacks_spec.rb
+++ b/spec/request/stacks_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe 'Stacks Request' do
       app_model2.buildpack_lifecycle_data.update(stack: stack.name, buildpacks: [buildpack.name])
     end
 
-    context 'as a space developer' do
+    context 'as a permitted user' do
       before do
         space.organization.add_user(user)
         space.add_developer(user)


### PR DESCRIPTION
Allow space supporter to get ssh_enabled app feature and to access apps in the stack.

Endpoints:
GET /v3/apps/:guid/ssh_enabled
GET v3/stacks/:guid/apps

Issue #2410

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
