### PR TITLE
Make PruneExcessAppRevisions job more memory efficient

### DIFF
--- a/app/jobs/runtime/prune_excess_app_revisions.rb
+++ b/app/jobs/runtime/prune_excess_app_revisions.rb
@@ -12,15 +12,15 @@ module VCAP::CloudController
           logger = Steno.logger('cc.background')
           logger.info('Cleaning up excess app revisions')
 
-          AppModel.each do |app|
-            revision_dataset = RevisionModel.where(app_guid: app.guid)
+          AppModel.select_map(:guid).each do |app_guid|
+            revision_dataset = RevisionModel.where(app_guid: app_guid)
             next if revision_dataset.count <= max_retained_revisions_per_app
 
             revisions_to_keep = revision_dataset.order(Sequel.desc(:created_at)).
                                 limit(max_retained_revisions_per_app).
                                 select(:id)
             delete_count = RevisionDelete.delete(revision_dataset.exclude(id: revisions_to_keep))
-            logger.info("Cleaned up #{delete_count} revision rows for app #{app.guid}")
+            logger.info("Cleaned up #{delete_count} revision rows for app #{app_guid}")
           end
         end
 


### PR DESCRIPTION
Authored-by: Seth Boyles <sboyles@pivotal.io>

This job unnecessarily loads every single AppModel into memory at once.  This is a simple change to only fetch AppModel guids, which is all that is needed anyway.

I briefly considered using [group by/having](https://sequel.jeremyevans.net/rdoc/files/doc/querying_rdoc.html#label-Having) to do some smarter querying, but this job is run infrequently enough (once a day) that I think this improvement should be sufficient.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
