### PR TITLE
Allow user to filter routes by service instance guid

### DIFF
--- a/app/fetchers/route_fetcher.rb
+++ b/app/fetchers/route_fetcher.rb
@@ -43,10 +43,10 @@ module VCAP::CloudController
 
         if message.requested?(:service_instance_guids)
           service_instance_route_guids = RouteBinding.
-            join(:routes, id: :route_id).
-            join(:service_instances, id: :route_bindings__service_instance_id).
-            where { { service_instances[:guid] => message.service_instance_guids } }.
-            select(:routes__guid)
+                                         join(:routes, id: :route_id).
+                                         join(:service_instances, id: :route_bindings__service_instance_id).
+                                         where { { service_instances[:guid] => message.service_instance_guids } }.
+                                         select(:routes__guid)
           dataset = dataset.where(guid: service_instance_route_guids)
         end
 

--- a/app/fetchers/route_fetcher.rb
+++ b/app/fetchers/route_fetcher.rb
@@ -36,9 +36,8 @@ module VCAP::CloudController
           dataset = dataset.where(domain_id: Domain.where(guid: message.domain_guids).select(:id))
         end
 
-        if message.requested?(:app_guids)
-          destinations_route_guids = RouteMappingModel.where(app_guid: message.app_guids).select(:route_guid)
-          dataset = dataset.where(guid: destinations_route_guids)
+        if message.requested?(:app_guids) || message.requested?(:service_instance_guids)
+          dataset = dataset.where(guid: combine_app_and_serivce_guids(message))
         end
 
         if message.requested?(:label_selector)
@@ -51,6 +50,22 @@ module VCAP::CloudController
         end
 
         super(message, dataset, Route)
+      end
+
+      def combine_app_and_serivce_guids(message)
+        if message.requested?(:app_guids) && message.requested?(:service_instance_guids)
+          app_guids = ServiceBinding.where(service_instance_guid: message.service_instance_guids).select(:app_guid)
+          return RouteMappingModel.where(app_guid: message.app_guids).where(app_guid: app_guids).select(:route_guid)
+        end
+
+        if message.requested?(:app_guids)
+          return RouteMappingModel.where(app_guid: message.app_guids).select(:route_guid)
+        end
+
+        if message.requested?(:service_instance_guids)
+          app_guids = ServiceBinding.where(service_instance_guid: message.service_instance_guids).select(:app_guid)
+          return RouteMappingModel.where(app_guid: app_guids).select(:route_guid)
+        end
       end
     end
   end

--- a/app/fetchers/route_fetcher.rb
+++ b/app/fetchers/route_fetcher.rb
@@ -36,8 +36,18 @@ module VCAP::CloudController
           dataset = dataset.where(domain_id: Domain.where(guid: message.domain_guids).select(:id))
         end
 
-        if message.requested?(:app_guids) || message.requested?(:service_instance_guids)
-          dataset = dataset.where(guid: combine_app_and_serivce_guids(message))
+        if message.requested?(:app_guids)
+          destinations_route_guids = RouteMappingModel.where(app_guid: message.app_guids).select(:route_guid)
+          dataset = dataset.where(guid: destinations_route_guids)
+        end
+
+        if message.requested?(:service_instance_guids)
+          service_instance_route_guids = RouteBinding.
+            join(:routes, id: :route_id).
+            join(:service_instances, id: :route_bindings__service_instance_id).
+            where { { service_instances[:guid] => message.service_instance_guids } }.
+            select(:routes__guid)
+          dataset = dataset.where(guid: service_instance_route_guids)
         end
 
         if message.requested?(:label_selector)
@@ -50,25 +60,6 @@ module VCAP::CloudController
         end
 
         super(message, dataset, Route)
-      end
-
-      def combine_app_and_serivce_guids(message)
-        if message.requested?(:app_guids) && message.requested?(:service_instance_guids)
-          app_guids = ServiceBinding.where(service_instance_guid: message.service_instance_guids).select(:app_guid)
-          return RouteMappingModel.where(app_guid: message.app_guids).where(app_guid: app_guids).select(:route_guid)
-        end
-
-        if message.requested?(:app_guids)
-          return RouteMappingModel.where(app_guid: message.app_guids).select(:route_guid)
-        end
-
-        if message.requested?(:service_instance_guids)
-          return RouteBinding.
-                 join(:routes, id: :route_id).
-                 join(:service_instances, id: :route_bindings__service_instance_id).
-                 where { { service_instances[:guid] => message.service_instance_guids } }.
-                 select(:routes__guid)
-        end
       end
     end
   end

--- a/app/fetchers/route_fetcher.rb
+++ b/app/fetchers/route_fetcher.rb
@@ -63,8 +63,11 @@ module VCAP::CloudController
         end
 
         if message.requested?(:service_instance_guids)
