### PR TITLE
Use V3ErrorHasher in LoggingContextJob when originating in a v3 endpoint

### DIFF
--- a/app/jobs/enqueuer.rb
+++ b/app/jobs/enqueuer.rb
@@ -41,8 +41,9 @@ module VCAP::CloudController
       def enqueue_job(job)
         @opts['guid'] = SecureRandom.uuid
         request_id = ::VCAP::Request.current_id
+        api_version = ::VCAP::Request.api_version
         timeout_job = TimeoutJob.new(job, job_timeout)
-        logging_context_job = LoggingContextJob.new(timeout_job, request_id)
+        logging_context_job = LoggingContextJob.new(timeout_job, request_id, api_version)
         Delayed::Job.enqueue(logging_context_job, @opts)
       end
 

--- a/app/jobs/wrapping_job.rb
+++ b/app/jobs/wrapping_job.rb
@@ -45,8 +45,8 @@ module VCAP::CloudController
         handler.reschedule_at(time, attempts) if handler.respond_to?(:reschedule_at)
       end
 
-      def error(job, e)
-        handler.error(job, e) if handler.respond_to?(:error)
+      def error(job, exception)
+        handler.error(job, exception) if handler.respond_to?(:error)
       end
 
       def display_name

--- a/app/presenters/base_error_hasher.rb
+++ b/app/presenters/base_error_hasher.rb
@@ -10,7 +10,7 @@ class BaseErrorHasher < Struct.new(:error)
   end
 
   def compound_error?
-    error.respond_to?(:underlying_errors)
+    error.is_a?(CloudController::Errors::CompoundError)
   end
 
   def api_error?

--- a/lib/vcap/request.rb
+++ b/lib/vcap/request.rb
@@ -7,6 +7,8 @@ module VCAP
     HEADER_BROKER_API_REQUEST_IDENTITY = 'X-Broker-API-Request-Identity'.freeze
     HEADER_ZIPKIN_B3_TRACEID = 'X-B3-TraceId'.freeze
     HEADER_ZIPKIN_B3_SPANID = 'X-B3-SpanId'.freeze
+    API_VERSION_V2 = 'v2'.freeze
+    API_VERSION_V3 = 'v3'.freeze
 
     class << self
       def current_id=(request_id)
@@ -20,6 +22,19 @@ module VCAP
 
       def current_id
         Thread.current[:vcap_request_id]
+      end
+
+      def api_version=(api_version)
+        Thread.current[:api_version] = api_version
+        if api_version.nil?
+          Steno.config.context.data.delete('api_version')
+        else
+          Steno.config.context.data['api_version'] = api_version
+        end
+      end
+
+      def api_version
+        Thread.current[:api_version]
       end
 
       def b3_trace_id=(trace_id)

--- a/middleware/security_context_setter.rb
+++ b/middleware/security_context_setter.rb
@@ -39,13 +39,12 @@ module CloudFoundry
 
       def error_message(env, error_name)
         api_error = CloudController::Errors::ApiError.new_from_details(error_name)
-        version = env['PATH_INFO'][0..2]
-
-        if version == '/v2'
-          ErrorPresenter.new(api_error, Rails.env.test?, V2ErrorHasher.new(api_error)).to_json
-        elsif version == '/v3'
-          ErrorPresenter.new(api_error, Rails.env.test?, V3ErrorHasher.new(api_error)).to_json
-        end
+        error_presenter = if VCAP::Request.api_version == VCAP::Request::API_VERSION_V3
+                            ErrorPresenter.new(api_error, Rails.env.test?, V3ErrorHasher.new(api_error))
+                          else
+                            ErrorPresenter.new(api_error, Rails.env.test?)
+                          end
+        error_presenter.to_json
       end
 
       def invalid_token!(env, headers)

--- a/middleware/vcap_request_id.rb
+++ b/middleware/vcap_request_id.rb
@@ -11,10 +11,12 @@ module CloudFoundry
       def call(env)
         env['cf.request_id'] = external_request_id(env) || internal_request_id
         ::VCAP::Request.current_id = env['cf.request_id']
+        ::VCAP::Request.api_version = api_version_from_path(env)
 
         status, headers, body = @app.call(env)
 
         ::VCAP::Request.current_id = nil
+        ::VCAP::Request.api_version = nil
         headers['X-VCAP-Request-ID'] = env['cf.request_id']
         [status, headers, body]
       end
@@ -30,6 +32,14 @@ module CloudFoundry
 
       def internal_request_id
         SecureRandom.uuid
+      end
+
+      def api_version_from_path(env)
+        path_info = env['PATH_INFO']
+        if path_info
+          version = path_info[1..2]
+          return version if [VCAP::Request::API_VERSION_V2, VCAP::Request::API_VERSION_V3].include?(version)
+        end
       end
     end
   end

--- a/spec/unit/lib/vcap/request_spec.rb
+++ b/spec/unit/lib/vcap/request_spec.rb
@@ -67,6 +67,39 @@ module VCAP
       end
     end
 
