### PR TITLE
Do not count admin requests

### DIFF
--- a/spec/unit/middleware/rate_limiter_spec.rb
+++ b/spec/unit/middleware/rate_limiter_spec.rb
@@ -307,7 +307,7 @@ module CloudFoundry
           _, _, _ = middleware.call(user_1_env)
           _, _, _ = middleware.call(user_1_env)
           status, response_headers, _ = middleware.call(user_1_env)
-          expect(response_headers['X-RateLimit-Remaining']).to eq('0')
+          expect(response_headers).not_to include('X-RateLimit-Remaining')
           expect(status).to eq(200)
           expect(app).to have_received(:call).at_least(:once)
         end


### PR DESCRIPTION
As admins are not rate limited, counting their requests in the database is not required and leads to unnecessary `UPDATE` statements on the `request_counts` table. This change skips rate limiting for admins completely, so that they also won't see any `X-RateLimit-*` headers.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
