### PR TITLE
Fix pollable job cleanup logger name

### DIFF
--- a/app/jobs/runtime/pollable_job_cleanup.rb
+++ b/app/jobs/runtime/pollable_job_cleanup.rb
@@ -5,10 +5,10 @@ module VCAP::CloudController
         CUTOFF_AGE_IN_DAYS = 90
 
         def perform
-          old_orphaned_blobs = PollableJobModel.where(Sequel.lit("created_at < CURRENT_TIMESTAMP - INTERVAL '?' DAY", CUTOFF_AGE_IN_DAYS))
-          logger = Steno.logger('cc.background.expired-orphaned-blob-cleanup')
-          logger.info("Cleaning up #{old_orphaned_blobs.count} OrphanedBlob rows")
-          old_orphaned_blobs.delete
+          old_pollable_jobs = PollableJobModel.where(Sequel.lit("created_at < CURRENT_TIMESTAMP - INTERVAL '?' DAY", CUTOFF_AGE_IN_DAYS))
+          logger = Steno.logger('cc.background.expired-pollable-jobs-cleanup')
+          logger.info("Cleaning up #{old_pollable_jobs.count} Jobs rows")
+          old_pollable_jobs.delete
         end
 
         def job_name_in_configuration

--- a/app/jobs/runtime/pollable_job_cleanup.rb
+++ b/app/jobs/runtime/pollable_job_cleanup.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
         def perform
           old_pollable_jobs = PollableJobModel.where(Sequel.lit("created_at < CURRENT_TIMESTAMP - INTERVAL '?' DAY", CUTOFF_AGE_IN_DAYS))
-          logger = Steno.logger('cc.background.expired-pollable-jobs-cleanup')
+          logger = Steno.logger('cc.background.pollable-job-cleanup')
           logger.info("Cleaning up #{old_pollable_jobs.count} Jobs rows")
           old_pollable_jobs.delete
         end

--- a/spec/unit/jobs/runtime/pollable_job_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/pollable_job_cleanup_spec.rb
@@ -4,19 +4,19 @@ module VCAP::CloudController
   module Jobs::Runtime
     RSpec.describe PollableJobCleanup, job_context: :worker do
       subject(:job) { PollableJobCleanup.new }
-      let!(:old_blob) { PollableJobModel.create(created_at: 91.days.ago) }
-      let!(:new_blob) { PollableJobModel.create(created_at: 1.days.ago) }
+      let!(:old_job) { PollableJobModel.create(created_at: 91.days.ago) }
+      let!(:new_job) { PollableJobModel.create(created_at: 1.days.ago) }
 
       it { is_expected.to be_a_valid_job }
 
       it 'removes pollable jobs that are older than the specified cutoff age' do
         job.perform
-        expect(PollableJobModel.find(guid: old_blob.guid)).to be_nil
+        expect(PollableJobModel.find(guid: old_job.guid)).to be_nil
       end
 
       it 'leaves the pollable jobs that are younger than the specified cutoff age' do
         job.perform
-        expect(PollableJobModel.find(guid: new_blob.guid)).to eq(new_blob)
+        expect(PollableJobModel.find(guid: new_job.guid)).to eq(new_job)
       end
 
       it 'knows its job name' do


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Fixes logger name ("cc.background.expired-orphaned-blob-cleanup" is used by another background job). Also fixes local variable names (looks like a copy&paste error from expired_orphaned_blob_cleanup.rb)

* An explanation of the use cases your change solves

* Links to any other associated PRs
We found this when investigating https://github.com/cloudfoundry/cloud_controller_ng/issues/2582

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
