### PR TITLE
Prevent users with space supporter role reaching v2 endpoints

### DIFF
--- a/docs/v3/source/includes/resources/roles/_valid_roles.md.erb
+++ b/docs/v3/source/includes/resources/roles/_valid_roles.md.erb
@@ -6,4 +6,6 @@
 - `space_auditor`
 - `space_developer`
 - `space_manager`
-- `space_supporter` - This role is under active development and is not supported
+- `space_supporter`
+  * This role is under active development and is not supported
+  * Users with only the space supporter role are not authorized to use the **V2** API

--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -8,6 +8,7 @@ require 'security_context_setter'
 require 'rate_limiter'
 require 'new_relic_custom_attributes'
 require 'zipkin'
+require 'block_v3_only_roles'
 
 module VCAP::CloudController
   class RackAppBuilder
@@ -41,6 +42,7 @@ module VCAP::CloudController
         use Rack::CommonLogger, logger if logger
 
         map '/' do
+          use CloudFoundry::Middleware::BlockV3OnlyRoles, { logger: Steno.logger('cc.unsupported_roles') }
           run FrontController.new(config)
         end
 

--- a/middleware/block_v3_only_roles.rb
+++ b/middleware/block_v3_only_roles.rb
@@ -1,0 +1,64 @@
+require 'mixins/client_ip'
+
+module CloudFoundry
+  module Middleware
+    class BlockV3OnlyRoles
+      def initialize(app, logger:)
+        @app                   = app
+        @logger                = logger
+      end
+
+      def call(env)
+        if !allowed_path?(env['PATH_INFO']) && v3_only_role_enabled? && v3_only_role?
+          [
+            403,
+            { 'Content-Type' => 'text/html' },
+            'You are not authorized to perform the requested action. See section \'Space Supporter Role in V2\' https://docs.cloudfoundry.org/concepts/roles.html',
+          ]
+        else
+          @app.call(env)
+        end
+      end
+
+      private
+
+      def v3_only_role?
+        current_user = VCAP::CloudController::SecurityContext.current_user
+        current_user.try(:id) && !globally_authenticated? && space_supporter_and_only_space_supporter?(current_user)
+      end
+
+      def allowed_path?(path)
+        ['/v2/info', '/'].include?(path)
+      end
+
+      def globally_authenticated?
+        roles.admin? || roles.admin_read_only? || roles.global_auditor?
+      end
+
+      def v3_only_role_enabled?
+        VCAP::CloudController::Config.config.get(:temporary_enable_space_supporter_role)
+      end
+
+      def space_supporter_and_only_space_supporter?(current_user)
+        user_roles =
+          VCAP::CloudController::SpaceManager.select(Sequel.as(VCAP::CloudController::RoleTypes::SPACE_MANAGER, :type)).limit(1).where(user_id: current_user.id).
+          union(VCAP::CloudController::SpaceDeveloper.select(Sequel.as(VCAP::CloudController::RoleTypes::SPACE_DEVELOPER, :type)).limit(1).where(user_id: current_user.id)).
+          union(VCAP::CloudController::SpaceAuditor.select(Sequel.as(VCAP::CloudController::RoleTypes::SPACE_AUDITOR, :type)).limit(1).where(user_id: current_user.id)).
+          union(VCAP::CloudController::SpaceSupporter.select(Sequel.as(VCAP::CloudController::RoleTypes::SPACE_SUPPORTER, :type)).limit(1).where(user_id: current_user.id)).
+          union(VCAP::CloudController::OrganizationManager.select(Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_MANAGER,
+                                                                            :type)).limit(1).where(user_id: current_user.id)).
+          union(VCAP::CloudController::OrganizationBillingManager.select(Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_BILLING_MANAGER,
+                                                                                   :type)).limit(1).where(user_id: current_user.id)).
+          union(VCAP::CloudController::OrganizationAuditor.select(Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_AUDITOR,
+                                                                            :type)).limit(1).where(user_id: current_user.id)).
+          all
+
+        user_roles.count == 1 && user_roles[0][:type] == 'space_supporter'
+      end
+
+      def roles
+        VCAP::CloudController::SecurityContext.roles
+      end
+    end
+  end
+end

--- a/spec/request/v2/auth_spec.rb
+++ b/spec/request/v2/auth_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
+require 'request_spec_shared_examples'
 
 RSpec.describe 'Auth' do
   let(:user) { VCAP::CloudController::User.make }
+  let(:user_header) { headers_for(user) }
 
   before do
     @test_mode = ENV['CC_TEST']
@@ -14,7 +16,7 @@ RSpec.describe 'Auth' do
 
   context 'when the user has a valid token' do
     it 'returns as normal' do
