### PR TITLE
Add separate check for active org

### DIFF
--- a/app/access/organization_access.rb
+++ b/app/access/organization_access.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
     def read_for_update?(org, params=nil)
       return true if context.queryer.can_write_globally?
       return false unless org.active?
-      return false unless context.queryer.can_write_to_org?(org.guid)
+      return false unless context.queryer.can_write_to_active_org?(org.guid)
 
       if params.present?
         return false if params.key?(:quota_definition_guid.to_s) || params.key?(:billing_enabled.to_s)
@@ -22,7 +22,7 @@ module VCAP::CloudController
       return true if context.queryer.can_write_globally?
 
       user_acting_on_themselves = user_acting_on_themselves?(params)
-      return false unless context.queryer.can_write_to_org?(org.guid) || user_acting_on_themselves
+      return false unless context.queryer.can_write_to_active_org?(org.guid) || user_acting_on_themselves
       return false unless org.active?
 
       validate!(org, params)
@@ -34,7 +34,7 @@ module VCAP::CloudController
       return true if context.queryer.can_write_globally?
       return false unless org.active?
 
-      context.queryer.can_write_to_org?(org.guid)
+      context.queryer.can_write_to_active_org?(org.guid)
     end
 
     def delete?(object)

--- a/app/access/route_access.rb
+++ b/app/access/route_access.rb
@@ -82,7 +82,7 @@ module VCAP::CloudController
       return false if route.wildcard_host? && route.domain.shared?
 
       FeatureFlag.raise_unless_enabled!(:route_creation) if is_create
-      context.queryer.can_write_to_space?(route.space.guid)
+      context.queryer.can_write_to_active_space?(route.space.guid)
     end
   end
 end

--- a/app/access/space_access.rb
+++ b/app/access/space_access.rb
@@ -48,7 +48,7 @@ module VCAP::CloudController
       return true if context.queryer.can_write_globally?
       return false if space.in_suspended_org?
 
-      context.queryer.can_write_to_org?(space.organization.guid)
+      context.queryer.can_write_to_active_org?(space.organization.guid)
     end
 
     def can_remove_related_object?(space, params)
@@ -61,7 +61,7 @@ module VCAP::CloudController
       return true if context.queryer.can_write_globally?
       return false if space.in_suspended_org?
 
-      context.queryer.can_write_to_org?(space.organization.guid) || context.queryer.can_update_space?(space.guid, space.organization.guid)
+      context.queryer.can_write_to_active_org?(space.organization.guid) || context.queryer.can_update_active_space?(space.guid, space.organization.guid)
     end
 
     def update?(space, params=nil)

--- a/app/controllers/v3/app_features_controller.rb
+++ b/app/controllers/v3/app_features_controller.rb
@@ -42,10 +42,11 @@ class AppFeaturesController < ApplicationController
     name = hashed_params[:name]
     resource_not_found!(:feature) unless APP_FEATURES.include?(name)
     if UNTRUSTED_APP_FEATURES.include?(name)
-      unauthorized! unless permission_queryer.can_manage_apps_in_space?(space.guid)
+      unauthorized! unless permission_queryer.can_manage_apps_in_active_space?(space.guid)
     else
-      unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+      unauthorized! unless permission_queryer.can_write_to_active_space?(space.guid)
     end
+    suspended! unless permission_queryer.is_space_active?(space.guid)
 
     message = VCAP::CloudController::AppFeatureUpdateMessage.new(hashed_params['body'])
     unprocessable!(message.errors.full_messages) unless message.valid?

--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -22,6 +22,10 @@ module V3ErrorsHelper
     raise CloudController::Errors::ApiError.new_from_details('NotAuthorized')
   end
 
+  def suspended!
+    raise CloudController::Errors::ApiError.new_from_details('OrgSuspended')
+  end
+
   def resource_not_found_with_message!(message)
     raise CloudController::Errors::ApiError.new_from_details('ResourceNotFound', message)
   end

--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -194,14 +194,15 @@ class OrganizationsV3Controller < ApplicationController
   def fetch_editable_org(guid)
     org = fetch_org(guid)
     org_not_found! unless org && permission_queryer.can_read_from_org?(org.guid)
-    unauthorized! unless roles.admin? || (org.managers.include?(current_user) && org.active?)
+    unauthorized! unless permission_queryer.can_write_to_active_org?(org.guid)
+    suspended! unless permission_queryer.is_org_active?(org.guid)
     org
   end
 
   def fetch_deletable_org(guid)
     org = fetch_org(guid)
     org_not_found! unless org && permission_queryer.can_read_from_org?(org.guid)
