### PR TITLE
Use subquery for window function (distinct queries)

### DIFF
--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -131,6 +131,26 @@ class Sequel::Dataset
       )
     end
   end
+
+  @unique_names_in_subquery = nil
+
+  class << self
+    attr_accessor :unique_names_in_subquery
+  end
+
+  # MySQL does not allow duplicate column names in a subquery select list, whereas PostgreSQL and MariaDB do.
+  def requires_unique_column_names_in_subquery_select_list?
+    if self.class.unique_names_in_subquery.nil?
+      begin
+        self.db.fetch('SELECT * FROM (SELECT 1 AS a, 1 AS a) AS t1').all
+        self.class.unique_names_in_subquery = false
+      rescue Sequel::DatabaseError
+        self.class.unique_names_in_subquery = true
+      end
+    end
+
+    self.class.unique_names_in_subquery
+  end
 end
 
 # Helper to create migrations.  This was added because

--- a/lib/cloud_controller/paging/sequel_paginator.rb
+++ b/lib/cloud_controller/paging/sequel_paginator.rb
@@ -15,7 +15,7 @@ module VCAP::CloudController
       sequel_dataset = sequel_dataset.order(sequel_order)
       sequel_dataset = sequel_dataset.order_append(Sequel.asc(Sequel.qualify(table_name, :guid))) if sequel_dataset.model.columns.include?(:guid)
 
-      records, count = if sequel_dataset.supports_window_functions? && !sequel_dataset.opts[:distinct]
+      records, count = if can_paginate_with_window_function?(sequel_dataset)
                          paginate_with_window_function(sequel_dataset, per_page, page, table_name)
                        else
                          paginate_with_extension(sequel_dataset, per_page, page)
@@ -24,24 +24,28 @@ module VCAP::CloudController
       PaginatedResult.new(records, count, pagination_options)
     end
 
+    def can_paginate_with_window_function?(dataset)
+      dataset.supports_window_functions? && (!dataset.opts[:distinct] || !dataset.requires_unique_column_names_in_subquery_select_list?)
+    end
+
     private
 
     def paginate_with_window_function(dataset, per_page, page, table_name)
-      dataset = dataset.limit(per_page, (page - 1) * per_page)
+      dataset = dataset.from_self if dataset.opts[:distinct]
       if dataset.opts[:graph]
         dataset = dataset.add_graph_aliases(pagination_total_results: [table_name, :pagination_total_results, Sequel.function(:count).*.over])
       else
         dataset = dataset.select_append(Sequel.as(Sequel.function(:count).*.over, :pagination_total_results))
       end
-      records = dataset.all
+      records = dataset.limit(per_page, (page - 1) * per_page).all
       count = records.any? ? records.first[:pagination_total_results] : 0
       records.each { |x| x.values.delete(:pagination_total_results) }
-      return records, count
+      [records, count]
     end
 
     def paginate_with_extension(dataset, per_page, page)
       query = dataset.extension(:pagination).paginate(page, per_page)
-      return query.all, query.pagination_record_count
+      [query.all, query.pagination_record_count]
     end
   end
 end


### PR DESCRIPTION
Using a subquery (`dataset.from_self`) ensures that the window function works with distinct queries too.

MySQL does not allow duplicate column names in a subquery select list (whereas PostgreSQL and MariaDB do); to prevent possible errors, do not paginate with window function for distinct queries on MySQL.

Add tests for `dataset.eager`; check associated resources and number of queries.

Running `EXPLAIN ANALYZE` on these queries shows that adding a subquery adds no complexity to the planned query at all.

Related PRs: #2527 and #2573.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
