### PR TITLE
Remove joins to space and org tables for permissions

### DIFF
--- a/app/controllers/v3/service_offerings_controller.rb
+++ b/app/controllers/v3/service_offerings_controller.rb
@@ -34,8 +34,8 @@ class ServiceOfferingsController < ApplicationController
               else
                 ServiceOfferingListFetcher.fetch(
                   message,
-                  readable_org_guids: permission_queryer.readable_org_guids,
-                  readable_space_guids: permission_queryer.readable_space_scoped_space_guids,
+                  readable_orgs: permission_queryer.readable_orgs,
+                  readable_spaces: permission_queryer.readable_space_scoped_spaces,
                   eager_loaded_associations: Presenters::V3::ServiceOfferingPresenter.associated_resources,
                 )
               end

--- a/app/controllers/v3/service_plans_controller.rb
+++ b/app/controllers/v3/service_plans_controller.rb
@@ -54,8 +54,8 @@ class ServicePlansController < ApplicationController
                 ServicePlanListFetcher.fetch(
                   message,
                   eager_loaded_associations: Presenters::V3::ServicePlanPresenter.associated_resources,
-                  readable_org_guids: permission_queryer.readable_org_guids,
-                  readable_space_guids: permission_queryer.readable_space_scoped_space_guids,
+                  readable_orgs: permission_queryer.readable_orgs,
+                  readable_spaces: permission_queryer.readable_space_scoped_spaces,
                 )
               end
 

--- a/app/fetchers/service_offering_list_fetcher.rb
+++ b/app/fetchers/service_offering_list_fetcher.rb
@@ -3,13 +3,13 @@ require 'fetchers/base_service_list_fetcher'
 module VCAP::CloudController
   class ServiceOfferingListFetcher < BaseServiceListFetcher
     class << self
-      def fetch(message, omniscient: false, readable_space_guids: [], readable_org_guids: [], eager_loaded_associations: [])
+      def fetch(message, omniscient: false, readable_spaces: [], readable_orgs: [], eager_loaded_associations: [])
         dataset = select_readable(
           Service.dataset.eager(eager_loaded_associations),
           message,
           omniscient: omniscient,
-          readable_org_guids: readable_org_guids,
-          readable_space_guids: readable_space_guids,
+          readable_orgs: readable_orgs,
+          readable_spaces: readable_spaces,
         )
 
         filter(message, dataset).select_all(:services).distinct

--- a/app/fetchers/service_plan_list_fetcher.rb
+++ b/app/fetchers/service_plan_list_fetcher.rb
@@ -3,13 +3,13 @@ require 'fetchers/base_service_list_fetcher'
 module VCAP::CloudController
   class ServicePlanListFetcher < BaseServiceListFetcher
     class << self
-      def fetch(message, omniscient: false, readable_space_guids: [], readable_org_guids: [], eager_loaded_associations: [])
+      def fetch(message, omniscient: false, readable_spaces: [], readable_orgs: [], eager_loaded_associations: [])
         dataset = select_readable(
           ServicePlan.dataset.eager(eager_loaded_associations),
           message,
           omniscient: omniscient,
-          readable_org_guids: readable_org_guids,
-          readable_space_guids: readable_space_guids,
+          readable_orgs: readable_orgs,
+          readable_spaces: readable_spaces,
         )
 
         filter(message, dataset).select_all(:service_plans).distinct

--- a/lib/cloud_controller/membership.rb
+++ b/lib/cloud_controller/membership.rb
@@ -29,12 +29,16 @@ module VCAP::CloudController
     end
 
     def org_guids_for_roles_subquery(roles)
+      orgs_for_roles_subquery(roles).select(:guid)
+    end
+
+    def orgs_for_roles_subquery(roles)
       org_role_dataset = OrganizationRole.where(type: org_roles(roles), user_id: @user.id)