-    unauthorized! unless roles.admin?
+    unauthorized! unless permission_queryer.can_write_globally?
     org
   end
 

--- a/app/controllers/v3/processes_controller.rb
+++ b/app/controllers/v3/processes_controller.rb
@@ -118,7 +118,8 @@ class ProcessesController < ApplicationController
   end
 
   def ensure_can_write
-    unauthorized! unless permission_queryer.can_manage_apps_in_space?(@space.guid)
+    unauthorized! unless permission_queryer.can_manage_apps_in_active_space?(@space.guid)
+    suspended! unless permission_queryer.is_space_active?(@space.guid)
   end
 
   def process_not_found!

--- a/app/controllers/v3/revisions_controller.rb
+++ b/app/controllers/v3/revisions_controller.rb
@@ -37,7 +37,8 @@ class RevisionsController < ApplicationController
     space = app.space
     org = space.organization
     resource_not_found!(:revision) unless permission_queryer.can_read_from_space?(space.guid, org.guid)
-    unauthorized! if needs_write_permissions && !permission_queryer.can_write_to_space?(space.guid)
+    unauthorized! if needs_write_permissions && !permission_queryer.can_write_to_active_space?(space.guid)
+    suspended! if needs_write_permissions && !permission_queryer.is_space_active?(space.guid)
     unauthorized! if needs_secrets_read_permission && !permission_queryer.can_read_secrets_in_space?(space.guid, org.guid)
 
     revision

--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -66,9 +66,11 @@ class RolesController < ApplicationController
 
     if role.for_space?
       org_guid = Space.find(guid: role.space_guid).organization.guid
-      unauthorized! unless permission_queryer.can_update_space?(role.space_guid, org_guid)
+      unauthorized! unless permission_queryer.can_update_active_space?(role.space_guid, org_guid)
+      suspended! unless permission_queryer.is_space_active?(role.space_guid)
     else
-      unauthorized! unless permission_queryer.can_write_to_org?(role.organization_guid)
+      unauthorized! unless permission_queryer.can_write_to_active_org?(role.organization_guid)
+      suspended! unless permission_queryer.is_org_active?(role.organization_guid)
 
       if role.type == VCAP::CloudController::RoleTypes::ORGANIZATION_USER
         org = Organization.find(id: role.organization_id)
@@ -95,7 +97,8 @@ class RolesController < ApplicationController
     unprocessable_space! if permission_queryer.can_read_from_org?(org.guid) &&
       !permission_queryer.can_read_from_space?(message.space_guid, org.guid)
 
-    unauthorized! unless permission_queryer.can_update_space?(message.space_guid, org.guid)
+    unauthorized! unless permission_queryer.can_update_active_space?(message.space_guid, org.guid)
+    suspended! unless permission_queryer.is_space_active?(message.space_guid)
 
     user_guid = message.user_guid || lookup_user_guid_in_uaa(message.username, message.user_origin, creating_space_role: true)
     user = fetch_readable_user(user_guid)
@@ -111,7 +114,8 @@ class RolesController < ApplicationController
   def create_org_role(message)
     org = Organization.find(guid: message.organization_guid)
     unprocessable_organization! unless org
-    unauthorized! unless permission_queryer.can_write_to_org?(message.organization_guid)
+    unauthorized! unless permission_queryer.can_write_to_active_org?(message.organization_guid)
+    suspended! unless permission_queryer.is_org_active?(message.organization_guid)
 
     if message.user_guid
       user_guid = message.user_guid

--- a/app/controllers/v3/service_brokers_controller.rb
+++ b/app/controllers/v3/service_brokers_controller.rb
@@ -59,6 +59,7 @@ class ServiceBrokersController < ApplicationController
       space = Space.where(guid: message.space_guid).first
       unprocessable_space! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
       unauthorized! unless permission_queryer.can_write_space_scoped_service_broker?(space.guid)
+      suspended! unless permission_queryer.is_space_active?(space.guid)
     else
       unauthorized! unless permission_queryer.can_write_global_service_broker?
     end
@@ -82,6 +83,7 @@ class ServiceBrokersController < ApplicationController
       space = service_broker.space
       broker_not_found! unless space && permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
       unauthorized! unless permission_queryer.can_write_space_scoped_service_broker?(space.guid)
+      suspended! unless permission_queryer.is_space_active?(space.guid)
     else
       broker_not_found! unless permission_queryer.can_read_globally?
       unauthorized! unless permission_queryer.can_write_global_service_broker?
