### PR TITLE
Use Concurrent::Semaphore for broker rate limiter

### DIFF
--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -39,10 +39,8 @@ module VCAP::CloudController
           }
         end
         if config.get(:max_concurrent_service_broker_requests) > 0
-          use CloudFoundry::Middleware::ServiceBrokerRateLimiter, {
-            logger: Steno.logger('cc.service_broker_rate_limiter'),
-            concurrent_limit: config.get(:max_concurrent_service_broker_requests),
-          }
+          CloudFoundry::Middleware::ServiceBrokerRequestCounter.instance.limit = config.get(:max_concurrent_service_broker_requests)
+          use CloudFoundry::Middleware::ServiceBrokerRateLimiter, logger: Steno.logger('cc.service_broker_rate_limiter')
         end
 
         if config.get(:security_event_logging, :enabled)

--- a/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
@@ -105,7 +105,6 @@ module VCAP::CloudController
             expect(CloudFoundry::Middleware::ServiceBrokerRateLimiter).to have_received(:new).with(
               anything,
               logger: instance_of(Steno::Logger),
-              concurrent_limit: 5,
             )
           end
         end


### PR DESCRIPTION
## A short explanation of the proposed change
Switch to using concurrent-ruby's semaphore for the service broker rate limiter

## An explanation of the use cases your change solves
The concurrent-ruby package has some classes that essentially do the
same thing as we were trying to do so we can use those rather than
relying on our own code

Also add the DELETE method into the rate limiter and add a log line for
when users exceed this limit for monitoring whether the limit is
correctly set

## Links to any other associated PRs
Improvement on #2563 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
