### PR TITLE
Use an optimised conversion proc for Postgres timestamps

### DIFF
--- a/spec/unit/lib/cloud_controller/db_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  RSpec.describe Sequel::Database do
+    describe 'when running with a PostgreSQL database', skip: User.db.database_type != :postgres do
+      let(:conversion_proc) { User.db.conversion_procs[1114] }
+
+      it "does not use the default method for 'timestamp without time zone' conversion" do
+        expect(conversion_proc).not_to be_a(Method)
+      end
+
+      describe 'when reading data from the database' do
+        it 'correctly converts timestamp fields using the custom conversion proc' do
+          t = Time.now
+          User.make
+
+          u = User.first
+          expect(u.created_at).to be_within(10.seconds).of t
+          expect(u.updated_at).to be_within(10.seconds).of t
+        end
+      end
+
+      describe 'when using the custom conversion proc' do
+        it 'converts timestamp strings in the ISO 8601 extended format without fractional seconds' do
+          t = conversion_proc.call('2013-12-11 10:09:08')
+          expect(t.to_i).to eq(Time.utc(2013, 12, 11, 10, 9, 8).to_i)
+        end
+
+        it 'converts timestamp strings in the ISO 8601 extended format with fractional seconds' do
+          t = conversion_proc.call('2013-12-11 10:09:08.765')
+          expect(t.to_i).to eq(Time.utc(2013, 12, 11, 10, 9, 8.765).to_i)
+        end
+
+        it 'does not support other timestamp formats (e.g. ISO 8601 basic format)' do
+          expect { conversion_proc.call('20131211T100908Z') }.to raise_error(StandardError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When looking at profiling data one can see that the timestamp conversion is mainly taking place in `Sequel::SequelMethods::convert_input_timestamp` and that the string returned from the database is actually parsed twice. The second parsing is done to check if the given string contains an offset - which is never the case as Postgres field type "timestamp without time zone" is used. So what happens boils down to something like this:
```
t = Time.parse(value)
Date._parse(value).has_key?(:offset)
(t + t.utc_offset).utc
```
Benchmarking this locally (1 million times) shows a (reference) time of 21.6 seconds.

Removing the unnecessary second parsing reduces the time to 12.7s.

As the timestamp format is fix (i.e. no heuristics are needed), the parsing can be done with strptime instead of parse. To distinguish between timestamp strings with and without fractional seconds, it is checked whether they contain a `.`:
```
DateTime.strptime(value, value.include?('.') ? '%Y-%m-%d %H:%M:%S.%N' : '%Y-%m-%d %H:%M:%S').to_time.utc
```
The measured benchmark time for this conversion is 4.0s.

By using `DateTime._strptime` to parse the timestamp and `Time.utc()` to construct a new `Time` object, the time can be reduced to 2.8s (for 1 million conversions, i.e. a factor of ~8):
```
dt = DateTime._strptime(value, value.include?('.') ? '%Y-%m-%d %H:%M:%S.%N' : '%Y-%m-%d %H:%M:%S')
Time.utc(dt[:year], dt[:mon], dt[:mday], dt[:hour], dt[:min], dt[:sec] + (dt[:sec_fraction] || 0))
```

With this change the conversion proc is overwritten by `Sequel::Postgres::DatabaseMethods.add_conversion_proc`.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