@@ -110,6 +112,7 @@ class ServiceBrokersController < ApplicationController
     else
       broker_not_found! unless permission_queryer.can_read_from_space?(service_broker.space.guid, service_broker.space.organization.guid)
       unauthorized! unless permission_queryer.can_write_space_scoped_service_broker?(service_broker.space.guid)
+      suspended! unless permission_queryer.is_space_active?(service_broker.space.guid)
     end
 
     broker_has_instances!(service_broker.name) if service_broker.has_service_instances?

--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -29,7 +29,7 @@ class ServiceRouteBindingsController < ApplicationController
 
   def show
     message = show_message
-    route_binding_not_found! unless @route_binding && can_read_space?(@route_binding.route.space)
+    route_binding_not_found! unless @route_binding && can_read_from_space?(@route_binding.route.space)
     presenter = Presenters::V3::ServiceRouteBindingPresenter.new(
       @route_binding,
       decorators: decorators(message)
@@ -63,8 +63,9 @@ class ServiceRouteBindingsController < ApplicationController
   end
 
   def destroy
-    route_binding_not_found! unless @route_binding && can_read_space?(@route_binding.route.space)
-    unauthorized! unless can_bind_in_space?(@route_binding.route.space)
+    route_binding_not_found! unless @route_binding && can_read_from_space?(@route_binding.route.space)
+    unauthorized! unless can_bind_in_active_space?(@route_binding.route.space)
+    suspended! unless is_space_active?(@route_binding.route.space)
 
     action = V3::ServiceRouteBindingDelete.new(user_audit_info)
     binding_operation_in_progress! if action.blocking_operation_in_progress?(@route_binding)
@@ -83,8 +84,9 @@ class ServiceRouteBindingsController < ApplicationController
   end
 
   def parameters
-    route_binding_not_found! unless @route_binding && can_read_space?(@route_binding.route.space)
-    unauthorized! unless can_write_space?(@route_binding.route.space)
+    route_binding_not_found! unless @route_binding && can_read_from_space?(@route_binding.route.space)
+    unauthorized! unless can_write_to_active_space?(@route_binding.route.space)
+    suspended! unless is_space_active?(@route_binding.route.space)
 
     fetcher = ServiceBindingRead.new
     parameters = fetcher.fetch_parameters(@route_binding)
@@ -98,8 +100,9 @@ class ServiceRouteBindingsController < ApplicationController
   end
 
   def update
-    route_binding_not_found! unless @route_binding.present? && can_read_space?(@route_binding.route.space)
-    unauthorized! unless can_write_space?(@route_binding.route.space)
+    route_binding_not_found! unless @route_binding.present? && can_read_from_space?(@route_binding.route.space)
+    unauthorized! unless can_write_to_active_space?(@route_binding.route.space)
+    suspended! unless is_space_active?(@route_binding.route.space)
 
     unprocessable!('The service route binding is being deleted') if delete_in_progress?(@route_binding)
 
@@ -193,18 +196,19 @@ class ServiceRouteBindingsController < ApplicationController
 
   def fetch_service_instance(guid)
     service_instance = VCAP::CloudController::ServiceInstance.first(guid: guid)
-    unless service_instance && can_read_space?(service_instance.space)
+    unless service_instance && can_read_from_space?(service_instance.space)
       service_instance_not_found!(guid)
     end
 
-    unauthorized! unless can_bind_in_space?(service_instance.space)
+    unauthorized! unless can_bind_in_active_space?(service_instance.space)
+    suspended! unless is_space_active?(service_instance.space)
 
     service_instance
   end
 
   def fetch_route(guid)
     route = VCAP::CloudController::Route.first(guid: guid)
-    unless route && can_read_space?(route.space)
+    unless route && can_read_from_space?(route.space)
       route_not_found!(guid)
     end
 
@@ -220,16 +224,20 @@ class ServiceRouteBindingsController < ApplicationController
     VCAP::CloudController::Repositories::ServiceEventRepository::WithUserActor.new(user_audit_info)
   end
 
-  def can_read_space?(space)
+  def can_read_from_space?(space)
     permission_queryer.can_read_from_space?(space.guid, space.organization_guid)
   end
 
-  def can_bind_in_space?(space)
-    permission_queryer.can_manage_apps_in_space?(space.guid)
+  def can_bind_in_active_space?(space)
+    permission_queryer.can_manage_apps_in_active_space?(space.guid)
   end
 
-  def can_write_space?(space)
-    permission_queryer.can_write_to_space?(space.guid)
+  def can_write_to_active_space?(space)
+    permission_queryer.can_write_to_active_space?(space.guid)
+  end
+
+  def is_space_active?(space)
+    permission_queryer.is_space_active?(space.guid)
   end
 
   def route_services_enabled?

--- a/app/controllers/v3/sidecars_controller.rb
+++ b/app/controllers/v3/sidecars_controller.rb
@@ -49,7 +49,8 @@ class SidecarsController < ApplicationController
   def create
     app, space, org = AppFetcher.new.fetch(hashed_params[:guid])
     resource_not_found!(:app) unless app && permission_queryer.can_read_from_space?(space.guid, org.guid)
-    unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.can_write_to_active_space?(space.guid)
+    suspended! unless permission_queryer.is_space_active?(space.guid)
 
     message = SidecarCreateMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
@@ -79,7 +80,8 @@ class SidecarsController < ApplicationController
     resource_not_found!(:sidecar) unless sidecar
     space = sidecar.app.space
     resource_not_found!(:sidecar) unless permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
-    unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.can_write_to_active_space?(space.guid)
+    suspended! unless permission_queryer.is_space_active?(space.guid)
 
     message = SidecarUpdateMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
@@ -96,7 +98,8 @@ class SidecarsController < ApplicationController
     resource_not_found!(:sidecar) unless sidecar
     space = sidecar.app.space
     resource_not_found!(:sidecar) unless permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
-    unauthorized! unless permission_queryer.can_write_to_space?(space.guid)
+    unauthorized! unless permission_queryer.can_write_to_active_space?(space.guid)
+    suspended! unless permission_queryer.is_space_active?(space.guid)
 
     SidecarDelete.delete(sidecar)
     head :no_content

--- a/app/controllers/v3/space_features_controller.rb
+++ b/app/controllers/v3/space_features_controller.rb
@@ -28,7 +28,8 @@ class SpaceFeaturesController < ApplicationController
     space = SpaceFetcher.new.fetch(hashed_params[:guid])
     resource_not_found!(:space) unless space && permission_queryer.can_read_from_space?(space.guid, space.organization.guid)
     resource_not_found!(:feature) unless SPACE_FEATURE == hashed_params[:name]
-    unauthorized! unless permission_queryer.can_update_space?(space.guid, space.organization.guid)
+    unauthorized! unless permission_queryer.can_update_active_space?(space.guid, space.organization.guid)
+    suspended! unless permission_queryer.is_space_active?(space.guid)
 
     space.update(allow_ssh: message.enabled)
 

--- a/app/controllers/v3/space_quotas_controller.rb
+++ b/app/controllers/v3/space_quotas_controller.rb
@@ -15,7 +15,8 @@ class SpaceQuotasController < ApplicationController
     message = VCAP::CloudController::SpaceQuotasCreateMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
 
-    unauthorized! unless permission_queryer.can_write_to_org?(message.organization_guid)
+    unauthorized! unless permission_queryer.can_write_to_active_org?(message.organization_guid)
+    suspended! unless permission_queryer.is_org_active?(message.organization_guid)
 
     org = Organization.find(guid: message.organization_guid)
     unprocessable_organization!(message.organization_guid) unless org
@@ -62,7 +63,8 @@ class SpaceQuotasController < ApplicationController
       readable_space_quota_guids.include?(space_quota.guid)
 
     unauthorized! unless permission_queryer.can_write_globally? ||
-      (space_quota && permission_queryer.can_write_to_org?(space_quota.organization_guid))
+      (space_quota && permission_queryer.can_write_to_active_org?(space_quota.organization_guid))
+    suspended! unless space_quota && permission_queryer.is_org_active?(space_quota.organization_guid)
 
     message = VCAP::CloudController::OrganizationQuotasUpdateMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
@@ -84,7 +86,8 @@ class SpaceQuotasController < ApplicationController
       readable_space_quota_guids.include?(space_quota.guid)
 
     unauthorized! unless permission_queryer.can_write_globally? ||
-      (space_quota && permission_queryer.can_write_to_org?(space_quota.organization_guid))
+      (space_quota && permission_queryer.can_write_to_active_org?(space_quota.organization_guid))
+    suspended! unless space_quota && permission_queryer.is_org_active?(space_quota.organization_guid)
 
     message = SpaceQuotaApplyMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
@@ -108,7 +111,8 @@ class SpaceQuotasController < ApplicationController
       readable_space_quota_guids.include?(space_quota.guid)
 
     unauthorized! unless permission_queryer.can_write_globally? ||
-      (space_quota && permission_queryer.can_write_to_org?(space_quota.organization_guid))
+      (space_quota && permission_queryer.can_write_to_active_org?(space_quota.organization_guid))
+    suspended! unless space_quota && permission_queryer.is_org_active?(space_quota.organization_guid)
 
     space_guid = hashed_params[:space_guid]
     space = Space.first(guid: space_guid)
@@ -129,7 +133,8 @@ class SpaceQuotasController < ApplicationController
       readable_space_quota_guids.include?(space_quota.guid)
 
     unauthorized! unless permission_queryer.can_write_globally? ||
-      (space_quota && permission_queryer.can_write_to_org?(space_quota.organization_guid))
+      (space_quota && permission_queryer.can_write_to_active_org?(space_quota.organization_guid))
+    suspended! unless space_quota && permission_queryer.is_org_active?(space_quota.organization_guid)
 
     unprocessable!('This quota is applied to one or more spaces. Remove this quota from all spaces before deleting.') unless space_quota.spaces.empty?
 

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -108,6 +108,11 @@
   http_code: 429
   message: "Service broker concurrent request limit exceeded"
 
+10017:
+  name: OrgSuspended
+  http_code: 403
+  message: "The organization is suspended"
+
 20001:
   name: UserInvalid
   http_code: 400

--- a/spec/request/app_features_spec.rb
+++ b/spec/request/app_features_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'App Features' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -161,7 +161,7 @@ RSpec.describe 'App Features' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'Apps' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -2033,7 +2033,7 @@ RSpec.describe 'Apps' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -2232,7 +2232,7 @@ RSpec.describe 'Apps' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -2368,7 +2368,7 @@ RSpec.describe 'Apps' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+            %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
             h
           end
 
@@ -2537,7 +2537,7 @@ RSpec.describe 'Apps' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+            %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
             h
           end
 
@@ -2646,7 +2646,7 @@ RSpec.describe 'Apps' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -2808,7 +2808,7 @@ RSpec.describe 'Apps' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+            %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
             h
           end
 
@@ -2930,7 +2930,7 @@ RSpec.describe 'Apps' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+            %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
             h
           end
 
@@ -3109,7 +3109,7 @@ RSpec.describe 'Apps' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_supporter space_developer].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -3316,7 +3316,7 @@ RSpec.describe 'Apps' do
     context 'when organization is suspended' do
       let(:expected_codes_and_responses) do
         h = super()
