### PR TITLE
Improve isolation segments performance

### DIFF
--- a/app/controllers/v3/domains_controller.rb
+++ b/app/controllers/v3/domains_controller.rb
@@ -18,8 +18,7 @@ class DomainsController < ApplicationController
     message = DomainsListMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?
 
-    org_guids = permission_queryer.readable_org_guids_for_domains
-    dataset = DomainFetcher.fetch(message, org_guids)
+    dataset = DomainFetcher.fetch(message, permission_queryer.readable_org_guids_for_domains_query)
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::DomainPresenter,
@@ -162,10 +161,9 @@ class DomainsController < ApplicationController
   end
 
   def find_domain(message)
-    readable_org_guids = permission_queryer.readable_org_guids_for_domains
     domain = DomainFetcher.fetch(
       message,
-      readable_org_guids
+      permission_queryer.readable_org_guids_for_domains_query
     ).first
 
     domain

--- a/app/controllers/v3/isolation_segments_controller.rb
+++ b/app/controllers/v3/isolation_segments_controller.rb
@@ -44,7 +44,7 @@ class IsolationSegmentsController < ApplicationController
     dataset = if permission_queryer.can_read_globally?
                 IsolationSegmentListFetcher.fetch_all(message)
               else
-                IsolationSegmentListFetcher.fetch_for_organizations(message, org_guids: permission_queryer.readable_org_guids)
+                IsolationSegmentListFetcher.fetch_for_organizations(message, org_guids: permission_queryer.readable_org_guids_query)
               end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
@@ -90,7 +90,7 @@ class IsolationSegmentsController < ApplicationController
     organizations = if permission_queryer.can_read_globally?
                       fetcher.fetch_all
                     else
