### PR TITLE
Enforce service name uniqueness in shared services in spaces

### DIFF
--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -57,6 +57,11 @@ module VCAP::CloudController
         error_msg = "A service instance called #{service_instance.name} already exists in #{space.name}."
         error!(error_msg)
       end
+
+      if space.service_instances_shared_from_other_spaces.map(&:name).include?(service_instance.name)
+        error_msg = "A service instance called #{service_instance.name} has already been shared with #{space.name}."
+        error!(error_msg)
+      end
     end
 
     def validate_not_sharing_to_self!(service_instance, spaces)


### PR DESCRIPTION
Fixes https://github.com/cloudfoundry/cloud_controller_ng/issues/2306

Tested this locally on a bosh lite using the repro steps in the above issue, 

```
$ cf share-service si -s target -o target
Sharing service instance si into org target / space target as admin...
A service instance called si has already been shared with target.
FAILED
```

Locally rake bundle exec rake spec and it passed.


Co-authored-by: Brandon Potts <bpotts@vmware.com>
Co-authored-by: Seth Boyles <sboyles@pivotal.io>
Co-authored-by: Jenna Goldstrich <jgoldstrich@pivotal.io>