-          app_guids = ServiceBinding.where(service_instance_guid: message.service_instance_guids).select(:app_guid)
-          return RouteMappingModel.where(app_guid: app_guids).select(:route_guid)
+          return RouteBinding.
+                 join(:routes, id: :route_id).
+                 join(:service_instances, id: :route_bindings__service_instance_id).
+                 where { { service_instances[:guid] => message.service_instance_guids } }.
+                 select(:routes__guid)
         end
       end
     end

--- a/app/messages/routes_list_message.rb
+++ b/app/messages/routes_list_message.rb
@@ -12,6 +12,7 @@ module VCAP::CloudController
       :include,
       :label_selector,
       :ports,
+      :service_instance_guids,
     ]
 
     validates_with NoAdditionalParamsValidator
@@ -24,9 +25,10 @@ module VCAP::CloudController
     validates :organization_guids, allow_nil: true, array: true
     validates :domain_guids, allow_nil: true, array: true
     validates :ports, allow_nil: true, array: true
+    validates :service_instance_guids, allow_nil: true, array: true
 
     def self.from_params(params)
-      super(params, %w(hosts space_guids organization_guids domain_guids app_guids paths ports include))
+      super(params, %w(hosts space_guids organization_guids domain_guids app_guids paths ports include service_instance_guids))
     end
   end
 end

--- a/docs/v3/source/includes/resources/routes/_list.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list.md.erb
@@ -37,6 +37,7 @@ Name | Type | Description
 **paths** | _list of strings_ | Comma-delimited list of paths to filter by (e.g. `/path1,/path2`)
 **ports** | _list of integers_ | Comma-delimited list of ports to filter by (e.g. `3306,5432`)
 **space_guids** | _list of strings_ | Comma-delimited list of space guids to filter by
+**service_instance_guids** | _list of strings_ | Comma-delimited list of service instance guids to filter by
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe 'Routes Request' do
             per_page: '10',
             order_by: 'updated_at',
             space_guids: ['foo', 'bar'],
+            service_instance_guids: ['baz', 'qux'],
             organization_guids: ['foo', 'bar'],
             domain_guids: ['foo', 'bar'],
             app_guids: ['foo', 'bar'],
@@ -608,6 +609,34 @@ RSpec.describe 'Routes Request' do
             expect(parsed_response['resources'].size).to eq(2)
             expect(parsed_response['resources'].map { |resource| resource['port'] }).to contain_exactly(route_with_ports_0.port, route_with_ports_1.port)
           end
+        end
+      end
+
+      context 'service instance guids filter' do
+        let!(:app_model_with_service_instances) { VCAP::CloudController::AppModel.make(space: space) }
+        let(:service_instance_one) do
+          VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'si-name-1')
+        end
+        let(:service_instance_two) do
+          VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'si-name-2')
+        end
+        let!(:service_binding_one) { VCAP::CloudController::ServiceBinding.make(app: app_model_with_service_instances, service_instance: service_instance_one) }
+        let!(:service_binding_two) { VCAP::CloudController::ServiceBinding.make(app: app_model_with_service_instances, service_instance: service_instance_two) }
+        let!(:route_mapping_one) { VCAP::CloudController::RouteMappingModel.make(app: app_model_with_service_instances, route: route_with_service_instance_one) }
+        let!(:route_mapping_two) { VCAP::CloudController::RouteMappingModel.make(app: app_model_with_service_instances, route: route_with_service_instance_two) }
+
+        let!(:route_with_service_instance_one) do
+          VCAP::CloudController::Route.make(space: space, host: 'host-with-service-instance-one', domain: domain, path: '/path1', guid: 'route-with-service-instance-one')
+        end
+        let!(:route_with_service_instance_two) do
+          VCAP::CloudController::Route.make(space: space, host: 'host-with-service-instance-two', domain: domain, path: '/path2', guid: 'route-with-service-instance-two')
+        end
+
+        it 'returns routes filtered by service instance guid' do
+          get "/v3/routes?service_instance_guids=#{service_instance_one.guid},#{service_instance_two.guid}", nil, admin_header
+          expect(last_response).to have_status_code(200)
+          expect(parsed_response['resources'].size).to eq(2)
+          expect(parsed_response['resources'].map { |resource| resource['guid'] }).to contain_exactly('route-with-service-instance-one', 'route-with-service-instance-two')
         end
       end
     end

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -613,17 +613,12 @@ RSpec.describe 'Routes Request' do
       end
 
       context 'service instance guids filter' do
-        let!(:app_model_with_service_instances) { VCAP::CloudController::AppModel.make(space: space) }
         let(:service_instance_one) do