-        %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+        %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
         h
       end
 

--- a/spec/request/builds_spec.rb
+++ b/spec/request/builds_spec.rb
@@ -723,7 +723,7 @@ RSpec.describe 'Builds' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -897,7 +897,7 @@ RSpec.describe 'Deployments' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 

--- a/spec/request/domains_spec.rb
+++ b/spec/request/domains_spec.rb
@@ -985,7 +985,7 @@ RSpec.describe 'Domains Request' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -1167,7 +1167,7 @@ RSpec.describe 'Domains Request' do
 
             expect(last_response.status).to eq(422)
 
-            expect(parsed_response['errors'][0]['detail']).to eq "You do not have sufficient permissions for organization '#{shared_org3.name}' to share domain."
+            expect(parsed_response['errors'][0]['detail']).to eq "Organization '#{shared_org3.name}' is suspended."
           end
         end
 
@@ -1534,7 +1534,7 @@ RSpec.describe 'Domains Request' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -1658,7 +1658,7 @@ RSpec.describe 'Domains Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -1820,7 +1820,7 @@ RSpec.describe 'Domains Request' do
       let(:expected_codes_and_responses) do
         h = Hash.new(code: 403, errors: CF_NOT_AUTHORIZED)
         %w[org_billing_manager no_role].each { |r| h[r] = { code: 404 } }
