### PR TITLE
Fix 500 error when listing sidecars for a resource that doesn't exist

### DIFF
--- a/app/fetchers/sidecar_list_fetcher.rb
+++ b/app/fetchers/sidecar_list_fetcher.rb
@@ -5,12 +5,12 @@ module VCAP::CloudController
     class << self
       def fetch_for_app(message, app_guid)
         app, _, _ = AppFetcher.new.fetch(app_guid)
-        [app, filter(message, app.sidecars_dataset)]
+        [app, filter(message, app&.sidecars_dataset)]
       end
 
       def fetch_for_process(message, process_guid)
         process, _, _ = ProcessFetcher.fetch(process_guid: process_guid)
-        [process, filter(message, process.sidecars_dataset)]
+        [process, filter(message, process&.sidecars_dataset)]
       end
 
       private

--- a/spec/request/sidecars_spec.rb
+++ b/spec/request/sidecars_spec.rb
@@ -468,6 +468,13 @@ RSpec.describe 'Sidecars' do
         expect(parsed_response).to be_a_response_like(expected_response)
       end
 
+      context 'when the process does not exist' do
+        it 'returns a 404 error' do
+          get '/v3/processes/fake-process-guid/sidecars?per_page=2', nil, user_header
+          expect(last_response.status).to eq(404), last_response.body
+        end
+      end
+
       context 'filtering on created_ats and updated_ats' do
         let(:app_model3) { VCAP::CloudController::AppModel.make }
         let!(:process3) { VCAP::CloudController::ProcessModel.make(
@@ -601,6 +608,13 @@ RSpec.describe 'Sidecars' do
             ]
           }
       )
+      end
+
+      context 'when the app does not exist' do
+        it 'returns a 404 error' do
+          get '/v3/apps/fake-app-guid/sidecars?per_page=2', nil, user_header
+          expect(last_response.status).to eq(404), last_response.body
+        end
       end
 
       it_behaves_like 'list_endpoint_with_common_filters' do

--- a/spec/unit/fetchers/sidecar_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/sidecar_list_fetcher_spec.rb
@@ -21,6 +21,15 @@ module VCAP::CloudController
         expect(app).to eq(app_model)
         expect(results).to contain_exactly(sidecar1, sidecar2)
       end
+
+      context 'when the app does not exist' do
+        it 'returns nil for the app' do
+          app, results = fetcher.fetch_for_app(message, 'non-existant-app-guid')
+
+          expect(app).to be_nil
+          expect(results).to be_nil
+        end
+      end
     end
 
     describe '#fetch_for_process' do
@@ -61,6 +70,15 @@ module VCAP::CloudController
 
         expect(process).to eq(worker_process)
         expect(results).to contain_exactly(sidecar2)
+      end
+
+      context 'when the process does not exist' do
+        it 'returns nil for the app' do
+          process, results = fetcher.fetch_for_process(message, 'non-existant-process-guid')
+
+          expect(process).to be_nil
+          expect(results).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
* A short explanation of the proposed change:

The list sidecars for an app/process endpoints would return a `500 - UnknownError` response if the app/process didn't exist. This PR adds some tests and a nil check to correctly return `404` errors.

* An explanation of the use cases your change solves

Makes these endpoints behave correctly.

* Links to any other associated PRs

N/A

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats) (nope)