-                      fetcher.fetch_for_organizations(org_guids: permission_queryer.readable_org_guids)
+                      fetcher.fetch_for_organizations(org_guids: permission_queryer.readable_org_guids_query)
                     end
 
     render status: :ok, json: Presenters::V3::ToManyRelationshipPresenter.new(
@@ -104,7 +104,7 @@ class IsolationSegmentsController < ApplicationController
     spaces = if permission_queryer.can_read_globally?
                fetcher.fetch_all
              else
-               fetcher.fetch_for_spaces(space_guids: permission_queryer.readable_supporter_space_guids)
+               fetcher.fetch_for_spaces(space_guids: permission_queryer.readable_supporter_space_guids_query)
              end
 
     render status: :ok, json: Presenters::V3::ToManyRelationshipPresenter.new(
@@ -173,7 +173,7 @@ class IsolationSegmentsController < ApplicationController
     isolation_segment = if permission_queryer.can_read_globally?
                           IsolationSegmentModel.first(guid: guid)
                         else
-                          IsolationSegmentModel.dataset.where(organizations: Organization.where(guid: permission_queryer.readable_org_guids)).first(guid: guid)
+                          IsolationSegmentModel.dataset.where(organizations: Organization.where(guid: permission_queryer.readable_org_guids_query)).first(guid: guid)
                         end
     resource_not_found!(:isolation_segment) unless isolation_segment
     isolation_segment

--- a/app/controllers/v3/isolation_segments_controller.rb
+++ b/app/controllers/v3/isolation_segments_controller.rb
@@ -32,8 +32,7 @@ class IsolationSegmentsController < ApplicationController
   end
 
   def show
-    isolation_segment_model = find_isolation_segment(hashed_params[:guid])
-    resource_not_found!(:isolation_segment) unless permission_queryer.can_read_from_isolation_segment?(isolation_segment_model)
+    isolation_segment_model = find_readable_isolation_segment(hashed_params[:guid])
 
     render status: :ok, json: Presenters::V3::IsolationSegmentPresenter.new(isolation_segment_model)
   end
@@ -85,8 +84,7 @@ class IsolationSegmentsController < ApplicationController
   end
 
   def relationships_orgs
-    isolation_segment_model = find_isolation_segment(hashed_params[:guid])
-    resource_not_found!(:isolation_segment) unless can_list_organizations?(isolation_segment_model)
+    isolation_segment_model = find_readable_isolation_segment(hashed_params[:guid])
 
     fetcher = IsolationSegmentOrganizationsFetcher.new(isolation_segment_model)
     organizations = if permission_queryer.can_read_globally?
@@ -100,8 +98,7 @@ class IsolationSegmentsController < ApplicationController
   end
 
   def relationships_spaces
-    isolation_segment_model = find_isolation_segment(hashed_params[:guid])
-    resource_not_found!(:isolation_segment) unless permission_queryer.can_read_from_isolation_segment?(isolation_segment_model)
+    isolation_segment_model = find_readable_isolation_segment(hashed_params[:guid])
 
     fetcher = IsolationSegmentSpacesFetcher.new(isolation_segment_model)
     spaces = if permission_queryer.can_read_globally?
@@ -166,12 +163,18 @@ class IsolationSegmentsController < ApplicationController
     [isolation_segment_model, organizations]
   end
 
-  def can_list_organizations?(isolation_segment)
-    permission_queryer.can_read_globally? || isolation_segment.organizations.any? { |org| permission_queryer.can_read_from_org?(org.guid) }
-  end
-
   def find_isolation_segment(guid)
     isolation_segment = IsolationSegmentModel.first(guid: guid)
+    resource_not_found!(:isolation_segment) unless isolation_segment
+    isolation_segment
+  end
+
+  def find_readable_isolation_segment(guid)
+    isolation_segment = if permission_queryer.can_read_globally?
+                          IsolationSegmentModel.first(guid: guid)
+                        else
+                          IsolationSegmentModel.dataset.where(organizations: Organization.where(guid: permission_queryer.readable_org_guids)).first(guid: guid)
+                        end
     resource_not_found!(:isolation_segment) unless isolation_segment
     isolation_segment
   end

--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -142,7 +142,7 @@ class OrganizationsV3Controller < ApplicationController
     message = DomainsListMessage.from_params(query_params.except(:guid))
     invalid_param!(message.errors.full_messages) unless message.valid?
 
-    domains = DomainFetcher.fetch(message, permission_queryer.readable_org_guids_for_domains.where(guid: org.guid))
+    domains = DomainFetcher.fetch(message, permission_queryer.readable_org_guids_for_domains_query.where(guid: org.guid))
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::DomainPresenter,
@@ -159,7 +159,7 @@ class OrganizationsV3Controller < ApplicationController
     domain = org.default_domain
 
     domain_not_found! unless domain
-    domain_not_found! if domain.private? && permission_queryer.readable_org_guids_for_domains.where(guid: org.guid).empty?
+    domain_not_found! if domain.private? && permission_queryer.readable_org_guids_for_domains_query.where(guid: org.guid).empty?
 
     render status: :ok, json: Presenters::V3::DomainPresenter.new(domain, visible_org_guids: permission_queryer.readable_org_guids)
   end

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -121,6 +121,14 @@ class VCAP::CloudController::Permissions
     end
   end
 
+  def readable_org_guids_query
+    if can_read_globally?
+      VCAP::CloudController::Organization.select(:guid)
+    else
+      membership.org_guids_for_roles_subquery(ROLES_FOR_ORG_READING)
+    end
+  end
+
   def readable_org_guids_for_domains_query
     if can_read_globally?
       VCAP::CloudController::Organization.select(:guid)
@@ -161,6 +169,14 @@ class VCAP::CloudController::Permissions
       VCAP::CloudController::Space.select(:guid).all.map(&:guid)
     else
       membership.space_guids_for_roles(ROLES_FOR_SPACE_SUPPORTER_READING)
+    end
+  end
+
+  def readable_supporter_space_guids_query
+    if can_read_globally?
+      VCAP::CloudController::Space.select(:guid)
+    else
+      membership.space_guids_for_roles_subquery(ROLES_FOR_SPACE_SUPPORTER_READING)
     end
   end
 

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -121,7 +121,7 @@ class VCAP::CloudController::Permissions
     end
   end
 
-  def readable_org_guids_for_domains
+  def readable_org_guids_for_domains_query
     if can_read_globally?
       VCAP::CloudController::Organization.select(:guid)
     else

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -323,7 +323,7 @@ class VCAP::CloudController::Permissions
     VCAP::CloudController::SecurityContext.roles
   end
 
-  def contains_any(a, b)
+  def contains_any(a, b) # rubocop:disable Naming/MethodParameterName
     !(a & b).empty?
   end
 end

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -206,8 +206,8 @@ class VCAP::CloudController::Permissions
 
   def can_read_from_isolation_segment?(isolation_segment)
     can_read_globally? ||
-      isolation_segment.spaces.any? { |space| can_read_from_space?(space.guid, space.organization.guid) } ||
-      isolation_segment.organizations.any? { |org| can_read_from_org?(org.guid) }
+      contains_any(isolation_segment.spaces.map(&:guid), readable_space_guids) ||
+      contains_any(isolation_segment.organizations.map(&:guid), readable_org_guids)
   end
 
   def readable_route_guids
@@ -323,5 +323,9 @@ class VCAP::CloudController::Permissions
 
   def roles
     VCAP::CloudController::SecurityContext.roles
+  end
+
+  def contains_any(a, b)
+    !(a & b).empty?
   end
 end

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -205,9 +205,7 @@ class VCAP::CloudController::Permissions
   end
 
   def can_read_from_isolation_segment?(isolation_segment)
-    can_read_globally? ||
-      contains_any(isolation_segment.spaces.map(&:guid), readable_space_guids) ||
-      contains_any(isolation_segment.organizations.map(&:guid), readable_org_guids)
+    can_read_globally? || contains_any(isolation_segment.organizations.map(&:guid), readable_org_guids)
   end
 
   def readable_route_guids

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -222,7 +222,6 @@ module UserHelpers
     orgs.each do |org|
       allow(permissions_double(user)).to receive(:can_read_from_org?).with(org.guid).and_return(true)
     end
-    stub_readable_org_guids_for(user, orgs)
 
     allow(permissions_double(user)).to receive(:can_read_from_space?).and_return(false)
     allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).and_return(false)
@@ -231,6 +230,7 @@ module UserHelpers
       allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).with(space.guid, space.organization_guid).and_return(true)
     end
 
