### PR TITLE
Try upgrading to rails 6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,10 +47,10 @@ gem 'vmstat', '~> 2.3'
 gem 'yajl-ruby'
 
 # Rails Components
-gem 'actionpack', '~> 5.2.4', '>= 5.2.4.6'
-gem 'actionview', '~> 5.2.4', '>= 5.2.4.3'
-gem 'activemodel', '~> 5.2.4', '>= 5.2.4.3'
-gem 'railties', '~> 5.2.4', '>= 5.2.4.6'
+gem 'actionpack', '~> 6.0.4'
+gem 'actionview', '~> 6.0.4'
+gem 'activemodel', '~> 6.0.4'
+gem 'railties', '~> 6.0.4'
 
 # Blobstore and Bits Service Dependencies
 gem 'azure-storage', '0.14.0.preview' # https://github.com/Azure/azure-storage-ruby/issues/122

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,26 +35,27 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (5.2.6)
-      actionview (= 5.2.6)
-      activesupport (= 5.2.6)
+    actionpack (6.0.4.4)
+      actionview (= 6.0.4.4)
+      activesupport (= 6.0.4.4)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.6)
-      activesupport (= 5.2.6)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionview (6.0.4.4)
+      activesupport (= 6.0.4.4)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activemodel (5.2.6)
-      activesupport (= 5.2.6)
-    activesupport (5.2.6)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activemodel (6.0.4.4)
+      activesupport (= 6.0.4.4)
+    activesupport (6.0.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aliyun-sdk (0.8.0)
@@ -267,7 +268,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     loggregator_emitter (5.2.0)
       beefcake (~> 1.0.0)
-    loofah (2.12.0)
+    loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     machinist (1.0.6)
@@ -279,7 +280,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.1115)
     mini_portile2 (2.6.1)
-    minitest (5.14.4)
+    minitest (5.15.0)
     ms_rest (0.6.4)
       concurrent-ruby (~> 1.0)
       faraday (~> 0.9)
@@ -339,14 +340,14 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.3.0)
+    rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    railties (5.2.6)
-      actionpack (= 5.2.6)
-      activesupport (= 5.2.6)
+    railties (6.0.4.4)
+      actionpack (= 6.0.4.4)
+      activesupport (= 6.0.4.4)
       method_source
       rake (>= 0.8.7)
-      thor (>= 0.19.0, < 2.0)
+      thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.6)
     rb-fsevent (0.11.0)
@@ -502,6 +503,7 @@ GEM
     xml-simple (1.1.5)
     yajl-ruby (1.4.1)
     yard (0.9.26)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
@@ -511,9 +513,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionpack (~> 5.2.4, >= 5.2.4.6)
-  actionview (~> 5.2.4, >= 5.2.4.3)
-  activemodel (~> 5.2.4, >= 5.2.4.3)
+  actionpack (~> 6.0.4)
+  actionview (~> 6.0.4)
+  activemodel (~> 6.0.4)
   addressable
   allowy (>= 2.1.0)
   awesome_print
@@ -564,7 +566,7 @@ DEPENDENCIES
   pry-byebug
   public_suffix
   rack-test
-  railties (~> 5.2.4, >= 5.2.4.6)
+  railties (~> 6.0.4)
   rake
   retryable
   rfc822

--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -71,6 +71,7 @@ class ApplicationController < ActionController::Base
   rescue_from CloudController::Errors::InvalidAuthToken, with: :handle_invalid_auth_token
   rescue_from CloudController::Errors::ApiError, with: :handle_api_error
   rescue_from CloudController::Errors::CompoundError, with: :handle_compound_error
+  rescue_from ActionDispatch::Http::Parameters::ParseError, with: :handle_invalid_request_body
 
   def configuration
     Config.config
@@ -183,6 +184,11 @@ class ApplicationController < ActionController::Base
 
   def handle_blobstore_error(error)
     error = CloudController::Errors::ApiError.new_from_details('BlobstoreError', error.message)
+    handle_api_error(error)
+  end
+
+  def handle_invalid_request_body(_error)
+    error = CloudController::Errors::ApiError.new_from_details('MessageParseError', 'invalid request body')
     handle_api_error(error)
   end
 

--- a/spec/request/errors_spec.rb
+++ b/spec/request/errors_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Errors' do
     it 'it returns a MessageParseError' do
       expect {
         patch '/v3/apps/some-guid/features/ssh', '}}-invalid', user_header
-      }.to output("Error occurred while parsing request parameters.\nContents:\n\n}}-invalid\n").to_stderr
+      }.to output(/Error occurred while parsing request parameters.\nContents:\n\n}}-invalid\n/).to_stderr
 
       expect(last_response.status).to eq(400)
       expect(last_response.body).to include('Request invalid due to parse error: invalid request body')

--- a/spec/request/space_manifests_spec.rb
+++ b/spec/request/space_manifests_spec.rb
@@ -1029,9 +1029,10 @@ RSpec.describe 'Space Manifests' do
 
         it 'returns an appropriate error' do
           headers = yml_headers(user_header)
-          headers['CONTENT_TYPE'] = 'bogus'
+          headers['CONTENT_TYPE'] = 'application/bogus'
 
           post "/v3/spaces/#{space.guid}/manifest_diff", yml_manifest, headers
+
           parsed_response = MultiJson.load(last_response.body)
 
           expect(last_response).to have_status_code(400)


### PR DESCRIPTION
Co-authored-by: Seth Boyles <sboyles@pivotal.io>
Co-authored-by: Michael Oleske <moleske@pivotal.io>

- [x] Passed units
- [ ] Passed CATS
- [x] Passed BARAS

This seems like a good intermediate step before upgrading our Rails dependencies to 6.1.  Upgrading to [6.1 directly](https://github.com/cloudfoundry/cloud_controller_ng/pull/2598) results in 283 unit test failures, while this only resulted in 3.  Hopefully this is just because [Rails 6.1 removes a lot of deprecated features](https://guides.rubyonrails.org/6_1_release_notes.html), and we tackle those by turning on deprecation warnings before upgrading to 6.1
