### PR TITLE
Implement service_instance rate limit for specific requests

### DIFF
--- a/config/bosh-lite.yml
+++ b/config/bosh-lite.yml
@@ -246,6 +246,8 @@ rate_limiter:
   general_limit: 2000
   unauthenticated_limit: 100
   reset_interval_in_minutes: 60
+service_instance_rate_limiter:
+  enabled: true
   service_instance_limit: 5
   service_instance_reset_interval_in_minutes: 5
 

--- a/config/bosh-lite.yml
+++ b/config/bosh-lite.yml
@@ -246,6 +246,8 @@ rate_limiter:
   general_limit: 2000
   unauthenticated_limit: 100
   reset_interval_in_minutes: 60
+  service_instance_limit: 5
+  service_instance_reset_interval_in_minutes: 5
 
 diego:
   file_server_url: http://file-server.service.cf.internal:8080

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -258,6 +258,8 @@ rate_limiter:
   general_limit: 2000
   unauthenticated_limit: 100
   reset_interval_in_minutes: 60
+  service_instance_limit: 5
+  service_instance_reset_interval_in_minutes: 5
 
 diego:
   file_server_url: http://file-server.service.cf.internal:8080

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -258,6 +258,8 @@ rate_limiter:
   general_limit: 2000
   unauthenticated_limit: 100
   reset_interval_in_minutes: 60
+service_instance_rate_limiter:
+  enabled: true
   service_instance_limit: 5
   service_instance_reset_interval_in_minutes: 5
 

--- a/db/migrations/20210901203738_add_service_broker_rate_limit_for_request_counts.rb
+++ b/db/migrations/20210901203738_add_service_broker_rate_limit_for_request_counts.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  change do
+    alter_table :request_counts do
+      add_column :service_instance_count, Integer, default: 0
+      add_column :service_instance_valid_until, Time
+    end
+  end
+end

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -103,6 +103,11 @@
   http_code: 503
   message: "%s"
 
+10016:
+  name: ServiceInstanceRateLimitExceeded
+  http_code: 429
+  message: "Service Instance Rate Limit Exceeded"
+
 20001:
   name: UserInvalid
   http_code: 400

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -286,6 +286,9 @@ module VCAP::CloudController
               general_limit: Integer,
               unauthenticated_limit: Integer,
               reset_interval_in_minutes: Integer,
+            },
+            service_instance_rate_limiter: {
+              enabled: bool,
               service_instance_limit: Integer,
               service_instance_reset_interval_in_minutes: Integer,
             },

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -286,6 +286,8 @@ module VCAP::CloudController
               general_limit: Integer,
               unauthenticated_limit: Integer,
               reset_interval_in_minutes: Integer,
+              service_instance_limit: Integer,
+              service_instance_reset_interval_in_minutes: Integer,
             },
             shared_isolation_segment_name: String,
 

--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -27,14 +27,16 @@ module VCAP::CloudController
         use CloudFoundry::Middleware::SecurityContextSetter, configurer
         use CloudFoundry::Middleware::RequestLogs, request_logs
         use CloudFoundry::Middleware::Zipkin
-        if config.get(:rate_limiter, :enabled)
+        if config.get(:rate_limiter, :enabled) || config.get(:service_instance_rate_limiter, :enabled)
           use CloudFoundry::Middleware::RateLimiter, {
             logger: Steno.logger('cc.rate_limiter'),
+            general_limit_enabled: config.get(:rate_limiter, :enabled),
             general_limit: config.get(:rate_limiter, :general_limit),
             unauthenticated_limit: config.get(:rate_limiter, :unauthenticated_limit),
             interval: config.get(:rate_limiter, :reset_interval_in_minutes),
-            service_limit: config.get(:rate_limiter, :service_instance_limit),
-            service_interval: config.get(:rate_limiter, :service_instance_reset_interval_in_minutes)
+            service_rate_limit_enabled: config.get(:service_instance_rate_limiter, :enabled),
+            service_limit: config.get(:service_instance_rate_limiter, :service_instance_limit),
+            service_interval: config.get(:service_instance_rate_limiter, :service_instance_reset_interval_in_minutes)
           }
         end
 