+    describe '.api_version' do
+      after do
+        Request.api_version = nil
+      end
+
+      let(:api_version) { Request::API_VERSION_V3 }
+      let(:data) { {} }
+
+      before do
+        allow(Steno.config.context).to receive(:data).and_return(data)
+      end
+
+      it 'sets the new api_version value' do
+        Request.api_version = api_version
+
+        expect(Request.api_version).to eq api_version
+        expect(Steno.config.context.data.fetch('api_version')).to eq api_version
+      end
+
+      it 'deletes from steno context when set to nil' do
+        Request.api_version = nil
+
+        expect(Request.api_version).to be_nil
+        expect(Steno.config.context.data.key?('api_version')).to be false
+      end
+
+      it 'uses the :api_version thread local' do
+        Request.api_version = api_version
+
+        expect(Thread.current[:api_version]).to eq(api_version)
+      end
+    end
+
     describe '.b3_trace_id' do
       after do
         Request.b3_trace_id = nil

--- a/spec/unit/middleware/rate_limiter_spec.rb
+++ b/spec/unit/middleware/rate_limiter_spec.rb
@@ -316,8 +316,13 @@ module CloudFoundry
       context 'when limit has exceeded' do
         let(:general_limit) { 0 }
         let(:path_info) { '/v2/foo' }
+        let(:api_version) { VCAP::Request::API_VERSION_V2 }
         let(:middleware_env) do
           { 'cf.user_guid' => 'user-id-1', 'PATH_INFO' => path_info }
+        end
+
+        before do
+          allow(VCAP::Request).to receive(:api_version).and_return(api_version)
         end
 
         it 'returns 429 response' do
@@ -364,6 +369,7 @@ module CloudFoundry
 
         context 'when the path is /v3/*' do
           let(:path_info) { '/v3/foo' }
+          let(:api_version) { VCAP::Request::API_VERSION_V3 }
 
           it 'formats the response error in v3 format' do
             _, _, body = middleware.call(middleware_env)
@@ -378,6 +384,7 @@ module CloudFoundry
 
         context 'when the user is unauthenticated' do
           let(:path_info) { '/v3/foo' }
+          let(:api_version) { VCAP::Request::API_VERSION_V3 }
           let(:unauthenticated_env) { { 'some' => 'env', 'PATH_INFO' => path_info } }
 
           it 'suggests they log in' do

--- a/spec/unit/middleware/security_context_setter_spec.rb
+++ b/spec/unit/middleware/security_context_setter_spec.rb
@@ -7,6 +7,7 @@ module CloudFoundry
       let(:middleware) { SecurityContextSetter.new(app, security_context_configurer) }
       let(:app) { double(:app, call: [200, {}, 'a body']) }
       let(:path_info) { '/v2/foo' }
+      let(:api_version) { VCAP::Request::API_VERSION_V2 }
       let(:env) do
         {
           'HTTP_AUTHORIZATION' => 'auth-token',
@@ -15,6 +16,10 @@ module CloudFoundry
       end
       let(:token_decoder) { instance_double(VCAP::CloudController::UaaTokenDecoder) }
       let(:security_context_configurer) { VCAP::CloudController::Security::SecurityContextConfigurer.new(token_decoder) }
+
+      before do
+        allow(VCAP::Request).to receive(:api_version).and_return(api_version)
+      end
 
       describe '#call' do
         let(:token_information) { { 'user_id' => 'user-id-1', 'user_name' => 'mrpotato' } }
@@ -141,6 +146,7 @@ module CloudFoundry
 
           context 'when the path is /v3/*' do
             let(:path_info) { '/v3/foo' }
+            let(:api_version) { VCAP::Request::API_VERSION_V3 }
             it 'throws an error' do
               _, _, body = middleware.call(env)
               json_body = JSON.parse(body.first)


### PR DESCRIPTION
The `LoggingContextJob` does not use the correct `ErrorHasher` based on the endpoint (i.e. v2 vs v3) of the originating request. This change makes the api version available to the `LoggingContextJob` (via `Enqueuer`) by setting it in the middleware (similar to the VCAP-Request-ID). No dedicated middleware was introduced; instead it has been added to the existing `VcapRequestId` middleware as it can be removed when v2 is discontinued.

Besides using the api version from the current thread in the `LoggingContextJob` to decide whether `V2ErrorHasher` (default) or `V3ErrorHasher` should be used, the same is done in other places where this differentiation is needed (i.e. `SecurityContextSetter`, `RateLimiter`).

When checking for a 'compound_error?' the `BaseErrorHasher` uses the instance type rather than duck-typing as the `V3ErrorHasher` can only handle `CompoundError`s correctly, i.e. it expects 'underlying_errors' to be `ApiError`s with fields `message`, `name` and `code`.

This PR has been 'extracted' from #2537 for an easier review.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
