### PR TITLE
Remove `temporary_enable_space_supporter_role` flag

### DIFF
--- a/app/messages/role_create_message.rb
+++ b/app/messages/role_create_message.rb
@@ -13,12 +13,6 @@ module VCAP::CloudController
         in: VCAP::CloudController::RoleTypes::ALL_ROLES,
         message: "must be one of the allowed types #{VCAP::CloudController::RoleTypes::ALL_ROLES}"
       }
-    validates :type,
-      unless: -> { Config.config.get(:temporary_enable_space_supporter_role) },
-      exclusion: {
-        in: [VCAP::CloudController::RoleTypes::SPACE_SUPPORTER],
-        message: 'space supporter role not enabled',
-      }
 
     delegate :space_guid, :user_guid, :organization_guid, :username, :user_origin, to: :relationships_message
 

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -11,7 +11,6 @@ module VCAP::CloudController
             external_port: Integer,
             external_domain: String,
             temporary_disable_deployments: bool,
-            optional(:temporary_enable_space_supporter_role) => bool,
             temporary_use_logcache: bool,
             optional(:temporary_disable_v2_staging) => bool,
             tls_port: Integer,

--- a/middleware/block_v3_only_roles.rb
+++ b/middleware/block_v3_only_roles.rb
@@ -9,7 +9,7 @@ module CloudFoundry
       end
 
       def call(env)
-        if !allowed_path?(env['PATH_INFO']) && v3_only_role_enabled? && v3_only_role?
+        if !allowed_path?(env['PATH_INFO']) && v3_only_role?
           [
             403,
             { 'Content-Type' => 'text/html' },
@@ -33,10 +33,6 @@ module CloudFoundry
 
       def globally_authenticated?
         roles.admin? || roles.admin_read_only? || roles.global_auditor?
-      end
-
-      def v3_only_role_enabled?
-        VCAP::CloudController::Config.config.get(:temporary_enable_space_supporter_role)
       end
 
       def space_supporter_and_only_space_supporter?(current_user)

--- a/spec/request/v2/auth_spec.rb
+++ b/spec/request/v2/auth_spec.rb
@@ -44,10 +44,6 @@ RSpec.describe 'Auth' do
   end
 
   context 'space supporter' do
-    before do
-      TestConfig.override(temporary_enable_space_supporter_role: true)
-    end
-
     let(:space1) { VCAP::CloudController::Space.make }
     let(:space2) { VCAP::CloudController::Space.make }
     let(:space3) { VCAP::CloudController::Space.make }
@@ -71,13 +67,6 @@ RSpec.describe 'Auth' do
           get '/v2/spaces', nil, user_header
           expect(last_response.status).to eq(403)
           expect(last_response.body).to match %r(You are not authorized to perform the requested action. See section 'Space Supporter Role in V2' https://docs.cloudfoundry.org/concepts/roles.html)
-        end
-
-        it 'does not error when the space supporter role is disabled' do
-          TestConfig.override(temporary_enable_space_supporter_role: false)
-
-          get '/v2/apps', nil, user_header
-          expect(last_response.status).to eq(200)
         end
 
         it 'does not error when hitting info' do

--- a/spec/unit/messages/role_create_message_spec.rb
+++ b/spec/unit/messages/role_create_message_spec.rb
@@ -129,30 +129,7 @@ module VCAP::CloudController
         end
       end
 
-      describe 'space_supporter role' do
-        let(:type) { 'space_supporter' }
-
-        context 'when the config flag is enabled' do
-          it 'is valid' do
-            TestConfig.override(temporary_enable_space_supporter_role: true)
-            message = RoleCreateMessage.new(space_params)
-            expect(message).to be_valid
-          end
-        end
-
-        context 'when the flag is disabled' do
-          it 'is invalid' do
-            TestConfig.override(temporary_enable_space_supporter_role: false)
-            message = RoleCreateMessage.new(space_params)
-            expect(message).not_to be_valid
-          end
-        end
-      end
-
       context 'for space roles' do
-        before do
-          TestConfig.override(temporary_enable_space_supporter_role: true)
-        end
         VCAP::CloudController::RoleTypes::SPACE_ROLES.each do |space_type|
           context "when the type is #{space_type}" do
             let(:type) { space_type }
@@ -180,10 +157,6 @@ module VCAP::CloudController
       end
 
       context 'for org roles' do
-        before do
-          TestConfig.override(temporary_enable_space_supporter_role: true)
-        end
-
         VCAP::CloudController::RoleTypes::ORGANIZATION_ROLES.each do |org_type|
           context "when the type is #{org_type}" do
             let(:type) { org_type }


### PR DESCRIPTION
* A short explanation of the proposed change:

This flag was used while we were adding the new role, now that the role is ready to go so we can remove the flag

* Links to any other associated PRs

Issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/2469
capi-release PR: https://github.com/cloudfoundry/capi-release/pull/205

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