--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -33,6 +33,8 @@ module VCAP::CloudController
             general_limit: config.get(:rate_limiter, :general_limit),
             unauthenticated_limit: config.get(:rate_limiter, :unauthenticated_limit),
             interval: config.get(:rate_limiter, :reset_interval_in_minutes),
+            service_limit: config.get(:rate_limiter, :service_instance_limit),
+            service_interval: config.get(:rate_limiter, :service_instance_reset_interval_in_minutes)
           }
         end
 

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -16,8 +16,8 @@ module CloudFoundry
         @service_limit         = service_limit
         @service_interval      = service_interval
       end
-      # rubocop:disable Metrics/CyclomaticComplexity
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def call(env)
         rate_limit_headers = {}
 

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -35,7 +35,7 @@ module CloudFoundry
             rate_limit_headers['X-RateLimit-Reset']     = request_count.service_instance_valid_until.utc.to_i.to_s
             rate_limit_headers['X-RateLimit-Remaining'] = [0, @service_limit - service_instance_count].max.to_s
 
-            return too_many_requests!(env, rate_limit_headers, true) if not_admin exceeded_service_instance_rate_limit(service_instance_count)
+            return too_many_requests!(env, rate_limit_headers, true) if exceeded_service_instance_rate_limit(service_instance_count)
 
             increment_service_instance_request_count!(request_count)
           elsif @general_limit_enabled

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -5,42 +5,59 @@ module CloudFoundry
     class RateLimiter
       include CloudFoundry::Middleware::ClientIp
 
-      def initialize(app, logger:, general_limit:, unauthenticated_limit:, interval:)
+      def initialize(app, logger:, general_limit_enabled:, general_limit:, unauthenticated_limit:, interval:, service_rate_limit_enabled:, service_limit:, service_interval:)
         @app                   = app
         @logger                = logger
+        @general_limit_enabled = general_limit_enabled
         @general_limit         = general_limit
         @unauthenticated_limit = unauthenticated_limit
         @interval              = interval
+        @service_rate_limit_enabled = service_rate_limit_enabled
+        @service_limit         = service_limit
+        @service_interval      = service_interval
       end
+      # rubocop:disable Metrics/CyclomaticComplexity
 
       def call(env)
         rate_limit_headers = {}
 
         request = ActionDispatch::Request.new(env)
-
         unless skip_rate_limiting?(env, request)
           user_guid = user_token?(env) ? env['cf.user_guid'] : client_ip(request)
+          if @service_rate_limit_enabled && service_instance_request?(request) && rate_limited_methods?(env) && user_token?(env)
+            request_count = VCAP::CloudController::RequestCount.find_or_create(user_guid: user_guid) do |created_request_count|
+              created_request_count.service_instance_valid_until = Time.now + @service_interval.minutes
+            end
+            reset_service_instance_request_count(request_count) if reset_service_instance_interval_expired(request_count)
+            service_instance_count = request_count.service_instance_count + 1
+            rate_limit_headers['X-RateLimit-Limit']     = @service_limit.to_s
+            rate_limit_headers['X-RateLimit-Reset']     = request_count.service_instance_valid_until.utc.to_i.to_s
+            rate_limit_headers['X-RateLimit-Remaining'] = [0, @service_limit - service_instance_count].max.to_s
 
