### PR TITLE
Eager load required fields only

### DIFF
--- a/app/decorators/field_service_offering_service_broker_decorator.rb
+++ b/app/decorators/field_service_offering_service_broker_decorator.rb
@@ -12,6 +12,12 @@ module VCAP::CloudController
       @fields = fields[:service_broker].to_set.intersection(self.class.allowed)
     end
 
+    def associated_fields
+      {
+        service_broker: [:created_at, :name]
+      }
+    end
+
     def decorate(hash, service_offerings)
       hash[:included] ||= {}
       service_brokers = service_offerings.map(&:service_broker).uniq
@@ -21,7 +27,6 @@ module VCAP::CloudController
         broker_view[:guid] = broker.guid if @fields.include?('guid')
         broker_view
       end
-
       hash
     end
   end

--- a/app/decorators/field_service_plan_service_broker_decorator.rb
+++ b/app/decorators/field_service_plan_service_broker_decorator.rb
@@ -12,6 +12,14 @@ module VCAP::CloudController
       @fields = fields[:'service_offering.service_broker'].to_set.intersection(self.class.allowed)
     end
 
+    def associated_fields
+      {
+        service: {
+          service_broker: [:guid, :created_at, :name]
+        }
+      }
+    end
+
     def decorate(hash, service_plans)
       hash[:included] ||= {}
       service_offerings = service_plans.map(&:service).uniq
@@ -22,7 +30,6 @@ module VCAP::CloudController
         broker_view[:guid] = broker.guid if @fields.include?('guid')
         broker_view
       end
-
       hash
     end
   end

--- a/app/decorators/include_service_plan_service_offering_decorator.rb
+++ b/app/decorators/include_service_plan_service_offering_decorator.rb
@@ -1,19 +1,22 @@
 module VCAP::CloudController
   class IncludeServicePlanServiceOfferingDecorator
     class << self
+      def associated_fields
+        {
+          service: Presenters::V3::ServiceOfferingPresenter.all_fields
+        }
+      end
+
       def match?(include)
         include&.include?('service_offering')
       end
 
       def decorate(hash, service_plans)
         hash[:included] ||= {}
-        service_offerings = Service.where(id: service_plans.map(&:service_id).uniq).
-                            eager(Presenters::V3::ServiceOfferingPresenter.associated_resources).all
-
+        service_offerings = service_plans.map(&:service).uniq
         hash[:included][:service_offerings] = service_offerings.sort_by(&:created_at).map do |service_offering|
           Presenters::V3::ServiceOfferingPresenter.new(service_offering).to_hash
         end
-
         hash
       end
     end

--- a/app/decorators/include_service_plan_space_organization_decorator.rb
+++ b/app/decorators/include_service_plan_space_organization_decorator.rb
@@ -1,17 +1,26 @@
 module VCAP::CloudController
   class IncludeServicePlanSpaceOrganizationDecorator
     class << self
+      def associated_fields
+        {
+          service: {
+            service_broker: {
+              space: Presenters::V3::SpacePresenter.all_fields + [{
+                organization: Presenters::V3::OrganizationPresenter.all_fields
+              }],
+            }
+          }
+        }
+      end
+
       def match?(include)
         include&.include?('space.organization')
       end
 
       def decorate(hash, service_plans)
         hash[:included] ||= {}
-        spaces = Space.where(id: service_plans.map { |p| p.service.service_broker.space_id }.compact.uniq).
-                 order(:created_at).eager(Presenters::V3::SpacePresenter.associated_resources).all
-        orgs = Organization.where(id: spaces.map(&:organization_id).uniq).order(:created_at).
-               eager(Presenters::V3::OrganizationPresenter.associated_resources).all
-
+        spaces = service_plans.map { |p| p.service.service_broker.space }.compact.uniq
+        orgs = spaces.map(&:organization).uniq
         hash[:included][:spaces] = spaces.sort_by(&:created_at).map { |space| Presenters::V3::SpacePresenter.new(space).to_hash }
         hash[:included][:organizations] = orgs.sort_by(&:created_at).map { |org| Presenters::V3::OrganizationPresenter.new(org).to_hash }
         hash

