### PR TITLE
Rate limit endpoints that interact with service brokers

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -263,6 +263,8 @@ rate_limiter:
   global_unauthenticated_limit: 1000
   reset_interval_in_minutes: 60
 
+max_concurrent_service_broker_requests: 0
+
 diego:
   file_server_url: http://file-server.service.cf.internal:8080
   cc_uploader_url: https://cc-uploader.service.cf.internal:9091

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -103,6 +103,11 @@
   http_code: 503
   message: "%s"
 
+10016:
+  name: ServiceBrokerRateLimitExceeded
+  http_code: 429
+  message: "Service broker concurrent request limit exceeded"
+
 20001:
   name: UserInvalid
   http_code: 400

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -291,6 +291,7 @@ module VCAP::CloudController
               global_unauthenticated_limit: Integer,
               reset_interval_in_minutes: Integer,
             },
+            max_concurrent_service_broker_requests: Integer,
             shared_isolation_segment_name: String,
 
             opi: {

--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -6,6 +6,7 @@ require 'request_logs'
 require 'cef_logs'
 require 'security_context_setter'
 require 'rate_limiter'
+require 'service_broker_rate_limiter'
 require 'new_relic_custom_attributes'
 require 'zipkin'
 require 'block_v3_only_roles'
@@ -35,6 +36,12 @@ module VCAP::CloudController
             per_process_unauthenticated_limit: config.get(:rate_limiter, :per_process_unauthenticated_limit),
             global_unauthenticated_limit: config.get(:rate_limiter, :global_unauthenticated_limit),
             interval: config.get(:rate_limiter, :reset_interval_in_minutes),
+          }
+        end
+        if config.get(:max_concurrent_service_broker_requests) > 0
+          use CloudFoundry::Middleware::ServiceBrokerRateLimiter, {
+            logger: Steno.logger('cc.service_broker_rate_limiter'),
+            concurrent_limit: config.get(:max_concurrent_service_broker_requests),
           }
         end
 

--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -1,0 +1,97 @@
+module CloudFoundry
+  module Middleware
+    class ServiceBrokerRequestCounter
+      include Singleton
+
+      def initialize
+        @mutex = Mutex.new
+        @data = {}
+      end
+
+      def can_make_request?(user_guid, limit)
+        @mutex.synchronize do
+          request_count = @data.fetch(user_guid, 0)
+          return false if request_count + 1 > limit
+
+          @data[user_guid] = request_count + 1
+          true
+        end
+      end
+
+      def decrement(user_guid)
+        @mutex.synchronize do
+          @data[user_guid] = @data[user_guid] - 1
+        end
+      end
+    end
+
+    class ServiceBrokerRateLimiter
+      def initialize(app, logger:, concurrent_limit:)
+        @app                               = app
+        @logger                            = logger
+        @concurrent_limit = concurrent_limit
+        @request_counter = ServiceBrokerRequestCounter.instance
+      end
+
+      def call(env)
+        request = ActionDispatch::Request.new(env)
+        user_guid = env['cf.user_guid']
+
+        unless skip_rate_limiting?(env, request)
+          return too_many_requests!(env) unless @request_counter.can_make_request?(user_guid, @concurrent_limit)
+
+          status, headers, body = @app.call(env)
+          @request_counter.decrement(user_guid)
+          return [status, headers, body]
+        end
+
+        @app.call(env)
+      end
+
+      private
+
+      def skip_rate_limiting?(env, request)
+        return admin? || !is_service_request?(request) || !rate_limit_method?(request)
+      end
+
+      def admin?
+        VCAP::CloudController::SecurityContext.admin? || VCAP::CloudController::SecurityContext.admin_read_only?
+      end
+
+      def is_service_request?(request)
+        [
+          %r{\A/v2/service_instances},
+          %r{\A/v2/service_bindings},
+          %r{\A/v2/service_keys},
+          %r{\A/v3/service_instances},
+          %r{\A/v3/service_credential_bindings},
+          %r{\A/v3/service_route_bindings},
+        ].any? { |re| request.fullpath.match re }
+      end
+
+      def rate_limit_method?(request)
+        %w(PATCH PUT POST).include? request.method
+      end
+
+      def user_token?(env)
+        !!env['cf.user_guid']
+      end
+
+      def too_many_requests!(env)
+        message = rate_limit_error(env).to_json
+        [429, {}, [message]]
+      end
+
+      def rate_limit_error(env)
+        error_name = 'ServiceBrokerRateLimitExceeded'
+        api_error = CloudController::Errors::ApiError.new_from_details(error_name)
+        version   = env['PATH_INFO'][0..2]
+        if version == '/v2'
+          ErrorPresenter.new(api_error, Rails.env.test?, V2ErrorHasher.new(api_error)).to_hash
+        elsif version == '/v3'
+          ErrorPresenter.new(api_error, Rails.env.test?, V3ErrorHasher.new(api_error)).to_hash
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
@@ -91,6 +91,36 @@ module VCAP::CloudController
         end
       end
 