-          request_count = VCAP::CloudController::RequestCount.find_or_create(user_guid: user_guid) do |created_request_count|
-            created_request_count.valid_until = Time.now + @interval.minutes
+            return too_many_requests!(env, rate_limit_headers, true) if not_admin exceeded_service_instance_rate_limit(service_instance_count)
+
+            increment_service_instance_request_count!(request_count)
+          elsif @general_limit_enabled
+            request_count = VCAP::CloudController::RequestCount.find_or_create(user_guid: user_guid) do |created_request_count|
+              created_request_count.valid_until = Time.now + @interval.minutes
+            end
+            reset_request_count(request_count) if reset_interval_expired(request_count)
+
+            count = request_count.count + 1
+            rate_limit_headers['X-RateLimit-Limit']     = request_limit(env).to_s
+            rate_limit_headers['X-RateLimit-Reset']     = request_count.valid_until.utc.to_i.to_s
+            rate_limit_headers['X-RateLimit-Remaining'] = [0, request_limit(env) - count].max.to_s
+
+            return too_many_requests!(env, rate_limit_headers, false) if exceeded_rate_limit(count, env)
+
+            increment_request_count!(request_count)
           end
-
-          reset_request_count(request_count) if reset_interval_expired(request_count)
-
-          count = request_count.count + 1
-
-          rate_limit_headers['X-RateLimit-Limit']     = request_limit(env).to_s
-          rate_limit_headers['X-RateLimit-Reset']     = request_count.valid_until.utc.to_i.to_s
-          rate_limit_headers['X-RateLimit-Remaining'] = [0, request_limit(env) - count].max.to_s
-
-          return too_many_requests!(env, rate_limit_headers) if exceeded_rate_limit(count, env)
-
-          increment_request_count!(request_count)
         end
 
         status, headers, body = @app.call(env)
         [status, headers.merge(rate_limit_headers), body]
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       private
 
@@ -53,8 +70,25 @@ module CloudFoundry
         request.fullpath.match(%r{\A(?:/v2/info|/v3|/|/healthz)\z})
       end
 
+      def service_instance_request?(request)
+        request.fullpath.match(%r{\A(?:/v2/service_instances|/v3/service_instances)})
+      end
+
       def internal_api?(request)
         request.fullpath.match(%r{\A/internal})
+      end
+
+      def rate_limited_methods?(env)
+        rate_limit_methods = [
+          'PATCH',
+          'POST',
+          'PUT'
+        ]
+        if rate_limit_methods.include?env['REQUEST_METHOD']
+          return true
+        end
+
+        false
       end
 
       def basic_auth?(auth)
@@ -69,20 +103,28 @@ module CloudFoundry
         request_count.update(count: Sequel.expr(1) + :count)
       end
 
+      def increment_service_instance_request_count!(request_count)
+        request_count.update(service_instance_count: Sequel.expr(1) + :service_instance_count)
+      end
+
       def request_limit(env)
         @request_limit ||= user_token?(env) ? @general_limit : @unauthenticated_limit
       end
 
-      def too_many_requests!(env, rate_limit_headers)
+      def too_many_requests!(env, rate_limit_headers, is_service_call)
         rate_limit_headers['Retry-After']    = rate_limit_headers['X-RateLimit-Reset']
         rate_limit_headers['Content-Type']   = 'text/plain; charset=utf-8'
-        message                              = rate_limit_error(env).to_json
+        message                              = rate_limit_error(env, is_service_call).to_json
         rate_limit_headers['Content-Length'] = message.length.to_s
         [429, rate_limit_headers, [message]]
       end
 
-      def rate_limit_error(env)
-        error_name = user_token?(env) ? 'RateLimitExceeded' : 'IPBasedRateLimitExceeded'
+      def rate_limit_error(env, is_service_call)
+        if is_service_call
+          error_name = user_token?(env) ? 'ServiceInstanceRateLimitExceeded' : 'IPBasedRateLimitExceeded'
+        else
+          error_name = user_token?(env) ? 'RateLimitExceeded' : 'IPBasedRateLimitExceeded'
+        end
         api_error = CloudController::Errors::ApiError.new_from_details(error_name)
         version   = env['PATH_INFO'][0..2]
         if version == '/v2'
@@ -96,13 +138,34 @@ module CloudFoundry
         count > request_limit(env)
       end
 
