### PR TITLE
Update manifest diff docs to use `--data-binary` flag

### DIFF
--- a/docs/v3/source/includes/resources/manifests/_create_diff.md
+++ b/docs/v3/source/includes/resources/manifests/_create_diff.md
@@ -9,7 +9,7 @@ curl "https://api.example.org/v3/spaces/[guid]/manifest_diff" \
   -X POST \
   -H "Content-Type: application/x-yaml" \
   -H "Authorization: bearer [token]" \
-  -d @/path/to/manifest.yml
+  --data-binary @/path/to/manifest.yml
 ```
 
 ```


### PR DESCRIPTION
Update manifest diff docs to use `--data-binary` flag. The `-d` flag causes curl to strip newlines which makes the manifest YAML invalid.

If you call the endpoint with `-d` you'll get a 500 error which is probably a problem in itself.

```
{
  "errors": [
    {
      "title": "UnknownError",
      "detail": "An unknown error occurred.",
      "code": 10001
    }
  ]
}
```

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [] I have run all the unit tests using `bundle exec rake`

* [] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
