### PR TITLE
Fix blobstore errors for droplets from CF Docker apps

### DIFF
--- a/lib/cloud_controller/bits_expiration.rb
+++ b/lib/cloud_controller/bits_expiration.rb
@@ -12,7 +12,8 @@ module VCAP::CloudController
     def expire_droplets!(app)
       expirable_candidates = DropletModel.
                              where(state: DropletModel::STAGED_STATE, app_guid: app.guid).
-                             exclude(guid: app.droplet_guid)
+                             exclude(guid: app.droplet_guid).
+                             exclude(droplet_hash: nil)
 
       return if expirable_candidates.count < droplets_storage_count
 

--- a/lib/cloud_controller/bits_expiration.rb
+++ b/lib/cloud_controller/bits_expiration.rb
@@ -12,8 +12,7 @@ module VCAP::CloudController
     def expire_droplets!(app)
       expirable_candidates = DropletModel.
                              where(state: DropletModel::STAGED_STATE, app_guid: app.guid).
-                             exclude(guid: app.droplet_guid).
-                             exclude(droplet_hash: nil)
+                             exclude(guid: app.droplet_guid)
 
       return if expirable_candidates.count < droplets_storage_count
 
@@ -21,7 +20,9 @@ module VCAP::CloudController
 
       droplets_to_expire.each do |droplet|
         droplet.update(state: DropletModel::EXPIRED_STATE)
-        enqueue_droplet_delete_job(droplet.guid)
+        if droplet.droplet_hash
+          enqueue_droplet_delete_job(droplet.guid)
+        end
       end
     end
 

--- a/lib/cloud_controller/bits_expiration.rb
+++ b/lib/cloud_controller/bits_expiration.rb
@@ -20,9 +20,7 @@ module VCAP::CloudController
 
       droplets_to_expire.each do |droplet|
         droplet.update(state: DropletModel::EXPIRED_STATE)
-        if droplet.droplet_hash
-          enqueue_droplet_delete_job(droplet.guid)
-        end
+        enqueue_droplet_delete_job(droplet.guid) if droplet.droplet_hash
       end
     end
 

--- a/spec/unit/jobs/runtime/expired_blob_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/expired_blob_cleanup_spec.rb
@@ -13,20 +13,13 @@ module VCAP::CloudController
 
       describe 'droplets' do
         context 'expired' do
-          let!(:expired_droplet) { DropletModel.make(state: DropletModel::EXPIRED_STATE) }
+          let!(:expired_droplet) { DropletModel.make(state: DropletModel::EXPIRED_STATE, droplet_hash: 'not-nil', docker_receipt_image: nil) }
+          DropletModel.make(state: DropletModel::EXPIRED_STATE, droplet_hash: nil, docker_receipt_image: 'repo/test-app')
           let!(:non_expired_droplet) { DropletModel.make }
 
           it 'enqueues a deletion job when droplet_hash is not nil' do
-            expired_droplet.update(droplet_hash: 'not-nil')
-
             expect { job.perform }.to change { Delayed::Job.count }.by(1)
             expect(Delayed::Job.last.handler).to include('DeleteExpiredDropletBlob')
-          end
-
-          it 'does nothing when droplet_hash is nil' do
-            expired_droplet.update(droplet_hash: nil)
-
-            expect { job.perform }.not_to change { Delayed::Job.count }.from(0)
           end
         end
 

--- a/spec/unit/jobs/runtime/expired_blob_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/expired_blob_cleanup_spec.rb
@@ -12,32 +12,31 @@ module VCAP::CloudController
       end
 
       describe 'droplets' do
-        context 'expired' do
-          let!(:expired_droplet) { DropletModel.make(state: DropletModel::EXPIRED_STATE, droplet_hash: 'not-nil', docker_receipt_image: nil) }
-          DropletModel.make(state: DropletModel::EXPIRED_STATE, droplet_hash: nil, docker_receipt_image: 'repo/test-app')
-          let!(:non_expired_droplet) { DropletModel.make }
+        let!(:buildpack_droplet) { DropletModel.make(droplet_hash: 'not-nil', docker_receipt_image: nil) }
+        let!(:docker_droplet) { DropletModel.make(droplet_hash: nil, docker_receipt_image: 'repo/test-app') }
+        let!(:staged_droplet) { DropletModel.make(state: DropletModel::STAGED_STATE) }
 
