### PR TITLE
Use permissions subqueries in service list fetchers

### DIFF
--- a/app/controllers/v3/service_offerings_controller.rb
+++ b/app/controllers/v3/service_offerings_controller.rb
@@ -34,8 +34,8 @@ class ServiceOfferingsController < ApplicationController
               else
                 ServiceOfferingListFetcher.fetch(
                   message,
-                  readable_orgs: permission_queryer.readable_orgs,
-                  readable_spaces: permission_queryer.readable_space_scoped_spaces,
+                  readable_orgs_query: permission_queryer.readable_orgs_query,
+                  readable_spaces_query: permission_queryer.readable_space_scoped_spaces_query,
                   eager_loaded_associations: Presenters::V3::ServiceOfferingPresenter.associated_resources,
                 )
               end

--- a/app/controllers/v3/service_plans_controller.rb
+++ b/app/controllers/v3/service_plans_controller.rb
@@ -54,8 +54,8 @@ class ServicePlansController < ApplicationController
                 ServicePlanListFetcher.fetch(
                   message,
                   eager_loaded_associations: Presenters::V3::ServicePlanPresenter.associated_resources,
-                  readable_orgs: permission_queryer.readable_orgs,
-                  readable_spaces: permission_queryer.readable_space_scoped_spaces,
+                  readable_orgs_query: permission_queryer.readable_orgs_query,
+                  readable_spaces_query: permission_queryer.readable_space_scoped_spaces_query,
                 )
               end
 

--- a/app/fetchers/service_offering_list_fetcher.rb
+++ b/app/fetchers/service_offering_list_fetcher.rb
@@ -3,13 +3,13 @@ require 'fetchers/base_service_list_fetcher'
 module VCAP::CloudController
   class ServiceOfferingListFetcher < BaseServiceListFetcher
     class << self
-      def fetch(message, omniscient: false, readable_spaces: [], readable_orgs: [], eager_loaded_associations: [])
+      def fetch(message, omniscient: false, readable_spaces_query: nil, readable_orgs_query: nil, eager_loaded_associations: [])
         dataset = select_readable(
           Service.dataset.eager(eager_loaded_associations),
           message,
           omniscient: omniscient,
-          readable_orgs: readable_orgs,
-          readable_spaces: readable_spaces,
+          readable_orgs_query: readable_orgs_query,
+          readable_spaces_query: readable_spaces_query,
         )
 
         filter(message, dataset).select_all(:services).distinct

--- a/app/fetchers/service_plan_list_fetcher.rb
+++ b/app/fetchers/service_plan_list_fetcher.rb
@@ -3,13 +3,13 @@ require 'fetchers/base_service_list_fetcher'
 module VCAP::CloudController
   class ServicePlanListFetcher < BaseServiceListFetcher
     class << self
-      def fetch(message, omniscient: false, readable_spaces: [], readable_orgs: [], eager_loaded_associations: [])
+      def fetch(message, omniscient: false, readable_spaces_query: nil, readable_orgs_query: nil, eager_loaded_associations: [])
         dataset = select_readable(
           ServicePlan.dataset.eager(eager_loaded_associations),
           message,
           omniscient: omniscient,
-          readable_orgs: readable_orgs,
-          readable_spaces: readable_spaces,
+          readable_orgs_query: readable_orgs_query,
+          readable_spaces_query: readable_spaces_query,
         )
 
         filter(message, dataset).select_all(:service_plans).distinct

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -123,10 +123,14 @@ class VCAP::CloudController::Permissions
   end
 
   def readable_orgs
+    readable_orgs_query.all
+  end
+
+  def readable_orgs_query
     if can_read_globally?
-      VCAP::CloudController::Organization.select(:id, :guid).all
+      VCAP::CloudController::Organization.select(:id, :guid)
     else
-      membership.orgs_for_roles_subquery(ROLES_FOR_ORG_READING).all
+      membership.orgs_for_roles_subquery(ROLES_FOR_ORG_READING)
     end
   end
 
@@ -250,10 +254,14 @@ class VCAP::CloudController::Permissions
   end
 
   def readable_space_scoped_spaces
+    readable_space_scoped_spaces_query.all
+  end
+
+  def readable_space_scoped_spaces_query
     if can_read_globally?
-      VCAP::CloudController::Space.select(:id, :guid).all
+      VCAP::CloudController::Space.select(:id, :guid)
     else
-      membership.spaces_for_roles_subquery(SPACE_ROLES).all
+      membership.spaces_for_roles_subquery(SPACE_ROLES)
     end
   end
 

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -168,6 +168,26 @@ module VCAP::CloudController
       end
     end
 
+    describe '#readable_orgs' do
+      it 'calls all on subquery' do
+        org_records = double
+        subquery = instance_double(Sequel::Dataset)
+        expect(subquery).to receive(:all).and_return(org_records)
+        expect(permissions).to receive(:readable_orgs_query).and_return(subquery)
+        expect(permissions.readable_orgs).to be(org_records)
+      end
+    end
+
+    describe '#readable_orgs_query' do
+      it 'returns subquery from membership' do
+        membership = instance_double(Membership)
+        subquery = instance_double(Sequel::Dataset)
+        expect(Membership).to receive(:new).with(user).and_return(membership)
+        expect(membership).to receive(:orgs_for_roles_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
+        expect(permissions.readable_orgs_query).to be(subquery)
+      end
+    end
+
     describe '#readable_org_guids_for_domains_query' do
       context 'when user has valid membership' do
         let(:membership) { instance_double(Membership) }
@@ -617,6 +637,26 @@ module VCAP::CloudController
         actual_space_guids = permissions.readable_space_scoped_space_guids
 
         expect(actual_space_guids).to eq(space_guids)
+      end
+    end
+
+    describe '#readable_space_scoped_spaces' do
+      it 'calls all on subquery' do
+        space_records = double
+        subquery = instance_double(Sequel::Dataset)
+        expect(subquery).to receive(:all).and_return(space_records)
+        expect(permissions).to receive(:readable_space_scoped_spaces_query).and_return(subquery)
+        expect(permissions.readable_space_scoped_spaces).to be(space_records)
+      end
+    end
+
+    describe '#readable_space_scoped_spaces_query' do
+      it 'returns subquery from membership' do
+        membership = instance_double(Membership)
+        subquery = instance_double(Sequel::Dataset)
+        expect(Membership).to receive(:new).with(user).and_return(membership)
+        expect(membership).to receive(:spaces_for_roles_subquery).with(Permissions::SPACE_ROLES).and_return(subquery)
+        expect(permissions.readable_space_scoped_spaces_query).to be(subquery)
       end
     end
 


### PR DESCRIPTION
Add `readable_orgs_query` and `readable_space_scoped_spaces_query` to `Permissions` and use them as input to `ServiceOfferingListFetcher.fetch` and `ServicePlanListFetcher.fetch`.

When running the [cf-performance-tests](https://github.com/cloudfoundry-incubator/cf-performance-tests) locally, improvements for the following endpoints could be observed:

| Request | before | after |
| -- | -- | -- |
| GET /v3/service_plans as regular user | 20.756 | 2.473 |
| GET /v3/service_plans?service_offering_guids=... as regular user | 1.382 | 0.362 |

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