--- a/app/presenters/mixins/association_presentation_helpers.rb
+++ b/app/presenters/mixins/association_presentation_helpers.rb
@@ -1,0 +1,63 @@
+module VCAP::CloudController::Presenters::Mixins
+  module AssociationPresentationHelpers
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def merge_fields(fields, more_fields=nil)
+        all_fields = Array.wrap(fields)
+        all_fields += Array.wrap(more_fields) if more_fields
+        all_fields.reduce { |f1, f2| _merge_fields(f1, f2) }
+      end
+
+      def associations(fields)
+        Array.wrap(_associations(fields))
+      end
+
+      private
+
+      def _merge_fields(fields_hash1, fields_hash2)
+        fields_hash1.deep_merge(fields_hash2) do |_, value1, value2|
+          fields, associations = _fields_and_associations(Array.wrap(value1) + Array.wrap(value2))
+          [*fields.uniq, associations.reduce { |h1, h2| _merge_fields(h1, h2) }].compact
+        end
+      end
+
+      def _associations(hash)
+        associations = hash.map do |key, value|
+          fields, associations = _fields_and_associations(value)
+          proc_callback = fields.empty? || fields.include?(:*) ? nil : proc { |ds| ds.select(*fields) }
+          cascaded_associations = associations.map { |h| _associations(h) }.reduce { |h1, h2| h1.deep_merge(h2) { raise 'duplicate key' } }
+
+          if proc_callback && cascaded_associations
+            { key => { proc_callback => cascaded_associations } }
+          elsif proc_callback || cascaded_associations
+            { key => proc_callback || cascaded_associations }
+          else
+            key
+          end
+        end
+        associations.length > 1 ? associations : associations[0]
+      end
+
+      def _fields_and_associations(values)
+        fields = []
+        associations = []
+        Array.wrap(values).each do |value|
+          case value
+          when Symbol
+            fields << value
+          when Hash
+            associations << value
+          when Array
+            f, a = _fields_and_associations(v)
+            fields += f
+            associations += a
+          else
+            raise 'illegal type'
+          end
+        end
+        [fields, associations]
+      end
+    end
+  end
+end

--- a/app/presenters/mixins/metadata_presentation_helpers.rb
+++ b/app/presenters/mixins/metadata_presentation_helpers.rb
@@ -5,11 +5,28 @@ module VCAP::CloudController::Presenters::Mixins
     extend ActiveSupport::Concern
 
     class_methods do
-      def associated_resources
+      def associated_resources(fields=nil)
         [
           :labels,
           :annotations
         ]
+      end
+
+      def all_fields
+        [
+          :*,
+          associated_fields,
+          {
+            labels: :*
+          },
+          {
+            annotations: :*
+          }
+        ]
+      end
+
+      def associated_fields
+        {}
       end
     end
 

--- a/app/presenters/v3/organization_presenter.rb
+++ b/app/presenters/v3/organization_presenter.rb
@@ -10,6 +10,12 @@ module VCAP::CloudController::Presenters::V3
       def associated_resources
         super << :quota_definition
       end
+
+      def associated_fields
+        {
+          quota_definition: :* # TODO: select required fields only
+        }
+      end
     end
 
     def to_hash

--- a/app/presenters/v3/service_offering_presenter.rb
+++ b/app/presenters/v3/service_offering_presenter.rb
@@ -2,17 +2,25 @@ require 'presenters/v3/base_presenter'
 require 'models/helpers/metadata_helpers'
 require 'presenters/mixins/metadata_presentation_helpers'
 require 'presenters/api_url_builder'
+require 'presenters/mixins/association_presentation_helpers'
 
 module VCAP::CloudController
   module Presenters
     module V3
       class ServiceOfferingPresenter < BasePresenter
         include VCAP::CloudController::Presenters::Mixins::MetadataPresentationHelpers
+        include VCAP::CloudController::Presenters::Mixins::AssociationPresentationHelpers
 
         class << self
           # :labels and :annotations come from MetadataPresentationHelpers
-          def associated_resources
-            super + [:service_broker]
+          def associated_resources(fields=nil)
+            super + associations(merge_fields(associated_fields, fields))
+          end
+
+          def associated_fields
+            {
+              service_broker: [:id, :guid]
+            }
           end
         end
 

--- a/app/presenters/v3/service_plan_presenter.rb
+++ b/app/presenters/v3/service_plan_presenter.rb
@@ -2,17 +2,29 @@ require 'json'
 require 'json-schema'
 require 'presenters/v3/base_presenter'
 require 'presenters/mixins/metadata_presentation_helpers'
+require 'presenters/mixins/association_presentation_helpers'
 
 module VCAP::CloudController
   module Presenters
     module V3
       class ServicePlanPresenter < BasePresenter
         include VCAP::CloudController::Presenters::Mixins::MetadataPresentationHelpers
+        include VCAP::CloudController::Presenters::Mixins::AssociationPresentationHelpers
 
         class << self
           # :labels and :annotations come from MetadataPresentationHelpers
