### PR TITLE
Delete binding from db when binding request to service broker fails

### DIFF
--- a/spec/support/shared_examples/v3_service_binding_create.rb
+++ b/spec/support/shared_examples/v3_service_binding_create.rb
@@ -38,15 +38,12 @@ RSpec.shared_examples 'service binding creation' do |binding_model|
           allow(VCAP::Services::ServiceClientProvider).to receive(:provide).and_return(client)
         end
 
-        it 'marks the binding as failed' do
+        it 'deletes the binding' do
           expect {
             action.bind(precursor)
           }.to raise_error(BadError)
 
-          binding = precursor.reload
-          expect(binding.last_operation.type).to eq('create')
-          expect(binding.last_operation.state).to eq('failed')
-          expect(binding.last_operation.description).to eq('BadError')
+          expect { precursor.reload }.to raise_error(Sequel::NoExistingObject)
         end
       end
 


### PR DESCRIPTION
When the binding request to the service broker fails (e.g. times out), orphan mitigation was already triggered (i.e. unbind request sent to the service broker) but the database entry was kept. This led to errors when calling `cf bind-service` a second time (`App .. is already bound to service instance ..`).

With this change we remove the binding from the database when the initial binding request to the service broker fails. Thus we also changed an already existing test.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