-      org_guid_dataset = Organization.where(id: org_role_dataset.select(:organization_id)).select(:guid)
+      org_guid_dataset = Organization.where(id: org_role_dataset.select(:organization_id)).select(:id, :guid)
 
       space_role_dataset = SpaceRole.where(type: space_roles(roles), user_id: @user.id)
       spaces_dataset = Space.where(id: space_role_dataset.select(:space_id))
-      org_guids_for_space_roles_dataset = Organization.where(id: spaces_dataset.select(:organization_id)).select(:guid)
+      org_guids_for_space_roles_dataset = Organization.where(id: spaces_dataset.select(:organization_id)).select(:id, :guid)
 
       org_guids_for_space_roles_dataset.union(org_guid_dataset)
     end
@@ -44,11 +48,15 @@ module VCAP::CloudController
     end
 
     def space_guids_for_roles_subquery(roles)
+      spaces_for_roles_subquery(roles).select(:guid)
+    end
+
+    def spaces_for_roles_subquery(roles)
       space_role_dataset = SpaceRole.where(type: space_roles(roles), user_id: @user.id)
-      space_guid_dataset = Space.where(id: space_role_dataset.select(:space_id)).select(:guid)
+      space_guid_dataset = Space.where(id: space_role_dataset.select(:space_id)).select(:id, :guid)
 
       org_role_dataset = OrganizationRole.where(type: org_roles(roles), user_id: @user.id)
-      space_guids_for_org_roles_dataset = Space.where(organization_id: org_role_dataset.select(:organization_id)).select(:guid)
+      space_guids_for_org_roles_dataset = Space.where(organization_id: org_role_dataset.select(:organization_id)).select(:id, :guid)
 
       space_guids_for_org_roles_dataset.union(space_guid_dataset)
     end

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -122,6 +122,14 @@ class VCAP::CloudController::Permissions
     end
   end
 
+  def readable_orgs
+    if can_read_globally?
+      VCAP::CloudController::Organization.select(:id, :guid).all
+    else
+      membership.orgs_for_roles_subquery(ROLES_FOR_ORG_READING).all
+    end
+  end
+
   def readable_org_guids_for_domains_query
     if can_read_globally?
       VCAP::CloudController::Organization.select(:guid)
@@ -238,6 +246,14 @@ class VCAP::CloudController::Permissions
       VCAP::CloudController::Space.select(:guid).all.map(&:guid)
     else
       membership.space_guids_for_roles(SPACE_ROLES)
+    end
+  end
+
+  def readable_space_scoped_spaces
+    if can_read_globally?
+      VCAP::CloudController::Space.select(:id, :guid).all
+    else
+      membership.spaces_for_roles_subquery(SPACE_ROLES).all
     end
   end
 

--- a/spec/unit/fetchers/service_offering_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_offering_list_fetcher_spec.rb
@@ -65,12 +65,12 @@ module VCAP::CloudController
           end
         end
 
-        context 'when `readable_org_guids` are specified' do
+        context 'when `readable_orgs` are specified' do
           it 'includes public plans and ones for those orgs' do
             service_offerings = fetcher.fetch(
               message,
-              readable_org_guids: [org_1.guid, org_3.guid],
-              readable_space_guids: [],
+              readable_orgs: [org_1, org_3],
+              readable_spaces: [],
             ).all
 
             expect(service_offerings).to contain_exactly(
@@ -83,12 +83,12 @@ module VCAP::CloudController
           end
         end
 
-        context 'when both `readable_space_guids` and `readable_org_guids` are specified' do
+        context 'when both `readable_spaces` and `readable_orgs` are specified' do
           it 'includes public plans, ones for those spaces and ones for those orgs' do
             service_offerings = fetcher.fetch(
               message,
-              readable_space_guids: [space_3.guid],
-              readable_org_guids: [org_3.guid],
+              readable_spaces: [space_3],
+              readable_orgs: [org_3],
             ).all
 
             expect(service_offerings).to contain_exactly(
@@ -152,8 +152,8 @@ module VCAP::CloudController
 
               service_offerings = ServiceOfferingListFetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid],
-                readable_space_guids: [],
+                readable_orgs: [org_1],
+                readable_spaces: [],
               ).all
 
               expect(service_offerings).to contain_exactly(org_restricted_offering_1, public_offering)