-          def associated_resources
-            super + [{ service: :service_broker }, { service: { service_broker: :space } }]
+          def associated_resources(fields=nil)
+            super + associations(merge_fields(associated_fields, fields))
+          end
+
+          def associated_fields
+            {
+              service: [:id, :guid, :bindable, :service_broker_id, {
+                service_broker: [:id, :space_id, {
+                  space: [:id, :guid]
+                }]
+              }]
+            }
           end
         end
 

--- a/app/presenters/v3/space_presenter.rb
+++ b/app/presenters/v3/space_presenter.rb
@@ -10,6 +10,12 @@ module VCAP::CloudController::Presenters::V3
       def associated_resources
         super << :organization
       end
+
+      def associated_fields
+        {
+          organization: :* # TODO: select required fields only
+        }
+      end
     end
 
     def to_hash

--- a/spec/request/service_offerings_spec.rb
+++ b/spec/request/service_offerings_spec.rb
@@ -619,7 +619,7 @@ RSpec.describe 'V3 service offerings' do
       it 'eager loads associated resources that the presenter specifies' do
         expect(VCAP::CloudController::ServiceOfferingListFetcher).to receive(:fetch).with(
           an_instance_of(VCAP::CloudController::ServiceOfferingsListMessage),
-          hash_including(eager_loaded_associations: [:labels, :annotations, :service_broker])
+          hash_including(eager_loaded_associations: [:labels, :annotations, instance_of(Hash)])
         ).and_call_original
 
         get '/v3/service_offerings', nil, admin_headers

--- a/spec/request/service_plans_spec.rb
+++ b/spec/request/service_plans_spec.rb
@@ -606,7 +606,7 @@ RSpec.describe 'V3 service plans' do
       it 'eager loads associated resources that the presenter specifies' do
         expect(VCAP::CloudController::ServicePlanListFetcher).to receive(:fetch).with(
           an_instance_of(VCAP::CloudController::ServicePlansListMessage),
-          hash_including(eager_loaded_associations: [:labels, :annotations, { service: :service_broker }, { service: { service_broker: :space } }])
+          hash_including(eager_loaded_associations: [:labels, :annotations, instance_of(Hash)])
         ).and_call_original
 
         get '/v3/service_plans', nil, admin_headers


### PR DESCRIPTION
Improve service plans / service offerings presenters and decorators.

The following diff shows how queries changed for the `/v3/service_plans` endpoint utilizing different decorators:

