### PR TITLE
Bump to hashdiff 1.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
     grpc (1.38.0-x86_64-linux)
       google-protobuf (~> 3.15)
       googleapis-common-protos-types (~> 1.0)
-    hashdiff (0.3.8)
+    hashdiff (1.0.1)
     honeycomb-beeline (2.7.0)
       libhoney (~> 1.14, >= 1.14.2)
     http (4.4.1)

--- a/app/actions/revision_resolver.rb
+++ b/app/actions/revision_resolver.rb
@@ -72,7 +72,7 @@ module VCAP::CloudController
           revision_to_create.commands_by_process_type
         ))
 
-        sidecars_differences = HashDiff.diff(
+        sidecars_differences = Hashdiff.diff(
           latest_revision.sidecars.sort_by(&:name).map(&:to_hash),
           revision_to_create.sidecars.sort_by(&:name).map(&:to_hash)
         )
@@ -87,7 +87,7 @@ module VCAP::CloudController
       end
 
       def list_process_command_changes(commands_by_process_type_a, commands_by_process_type_b)
-        commands_differences = HashDiff.diff(commands_by_process_type_a, commands_by_process_type_b)
+        commands_differences = Hashdiff.diff(commands_by_process_type_a, commands_by_process_type_b)
 
         commands_differences.map do |change_type, process_type, *command_change|
           if change_type == '+'

--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -1,7 +1,6 @@
 require 'cloud_controller/database_uri_generator'
 require 'cloud_controller/serializer'
 require 'models/helpers/process_types'
-require 'hashdiff'
 
 module VCAP::CloudController
   class AppModel < Sequel::Model(:apps)

--- a/spec/request/service_offerings_spec.rb
+++ b/spec/request/service_offerings_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'request_spec_shared_examples'
 require 'models/services/service_plan'
-require 'hashdiff'
 
 UNAUTHENTICATED = %w[unauthenticated].freeze
 

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'request_spec_shared_examples'
 require 'models/services/service_plan'
-require 'hashdiff'
 
 UNAUTHENTICATED = %w[unauthenticated].freeze
 

--- a/spec/support/matchers/be_a_response_like.rb
+++ b/spec/support/matchers/be_a_response_like.rb
@@ -56,7 +56,7 @@ RSpec::Matchers.define :be_a_response_like do |expected, problem_keys=[]|
   exception = nil
   failure_message do |actual|
     begin
-      diffs = HashDiff.best_diff(expected, actual)
+      diffs = Hashdiff.best_diff(expected, actual)
       if diffs
         diffs.each do |comparator, key, expected_value, actual_value|
           case comparator

--- a/spec/support/matchers/match_json_response.rb
+++ b/spec/support/matchers/match_json_response.rb
@@ -12,7 +12,7 @@ RSpec::Matchers.define :match_json_response do |expected|
     actual = actual.deep_symbolize_keys
 
     begin
-      diffs = HashDiff.best_diff(expected.deep_symbolize_keys, actual)
+      diffs = Hashdiff.best_diff(expected.deep_symbolize_keys, actual)
       if diffs
         diffs.each do |comparator, key, expected_value, actual_value|
           case comparator


### PR DESCRIPTION
- remove unneeded requires
- switch `HashDiff` to `Hashdiff`
- should fix #1644 created by dependabot

Authored-by: Michael Oleske <moleske@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