+      def exceeded_service_instance_rate_limit(service_instance_count)
+        service_instance_count > @service_limit
+      end
+
       def reset_interval_expired(request_count)
+        if !request_count.valid_until
+          return true
+        end
+
         request_count.valid_until < Time.now
       end
 
       def reset_request_count(request_count)
         @logger.info("Resetting request count of #{request_count.count} for user '#{request_count.user_guid}'")
         request_count.update(valid_until: Time.now + @interval.minutes, count: 0)
+      end
+
+      def reset_service_instance_interval_expired(request_count)
+        if !request_count.service_instance_valid_until
+          return true
+        end
+
+        request_count.service_instance_valid_until < Time.now
+      end
+
+      def reset_service_instance_request_count(request_count)
+        @logger.info("Resetting service instance request count of #{request_count.service_instance_count} for user '#{request_count.user_guid}'")
+        request_count.update(service_instance_valid_until: Time.now + @service_interval.minutes, service_instance_count: 0)
       end
 
       def admin?

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -16,6 +16,7 @@ module CloudFoundry
         @service_limit         = service_limit
         @service_interval      = service_interval
       end
+      # rubocop:disable Metrics/CyclomaticComplexity
 
       # rubocop:disable Metrics/CyclomaticComplexity
       def call(env)

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -16,9 +16,7 @@ module CloudFoundry
         @service_limit         = service_limit
         @service_interval      = service_interval
       end
-      # rubocop:disable Metrics/CyclomaticComplexity
 
-      # rubocop:disable Metrics/CyclomaticComplexity
       def call(env)
         rate_limit_headers = {}
 
@@ -58,7 +56,6 @@ module CloudFoundry
         status, headers, body = @app.call(env)
         [status, headers.merge(rate_limit_headers), body]
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
 
       private
 
@@ -85,7 +82,7 @@ module CloudFoundry
           'POST',
           'PUT'
         ]
-        if rate_limit_methods.include?env['REQUEST_METHOD']
+        if rate_limit_methods.include? env['REQUEST_METHOD']
           return true
         end
 

--- a/spec/request/rate_limit_spec.rb
+++ b/spec/request/rate_limit_spec.rb
@@ -158,5 +158,16 @@ RSpec.describe 'Rate Limiting' do
       parsed_response = MultiJson.load(last_response.body)
       expect(parsed_response['errors'].first['detail']).to include('Rate Limit Exceeded: Unauthenticated requests from this IP address have exceeded the limit')
     end
+    it 'uses the unauthenticated limit on service_instances endpoints' do
+      2.times do |n|
+        get '/v3/service_instances', nil, {}
+        expect(last_response.status).to eq(401), "rate limited after #{n} requests"
+      end
+
+      get '/v3/service_instances', nil, {}
+      expect(last_response.status).to eq(429)
+      parsed_response = MultiJson.load(last_response.body)
+      expect(parsed_response['errors'].first['detail']).to include('Rate Limit Exceeded: Unauthenticated requests from this IP address have exceeded the limit')
+    end
   end
 end

--- a/spec/request/rate_limit_spec.rb
+++ b/spec/request/rate_limit_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe 'Rate Limiting' do
         general_limit: 10,
         unauthenticated_limit: 2,
         reset_interval_in_minutes: 60,
+      },
+      service_instance_rate_limiter: {
+        enabled: true,
         service_instance_limit: 5,
         service_instance_reset_interval_in_minutes: 30
       }
@@ -85,7 +88,6 @@ RSpec.describe 'Rate Limiting' do
       end
 
       context 'that require existing service_instances' do
-        # let(:user) { VCAP::CloudController::User.make }
         let(:org) { VCAP::CloudController::Organization.make }
         let(:space) { VCAP::CloudController::Space.make(organization: org) }
         let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }

--- a/spec/request/rate_limit_spec.rb
+++ b/spec/request/rate_limit_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe 'Rate Limiting' do
         enabled: true,
         general_limit: 10,
         unauthenticated_limit: 2,
