### PR TITLE
Fetch existing service keys count only when quota is set

### DIFF
--- a/app/models/runtime/quota_constraints/max_service_keys_policy.rb
+++ b/app/models/runtime/quota_constraints/max_service_keys_policy.rb
@@ -1,10 +1,10 @@
 class MaxServiceKeysPolicy
   attr_reader :quota_definition
 
-  def initialize(service_key, existing_service_keys_count, quota_definition, error_name)
+  def initialize(service_key, existing_service_keys_dataset, quota_definition, error_name)
     @service_key = service_key
+    @existing_service_keys_dataset = existing_service_keys_dataset
     @quota_definition = quota_definition
-    @existing_service_keys_count = existing_service_keys_count
     @error_name = error_name
     @errors = service_key.errors
   end
@@ -19,7 +19,7 @@ class MaxServiceKeysPolicy
 
   def service_keys_quota_remaining?
     @quota_definition.total_service_keys == -1 || # unlimited
-      @existing_service_keys_count + requested_service_key <= @quota_definition.total_service_keys
+      @existing_service_keys_dataset.count + requested_service_key <= @quota_definition.total_service_keys
   end
 
   def requested_service_key

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -45,13 +45,13 @@ module VCAP::CloudController
       if service_instance
         MaxServiceKeysPolicy.new(
           self,
-          ServiceKey.filter(service_instance: space.organization.service_instances).count,
+          ServiceKey.filter(service_instance: space.organization.service_instances),
           space.organization.quota_definition,
           :service_keys_quota_exceeded
         ).validate
         MaxServiceKeysPolicy.new(
           self,
-          ServiceKey.filter(service_instance: space.service_instances).count,
+          ServiceKey.filter(service_instance: space.service_instances),
           space.space_quota_definition,
           :service_keys_space_quota_exceeded
         ).validate

--- a/spec/unit/models/runtime/quota_constraints/max_service_keys_policy_spec.rb
+++ b/spec/unit/models/runtime/quota_constraints/max_service_keys_policy_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe MaxServiceKeysPolicy do
   let(:total_service_keys) { 2 }
   let(:quota) { VCAP::CloudController::QuotaDefinition.make total_service_keys: total_service_keys }
   let(:existing_service_key_count) { 0 }
+  let(:existing_service_key_dataset) { double(Sequel::Dataset, count: existing_service_key_count) }
   let(:error_name) { :random_error_name }
 
-  let(:policy) { MaxServiceKeysPolicy.new(service_key, existing_service_key_count, quota, error_name) }
+  let(:policy) { MaxServiceKeysPolicy.new(service_key, existing_service_key_dataset, quota, error_name) }
 
   def make_service_key
     VCAP::CloudController::ServiceKey.make service_instance: service_instance


### PR DESCRIPTION
With this change the existing service keys count is fetched only when the quota for `total_service_keys` is not -1 (i.e. unlimited). This removes an unneeded database query.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
