### PR TITLE
Refactor permissions functions 

### DIFF
--- a/app/controllers/v3/app_features_controller.rb
+++ b/app/controllers/v3/app_features_controller.rb
@@ -17,7 +17,7 @@ class AppFeaturesController < ApplicationController
 
   def index
     app, space, org = AppFetcher.new.fetch(hashed_params[:app_guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     resources = presented_app_features(app)
 
     render status: :ok, json: {
@@ -28,7 +28,7 @@ class AppFeaturesController < ApplicationController
 
   def show
     app, space, org = AppFetcher.new.fetch(hashed_params[:app_guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     resource_not_found!(:feature) unless APP_FEATURES.include?(hashed_params[:name])
 
     render status: :ok, json: feature_presenter_for(hashed_params[:name], app)
@@ -37,12 +37,12 @@ class AppFeaturesController < ApplicationController
   def update
     app, space, org = AppFetcher.new.fetch(hashed_params[:app_guid])
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
 
     name = hashed_params[:name]
     resource_not_found!(:feature) unless APP_FEATURES.include?(name)
     if UNTRUSTED_APP_FEATURES.include?(name)
-      unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
+      unauthorized! unless permission_queryer.can_manage_apps_in_space?(space.guid)
     else
       unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
     end
@@ -57,7 +57,7 @@ class AppFeaturesController < ApplicationController
   def ssh_enabled
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
 
     render status: :ok, json: Presenters::V3::AppSshStatusPresenter.new(app, Config.config.get(:allow_app_ssh_access))
   end

--- a/app/controllers/v3/app_manifests_controller.rb
+++ b/app/controllers/v3/app_manifests_controller.rb
@@ -8,7 +8,7 @@ class AppManifestsController < ApplicationController
   def show
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     unauthorized! unless permission_queryer.can_read_secrets_in_space?(space.guid, org.guid)
 
     manifest_presenter = Presenters::V3::AppManifestPresenter.new(app, app.service_bindings, app.routes)

--- a/app/controllers/v3/app_revisions_controller.rb
+++ b/app/controllers/v3/app_revisions_controller.rb
@@ -14,7 +14,7 @@ class AppRevisionsController < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
 
     dataset = AppRevisionsListFetcher.fetch(app, message)
 
@@ -31,7 +31,7 @@ class AppRevisionsController < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
 
     dataset = AppRevisionsListFetcher.fetch_deployed(app)
 

--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -41,7 +41,7 @@ class AppsV3Controller < ApplicationController
     dataset = if permission_queryer.can_read_globally?
                 AppListFetcher.fetch_all(message, eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
               else
-                AppListFetcher.fetch(message, permission_queryer.readable_supporter_space_guids,
+                AppListFetcher.fetch(message, permission_queryer.readable_space_guids,
 eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
               end
 
@@ -69,7 +69,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
 
     decorators = []
     decorators << IncludeSpaceDecorator if IncludeSpaceDecorator.match?(message.include)
@@ -87,7 +87,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     space = Space.where(guid: message.space_guid).first
-    unprocessable_space! unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
+    unprocessable_space! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
     unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
     # TODO: only fail if also not `kpack` app lifecycle
     if message.lifecycle_type == VCAP::CloudController::PackageModel::DOCKER_TYPE
@@ -117,7 +117,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
 
     lifecycle = AppLifecycleProvider.provide_for_update(message, app)
@@ -142,7 +142,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
   def destroy
     app, space, org = AppDeleteFetcher.new.fetch(hashed_params[:guid])
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
 
     delete_action = AppDelete.new(user_audit_info)
@@ -157,9 +157,9 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
   def start
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     unprocessable_lacking_droplet! unless app.droplet
-    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.can_manage_apps_in_space?(space.guid)
 
     if app.lifecycle_type == DockerLifecycleDataModel::LIFECYCLE_TYPE
       FeatureFlag.raise_unless_enabled!(:diego_docker)
@@ -180,8 +180,8 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
   def stop
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
-    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    unauthorized! unless permission_queryer.can_manage_apps_in_space?(space.guid)
 
     AppStop.stop(app: app, user_audit_info: user_audit_info)
     TelemetryLogger.v3_emit(
@@ -199,9 +199,9 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
   def restart
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     unprocessable_lacking_droplet! unless app.droplet
-    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.can_manage_apps_in_space?(space.guid)
 
     if app.lifecycle_type == DockerLifecycleDataModel::LIFECYCLE_TYPE
       FeatureFlag.raise_unless_enabled!(:diego_docker)
@@ -228,7 +228,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
 
     dataset = AppBuildsListFetcher.fetch_all(app.guid, message)
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
@@ -244,7 +244,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
     FeatureFlag.raise_unless_enabled!(:env_var_visibility)
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     unauthorized! unless permission_queryer.can_read_app_environment_variables?(space.guid, org.guid)
     show_secrets = permission_queryer.can_read_system_environment_variables?(space.guid, org.guid)
 
@@ -260,7 +260,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     unauthorized! unless permission_queryer.can_read_app_environment_variables?(space.guid, org.guid)
 
     FeatureFlag.raise_unless_enabled!(:space_developer_env_var_visibility)
@@ -273,8 +273,8 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
   def update_environment_variables
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
-    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    unauthorized! unless permission_queryer.can_manage_apps_in_space?(space.guid)
 
     message = UpdateEnvironmentVariablesMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
@@ -290,8 +290,8 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
     cannot_remove_droplet! if hashed_params[:body].key?('data') && droplet_guid.nil?
     app, space, org, droplet = AssignCurrentDropletFetcher.new.fetch(app_guid, droplet_guid)
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
-    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
+    unauthorized! unless permission_queryer.can_manage_apps_in_space?(space.guid)
     deployment_in_progress! if app.deploying?
 
     AppAssignDroplet.new(user_audit_info).assign(app, droplet)
@@ -309,7 +309,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
   def current_droplet_relationship
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     droplet = DropletModel.where(guid: app.droplet_guid).eager(:space, space: :organization).first
 
     droplet_not_found! unless droplet
@@ -324,7 +324,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
   def current_droplet
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
     droplet = DropletModel.where(guid: app.droplet_guid).eager(:space, space: :organization).first
 
     droplet_not_found! unless droplet
@@ -334,7 +334,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
   def show_permissions
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
 
-    app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    app_not_found! unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
 
     render status: :ok, json: {
       read_basic_data: true,

--- a/app/controllers/v3/builds_controller.rb
+++ b/app/controllers/v3/builds_controller.rb
@@ -14,7 +14,7 @@ class BuildsController < ApplicationController
     dataset = if permission_queryer.can_read_globally?
                 BuildListFetcher.fetch_all(message, eager_loaded_associations: Presenters::V3::BuildPresenter.associated_resources)
               else
-                BuildListFetcher.fetch_for_spaces(message, space_guids: permission_queryer.readable_supporter_space_guids,
+                BuildListFetcher.fetch_for_spaces(message, space_guids: permission_queryer.readable_space_guids,
                   eager_loaded_associations: Presenters::V3::BuildPresenter.associated_resources)
               end
 
@@ -33,7 +33,7 @@ class BuildsController < ApplicationController
     package = PackageModel.where(guid: message.package_guid).
               eager(:app, :space, space: :organization, app: :buildpack_lifecycle_data).first
     unprocessable_package! unless package &&
-      permission_queryer.untrusted_can_write_to_space?(package.space.guid)
+      permission_queryer.can_manage_apps_in_space?(package.space.guid)
 
     FeatureFlag.raise_unless_enabled!(:diego_docker) if package.type == PackageModel::DOCKER_TYPE
 
@@ -92,7 +92,7 @@ class BuildsController < ApplicationController
   def show
     build = BuildModel.find(guid: hashed_params[:guid])
 
-    build_not_found! unless build && permission_queryer.untrusted_can_read_from_space?(build.app.space.guid, build.app.space.organization.guid)
+    build_not_found! unless build && permission_queryer.can_read_from_space?(build.app.space.guid, build.app.space.organization.guid)
 
     render status: :ok, json: Presenters::V3::BuildPresenter.new(build)
   end
@@ -100,7 +100,7 @@ class BuildsController < ApplicationController
   private
 
   def can_read_build?(space)
-    permission_queryer.can_update_build_state? || permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
+    permission_queryer.can_update_build_state? || permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
   end
 
   def create_valid_update_message

--- a/app/controllers/v3/isolation_segments_controller.rb
+++ b/app/controllers/v3/isolation_segments_controller.rb
@@ -104,7 +104,7 @@ class IsolationSegmentsController < ApplicationController
     spaces = if permission_queryer.can_read_globally?
                fetcher.fetch_all
              else
-               fetcher.fetch_for_spaces(space_guids: permission_queryer.readable_supporter_space_guids_query)
+               fetcher.fetch_for_spaces(space_guids: permission_queryer.readable_space_guids_query)
              end
 
     render status: :ok, json: Presenters::V3::ToManyRelationshipPresenter.new(

--- a/app/controllers/v3/processes_controller.rb
+++ b/app/controllers/v3/processes_controller.rb
@@ -26,14 +26,14 @@ class ProcessesController < ApplicationController
 
     if app_nested?
       app, dataset = ProcessListFetcher.fetch_for_app(message, eager_loaded_associations: Presenters::V3::ProcessPresenter.associated_resources)
-      app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(app.space.guid, app.organization.guid)
+      app_not_found! unless app && permission_queryer.can_read_from_space?(app.space.guid, app.organization.guid)
     else
       dataset = if permission_queryer.can_read_globally?
                   ProcessListFetcher.fetch_all(message, eager_loaded_associations: Presenters::V3::ProcessPresenter.associated_resources)
                 else
                   ProcessListFetcher.fetch_for_spaces(
                     message,
-                    space_guids: permission_queryer.readable_supporter_space_guids,
+                    space_guids: permission_queryer.readable_space_guids,
                     eager_loaded_associations: Presenters::V3::ProcessPresenter.associated_resources
                   )
                 end
@@ -109,16 +109,16 @@ class ProcessesController < ApplicationController
   def find_process_and_space
     if app_nested?
       @process, app, @space, org = ProcessFetcher.fetch_for_app_by_type(app_guid: hashed_params[:app_guid], process_type: hashed_params[:type])
-      app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(@space.guid, org.guid)
+      app_not_found! unless app && permission_queryer.can_read_from_space?(@space.guid, org.guid)
       process_not_found! unless @process
     else
       @process, @space, org = ProcessFetcher.fetch(process_guid: hashed_params[:process_guid])
-      process_not_found! unless @process && permission_queryer.untrusted_can_read_from_space?(@space.guid, org.guid)
+      process_not_found! unless @process && permission_queryer.can_read_from_space?(@space.guid, org.guid)
     end
   end
 
   def ensure_can_write
-    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(@space.guid)
+    unauthorized! unless permission_queryer.can_manage_apps_in_space?(@space.guid)
   end
 
   def process_not_found!

--- a/app/controllers/v3/revisions_controller.rb
+++ b/app/controllers/v3/revisions_controller.rb
@@ -36,7 +36,7 @@ class RevisionsController < ApplicationController
     app = revision.app
     space = app.space
     org = space.organization
-    resource_not_found!(:revision) unless permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    resource_not_found!(:revision) unless permission_queryer.can_read_from_space?(space.guid, org.guid)
     unauthorized! if needs_write_permissions && !permission_queryer.can_write_to_space?(space.guid)
     unauthorized! if needs_secrets_read_permission && !permission_queryer.can_read_secrets_in_space?(space.guid, org.guid)
 

--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -93,7 +93,7 @@ class RolesController < ApplicationController
     org = space.organization
 
     unprocessable_space! if permission_queryer.can_read_from_org?(org.guid) &&
-      !permission_queryer.untrusted_can_read_from_space?(message.space_guid, org.guid)
+      !permission_queryer.can_read_from_space?(message.space_guid, org.guid)
 
     unauthorized! unless permission_queryer.can_update_space?(message.space_guid, org.guid)
 

--- a/app/controllers/v3/routes_controller.rb
+++ b/app/controllers/v3/routes_controller.rb
@@ -147,7 +147,7 @@ class RoutesController < ApplicationController
   def route
     @route || begin
       @route = Route.find(guid: hashed_params[:guid])
-      route_not_found! unless @route && permission_queryer.untrusted_can_read_route?(@route.space.guid, @route.organization.guid)
+      route_not_found! unless @route && permission_queryer.can_read_route?(@route.space.guid, @route.organization.guid)
       @route
     end
   end

--- a/app/controllers/v3/security_groups_controller.rb
+++ b/app/controllers/v3/security_groups_controller.rb
@@ -83,7 +83,7 @@ class SecurityGroupsController < ApplicationController
 
     render status: :ok, json: Presenters::V3::SecurityGroupPresenter.new(
       security_group,
-      visible_space_guids: permission_queryer.readable_supporter_space_guids
+      visible_space_guids: permission_queryer.readable_space_guids
     )
   end
 
@@ -102,7 +102,7 @@ class SecurityGroupsController < ApplicationController
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
       path: '/v3/security_groups',
       message: message,
-      extra_presenter_args: { visible_space_guids: permission_queryer.readable_supporter_space_guids },
+      extra_presenter_args: { visible_space_guids: permission_queryer.readable_space_guids },
     )
   end
 

--- a/app/controllers/v3/service_brokers_controller.rb
+++ b/app/controllers/v3/service_brokers_controller.rb
@@ -40,7 +40,7 @@ class ServiceBrokersController < ApplicationController
 
     if service_broker.space_guid
       space = service_broker.space
-      broker_not_found! unless space && permission_queryer.untrusted_can_read_services_in_space?(space.guid, space.organization_guid)
+      broker_not_found! unless space && permission_queryer.can_read_services_in_space?(space.guid, space.organization_guid)
     else
       broker_not_found! unless permission_queryer.can_read_globally?
     end
@@ -57,7 +57,7 @@ class ServiceBrokersController < ApplicationController
     if message.space_guid
       FeatureFlag.raise_unless_enabled!(:space_scoped_private_broker_creation)
       space = Space.where(guid: message.space_guid).first
-      unprocessable_space! unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
+      unprocessable_space! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
       unauthorized! unless permission_queryer.can_write_space_scoped_service_broker?(space.guid)
     else
       unauthorized! unless permission_queryer.can_write_global_service_broker?
@@ -80,7 +80,7 @@ class ServiceBrokersController < ApplicationController
 
     if service_broker.space_guid
       space = service_broker.space
-      broker_not_found! unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
+      broker_not_found! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
       unauthorized! unless permission_queryer.can_write_space_scoped_service_broker?(space.guid)
     else
       broker_not_found! unless permission_queryer.can_read_globally?
@@ -108,7 +108,7 @@ class ServiceBrokersController < ApplicationController
       broker_not_found! unless permission_queryer.can_read_globally?
       unauthorized! unless permission_queryer.can_write_global_service_broker?
     else
-      broker_not_found! unless permission_queryer.untrusted_can_read_from_space?(service_broker.space.guid, service_broker.space.organization.guid)
+      broker_not_found! unless permission_queryer.can_read_from_space?(service_broker.space.guid, service_broker.space.organization.guid)
       unauthorized! unless permission_queryer.can_write_space_scoped_service_broker?(service_broker.space.guid)
     end
 

--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -272,13 +272,13 @@ class ServiceCredentialBindingsController < ApplicationController
       readable_spaces = service_instance.shared_spaces + [service_instance.space]
 
       readable_spaces.any? do |space|
-        permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
+        permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
       end
     end
   end
 
   def can_write_to_space?(space)
-    permission_queryer.untrusted_can_write_to_space?(space.guid)
+    permission_queryer.can_manage_apps_in_space?(space.guid)
   end
 
   def can_update_service_credentials_binding?(space)
@@ -330,7 +330,7 @@ class ServiceCredentialBindingsController < ApplicationController
     if permission_queryer.can_read_globally?
       :all
     else
-      permission_queryer.readable_supporter_space_guids
+      permission_queryer.readable_space_guids
     end
   end
 
@@ -351,7 +351,7 @@ class ServiceCredentialBindingsController < ApplicationController
   end
 
   def can_read_from_space?(space)
-    permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
+    permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
   end
 
   def binding_space

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -81,7 +81,7 @@ class ServiceInstancesV3Controller < ApplicationController
     message = build_create_message(hashed_params[:body])
 
     space = Space.first(guid: message.space_guid)
-    unprocessable_space! unless space && untrusted_can_read_space?(space)
+    unprocessable_space! unless space && can_read_space?(space)
     unauthorized! unless can_write_space?(space)
 
     case message.type
@@ -170,7 +170,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def relationships_shared_spaces
     service_instance = ServiceInstance.first(guid: hashed_params[:guid])
-    resource_not_found!(:service_instance) unless service_instance && untrusted_can_read_space?(service_instance.space)
+    resource_not_found!(:service_instance) unless service_instance && can_read_space?(service_instance.space)
 
     message = SharedSpacesShowMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?
@@ -361,10 +361,6 @@ class ServiceInstancesV3Controller < ApplicationController
     readable_spaces.any? do |space|
       permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
     end
-  end
-
-  def untrusted_can_read_space?(space)
-    permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
   end
 
   def can_read_space?(space)

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -47,7 +47,7 @@ class ServiceInstancesV3Controller < ApplicationController
                 ServiceInstanceListFetcher.fetch(
                   message,
                   eager_loaded_associations: Presenters::V3::ServiceInstancePresenter.associated_resources,
-                  readable_space_guids: permission_queryer.readable_supporter_space_guids,
+                  readable_space_guids: permission_queryer.readable_space_guids,
                 )
               end
 
@@ -359,12 +359,12 @@ class ServiceInstancesV3Controller < ApplicationController
     readable_spaces = service_instance.shared_spaces + [service_instance.space]
 
     readable_spaces.any? do |space|
-      permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
+      permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
     end
   end
 
   def untrusted_can_read_space?(space)
-    permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
+    permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
   end
 
   def can_read_space?(space)

--- a/app/controllers/v3/service_offerings_controller.rb
+++ b/app/controllers/v3/service_offerings_controller.rb
@@ -35,7 +35,7 @@ class ServiceOfferingsController < ApplicationController
                 ServiceOfferingListFetcher.fetch(
                   message,
                   readable_org_guids: permission_queryer.readable_org_guids,
-                  readable_space_guids: permission_queryer.readable_space_supporter_space_scoped_space_guids,
+                  readable_space_guids: permission_queryer.readable_space_scoped_space_guids,
                   eager_loaded_associations: Presenters::V3::ServiceOfferingPresenter.associated_resources,
                 )
               end

--- a/app/controllers/v3/service_plans_controller.rb
+++ b/app/controllers/v3/service_plans_controller.rb
@@ -55,7 +55,7 @@ class ServicePlansController < ApplicationController
                   message,
                   eager_loaded_associations: Presenters::V3::ServicePlanPresenter.associated_resources,
                   readable_org_guids: permission_queryer.readable_org_guids,
-                  readable_space_guids: permission_queryer.readable_space_supporter_space_scoped_space_guids,
+                  readable_space_guids: permission_queryer.readable_space_scoped_space_guids,
                 )
               end
 

--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -29,7 +29,7 @@ class ServiceRouteBindingsController < ApplicationController
 
   def show
     message = show_message
-    route_binding_not_found! unless @route_binding && untrusted_can_read_space?(@route_binding.route.space)
+    route_binding_not_found! unless @route_binding && can_read_space?(@route_binding.route.space)
     presenter = Presenters::V3::ServiceRouteBindingPresenter.new(
       @route_binding,
       decorators: decorators(message)
@@ -63,8 +63,8 @@ class ServiceRouteBindingsController < ApplicationController
   end
 
   def destroy
-    route_binding_not_found! unless @route_binding && untrusted_can_read_space?(@route_binding.route.space)
-    unauthorized! unless untrusted_can_write_space?(@route_binding.route.space)
+    route_binding_not_found! unless @route_binding && can_read_space?(@route_binding.route.space)
+    unauthorized! unless can_bind_in_space?(@route_binding.route.space)
 
     action = V3::ServiceRouteBindingDelete.new(user_audit_info)
     binding_operation_in_progress! if action.blocking_operation_in_progress?(@route_binding)
@@ -83,7 +83,7 @@ class ServiceRouteBindingsController < ApplicationController
   end
 
   def parameters
-    route_binding_not_found! unless @route_binding && untrusted_can_read_space?(@route_binding.route.space)
+    route_binding_not_found! unless @route_binding && can_read_space?(@route_binding.route.space)
     unauthorized! unless can_write_space?(@route_binding.route.space)
 
     fetcher = ServiceBindingRead.new
@@ -193,18 +193,18 @@ class ServiceRouteBindingsController < ApplicationController
 
   def fetch_service_instance(guid)
     service_instance = VCAP::CloudController::ServiceInstance.first(guid: guid)
-    unless service_instance && untrusted_can_read_space?(service_instance.space)
+    unless service_instance && can_read_space?(service_instance.space)
       service_instance_not_found!(guid)
     end
 
-    unauthorized! unless untrusted_can_write_space?(service_instance.space)
+    unauthorized! unless can_bind_in_space?(service_instance.space)
 
     service_instance
   end
 
   def fetch_route(guid)
     route = VCAP::CloudController::Route.first(guid: guid)
-    unless route && untrusted_can_read_space?(route.space)
+    unless route && can_read_space?(route.space)
       route_not_found!(guid)
     end
 
@@ -220,15 +220,11 @@ class ServiceRouteBindingsController < ApplicationController
     VCAP::CloudController::Repositories::ServiceEventRepository::WithUserActor.new(user_audit_info)
   end
 
-  def untrusted_can_read_space?(space)
-    permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
-  end
-
   def can_read_space?(space)
     permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
   end
 
-  def untrusted_can_write_space?(space)
+  def can_bind_in_space?(space)
     permission_queryer.can_manage_apps_in_space?(space.guid)
   end
 

--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -182,7 +182,7 @@ class ServiceRouteBindingsController < ApplicationController
   end
 
   def space_guids
-    permission_queryer.readable_supporter_space_guids
+    permission_queryer.readable_space_guids
   end
 
   def parse_create_request
@@ -221,15 +221,15 @@ class ServiceRouteBindingsController < ApplicationController
   end
 
   def untrusted_can_read_space?(space)
-    permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
+    permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
   end
 
   def can_read_space?(space)
-    permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization_guid)
+    permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
   end
 
   def untrusted_can_write_space?(space)
-    permission_queryer.untrusted_can_write_to_space?(space.guid)
+    permission_queryer.can_manage_apps_in_space?(space.guid)
   end
 
   def can_write_space?(space)

--- a/app/controllers/v3/sidecars_controller.rb
+++ b/app/controllers/v3/sidecars_controller.rb
@@ -16,7 +16,7 @@ class SidecarsController < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     app, dataset = SidecarListFetcher.fetch_for_app(message, hashed_params[:app_guid])
-    resource_not_found!(:app) unless app && permission_queryer.untrusted_can_read_from_space?(app.space.guid, app.organization.guid)
+    resource_not_found!(:app) unless app && permission_queryer.can_read_from_space?(app.space.guid, app.organization.guid)
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::SidecarPresenter,
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
@@ -29,7 +29,7 @@ class SidecarsController < ApplicationController
     invalid_param!(message.errors.full_messages) unless message.valid?
 
     process, dataset = SidecarListFetcher.fetch_for_process(message, hashed_params[:process_guid])
-    resource_not_found!(:process) unless process && permission_queryer.untrusted_can_read_from_space?(process.space.guid, process.organization.guid)
+    resource_not_found!(:process) unless process && permission_queryer.can_read_from_space?(process.space.guid, process.organization.guid)
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::SidecarPresenter,
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
@@ -41,7 +41,7 @@ class SidecarsController < ApplicationController
     sidecar = SidecarModel.find(guid: hashed_params[:guid])
     resource_not_found!(:sidecar) unless sidecar
     app = sidecar.app
-    resource_not_found!(:sidecar) unless permission_queryer.untrusted_can_read_from_space?(app.space.guid, app.space.organization.guid)
+    resource_not_found!(:sidecar) unless permission_queryer.can_read_from_space?(app.space.guid, app.space.organization.guid)
 
     render status: 200, json: Presenters::V3::SidecarPresenter.new(sidecar)
   end

--- a/app/controllers/v3/space_features_controller.rb
+++ b/app/controllers/v3/space_features_controller.rb
@@ -6,7 +6,7 @@ class SpaceFeaturesController < ApplicationController
 
   def index
     space = Space.find(guid: hashed_params[:guid])
-    resource_not_found!(:space) unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
+    resource_not_found!(:space) unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
 
     render status: :ok, json: {
       resources: [Presenters::V3::SpaceSshFeaturePresenter.new(space)],
@@ -15,7 +15,7 @@ class SpaceFeaturesController < ApplicationController
 
   def show
     space = SpaceFetcher.new.fetch(hashed_params[:guid])
-    resource_not_found!(:space) unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
+    resource_not_found!(:space) unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
     resource_not_found!(:feature) unless SPACE_FEATURE == hashed_params[:name]
 
     render status: :ok, json: Presenters::V3::SpaceSshFeaturePresenter.new(space)

--- a/app/controllers/v3/space_manifests_controller.rb
+++ b/app/controllers/v3/space_manifests_controller.rb
@@ -12,7 +12,7 @@ class SpaceManifestsController < ApplicationController
 
   def apply_manifest
     space = Space.find(guid: hashed_params[:guid])
-    space_not_found! unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
+    space_not_found! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
     unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
 
     messages = parsed_app_manifests.map { |app_manifest| AppManifestMessage.create_from_yml(app_manifest) }
@@ -44,7 +44,7 @@ class SpaceManifestsController < ApplicationController
 
   def diff_manifest
     space = Space.find(guid: hashed_params[:guid])
-    space_not_found! unless space && permission_queryer.untrusted_can_read_from_space?(space.guid, space.organization.guid)
+    space_not_found! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
     unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
 
     parsed_manifests = parsed_app_manifests.map(&:to_hash)

--- a/app/controllers/v3/space_quotas_controller.rb
+++ b/app/controllers/v3/space_quotas_controller.rb
@@ -36,7 +36,7 @@ class SpaceQuotasController < ApplicationController
 
     render status: :ok, json: Presenters::V3::SpaceQuotaPresenter.new(
       space_quota,
-      visible_space_guids: readable_supporter_space_guids
+      visible_space_guids: readable_space_guids
     )
   end
 
@@ -51,7 +51,7 @@ class SpaceQuotasController < ApplicationController
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
       path: '/v3/space_quotas',
       message: message,
-      extra_presenter_args: { visible_space_guids: readable_supporter_space_guids },
+      extra_presenter_args: { visible_space_guids: readable_space_guids },
     )
   end
 
@@ -153,9 +153,5 @@ class SpaceQuotasController < ApplicationController
 
   def readable_space_guids
     permission_queryer.readable_space_guids
-  end
-
-  def readable_supporter_space_guids
-    permission_queryer.readable_supporter_space_guids
   end
 end

--- a/app/controllers/v3/stacks_controller.rb
+++ b/app/controllers/v3/stacks_controller.rb
@@ -67,7 +67,7 @@ class StacksController < ApplicationController
     dataset = if permission_queryer.can_read_globally?
                 AppListFetcher.fetch_all(message)
               else
-                AppListFetcher.fetch(message, permission_queryer.readable_supporter_space_guids)
+                AppListFetcher.fetch(message, permission_queryer.readable_space_guids)
               end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(

--- a/app/controllers/v3/tasks_controller.rb
+++ b/app/controllers/v3/tasks_controller.rb
@@ -22,7 +22,7 @@ class TasksController < ApplicationController
 
     if app_nested?
       app, dataset = TaskListFetcher.fetch_for_app(message: message)
-      app_not_found! unless app && permission_queryer.untrusted_can_read_from_space?(app.space.guid, app.organization.guid)
+      app_not_found! unless app && permission_queryer.can_read_from_space?(app.space.guid, app.organization.guid)
       show_secrets = can_read_secrets?(app.organization, app.space)
     else
       dataset = if permission_queryer.can_read_globally?
@@ -68,9 +68,9 @@ class TasksController < ApplicationController
 
   def cancel
     task, space, org = TaskFetcher.new.fetch(task_guid: hashed_params[:task_guid])
-    task_not_found! unless task && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    task_not_found! unless task && permission_queryer.can_read_from_space?(space.guid, org.guid)
 
-    unauthorized! unless permission_queryer.untrusted_can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.can_manage_apps_in_space?(space.guid)
     TaskCancel.new(configuration).cancel(task: task, user_audit_info: user_audit_info)
 
     render status: :accepted, json: Presenters::V3::TaskPresenter.new(task.reload)
@@ -83,7 +83,7 @@ class TasksController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     task, space, org = TaskFetcher.new.fetch(task_guid: hashed_params[:task_guid])
-    task_not_found! unless task && permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    task_not_found! unless task && permission_queryer.can_read_from_space?(space.guid, org.guid)
     unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
 
     task = TaskUpdate.new.update(task, message)
@@ -100,7 +100,7 @@ class TasksController < ApplicationController
   private
 
   def readable_space_guids
-    permission_queryer.readable_supporter_space_guids
+    permission_queryer.readable_space_guids
   end
 
   def can_read_secrets?(org, space)
@@ -108,7 +108,7 @@ class TasksController < ApplicationController
   end
 
   def can_read_task?(org, space)
-    permission_queryer.untrusted_can_read_from_space?(space.guid, org.guid)
+    permission_queryer.can_read_from_space?(space.guid, org.guid)
   end
 
   def task_not_found!

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -270,16 +270,6 @@ class VCAP::CloudController::Permissions
       membership.has_any_roles?(ROLES_FOR_SPACE_SECRETS_READING, space_guid, org_guid)
   end
 
-  # def can_read_route?(space_guid, org_guid)
-  #   return true if can_read_globally?
-
-  #   space = VCAP::CloudController::Space.where(guid: space_guid).first
-  #   org = space.organization
-
-  #   space.has_member?(@user) || space.has_supporter?(@user) ||
-  #     @user.managed_organizations.include?(org) || @user.audited_organizations.include?(org)
-  # end
-
   def readable_app_guids
     VCAP::CloudController::AppModel.user_visible(@user, can_read_globally?).map(&:guid)
   end

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -19,14 +19,14 @@ class VCAP::CloudController::Permissions
     VCAP::CloudController::Membership::SPACE_MANAGER,
     VCAP::CloudController::Membership::SPACE_AUDITOR,
     VCAP::CloudController::Membership::ORG_MANAGER,
+    VCAP::CloudController::Membership::SPACE_SUPPORTER,
   ].freeze
 
-  ROLES_FOR_SPACE_SUPPORTER_READING ||= [
+  ROLES_FOR_DROPLET_DOWLOAD ||= [
     VCAP::CloudController::Membership::SPACE_DEVELOPER,
     VCAP::CloudController::Membership::SPACE_MANAGER,
     VCAP::CloudController::Membership::SPACE_AUDITOR,
     VCAP::CloudController::Membership::ORG_MANAGER,
-    VCAP::CloudController::Membership::SPACE_SUPPORTER,
   ].freeze
 
   ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS ||= [
@@ -38,11 +38,8 @@ class VCAP::CloudController::Permissions
     VCAP::CloudController::Membership::SPACE_DEVELOPER,
     VCAP::CloudController::Membership::SPACE_MANAGER,
     VCAP::CloudController::Membership::SPACE_AUDITOR,
-  ].freeze
-
-  SPACE_ROLES_INCLUDING_SUPPORTERS ||= (SPACE_ROLES + [
     VCAP::CloudController::Membership::SPACE_SUPPORTER,
-  ]).freeze
+  ].freeze
 
   SPACE_ROLES_FOR_EVENTS ||= [
     VCAP::CloudController::Membership::SPACE_AUDITOR,
@@ -63,7 +60,7 @@ class VCAP::CloudController::Permissions
     VCAP::CloudController::Membership::SPACE_DEVELOPER,
   ].freeze
 
-  ROLES_FOR_SPACE_SUPPORTER_WRITING ||= (ROLES_FOR_SPACE_WRITING + [
+  ROLES_FOR_APP_MANAGING ||= (ROLES_FOR_SPACE_WRITING + [
     VCAP::CloudController::Membership::SPACE_SUPPORTER,
   ]).freeze
 
@@ -133,7 +130,7 @@ class VCAP::CloudController::Permissions
     if can_read_globally?
       VCAP::CloudController::Organization.select(:guid)
     else
-      membership.org_guids_for_roles_subquery(ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + SPACE_ROLES_INCLUDING_SUPPORTERS)
+      membership.org_guids_for_roles_subquery(ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + SPACE_ROLES)
     end
   end
 
@@ -164,19 +161,11 @@ class VCAP::CloudController::Permissions
     end
   end
 
-  def readable_supporter_space_guids
-    if can_read_globally?
-      VCAP::CloudController::Space.select(:guid).all.map(&:guid)
-    else
-      membership.space_guids_for_roles(ROLES_FOR_SPACE_SUPPORTER_READING)
-    end
-  end
-
-  def readable_supporter_space_guids_query
+  def readable_space_guids_query
     if can_read_globally?
       VCAP::CloudController::Space.select(:guid)
     else
-      membership.space_guids_for_roles_subquery(ROLES_FOR_SPACE_SUPPORTER_READING)
+      membership.space_guids_for_roles_subquery(ROLES_FOR_SPACE_READING)
     end
   end
 
@@ -184,8 +173,8 @@ class VCAP::CloudController::Permissions
     can_read_globally? || membership.has_any_roles?(ROLES_FOR_SPACE_READING, space_guid, org_guid)
   end
 
-  def untrusted_can_read_from_space?(space_guid, org_guid)
-    can_read_globally? || membership.has_any_roles?(ROLES_FOR_SPACE_SUPPORTER_READING, space_guid, org_guid)
+  def can_download_droplet?(space_guid, org_guid)
+    can_read_globally? || membership.has_any_roles?(ROLES_FOR_DROPLET_DOWLOAD, space_guid, org_guid)
   end
 
   def can_read_secrets_in_space?(space_guid, org_guid)
@@ -193,7 +182,7 @@ class VCAP::CloudController::Permissions
       membership.has_any_roles?(ROLES_FOR_SPACE_SECRETS_READING, space_guid, org_guid)
   end
 
-  def untrusted_can_read_services_in_space?(space_guid, org_guid)
+  def can_read_services_in_space?(space_guid, org_guid)
     can_read_globally? || membership.has_any_roles?(ROLES_FOR_SPACE_SERVICES_READING, space_guid, org_guid)
   end
 
@@ -205,10 +194,10 @@ class VCAP::CloudController::Permissions
     VCAP::CloudController::Space.find(guid: space_guid)&.organization&.active?
   end
 
-  def untrusted_can_write_to_space?(space_guid)
+  def can_manage_apps_in_space?(space_guid)
     return true if can_write_globally?
 
-    return false unless membership.has_any_roles?(ROLES_FOR_SPACE_SUPPORTER_WRITING, space_guid)
+    return false unless membership.has_any_roles?(ROLES_FOR_APP_MANAGING, space_guid)
 
     VCAP::CloudController::Space.find(guid: space_guid)&.organization&.active?
   end
@@ -260,21 +249,14 @@ class VCAP::CloudController::Permissions
     end
   end
 
-  def readable_space_supporter_space_scoped_space_guids
-    if can_read_globally?
-      VCAP::CloudController::Space.select(:guid).all.map(&:guid)
-    else
-      membership.space_guids_for_roles(SPACE_ROLES_INCLUDING_SUPPORTERS)
-    end
-  end
-
   def can_read_route?(space_guid, org_guid)
     return true if can_read_globally?
 
     space = VCAP::CloudController::Space.where(guid: space_guid).first
     org = space.organization
 
-    space.has_member?(@user) || @user.managed_organizations.include?(org) ||
+    space.has_member?(@user) || space.has_supporter?(@user) ||
+      @user.managed_organizations.include?(org) ||
       @user.audited_organizations.include?(org)
   end
 
@@ -288,15 +270,15 @@ class VCAP::CloudController::Permissions
       membership.has_any_roles?(ROLES_FOR_SPACE_SECRETS_READING, space_guid, org_guid)
   end
 
-  def untrusted_can_read_route?(space_guid, org_guid)
-    return true if can_read_globally?
+  # def can_read_route?(space_guid, org_guid)
+  #   return true if can_read_globally?
 
-    space = VCAP::CloudController::Space.where(guid: space_guid).first
-    org = space.organization
+  #   space = VCAP::CloudController::Space.where(guid: space_guid).first
+  #   org = space.organization
 
-    space.has_member?(@user) || space.has_supporter?(@user) ||
-      @user.managed_organizations.include?(org) || @user.audited_organizations.include?(org)
-  end
+  #   space.has_member?(@user) || space.has_supporter?(@user) ||
+  #     @user.managed_organizations.include?(org) || @user.audited_organizations.include?(org)
+  # end
 
   def readable_app_guids
     VCAP::CloudController::AppModel.user_visible(@user, can_read_globally?).map(&:guid)

--- a/spec/request/app_features_spec.rb
+++ b/spec/request/app_features_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'App Features' do
         space.organization.add_user(user)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -85,7 +85,7 @@ RSpec.describe 'App Features' do
         }
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'revisions app feature' do
@@ -98,7 +98,7 @@ RSpec.describe 'App Features' do
         }
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -133,7 +133,7 @@ RSpec.describe 'App Features' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'revisions app feature' do
@@ -160,7 +160,7 @@ RSpec.describe 'App Features' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 end

--- a/spec/request/app_manifests_spec.rb
+++ b/spec/request/app_manifests_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'App Manifests' do
         space.remove_developer(user)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'for a buildpack' do

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'Apps' do
         space.organization.add_user(user)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the user can create an app' do
@@ -552,7 +552,7 @@ RSpec.describe 'Apps' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     describe 'query list parameters' do
@@ -1387,7 +1387,7 @@ RSpec.describe 'Apps' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the user has permission to view the app' do
@@ -1607,7 +1607,7 @@ RSpec.describe 'Apps' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when VCAP_SERVICES contains potentially sensitive information' do
@@ -1739,14 +1739,14 @@ RSpec.describe 'Apps' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       context 'when the space_developer_env_var_visibility feature flag is disabled' do
         before do
           VCAP::CloudController::FeatureFlag.make(name: 'space_developer_env_var_visibility', enabled: false, error_message: nil)
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:expected_codes_and_responses) do
             h = Hash.new(code: 403)
             h['admin'] = h['admin_read_only'] = { code: 200, response_object: expected_response }
@@ -1819,7 +1819,7 @@ RSpec.describe 'Apps' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     describe 'as a developer' do
@@ -1958,7 +1958,7 @@ RSpec.describe 'Apps' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -2019,7 +2019,7 @@ RSpec.describe 'Apps' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'deleting metadata' do
@@ -2207,7 +2207,7 @@ RSpec.describe 'Apps' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'telemetry' do
@@ -2329,7 +2329,7 @@ RSpec.describe 'Apps' do
           space.organization.add_user(user)
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'events' do
@@ -2484,7 +2484,7 @@ RSpec.describe 'Apps' do
           space.organization.add_user(user)
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
   end
@@ -2579,7 +2579,7 @@ RSpec.describe 'Apps' do
         space.organization.add_user(user)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'events' do
@@ -2727,7 +2727,7 @@ RSpec.describe 'Apps' do
           space.organization.add_user(user)
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'telemetry' do
@@ -2835,7 +2835,7 @@ RSpec.describe 'Apps' do
           space.organization.add_user(user)
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
   end
@@ -2869,7 +2869,7 @@ RSpec.describe 'Apps' do
       app_model.save
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
   end
 
   describe 'GET /v3/apps/:guid/droplets/current' do
@@ -2932,7 +2932,7 @@ RSpec.describe 'Apps' do
       app_model.save
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
   end
 
   describe 'PATCH /v3/apps/:guid/relationships/current_droplet' do
@@ -3000,7 +3000,7 @@ RSpec.describe 'Apps' do
         space.organization.add_user(user)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'events' do
@@ -3149,7 +3149,7 @@ RSpec.describe 'Apps' do
       space.organization.add_user(user)
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:update_request) do
         {
           var: {
@@ -3214,7 +3214,7 @@ RSpec.describe 'Apps' do
       space.organization.add_user(user)
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:expected_codes_and_responses) do
         h = Hash.new(code: 404)
         h['global_auditor'] = h['org_manager'] = h['space_auditor'] = h['space_manager'] = { code: 403 }
@@ -3231,7 +3231,7 @@ RSpec.describe 'Apps' do
         VCAP::CloudController::FeatureFlag.make(name: 'space_developer_env_var_visibility', enabled: false, error_message: nil)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:expected_codes_and_responses) do
           h = Hash.new(code: 404)
           h['global_auditor'] = h['org_manager'] = h['space_auditor'] = h['space_manager'] = h['space_developer'] = h['space_supporter'] = { code: 403 }
@@ -3278,6 +3278,6 @@ RSpec.describe 'Apps' do
       h.freeze
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
   end
 end

--- a/spec/request/buildpacks_spec.rb
+++ b/spec/request/buildpacks_spec.rb
@@ -695,7 +695,7 @@ RSpec.describe 'buildpacks' do
         space.organization.add_user(user)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -869,7 +869,7 @@ RSpec.describe 'buildpacks' do
 
         let(:expected_codes_and_responses) { Hash.new(code: 404).freeze }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'the buildpack exists' do
@@ -901,7 +901,7 @@ RSpec.describe 'buildpacks' do
 
         let(:expected_codes_and_responses) { Hash.new(code: 200, response_object: buildpack_response).freeze }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
   end

--- a/spec/request/builds_spec.rb
+++ b/spec/request/builds_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'Builds' do
     end
 
     context 'permissions' do
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| post '/v3/builds', create_request.to_json, user_headers } }
         let(:org) { space.organization }
         let(:user) { VCAP::CloudController::User.make }
@@ -403,7 +403,7 @@ RSpec.describe 'Builds' do
     end
 
     describe 'permissions' do
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| get '/v3/builds', nil, user_headers } }
         let(:org) { space.organization }
         let(:user) { VCAP::CloudController::User.make }
@@ -618,7 +618,7 @@ RSpec.describe 'Builds' do
     end
 
     describe 'permissions' do
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:org) { space.organization }
         let(:user) { VCAP::CloudController::User.make }
         let(:api_call) { lambda { |user_headers| get "v3/builds/#{build.guid}", nil, user_headers } }
@@ -690,7 +690,7 @@ RSpec.describe 'Builds' do
       end
 
       describe 'permissions' do
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:org) { space.organization }
           let(:user) { VCAP::CloudController::User.make }
           let(:api_call) { lambda { |user_headers| patch "/v3/builds/#{build_model.guid}", { metadata: metadata }.to_json, user_headers } }

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Deployments' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when a droplet is supplied with the request' do
@@ -865,7 +865,7 @@ RSpec.describe 'Deployments' do
       })
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       before do
         space.remove_developer(user)
       end
