### PR TITLE
Improve efficiency of pagination count query

### DIFF
--- a/lib/cloud_controller/paging/sequel_paginator.rb
+++ b/lib/cloud_controller/paging/sequel_paginator.rb
@@ -9,15 +9,20 @@ module VCAP::CloudController
       order_direction = pagination_options.order_direction
 
       table_name = sequel_dataset.model.table_name
+      # DISTINCT requires sorting the table. This is much faster to do for just the primary key which is all that is needed for COUNT
+      record_count = if sequel_dataset.opts.key?(:distinct)
+                       pk_column_name = "#{table_name}__#{sequel_dataset.model.primary_key}".to_sym
+                       sequel_dataset.select(pk_column_name).count
+                     end
       column_name = "#{table_name}__#{order_by}".to_sym
       sequel_order = order_direction == 'asc' ? Sequel.asc(column_name) : Sequel.desc(column_name)
 
       if sequel_dataset.model.columns.include?(:guid)
         guid_column_name = "#{table_name}__guid".to_sym
         guid_sequel_order = Sequel.asc(guid_column_name)
-        query = sequel_dataset.extension(:pagination).paginate(page, per_page).order(sequel_order, guid_sequel_order)
+        query = sequel_dataset.extension(:pagination).paginate(page, per_page, record_count).order(sequel_order, guid_sequel_order)
       else
-        query = sequel_dataset.extension(:pagination).paginate(page, per_page).order(sequel_order)
+        query = sequel_dataset.extension(:pagination).paginate(page, per_page, record_count).order(sequel_order)
       end
 
       PaginatedResult.new(query.all, query.pagination_record_count, pagination_options)


### PR DESCRIPTION
## A short explanation of the proposed change:
Only count the primary key fields for DISTINCT queries

## An explanation of the use cases your change solves
When paginating results, a COUNT is performed to get the total number of
results that would be returned by the query. For queries with a
DISTINCT in their SELECT, this requires the DB to perform a full
sort over the entire SELECT table.* columns (sometimes 15+) which can be
very slow. Since this is only being used for a COUNT, only a unique
identifier is needed to do the count which is already unique so does not
require sorting. This halves the EXPLAIN cost of some of the
service_plans queries since that is currently sorting over 15+ fields
just to return a single COUNT.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