+    stub_readable_org_guids_for(user, orgs, spaces)
     stub_readable_space_guids_for(user, spaces)
   end
 
@@ -240,14 +240,6 @@ module UserHelpers
 
   def allow_user_global_write_access(user)
     allow(permissions_double(user)).to receive(:can_write_globally?).and_return(true)
-  end
-
-  def allow_user_read_access_for_isolation_segment(user)
-    allow(permissions_double(user)).to receive(:can_read_from_isolation_segment?).and_return(true)
-  end
-
-  def disallow_user_read_access_for_isolation_segment(user)
-    allow(permissions_double(user)).to receive(:can_read_from_isolation_segment?).and_return(false)
   end
 
   def disallow_user_global_read_access(user)
@@ -283,8 +275,8 @@ module UserHelpers
     allow(permissions_double(user)).to receive(:readable_supporter_space_guids).and_return(spaces.map(&:guid))
   end
 
-  def stub_readable_org_guids_for(user, orgs)
-    allow(permissions_double(user)).to receive(:readable_org_guids).and_return(orgs.map(&:guid))
+  def stub_readable_org_guids_for(user, orgs, spaces=[])
+    allow(permissions_double(user)).to receive(:readable_org_guids).and_return(orgs.map(&:guid) + spaces.map(&:organization_guid))
   end
 
   def permissions_double(user)

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -222,6 +222,7 @@ module UserHelpers
     orgs.each do |org|
       allow(permissions_double(user)).to receive(:can_read_from_org?).with(org.guid).and_return(true)
     end
+    stub_readable_org_guids_for(user, orgs)
 
     allow(permissions_double(user)).to receive(:can_read_from_space?).and_return(false)
     allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).and_return(false)
@@ -230,7 +231,6 @@ module UserHelpers
       allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).with(space.guid, space.organization_guid).and_return(true)
     end
 
-    stub_readable_org_guids_for(user, orgs, spaces)
     stub_readable_space_guids_for(user, spaces)
   end
 
@@ -275,13 +275,13 @@ module UserHelpers
     allow(permissions_double(user)).to receive(:readable_supporter_space_guids).and_return(spaces.map(&:guid))
   end
 
-  def stub_readable_org_guids_for(user, orgs, spaces=[])
-    allow(permissions_double(user)).to receive(:readable_org_guids).and_return(orgs.map(&:guid) + spaces.map(&:organization_guid))
+  def stub_readable_org_guids_for(user, orgs)
+    allow(permissions_double(user)).to receive(:readable_org_guids).and_return(orgs.map(&:guid))
   end
 
   def permissions_double(user)
     @permissions ||= {}
-    @permissions[user.guid] ||= instance_double(VCAP::CloudController::Permissions).tap do |permissions|
+    @permissions[user.guid] ||= VCAP::CloudController::Permissions.new(user).tap do |permissions|
       allow(VCAP::CloudController::Permissions).to receive(:new).with(user).and_return(permissions)
       allow(permissions).to receive(:can_read_globally?).and_return(false)
     end

