### PR TITLE
Simplify roles query for performance

### DIFF
--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -159,10 +159,7 @@ class RolesController < ApplicationController
   end
 
   def readable_roles
-    roles_in_visible_spaces = Role.filter(space_id: visible_space_ids)
-    roles_in_visible_orgs = Role.filter(organization_id: visible_org_ids)
-
-    roles_in_visible_spaces.union(roles_in_visible_orgs)
+    Role.where(space_id: visible_space_ids).or(organization_id: visible_org_ids)
   end
 
   def visible_space_ids


### PR DESCRIPTION
## A short explanation of the proposed change:
Replace UNION-ed subqueries with single subquery and WHERE OR clause

## An explanation of the use cases your change solves
The many UNIONs (14 in total) were causing these queries to be extremely complex and slow on our largest landscapes resulting in impact to other queries being made (lots of temp blocks being written). This change simplifies the query so much it no longer needs temp blocks.

## Added context
The backing dataset for the Role class uses a UNION between all the
different org and space roles where the organization_id is -1 for space
roles and vice versa. This means that no role can have both a space_id
and an org_id so doing a SELECT WHERE space_id IN (space_ids) and UNION
that to SELECT WHERE org_id in (org_ids) can be replaced by just a
single select with an OR in the query clause

In our largest environments this reduced the complexity of this query
(using EXPLAIN ANALYZE) by nearly 30x

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
