### PR TITLE
Add index for service_instance_id to service_keys table

### DIFF
--- a/db/migrations/20211102133700_add_service_instance_id_index_to_service_keys.rb
+++ b/db/migrations/20211102133700_add_service_instance_id_index_to_service_keys.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :service_keys do
+      add_index :service_instance_id, name: :sk_svc_instance_id_index
+    end
+  end
+
+  down do
+    alter_table :service_keys do
+      drop_index :service_instance_id, name: :sk_svc_instance_id_index
+    end
+  end
+end


### PR DESCRIPTION
While improving the selection of existing service keys and reducing the number of database queries from 3 ([1]) to 1 ([2]), we found out that the sub-select queries were very slow (for a large number of service instances) due to a missing index.

[1]
```
SELECT * FROM "spaces" WHERE ("organization_id" = <ORG_ID>);
SELECT * FROM "service_instances" WHERE ("space_id" IN (<SPACE_IDS>));
SELECT count(*) AS "count" FROM "service_keys"
  WHERE ("service_instance_id" IN (<SERVICE_INSTANCE_IDS>)) LIMIT 1;
```

[2]
```
SELECT count(*) AS "count" FROM "service_keys"
  WHERE ("service_instance_id" IN (
    SELECT "id" FROM "service_instances" WHERE ("space_id" IN (
      SELECT "id" FROM "spaces" WHERE ("organization_id" = <ORG_ID>)
    ))
  )) LIMIT 1;
```

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