@@ -948,7 +948,7 @@ RSpec.describe 'Deployments' do
       h.freeze
     }
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
   end
 
   describe 'GET /v3/deployments/' do
@@ -1134,7 +1134,7 @@ RSpec.describe 'Deployments' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
           context 'pagination' do
             let(:pagination_hsh) do
@@ -1182,7 +1182,7 @@ RSpec.describe 'Deployments' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
           context 'pagination' do
             let(:pagination_hsh) do
@@ -1223,7 +1223,7 @@ RSpec.describe 'Deployments' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
           context 'pagination' do
             let(:pagination_hsh) do
@@ -1391,7 +1391,7 @@ RSpec.describe 'Deployments' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the deployment is running and has a previous droplet' do

--- a/spec/request/domains_spec.rb
+++ b/spec/request/domains_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe 'Domains Request' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', LOCAL_ROLES + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', LOCAL_ROLES
         end
 
         context 'when the domain is shared with an org that user is an org manager' do
@@ -294,7 +294,7 @@ RSpec.describe 'Domains Request' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', LOCAL_ROLES + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', LOCAL_ROLES
         end
       end
 
@@ -322,7 +322,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
         context 'pagination' do
           let(:pagination_hsh) do
@@ -367,7 +367,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
         context 'pagination' do
           let(:pagination_hsh) do