-      get '/v2/organizations', nil, headers_for(user)
+      get '/v2/organizations', nil, user_header
       expect(last_response.status).to eq 200
     end
   end
@@ -25,6 +27,114 @@ RSpec.describe 'Auth' do
 
       expect(last_response.status).to eq 401
       expect(last_response.body).to match /InvalidAuthToken/
+    end
+  end
+  context 'when user has a global token inaddtion to the space supporter role' do
+    let(:org) { VCAP::CloudController::Organization.make(created_at: 3.days.ago) }
+    let(:space) { VCAP::CloudController::Space.make(organization: org) }
+    let(:api_call) { lambda { |user_headers| get '/v2/apps', nil, user_headers } }
+    let(:expected_codes_and_responses) { Hash.new(code: 200).freeze }
+
+    before do
+      space.organization.add_user(user)
+      space.add_supporter(user)
+    end
+
+    it_behaves_like 'permissions for list endpoint', GLOBAL_SCOPES
+  end
+
+  context 'space supporter' do
+    before do
+      TestConfig.override(temporary_enable_space_supporter_role: true)
+    end
+
+    let(:space1) { VCAP::CloudController::Space.make }
+    let(:space2) { VCAP::CloudController::Space.make }
+    let(:space3) { VCAP::CloudController::Space.make }
+
+    context 'user with only space supporter role' do
+      before do
+        space1.organization.add_user(user)
+        space1.add_supporter(user)
+      end
+
+      describe 'GET /v2 endpoints' do
+        it 'errors on request' do
+          get '/v2/apps', nil, user_header
+          expect(last_response.status).to eq(403)
+          expect(last_response.body).to match %r(You are not authorized to perform the requested action. See section 'Space Supporter Role in V2' https://docs.cloudfoundry.org/concepts/roles.html)
+
+          get '/v2/orgs', nil, user_header
+          expect(last_response.status).to eq(403)
+          expect(last_response.body).to match %r(You are not authorized to perform the requested action. See section 'Space Supporter Role in V2' https://docs.cloudfoundry.org/concepts/roles.html)
+
+          get '/v2/spaces', nil, user_header
+          expect(last_response.status).to eq(403)
+          expect(last_response.body).to match %r(You are not authorized to perform the requested action. See section 'Space Supporter Role in V2' https://docs.cloudfoundry.org/concepts/roles.html)
+        end
+
+        it 'does not error when the space supporter role is disabled' do
+          TestConfig.override(temporary_enable_space_supporter_role: false)
+
+          get '/v2/apps', nil, user_header
+          expect(last_response.status).to eq(200)
+        end
+
+        it 'does not error when hitting info' do
+          get '/v2/info', nil, user_header
+          expect(last_response.status).to eq(200)
+        end
+
+        it 'does not error when hitting root' do
+          get '/', nil, user_header
+          expect(last_response.status).to eq(200)
+        end
+
+        context 'with multiple role assignments' do
+          before do
+            space2.organization.add_user(user)
+            space2.add_supporter(user)
+          end
+
+          it 'still throws a 403' do
+            get '/v2/spaces', nil, user_header
+            expect(last_response.status).to eq(403)
+            expect(last_response.body).to match %r(You are not authorized to perform the requested action. See section 'Space Supporter Role in V2' https://docs.cloudfoundry.org/concepts/roles.html)
+          end
+        end
+      end
+    end
+
+    context 'user with multiple role types' do
+      before do
+        space1.organization.add_user(user)
+        space2.organization.add_user(user)
+        space3.organization.add_user(user)
+        space1.add_supporter(user)
+        space2.add_developer(user)
+        space3.add_developer(user)
+      end
+
+      describe 'GET /v2 endpoints' do
+        it 'succeeds' do
+          get '/v2/apps', nil, user_header
+          expect(last_response.status).to eq(200)
+        end
+      end
+    end
+
+    context 'user does not have space supporter role' do
+      before do
+        space1.organization.add_user(user)
+        space1.add_developer(user)
+      end
+
+      describe 'GET /v2 endpoints' do
+        it 'succeeds' do
+          get '/v2/apps', nil, user_header
+          expect(last_response.status).to eq(200)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
* applies only to non root and info endpoints
* applies only if the space supporter role is the only role assigned
* applies only if the flag to enable usage of the space supporter is set
to true
* addresses https://github.com/cloudfoundry/cloud_controller_ng/issues/2434

Co-authored-by: Mona Mohebbi <mmohebbi@pivotal.io>
Co-authored-by: Merric de Launey <mdelauney@pivotal.io>
Co-authored-by: Matthew Kocher <mkocher@pivotal.io>
Co-authored-by: Weyman Fung <weymanf@vmware.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