+      describe 'ServiceBrokerRateLimiter' do
+        before do
+          allow(CloudFoundry::Middleware::ServiceBrokerRateLimiter).to receive(:new)
+        end
+
+        context 'when configuring a limit' do
+          before do
+            builder.build(TestConfig.override(max_concurrent_service_broker_requests: 5), request_metrics, request_logs).to_app
+          end
+
+          it 'enables the ServiceBrokerRateLimiter middleware' do
+            expect(CloudFoundry::Middleware::ServiceBrokerRateLimiter).to have_received(:new).with(
+              anything,
+              logger: instance_of(Steno::Logger),
+              concurrent_limit: 5,
+            )
+          end
+        end
+
+        context 'when not configuring a limit' do
+          before do
+            builder.build(TestConfig.override(max_concurrent_service_broker_requests: 0), request_metrics, request_logs).to_app
+          end
+
+          it 'does not enable the ServiceBrokerRateLimiter middleware' do
+            expect(CloudFoundry::Middleware::ServiceBrokerRateLimiter).not_to have_received(:new)
+          end
+        end
+      end
+
       describe 'New Relic custom attributes' do
         before do
           allow(CloudFoundry::Middleware::NewRelicCustomAttributes).to receive(:new)

--- a/spec/unit/middleware/service_broker_rate_limiter_spec.rb
+++ b/spec/unit/middleware/service_broker_rate_limiter_spec.rb
@@ -39,6 +39,14 @@ module CloudFoundry
           expect(app).to have_received(:call).once
         end
 
+        it 'still decrements the count when an error occurs in another middleware' do
+          allow(app).to receive(:call).and_raise 'an error'
+          expect { middleware.call(user_env) }.to raise_error('an error')
+          allow(app).to receive(:call).and_return [200, {}, 'a body']
+          status, _, _ = middleware.call(user_env)
+          expect(status).to eq(200)
+        end
+
         describe 'errors' do
           let(:middleware) { ServiceBrokerRateLimiter.new(app, logger: logger, concurrent_limit: 0) }
 

