### PR TITLE
Wrap all errors in delete_non_transactional_subresources

### DIFF
--- a/spec/unit/actions/app_delete_spec.rb
+++ b/spec/unit/actions/app_delete_spec.rb
@@ -329,10 +329,14 @@ module VCAP::CloudController
               end
             end
 
-            it 'raises the first error in the list' do
+            it 'raises the errors wrapped into a SubResourceError' do
               expect {
                 app_delete.delete(app_dataset)
-              }.to raise_error(StandardError, 'error 1')
+              }.to raise_error(AppDelete::SubResourceError) do |err|
+                expect(err.underlying_errors).to have(2).items
+                expect(err.underlying_errors).to all(be_a(StandardError))
+                expect(err.underlying_errors.map(&:message)).to eq(['error 1', 'error 2'])
+              end
             end
           end
         end


### PR DESCRIPTION
Fixes #2445.

It is unclear to me, why `delete_non_transactional_subresources` differentiates between `AsyncBindingDeletionsTriggered` and all other errors. In the end, all errors are raised, the difference is: first error raised as is vs. all errors wrapped into a `SubResourceError`.

So the idea of this PR is to always raise a `SubResourceError` containing all errors returned from `delete_bindings`. This ensures proper logging and saving to the database when executed as a job.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
