### PR TITLE
Only join required tables

### DIFF
--- a/app/fetchers/base_service_list_fetcher.rb
+++ b/app/fetchers/base_service_list_fetcher.rb
@@ -8,15 +8,18 @@ module VCAP::CloudController
       private
 
       def select_readable(dataset, message, omniscient: false, readable_space_guids: [], readable_org_guids: [])
-        dataset = join_tables(dataset, message, omniscient)
-
         if readable_org_guids.any?
+          dataset = join_service_plans(dataset)
+          dataset = join_plan_orgs(dataset)
+          dataset = join_broker_spaces(dataset)
+
           dataset = dataset.where do
             (Sequel[:service_plans][:public] =~ true) |
               (Sequel[:plan_orgs][:guid] =~ readable_org_guids) |
               (Sequel[:broker_spaces][:guid] =~ readable_space_guids)
           end
         elsif !omniscient
+          dataset = join_service_plans(dataset)
           dataset = dataset.where { Sequel[:service_plans][:public] =~ true }
         end
 
@@ -36,10 +39,12 @@ module VCAP::CloudController
 
       def filter(message, dataset, klass)
         if message.requested?(:service_broker_guids)
+          dataset = join_service_brokers(dataset)
           dataset = dataset.where { Sequel[:service_brokers][:guid] =~ message.service_broker_guids }
         end
 
         if message.requested?(:service_broker_names)
+          dataset = join_service_brokers(dataset)
           dataset = dataset.where { Sequel[:service_brokers][:name] =~ message.service_broker_names }
         end
 
@@ -47,6 +52,10 @@ module VCAP::CloudController
       end
 
       def filter_orgs(dataset, organization_guids)
+        dataset = join_service_plans(dataset)
+        dataset = join_plan_orgs(dataset)
+        dataset = join_broker_orgs(dataset)
+
         dataset.where do
           (Sequel[:service_plans][:public] =~ true) |
             (Sequel[:plan_orgs][:guid] =~ organization_guids) |
@@ -60,6 +69,10 @@ module VCAP::CloudController
           readable_space_guids: readable_space_guids,
           omniscient: omniscient,
         )
+
+        dataset = join_service_plans(dataset)
+        dataset = join_plan_spaces(dataset)
+        dataset = join_broker_spaces(dataset)
 
         dataset.where do
           (Sequel[:service_plans][:public] =~ true) |
@@ -78,14 +91,50 @@ module VCAP::CloudController
         [:space_guids, :organization_guids].any? { |filter| message.requested?(filter) }
       end
 
-      def join_all_parent_tables(dataset)
-        dataset.
-          join(:service_brokers, id: Sequel[:services][:service_broker_id]).
-          left_join(Sequel[:spaces].as(:broker_spaces), id: Sequel[:service_brokers][:space_id]).
-          left_join(Sequel[:organizations].as(:broker_orgs), id: Sequel[:broker_spaces][:organization_id]).
-          left_join(:service_plan_visibilities, service_plan_id: Sequel[:service_plans][:id]).
-          left_join(Sequel[:organizations].as(:plan_orgs), id: Sequel[:service_plan_visibilities][:organization_id]).
-          left_join(Sequel[:spaces].as(:plan_spaces), organization_id: Sequel[:plan_orgs][:id])
+      def join_service_plans(dataset)
+        dataset
+      end
+
+      def join_services(dataset)
+        dataset
+      end
+
+      def join_service_instances(dataset)
+        dataset = join_service_plans(dataset)
+        join(dataset, :inner, :service_instances, service_plan_id: Sequel[:service_plans][:id])
+      end
+
+      def join_service_brokers(dataset)
+        dataset = join_services(dataset)
+        join(dataset, :inner, :service_brokers, id: Sequel[:services][:service_broker_id])
+      end
+
+      def join_broker_spaces(dataset)
+        dataset = join_service_brokers(dataset)
+        join(dataset, :left, Sequel[:spaces].as(:broker_spaces), id: Sequel[:service_brokers][:space_id])
+      end
+
+      def join_broker_orgs(dataset)
+        dataset = join_broker_spaces(dataset)
+        join(dataset, :left, Sequel[:organizations].as(:broker_orgs), id: Sequel[:broker_spaces][:organization_id])
+      end
+
+      def join_plan_orgs(dataset)
+        dataset = join_service_plans(dataset)
+        dataset = join(dataset, :left, :service_plan_visibilities, service_plan_id: Sequel[:service_plans][:id])
+        join(dataset, :left, Sequel[:organizations].as(:plan_orgs), id: Sequel[:service_plan_visibilities][:organization_id])
+      end
+
+      def join_plan_spaces(dataset)
+        dataset = join_plan_orgs(dataset)
+        join(dataset, :left, Sequel[:spaces].as(:plan_spaces), organization_id: Sequel[:plan_orgs][:id])
+      end
+
+      def join(dataset, type, table, on)
+        dataset.opts[:join]&.each do |j|
+          return dataset if j.table_expr == table
+        end
+        dataset.join_table(type, table, on)
       end
     end
   end

--- a/app/fetchers/service_offering_list_fetcher.rb
+++ b/app/fetchers/service_offering_list_fetcher.rb
@@ -15,23 +15,10 @@ module VCAP::CloudController
         filter(message, dataset).select_all(:services).distinct
       end
 
-      def join_tables(dataset, message, omniscient)
-        need_all_parent_tables = !omniscient || visibility_filter?(message)
+      private
 
-        filter_properties = [
-          :service_broker_guids,
-          :service_broker_names,
-        ]
-
-        need_broker_tables = filter_properties.any? { |filter| message.requested?(filter) }
-
-        if need_all_parent_tables
-          dataset = join_all_parent_tables(dataset.left_join(:service_plans, service_id: Sequel[:services][:id]))
-        elsif need_broker_tables
-          dataset = dataset.join(:service_brokers, id: Sequel[:services][:service_broker_id])
-        end
-
-        dataset
+      def join_service_plans(dataset)
+        join(dataset, :left, :service_plans, service_id: Sequel[:services][:id])
       end
 
       def filter(message, dataset)


### PR DESCRIPTION
`ServicePlanListFetcher` and `ServiceOfferingListFetcher` `JOIN` multiple tables to be used in `WHERE` conditions. The actual set of tables to be joined depends on the provided filters. Instead of joining a superset of tables, this change ensures that only the required tables will be joined.

Unfortunately Postgres does not remove unnecessary `JOIN`s and so they possibly result in slower query execution times.

Before using another table in a `WHERE` clause, one simply has to call `join_<table>(dataset)`. This can even be done multiple times for each table as the underlying `join(dataset, type, table, on)` function ensures that only unique table expressions are added.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