-        reset_interval_in_minutes: 60
+        reset_interval_in_minutes: 60,
+        service_instance_limit: 5,
+        service_instance_reset_interval_in_minutes: 30
       }
     )
   end
@@ -30,6 +32,92 @@ RSpec.describe 'Rate Limiting' do
       expect(last_response.status).to eq(429)
       parsed_response = MultiJson.load(last_response.body)
       expect(parsed_response['errors'].first['detail']).to eq('Rate Limit Exceeded')
+    end
+    context 'using service instance endpoints' do
+      context 'with POST methods' do
+        it 'uses the service instance limit on v2' do
+          5.times do |n|
+            post('/v2/service_instances', nil, user_headers)
+            expect(last_response.status).to eq(400)
+          end
+
+          post('/v2/service_instances', nil, user_headers)
+          expect(last_response.status).to eq(429)
+          parsed_response = MultiJson.load(last_response.body)
+          expect(parsed_response.first.second).to eq('Service Instance Rate Limit Exceeded')
+        end
+        it 'uses the service instance limit on v3' do
+          5.times do |n|
+            post('/v3/service_instances', nil, user_headers)
+            expect(last_response.status).to eq(422)
+          end
+
+          post('/v3/service_instances', nil, user_headers)
+          expect(last_response.status).to eq(429)
+          parsed_response = MultiJson.load(last_response.body)
+          expect(parsed_response['errors'].first['detail']).to eq('Service Instance Rate Limit Exceeded')
+        end
+      end
+
+      context 'with GET methods' do
+        it 'uses the general limit on v2' do
+          10.times do |n|
+            get('/v2/service_instances', nil, user_headers)
+            expect(last_response.status).to eq(200)
+          end
+
+          get('/v2/service_instances', nil, user_headers)
+          expect(last_response.status).to eq(429)
+          parsed_response = MultiJson.load(last_response.body)
+          expect(parsed_response.first.second).to eq('Rate Limit Exceeded')
+        end
+        it 'uses the general limit on v3' do
+          10.times do |n|
+            get('/v3/service_instances', nil, user_headers)
+            expect(last_response.status).to eq(200)
+          end
+
+          get('/v3/service_instances', nil, user_headers)
+          expect(last_response.status).to eq(429)
+          parsed_response = MultiJson.load(last_response.body)
+          expect(parsed_response['errors'].first['detail']).to eq('Rate Limit Exceeded')
+        end
+      end
+
+      context 'that require existing service_instances' do
+        # let(:user) { VCAP::CloudController::User.make }
+        let(:org) { VCAP::CloudController::Organization.make }
+        let(:space) { VCAP::CloudController::Space.make(organization: org) }
+        let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
+        let(:guid) { instance.guid }
+
+        context 'with PUT methods' do
+          it 'uses the service instance limit on v2' do
+            5.times do |n|
+              put("/v2/service_instances/#{guid}", nil, user_headers)
+              expect(last_response.status).to eq(400)
+            end
+
+            put("/v2/service_instances/#{guid}", nil, user_headers)
+            expect(last_response.status).to eq(429)
+            parsed_response = MultiJson.load(last_response.body)
+            expect(parsed_response.first.second).to eq('Service Instance Rate Limit Exceeded')
+          end
+        end
+        context 'with PATCH methods' do
+          it 'uses the service instance limit on v3' do
+            5.times do |n|
+              patch("/v3/service_instances/#{guid}", nil, user_headers)
+              expect(last_response.status).to eq(200)
+            end
+
+            patch("/v3/service_instances/#{guid}", nil, user_headers)
+            expect(last_response.status).to eq(429)
+            parsed_response = MultiJson.load(last_response.body)
+            expect(parsed_response['errors'].first['detail']).to eq('Service Instance Rate Limit Exceeded')
+          end
+        end
+      end
     end
   end
 

--- a/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
@@ -55,6 +55,8 @@ module VCAP::CloudController
               reset_interval_in_minutes: 60,
               general_limit: 123,
               unauthenticated_limit: 1,
