### PR TITLE
Make `cf events` show when app instances get rescheduled

### DIFF
--- a/app/repositories/app_event_repository.rb
+++ b/app/repositories/app_event_repository.rb
@@ -14,7 +14,7 @@ module VCAP::CloudController
                            :docker_credentials].freeze
       SYSTEM_ACTOR_HASH = { guid: 'system', type: 'system', name: 'system', user_name: 'system' }.freeze
 
-      def create_app_exit_event(app, droplet_exited_payload)
+      def create_app_crash_event(app, droplet_exited_payload)
         VCAP::AppLogEmitter.emit(app.guid, "App instance exited with guid #{app.guid} payload: #{droplet_exited_payload}")
 
         actor    = { name: app.name, guid: app.guid, type: 'app' }

--- a/app/repositories/process_event_repository.rb
+++ b/app/repositories/process_event_repository.rb
@@ -109,6 +109,19 @@ module VCAP::CloudController
         )
       end
 
+      def self.record_rescheduling(process, rescheduling_payload)
+        VCAP::AppLogEmitter.emit(process.app.guid, 'Process is being rescheduled')
+
+        create_event(
+          process:    process,
+          type:       'audit.app.process.rescheduling',
+          actor_guid: process.guid,
+          actor_name: process.type,
+          actor_type: 'process',
+          metadata:   rescheduling_payload
+        )
+      end
+
       class << self
         private
 

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -300,8 +300,8 @@ RSpec.resource 'Events', type: [:api, :legacy_api] do
       }
     end
 
-    example 'List App Exited Events' do
-      app_event_repository.create_app_exit_event(test_app, droplet_exited_payload)
+    example 'List App Crashed Events' do
+      app_event_repository.create_app_crash_event(test_app, droplet_exited_payload)
 
       client.get '/v2/events?q=type:app.crash', {}, headers
       expect(status).to eq(200)

--- a/spec/unit/controllers/internal/app_rescheduling_controller_spec.rb
+++ b/spec/unit/controllers/internal/app_rescheduling_controller_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+## NOTICE: Prefer request specs over controller specs as per ADR #0003 ##
+
+module VCAP::CloudController
+  RSpec.describe AppReschedulingController do
+    describe 'POST /internal/v4/apps/:process_guid/rescheduling' do
+      let(:diego_process) { ProcessModelFactory.make(state: 'STARTED', diego: true) }
+      let(:process_guid) { Diego::ProcessGuid.from(diego_process.guid, 'some-version-guid') }
+      let(:url) { "/internal/v4/apps/#{process_guid}/rescheduling" }
+
+      let(:rescheduling_request) do
+        {
+          'instance' => Sham.guid,
+          'index'    => 3,
+          'cell_id'  => Sham.guid,
+          'reason'   => 'Helpful reason for rescheduling',
+        }
+      end
+
+      describe 'validation' do
+        context 'when sending invalid json' do
+          it 'fails with a 400' do
+            post url, 'this is not json'
+
+            expect(last_response.status).to eq(400)
+            expect(last_response.body).to match /MessageParseError/
+          end
+        end
+      end
+
+      it 'audits the process rescheduling event' do
+        post url, MultiJson.dump(rescheduling_request)
+        expect(last_response.status).to eq(200)
+
+        app_event = Event.find(actee: diego_process.guid, actor_type: 'process')
+
+        expect(app_event).to be
+        expect(app_event.space).to eq(diego_process.space)
+        expect(app_event.type).to eq('audit.app.process.rescheduling')
+        expect(app_event.actor_type).to eq('process')
+        expect(app_event.actor).to eq(diego_process.guid)
+        expect(app_event.actee_type).to eq('app')
+        expect(app_event.actee).to eq(diego_process.app.guid)
+        expect(app_event.metadata['instance']).to eq(rescheduling_request['instance'])
+        expect(app_event.metadata['index']).to eq(rescheduling_request['index'])
+        expect(app_event.metadata['cell_id']).to eq(rescheduling_request['cell_id'])
+        expect(app_event.metadata['reason']).to eq(rescheduling_request['reason'])
+      end
+
+      context 'when the app does no longer exist' do
+        before { diego_process.delete }
+
+        it 'fails with a 404' do
+          post url, MultiJson.dump(rescheduling_request)
+
+          expect(last_response.status).to eq(404)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/app_event_repository_spec.rb
+++ b/spec/unit/repositories/app_event_repository_spec.rb
@@ -185,7 +185,7 @@ module VCAP::CloudController
         end
       end
 
-      describe '#create_app_exit_event' do
+      describe '#create_app_crash_event' do
         let(:exiting_process) { ProcessModelFactory.make }
         let(:exit_description) { 'X' * AppEventRepository::TRUNCATE_THRESHOLD * 2 }
         let(:droplet_exited_payload) {
@@ -201,7 +201,7 @@ module VCAP::CloudController
         }
 
         it 'creates a new app exit event' do