-        h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+        h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
         h['admin'] = { code: 204 }
         h
       end
@@ -1841,7 +1841,7 @@ RSpec.describe 'Domains Request' do
       let(:expected_codes_and_responses) do
         h = Hash.new(code: 403, errors: CF_NOT_AUTHORIZED)
         %w[org_billing_manager no_role].each { |r| h[r] = { code: 404 } }
-        h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+        h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
         h['admin'] = { code: 204 }
         h
       end
@@ -2248,7 +2248,7 @@ RSpec.describe 'Domains Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 

--- a/spec/request/droplets_spec.rb
+++ b/spec/request/droplets_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'Droplets' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -1033,7 +1033,7 @@ RSpec.describe 'Droplets' do
     context 'when organization is suspended' do
       let(:expected_codes_and_responses) do
         h = super()
-        h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+        h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
         h
       end
 
@@ -1565,7 +1565,7 @@ RSpec.describe 'Droplets' do
     context 'when organization is suspended' do
       let(:expected_codes_and_responses) do
         h = super()
-        h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+        h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
         h
       end
 
@@ -1670,7 +1670,7 @@ RSpec.describe 'Droplets' do
     context 'when organization is suspended' do
       let(:expected_codes_and_responses) do
         h = super()
-        h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+        h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
         h
       end
 
