### PR TITLE
Speed up security groups

### DIFF
--- a/app/controllers/v3/security_groups_controller.rb
+++ b/app/controllers/v3/security_groups_controller.rb
@@ -78,8 +78,8 @@ class SecurityGroupsController < ApplicationController
   end
 
   def show
-    resource_not_found!(:security_group) unless permission_queryer.readable_security_group_guids.include?(hashed_params[:guid])
-    security_group = SecurityGroup.first(guid: hashed_params[:guid])
+    security_group = SecurityGroupFetcher.fetch(hashed_params[:guid], permission_queryer.readable_security_group_guids_query)
+    resource_not_found!(:security_group) unless security_group
 
     render status: :ok, json: Presenters::V3::SecurityGroupPresenter.new(
       security_group,
@@ -94,7 +94,7 @@ class SecurityGroupsController < ApplicationController
     dataset = if permission_queryer.can_read_globally?
                 SecurityGroupListFetcher.fetch_all(message)
               else
-                SecurityGroupListFetcher.fetch(message, permission_queryer.readable_security_group_guids)
+                SecurityGroupListFetcher.fetch(message, permission_queryer.readable_security_group_guids_query)
               end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(

--- a/app/fetchers/security_group_fetcher.rb
+++ b/app/fetchers/security_group_fetcher.rb
@@ -1,0 +1,17 @@
+module VCAP::CloudController
+  class SecurityGroupFetcher
+    class << self
+      def fetch(guid, visible_security_group_guids=nil)
+        dataset = SecurityGroup.where(guid: guid)
+        dataset = dataset.where(guid: visible_security_group_guids) if visible_security_group_guids
+        dataset = eager_load_running_and_staging_space_guids(dataset)
+        dataset.all.first
+      end
+
+      def eager_load_running_and_staging_space_guids(dataset)
+        select_guid = proc { |ds| ds.select(:guid) }
+        dataset.eager(spaces: select_guid, staging_spaces: select_guid)
+      end
+    end
+  end
+end

--- a/app/fetchers/security_group_list_fetcher.rb
+++ b/app/fetchers/security_group_list_fetcher.rb
@@ -2,17 +2,20 @@ require 'cloud_controller/paging/sequel_paginator'
 require 'cloud_controller/paging/paginated_result'
 require 'fetchers/label_selector_query_generator'
 require 'fetchers/base_list_fetcher'
+require 'fetchers/security_group_fetcher'
 
 module VCAP::CloudController
   class SecurityGroupListFetcher < BaseListFetcher
     class << self
       def fetch_all(message)
         dataset = SecurityGroup.dataset
+        dataset = SecurityGroupFetcher.eager_load_running_and_staging_space_guids(dataset)
         filter(message, dataset)
       end
 
       def fetch(message, visible_security_group_guids)
         dataset = SecurityGroup.where(guid: visible_security_group_guids)
+        dataset = SecurityGroupFetcher.eager_load_running_and_staging_space_guids(dataset)
         filter(message, dataset)
       end
 

--- a/app/presenters/v3/security_group_presenter.rb
+++ b/app/presenters/v3/security_group_presenter.rb
@@ -25,10 +25,10 @@ module VCAP::CloudController::Presenters::V3
         },
         relationships: {
           running_spaces: {
-            data: space_guid_hash_for(security_group.spaces_dataset)
+            data: space_guid_hash_for(security_group.spaces)
           },
           staging_spaces: {
-            data: space_guid_hash_for(security_group.staging_spaces_dataset)
+            data: space_guid_hash_for(security_group.staging_spaces)
           }
         },
         links: build_links,
@@ -41,8 +41,8 @@ module VCAP::CloudController::Presenters::V3
       @resource
     end
 
-    def space_guid_hash_for(dataset)
-      dataset.select(:guid).all.select { |space| @visible_space_guids.include? space.guid }.map { |space| { guid: space.guid } }
+    def space_guid_hash_for(spaces)
+      spaces.select { |space| @visible_space_guids.include? space.guid }.map { |space| { guid: space.guid } }
     end
 
     def build_links

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -111,11 +111,7 @@ class VCAP::CloudController::Permissions
   end
 
   def readable_org_guids
-    if can_read_globally?
-      VCAP::CloudController::Organization.select(:guid).all.map(&:guid)
-    else
-      membership.org_guids_for_roles(ROLES_FOR_ORG_READING)
-    end
+    readable_org_guids_query.all.map(&:guid)
   end
 
   def readable_org_guids_query
@@ -154,11 +150,7 @@ class VCAP::CloudController::Permissions
   end
 
   def readable_space_guids
-    if can_read_globally?
-      VCAP::CloudController::Space.select(:guid).all.map(&:guid)
-    else
-      membership.space_guids_for_roles(ROLES_FOR_SPACE_READING)
-    end
+    readable_space_guids_query.all.map(&:guid)
   end
 
   def readable_space_guids_query
@@ -283,7 +275,11 @@ class VCAP::CloudController::Permissions
   end
 
   def readable_security_group_guids
-    VCAP::CloudController::SecurityGroup.user_visible(@user, can_read_globally?).map(&:guid)
+    readable_security_group_guids_query.all.map(&:guid)
+  end
+
+  def readable_security_group_guids_query
+    VCAP::CloudController::SecurityGroup.user_visible(@user, can_read_globally?).select(:guid)
   end
 
   def can_update_build_state?

--- a/spec/unit/fetchers/security_group_fetcher_spec.rb
+++ b/spec/unit/fetchers/security_group_fetcher_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'fetchers/security_group_fetcher'
+
+module VCAP::CloudController
+  RSpec.describe SecurityGroupFetcher do
+    let(:fetcher) { SecurityGroupFetcher }
+    let!(:security_group_1) { SecurityGroup.make }
+    let!(:security_group_2) { SecurityGroup.make }
+    let(:associated_space) { Space.make }
+    let(:visible_security_groups) { nil }
+    let(:security_group) { fetcher.fetch(security_group_1.guid, visible_security_groups) }
+
+    describe '#fetch' do
+      it 'eager loads running and staging spaces' do
+        expect(security_group.associations.keys).to contain_exactly(:spaces, :staging_spaces)
+      end
+
+      it 'eager loads space guids only' do
+        security_group_1.add_space(associated_space)
+        security_group_1.add_staging_space(associated_space)
+        [:spaces, :staging_spaces].each do |key|
+          expect(security_group.associations[key].length).to eq(1)
+          expect(security_group.associations[key].first.keys).to contain_exactly(:guid)
+        end
+      end
+
+      it 'returns the security group' do
+        expect(security_group).to eq(security_group_1)
+      end
+
+      context 'security group guid in visible_security_group_guids' do
+        let(:visible_security_groups) { [security_group_1.guid] }
+
+        it 'returns the security group' do
+          expect(security_group).to eq(security_group_1)
+        end
+      end
+
+      context 'security group guid not in visible_security_group_guids' do
+        let(:visible_security_groups) { [security_group_2.guid] }
+
+        it 'returns nil' do
+          expect(security_group).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -146,12 +146,15 @@ module VCAP::CloudController
         expect(org_guids).to include(org2_guid)
       end
 
-      it 'returns org guids from membership' do
-        org_guids = double
-        membership = instance_double(Membership, org_guids_for_roles: org_guids)
+      it 'returns org guids from membership via subquery' do
+        guid1, guid2 = double
+        org_guid_records = [double(guid: guid1), double(guid: guid2)]
+        membership = instance_double(Membership)
+        subquery = instance_double(Sequel::Dataset)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(permissions.readable_org_guids).to eq(org_guids)
-        expect(membership).to have_received(:org_guids_for_roles).with(Permissions::ROLES_FOR_ORG_READING)
+        expect(membership).to receive(:org_guids_for_roles_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
+        expect(subquery).to receive(:all).and_return(org_guid_records)
+        expect(permissions.readable_org_guids).to eq([guid1, guid2])
       end
     end
 
@@ -383,12 +386,15 @@ module VCAP::CloudController
         expect(space_guids).to include(space2.guid)
       end
 
-      it 'returns space guids from membership' do
-        space_guids = double
-        membership = instance_double(Membership, space_guids_for_roles: space_guids)
+      it 'returns space guids from membership via subquery' do
+        guid1, guid2 = double
+        space_guid_records = [double(guid: guid1), double(guid: guid2)]
+        membership = instance_double(Membership)
+        subquery = instance_double(Sequel::Dataset)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(permissions.readable_space_guids).to eq(space_guids)
-        expect(membership).to have_received(:space_guids_for_roles).with(Permissions::ROLES_FOR_SPACE_READING)
+        expect(membership).to receive(:space_guids_for_roles_subquery).with(Permissions::ROLES_FOR_SPACE_READING).and_return(subquery)
+        expect(subquery).to receive(:all).and_return(space_guid_records)
+        expect(permissions.readable_space_guids).to eq([guid1, guid2])
       end
     end
 


### PR DESCRIPTION
This PR is a follow up for #2255 and further improves the performance of /v3/security_groups endpoints. Running and staging space guids are eagerly loaded (only the guids by modifying the dataset used for eager loading). The same is done when a single security group is fetched. Furthermore permission checks are done as part of the where clauses.

Here are some results of locally executed performance tests:

|User|Request|X-Runtime before change|X-Runtime after change|
|--|--|--|--|
|as admin|GET /v3/security_groups?per_page=500 \*|5.520s|3.492s|
|as regular user|GET /v3/security_groups/:guid|0.158s|0.029s|

\* each security group is assigned to 500 spaces

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
