### PR TITLE
Fix ServiceInstanceNameTooLong error message

### DIFF
--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -246,7 +246,7 @@
 60009:
   name: ServiceInstanceNameTooLong
   http_code: 400
-  message: "You have requested an invalid service instance name. Names are limited to 50 characters."
+  message: "You have requested an invalid service instance name. Names are limited to 255 characters."
 
 60010:
   name: ServiceInstanceOrganizationNotAuthorized


### PR DESCRIPTION
* A short explanation of the proposed change:
Just a fix of an error message.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