--- a/spec/unit/controllers/v3/tasks_controller_spec.rb
+++ b/spec/unit/controllers/v3/tasks_controller_spec.rb
@@ -358,7 +358,6 @@ RSpec.describe TasksController, type: :controller do
 
   describe '#show' do
     let!(:task) { VCAP::CloudController::TaskModel.make name: 'mytask', app_guid: app_model.guid, memory_in_mb: 2048 }
-    let(:user) { set_current_user(VCAP::CloudController::User.make) }
 
     before do
       allow_user_read_access_for(user, spaces: [space])
@@ -425,8 +424,6 @@ RSpec.describe TasksController, type: :controller do
   end
 
   describe '#index' do
-    let(:user) { set_current_user(VCAP::CloudController::User.make) }
-
     before do
       allow_user_read_access_for(user, spaces: [space])
     end
@@ -585,7 +582,6 @@ RSpec.describe TasksController, type: :controller do
 
   describe '#cancel' do
     let!(:task) { VCAP::CloudController::TaskModel.make name: 'usher', app_guid: app_model.guid }
-    let(:user) { set_current_user(VCAP::CloudController::User.make) }
 
     before do
       allow_user_read_access_for(user, spaces: [space])
@@ -660,8 +656,6 @@ RSpec.describe TasksController, type: :controller do
     let(:task) { VCAP::CloudController::TaskModel.make(app: app_model) }
 
     before do
-      user = VCAP::CloudController::User.make
-      set_current_user(user)
       allow_user_read_access_for(user, spaces: [space])
       allow_user_write_access(user, space: space)
     end

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -151,7 +151,17 @@ module VCAP::CloudController
         membership = instance_double(Membership, org_guids_for_roles: org_guids)
         expect(Membership).to receive(:new).with(user).and_return(membership)
         expect(permissions.readable_org_guids).to eq(org_guids)