@@ -426,7 +426,7 @@ RSpec.describe 'Domains Request' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', LOCAL_ROLES + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', LOCAL_ROLES
         end
 
         context 'pagination' do
@@ -650,7 +650,7 @@ RSpec.describe 'Domains Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'there are route matches' do
@@ -678,7 +678,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when querying with only host' do
@@ -705,7 +705,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when querying with only port' do
@@ -741,7 +741,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
         context 'when querying a TCP route without filtering the port' do
           it 'returns no matching routes' do
@@ -848,7 +848,7 @@ RSpec.describe 'Domains Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       context 'when the Routing API is unavailable' do
         let(:user_header) { admin_headers_for(user) }
@@ -984,7 +984,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       describe 'invalid private domains' do
@@ -1508,7 +1508,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
 
@@ -1553,7 +1553,7 @@ RSpec.describe 'Domains Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1583,7 +1583,7 @@ RSpec.describe 'Domains Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
 
       context 'deleting metadata' do
         it_behaves_like 'resource with metadata' do
@@ -1619,7 +1619,7 @@ RSpec.describe 'Domains Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
     end
 
     describe 'when deleting a shared private domain as an org manager of the shared organization' do
@@ -1798,7 +1798,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
       end
 
       context 'when the user is a billing manager is the shared org' do
@@ -1826,7 +1826,7 @@ RSpec.describe 'Domains Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
       end
     end
   end
