### PR TITLE
As an auditor, I can see that information about destination protocol …

### DIFF
--- a/app/repositories/app_event_repository.rb
+++ b/app/repositories/app_event_repository.rb
@@ -108,7 +108,8 @@ module VCAP::CloudController
           route_mapping_guid: route_mapping.guid,
           destination_guid: route_mapping.guid,
           process_type: route_mapping.process_type,
-          weight: route_mapping.weight
+          weight: route_mapping.weight,
+          protocol: route_mapping.protocol,
         })
         create_app_audit_event('audit.app.map-route', app, app.space, actor_hash, metadata)
       end
@@ -123,7 +124,8 @@ module VCAP::CloudController
           route_mapping_guid: route_mapping.guid,
           destination_guid: route_mapping.guid,
           process_type: route_mapping.process_type,
-          weight: route_mapping.weight
+          weight: route_mapping.weight,
+          protocol: route_mapping.protocol,
         })
         create_app_audit_event('audit.app.unmap-route', app, app.space, actor_hash, metadata)
       end

--- a/spec/request/route_destinations_spec.rb
+++ b/spec/request/route_destinations_spec.rb
@@ -319,7 +319,8 @@ RSpec.describe 'Route Destinations Request' do
               route_mapping_guid: new_destination['guid'],
               destination_guid: new_destination['guid'],
               process_type: 'web',
-              weight: nil
+              weight: nil,
+              protocol: 'http2',
             }.to_json,
           }
         end
@@ -1206,7 +1207,8 @@ RSpec.describe 'Route Destinations Request' do
               route_mapping_guid: destination_to_delete.guid,
               destination_guid: destination_to_delete.guid,
               process_type: destination_to_delete.process_type,
-              weight: nil
+              weight: nil,
+              protocol: 'http1',
             }.to_json,
           }
         end

--- a/spec/request/v2/route_mappings_spec.rb
+++ b/spec/request/v2/route_mappings_spec.rb
@@ -179,7 +179,8 @@ RSpec.describe 'RouteMappings' do
         'destination_guid' => route_mapping.guid,
         'route_mapping_guid' => route_mapping.guid,
         'process_type' => 'web',
-        'weight' => nil
+        'weight' => nil,
+        'protocol' => 'http1'
       })
     end
   end
@@ -205,7 +206,8 @@ RSpec.describe 'RouteMappings' do
         'destination_guid' => route_mapping.guid,
         'route_mapping_guid' => route_mapping.guid,
         'process_type' => 'web',
-        'weight' => nil
+        'weight' => nil,
+        'protocol' => 'http1'
       })
     end
   end

--- a/spec/unit/repositories/app_event_repository_spec.rb
+++ b/spec/unit/repositories/app_event_repository_spec.rb
@@ -296,6 +296,30 @@ module VCAP::CloudController
               expect(event.metadata[:weight]).to eq(100)
             end
           end
+          context 'when the route mapping has no protocol' do
+            let(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'potato') }
+
+            it 'creates a new app.map_route audit event with appropriate metadata' do
+              event = app_event_repository.record_map_route(user_audit_info, route_mapping)
+              expect(event.metadata[:route_guid]).to eq(route.guid)
+              expect(event.metadata[:route_mapping_guid]).to eq(route_mapping.guid)
+              expect(event.metadata[:destination_guid]).to eq(route_mapping.guid)
+              expect(event.metadata[:process_type]).to eq('potato')
+              expect(event.metadata[:protocol]).to eq('http1')
+            end
+          end
+          context 'when the route mapping has a protocol' do
+            let(:route_mapping) { RouteMappingModel.make(route: route, app: app, process_type: 'potato', protocol: 'http2') }
+
+            it 'creates a new app.map_route audit event with appropriate metadata' do
+              event = app_event_repository.record_map_route(user_audit_info, route_mapping)
+              expect(event.metadata[:route_guid]).to eq(route.guid)
+              expect(event.metadata[:route_mapping_guid]).to eq(route_mapping.guid)
+              expect(event.metadata[:destination_guid]).to eq(route_mapping.guid)
+              expect(event.metadata[:process_type]).to eq('potato')
+              expect(event.metadata[:protocol]).to eq('http2')
+            end
+          end
         end
       end
 


### PR DESCRIPTION
…in map-route audit events

Root Issue: cloudfoundry/routing-release#200

Co-authored-by: Greg Cobb <gcobb@pivotal.io>
Co-authored-by: Michael Oleske <moleske@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
When I map a route to an app then the requested destination protocol should appear in the audit event. The audit event should include the protocol request by the user. If the user does not specify a protocol (thereby using the default protocol for the mapped route), then the audit even should have null protocol. 

* An explanation of the use cases your change solves
Auditors can get http2 usage data through the monitoring the map route event

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

cc @Gerg 