-          event = app_event_repository.create_app_exit_event(exiting_process, droplet_exited_payload)
+          event = app_event_repository.create_app_crash_event(exiting_process, droplet_exited_payload)
           expect(event.type).to eq('app.crash')
           expect(event.actor).to eq(exiting_process.guid)
           expect(event.actor_type).to eq('app')
@@ -222,7 +222,7 @@ module VCAP::CloudController
         it 'logs the event' do
           expect(VCAP::AppLogEmitter).to receive(:emit).with(exiting_process.guid, "App instance exited with guid #{exiting_process.guid} payload: #{droplet_exited_payload}")
 
-          app_event_repository.create_app_exit_event(exiting_process, droplet_exited_payload)
+          app_event_repository.create_app_crash_event(exiting_process, droplet_exited_payload)
         end
       end
 

--- a/spec/unit/repositories/process_event_repository_spec.rb
+++ b/spec/unit/repositories/process_event_repository_spec.rb
@@ -247,6 +247,35 @@ module VCAP::CloudController
           expect(event.metadata).to eq(crash_payload)
         end
       end
+
+      describe '.record_rescheduling' do
+        let(:rescheduling_payload) {
+          {
+            'instance' => Sham.guid,
+            'index' => 3,
+            'cell_id' => 'some-cell',
+            'reason' => 'Helpful reason for rescheduling'
+          }
+        }
+
+        it 'creates a new audit.app.process.rescheduling event' do
+          event = ProcessEventRepository.record_rescheduling(process, rescheduling_payload)
+          event.reload
+
+          expect(event.type).to eq('audit.app.process.rescheduling')
+          expect(event.actor).to eq(process.guid)
+          expect(event.actor_type).to eq('process')
+          expect(event.actor_name).to eq('potato')
+          expect(event.actor_username).to eq('')
+          expect(event.actee).to eq(app.guid)
+          expect(event.actee_type).to eq('app')
+          expect(event.actee_name).to eq('zach-loves-kittens')
+          expect(event.space_guid).to eq(app.space.guid)
+          expect(event.organization_guid).to eq(app.space.organization.guid)
+
+          expect(event.metadata).to eq(rescheduling_payload)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**A short explanation of the proposed change:** This commit goes alongside work to TPS and runtimeschema. Together they allow CF-for-VMs users to see when their app instances get evacuated from Diego Cells.

**An explanation of the use cases your change solves:** As a user running a complex web service on top of Cloud Foundry, it can be confusing when apps seem to restart for no reason. Even once users understand this happens during Diego updates, they still have no automatic insight into when that happened.

The audit event is called `audit.app.process.rescheduling` so that it can be generic to whatever container scheduler is used behind the scenes. For instance Eirini could talk to this endpoint and provide a different `reason` string to explain the rescheduling.

**Links to any other associated PRs:**
* https://github.com/cloudfoundry/runtimeschema/pull/16
* https://github.com/cloudfoundry/tps/pull/14

**Previous discussion:** https://cloudfoundry.slack.com/archives/C07C04W4Q/p1627261539009700 and https://github.com/cloudfoundry/cloud_controller_ng/issues/2327

**A preview of what `cf events` looks like during a Diego cell recreate:**

```
$ cf events http-tester
Getting events for app http-tester in org 46bit / space 46bit as admin...
time                          event                            actor   description
2021-07-28T10:10:34.00+0000   audit.app.process.rescheduling   web     index: 10, reason: Cell is being evacuated, cell_id: 4511f2ac-e912-49b4-89eb-e679f9f7a77c, instance: e7689c47-4dc5-454c-4252-acc3
2021-07-28T10:10:34.00+0000   audit.app.process.rescheduling   web     index: 13, reason: Cell is being evacuated, cell_id: 4511f2ac-e912-49b4-89eb-e679f9f7a77c, instance: 4c9f7b57-561e-48f8-49c0-1d3f
2021-07-28T10:10:33.00+0000   audit.app.process.rescheduling   web     index: 4, reason: Cell is being evacuated, cell_id: 4511f2ac-e912-49b4-89eb-e679f9f7a77c, instance: 2a8b7d41-b570-420e-6d3f-074e
2021-07-28T10:10:33.00+0000   audit.app.process.rescheduling   web     index: 0, reason: Cell is being evacuated, cell_id: 4511f2ac-e912-49b4-89eb-e679f9f7a77c, instance: 4a76948b-e014-469b-7543-f895
2021-07-28T10:10:33.00+0000   audit.app.process.rescheduling   web     index: 15, reason: Cell is being evacuated, cell_id: 4511f2ac-e912-49b4-89eb-e679f9f7a77c, instance: 77db0b0b-9fae-4a9b-6667-f34a
```

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)
* [x] I have viewed, signed, and submitted the Contributor License Agreement
* [x] I have made this pull request to the `main` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