@@ -1841,7 +1841,7 @@ RSpec.describe 'Droplets' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 

--- a/spec/request/organizations_spec.rb
+++ b/spec/request/organizations_spec.rb
@@ -1090,7 +1090,7 @@ module VCAP::CloudController
         let(:expected_codes_and_responses) do
           h = Hash.new(code: 403, errors: CF_NOT_AUTHORIZED)
           h['admin'] = { code: 200 }
-          h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h['no_role'] = { code: 404 }
           h
         end
@@ -1295,7 +1295,7 @@ module VCAP::CloudController
         let(:expected_codes_and_responses) do
           h = Hash.new(code: 403, errors: CF_NOT_AUTHORIZED)
           h['admin'] = { code: 200 }
-          h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h['no_role'] = { code: 404 }
           h
         end

--- a/spec/request/packages_spec.rb
+++ b/spec/request/packages_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Packages' do
         context 'when organization is suspended ' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -224,7 +224,7 @@ RSpec.describe 'Packages' do
         context 'when target organization is suspended ' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -241,7 +241,7 @@ RSpec.describe 'Packages' do
 
           let(:expected_codes_and_responses) do
             h = super()
-            h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -1006,7 +1006,7 @@ RSpec.describe 'Packages' do
       context 'when organization is suspended ' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -1167,7 +1167,7 @@ RSpec.describe 'Packages' do
       context 'when organization is suspended ' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -1257,7 +1257,7 @@ RSpec.describe 'Packages' do
       context 'when organization is suspended ' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -679,7 +679,7 @@ RSpec.describe 'Processes' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -850,7 +850,7 @@ RSpec.describe 'Processes' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -1020,7 +1020,7 @@ RSpec.describe 'Processes' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 

--- a/spec/request/revisions_spec.rb
+++ b/spec/request/revisions_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe 'Revisions' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 

--- a/spec/request/roles_spec.rb
+++ b/spec/request/roles_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'Roles Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -248,7 +248,7 @@ RSpec.describe 'Roles Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -1594,7 +1594,7 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -1622,7 +1622,7 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 

--- a/spec/request/route_destinations_spec.rb
+++ b/spec/request/route_destinations_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe 'Route Destinations Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -783,7 +783,7 @@ RSpec.describe 'Route Destinations Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -1194,7 +1194,7 @@ RSpec.describe 'Route Destinations Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -1339,7 +1339,7 @@ RSpec.describe 'Route Destinations Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -1752,7 +1752,7 @@ RSpec.describe 'Routes Request' do
             code: 201,
             response_object: route_json
           }
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -2419,7 +2419,7 @@ RSpec.describe 'Routes Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -2593,7 +2593,7 @@ RSpec.describe 'Routes Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -2739,7 +2739,7 @@ RSpec.describe 'Routes Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -3024,7 +3024,7 @@ RSpec.describe 'Routes Request' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 

--- a/spec/request/security_groups_spec.rb
+++ b/spec/request/security_groups_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe 'Security_Groups Request' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+            %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
             h
           end
 
@@ -451,7 +451,7 @@ RSpec.describe 'Security_Groups Request' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+            %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
             h
           end
 
@@ -1298,7 +1298,7 @@ RSpec.describe 'Security_Groups Request' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+            %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
             h
           end
 
@@ -1397,7 +1397,7 @@ RSpec.describe 'Security_Groups Request' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+            %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
             h
           end
 

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -1578,7 +1578,7 @@ RSpec.describe 'v3 service route bindings' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -1665,7 +1665,7 @@ RSpec.describe 'v3 service route bindings' do
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 

--- a/spec/request/sidecars_spec.rb
+++ b/spec/request/sidecars_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'Sidecars' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -349,7 +349,7 @@ RSpec.describe 'Sidecars' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -773,7 +773,7 @@ RSpec.describe 'Sidecars' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 

--- a/spec/request/space_features_spec.rb
+++ b/spec/request/space_features_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Space Features' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_manager org_manager].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 

--- a/spec/request/space_manifests_spec.rb
+++ b/spec/request/space_manifests_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe 'Space Manifests' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -675,7 +675,7 @@ RSpec.describe 'Space Manifests' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 

--- a/spec/request/space_quotas_spec.rb
+++ b/spec/request/space_quotas_spec.rb
@@ -155,7 +155,7 @@ module VCAP::CloudController
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -458,7 +458,7 @@ module VCAP::CloudController
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -757,7 +757,7 @@ module VCAP::CloudController
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -830,7 +830,7 @@ module VCAP::CloudController
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 
@@ -901,7 +901,7 @@ module VCAP::CloudController
         context 'when organization is suspended' do
           let(:expected_codes_and_responses) do
             h = super()