@@ -1883,7 +1883,7 @@ RSpec.describe 'Domains Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when getting a private domain' do
@@ -1937,7 +1937,7 @@ RSpec.describe 'Domains Request' do
         end
 
         let(:api_call) { lambda { |user_headers| get "/v3/domains/#{private_domain.guid}", nil, user_headers } }
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when the domain has been shared with another organization' do
@@ -1999,7 +1999,7 @@ RSpec.describe 'Domains Request' do
             ).freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', LOCAL_ROLES + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', LOCAL_ROLES
         end
 
         context 'when the user can read globally' do
@@ -2096,7 +2096,7 @@ RSpec.describe 'Domains Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'updating an existing private domain' do
@@ -2154,7 +2154,7 @@ RSpec.describe 'Domains Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'updating an existing, shared private domain' do
@@ -2215,7 +2215,7 @@ RSpec.describe 'Domains Request' do
         domain.add_shared_organization(org)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 end

--- a/spec/request/droplets_spec.rb
+++ b/spec/request/droplets_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Droplets' do
     end
 
     describe 'when creating a droplet' do
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| post '/v3/droplets', params.to_json, user_headers } }
 
         let(:droplet_json) do
@@ -262,7 +262,7 @@ RSpec.describe 'Droplets' do
         droplet_model.buildpack_lifecycle_data.update(buildpacks: [{ key: 'http://buildpack.git.url.com', version: '0.3', name: 'git' }], stack: 'stack-name')
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the droplet has a docker lifecycle' do
@@ -328,7 +328,7 @@ RSpec.describe 'Droplets' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -389,7 +389,7 @@ RSpec.describe 'Droplets' do
         expect(failures).to eq(0)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       it 'downloads the bit(s) for a droplet' do
         get "/v3/droplets/#{guid}/download", nil, developer_headers
@@ -715,7 +715,7 @@ RSpec.describe 'Droplets' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     it 'list all droplets with a buildpack lifecycle' do
@@ -996,7 +996,7 @@ RSpec.describe 'Droplets' do
   describe 'DELETE /v3/droplets/:guid' do
     let!(:droplet) { VCAP::CloudController::DropletModel.make(:buildpack, app_guid: app_model.guid) }
 
-    it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
       let(:api_call) { lambda { |user_headers| delete "/v3/droplets/#{droplet.guid}", nil, user_headers } }
       let(:db_check) do
         lambda do
@@ -1268,7 +1268,7 @@ RSpec.describe 'Droplets' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1463,7 +1463,7 @@ RSpec.describe 'Droplets' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1495,7 +1495,7 @@ RSpec.describe 'Droplets' do
       og_droplet.buildpack_lifecycle_data.update(buildpacks: ['http://buildpack.git.url.com'], stack: 'stack-name')
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:api_call) { lambda { |user_headers| post "/v3/droplets?source_guid=#{og_droplet.guid}", copy_request_json, user_headers } }
       let(:expected_copied_response) do
         {
@@ -1617,7 +1617,7 @@ RSpec.describe 'Droplets' do
       allow(File).to receive(:stat).and_return(instance_double(File::Stat, size: 12))
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:expected_event_hash) do
         {
           type: 'audit.app.droplet.upload',
@@ -1728,7 +1728,7 @@ RSpec.describe 'Droplets' do
     context 'when the droplet exists' do
       let(:guid) { og_droplet.guid }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:droplet_json) do
           {
             guid: og_droplet.guid,

--- a/spec/request/environment_variable_groups_spec.rb
+++ b/spec/request/environment_variable_groups_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Environment group variables' do
         space.organization.add_user(user)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -197,7 +197,7 @@ RSpec.describe 'Environment group variables' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when request input message is invalid' do

--- a/spec/request/events_spec.rb
+++ b/spec/request/events_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'Events' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     context 'filtering by type' do
@@ -277,7 +277,7 @@ RSpec.describe 'Events' do
           )
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
         context 'and the space has been deleted' do
           before do
@@ -380,7 +380,7 @@ RSpec.describe 'Events' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
         context 'and the org has been deleted' do
           before do
@@ -458,7 +458,7 @@ RSpec.describe 'Events' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
 

--- a/spec/request/isolation_segments_spec.rb
+++ b/spec/request/isolation_segments_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'IsolationSegmentModels' do
         space.update(isolation_segment_guid: isolation_segment_model.guid)
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| get "/v3/isolation_segments/#{isolation_segment_model.guid}/relationships/organizations", nil, user_headers } }
         let(:org) { space.organization }
         let(:user) { VCAP::CloudController::User.make }