-          VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'si-name-1')
+          VCAP::CloudController::ManagedServiceInstance.make(:routing, space: space, name: 'si-name-1')
         end
         let(:service_instance_two) do
-          VCAP::CloudController::ManagedServiceInstance.make(space: space, name: 'si-name-2')
+          VCAP::CloudController::ManagedServiceInstance.make(:routing, space: space, name: 'si-name-2')
         end
-        let!(:service_binding_one) { VCAP::CloudController::ServiceBinding.make(app: app_model_with_service_instances, service_instance: service_instance_one) }
-        let!(:service_binding_two) { VCAP::CloudController::ServiceBinding.make(app: app_model_with_service_instances, service_instance: service_instance_two) }
-        let!(:route_mapping_one) { VCAP::CloudController::RouteMappingModel.make(app: app_model_with_service_instances, route: route_with_service_instance_one) }
-        let!(:route_mapping_two) { VCAP::CloudController::RouteMappingModel.make(app: app_model_with_service_instances, route: route_with_service_instance_two) }
 
         let!(:route_with_service_instance_one) do
           VCAP::CloudController::Route.make(space: space, host: 'host-with-service-instance-one', domain: domain, path: '/path1', guid: 'route-with-service-instance-one')
@@ -631,6 +626,9 @@ RSpec.describe 'Routes Request' do
         let!(:route_with_service_instance_two) do
           VCAP::CloudController::Route.make(space: space, host: 'host-with-service-instance-two', domain: domain, path: '/path2', guid: 'route-with-service-instance-two')
         end
+
+        let!(:route_mapping_one) { VCAP::CloudController::RouteBinding.make(route: route_with_service_instance_one, service_instance: service_instance_one) }
+        let!(:route_mapping_two) { VCAP::CloudController::RouteBinding.make(route: route_with_service_instance_two, service_instance: service_instance_two) }
 
         it 'returns routes filtered by service instance guid' do
           get "/v3/routes?service_instance_guids=#{service_instance_one.guid},#{service_instance_two.guid}", nil, admin_header

--- a/spec/unit/fetchers/route_fetcher_spec.rb
+++ b/spec/unit/fetchers/route_fetcher_spec.rb
@@ -262,9 +262,10 @@ module VCAP::CloudController
       end
 
       context 'when fetching routes by service_instance_guid and app_guid' do
-        let!(:service_instance) { ManagedServiceInstance.make(space: space2, name: 'service-instance') }
+        let!(:service_instance) { ManagedServiceInstance.make(:routing, space: space2, name: 'service-instance') }
+        let!(:service_binding) { RouteBinding.make(service_instance: service_instance, route: route3) }
+
         let!(:app_model) { AppModel.make(space: space2) }
-        let!(:service_binding) { ServiceBinding.make(app: app_model, service_instance: service_instance) }
         let!(:route_mapping) { RouteMappingModel.make(app: app_model, route: route3) }
 
         context 'when there is a matching route' do

--- a/spec/unit/fetchers/route_fetcher_spec.rb
+++ b/spec/unit/fetchers/route_fetcher_spec.rb
@@ -236,6 +236,31 @@ module VCAP::CloudController
           expect(results).to contain_exactly(route1, route2)
         end
       end
+
+      context 'when fetching routes by service_instance_guid' do
+        let!(:service_instance) { ManagedServiceInstance.make(space: space2, name: 'service-instance') }
+        let!(:app_model) { AppModel.make(space: space2) }
+        let!(:service_binding) { ServiceBinding.make(app: app_model, service_instance: service_instance) }
+        let!(:route_mapping) { RouteMappingModel.make(app: app_model, route: route3) }
+        context 'when there is a matching route' do
+          let(:routes_filter) { { service_instance_guids: service_instance.guid } }
+
+          it 'only returns the matching route' do
+            results = RouteFetcher.fetch(message, Route.where(guid: [route2.guid, route3.guid])).all
+            expect(results.length).to eq(1)
+            expect(results[0].guid).to eq(route3.guid)
+          end
+        end
+
+        context 'when there is no matching route' do
+          let(:routes_filter) { { service_instance_guids: '???' } }
+
+          it 'returns no routes' do
+            results = RouteFetcher.fetch(message, Route.where(guid: [route2.guid, route3.guid])).all
+            expect(results.length).to eq(0)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
closes #2433

Authored-by: Michael Oleske <moleske@pivotal.io>

Things you should check
- make sure I followed the right rubyisms (still getting used to ruby)
- that database query looks efficient to you (seemed alright)
- the implementation in route_fetcher has the extra function because rubocop was giving me failure about "cyclomatic complexity".  I don't really like the solution I wrote, but it made rubocop happy
- docs look right

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