-            h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+            h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
             h
           end
 

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Spaces' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -913,7 +913,7 @@ RSpec.describe 'Spaces' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[org_manager space_manager].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[org_manager space_manager].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 
@@ -1086,7 +1086,7 @@ RSpec.describe 'Spaces' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['org_manager'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['org_manager'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -1150,7 +1150,7 @@ RSpec.describe 'Spaces' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
           h
         end
 

--- a/spec/request/tasks_spec.rb
+++ b/spec/request/tasks_spec.rb
@@ -580,7 +580,7 @@ RSpec.describe 'Tasks' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 
@@ -659,7 +659,7 @@ RSpec.describe 'Tasks' do
     context 'when organization is suspended' do
       let(:expected_codes_and_responses) do
         h = super()
-        %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_NOT_AUTHORIZED } }
+        %w[space_developer space_supporter].each { |r| h[r] = { code: 403, errors: CF_ORG_SUSPENDED } }
         h
       end
 
@@ -1206,7 +1206,7 @@ RSpec.describe 'Tasks' do
       context 'when organization is suspended' do
         let(:expected_codes_and_responses) do
           h = super()
-          h['space_developer'] = { code: 403, errors: CF_NOT_AUTHORIZED }
+          h['space_developer'] = { code: 403, errors: CF_ORG_SUSPENDED }
           h
         end
 

--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -23,6 +23,12 @@ CF_NOT_AUTHORIZED = [
   code: 10003
 ].freeze
 
+CF_ORG_SUSPENDED = [
+  detail: 'The organization is suspended',
+  title: 'CF-OrgSuspended',
+  code: 10017
+].freeze
+
 RSpec.shared_examples 'paginated response' do |endpoint|
   it 'returns pagination information' do
     expect_filtered_resources(endpoint, 'per_page=1', resources[0, 1])

--- a/spec/support/shared_examples/access/access_spec_helper.rb
+++ b/spec/support/shared_examples/access/access_spec_helper.rb
@@ -11,9 +11,9 @@ RSpec.shared_examples 'an access control' do |operation, table, expected_error=n
           can_read_globally = [:admin, :admin_read_only, :global_auditor].include?(role)
           can_write_globally = role == :admin
 
-          can_write_to_org = can_write_globally
-          can_write_to_space = can_write_globally
-          can_update_space = can_write_globally
+          can_write_to_active_org = can_write_globally
+          can_write_to_active_space = can_write_globally
+          can_update_active_space = can_write_globally
 
           can_read_from_org = can_read_globally
           can_read_from_space = can_read_globally
@@ -24,15 +24,15 @@ RSpec.shared_examples 'an access control' do |operation, table, expected_error=n
               o.auditors.include?(user) || o.billing_managers.include?(user)
             can_read_from_space ||= o.managers.include?(user)
 
-            can_write_to_org ||= o.managers.include?(user)
+            can_write_to_active_org ||= o.managers.include?(user)
             can_read_route ||= o.managers.include?(user) ||
               o.auditors.include?(user)
           end
 
           if s
             can_read_from_space ||= s.has_member?(user)
-            can_write_to_space ||= s.has_developer?(user)
-            can_update_space ||= s.managers.include?(user)
+            can_write_to_active_space ||= s.has_developer?(user)
+            can_update_active_space ||= s.managers.include?(user)
 
             can_read_route ||= s.has_member?(user)
           end
@@ -44,9 +44,9 @@ RSpec.shared_examples 'an access control' do |operation, table, expected_error=n
           allow(queryer).to receive(:can_read_from_space?).and_return(can_read_from_space)
           allow(queryer).to receive(:can_read_route?).and_return(can_read_route)
 
-          allow(queryer).to receive(:can_write_to_org?).and_return(can_write_to_org)
-          allow(queryer).to receive(:can_write_to_space?).and_return(can_write_to_space)
-          allow(queryer).to receive(:can_update_space?).and_return(can_update_space)
+          allow(queryer).to receive(:can_write_to_active_org?).and_return(can_write_to_active_org)
+          allow(queryer).to receive(:can_write_to_active_space?).and_return(can_write_to_active_space)
+          allow(queryer).to receive(:can_update_active_space?).and_return(can_update_active_space)
         end
 
         saved_error = nil

--- a/spec/support/space_restricted_response_generators.rb
+++ b/spec/support/space_restricted_response_generators.rb
@@ -39,6 +39,14 @@ module SpaceRestrictedResponseGenerators
     }]
   end
 