-          it 'enqueues a deletion job when droplet_hash is not nil' do
+        context 'expired' do
+          before do
+            buildpack_droplet.update(state: DropletModel::EXPIRED_STATE)
+            docker_droplet.update(state: DropletModel::EXPIRED_STATE)
+          end
+
+          it 'enqueues a deletion job only for buildpack droplets' do
             expect { job.perform }.to change { Delayed::Job.count }.by(1)
             expect(Delayed::Job.last.handler).to include('DeleteExpiredDropletBlob')
           end
         end
 
         context 'failed' do
-          let!(:expired_droplet) { DropletModel.make(state: DropletModel::FAILED_STATE) }
-          let!(:non_expired_droplet) { DropletModel.make }
-
-          it 'enqueues a deletion job when droplet_hash is not nil' do
-            expired_droplet.update(droplet_hash: 'not-nil')
-
-            expect { job.perform }.to change { Delayed::Job.count }.by(1)
-            expect(Delayed::Job.last.handler).to include('DeleteExpiredDropletBlob')
+          before do
+            buildpack_droplet.update(state: DropletModel::FAILED_STATE)
+            docker_droplet.update(state: DropletModel::FAILED_STATE)
           end
 
-          it 'does nothing when droplet_hash is nil' do
-            expired_droplet.update(droplet_hash: nil)
-
-            expect { job.perform }.not_to change { Delayed::Job.count }.from(0)
+          it 'enqueues a deletion job only for buildpack droplets' do
+            expect { job.perform }.to change { Delayed::Job.count }.by(1)
+            expect(Delayed::Job.last.handler).to include('DeleteExpiredDropletBlob')
           end
         end
       end

--- a/spec/unit/lib/cloud_controller/bits_expiration_spec.rb
+++ b/spec/unit/lib/cloud_controller/bits_expiration_spec.rb
@@ -62,8 +62,8 @@ module VCAP::CloudController
         end
       end
 
-      it 'it does not enqueue a job to delete the blob' do
-        expect { BitsExpiration.new.expire_droplets!(app) }.not_to change { Delayed::Job.count }.from(0)
+      it 'does not enqueue a job to delete the blob' do
+        expect { BitsExpiration.new.expire_droplets!(app) }.not_to change { Delayed::Job.count }
       end
     end
 

--- a/spec/unit/lib/cloud_controller/bits_expiration_spec.rb
+++ b/spec/unit/lib/cloud_controller/bits_expiration_spec.rb
@@ -41,12 +41,14 @@ module VCAP::CloudController
       end
     end
 
-    context 'with droplets' do
+    context 'with docker cf apps' do
       before do
         t        = Time.now
         @current = DropletModel.make(
           app_guid:     app.guid,
-          created_at:   t
+          created_at:   t,
+          droplet_hash: nil,
+          docker_receipt_image: 'repo/test-app',
         )
         app.update(droplet: @current)
 
@@ -54,6 +56,32 @@ module VCAP::CloudController
           DropletModel.make(
             app_guid:     app.guid,
             created_at:   t + i,
+            droplet_hash: nil,
+            docker_receipt_image: 'repo/test-app',
+          )
+        end
+      end
+
+      it 'it does not enqueue a job to delete the blob' do
+        expect { BitsExpiration.new.expire_droplets!(app) }.not_to change { Delayed::Job.count }.from(0)
+      end
+    end
+
+    context 'with droplets' do
+      before do
+        t        = Time.now
+        @current = DropletModel.make(
+          app_guid:     app.guid,
+          created_at:   t,
+          droplet_hash: 'current_droplet_hash',
+        )
+        app.update(droplet: @current)
+
+        10.times do |i|
+          DropletModel.make(
+            app_guid:     app.guid,
+            created_at:   t + i,
+            droplet_hash: 'current_droplet_hash',
           )
         end
       end


### PR DESCRIPTION
* A short explanation of the proposed change:
PR fixes droplet deletion error messages for Docker apps. For details, see https://github.com/cloudfoundry/cloud_controller_ng/issues/2582

* An explanation of the use cases your change solves
See https://github.com/cloudfoundry/cloud_controller_ng/issues/2582

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