-        expect(membership).to have_received(:org_guids_for_roles).with(VCAP::CloudController::Permissions::ROLES_FOR_ORG_READING)
+        expect(membership).to have_received(:org_guids_for_roles).with(Permissions::ROLES_FOR_ORG_READING)
+      end
+    end
+
+    describe '#readable_org_guids_query' do
+      it 'returns subquery from membership' do
+        membership = instance_double(Membership)
+        subquery = instance_double(Sequel::Dataset)
+        expect(Membership).to receive(:new).with(user).and_return(membership)
+        expect(membership).to receive(:org_guids_for_roles_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
+        expect(permissions.readable_org_guids_query).to be(subquery)
       end
     end
 
@@ -378,7 +388,7 @@ module VCAP::CloudController
         membership = instance_double(Membership, space_guids_for_roles: space_guids)
         expect(Membership).to receive(:new).with(user).and_return(membership)
         expect(permissions.readable_space_guids).to eq(space_guids)
-        expect(membership).to have_received(:space_guids_for_roles).with(VCAP::CloudController::Permissions::ROLES_FOR_SPACE_READING)
+        expect(membership).to have_received(:space_guids_for_roles).with(Permissions::ROLES_FOR_SPACE_READING)
       end
     end
 
@@ -433,7 +443,17 @@ module VCAP::CloudController
         membership = instance_double(Membership, space_guids_for_roles: space_guids)
         expect(Membership).to receive(:new).with(user).and_return(membership)
         expect(permissions.readable_supporter_space_guids).to eq(space_guids)
-        expect(membership).to have_received(:space_guids_for_roles).with(VCAP::CloudController::Permissions::ROLES_FOR_SPACE_SUPPORTER_READING)
+        expect(membership).to have_received(:space_guids_for_roles).with(Permissions::ROLES_FOR_SPACE_SUPPORTER_READING)
+      end
+    end
+
+    describe '#readable_supporter_space_guids_query' do
+      it 'returns subquery from membership' do
+        membership = instance_double(Membership)
+        subquery = instance_double(Sequel::Dataset)
+        expect(Membership).to receive(:new).with(user).and_return(membership)
+        expect(membership).to receive(:space_guids_for_roles_subquery).with(Permissions::ROLES_FOR_SPACE_SUPPORTER_READING).and_return(subquery)
+        expect(permissions.readable_supporter_space_guids_query).to be(subquery)
       end
     end
 
@@ -601,7 +621,7 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         expect(Membership).to receive(:new).with(user).and_return(membership)
         expect(membership).to receive(:space_guids_for_roles).
-          with(VCAP::CloudController::Permissions::ROLES_FOR_SPACE_SECRETS_READING).
+          with(Permissions::ROLES_FOR_SPACE_SECRETS_READING).
           and_return(space_guids)
 
         actual_space_guids = permissions.readable_secret_space_guids
@@ -640,7 +660,7 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         expect(Membership).to receive(:new).with(user).and_return(membership)
         expect(membership).to receive(:space_guids_for_roles).
-          with(VCAP::CloudController::Permissions::SPACE_ROLES).
+          with(Permissions::SPACE_ROLES).
           and_return(space_guids)
 
         actual_space_guids = permissions.readable_space_scoped_space_guids
@@ -861,9 +881,9 @@ module VCAP::CloudController
     end
 
     describe '#readable_event_dataset' do
-      let!(:unscoped_event) { VCAP::CloudController::Event.make(actee: 'dir/key', type: 'blob.remove_orphan', organization_guid: '') }
-      let!(:org_scoped_event) { VCAP::CloudController::Event.make(created_at: Time.now + 100, type: 'audit.organization.create', actee: org_guid, organization_guid: org_guid) }
-      let!(:space_scoped_event) { VCAP::CloudController::Event.make(space_guid: space_guid, actee: space_guid, type: 'audit.app.restart') }
+      let!(:unscoped_event) { Event.make(actee: 'dir/key', type: 'blob.remove_orphan', organization_guid: '') }
+      let!(:org_scoped_event) { Event.make(created_at: Time.now + 100, type: 'audit.organization.create', actee: org_guid, organization_guid: org_guid) }
+      let!(:space_scoped_event) { Event.make(space_guid: space_guid, actee: space_guid, type: 'audit.app.restart') }
 
       it 'returns all events for admins' do
         user = set_current_user_as_admin
@@ -890,11 +910,9 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         expect(Membership).to receive(:new).with(user).and_return(membership)
         expect(membership).to receive(:space_guids_for_roles).
-          with(VCAP::CloudController::Permissions::SPACE_ROLES_FOR_EVENTS).
+          with(Permissions::SPACE_ROLES_FOR_EVENTS).
           and_return([space_guid])
-        expect(membership).to receive(:org_guids_for_roles).
-          with(VCAP::CloudController::Membership::ORG_AUDITOR).
-          and_return([])
+        expect(membership).to receive(:org_guids_for_roles).with(Membership::ORG_AUDITOR).and_return([])
         event_guids = Permissions.new(user).readable_event_dataset.map(&:guid)
 
         expect(event_guids).to contain_exactly(space_scoped_event.guid)
@@ -904,11 +922,9 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         expect(Membership).to receive(:new).with(user).and_return(membership)
         expect(membership).to receive(:space_guids_for_roles).
-          with(VCAP::CloudController::Permissions::SPACE_ROLES_FOR_EVENTS).
+          with(Permissions::SPACE_ROLES_FOR_EVENTS).
           and_return([])
-        expect(membership).to receive(:org_guids_for_roles).
-          with(VCAP::CloudController::Membership::ORG_AUDITOR).
-          and_return(org_guid)
+        expect(membership).to receive(:org_guids_for_roles).with(Membership::ORG_AUDITOR).and_return(org_guid)
         event_guids = Permissions.new(user).readable_event_dataset.map(&:guid)
 
         expect(event_guids).to contain_exactly(org_scoped_event.guid)

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -155,7 +155,7 @@ module VCAP::CloudController
       end
     end
 
-    describe '#readable_org_guids_for_domains' do
+    describe '#readable_org_guids_for_domains_query' do
       context 'when user has valid membership' do
         let(:membership) { instance_double(Membership) }
         let(:space_guid) { double(:space_guid) }
@@ -175,7 +175,7 @@ module VCAP::CloudController
             with(Permissions::SPACE_ROLES_INCLUDING_SUPPORTERS).
             and_return([space_guid])
 
-          expect(permissions.readable_org_guids_for_domains).
+          expect(permissions.readable_org_guids_for_domains_query).
             to be(subquery)
         end
       end


### PR DESCRIPTION
Improve performance of isolation segments endpoints by removing unnecessary calls (`can_read_from_space?`) and combining the loading of data with the permissions check.

Please also see the commit messages.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