@@ -168,8 +168,8 @@ module VCAP::CloudController
 
               service_offerings = ServiceOfferingListFetcher.fetch(
                 message,
-                readable_org_guids: [],
-                readable_space_guids: [],
+                readable_orgs: [],
+                readable_spaces: [],
               ).all
 
               expect(service_offerings).to contain_exactly(public_offering)
@@ -187,8 +187,8 @@ module VCAP::CloudController
 
               service_offerings = ServiceOfferingListFetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid],
-                readable_space_guids: [space_1.guid],
+                readable_orgs: [org_1],
+                readable_spaces: [space_1],
               ).all
 
               expect(service_offerings).to contain_exactly(public_offering, org_restricted_offering_1, space_scoped_offering_1)
@@ -222,8 +222,8 @@ module VCAP::CloudController
               }.with_indifferent_access)
               service_offerings = ServiceOfferingListFetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid],
-                readable_space_guids: [space_1.guid],
+                readable_orgs: [org_1],
+                readable_spaces: [space_1],
               ).all
               expect(service_offerings).to contain_exactly(space_scoped_offering_1, org_restricted_offering_1, public_offering)
             end
@@ -236,8 +236,8 @@ module VCAP::CloudController
               }.with_indifferent_access)
               service_offerings = ServiceOfferingListFetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid, org_2.guid],
-                readable_space_guids: [space_1.guid],
+                readable_orgs: [org_1, org_2],
+                readable_spaces: [space_1],
               ).all
               expect(service_offerings).to contain_exactly(space_scoped_offering_1, org_restricted_offering_1, public_offering)
             end
@@ -251,8 +251,8 @@ module VCAP::CloudController
 
               service_offerings = ServiceOfferingListFetcher.fetch(
                 message,
-                readable_org_guids: [],
-                readable_space_guids: [],
+                readable_orgs: [],
+                readable_spaces: [],
               ).all
 
               expect(service_offerings).to contain_exactly(public_offering)
@@ -289,8 +289,8 @@ module VCAP::CloudController
               }.with_indifferent_access)
               service_offerings = ServiceOfferingListFetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid, org_2.guid],
-                readable_space_guids: [space_1.guid],
+                readable_orgs: [org_1, org_2],
+                readable_spaces: [space_1],
               ).all
               expect(service_offerings).to contain_exactly(public_offering)
             end

--- a/spec/unit/fetchers/service_plan_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_plan_list_fetcher_spec.rb
@@ -78,12 +78,12 @@ module VCAP::CloudController
           end
         end
 
-        context 'when `readable_org_guids` are specified' do
+        context 'when `readable_org` are specified' do
           it 'includes public plans and ones for those orgs' do
             service_plans = fetcher.fetch(
               message,
-              readable_org_guids: [org_1.guid, org_3.guid],
-              readable_space_guids: [],
+              readable_orgs: [org_1, org_3],
+              readable_spaces: [],
             ).all
 
             expect(service_plans).to contain_exactly(
@@ -96,12 +96,12 @@ module VCAP::CloudController
           end
         end
 
-        context 'when both `readable_space_guids` and `readable_org_guids` are specified' do
+        context 'when both `readable_spaces` and `readable_orgs` are specified' do
           it 'includes public plans, ones for those spaces and ones for those orgs' do
             service_plans = fetcher.fetch(
               message,
-              readable_space_guids: [space_3.guid],
-              readable_org_guids: [org_3.guid],
+              readable_spaces: [space_3],
+              readable_orgs: [org_3],
             ).all
 
             expect(service_plans).to contain_exactly(
@@ -165,8 +165,8 @@ module VCAP::CloudController
 
               service_plans = fetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid],
-                readable_space_guids: [],
+                readable_orgs: [org_1],
+                readable_spaces: [],
               ).all
 
               expect(service_plans).to contain_exactly(org_restricted_plan_1, public_plan)
