### PR TITLE
Drop unused spaces_application_supporters table

### DIFF
--- a/db/migrations/20220111112500_drop_spaces_application_supporters_table.rb
+++ b/db/migrations/20220111112500_drop_spaces_application_supporters_table.rb
@@ -1,0 +1,6 @@
+Sequel.migration do
+  change do
+    # This table is superseded by spaces_supporters.
+    drop_table?(:spaces_application_supporters)
+  end
+end

--- a/spec/unit/models/runtime/space_supporter_spec.rb
+++ b/spec/unit/models/runtime/space_supporter_spec.rb
@@ -20,7 +20,5 @@ module VCAP::CloudController
 
       expect(app_supporter.guid).to be_a_guid
     end
-
-    it_should_be_removed(by: '2022/01/08', explanation: 'Timebox failure: spaces_application_supporters table is no longer being used. Consider removing it.')
   end
 end


### PR DESCRIPTION
- Table is superseded by spaces_supporters.
- Remove time bomb test.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
