### PR TITLE
Don't fetch feature flag twice

### DIFF
--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -171,6 +171,10 @@ module VCAP::CloudController
     end
 
     describe '.raise_unless_enabled!' do
+      before do
+        allow(FeatureFlag).to receive(:find).once.and_call_original
+      end
+
       context 'when the flag is enabled' do
         before do
           feature_flag.enabled = true


### PR DESCRIPTION
When using `FeatureFlag.raise_unless_enabled!` the feature flag was selected twice from the database (i.e. a second time as part of calling `FeatureFlag.enabled?`).

The code has been refactored to ensure that only a single select is performed.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