--- a/spec/unit/middleware/service_broker_rate_limiter_spec.rb
+++ b/spec/unit/middleware/service_broker_rate_limiter_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+module CloudFoundry
+  module Middleware
+    RSpec.describe ServiceBrokerRateLimiter do
+      let(:app) { double(:app) }
+      let(:logger) { double('logger', info: nil) }
+      let(:path_info) { '/v3/service_instances' }
+      let(:user_env) { { 'cf.user_guid' => 'user_guid', 'PATH_INFO' => path_info } }
+      let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/service_instances', method: 'POST') }
+      let(:middleware) { ServiceBrokerRateLimiter.new(app, logger: logger, concurrent_limit: 1) }
+
+      before(:each) do
+        allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+        allow(app).to receive(:call) do
+          sleep(1)
+          [200, {}, 'a body']
+        end
+      end
+
+      describe 'included requests' do
+        it 'allows a service broker request within the limit' do
+          status, _, _ = middleware.call(user_env)
+          expect(status).to eq(200)
+        end
+
+        it 'allows sequential requests' do
+          status, _, _ = middleware.call(user_env)
+          expect(status).to eq(200)
+          status, _, _ = middleware.call(user_env)
+          expect(status).to eq(200)
+        end
+
+        it 'does not allow more than the max number of concurrent requests' do
+          threads = 2.times.map { Thread.new { Thread.current[:status], _, _ = middleware.call(user_env) } }
+          statuses = threads.map { |t| t.join[:status] }
+          expect(statuses).to include(200)
+          expect(statuses).to include(429)
+          expect(app).to have_received(:call).once
+        end
+
+        describe 'errors' do
+          let(:middleware) { ServiceBrokerRateLimiter.new(app, logger: logger, concurrent_limit: 0) }
+
+          context 'when the path is /v2/*' do
+            let(:path_info) { '/v2/service_instances' }
+            it 'formats the response error in v2 format' do
+              _, _, body = middleware.call(user_env)
+              json_body = JSON.parse(body.first)
+              expect(json_body).to include(
+                'code' => 10016,
+                'description' => 'Service broker concurrent request limit exceeded',
+                'error_code' => 'CF-ServiceBrokerRateLimitExceeded',
+              )
+            end
+          end
+
+          context 'when the path is /v3/*' do
+            let(:path_info) { '/v3/service_instances' }
+
+            it 'formats the response error in v3 format' do
+              _, _, body = middleware.call(user_env)
+              json_body = JSON.parse(body.first)
+              expect(json_body['errors'].first).to include(
+                'code' => 10016,
+                'detail' => 'Service broker concurrent request limit exceeded',
+                'title' => 'CF-ServiceBrokerRateLimitExceeded',
+              )
+            end
+          end
+        end
+      end
+
+      describe 'skipped requests' do
+        let(:request_counter) { double }
+        before(:each) { middleware.instance_variable_set('@request_counter', request_counter) }
+
+        context 'user is an admin' do
+          before do
+            allow(VCAP::CloudController::SecurityContext).to receive(:admin?).and_return(true)
+          end
+
+          it 'does not rate limit them' do
+            _, _, _ = middleware.call(user_env)
+            expect(request_counter).not_to receive(:can_make_request?)
+            expect(app).to have_received(:call)
+          end
+        end
+
+        context 'endpoint does not interact with service brokers' do
+          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/apps') }
+
+          it 'does not rate limit them' do
+            _, _, _ = middleware.call(user_env)
+            expect(request_counter).not_to receive(:can_make_request?)
+            expect(app).to have_received(:call)
+          end
+        end
+
+        context 'endpoint does not use included method' do
+          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/service_instances', method: 'GET') }
+
+          it 'does not rate limit them' do
+            _, _, _ = middleware.call(user_env)
+            expect(request_counter).not_to receive(:can_make_request?)
+            expect(app).to have_received(:call)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## A short explanation of the proposed change

Limit the maximum number of concurrent requests per-user to a VM that
may interact with a service broker. This can help mitigate the webserver
request queue filling up with requests waiting on slow service brokers.

## An explanation of the use cases your change solves

Rather than sending rate limit headers as the main API rate limiter
does, instead this just returns a nicely formatted error (based on v2 or
v3 formatting) as it is concerned with concurrency rather than max
limits over time with resets etc.

Some requests will hit these endpoints (e.g. v3 user provided service
instances) that don't require access to a broker but these should be so
fast that the concurrency limit is not as much of a problem.

0 or negative configuration for the max value is taken to mean "do not
enable this feature"

## Links to any other associated PRs
#2512 unfortunately isn't as applicable now that rate limiting is done in memory so this is a reimagining of this given the current structure of the code
TODO: CAPI PR to follow

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