@@ -129,7 +129,7 @@ RSpec.describe 'IsolationSegmentModels' do
     end
 
     context 'permissions' do
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| get "/v3/isolation_segments/#{isolation_segment_model.guid}/relationships/spaces", nil, user_headers } }
         let(:org) { space1.organization }
         let(:space) { space1 }
@@ -225,7 +225,7 @@ RSpec.describe 'IsolationSegmentModels' do
         assigner.assign(isolation_segment_model, [space.organization])
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| get "/v3/isolation_segments/#{isolation_segment_model.guid}", nil, user_headers } }
         let(:org) { space.organization }
         let(:user) { VCAP::CloudController::User.make }
@@ -238,7 +238,7 @@ RSpec.describe 'IsolationSegmentModels' do
     end
 
     context 'permissions for unscoped isolation segments' do
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| get "/v3/isolation_segments/#{isolation_segment_model.guid}", nil, user_headers } }
         let(:org) { space.organization }
         let(:user) { VCAP::CloudController::User.make }
@@ -478,7 +478,7 @@ RSpec.describe 'IsolationSegmentModels' do
       before do
         assigner.assign(iso_seg1, [space.organization])
       end
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| get '/v3/isolation_segments', nil, user_headers } }
         let(:org) { space.organization }
         let(:user) { VCAP::CloudController::User.make }

--- a/spec/request/jobs_spec.rb
+++ b/spec/request/jobs_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe 'Jobs' do
         space.organization.add_user(user)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 end

--- a/spec/request/organization_quotas_spec.rb
+++ b/spec/request/organization_quotas_spec.rb
@@ -80,7 +80,7 @@ module VCAP::CloudController
           }.by 1
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'using provided params' do
@@ -210,7 +210,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
         it_behaves_like 'list_endpoint_with_common_filters' do
           let(:resource_klass) { VCAP::CloudController::QuotaDefinition }
@@ -277,7 +277,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when the organization_quota had no associated organizations' do
@@ -382,7 +382,7 @@ module VCAP::CloudController
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       context 'when the organization_quota does not exist' do
         it 'returns a 404 with a helpful message' do
@@ -487,7 +487,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when an org guid does not exist' do
@@ -541,7 +541,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
       end
 
       context 'when the user is not logged in' do

--- a/spec/request/organizations_spec.rb
+++ b/spec/request/organizations_spec.rb
@@ -320,7 +320,7 @@ module VCAP::CloudController
           organization3.remove_user(user)
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
           let(:api_call) { lambda { |user_headers| get 'v3/organizations', nil, user_headers } }
           let(:space) { VCAP::CloudController::Space.make }
           let(:org) { space.organization }
@@ -578,7 +578,7 @@ module VCAP::CloudController
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
         end
 
         describe 'when filtering by name' do
@@ -597,7 +597,7 @@ module VCAP::CloudController
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
         end
 
         describe 'when filtering by guid' do
@@ -616,7 +616,7 @@ module VCAP::CloudController
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
         end
 
         describe 'when filtering by organization_guid' do
@@ -639,7 +639,7 @@ module VCAP::CloudController
             h.freeze
           end
 
-          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
         end
       end
 
@@ -906,7 +906,7 @@ module VCAP::CloudController
             }
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
         end
 
         context 'when at least one non-internal shared domain exists' do
@@ -940,7 +940,7 @@ module VCAP::CloudController
             }
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
         end
       end
 
@@ -954,7 +954,7 @@ module VCAP::CloudController
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when only tcp domains exist' do
@@ -967,7 +967,7 @@ module VCAP::CloudController
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when no domains exist' do
@@ -978,7 +978,7 @@ module VCAP::CloudController
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
 
@@ -1018,7 +1018,7 @@ module VCAP::CloudController
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       context 'when the org does not exist' do
         it 'returns a 404' do
@@ -1110,7 +1110,7 @@ module VCAP::CloudController
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       context 'when the org is suspended' do
         before do
@@ -1118,7 +1118,7 @@ module VCAP::CloudController
           expected_response_object['suspended'] = true
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
 
@@ -1340,7 +1340,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
       end
 
       describe 'when the user is not logged in' do

--- a/spec/request/packages_spec.rb
+++ b/spec/request/packages_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'Packages' do
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
 
@@ -214,7 +214,7 @@ RSpec.describe 'Packages' do
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
   end
@@ -271,7 +271,7 @@ RSpec.describe 'Packages' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     context 'when listing paginated results of all packages for an app' do
@@ -528,7 +528,7 @@ RSpec.describe 'Packages' do
         Hash.new(code: 200, response_object: packages_response_object)
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     context 'when listing a subset of packages' do
@@ -790,7 +790,7 @@ RSpec.describe 'Packages' do
       h
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
   end
 
   describe 'POST /v3/packages/:guid/upload' do
@@ -966,7 +966,7 @@ RSpec.describe 'Packages' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1049,7 +1049,7 @@ RSpec.describe 'Packages' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1116,7 +1116,7 @@ RSpec.describe 'Packages' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1196,7 +1196,7 @@ RSpec.describe 'Packages' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe 'Processes' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -454,7 +454,7 @@ RSpec.describe 'Processes' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -587,7 +587,7 @@ RSpec.describe 'Processes' do
       end
 
       # while this endpoint returns a list, it's easier to test as a single object since it doesn't paginate
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -674,7 +674,7 @@ RSpec.describe 'Processes' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     it 'updates the process' do
@@ -968,7 +968,7 @@ RSpec.describe 'Processes' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1162,7 +1162,7 @@ RSpec.describe 'Processes' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1248,7 +1248,7 @@ RSpec.describe 'Processes' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1548,7 +1548,7 @@ RSpec.describe 'Processes' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 end

--- a/spec/request/revisions_spec.rb
+++ b/spec/request/revisions_spec.rb
@@ -72,14 +72,14 @@ RSpec.describe 'Revisions' do
       h
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
   end
 
   describe 'GET /v3/apps/:guid/revisions' do
     let!(:revision2) { VCAP::CloudController::RevisionModel.make(app: app_model, version: 43, description: 'New droplet deployed') }
 
     context 'gets all revisions for an app' do
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| get "/v3/apps/#{app_model.guid}/revisions", { per_page: '2' }, user_headers } }
         let(:revision_response_object) do
           {
@@ -552,7 +552,7 @@ RSpec.describe 'Revisions' do
     let!(:process2) { VCAP::CloudController::ProcessModel.make(app: app_model, revision: revision2, type: 'worker', state: 'STARTED') }
     let!(:process3) { VCAP::CloudController::ProcessModel.make(app: app_model, revision: revision3, type: 'web', state: 'STOPPED') }
 
-    it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
       let(:api_call) { lambda { |user_headers| get "/v3/apps/#{app_model.guid}/revisions/deployed?per_page=2", nil, user_headers } }
       let(:revision_response_object) do
         {

--- a/spec/request/roles_spec.rb
+++ b/spec/request/roles_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Roles Request' do
         org.add_user(user_with_role)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       context 'when user is invalid' do
         let(:params) do
@@ -207,7 +207,7 @@ RSpec.describe 'Roles Request' do
         org.add_user(user_with_role)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       context 'when organization is invalid' do
         let(:params) do
@@ -315,7 +315,7 @@ RSpec.describe 'Roles Request' do
           org.add_user(user_with_role)
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when there are multiple users with the same username' do
@@ -437,7 +437,7 @@ RSpec.describe 'Roles Request' do
         allow(uaa_client).to receive(:usernames_for_ids).with([user_unaffiliated.guid]).and_return({ user_unaffiliated.guid => 'bob_unaffiliated' })
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'creating a role by username and origin' do
@@ -508,7 +508,7 @@ RSpec.describe 'Roles Request' do
         org.add_user(user_with_role)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       context 'when the flag to set roles by username is disabled' do
         before do
@@ -543,7 +543,7 @@ RSpec.describe 'Roles Request' do
           h['org_billing_manager'] = { code: 422 }
           h
         end
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when there is no user with the given username and origin' do
@@ -672,7 +672,7 @@ RSpec.describe 'Roles Request' do
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
         context 'when the flag to set roles by username is disabled' do
           before do
@@ -688,7 +688,7 @@ RSpec.describe 'Roles Request' do
             h
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
         end
       end
     end
@@ -1038,7 +1038,7 @@ RSpec.describe 'Roles Request' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
       context 'when the user is not logged in' do
         it 'returns 401 for Unauthenticated requests' do
@@ -1076,7 +1076,7 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
     context 'listing roles with overlapping timestamps' do
       let!(:user_jeff) { VCAP::CloudController::User.make(guid: 'jeff-guid') }
@@ -1363,7 +1363,7 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
         org.add_user(user_with_role)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when getting a org role' do
@@ -1400,7 +1400,7 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the role does not exist' do
@@ -1561,7 +1561,7 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
     end
 
     context 'when deleting an org role' do
@@ -1575,7 +1575,7 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
 
       context 'and the user still has a role in a space within that org' do
         let(:org_user_role) { VCAP::CloudController::OrganizationUser.find(user_id: user_with_role.id) }

--- a/spec/request/route_destinations_spec.rb
+++ b/spec/request/route_destinations_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe 'Route Destinations Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the route does not exist' do
@@ -302,7 +302,7 @@ RSpec.describe 'Route Destinations Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:expected_event_hash) do
           new_destination = parsed_response['destinations'].detect { |dst| dst['guid'] != existing_destination.guid }
 
@@ -777,7 +777,7 @@ RSpec.describe 'Route Destinations Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       context 'when the user is not logged in' do
         it 'returns 401 for Unauthenticated requests' do
@@ -1191,7 +1191,7 @@ RSpec.describe 'Route Destinations Request' do
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
         let(:expected_event_hash) do
           {
             type: 'audit.app.unmap-route',

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     describe 'includes' do
@@ -979,7 +979,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     describe 'when the user is not logged in' do
@@ -1203,7 +1203,7 @@ RSpec.describe 'Routes Request' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
         end
       end
 
@@ -1366,7 +1366,7 @@ RSpec.describe 'Routes Request' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
         end
       end
     end
@@ -1464,7 +1464,7 @@ RSpec.describe 'Routes Request' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
         end
       end
 
@@ -1535,7 +1535,7 @@ RSpec.describe 'Routes Request' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
         end
       end
 
@@ -1623,7 +1623,7 @@ RSpec.describe 'Routes Request' do
         end
 
         context 'and the user provides a valid port' do
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
           context 'and a route with the domain and port already exist' do
             let!(:duplicate_route) { VCAP::CloudController::Route.make(host: '', space: space, domain: domain, port: 123) }
@@ -1661,7 +1661,7 @@ RSpec.describe 'Routes Request' do
             }
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
           context 'and randomly selected port is already in use' do
             let(:existing_route) { VCAP::CloudController::Route.make(host: '', space: space, domain: domain, port: 123) }
@@ -1757,7 +1757,7 @@ RSpec.describe 'Routes Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
 
@@ -1878,7 +1878,7 @@ RSpec.describe 'Routes Request' do
             h.freeze
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
         end
       end
     end
@@ -2112,7 +2112,7 @@ RSpec.describe 'Routes Request' do
         VCAP::CloudController::Config.config.set(:system_domain, domain.name)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     describe 'quotas' do
@@ -2418,7 +2418,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the user is not a member in the routes org' do
@@ -2478,7 +2478,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when route does not exist' do
@@ -2568,7 +2568,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
         let(:expected_event_hash) do
           {
             type: 'audit.route.delete-request',
@@ -2703,7 +2703,7 @@ RSpec.describe 'Routes Request' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     context 'ports filter' do

--- a/spec/request/security_groups_spec.rb
+++ b/spec/request/security_groups_spec.rb
@@ -696,7 +696,7 @@ RSpec.describe 'Security_Groups Request' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     context 'filtering security groups' do
@@ -820,7 +820,7 @@ RSpec.describe 'Security_Groups Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'getting a security group NOT globally enabled, associated with spaces' do
@@ -892,7 +892,7 @@ RSpec.describe 'Security_Groups Request' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'getting a security group globally enabled' do
@@ -927,7 +927,7 @@ RSpec.describe 'Security_Groups Request' do
         Hash.new(code: 200, response_object: expected_response)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'security group does not exist' do

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'V3 service brokers' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     describe 'global service brokers' do
@@ -212,7 +212,7 @@ RSpec.describe 'V3 service brokers' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     describe 'spaced-scoped service brokers' do
@@ -268,7 +268,7 @@ RSpec.describe 'V3 service brokers' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
       it 'returns 200 OK and an empty list of brokers for space developer in another space' do
         expect_empty_list(space_developer_alternate_space_headers)
@@ -401,7 +401,7 @@ RSpec.describe 'V3 service brokers' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the service broker is space scoped' do
@@ -458,7 +458,7 @@ RSpec.describe 'V3 service brokers' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       it 'returns 404 Not Found for space developer in another space' do
         is_expected.to_not find_broker(broker_guid: space_scoped_service_broker.guid, with: space_developer_alternate_space_headers)
@@ -493,7 +493,7 @@ RSpec.describe 'V3 service brokers' do
       }
 
       context 'global service broker' do
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:api_call) { ->(user_headers) { patch "/v3/service_brokers/#{broker.guid}", update_request_body.to_json, user_headers } }
           let(:expected_codes_and_responses) do
             Hash.new(code: 404).tap do |h|
@@ -524,7 +524,7 @@ RSpec.describe 'V3 service brokers' do
           )
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:api_call) { ->(user_headers) { patch "/v3/service_brokers/#{broker.guid}", update_request_body.to_json, user_headers } }
 
           let(:expected_codes_and_responses) { responses_for_space_restricted_update_endpoint }