+  def self.suspended_response
+    [{
+      'detail' => 'The organization is suspended',
+      'title' => 'CF-OrgSuspended',
+      'code' => 10017,
+    }]
+  end
+
   def responses_for_space_restricted_single_endpoint(response_object, permitted_roles: nil)
     permitted_roles ||= SpaceRestrictedResponseGenerators.default_permitted_roles
 
@@ -84,7 +92,7 @@ module SpaceRestrictedResponseGenerators
         h[role] = { code: success_code }
       end
       suspended_roles.each do |role|
-        h[role] = { code: 403, errors: SpaceRestrictedResponseGenerators.forbidden_response }
+        h[role] = { code: 403, errors: SpaceRestrictedResponseGenerators.suspended_response }
       end
       %w[no_role org_auditor org_billing_manager].each do |role|
         h[role] = { code: 422 } # TODO: status code 422 for 'no_role' is not correct for all endpoints
@@ -101,7 +109,7 @@ module SpaceRestrictedResponseGenerators
         h[role] = { code: success_code }
       end
       suspended_roles.each do |role|
-        h[role] = { code: 403, errors: SpaceRestrictedResponseGenerators.forbidden_response }
+        h[role] = { code: 403, errors: SpaceRestrictedResponseGenerators.suspended_response }
       end
       %w[no_role org_auditor org_billing_manager].each do |role|
         h[role] = { code: 404 }
@@ -118,7 +126,7 @@ module SpaceRestrictedResponseGenerators
         h[role] = { code: success_code }
       end
       suspended_roles.each do |role|
-        h[role] = { code: 403, errors: SpaceRestrictedResponseGenerators.forbidden_response }
+        h[role] = { code: 403, errors: SpaceRestrictedResponseGenerators.suspended_response }
       end
       %w[no_role org_auditor org_billing_manager].each do |role|
         h[role] = { code: 404 }

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -213,8 +213,8 @@ module UserHelpers
   end
 
   def allow_user_write_access(user, space:)
-    allow(permissions_double(user)).to receive(:can_write_to_space?).with(space.guid).and_return(true)
-    allow(permissions_double(user)).to receive(:can_manage_apps_in_space?).with(space.guid).and_return(true)
+    allow(permissions_double(user)).to receive(:can_write_to_active_space?).with(space.guid).and_return(true)
+    allow(permissions_double(user)).to receive(:can_manage_apps_in_active_space?).with(space.guid).and_return(true)
   end
 
   def allow_user_read_access_for(user, orgs: [], spaces: [])
@@ -266,8 +266,8 @@ module UserHelpers
   end
 
   def disallow_user_write_access(user, space:)
-    allow(permissions_double(user)).to receive(:can_write_to_space?).with(space.guid).and_return(false)
-    allow(permissions_double(user)).to receive(:can_manage_apps_in_space?).with(space.guid).and_return(false)
+    allow(permissions_double(user)).to receive(:can_write_to_active_space?).with(space.guid).and_return(false)
+    allow(permissions_double(user)).to receive(:can_manage_apps_in_active_space?).with(space.guid).and_return(false)
   end
 
   def stub_readable_space_guids_for(user, spaces)

--- a/spec/unit/controllers/v3/deployments_controller_spec.rb
+++ b/spec/unit/controllers/v3/deployments_controller_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe DeploymentsController, type: :controller do
         it 'returns 422 with an error message' do
           post :create, params: request_body, as: :json
           expect(response.status).to eq 422
-          expect(response.body).to include('Unable to use app. Ensure that the app exists and you have access to it.')
+          expect(response.body).to include('Unable to use app. Ensure that the app exists and you have access to it and the organization is not suspended.')
         end
       end
 
@@ -377,7 +377,7 @@ RSpec.describe DeploymentsController, type: :controller do
       it 'returns 422 with an error message' do
         post :create, params: request_body, as: :json
         expect(response.status).to eq 422
-        expect(response.body).to include('Unable to use app. Ensure that the app exists and you have access to it.')
+        expect(response.body).to include('Unable to use app. Ensure that the app exists and you have access to it and the organization is not suspended.')
       end
     end
 


### PR DESCRIPTION
The checks if an org is suspended and the user has write permissions are implemented in the same method. Thus an 'unauthorized' error could be misleading if a user is e.g. space developer but the org is suspended. With this PR the check for a suspended org is moved into a dedicated method and all controllers have been adapted to return a different error in case the user has write permissions but the org is suspended (still an HTTP 403 error but with a different message).

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
