### PR TITLE
Improve service keys quota check performance

### DIFF
--- a/app/models/runtime/quota_constraints/max_service_keys_policy.rb
+++ b/app/models/runtime/quota_constraints/max_service_keys_policy.rb
@@ -1,10 +1,10 @@
 class MaxServiceKeysPolicy
   attr_reader :quota_definition
 
-  def initialize(service_key, existing_service_keys_count, quota_definition, error_name)
+  def initialize(service_key, existing_service_keys_dataset, quota_definition, error_name)
     @service_key = service_key
+    @existing_service_keys_dataset = existing_service_keys_dataset
     @quota_definition = quota_definition
-    @existing_service_keys_count = existing_service_keys_count
     @error_name = error_name
     @errors = service_key.errors
   end
@@ -19,7 +19,7 @@ class MaxServiceKeysPolicy
 
   def service_keys_quota_remaining?
     @quota_definition.total_service_keys == -1 || # unlimited
-      @existing_service_keys_count + requested_service_key <= @quota_definition.total_service_keys
+      @existing_service_keys_dataset.count + requested_service_key <= @quota_definition.total_service_keys
   end
 
   def requested_service_key

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -43,15 +43,16 @@ module VCAP::CloudController
       validates_unique [:name, :service_instance_id]
 
       if service_instance
+        space_ids_for_org_dataset = Space.where(organization_id: space.organization.id).select(:id)
         MaxServiceKeysPolicy.new(
           self,
-          ServiceKey.filter(service_instance: space.organization.service_instances),
+          ServiceKey.filter(service_instance: ServiceInstance.where(space_id: space_ids_for_org_dataset)),
           space.organization.quota_definition,
           :service_keys_quota_exceeded
         ).validate
         MaxServiceKeysPolicy.new(
           self,
-          ServiceKey.filter(service_instance: space.service_instances),
+          ServiceKey.filter(service_instance: ServiceInstance.where(space_id: space.id)),
           space.space_quota_definition,
           :service_keys_space_quota_exceeded
         ).validate

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -45,13 +45,13 @@ module VCAP::CloudController
       if service_instance
         MaxServiceKeysPolicy.new(
           self,
-          ServiceKey.filter(service_instance: space.organization.service_instances).count,
+          ServiceKey.filter(service_instance: space.organization.service_instances),
           space.organization.quota_definition,
           :service_keys_quota_exceeded
         ).validate
         MaxServiceKeysPolicy.new(
           self,
-          ServiceKey.filter(service_instance: space.service_instances).count,
+          ServiceKey.filter(service_instance: space.service_instances),
           space.space_quota_definition,
           :service_keys_space_quota_exceeded
         ).validate

--- a/db/migrations/20211102133700_add_service_instance_id_index_to_service_keys.rb
+++ b/db/migrations/20211102133700_add_service_instance_id_index_to_service_keys.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :service_keys do
+      add_index :service_instance_id, name: :sk_svc_instance_id_index
+    end
+  end
+
+  down do
+    alter_table :service_keys do
+      drop_index :service_instance_id, name: :sk_svc_instance_id_index
+    end
+  end
+end

--- a/spec/unit/models/runtime/quota_constraints/max_service_keys_policy_spec.rb
+++ b/spec/unit/models/runtime/quota_constraints/max_service_keys_policy_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe MaxServiceKeysPolicy do
   let(:total_service_keys) { 2 }
   let(:quota) { VCAP::CloudController::QuotaDefinition.make total_service_keys: total_service_keys }
   let(:existing_service_key_count) { 0 }
+  let(:existing_service_key_dataset) { double(Sequel::Dataset, count: existing_service_key_count) }
   let(:error_name) { :random_error_name }
 
-  let(:policy) { MaxServiceKeysPolicy.new(service_key, existing_service_key_count, quota, error_name) }
+  let(:policy) { MaxServiceKeysPolicy.new(service_key, existing_service_key_dataset, quota, error_name) }
 
   def make_service_key
     VCAP::CloudController::ServiceKey.make service_instance: service_instance


### PR DESCRIPTION
The performance of the service keys quota check is improved by the following means:
- Fetch existing service keys count only when the quota for total_service_keys is not -1 (i.e. unlimited).
- Fetch service instances as subquery.
- Add index for `service_instance_id` to `service_keys` table.

When running the [new tests](https://github.com/cloudfoundry-incubator/cf-performance-tests/pull/7) added to [cf-performance-tests](https://github.com/cloudfoundry-incubator/cf-performance-tests) locally, the response time decreases from ~2,9 to 0,05 seconds with the changes in this PR.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