@@ -1007,7 +1007,7 @@ RSpec.describe 'V3 service brokers' do
     end
 
     context 'global service broker' do
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| post '/v3/service_brokers', global_broker_request_body.to_json, user_headers } }
         let(:expected_codes_and_responses) do
           Hash.new(code: 403).tap do |h|
@@ -1058,7 +1058,7 @@ RSpec.describe 'V3 service brokers' do
         }
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| post '/v3/service_brokers', space_scoped_broker_request_body.to_json, user_headers } }
 
         let(:expected_codes_and_responses) { responses_for_space_restricted_create_endpoint }
@@ -1447,7 +1447,7 @@ RSpec.describe 'V3 service brokers' do
       context 'global broker' do
         let(:broker) { global_broker }
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
           let(:expected_codes_and_responses) {
             Hash.new(code: 404).tap do |h|
               h['admin'] = { code: 202 }
@@ -1461,7 +1461,7 @@ RSpec.describe 'V3 service brokers' do
       context 'space-scoped broker' do
         let(:broker) { VCAP::CloudController::ServiceBroker.make(space_id: space.id) }
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
           let(:expected_codes_and_responses) { responses_for_space_restricted_async_delete_endpoint }
         end
 

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -615,7 +615,7 @@ RSpec.describe 'v3 service credential bindings' do
     }
 
     context 'permissions' do
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:expected_codes_and_responses) do
           h = Hash.new(code: 404, response_object: binding_credentials)
           h['admin'] = h['admin_read_only'] = h['space_developer'] = { code: 200 }
@@ -784,7 +784,7 @@ RSpec.describe 'v3 service credential bindings' do
         stub_param_broker_request_for_binding(binding, binding_params)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:expected_codes_and_responses) do
           responses_for_space_restricted_single_endpoint(
             binding_params,
@@ -1112,7 +1112,7 @@ RSpec.describe 'v3 service credential bindings' do
       context 'user-provided service' do
         let(:service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make(space: space, **service_instance_details) }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:expected_codes_and_responses) do
             Hash.new(code: 403).tap do |h|
               h['admin'] = h['space_developer'] = h['space_supporter'] = { code: 201 }
@@ -1256,7 +1256,7 @@ RSpec.describe 'v3 service credential bindings' do
 
         context 'permissions' do
           context 'users in the originating service instance space' do
-            it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+            it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
               let(:expected_codes_and_responses) do
                 Hash.new(code: 403).tap do |h|
                   h['admin'] = h['space_developer'] = h['space_supporter'] = { code: 202 }
@@ -1281,7 +1281,7 @@ RSpec.describe 'v3 service credential bindings' do
               service_instance.add_shared_space(space)
             end
 
-            it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+            it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
               let(:expected_codes_and_responses) do
                 Hash.new(code: 403).tap do |h|
                   h['admin'] = h['space_developer'] = h['space_supporter'] = { code: 202 }
@@ -1386,7 +1386,7 @@ RSpec.describe 'v3 service credential bindings' do
 
       context 'permissions' do
         context 'users in the originating service instance space' do
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
             let(:expected_codes_and_responses) do
               Hash.new(code: 403).tap do |h|
                 h['admin'] = h['space_developer'] = h['space_supporter'] = { code: 202 }
@@ -1413,7 +1413,7 @@ RSpec.describe 'v3 service credential bindings' do
             service_instance.add_shared_space(space)
           end
 
-          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+          it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
             let(:expected_codes_and_responses) do
               Hash.new(code: 403).tap do |h|
                 h['admin'] = { code: 202 }
@@ -2112,7 +2112,7 @@ RSpec.describe 'v3 service credential bindings' do
         }
 
         context 'users in the originating service instance space' do
-          it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+          it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
             let(:expected_codes_and_responses) do
               Hash.new(code: 403).tap do |h|
                 h['admin'] = h['space_developer'] = h['space_supporter'] = { code: 202 }
@@ -2137,7 +2137,7 @@ RSpec.describe 'v3 service credential bindings' do
             service_instance.add_shared_space(space)
           end
 
-          it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+          it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
             let(:expected_codes_and_responses) do
               Hash.new(code: 403).tap do |h|
                 h['admin'] = h['space_developer'] = h['space_supporter'] = { code: 202 }

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -562,7 +562,6 @@ RSpec.describe 'V3 service instances' do
           response_object: parameters,
         )
 
-        # h['space_supporter'] = { code: 403 }
         h['org_auditor'] = { code: 404 }
         h['org_billing_manager'] = { code: 404 }
         h['no_role'] = { code: 404 }

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'V3 service instances' do
         Hash.new(code: 404)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'managed service instance' do
@@ -29,11 +29,11 @@ RSpec.describe 'V3 service instances' do
       let(:expected_codes_and_responses) do
         responses_for_space_restricted_single_endpoint(
           create_managed_json(instance),
-          permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_supporter']
+          permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'user-provided service instance' do
@@ -43,11 +43,11 @@ RSpec.describe 'V3 service instances' do
       let(:expected_codes_and_responses) do
         responses_for_space_restricted_single_endpoint(
           create_user_provided_json(instance),
-          permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_supporter']
+          permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'shared service instance' do
@@ -62,11 +62,11 @@ RSpec.describe 'V3 service instances' do
       let(:expected_codes_and_responses) do
         responses_for_space_restricted_single_endpoint(
           create_managed_json(instance),
-          permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_supporter']
+          permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'fields' do
@@ -251,7 +251,7 @@ RSpec.describe 'V3 service instances' do
           h
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
       end
 
       describe 'filters' do
@@ -500,7 +500,7 @@ RSpec.describe 'V3 service instances' do
   end
 
   describe 'GET /v3/service_instances/:guid/credentials' do
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:api_call) { lambda { |user_headers| get "/v3/service_instances/#{guid}/credentials", nil, user_headers } }
       let(:credentials) { { 'fake-key' => 'fake-value' } }
       let(:instance) { VCAP::CloudController::UserProvidedServiceInstance.make(space: space, credentials: credentials) }
@@ -550,7 +550,7 @@ RSpec.describe 'V3 service instances' do
         to_return(status: response_code, body: body)
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:api_call) { lambda { |user_headers| get "/v3/service_instances/#{guid}/parameters", nil, user_headers } }
       let(:parameters) { { 'some-key' => 'some-value' } }
       let(:body) { { 'parameters' => parameters }.to_json }
@@ -562,7 +562,7 @@ RSpec.describe 'V3 service instances' do
           response_object: parameters,
         )
 
-        h['space_supporter'] = { code: 403 }
+        # h['space_supporter'] = { code: 403 }
         h['org_auditor'] = { code: 404 }
         h['org_billing_manager'] = { code: 404 }
         h['no_role'] = { code: 404 }
@@ -656,7 +656,7 @@ RSpec.describe 'V3 service instances' do
     end
 
     context 'when the instance is shared' do
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| get "/v3/service_instances/#{guid}/parameters", nil, user_headers } }
         let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: another_space, service_plan: service_plan) }
         let(:parameters) { { 'some-key' => 'some-value' } }
@@ -730,7 +730,7 @@ RSpec.describe 'V3 service instances' do
       headers_for(user)
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:expected_codes_and_responses) { responses_for_space_restricted_create_endpoint(success_code: 201) }
     end
 
@@ -1506,7 +1506,7 @@ RSpec.describe 'V3 service instances' do
       {}
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:guid) { VCAP::CloudController::ServiceInstance.make(space: space).guid }
       let(:expected_codes_and_responses) { responses_for_space_restricted_update_endpoint(success_code: 200) }
     end
@@ -2618,7 +2618,7 @@ RSpec.describe 'V3 service instances' do
         }
       }
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
         let(:expected_codes_and_responses) { responses_for_space_restricted_delete_endpoint }
       end
 
@@ -3325,7 +3325,7 @@ RSpec.describe 'V3 service instances' do
     end
 
     describe 'permissions' do
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:expected_codes_and_responses) { responses_for_space_restricted_update_endpoint(success_code: 200) }
       end
 
@@ -3338,7 +3338,7 @@ RSpec.describe 'V3 service instances' do
           space
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:expected_codes_and_responses) do
             responses_for_org_suspended_space_restricted_update_endpoint(success_code: 200).merge({ 'space_developer' => { code: 422 } })
           end
@@ -3550,11 +3550,11 @@ RSpec.describe 'V3 service instances' do
         }
       }
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
         let(:expected_codes_and_responses) { responses_for_space_restricted_delete_endpoint }
       end
 
-      it_behaves_like 'permissions for delete endpoint when organization is suspended', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for delete endpoint when organization is suspended', ALL_PERMISSIONS do
         let(:expected_codes) { responses_for_org_suspended_space_restricted_delete_endpoint(success_code: 204) }
       end
     end
@@ -3682,7 +3682,7 @@ RSpec.describe 'V3 service instances' do
     describe 'permissions in originating space' do
       let(:api_call) { lambda { |user_headers| get "/v3/service_instances/#{instance.guid}/relationships/shared_spaces", nil, user_headers } }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:expected_response) do
           {
             data: [{ guid: other_space.guid }],
@@ -3695,7 +3695,7 @@ RSpec.describe 'V3 service instances' do
         let(:expected_codes_and_responses) do
           responses_for_space_restricted_single_endpoint(
             expected_response,
-            permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_supporter']
+            permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles
           )
         end
       end
@@ -3819,7 +3819,7 @@ RSpec.describe 'V3 service instances' do
         responses_for_space_restricted_single_endpoint(response_object)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the instance does not exist' do

--- a/spec/request/service_offerings_spec.rb
+++ b/spec/request/service_offerings_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'V3 service offerings' do
         Hash.new(code: 404)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     context 'when service plan is not available in any orgs' do
@@ -42,7 +42,7 @@ RSpec.describe 'V3 service offerings' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     context 'when service offering is publicly available' do
@@ -53,7 +53,7 @@ RSpec.describe 'V3 service offerings' do
         Hash.new(successful_response)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -66,7 +66,7 @@ RSpec.describe 'V3 service offerings' do
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe 'V3 service offerings' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     context 'when service offering comes from space scoped broker' do
@@ -119,7 +119,7 @@ RSpec.describe 'V3 service offerings' do
           )
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'the user is in a different space to the service broker' do
@@ -135,7 +135,7 @@ RSpec.describe 'V3 service offerings' do
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'the user is a SpaceDeveloper in the space of the broker, but is targeting a different space' do
@@ -154,7 +154,7 @@ RSpec.describe 'V3 service offerings' do
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
     end
 
@@ -302,7 +302,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     describe 'pagination' do
@@ -655,7 +655,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     context 'when the service offering exists and has no plans' do
@@ -680,7 +680,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     context 'when the service offering exists and has public plans' do
@@ -694,7 +694,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     context 'when the service offering exists and has org-scoped plans' do
@@ -714,7 +714,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     context 'when the service offering is from a space-scoped service broker' do
@@ -745,7 +745,7 @@ RSpec.describe 'V3 service offerings' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     describe 'audit events' do
@@ -865,7 +865,7 @@ RSpec.describe 'V3 service offerings' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'when the service offering exists and has public plans' do
@@ -881,7 +881,7 @@ RSpec.describe 'V3 service offerings' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'when the service offering exists and has org-scoped plans' do
@@ -903,7 +903,7 @@ RSpec.describe 'V3 service offerings' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'when the service offering is from a space-scoped service broker' do
@@ -937,7 +937,7 @@ RSpec.describe 'V3 service offerings' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
     end
   end

--- a/spec/request/service_plan_visibility_spec.rb
+++ b/spec/request/service_plan_visibility_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'V3 service plan visibility' do
         )
       }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'for admin-only plans' do