+              service_instance_reset_interval_in_minutes: 456,
+              service_instance_limit: 2,
             }), request_metrics, request_logs).to_app
           end
 
@@ -64,7 +66,9 @@ module VCAP::CloudController
               logger: instance_of(Steno::Logger),
               general_limit: 123,
               unauthenticated_limit: 1,
-              interval: 60
+              interval: 60,
+              service_interval: 456,
+              service_limit: 2
             )
           end
         end

--- a/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
@@ -79,18 +79,18 @@ module VCAP::CloudController
 
         context 'when configuring one rate limter to on and the other off' do
           describe 'when general_limit_enabled is off but service limiter is on' do
-          before do
-            builder.build(TestConfig.override(rate_limiter: {
-              enabled: false,
-              reset_interval_in_minutes: 60,
-              general_limit: 123,
-              unauthenticated_limit: 1,
-            }, service_instance_rate_limiter: {
-              enabled: true,
-              service_instance_reset_interval_in_minutes: 456,
-              service_instance_limit: 2,
-              }), request_metrics, request_logs).to_app
-          end
+            before do
+              builder.build(TestConfig.override(rate_limiter: {
+                enabled: false,
+                reset_interval_in_minutes: 60,
+                general_limit: 123,
+                unauthenticated_limit: 1,
+              }, service_instance_rate_limiter: {
+                enabled: true,
+                service_instance_reset_interval_in_minutes: 456,
+                service_instance_limit: 2,
+                }), request_metrics, request_logs).to_app
+            end
             it 'enables the RateLimiter middleware' do
               expect(CloudFoundry::Middleware::RateLimiter).to have_received(:new).with(
                 anything,

--- a/spec/unit/middleware/rate_limiter_spec.rb
+++ b/spec/unit/middleware/rate_limiter_spec.rb
@@ -459,8 +459,6 @@ module CloudFoundry
 
             _, response_headers, _ = middleware_general_on_services_off.call(user_1_env)
             expect(response_headers['X-RateLimit-Remaining']).to eq('96')
-
-
           end
         end
       end

--- a/spec/unit/middleware/service_instance_rate_limiter_spec.rb
+++ b/spec/unit/middleware/service_instance_rate_limiter_spec.rb
@@ -291,7 +291,7 @@ module CloudFoundry
           middleware.call(user_1_env)
           middleware.call(user_1_env)
           status, response_headers, _ = middleware.call(user_1_env)
-          expect(response_headers['X-RateLimit-Remaining']).to eq('0')
+          expect(response_headers).not_to include('X-RateLimit-Remaining')
           expect(status).to eq(200)
           expect(app).to have_received(:call).at_least(:once)
         end

--- a/spec/unit/middleware/service_instance_rate_limiter_spec.rb
+++ b/spec/unit/middleware/service_instance_rate_limiter_spec.rb
@@ -177,7 +177,7 @@ module CloudFoundry
 
       it 'does not drop headers created in next middleware to service_instances requests' do
         allow(app).to receive(:call).and_return([200, { 'from' => 'wrapped-app' }, 'a body'])
-        _, headers, _ = middleware.call({'PATH_INFO' => path_info, 'REQUEST_METHOD' => 'POST'})
+        _, headers, _ = middleware.call({ 'PATH_INFO' => path_info, 'REQUEST_METHOD' => 'POST' })
         expect(headers).to match(hash_including('from' => 'wrapped-app'))
       end
 
@@ -439,12 +439,9 @@ module CloudFoundry
 
             _, response_headers, _ = middleware_general_on_services_off.call(service_instance_env)
             expect(response_headers['X-RateLimit-Remaining']).to eq('2')
-
           end
-
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
Implement a rate limiter for service-instance PUT/POST/PATCH request. This is to allow platform operators a finer degree of rate limiting for service brokers and their associated services.

* Links to any other associated PRs:
https://github.com/cloudfoundry/capi-release/pull/206

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
