### PR TITLE
app/models/runtime/role.rb defines SPACE_OR_ORGANIZATION_NOT_SPECIFIED

### DIFF
--- a/app/models/runtime/organization_role.rb
+++ b/app/models/runtime/organization_role.rb
@@ -1,8 +1,6 @@
 require 'models/helpers/role_types'
 
 module VCAP::CloudController
-  SPACE_OR_ORGANIZATION_NOT_SPECIFIED = -1
-
   # creating a new model backed by a smaller union will allow us to manipulate org roles with out handling too much excess data
   class OrganizationRole < Role
     set_dataset(

--- a/app/models/runtime/space_role.rb
+++ b/app/models/runtime/space_role.rb
@@ -1,8 +1,6 @@
 require 'models/helpers/role_types'
 
 module VCAP::CloudController
-  SPACE_OR_ORGANIZATION_NOT_SPECIFIED = -1
-
   # creating a new model backed by a smaller union will allow us to manipulate space roles with out handling too much excess data
   class SpaceRole < Role
     set_dataset(


### PR DESCRIPTION
Both `OrganizationRole` and `SpaceRole` inherit from `Role`, thus the constant is already available.

With this change warnings like "already initialized constant VCAP::CloudController::SPACE_OR_ORGANIZATION_NOT_SPECIFIED" will not be issued anymore.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