```diff
 ======================================================================================================================================================================
 === cf curl "/v3/service_plans" ===
 ======================================================================================================================================================================

 SELECT count(*) AS "count" FROM (SELECT DISTINCT "service_plans".* FROM "service_plans" ORDER BY "service_plans"."id" ASC, "service_plans"."guid" ASC) AS "t1" LIMIT 1
 SELECT DISTINCT "service_plans".* FROM "service_plans" ORDER BY "service_plans"."id" ASC, "service_plans"."guid" ASC LIMIT 50 OFFSET 0
 SELECT * FROM "service_plan_labels" WHERE ("service_plan_labels"."resource_guid" IN (<GUIDs>))
 SELECT * FROM "service_plan_annotations" WHERE ("service_plan_annotations"."resource_guid" IN (<GUIDs>))
-SELECT * FROM "services" WHERE ("services"."id" IN (<IDs>))
-SELECT * FROM "service_brokers" WHERE ("service_brokers"."id" IN (<IDs>))
-SELECT * FROM "spaces" WHERE ("spaces"."id" IN (<IDs>))
+SELECT "id", "guid", "bindable", "service_broker_id" FROM "services" WHERE ("services"."id" IN (<IDs>))
+SELECT "id", "space_id" FROM "service_brokers" WHERE ("service_brokers"."id" IN (<IDs>))
+SELECT "id", "guid" FROM "spaces" WHERE ("spaces"."id" IN (<IDs>))


 ======================================================================================================================================================================
 === cf curl "/v3/service_plans?fields[service_offering.service_broker]=guid,name" ===
 ======================================================================================================================================================================

 SELECT count(*) AS "count" FROM (SELECT DISTINCT "service_plans".* FROM "service_plans" ORDER BY "service_plans"."id" ASC, "service_plans"."guid" ASC) AS "t1" LIMIT 1
 SELECT DISTINCT "service_plans".* FROM "service_plans" ORDER BY "service_plans"."id" ASC, "service_plans"."guid" ASC LIMIT 50 OFFSET 0
 SELECT * FROM "service_plan_labels" WHERE ("service_plan_labels"."resource_guid" IN (<GUIDs>))
 SELECT * FROM "service_plan_annotations" WHERE ("service_plan_annotations"."resource_guid" IN (<GUIDs>))
-SELECT * FROM "services" WHERE ("services"."id" IN (<IDs>))
-SELECT * FROM "service_brokers" WHERE ("service_brokers"."id" IN (<IDs>))
-SELECT * FROM "spaces" WHERE ("spaces"."id" IN (<IDs>))
+SELECT "id", "guid", "bindable", "service_broker_id" FROM "services" WHERE ("services"."id" IN (<IDs>))
+SELECT "id", "space_id", "guid", "created_at", "name" FROM "service_brokers" WHERE ("service_brokers"."id" IN (<IDs>))
+SELECT "id", "guid" FROM "spaces" WHERE ("spaces"."id" IN (<IDs>))


 ======================================================================================================================================================================
 === cf curl "/v3/service_plans?include=service_offering" ===
 ======================================================================================================================================================================

 SELECT count(*) AS "count" FROM (SELECT DISTINCT "service_plans".* FROM "service_plans" ORDER BY "service_plans"."id" ASC, "service_plans"."guid" ASC) AS "t1" LIMIT 1
 SELECT DISTINCT "service_plans".* FROM "service_plans" ORDER BY "service_plans"."id" ASC, "service_plans"."guid" ASC LIMIT 50 OFFSET 0
 SELECT * FROM "service_plan_labels" WHERE ("service_plan_labels"."resource_guid" IN (<GUIDs>))
 SELECT * FROM "service_plan_annotations" WHERE ("service_plan_annotations"."resource_guid" IN (<GUIDs>))
 SELECT * FROM "services" WHERE ("services"."id" IN (<IDs>))
-SELECT * FROM "service_brokers" WHERE ("service_brokers"."id" IN (<IDs>))
-SELECT * FROM "spaces" WHERE ("spaces"."id" IN (<IDs>))
-SELECT * FROM "services" WHERE ("id" IN (<IDs>))
-SELECT * FROM "service_brokers" WHERE ("service_brokers"."id" IN (<IDs>))
+SELECT "id", "space_id", "guid" FROM "service_brokers" WHERE ("service_brokers"."id" IN (<IDs>))
+SELECT "id", "guid" FROM "spaces" WHERE ("spaces"."id" IN (<IDs>))
 SELECT * FROM "service_offering_labels" WHERE ("service_offering_labels"."resource_guid" IN (<GUIDs>))
 SELECT * FROM "service_offering_annotations" WHERE ("service_offering_annotations"."resource_guid" IN (<GUIDs>))


 ======================================================================================================================================================================
 === cf curl "/v3/service_plans?include=space.organization" ===
 ======================================================================================================================================================================

 SELECT count(*) AS "count" FROM (SELECT DISTINCT "service_plans".* FROM "service_plans" ORDER BY "service_plans"."id" ASC, "service_plans"."guid" ASC) AS "t1" LIMIT 1
 SELECT DISTINCT "service_plans".* FROM "service_plans" ORDER BY "service_plans"."id" ASC, "service_plans"."guid" ASC LIMIT 50 OFFSET 0
 SELECT * FROM "service_plan_labels" WHERE ("service_plan_labels"."resource_guid" IN (<GUIDs>))
 SELECT * FROM "service_plan_annotations" WHERE ("service_plan_annotations"."resource_guid" IN (<GUIDs>))
-SELECT * FROM "services" WHERE ("services"."id" IN (<IDs>))
-SELECT * FROM "service_brokers" WHERE ("service_brokers"."id" IN (<IDs>))
+SELECT "id", "guid", "bindable", "service_broker_id" FROM "services" WHERE ("services"."id" IN (<IDs>))
+SELECT "id", "space_id" FROM "service_brokers" WHERE ("service_brokers"."id" IN (<IDs>))
 SELECT * FROM "spaces" WHERE ("spaces"."id" IN (<IDs>))
-SELECT * FROM "spaces" WHERE ("id" IN (<IDs>)) ORDER BY "created_at"
 SELECT * FROM "organizations" WHERE ("organizations"."id" IN (<IDs>))
-SELECT * FROM "organizations" WHERE ("id" IN (<IDs>)) ORDER BY "created_at"
 SELECT * FROM "quota_definitions" WHERE ("quota_definitions"."id" IN (<IDs>))
 SELECT * FROM "space_labels" WHERE ("space_labels"."resource_guid" IN (<GUIDs>))
 SELECT * FROM "space_annotations" WHERE ("space_annotations"."resource_guid" IN (<GUIDs>))
 SELECT * FROM "organization_labels" WHERE ("organization_labels"."resource_guid" IN (<GUIDs>))
 SELECT * FROM "organization_annotations" WHERE ("organization_annotations"."resource_guid" IN (<GUIDs>))
```

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
