### PR TITLE
Improve label selection performance

### DIFF
--- a/app/fetchers/label_selector_query_generator.rb
+++ b/app/fetchers/label_selector_query_generator.rb
@@ -2,65 +2,23 @@ module VCAP::CloudController
   class LabelSelectorQueryGenerator
     class << self
       def add_selector_queries(label_klass:, resource_dataset:, requirements:, resource_klass:)
-        requirements.reduce(nil) do |accumulated_dataset, requirement|
+        resource_guid = Sequel.qualify(resource_klass.table_name, :guid)
+        requirements.each do |requirement|
           case requirement.operator
-          when :in
-            dataset_for_requirement = evaluate_in(label_klass, resource_dataset, requirement, resource_klass)
-          when :notin
-            dataset_for_requirement = evaluate_notin(label_klass, resource_dataset, requirement, resource_klass)
-          when :equal
-            dataset_for_requirement = evaluate_equal(label_klass, resource_dataset, requirement, resource_klass)
-          when :not_equal
-            dataset_for_requirement = evaluate_not_equal(label_klass, resource_dataset, requirement, resource_klass)
+          when :in, :equal
+            resource_dataset = resource_dataset.where(resource_guid => guids_for_set_inclusion(label_klass, requirement))
+          when :notin, :not_equal
+            resource_dataset = resource_dataset.exclude(resource_guid => guids_for_set_inclusion(label_klass, requirement))
           when :exists
-            dataset_for_requirement = evaluate_exists(label_klass, resource_dataset, requirement, resource_klass)
+            resource_dataset = resource_dataset.where(resource_guid => guids_for_existence(label_klass, requirement))
           when :not_exists
-            dataset_for_requirement = evaluate_not_exists(label_klass, resource_dataset, requirement, resource_klass)
-          end
-          # Doing multiple self-joins here instead of building a chain of WHERE/AND
-          # clauses for performance concerns. It may be worthwhile in the future to do a performance
-          # benchmark or comparision of the two execution plans to see if that is a large concern
-          if accumulated_dataset.nil?
-            dataset_for_requirement
-          else
-            accumulated_dataset.join(dataset_for_requirement, { guid: Sequel[resource_klass.table_name][:guid] })
+            resource_dataset = resource_dataset.exclude(resource_guid => guids_for_existence(label_klass, requirement))
           end
         end
+        resource_dataset.qualify(resource_klass.table_name)
       end
 
       private
-
-      def evaluate_in(label_klass, resource_dataset, requirement, resource_klass)
-        resource_dataset.
-          where(Sequel.qualify(resource_klass.table_name, :guid) => guids_for_set_inclusion(label_klass, requirement)).
-          qualify(resource_klass.table_name)
-      end
-
-      def evaluate_notin(label_klass, resource_dataset, requirement, resource_klass)
-        resource_dataset.
-          exclude(Sequel.qualify(resource_klass.table_name, :guid) => guids_for_set_inclusion(label_klass, requirement)).
-          qualify(resource_klass.table_name)
-      end
-
-      def evaluate_equal(label_klass, resource_dataset, requirement, resource_klass)
-        evaluate_in(label_klass, resource_dataset, requirement, resource_klass)
-      end
-
-      def evaluate_not_equal(label_klass, resource_dataset, requirement, resource_klass)
-        evaluate_notin(label_klass, resource_dataset, requirement, resource_klass)
-      end
-
-      def evaluate_exists(label_klass, resource_dataset, requirement, resource_klass)
-        resource_dataset.
-          where(Sequel.qualify(resource_klass.table_name, :guid) => guids_for_existence(label_klass, requirement)).
-          qualify(resource_klass.table_name)
-      end
-
-      def evaluate_not_exists(label_klass, resource_dataset, requirement, resource_klass)
-        resource_dataset.
-          exclude(Sequel.qualify(resource_klass.table_name, :guid) => guids_for_existence(label_klass, requirement)).
-          qualify(resource_klass.table_name)
-      end
 
       def guids_for_set_inclusion(label_klass, requirement)
         label_klass.

--- a/app/messages/validators/label_selector_requirement_validator.rb
+++ b/app/messages/validators/label_selector_requirement_validator.rb
@@ -4,12 +4,19 @@ require 'messages/metadata_validator_helper'
 
 module VCAP::CloudController::Validators
   class LabelSelectorRequirementValidator < ActiveModel::Validator
+    MAX_REQUIREMENTS = 50
     MISSING_LABEL_SELECTOR_ERROR = 'Missing label_selector value'.freeze
+    TOO_MANY_REQUIREMENTS_ERROR = "Too many label_selector requirements (maximum is #{MAX_REQUIREMENTS})".freeze
     INVALID_LABEL_SELECTOR_ERROR = 'Invalid label_selector value'.freeze
 
     def validate(record)
       if record.requirements.empty?
         record.errors[:base] << MISSING_LABEL_SELECTOR_ERROR
+        return
+      end
+
+      if record.requirements.length > MAX_REQUIREMENTS
+        record.errors[:base] << TOO_MANY_REQUIREMENTS_ERROR
         return
       end
 

--- a/docs/v3/source/includes/concepts/_metadata.md.erb
+++ b/docs/v3/source/includes/concepts/_metadata.md.erb
@@ -146,7 +146,7 @@ cf curl /v3/apps?label_selector=env=dev,%21chargeback-code,tier%20in%20%28backen
 ```
 
 Selectors allow users to filter and group API resources by the labels applied to them. A selector consists of one or
-more `requirements` in a comma-delimited list.
+more `requirements` in a comma-delimited list. The maximum number of `requirements` in a single selector is 50.
 
 _eg:_ `env=dev,!chargeback-code,tier in (backend,worker)`
 

--- a/spec/unit/messages/validators/label_selector_requirement_validator_spec.rb
+++ b/spec/unit/messages/validators/label_selector_requirement_validator_spec.rb
@@ -22,6 +22,14 @@ module VCAP::CloudController::Validators
       end
     end
 
+    context 'when there are too many requirements' do
+      let(:requirements) { Array.new(LabelSelectorRequirementValidator::MAX_REQUIREMENTS + 1) }
+      it 'fails' do
+        expect(message).not_to be_valid
+        expect(message.errors_on(:base)).to include(/^Too many label_selector requirements/)
+      end
+    end
+
     context 'when there are no valid requirements' do
       let(:requirements) { [nil, nil, nil] }
       it 'fails' do


### PR DESCRIPTION
By replacing `JOIN`s with `WHERE` clauses for label selection, the performance can be improved significantly.

A locally running Cloud Controller (with CCDB in a Docker container) was used to measure the impact of this change.

500 spaces have been created (without any labels, i.e. the returned list was always empty). The following command was executed:
```
cf curl "/v3/spaces?label_selector=key0,key1,...,keyn"
```

The captured `X-Runtime` header value:

|# of keys|before change|after change|
|---|---|---|
|5|0.060553|0.007187|
|10|1.110025|0.017798|
|20|49.877381|0.039163|
|50|504 Gateway Time-out|0.349810|

Besides improving the database query performance, it is also wise to limit the number of `label_selector` requirements to prevent the creation of too complex/large queries. 50 selectors should still be enough for almost all use-cases.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) *

\* We cannot run all CATS on our foundations as we do not enable all CF features, but all the executed tests were successful:
```
Ran 136 of 216 Specs
SUCCESS! -- 136 Passed | 0 Failed | 3 Pending | 77 Skipped
```