### PR TITLE
Create new table to store newly created space_supporters in an appropriately named table

### DIFF
--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -128,7 +128,7 @@ module VCAP::CloudController
       space_guids = Space.join(:spaces_developers, space_id: :id, user_id: user.id).select(:spaces__guid).
                     union(Space.join(:spaces_managers, space_id: :id, user_id: user.id).select(:spaces__guid)).
                     union(Space.join(:spaces_auditors, space_id: :id, user_id: user.id).select(:spaces__guid)).
-                    union(Space.join(:spaces_application_supporters, space_id: :id, user_id: user.id).select(:spaces__guid)).
+                    union(Space.join(:spaces_supporters, space_id: :id, user_id: user.id).select(:spaces__guid)).
                     union(Space.join(:organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__guid))
       {
         apps__guid: AppModel.where(space: space_guids.all).select(:guid)

--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -166,7 +166,7 @@ module VCAP::CloudController
            ).union(
              Space.dataset.join_table(:inner, :spaces_auditors, space_id: :id, user_id: user.id).select(:spaces__id)
            ).union(
-             Space.dataset.join_table(:inner, :spaces_application_supporters, space_id: :id, user_id: user.id).select(:spaces__id)
+             Space.dataset.join_table(:inner, :spaces_supporters, space_id: :id, user_id: user.id).select(:spaces__id)
            ).union(
              Space.dataset.join_table(:inner, :organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__id)
            ).union(

--- a/app/models/runtime/security_group.rb
+++ b/app/models/runtime/security_group.rb
@@ -37,12 +37,12 @@ module VCAP::CloudController
 
       Sequel.or([
         [:spaces, user.spaces_dataset],
-        [:spaces, user.application_supported_spaces_dataset],
+        [:spaces, user.supported_spaces_dataset],
         [:spaces, user.managed_spaces_dataset],
         [:spaces, user.audited_spaces_dataset],
         [:spaces, managed_organizations_spaces_dataset],
         [:staging_spaces, user.spaces_dataset],
-        [:staging_spaces, user.application_supported_spaces_dataset],
+        [:staging_spaces, user.supported_spaces_dataset],
         [:staging_spaces, user.managed_spaces_dataset],
         [:staging_spaces, user.audited_spaces_dataset],
         [:staging_spaces, managed_organizations_spaces_dataset],

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -30,7 +30,7 @@ module VCAP::CloudController
     define_user_group :developers, reciprocal: :spaces, before_add: :validate_developer
     define_user_group :managers, reciprocal: :managed_spaces, before_add: :validate_manager
     define_user_group :auditors, reciprocal: :audited_spaces, before_add: :validate_auditor
-    define_user_group :application_supporters, reciprocal: :application_supporter_spaces, before_add: :validate_supporter
+    define_user_group :supporters, reciprocal: :supporter_spaces, before_add: :validate_supporter
 
     many_to_one :organization, before_set: :validate_change_organization
 
@@ -156,7 +156,7 @@ module VCAP::CloudController
     export_attributes :name, :organization_guid, :space_quota_definition_guid, :allow_ssh
 
     import_attributes :name, :organization_guid, :developer_guids, :allow_ssh, :isolation_segment_guid,
-      :manager_guids, :auditor_guids, :application_supporter_guids, :security_group_guids, :space_quota_definition_guid
+      :manager_guids, :auditor_guids, :supporter_guids, :security_group_guids, :space_quota_definition_guid
 
     strip_attributes :name
 
@@ -196,7 +196,7 @@ module VCAP::CloudController
     end
 
     def has_supporter?(user)
-      user.present? && application_supporters_dataset.where(user_id: user.id).present?
+      user.present? && supporters_dataset.where(user_id: user.id).present?
     end
 
     def has_member?(user)
@@ -266,7 +266,7 @@ module VCAP::CloudController
         spaces__id: dataset.join_table(:inner, :spaces_developers, space_id: :id, user_id: user.id).select(:spaces__id).
           union(dataset.join_table(:inner, :spaces_managers, space_id: :id, user_id: user.id).select(:spaces__id)).
           union(dataset.join_table(:inner, :spaces_auditors, space_id: :id, user_id: user.id).select(:spaces__id)).
-          union(dataset.join_table(:inner, :spaces_application_supporters, space_id: :id, user_id: user.id).select(:spaces__id)).
+          union(dataset.join_table(:inner, :spaces_supporters, space_id: :id, user_id: user.id).select(:spaces__id)).
           union(dataset.join_table(:inner, :organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__id)).
           select(:id)
       }

--- a/app/models/runtime/space_quota_definition.rb
+++ b/app/models/runtime/space_quota_definition.rb
@@ -50,7 +50,7 @@ module VCAP::CloudController
       Sequel.or([
         [:organization, user.managed_organizations_dataset],
         [:spaces, user.spaces_dataset],
-        [:spaces, user.application_supported_spaces_dataset],
+        [:spaces, user.supported_spaces_dataset],
         [:spaces, user.managed_spaces_dataset],
         [:spaces, user.audited_spaces_dataset]
       ])

--- a/app/models/runtime/space_supporter.rb
+++ b/app/models/runtime/space_supporter.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class SpaceSupporter < Sequel::Model(:spaces_application_supporters)
+  class SpaceSupporter < Sequel::Model(:spaces_supporters)
     include SpaceRoleMixin
 
     def type

--- a/app/models/runtime/user.rb
+++ b/app/models/runtime/user.rb
@@ -45,10 +45,10 @@ module VCAP::CloudController
       join_table: 'spaces_auditors',
       right_key: :space_id, reciprocal: :auditors
 
-    many_to_many :application_supported_spaces,
+    many_to_many :supported_spaces,
       class: 'VCAP::CloudController::Space',
-      join_table: 'spaces_application_supporters',
-      right_key: :space_id, reciprocal: :application_supporters
+      join_table: 'spaces_supporters',
+      right_key: :space_id, reciprocal: :supporters
 
     one_to_many :labels, class: 'VCAP::CloudController::UserLabelModel', key: :resource_guid, primary_key: :guid
     one_to_many :annotations, class: 'VCAP::CloudController::UserAnnotationModel', key: :resource_guid, primary_key: :guid
@@ -60,7 +60,7 @@ module VCAP::CloudController
     add_association_dependencies audited_organizations: :nullify
     add_association_dependencies spaces: :nullify
     add_association_dependencies managed_spaces: :nullify
-    add_association_dependencies application_supported_spaces: :nullify
+    add_association_dependencies supported_spaces: :nullify
     add_association_dependencies labels: :destroy
     add_association_dependencies annotations: :destroy
 

--- a/db/migrations/20210708215223_create_spaces_supporters_table.rb
+++ b/db/migrations/20210708215223_create_spaces_supporters_table.rb
@@ -1,0 +1,20 @@
+Sequel.migration do
+  change do
+    create_table :spaces_supporters do
+      primary_key :id, name: :spaces_supporters_pk
+      String :role_guid, size: 255
+      Integer :space_id, null: false
+      Integer :user_id, null: false
+      Timestamp :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      Timestamp :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+
+      foreign_key [:space_id], :spaces, name: :spaces_supporters_space_fk
+      foreign_key [:user_id], :users, name: :spaces_supporters_user_fk
+
+      index [:space_id, :user_id], unique: true, name: :spaces_supporters_user_space_index
+      index :role_guid, name: :spaces_supporters_role_guid_index
+      index :created_at, name: :spaces_supporters_created_at_index
+      index :updated_at, name: :spaces_supporters_updated_at_index
+    end
+  end
+end

--- a/decisions/0010-renaming-space-application-suporter-role-to-space-supporter.md
+++ b/decisions/0010-renaming-space-application-suporter-role-to-space-supporter.md
@@ -1,0 +1,36 @@
+4: Adding key prefix to annotations
+================================
+
+Date: 2021-07-08
+
+Status
+------
+
+Pending
+
+
+Context
+-------
+We have received pushback from the community that the name for the new SpaceApplicationSupporter role (proposed [here](https://docs.google.com/document/d/1qkd8e7PtT0yiS3Ud1on3hSc1TKmSmDmJOCqXGuZ9qi8/edi)) is confusing and does not line up with existing naming conventions. The role is designed to meet the needs of an app support engineer, however the role space developer is designed to meet the needs of an app developer but does not include the word app explicitly. Including the word app is confusing because it might imply to a consumer of API endpoints that this role can only access the `v3/apps` endpoints, however this user will have permissions across much more resources. Since this roles is still experimental and under active development we felt that now would be the time to change it to SpaceSupporter.
+
+However, creating a migration to rename the table causes many cloud controller endpoints in the latest CAPI release to fail, because many permissions check will check any existing role tables to see if the current user has a role in the associated space. 
+
+
+Decision
+--------
+1. Create a new table to store new space supporter roles
+1. Create a [time bomb test](https://github.com/cloudfoundry/cloud_controller_ng/blob/b6ba5196722728a221034aadad076646f43f5de3/spec/support/deprecation_helpers.rb) to tell us to consider dropping the old table. This will give users enough time to upgrade to a release that includes both tables and the lates code before upgrading again to a release that includes the latest code and only the latest table name.
+
+We **will not** attempt to migrate existing data into this new structure because in our current state the creation of this role is still blocked by a [flag](https://github.com/cloudfoundry/cloud_controller_ng/blob/5cce873a10cdf17fa2331efa9b6c298643360710/app/messages/role_create_message.rb#L16-L21), that is undocumented and hidden from users. Additionally, as we have been updating various endpoints to allow access to this role, we have been (documenting) that this role is unsupported and not ready for use. 
+
+Consequences
+------------
+
+### Positive Consequences
+* We will end up in a state where we are able to contain all of the data we need without extra cruft or data loss.
+
+
+### Negative Consequences
+* Users will have to have an empty and unnecessary table for at least one upgrade version
+* Some users might not upgrade frequently enough and will experience some down time
+

--- a/lib/cloud_controller/membership.rb
+++ b/lib/cloud_controller/membership.rb
@@ -50,7 +50,7 @@ module VCAP::CloudController
         when SPACE_AUDITOR
           @user.audited_spaces.map(&:guid)
         when SPACE_SUPPORTER
-          @user.application_supported_spaces.map(&:guid)
+          @user.supported_spaces.map(&:guid)
         when ORG_USER
           @user.organizations_dataset.join(
             :spaces, spaces__organization_id: :organizations__id
@@ -92,7 +92,7 @@ module VCAP::CloudController
             association_join(:organization).map(&:guid)
         when SPACE_SUPPORTER
           @space_supporter ||=
-            @user.application_supported_spaces_dataset.
+            @user.supported_spaces_dataset.
             association_join(:organization).map(&:guid)
         when ORG_USER
           @org_user ||=

--- a/spec/unit/models/runtime/space_spec.rb
+++ b/spec/unit/models/runtime/space_spec.rb
@@ -536,7 +536,7 @@ module VCAP::CloudController
     describe 'Serialization' do
       it { is_expected.to export_attributes :name, :organization_guid, :space_quota_definition_guid, :allow_ssh }
       it { is_expected.to import_attributes :name, :organization_guid, :developer_guids, :manager_guids, :isolation_segment_guid,
-        :auditor_guids, :application_supporter_guids, :security_group_guids, :space_quota_definition_guid, :allow_ssh
+        :auditor_guids, :supporter_guids, :security_group_guids, :space_quota_definition_guid, :allow_ssh
       }
     end
 

--- a/spec/unit/models/runtime/space_supporter_spec.rb
+++ b/spec/unit/models/runtime/space_supporter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'date'
 
 module VCAP::CloudController
   RSpec.describe SpaceSupporter, type: :model do
@@ -19,5 +20,7 @@ module VCAP::CloudController
 
       expect(app_supporter.guid).to be_a_guid
     end
+
+    it_should_be_removed(by: '2022/01/08', explanation: 'Timebox failure: spaces_application_supporters table is no longer being used. Consider removing it.')
   end
 end

--- a/spec/unit/models/runtime/user_spec.rb
+++ b/spec/unit/models/runtime/user_spec.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
       it { is_expected.to have_associated :spaces }
       it { is_expected.to have_associated :managed_spaces, class: Space }
       it { is_expected.to have_associated :audited_spaces, class: Space }
-      it { is_expected.to have_associated :application_supported_spaces, class: Space }
+      it { is_expected.to have_associated :supported_spaces, class: Space }
 
       describe 'destroy dependent associations' do
         let(:user) { User.make }


### PR DESCRIPTION
* A short explanation of the proposed change:
We have created a migration to create a new table with a name that matches the new role title. We also introduced a time bomb test that will remind us that an unused table exists in 6 months so we can consider removing it after we have give users enough time to upgrade their capi-release versions.

* An explanation of the use cases your change solves
This solves the problem of having a table name that is inconsistent with the role name.

* Links to any other associated PRs
Follow up to:
https://github.com/cloudfoundry/cloud_controller_ng/pull/2375


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)


Opening this in lieu of https://github.com/cloudfoundry/cloud_controller_ng/pull/2384 as we were facing an EasyCLA issue after rebasing off of main