@@ -181,8 +181,8 @@ module VCAP::CloudController
 
               service_plans = fetcher.fetch(
                 message,
-                readable_org_guids: [],
-                readable_space_guids: [],
+                readable_orgs: [],
+                readable_spaces: [],
               ).all
 
               expect(service_plans).to contain_exactly(public_plan)
@@ -200,8 +200,8 @@ module VCAP::CloudController
 
               service_plans = fetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid],
-                readable_space_guids: [space_1.guid],
+                readable_orgs: [org_1],
+                readable_spaces: [space_1],
               ).all
 
               expect(service_plans).to contain_exactly(public_plan, org_restricted_plan_1, space_scoped_plan_1)
@@ -235,8 +235,8 @@ module VCAP::CloudController
               }.with_indifferent_access)
               service_plans = fetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid],
-                readable_space_guids: [space_1.guid],
+                readable_orgs: [org_1],
+                readable_spaces: [space_1],
               ).all
               expect(service_plans).to contain_exactly(space_scoped_plan_1, org_restricted_plan_1, public_plan)
             end
@@ -249,8 +249,8 @@ module VCAP::CloudController
               }.with_indifferent_access)
               service_plans = fetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid, org_2.guid],
-                readable_space_guids: [space_1.guid],
+                readable_orgs: [org_1, org_2],
+                readable_spaces: [space_1],
               ).all
               expect(service_plans).to contain_exactly(space_scoped_plan_1, org_restricted_plan_1, public_plan)
             end
@@ -264,8 +264,8 @@ module VCAP::CloudController
 
               service_plans = fetcher.fetch(
                 message,
-                readable_org_guids: [],
-                readable_space_guids: [],
+                readable_orgs: [],
+                readable_spaces: [],
               ).all
 
               expect(service_plans).to contain_exactly(public_plan)
@@ -302,8 +302,8 @@ module VCAP::CloudController
               }.with_indifferent_access)
               service_plans = fetcher.fetch(
                 message,
-                readable_org_guids: [org_1.guid, org_2.guid],
-                readable_space_guids: [space_1.guid],
+                readable_orgs: [org_1, org_2],
+                readable_spaces: [space_1],
               ).all
               expect(service_plans).to contain_exactly(public_plan)
             end
@@ -464,7 +464,7 @@ module VCAP::CloudController
         context 'when org user' do
           let(:org_1) { Organization.make }
           let(:space_1) { Space.make(organization: org_1) }
-          let(:service_plans) { fetcher.fetch(message, omniscient: false, readable_space_guids: [space_1.guid], readable_org_guids: [org_1.guid]).all }
+          let(:service_plans) { fetcher.fetch(message, omniscient: false, readable_spaces: [space_1], readable_orgs: [org_1]).all }
 
           it_behaves_like 'filtered service plans fetcher'
         end


### PR DESCRIPTION
## A short explanation of the proposed change
Don't join to space/org tables just to filter permissions by `guid` when we could use `id` instead

## An explanation of the use cases your change solves
Unfiltered (i.e. no `space_guids` or `org_guids` query params) will have 2 less joins in this (fairly large) statement to do so queries should be simpler and just faster.

## Info
There were 2 joins performed to the space and org tables just so that
the permissions check could filter by readable space guids and readable
org guids. As we fetch the entire space/org object in the permissions
check, it is simple to just grab the IDs instead. As the tables
reference the space_id and organization_id, we can avoid joining to
space and org and just do a WHERE IN check on those columns instead. For
filtering, the API still accepts GUIDs so the joins are still performed
there.

## Links to any other associated PRs
Similar theme to #2528 in terms of speeding up this endpoint

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