@@ -50,7 +50,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'for space-scoped plans' do
@@ -92,7 +92,7 @@ RSpec.describe 'V3 service plan visibility' do
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'for org-restricted plans' do
@@ -143,7 +143,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       }
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -170,13 +170,13 @@ RSpec.describe 'V3 service plan visibility' do
         let(:req_body) { { type: 'admin' } }
         let(:successful_response) { { code: 200, response_object: { type: 'admin' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'and its being updated to "public"' do
         let(:successful_response) { { code: 200, response_object: { type: 'public' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'and its being updated to "organization"' do
@@ -184,7 +184,7 @@ RSpec.describe 'V3 service plan visibility' do
         let(:org_response) { [{ name: org.name, guid: org.guid }, { name: other_org.name, guid: other_org.guid }] }
         let(:successful_response) { { code: 200, response_object: { type: 'organization', organizations: org_response } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
 
@@ -200,14 +200,14 @@ RSpec.describe 'V3 service plan visibility' do
       context 'and its being updated to "public"' do
         let(:successful_response) { { code: 200, response_object: { type: 'public' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'and its being updated to "admin"' do
         let(:req_body) { { type: 'admin' } }
         let(:successful_response) { { code: 200, response_object: { type: 'admin' } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'and its being updated to "organization"' do
@@ -215,7 +215,7 @@ RSpec.describe 'V3 service plan visibility' do
         let(:org_response) { [{ name: org.name, guid: org.guid }, { name: other_org.name, guid: other_org.guid }] }
         let(:successful_response) { { code: 200, response_object: { type: 'organization', organizations: org_response } } }
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
 
@@ -259,7 +259,7 @@ RSpec.describe 'V3 service plan visibility' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:after_request_check) do
             lambda do
               visibilities = VCAP::CloudController::ServicePlanVisibility.where(service_plan: service_plan).all
@@ -289,7 +289,7 @@ RSpec.describe 'V3 service plan visibility' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:after_request_check) do
             lambda do
               visibilities = VCAP::CloudController::ServicePlanVisibility.where(service_plan: service_plan).all
@@ -551,7 +551,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       it 'returns a 404 for users of other orgs' do
         new_org = VCAP::CloudController::Organization.make
@@ -630,7 +630,7 @@ RSpec.describe 'V3 service plan visibility' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
     end
 
     it 'creates an audit event' do

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'V3 service plans' do
         Hash.new(code: 404)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     context 'when there is a public service plan' do
@@ -40,7 +40,7 @@ RSpec.describe 'V3 service plans' do
         )
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -68,7 +68,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'space scoped broker' do
@@ -92,7 +92,7 @@ RSpec.describe 'V3 service plans' do
           )
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
     end
 
@@ -278,7 +278,7 @@ RSpec.describe 'V3 service plans' do
         end
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
 
       context 'when the hide_marketplace_from_unauthenticated_users feature flag is enabled' do
         before do
@@ -642,7 +642,7 @@ RSpec.describe 'V3 service plans' do
         end
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
     end
 
     context 'when the service plan exists and has no service instances' do
@@ -660,7 +660,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'when the plan is public' do
@@ -673,7 +673,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'when the plan is visible only on some orgs' do
@@ -691,7 +691,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'when the plan is from a space-scoped service broker' do
@@ -712,7 +712,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
     end
 
@@ -811,7 +811,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'when the plan is public' do
@@ -824,7 +824,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'when the plan is visible only on some orgs' do
@@ -842,7 +842,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
 
       context 'when the plan is from a space-scoped service broker' do
@@ -863,7 +863,7 @@ RSpec.describe 'V3 service plans' do
           end
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + UNAUTHENTICATED
       end
     end
   end

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'v3 service route bindings' do
         Hash.new(code: 200, response_objects: [])
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     describe 'a mix of bindings' do
@@ -121,7 +121,7 @@ RSpec.describe 'v3 service route bindings' do
         VCAP::CloudController::AnnotationsUpdate.update(route_binding_2, route_binding_2_metadata[:annotations], VCAP::CloudController::RouteBindingAnnotationModel)
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     describe 'filtering' do
@@ -305,7 +305,7 @@ RSpec.describe 'v3 service route bindings' do
         VCAP::CloudController::AnnotationsUpdate.update(route_binding, metadata[:annotations], VCAP::CloudController::RouteBindingAnnotationModel)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'managed service instance' do
@@ -318,7 +318,7 @@ RSpec.describe 'v3 service route bindings' do
         VCAP::CloudController::AnnotationsUpdate.update(route_binding, metadata[:annotations], VCAP::CloudController::RouteBindingAnnotationModel)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'does not exist' do
@@ -899,7 +899,7 @@ RSpec.describe 'v3 service route bindings' do
       end
 
       describe 'permissions' do
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:expected_codes_and_responses) do
             Hash.new(code: 403).tap do |h|
               h['admin'] = { code: 202 }
@@ -999,7 +999,7 @@ RSpec.describe 'v3 service route bindings' do
       it_behaves_like 'create route binding'
 
       context 'permissions' do
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
           let(:expected_codes_and_responses) do
             Hash.new(code: 403).tap do |h|
               h['admin'] = { code: 201 }
@@ -1156,7 +1156,7 @@ RSpec.describe 'v3 service route bindings' do
           end
         }
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
 
         it 'creates an audit log' do
           api_call.call(admin_headers)
@@ -1205,7 +1205,7 @@ RSpec.describe 'v3 service route bindings' do
           }
         end
 
-        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
 
         it 'responds with a job resource' do
           api_call.call(space_dev_headers)
@@ -1573,7 +1573,7 @@ RSpec.describe 'v3 service route bindings' do
           to_return(status: broker_status_code, body: broker_response.to_json, headers: {})
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       it 'calls the broker with the identity header' do
         api_call.call(space_dev_headers)
@@ -1643,7 +1643,7 @@ RSpec.describe 'v3 service route bindings' do
         end
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       it 'returns the appropriate error' do
         api_call.call(admin_headers)
@@ -1682,7 +1682,7 @@ RSpec.describe 'v3 service route bindings' do
 
     it_behaves_like 'metadata update for service binding', 'service_route_binding'
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:response_object) {
         expected_json(
           binding_guid: binding.guid,

--- a/spec/request/sidecars_spec.rb
+++ b/spec/request/sidecars_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe 'Sidecars' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -525,7 +525,7 @@ RSpec.describe 'Sidecars' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -648,7 +648,7 @@ RSpec.describe 'Sidecars' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
   end
 

--- a/spec/request/space_features_spec.rb
+++ b/spec/request/space_features_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe 'Space Features' do
     let(:expected_codes_and_responses) do
       responses_for_space_restricted_single_endpoint(
         space_features_json,
-        permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_supporter']
+        permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles
       )
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
   end
 
   describe 'GET /v3/spaces/:guid/features/:name' do
@@ -51,11 +51,11 @@ RSpec.describe 'Space Features' do
     let(:expected_codes_and_responses) do
       responses_for_space_restricted_single_endpoint(
         space_ssh_feature_json,
-        permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles + ['space_supporter']
+        permitted_roles: SpaceRestrictedResponseGenerators.default_permitted_roles
       )
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
   end
 
   describe 'PATCH /v3/spaces/:guid/features/:name' do

--- a/spec/request/space_manifests_spec.rb
+++ b/spec/request/space_manifests_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'Space Manifests' do
         space.remove_developer(user)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:api_call) { lambda { |user_headers| post "/v3/spaces/#{space.guid}/actions/apply_manifest", yml_manifest, yml_headers(user_headers) } }
         let(:org) { space.organization }
         let(:expected_codes_and_responses) do
@@ -650,7 +650,7 @@ RSpec.describe 'Space Manifests' do
         default_manifest.to_yaml
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the app name has changed' do

--- a/spec/request/space_quotas_spec.rb
+++ b/spec/request/space_quotas_spec.rb
@@ -27,7 +27,7 @@ module VCAP::CloudController
           h
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when the space quota has no associated spaces' do
@@ -43,7 +43,7 @@ module VCAP::CloudController
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when the space quota is owned by an org where the current user does not have a role' do
@@ -59,7 +59,7 @@ module VCAP::CloudController
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when the space quota does not exist' do
@@ -300,7 +300,7 @@ module VCAP::CloudController
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
       end
 
       context 'with filters' do

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe 'Spaces' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -465,7 +465,7 @@ RSpec.describe 'Spaces' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -619,7 +619,7 @@ RSpec.describe 'Spaces' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -771,7 +771,7 @@ RSpec.describe 'Spaces' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -854,7 +854,7 @@ RSpec.describe 'Spaces' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:expected_event_hash) do
           {
             type: 'audit.space.update',
@@ -1025,7 +1025,7 @@ RSpec.describe 'Spaces' do
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS do
         let(:expected_event_hash) do
           {
             type: 'audit.space.delete-request',
@@ -1087,7 +1087,7 @@ RSpec.describe 'Spaces' do
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
     end
 
     context 'when user does not specify unmapped query param' do
@@ -1158,7 +1158,7 @@ RSpec.describe 'Spaces' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 
@@ -1192,7 +1192,7 @@ RSpec.describe 'Spaces' do
         h
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 

--- a/spec/request/stacks_spec.rb
+++ b/spec/request/stacks_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Stacks Request' do
     let(:api_call) { lambda { |user_header| get '/v3/stacks', nil, user_header } }
 
     context 'lists all stacks' do
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
         let(:stacks_response_object) do
           {
             'pagination' => {
@@ -281,7 +281,7 @@ RSpec.describe 'Stacks Request' do
       Hash.new(code: 200, response_object: stacks_response_object)
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
   end
 
   describe 'GET /v3/stacks/:guid/apps' do
@@ -520,7 +520,7 @@ RSpec.describe 'Stacks Request' do
         h
       end
 
-      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
     context 'user is not logged in' do

--- a/spec/request/tasks_spec.rb
+++ b/spec/request/tasks_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe 'Tasks' do
       end
     end
 
-    it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
       let(:api_call) { lambda { |user_headers| get '/v3/tasks', nil, user_headers } }
       let(:task1) do
         VCAP::CloudController::TaskModel.make(
@@ -398,7 +398,7 @@ RSpec.describe 'Tasks' do
   end
 
   describe 'GET /v3/tasks/:guid' do
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:task) do
         VCAP::CloudController::TaskModel.make(
           name:         'task',
@@ -562,7 +562,7 @@ RSpec.describe 'Tasks' do
       expect(parsed_response).to be_a_response_like(expected_response)
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       before do
         space.remove_developer(user)
       end
@@ -592,7 +592,7 @@ RSpec.describe 'Tasks' do
       allow(bbs_task_client).to receive(:cancel_task)
     end
 
-    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
       let(:api_call) { lambda { |user_headers| post "/v3/tasks/#{task.guid}/actions/cancel", nil, user_headers } }
       let(:expected_response) do
         {
@@ -762,7 +762,7 @@ RSpec.describe 'Tasks' do
       end
     end
 
-    it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+    it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS do
       let(:api_call) { lambda { |user_headers| get "/v3/apps/#{app_model.guid}/tasks", nil, user_headers } }
       let(:task1) do
         VCAP::CloudController::TaskModel.make(

--- a/spec/request/users_spec.rb
+++ b/spec/request/users_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'Users Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
       end
 
       context 'when the actee has an org or space role' do
@@ -213,7 +213,7 @@ RSpec.describe 'Users Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
       end
     end
 
@@ -232,7 +232,7 @@ RSpec.describe 'Users Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
       end
 
       context 'when filtering by usernames and origins' do
@@ -280,7 +280,7 @@ RSpec.describe 'Users Request' do
           )
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
       end
 
       context 'when filtering by usernames' do
@@ -305,7 +305,7 @@ RSpec.describe 'Users Request' do
           )
         end
 
-        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
         context 'when UAA is disabled' do
           before do
@@ -452,7 +452,7 @@ RSpec.describe 'Users Request' do
         h.freeze
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the actee has an org or space role' do
@@ -472,7 +472,7 @@ RSpec.describe 'Users Request' do
         org.add_user(actee)
       end
 
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
 
     context 'when the user is not logged in' do
@@ -852,7 +852,7 @@ RSpec.describe 'Users Request' do
           h.freeze
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when the actee has an org or space role' do
@@ -874,7 +874,7 @@ RSpec.describe 'Users Request' do
           org.add_user(actee)
         end
 
-        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter']
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
 
       context 'when metadata is invalid' do
@@ -926,7 +926,7 @@ RSpec.describe 'Users Request' do
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
     end
 
     context 'when the actee has an org or space role' do
@@ -941,7 +941,7 @@ RSpec.describe 'Users Request' do
         h
       end
 
-      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS + ['space_supporter']
+      it_behaves_like 'permissions for delete endpoint', ALL_PERMISSIONS
     end
 
     context 'when the user is not logged in' do
@@ -989,7 +989,7 @@ RSpec.describe 'Users Request' do
     end
 
     context 'permissions' do
-      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS + ['space_supporter'] do
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS do
         let(:expected_codes_and_responses) do
           h = Hash.new(code: 404)
           h['admin'] = { code: 202 }

--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -8,6 +8,7 @@ LOCAL_ROLES = %w[
   space_developer
   space_manager
   space_auditor
+  space_supporter
   org_manager
   org_auditor
   org_billing_manager

--- a/spec/support/space_restricted_response_generators.rb
+++ b/spec/support/space_restricted_response_generators.rb
@@ -7,6 +7,7 @@ module SpaceRestrictedResponseGenerators
       space_developer
       space_manager
       space_auditor
+      space_supporter
       org_manager
     )
   end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -214,7 +214,7 @@ module UserHelpers
 
   def allow_user_write_access(user, space:)
     allow(permissions_double(user)).to receive(:can_write_to_space?).with(space.guid).and_return(true)
-    allow(permissions_double(user)).to receive(:untrusted_can_write_to_space?).with(space.guid).and_return(true)
+    allow(permissions_double(user)).to receive(:can_manage_apps_in_space?).with(space.guid).and_return(true)
   end
 
   def allow_user_read_access_for(user, orgs: [], spaces: [])
@@ -225,10 +225,10 @@ module UserHelpers
     stub_readable_org_guids_for(user, orgs)
 
     allow(permissions_double(user)).to receive(:can_read_from_space?).and_return(false)
-    allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).and_return(false)
+    allow(permissions_double(user)).to receive(:can_read_from_space?).and_return(false)
     spaces.each do |space|
       allow(permissions_double(user)).to receive(:can_read_from_space?).with(space.guid, space.organization_guid).and_return(true)
-      allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).with(space.guid, space.organization_guid).and_return(true)
+      allow(permissions_double(user)).to receive(:can_read_from_space?).with(space.guid, space.organization_guid).and_return(true)
     end
 
     stub_readable_space_guids_for(user, spaces)
@@ -252,7 +252,7 @@ module UserHelpers
 
   def disallow_user_read_access(user, space:)
     allow(permissions_double(user)).to receive(:can_read_from_space?).with(space.guid, space.organization_guid).and_return(false)
-    allow(permissions_double(user)).to receive(:untrusted_can_read_from_space?).with(space.guid, space.organization_guid).and_return(false)
+    allow(permissions_double(user)).to receive(:can_read_from_space?).with(space.guid, space.organization_guid).and_return(false)
   end
 
   def disallow_user_build_update_access(user)
@@ -267,12 +267,12 @@ module UserHelpers
 
   def disallow_user_write_access(user, space:)
     allow(permissions_double(user)).to receive(:can_write_to_space?).with(space.guid).and_return(false)
-    allow(permissions_double(user)).to receive(:untrusted_can_write_to_space?).with(space.guid).and_return(false)
+    allow(permissions_double(user)).to receive(:can_manage_apps_in_space?).with(space.guid).and_return(false)
   end
 
   def stub_readable_space_guids_for(user, spaces)
     allow(permissions_double(user)).to receive(:readable_space_guids).and_return(spaces.map(&:guid))
-    allow(permissions_double(user)).to receive(:readable_supporter_space_guids).and_return(spaces.map(&:guid))
+    allow(permissions_double(user)).to receive(:readable_space_guids).and_return(spaces.map(&:guid))
   end
 
   def stub_readable_org_guids_for(user, orgs)

--- a/spec/unit/controllers/v3/app_manifests_controller_spec.rb
+++ b/spec/unit/controllers/v3/app_manifests_controller_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe AppManifestsController, type: :controller do
             'space_developer' => 200,
             'space_manager' => 403,
             'space_auditor' => 403,
+            'space_supporter' => 403,
             'org_manager' => 403,
             'org_auditor' => 404,
             'org_billing_manager' => 404,

--- a/spec/unit/controllers/v3/packages_controller_spec.rb
+++ b/spec/unit/controllers/v3/packages_controller_spec.rb
@@ -675,6 +675,7 @@ RSpec.describe PackagesController, type: :controller do
             'space_developer' => 200,
             'space_manager' => 403,
             'space_auditor' => 403,
+            'space_supporter' => 403,
             'org_manager' => 403,
             'org_auditor' => 404,
             'org_billing_manager' => 404,

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -175,14 +175,14 @@ module VCAP::CloudController
 
         before do
           allow(membership).to receive(:org_guids_for_roles_subquery).
-            with(Permissions::ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + Permissions::SPACE_ROLES_INCLUDING_SUPPORTERS).
+            with(Permissions::ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + Permissions::SPACE_ROLES).
             and_return(subquery)
           allow(Membership).to receive(:new).with(user).and_return(membership)
         end
 
         it 'combines readable orgs for both org-scoped and space-scoped roles' do
           allow(membership).to receive(:space_guids_for_roles).
-            with(Permissions::SPACE_ROLES_INCLUDING_SUPPORTERS).
+            with(Permissions::SPACE_ROLES).
             and_return([space_guid])
 
           expect(permissions.readable_org_guids_for_domains_query).
@@ -392,7 +392,7 @@ module VCAP::CloudController
       end
     end
 
-    describe '#readable_supporter_space_guids' do
+    describe '#readable_space_guids' do
       it 'returns all the space guids for admins' do
         user = set_current_user_as_admin
         subject = Permissions.new(user)
@@ -402,7 +402,7 @@ module VCAP::CloudController
         org2 = Organization.make
         space2 = Space.make(organization: org2)
 
-        space_guids = subject.readable_supporter_space_guids
+        space_guids = subject.readable_space_guids
 
         expect(space_guids).to include(space1.guid)
         expect(space_guids).to include(space2.guid)
@@ -417,7 +417,7 @@ module VCAP::CloudController
         org2 = Organization.make
         space2 = Space.make(organization: org2)
 
-        space_guids = subject.readable_supporter_space_guids
+        space_guids = subject.readable_space_guids
 
         expect(space_guids).to include(space1.guid)
         expect(space_guids).to include(space2.guid)
@@ -432,7 +432,7 @@ module VCAP::CloudController
         org2 = Organization.make
         space2 = Space.make(organization: org2)
 
-        space_guids = subject.readable_supporter_space_guids
+        space_guids = subject.readable_space_guids
 
         expect(space_guids).to include(space1.guid)
         expect(space_guids).to include(space2.guid)
@@ -442,18 +442,18 @@ module VCAP::CloudController
         space_guids = double
         membership = instance_double(Membership, space_guids_for_roles: space_guids)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(permissions.readable_supporter_space_guids).to eq(space_guids)
-        expect(membership).to have_received(:space_guids_for_roles).with(Permissions::ROLES_FOR_SPACE_SUPPORTER_READING)
+        expect(permissions.readable_space_guids).to eq(space_guids)
+        expect(membership).to have_received(:space_guids_for_roles).with(Permissions::ROLES_FOR_SPACE_READING)
       end
     end
 
-    describe '#readable_supporter_space_guids_query' do
+    describe '#readables_space_guids_query' do
       it 'returns subquery from membership' do
         membership = instance_double(Membership)
         subquery = instance_double(Sequel::Dataset)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(membership).to receive(:space_guids_for_roles_subquery).with(Permissions::ROLES_FOR_SPACE_SUPPORTER_READING).and_return(subquery)
-        expect(permissions.readable_supporter_space_guids_query).to be(subquery)
+        expect(membership).to receive(:space_guids_for_roles_subquery).with(Permissions::ROLES_FOR_SPACE_READING).and_return(subquery)
+        expect(permissions.readable_space_guids_query).to be(subquery)
       end
     end
 
@@ -735,33 +735,33 @@ module VCAP::CloudController
       end
     end
 
-    describe '#untrusted_can_write_to_space?' do
+    describe '#can_manage_apps_in_space?' do
       context 'user has no membership' do
         context 'and user is an admin' do
           it 'returns true' do
             set_current_user(user, { admin: true })
-            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be true
+            expect(permissions.can_manage_apps_in_space?(space_guid)).to be true
           end
         end
 
         context 'and user is admin_read_only' do
           it 'return false' do
             set_current_user_as_admin_read_only
-            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+            expect(permissions.can_manage_apps_in_space?(space_guid)).to be false
           end
         end
 
         context 'and user is global auditor' do
           it 'return false' do
             set_current_user_as_global_auditor
-            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+            expect(permissions.can_manage_apps_in_space?(space_guid)).to be false
           end
         end
 
         context 'and user is not an admin' do
           it 'return false' do
             set_current_user(user)
-            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+            expect(permissions.can_manage_apps_in_space?(space_guid)).to be false
           end
         end
       end
@@ -770,13 +770,13 @@ module VCAP::CloudController
         it 'returns true for space developer' do
           org.add_user(user)
           space.add_developer(user)
-          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be true
+          expect(permissions.can_manage_apps_in_space?(space_guid)).to be true
         end
 
         it 'returns true for space supporter' do
           org.add_user(user)
           space.add_supporter(user)
-          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be true
+          expect(permissions.can_manage_apps_in_space?(space_guid)).to be true
         end
 
         context "and the space's org is suspended" do
@@ -784,32 +784,32 @@ module VCAP::CloudController
             org.add_user(user)
             space.add_developer(user)
             org.update(status: Organization::SUSPENDED)
-            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be_falsey
+            expect(permissions.can_manage_apps_in_space?(space_guid)).to be_falsey
           end
 
           it 'returns false for the space supporter' do
             org.add_user(user)
             space.add_supporter(user)
             org.update(status: Organization::SUSPENDED)
-            expect(permissions.untrusted_can_write_to_space?(space_guid)).to be_falsey
+            expect(permissions.can_manage_apps_in_space?(space_guid)).to be_falsey
           end
         end
 
         it 'returns false for space manager' do
           org.add_user(user)
           space.add_manager(user)
-          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+          expect(permissions.can_manage_apps_in_space?(space_guid)).to be false
         end
 
         it 'returns false for space auditor' do
           org.add_user(user)
           space.add_auditor(user)
-          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+          expect(permissions.can_manage_apps_in_space?(space_guid)).to be false
         end
 
         it 'returns false for org manager' do
           org.add_manager(user)
-          expect(permissions.untrusted_can_write_to_space?(space_guid)).to be false
+          expect(permissions.can_manage_apps_in_space?(space_guid)).to be false
         end
       end
     end
@@ -1218,11 +1218,11 @@ module VCAP::CloudController
         expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
-      it 'returns false for space supporter' do
+      it 'returns true for space supporter' do
         org.add_user(user)
         space.add_supporter(user)
 
-        expect(permissions.can_read_route?(space_guid, org_guid)).to be false
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns false for org billing manager' do
@@ -1243,79 +1243,79 @@ module VCAP::CloudController
       end
     end
 
-    describe '#untrusted_can_read_route?' do
+    describe '#can_read_route?' do
       it 'returns true if user is an admin' do
         set_current_user(user, { admin: true })
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns true if user is a read-only admin' do
         set_current_user(user, { admin_read_only: true })
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns true if user is a global auditor' do
         set_current_user_as_global_auditor
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns true for space developer' do
         org.add_user(user)
         space.add_developer(user)
 
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns true for space manager' do
         org.add_user(user)
         space.add_manager(user)
 
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns true for space auditor' do
         org.add_user(user)
         space.add_auditor(user)
 
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns true for space supporter' do
         org.add_user(user)
         space.add_supporter(user)
 
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns true for org manager' do
         org.add_user(user)
         org.add_manager(user)
 
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns true for org auditor' do
         org.add_user(user)
         org.add_auditor(user)
 
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be true
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be true
       end
 
       it 'returns false for org billing manager' do
         org.add_user(user)
         org.add_billing_manager(user)
 
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be false
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be false
       end
 
       it 'returns false for regular org user' do
         org.add_user(user)
 
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be false
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be false
       end
 
       it 'returns false for other user' do
-        expect(permissions.untrusted_can_read_route?(space_guid, org_guid)).to be false
+        expect(permissions.can_read_route?(space_guid, org_guid)).to be false
       end
     end
 


### PR DESCRIPTION
Now that space supporter implementation is complete we can collapse a
bunch of functions in permissions.rb and finalize naming conventions
that we're mostly happy with.

* include space supporter in ALL_PERMISSIONS
* removed space supporter specific mentions in permissions.rb

Co-authored-by: Mona Mohebbi <mmohebbi@pivotal.io>
Co-authored-by: Merric de Launey <mdelauney@pivotal.io>
Co-authored-by: Matthew Kocher <mkocher@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)