### PR TITLE
Revert "Use file upload start time to calculate token validity"

### DIFF
--- a/app/controllers/runtime/app_bits_upload_controller.rb
+++ b/app/controllers/runtime/app_bits_upload_controller.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController
     def check_authentication(operation)
       auth                  = env['HTTP_AUTHORIZATION']
       grace_period          = config.get(:app_bits_upload_grace_period_in_seconds)
-      relaxed_token_decoder = VCAP::CloudController::UaaTokenDecoder.new(config.get(:uaa), grace_period_in_seconds: grace_period)
+      relaxed_token_decoder = VCAP::CloudController::UaaTokenDecoder.new(config.get(:uaa), grace_period)
       VCAP::CloudController::Security::SecurityContextConfigurer.new(relaxed_token_decoder).configure(auth)
       super
     end

--- a/app/messages/buildpack_upload_message.rb
+++ b/app/messages/buildpack_upload_message.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
   class BuildpackUploadMessage < BaseMessage
     class MissingFilePathError < StandardError; end
 
-    register_allowed_keys [:bits_path, :bits_name, :upload_start_time]
+    register_allowed_keys [:bits_path, :bits_name]
 
     validates_with NoAdditionalKeysValidator
 

--- a/app/messages/droplet_upload_message.rb
+++ b/app/messages/droplet_upload_message.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
   class DropletUploadMessage < BaseMessage
     class MissingFilePathError < StandardError; end
 
-    register_allowed_keys [:bits_path, :bits_name, :upload_start_time]
+    register_allowed_keys [:bits_path, :bits_name]
 
     validates_with NoAdditionalKeysValidator
 

--- a/app/messages/package_upload_message.rb
+++ b/app/messages/package_upload_message.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
   class PackageUploadMessage < BaseMessage
     class MissingFilePathError < StandardError; end
 
-    register_allowed_keys [:bits_path, :bits_name, :upload_start_time, :resources]
+    register_allowed_keys [:bits_path, :bits_name, :resources]
 
     validates_with NoAdditionalKeysValidator
 

--- a/spec/unit/lib/uaa/uaa_token_decoder_spec.rb
+++ b/spec/unit/lib/uaa/uaa_token_decoder_spec.rb
@@ -30,7 +30,7 @@ module VCAP::CloudController
     describe '.new' do
       context 'when the decoder is created with a grace period' do
         context 'and that grace period is negative' do
-          subject { UaaTokenDecoder.new(uaa_config, grace_period_in_seconds: -10) }
+          subject { UaaTokenDecoder.new(uaa_config, -10) }
 
           it 'logs a warning that the grace period was changed to 0' do
             expect(logger).to receive(:warn).with(/negative grace period interval.*-10.*is invalid, changed to 0/i)
@@ -39,7 +39,7 @@ module VCAP::CloudController
         end
 
         context 'and that grace period is not an integer' do
-          subject { UaaTokenDecoder.new(uaa_config, grace_period_in_seconds: 'blabla') }
+          subject { UaaTokenDecoder.new(uaa_config, 'blabla') }
 
           it 'raises an ArgumentError' do
             expect {
@@ -445,50 +445,8 @@ module VCAP::CloudController
           end
         end
 
-        context 'when the decoder has an alternate reference time specified' do
-          subject { UaaTokenDecoder.new(uaa_config, alternate_reference_time: Time.now.utc.to_i - 100) }
-          let(:token_content) do
-            { 'aud'     => 'resource-id',
-              'payload' => 123,
-              'exp'     => Time.now.utc.to_i,
-              'iss'     => uaa_issuer_string,
-              'jti'     => 'adb2aa5535d04a3180ec56927c859549',
-            }
-          end
-
-          let(:token) { generate_token(rsa_key, token_content) }
-
-          context 'and the token is currently expired but had not expired at the alternate reference time' do
-            it 'decodes the token' do
-              token_content['exp'] = Time.now.utc.to_i - 50
-              expect(logger).to receive(:info).with(/using alternate reference time/i)
-              expect(subject.decode_token("bearer #{token}")).to eq token_content
-            end
-          end
-
-          context 'and the token was expired at the alternate reference time' do
-            it 'raises and logs a warning about the expired token' do
-              token_content['exp'] = Time.now.utc.to_i - 150
-              expect(logger).to receive(:info).with(/using alternate reference time/i)
-              expect(logger).to receive(:warn).with(/token expired/i)
-              expect {
-                subject.decode_token("bearer #{token}")
-              }.to raise_error(VCAP::CloudController::UaaTokenDecoder::BadToken)
-            end
-          end
-        end
-
-        context 'when the decoder has both a grace period and an alternate reference time specified' do
-          subject { UaaTokenDecoder.new(uaa_config, grace_period_in_seconds: 100, alternate_reference_time: '123') }
-          it 'raises an ArgumentError' do
-            expect {
-              subject
-            }.to raise_error(ArgumentError, /grace period and alternate reference time cannot be used together/i)
-          end
-        end
-
-        context 'when the decoder has a grace period specified' do
-          subject { UaaTokenDecoder.new(uaa_config, grace_period_in_seconds: 100) }
+        context 'when the decoder has an grace period specified' do
+          subject { UaaTokenDecoder.new(uaa_config, 100) }
           let(:token_content) do
             { 'aud'     => 'resource-id',
               'payload' => 123,
@@ -519,7 +477,7 @@ module VCAP::CloudController
           end
 
           context 'and that grace period interval is negative' do
-            subject { UaaTokenDecoder.new(uaa_config, grace_period_in_seconds: -10) }
+            subject { UaaTokenDecoder.new(uaa_config, -10) }
 
             it 'sets the grace period to be 0 instead' do
               token_content['exp'] = Time.now.utc.to_i


### PR DESCRIPTION
Revert https://github.com/cloudfoundry/cloud_controller_ng/pull/2452 due to failing pipelines, see comment on issue