### PR TITLE
Remove experimental tags from v3 docs

### DIFF
--- a/docs/v3/README.md
+++ b/docs/v3/README.md
@@ -34,7 +34,7 @@ Style Rules
   - alphabetical everything else
 - Object names should be lowercased and separated by a space
 - Every object description should have examples
-- Every request should have a "Permitted Roles"
+- Every request should have a "Permitted roles"
   - Use "All Roles" to define any set of permissions that do not apply to org/space managers, developers, etc.
 - Optional params should be omitted from request examples.
 

--- a/docs/v3/source/includes/concepts/_filters.md.erb
+++ b/docs/v3/source/includes/concepts/_filters.md.erb
@@ -46,7 +46,7 @@ This will return all buildpacks with stack `NULL`.
 
 This will return all routes with hostname `"hostname1"`, `""` OR `"hostname2"`.
 
-#### Relational Operators (Experimental)
+#### Relational Operators
 
 Some fields (e.g. `created_at` and `updated_at`) can be filtered using relational operators when listing resources.
 
@@ -68,7 +68,7 @@ Timestamps must be in [standard timestamp format](#timestamps).
 **gt**       | Return resources strictly greater than the given value for the filtered attribute
 **gte**      | Return resources greater than or equal to the given value for the filtered attribute
 
-#### Exclusion Operator (Experimental)
+#### Exclusion Operator
 
 Some fields support filtering on all values except a given set of values.
 

--- a/docs/v3/source/includes/resources/admin/_clear_buildpack_cache.md.erb
+++ b/docs/v3/source/includes/resources/admin/_clear_buildpack_cache.md.erb
@@ -28,7 +28,7 @@ unnecessary blobs.
 #### Definition
 `POST /v3/admin/actions/clear_buildpack_cache`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/app_features/_get.md.erb
+++ b/docs/v3/source/includes/resources/app_features/_get.md.erb
@@ -26,8 +26,8 @@ Content-Type: application/json
 
 #### Permitted roles
 
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -35,4 +35,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/app_features/_list.md.erb
+++ b/docs/v3/source/includes/resources/app_features/_list.md.erb
@@ -28,8 +28,8 @@ This endpoint retrieves the list of features for the specified app.
 
 #### Permitted roles
 
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -37,4 +37,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/app_features/_update.md.erb
+++ b/docs/v3/source/includes/resources/app_features/_update.md.erb
@@ -38,4 +38,4 @@ Role | Notes
 --- | ---
 Admin |
 Space Developer |
-Space Supporter | Experimental; Can only update **revisions** feature
+Space Supporter | Can only update **revisions** feature

--- a/docs/v3/source/includes/resources/app_usage_events/_delete.md.erb
+++ b/docs/v3/source/includes/resources/app_usage_events/_delete.md.erb
@@ -25,7 +25,7 @@ Destroys all existing events. Populates new usage events, one for each started a
 
 `POST /v3/app_usage_events/actions/destructively_purge_all_and_reseed`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/app_usage_events/_get.md.erb
+++ b/docs/v3/source/includes/resources/app_usage_events/_get.md.erb
@@ -27,7 +27,7 @@ Retrieve an app usage event.
 
 `GET /v3/app_usage_events/:guid`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/app_usage_events/_list.md.erb
+++ b/docs/v3/source/includes/resources/app_usage_events/_list.md.erb
@@ -36,9 +36,9 @@ Name | Type | Description
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid value is `created_at`
 **after_guid** | _string_ | Filters out events before and including the event with the given guid
 **guids** | _list of strings_ | Comma-delimited list of usage event guids to filter by
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 All Roles |

--- a/docs/v3/source/includes/resources/apps/_current_droplet.md.erb
+++ b/docs/v3/source/includes/resources/apps/_current_droplet.md.erb
@@ -30,8 +30,8 @@ Set the current droplet for an app. The current droplet is the droplet that the 
 
 #### Permitted roles
 
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_env.md.erb
+++ b/docs/v3/source/includes/resources/apps/_env.md.erb
@@ -80,4 +80,4 @@ Role | Notes
 Admin |
 Admin Read-Only |
 Space Developer |
-Space Supporter | Experimental, system_env_json redacted
+Space Supporter | `system_env_json` redacted

--- a/docs/v3/source/includes/resources/apps/_environment_variables.md.erb
+++ b/docs/v3/source/includes/resources/apps/_environment_variables.md.erb
@@ -40,9 +40,9 @@ For the entire list of environment variables that will be available to the app a
 `GET /v3/apps/:guid/environment_variables`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Space Developer |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_get.md.erb
+++ b/docs/v3/source/includes/resources/apps/_get.md.erb
@@ -31,8 +31,8 @@ Name | Type | Description
 **include**| _list of strings_ | Optionally include additional related resources in the response; valid values are `space` and `space.organization`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -40,4 +40,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_get_current_droplet.md.erb
+++ b/docs/v3/source/includes/resources/apps/_get_current_droplet.md.erb
@@ -25,8 +25,8 @@ Content-Type: application/json
 `GET /v3/apps/:guid/droplets/current`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -34,4 +34,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_get_current_droplet_relationship.md.erb
+++ b/docs/v3/source/includes/resources/apps/_get_current_droplet_relationship.md.erb
@@ -29,8 +29,8 @@ This endpoint retrieves the current droplet relationship for an app.
 `GET /v3/apps/:guid/relationships/current_droplet`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -38,4 +38,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_list.md.erb
+++ b/docs/v3/source/includes/resources/apps/_list.md.erb
@@ -41,8 +41,8 @@ Name | Type | Description
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **lifecycle_type** | _string_ | [Lifecycle](#lifecycles) type to filter by; valid values are `buildpack`, `docker`
 **include**| _list of strings_ | Optionally include a list of unique related resources in the response; valid values are `space` and `spaceorganization`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/apps/_permissions.md.erb
+++ b/docs/v3/source/includes/resources/apps/_permissions.md.erb
@@ -32,8 +32,8 @@ developers can read sensitive data.
 `GET /v3/apps/:guid/permissions`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -41,4 +41,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_restart.md.erb
+++ b/docs/v3/source/includes/resources/apps/_restart.md.erb
@@ -33,8 +33,8 @@ For restarting applications without downtime, see the [deployments](#deployments
 
 #### Permitted roles
 
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_ssh_enabled.md.erb
+++ b/docs/v3/source/includes/resources/apps/_ssh_enabled.md.erb
@@ -30,8 +30,8 @@ whether it is disabled globally, at the space level, or at the app level.
 `GET /v3/apps/:guid/ssh_enabled` <br>
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -39,4 +39,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_start.md.erb
+++ b/docs/v3/source/includes/resources/apps/_start.md.erb
@@ -26,8 +26,8 @@ Content-Type: application/json
 
 #### Permitted roles
 
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_stop.md.erb
+++ b/docs/v3/source/includes/resources/apps/_stop.md.erb
@@ -26,8 +26,8 @@ Content-Type: application/json
 
 #### Permitted roles
 
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/apps/_update_environment_variables.md.erb
+++ b/docs/v3/source/includes/resources/apps/_update_environment_variables.md.erb
@@ -52,8 +52,8 @@ Environment variable names may not start with VCAP_. PORT is not a valid environ
 `PATCH /v3/apps/:guid/environment_variables`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/audit_events/_get.md.erb
+++ b/docs/v3/source/includes/resources/audit_events/_get.md.erb
@@ -34,4 +34,4 @@ Global Auditor |
 Org Auditor | Cannot see events which occurred in orgs that the user does not belong to
 Space Auditor | Cannot see events which occurred in spaces that the user does not belong to
 Space Developer | Cannot see events which occurred in spaces that the user does not belong to
-Space Supporter | Experimental; Cannot see events which occurred in spaces that the user does not belong to
+Space Supporter | Cannot see events which occurred in spaces that the user does not belong to

--- a/docs/v3/source/includes/resources/audit_events/_list.md.erb
+++ b/docs/v3/source/includes/resources/audit_events/_list.md.erb
@@ -31,18 +31,18 @@ Retrieve all audit events the user has access to.
 Name | Type | Description
 ---- | ---- | ------------
 **types** | _list of strings_ | Comma-delimited list of event types to filter by
-**target_guids** | _list of strings_ | Comma-delimited list of target guids to filter by. Also supports [filtering by exclusion](#exclusion-operator-experimental).
+**target_guids** | _list of strings_ | Comma-delimited list of target guids to filter by. Also supports [filtering by exclusion](#exclusion-operator).
 **space_guids** | _list of strings_ | Comma-delimited list of space guids to filter by
 **organization_guids** | _list of strings_ | Comma-delimited list of organization guids to filter by
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -51,4 +51,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/buildpacks/_delete.md
+++ b/docs/v3/source/includes/resources/buildpacks/_delete.md
@@ -22,7 +22,7 @@ Location: https://api.example.org/v3/jobs/[guid]
 #### Definition
 `DELETE /v3/buildpacks/:guid`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/buildpacks/_list.md.erb
+++ b/docs/v3/source/includes/resources/buildpacks/_list.md.erb
@@ -36,8 +36,8 @@ Name | Type | Description
 **stacks**| _list of strings_ | Comma-delimited list of stack names to filter by
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, and `position`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/builds/_create.md.erb
+++ b/docs/v3/source/includes/resources/builds/_create.md.erb
@@ -48,8 +48,8 @@ Name | Type | Description | Default
 
 #### Permitted roles
  |
---- | ---
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental
+Space Supporter |
 

--- a/docs/v3/source/includes/resources/builds/_get.md.erb
+++ b/docs/v3/source/includes/resources/builds/_get.md.erb
@@ -26,7 +26,7 @@ Content-Type: application/json
 
 #### Permitted roles
  |
---- | ---
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -34,4 +34,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/builds/_list.md.erb
+++ b/docs/v3/source/includes/resources/builds/_list.md.erb
@@ -37,8 +37,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/builds/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/builds/_list_for_app.md.erb
@@ -35,12 +35,12 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
- Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -48,4 +48,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/builds/_update.md.erb
+++ b/docs/v3/source/includes/resources/builds/_update.md.erb
@@ -33,8 +33,8 @@ Name | Type | Description
 ---- | ---- | -----------
 **metadata.labels** | [_label object_](#labels) | Labels applied to the build
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the build
-**state** *(experimental)* | _string_ | Build status; valid values are `FAILED` or `STAGED` (field can only be passed by Build State Updaters)
-**lifecycle.data.image** *(experimental)* | _string_ | Image reference tag where the built complete image was stored (field can only be passed by Build State Updaters)
+**state** | _string_ | Build status; valid values are `FAILED` or `STAGED` (field can only be passed by Build State Updaters)
+**lifecycle.data.image** | _string_ | Image reference tag where the built complete image was stored (field can only be passed by Build State Updaters)
 
 #### Permitted roles
 

--- a/docs/v3/source/includes/resources/deployments/_cancel.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_cancel.md.erb
@@ -23,8 +23,8 @@ HTTP/1.1 200 OK
 `POST /v3/deployments/:guid/actions/cancel`
 
 #### Permitted roles
- Roles | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/deployments/_create.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_create.md.erb
@@ -84,8 +84,8 @@ Name | Type | Description | Default
 <sup>1 Only a droplet _or_ a revision may be provided, not both.</sup>
 
 #### Permitted roles
- Roles | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/deployments/_get.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_get.md.erb
@@ -25,8 +25,8 @@ Content-Type: application/json
 `GET /v3/deployments/:guid`
 
 #### Permitted roles
- Roles | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -34,4 +34,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/deployments/_list.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_list.md.erb
@@ -38,10 +38,10 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
- Roles | Notes
---- | ---
+ |
+--- |
 All Roles |

--- a/docs/v3/source/includes/resources/deployments/_update.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_update.md.erb
@@ -35,7 +35,7 @@ Name | Type | Description
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the deployment
 
 #### Permitted roles
- Roles | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |

--- a/docs/v3/source/includes/resources/domains/_get.md.erb
+++ b/docs/v3/source/includes/resources/domains/_get.md.erb
@@ -37,4 +37,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/domains/_list.md.erb
+++ b/docs/v3/source/includes/resources/domains/_list.md.erb
@@ -37,8 +37,8 @@ Retrieve all domains the user has access to.
 | **per_page**           | _integer_         | Number of results per page; <br>valid values are 1 through 5000
 | **order_by**           | _string_          | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`
 | **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
 

--- a/docs/v3/source/includes/resources/domains/_share.md.erb
+++ b/docs/v3/source/includes/resources/domains/_share.md.erb
@@ -41,7 +41,7 @@ Name     | Type     | Description
 
 #### Permitted roles
 
-Role | Notes
------ | ---
+ |
+----- |
 Admin |
 Org Manager |

--- a/docs/v3/source/includes/resources/droplets/_delete.md
+++ b/docs/v3/source/includes/resources/droplets/_delete.md
@@ -22,7 +22,7 @@ Location: https://api.example.org/v3/jobs/[guid]
 #### Definition
 `DELETE /v3/droplets/:guid`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/droplets/_get.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_get.md.erb
@@ -34,4 +34,4 @@ Org Manager | Some fields are redacted
 Space Auditor | Some fields are redacted
 Space Developer |
 Space Manager | Some fields are redacted
-Space Supporter | Experimental; Some fields are redacted
+Space Supporter | Some fields are redacted

--- a/docs/v3/source/includes/resources/droplets/_list.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_list.md.erb
@@ -39,8 +39,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at` and `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/droplets/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_list_for_app.md.erb
@@ -39,8 +39,8 @@ Name | Type | Description
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
-Role | Notes |
---- | --- |
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -48,4 +48,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/droplets/_list_for_package.md.erb
+++ b/docs/v3/source/includes/resources/droplets/_list_for_package.md.erb
@@ -38,8 +38,8 @@ Name | Type | Description
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
-Role | Notes |
---- | --- |
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -47,4 +47,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/feature_flags/_list.md.erb
+++ b/docs/v3/source/includes/resources/feature_flags/_list.md.erb
@@ -33,7 +33,7 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to `name` ascending; prepend with `-` to sort descending. <br>Valid value is `name`
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/isolation_segments/_list.md.erb
+++ b/docs/v3/source/includes/resources/isolation_segments/_list.md.erb
@@ -37,8 +37,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, and `name`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/manifests/_create_diff.md
+++ b/docs/v3/source/includes/resources/manifests/_create_diff.md
@@ -63,7 +63,7 @@ Name           | Type | Description
 
 `POST /v3/spaces/:guid/manifest_diff`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/manifests/_get.md
+++ b/docs/v3/source/includes/resources/manifests/_get.md
@@ -40,7 +40,7 @@ Generate a manifest for an app and its underlying processes.
 #### Definition
 `GET /v3/apps/:guid/manifest`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/organization_quotas/_apply.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_apply.md.erb
@@ -42,6 +42,6 @@ Name | Type | Description
 
 #### Permitted roles
 
-Role | Notes
---- | ---
+ |
+--- |
 Admin |

--- a/docs/v3/source/includes/resources/organization_quotas/_create.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_create.md.erb
@@ -60,6 +60,6 @@ Name | Type | Description | Default |
 
 #### Permitted roles
 
-Role | Notes
---- | ---
+ |
+--- |
 Admin |

--- a/docs/v3/source/includes/resources/organization_quotas/_delete.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_delete.md.erb
@@ -26,7 +26,7 @@ Location: https://api.example.org/v3/jobs/[guid]
 
 #### Permitted roles
 
-Role  | Notes
---- | ---
+ |
+--- |
 Admin |
 

--- a/docs/v3/source/includes/resources/organization_quotas/_get.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_get.md.erb
@@ -40,4 +40,4 @@ Org Billing Manager | Response will only include guids of billing-managed organi
 Space Auditor | Response will only include guids of parent organizations
 Space Developer | Response will only include guids of parent organizations
 Space Manager | Response will only include guids of parent organizations
-Space Supporter | Experimental / Response will only include guids of parent organizations
+Space Supporter | Response will only include guids of parent organizations

--- a/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
@@ -36,8 +36,8 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
 
@@ -52,4 +52,4 @@ Org Billing Manager | Response will only include guids of billing-managed organi
 Space Auditor | Response will only include guids of parent organizations
 Space Developer | Response will only include guids of parent organizations
 Space Manager | Response will only include guids of parent organizations
-Space Supporter | Experimental / Response will only include guids of parent organizations
+Space Supporter | Response will only include guids of parent organizations

--- a/docs/v3/source/includes/resources/organization_quotas/_update.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_update.md.erb
@@ -69,6 +69,6 @@ Name | Type | Description
 
 #### Permitted roles
 
-Role | Notes
------ | ---
+ |
+----- |
 Admin |

--- a/docs/v3/source/includes/resources/organizations/_get_default_domain.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_get_default_domain.md.erb
@@ -38,4 +38,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/organizations/_list.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_list.md.erb
@@ -36,8 +36,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, and `name`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/organizations/_list_users.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_list_users.md.erb
@@ -37,8 +37,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at` and `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/packages/_delete.md
+++ b/docs/v3/source/includes/resources/packages/_delete.md
@@ -22,7 +22,7 @@ Location: https://api.example.org/v3/jobs/[guid]
 #### Definition
 `DELETE /v3/packages/:guid`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/packages/_get.md.erb
+++ b/docs/v3/source/includes/resources/packages/_get.md.erb
@@ -25,8 +25,8 @@ Content-Type: application/json
 `GET /v3/packages/:guid`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -34,4 +34,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/packages/_list.md.erb
+++ b/docs/v3/source/includes/resources/packages/_list.md.erb
@@ -40,8 +40,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/packages/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/packages/_list_for_app.md.erb
@@ -36,12 +36,12 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -49,4 +49,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/processes/_get.md.erb
+++ b/docs/v3/source/includes/resources/processes/_get.md.erb
@@ -35,4 +35,4 @@ Org Manager | Some fields are redacted
 Space Auditor | Some fields are redacted
 Space Developer |
 Space Manager | Some fields are redacted
-Space Supporter | Experimental; Some fields are redacted
+Space Supporter | Some fields are redacted

--- a/docs/v3/source/includes/resources/processes/_list.md.erb
+++ b/docs/v3/source/includes/resources/processes/_list.md.erb
@@ -39,8 +39,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/processes/_list_for_app.md.erb
@@ -36,12 +36,12 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
-Roles | Notes |
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |

--- a/docs/v3/source/includes/resources/processes/_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_object.md.erb
@@ -19,7 +19,7 @@ Name | Type | Description
 **disk_in_mb** | _integer_ | The disk in MB allocated per instance
 **health_check** | [_health check object_](#the-health-check-object) | The health check to perform on the process
 **relationships.app** | [_to-one relationship_](#to-one-relationships) | The app the process belongs to
-**relationships.revision** (*experimental*)| [_to-one relationship_](#to-one-relationships) | The app revision the process is currently running
+**relationships.revision** | [_to-one relationship_](#to-one-relationships) | The app revision the process is currently running
 **metadata.labels** | [_label object_](#labels) | Labels applied to the process
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the process
 **links** | [_links object_](#links) | Links to related resources

--- a/docs/v3/source/includes/resources/processes/_stats.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats.md.erb
@@ -35,4 +35,4 @@ Org Manager | Some fields are redacted
 Space Auditor | Some fields are redacted
 Space Developer |
 Space Manager | Some fields are redacted
-Space Supporter | Experimental; Some fields are redacted
+Space Supporter | Some fields are redacted

--- a/docs/v3/source/includes/resources/processes/_terminate_instance.md
+++ b/docs/v3/source/includes/resources/processes/_terminate_instance.md
@@ -26,7 +26,7 @@ This allows a user to stop a single misbehaving instance of a process.
 `DELETE /v3/processes/:guid/instances/:index` <br>
 `DELETE /v3/apps/:guid/processes/:type/instances/:index`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/revisions/_deployed_list.md.erb
+++ b/docs/v3/source/includes/resources/revisions/_deployed_list.md.erb
@@ -36,8 +36,8 @@ Name | Type | Description
 **order_by** | _string_ | Value to sort by. Defaults to ascending, prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -45,4 +45,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/revisions/_get.md.erb
+++ b/docs/v3/source/includes/resources/revisions/_get.md.erb
@@ -25,8 +25,8 @@ Content-Type: application/json
 `GET /v3/revisions/:guid`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -34,4 +34,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/revisions/_list.md.erb
+++ b/docs/v3/source/includes/resources/revisions/_list.md.erb
@@ -35,12 +35,12 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -48,4 +48,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/revisions/_object.md.erb
+++ b/docs/v3/source/includes/resources/revisions/_object.md.erb
@@ -17,7 +17,7 @@ Name | Type | Description
 **created_at** | _[timestamp](#timestamps)_ | The time with zone when the object was created
 **updated_at** | _[timestamp](#timestamps)_ | The time with zone when the object was last updated
 **description** | _string_ | A short description of the reason for revision
-**deployable** _(experimental)_ | _boolean_ | Indicates if the revision's droplet is staged and the revision can be used to [create a deployment](#create-a-deployment)
+**deployable** | _boolean_ | Indicates if the revision's droplet is staged and the revision can be used to [create a deployment](#create-a-deployment)
 **relationships.app** | [_to-one relationship_](#to-one-relationships) | The app the revision is associated with
 **metadata.labels** | [_label object_](#labels) | Labels applied to the revision
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the revision

--- a/docs/v3/source/includes/resources/roles/_list.md.erb
+++ b/docs/v3/source/includes/resources/roles/_list.md.erb
@@ -40,8 +40,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **include** | _list of strings_ | Optionally include a list of unique related resources in the response; <br>valid values are `user`, `space`, and `organization`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/routes/_check_route_reservations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_check_route_reservations.md.erb
@@ -48,4 +48,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/routes/_create.md.erb
+++ b/docs/v3/source/includes/resources/routes/_create.md.erb
@@ -61,9 +61,9 @@ Content-Type: application/json
 
 #### Permitted roles
 
-Role  | Notes
------ | ---
+ |
+----- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |
 

--- a/docs/v3/source/includes/resources/routes/_delete.md.erb
+++ b/docs/v3/source/includes/resources/routes/_delete.md.erb
@@ -24,8 +24,8 @@ Location: https://api.example.org/v3/jobs/[guid]
 
 #### Permitted roles
 
-Role  | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/routes/_delete_unmapped.md.erb
+++ b/docs/v3/source/includes/resources/routes/_delete_unmapped.md.erb
@@ -26,10 +26,10 @@ Deletes all routes in a space that are not mapped to any applications and not bo
 
 #### Permitted roles
 
-Role  | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |
 
 **Note**: `unmapped=true` is a required query parameter; always include it.

--- a/docs/v3/source/includes/resources/routes/_get.md.erb
+++ b/docs/v3/source/includes/resources/routes/_get.md.erb
@@ -32,8 +32,8 @@ Name | Type | Description
 
 #### Permitted roles
 
-Role  | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -42,4 +42,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/routes/_insert_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_insert_destinations.md.erb
@@ -57,8 +57,8 @@ replace all destinations for a route at once using the [replace destinations end
 
 #### Permitted roles
 
-| Role            | Notes |
-| --------------- | --- |
+|                 |
+| --------------- |
 | Admin           |
 | Space Developer |
-| Space Supporter | Experimental |
+| Space Supporter |

--- a/docs/v3/source/includes/resources/routes/_list.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list.md.erb
@@ -43,8 +43,8 @@ Name | Type | Description
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **include** | _string_ | Optionally include a list of unique related resources in the response <br>Valid values are `domain`, `space.organization`, `space`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/routes/_list_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_destinations.md.erb
@@ -35,8 +35,8 @@ Name | Type | Description
 
 #### Permitted roles
 
-Role  | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -45,4 +45,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_for_app.md.erb
@@ -42,8 +42,8 @@ Name | Type | Description
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
-Role  | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -51,4 +51,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/routes/_remove_destination.md.erb
+++ b/docs/v3/source/includes/resources/routes/_remove_destination.md.erb
@@ -25,8 +25,8 @@ Remove a destination from a route.
 
 #### Permitted roles
 
-Role  | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/routes/_replace_destinations.md.erb
+++ b/docs/v3/source/includes/resources/routes/_replace_destinations.md.erb
@@ -94,8 +94,8 @@ and unweighted destinations for a route is not allowed.
 
 #### Permitted roles
 
-| Role            | Notes |
-| --------------- | --- |
+|                 |
+| --------------- |
 | Admin           |
 | Space Developer |
-| Space Supporter | Experimental |
+| Space Supporter |

--- a/docs/v3/source/includes/resources/routes/_update.md.erb
+++ b/docs/v3/source/includes/resources/routes/_update.md.erb
@@ -40,8 +40,8 @@ Content-Type: application/json
 
 #### Permitted roles
 
-Role | Notes
------ | ---
+ |
+----- |
 Admin |
 Space Developer |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/security_groups/_get.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_get.md.erb
@@ -36,5 +36,5 @@ Org Manager | Can see globally enabled security groups or groups associated with
 Space Auditor | Can see globally enabled security groups or groups associated with a space they can see
 Space Developer | Can see globally enabled security groups or groups associated with a space they can see
 Space Manager | Can see globally enabled security groups or groups associated with a space they can see
-Space Supporter | Experimental. Can see globally enabled security groups or groups associated with a space they can see
+Space Supporter | Can see globally enabled security groups or groups associated with a space they can see
 

--- a/docs/v3/source/includes/resources/security_groups/_list.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list.md.erb
@@ -37,8 +37,8 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
 Role | Notes
@@ -52,4 +52,4 @@ Org Manager | Can see globally–enabled security groups or groups associated wi
 Space Auditor | Can see globally–enabled security groups or groups associated with a space they can see
 Space Developer | Can see globally–enabled security groups or groups associated with a space they can see
 Space Manager | Can see globally–enabled security groups or groups associated with a space they can see
-Space Supporter | Experimental. Can see globally–enabled security groups or groups associated with a space they can see
+Space Supporter | Can see globally–enabled security groups or groups associated with a space they can see

--- a/docs/v3/source/includes/resources/security_groups/_list_running_security_groups.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list_running_security_groups.md.erb
@@ -47,4 +47,4 @@ Org Manager | Can see globally-enabled security groups and groups associated wit
 Space Auditor | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Developer | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Manager | Can see globally-enabled security groups and groups associated with spaces where they have this role
-Space Supporter | Experimental. Can see globally-enabled security groups and groups associated with spaces where they have this role
+Space Supporter | Can see globally-enabled security groups and groups associated with spaces where they have this role

--- a/docs/v3/source/includes/resources/security_groups/_list_staging_security_groups.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list_staging_security_groups.md.erb
@@ -47,4 +47,4 @@ Org Manager | Can see globally-enabled security groups and groups associated wit
 Space Auditor | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Developer | Can see globally-enabled security groups and groups associated with spaces where they have this role
 Space Manager | Can see globally-enabled security groups and groups associated with spaces where they have this role
-Space Supporter | Experimental. Can see globally-enabled security groups and groups associated with spaces where they have this role
+Space Supporter | Can see globally-enabled security groups and groups associated with spaces where they have this role

--- a/docs/v3/source/includes/resources/service_brokers/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_get.md.erb
@@ -33,4 +33,4 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Space Developer | Only space-scoped brokers
-Space Supporter | Experimental; Only space-scoped brokers
+Space Supporter | Only space-scoped brokers

--- a/docs/v3/source/includes/resources/service_brokers/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_list.md.erb
@@ -36,8 +36,8 @@ Name | Type | Description
 **space_guids** | _list of strings_ | Comma-delimited list of space GUIDs to filter by
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
 Role | Notes
@@ -46,5 +46,5 @@ Admin |
 Admin Read-Only |
 Global Auditor |
 Space Developer | Only space-scoped brokers
-Space Supporter | Experimental; Only space-scoped brokers
+Space Supporter | Only space-scoped brokers
 Other | Will receive an empty list

--- a/docs/v3/source/includes/resources/service_credential_bindings/_create.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_create.md.erb
@@ -126,4 +126,4 @@ Role | Notes
 --- | ---
 Admin |
 Space Developer |
-Space Supporter | Experimental. Only allowed to create bindings of type `app`.
+Space Supporter | Only allowed to create bindings of type `app`.

--- a/docs/v3/source/includes/resources/service_credential_bindings/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_delete.md.erb
@@ -35,9 +35,9 @@ respond synchronously to the delete request.
 #### Definition
 `DELETE /v3/service_credential_bindings/:guid`
 
-#### Permitted Roles
-Role | Notes
---- | ---
+#### Permitted roles
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_credential_bindings/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_get.md.erb
@@ -45,8 +45,8 @@ Name | Type | Description
 **include** | _list of strings_ | Optionally include a list of unique related resources in the response. Valid values are: `app`, `service_instance`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -54,4 +54,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_credential_bindings/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_list.md.erb
@@ -42,8 +42,8 @@ Name | Type | Description
 **service_offering_names** | _list of strings_ | Comma-delimited list of service offering names to filter by
 **type** | _list of strings_ | Type of credential binding to filter by. Valid values are: `app` or `key`
 **guids** | _list of strings_ | Comma-delimited list of service route binding guids to filter by
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 **include** | _list of strings_ | Optionally include a list of unique related resources in the response. Valid values are: `app`, `service_instance`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **page** | _integer_ | Page to display; valid values are integers >= 1
@@ -51,8 +51,8 @@ Name | Type | Description
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`, and `name`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -60,4 +60,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_credential_bindings/_object.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_object.md.erb
@@ -19,7 +19,7 @@ Name | Type | Description
 **guid** | _uuid_ | Unique identifier for the service credential binding
 **name** | _string_ | Name of the binding. `null` when it's not defined.
 **type** | _string_ | Either `app` or `key`
-**last_operation** (*experimental*)| _[last operation object](#the-last-operation-object-for-service-credential-binding)_ | The last operation of this binding
+**last_operation** | _[last operation object](#the-last-operation-object-for-service-credential-binding)_ | The last operation of this binding
 **created_at** | _[timestamp](#timestamps)_ | The time with zone when the object was created
 **updated_at** | _[timestamp](#timestamps)_ | The time with zone when the object was last updated
 **metadata.labels** | [_label object_](#labels) | Labels applied to the service credential binding

--- a/docs/v3/source/includes/resources/service_credential_bindings/_parameters.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_parameters.md.erb
@@ -33,9 +33,9 @@ This endpoint is not available for User-Provided Service Instances.
 `GET /v3/service_credential_bindings/:guid/parameters`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Space Developer |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_instances/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_delete.md.erb
@@ -49,7 +49,7 @@ Name | Type | Description
 ---- | ---- | ------------
 **purge** | _boolean_ | If `true`, deletes the service instance and all associated resources without any interaction with the service broker.
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/service_instances/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_get.md.erb
@@ -56,8 +56,8 @@ service_plan.service_offering| `name`, `guid`, `description`, `documentation_url
 service_plan.service_offering.service_broker| `name`, `guid`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -65,4 +65,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list.md.erb
@@ -40,8 +40,8 @@ Name | Type | Description
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`, and `name`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **fields** | [_fields parameter_](#fields-parameter) | [_Allowed values_](#service-instances-list-fields)
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 
 ##### Service Instances List Fields

--- a/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
@@ -39,8 +39,8 @@ space | `guid`, `name`, `relationships.organization`
 space.organization| `guid`, `name`
 
 #### Permitted roles (in the service instance's originating space)
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -48,4 +48,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_instances/_update.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_update.md.erb
@@ -35,7 +35,7 @@ curl "https://api.example.org/v3/service_instances/[guid]" \
 ```
 
 ```
-(Experimental) Example Request for Managed Service Instance Upgrade (maintenance_info update)
+Example Request for Managed Service Instance Upgrade (maintenance_info update)
 ```
 
 ```shell
@@ -72,7 +72,7 @@ Location: https://api.example.org/v3/jobs/af5c57f6-8769-41fa-a499-2c84ed896788
 ```
 
 ```
-(Experimental) Example Request for User-Provided Service Instance
+Example Request for User-Provided Service Instance
 ```
 
 ```shell
@@ -101,7 +101,7 @@ curl "https://api.example.org/v3/service_instances/[guid]" \
 ```
 
 ```
-(Experimental) Example Response for User-Provided Service Instance
+Example Response for User-Provided Service Instance
 ```
 
 ```http

--- a/docs/v3/source/includes/resources/service_offerings/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_offerings/_list.md.erb
@@ -37,12 +37,12 @@ Name | Type | Description
 **space_guids** | _list of strings_ | Comma-delimited list of space GUIDs to filter by
 **organization_guids** | _list of strings_ | Comma-delimited list of organization GUIDs to filter by
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**fields** (*experimental*)| [_fields parameter_](#fields-parameter) | [_Allowed values_](#service-offerings-list-fields)
+**fields** | [_fields parameter_](#fields-parameter) | [_Allowed values_](#service-offerings-list-fields)
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at` and `name`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 ##### Service Offerings List Fields
 

--- a/docs/v3/source/includes/resources/service_plans/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_plans/_list.md.erb
@@ -45,9 +45,9 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**fields** (*experimental*)| [_fields parameter_](#fields-parameter) | [_Allowed values_](#service-plans-list-fields)
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**fields** | [_fields parameter_](#fields-parameter) | [_Allowed values_](#service-plans-list-fields)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 The **organization_guids** and **space_guids** filters do not filter plans that are public.
 They both act on plans that are restricted to certain organizations, and to plans from space-scoped

--- a/docs/v3/source/includes/resources/service_route_bindings/_create.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_create.md.erb
@@ -87,8 +87,8 @@ Name | Type | Description |
 
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_route_bindings/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_delete.md.erb
@@ -36,9 +36,9 @@ responds with a job which can be used to track the progress of the delete operat
 #### Definition
 `DELETE /v3/service_route_bindings/:guid`
 
-#### Permitted Roles
-Role | Notes
---- | ---
+#### Permitted roles
+ |
+--- |
 Admin |
 Space Developer |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_route_bindings/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_get.md.erb
@@ -33,8 +33,8 @@ Name | Type | Description
 **include** | _list of strings_ | Optionally include a list of unique related resources in the response. Valid values are: `route`, `service_instance`
 
 #### Permitted roles
-Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -42,4 +42,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_route_bindings/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_list.md.erb
@@ -36,8 +36,8 @@ Name | Type | Description
 **service_instance_names** | _list of strings_ | Comma-delimited list of service instance names to filter by
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **guids** | _list of strings_ | Comma-delimited list of service route binding guids to filter by
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 **include** | _list of strings_ | Optionally include a list of unique related resources in the response. Valid values are: `route`, `service_instance`
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
@@ -45,7 +45,7 @@ Name | Type | Description
 
 #### Permitted roles
  |
---- | ---
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -53,4 +53,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_usage_events/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_usage_events/_delete.md.erb
@@ -24,7 +24,7 @@ Destroys all existing events. Populates new usage events, one for each existing 
 
 `POST /v3/service_usage_events/actions/destructively_purge_all_and_reseed`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/service_usage_events/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_usage_events/_get.md.erb
@@ -27,7 +27,7 @@ Retrieve a service usage event.
 
 `GET /v3/service_usage_events/:guid`
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 Admin |

--- a/docs/v3/source/includes/resources/service_usage_events/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_usage_events/_list.md.erb
@@ -38,10 +38,10 @@ Name | Type | Description
 **guids** | _list of strings_ | Comma-delimited list of usage event guids to filter by
 **service_instance_types** | _list of strings_ | Comma-delimited list of service instance types to filter by; valid values are `managed_service_instance` and `user_provided_service_instance`
 **service_offering_guids** | _list of strings_ | Comma-delimited list of service offering guids to filter by
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
-#### Permitted Roles
+#### Permitted roles
  |
 --- | ---
 All Roles |

--- a/docs/v3/source/includes/resources/sidecars/_get.md.erb
+++ b/docs/v3/source/includes/resources/sidecars/_get.md.erb
@@ -26,7 +26,7 @@ Content-Type: application/json
 
 #### Permitted roles
  |
---- | ---
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -34,4 +34,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/sidecars/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/sidecars/_list_for_app.md.erb
@@ -33,12 +33,12 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |
---- | ---
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -46,4 +46,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/sidecars/_list_for_process.md.erb
+++ b/docs/v3/source/includes/resources/sidecars/_list_for_process.md.erb
@@ -33,8 +33,8 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |
@@ -46,4 +46,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/space_features/_get.md.erb
+++ b/docs/v3/source/includes/resources/space_features/_get.md.erb
@@ -25,8 +25,8 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/features/:name`
 
 #### Permitted roles
- Role | Notes
---- | --- |
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -34,4 +34,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/space_features/_list.md.erb
+++ b/docs/v3/source/includes/resources/space_features/_list.md.erb
@@ -27,8 +27,8 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/features`
 
 #### Permitted roles
- Role | Notes
---- | ---
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -36,4 +36,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/space_quotas/_list.md.erb
+++ b/docs/v3/source/includes/resources/space_quotas/_list.md.erb
@@ -37,8 +37,8 @@ Name | Type | Description
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
 

--- a/docs/v3/source/includes/resources/spaces/_delete.md
+++ b/docs/v3/source/includes/resources/spaces/_delete.md
@@ -27,8 +27,8 @@ Location: https://api.example.org/v3/jobs/[guid]
 
 #### Permitted roles
 
-Role  | Notes
---- | ---
+ |
+--- |
 Admin |
 Org Manager |
 

--- a/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_get_a_space.md.erb
@@ -35,8 +35,8 @@ Name | Type | Description
 
 
 #### Permitted roles
- Role | Notes
---- | --- |
+ |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -44,4 +44,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/spaces/_list.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_list.md.erb
@@ -38,8 +38,8 @@ Name | Type | Description
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `name`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **include** | _string_ | Optionally include a list of unique related resources in the response; <br>valid value is `organization`
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/spaces/_list_users.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_list_users.md.erb
@@ -37,12 +37,12 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at` and `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
- Role | Notes
---- | ---
+  |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -50,4 +50,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/spaces/get_assigned_isolation_segment.md.erb
+++ b/docs/v3/source/includes/resources/spaces/get_assigned_isolation_segment.md.erb
@@ -25,8 +25,8 @@ Content-Type: application/json
 `GET /v3/spaces/:guid/relationships/isolation_segment`
 
 #### Permitted roles
- Role | Notes
---- | --- |
+  |
+--- |
 Admin |
 Admin Read-Only |
 Global Auditor |
@@ -34,4 +34,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
-Space Supporter | Experimental |
+Space Supporter |

--- a/docs/v3/source/includes/resources/stacks/_apps.md.erb
+++ b/docs/v3/source/includes/resources/stacks/_apps.md.erb
@@ -34,10 +34,10 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`, and `name`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
-|
+ |
 --- | ---
 All Roles |

--- a/docs/v3/source/includes/resources/stacks/_list.md.erb
+++ b/docs/v3/source/includes/resources/stacks/_list.md.erb
@@ -35,8 +35,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`, and `name`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/tasks/_cancel.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_cancel.md.erb
@@ -34,8 +34,8 @@ Canceling a task that is in `SUCCEEDED` or `FAILED` state will return an error.
 `PUT /v3/tasks/:guid/cancel` _(Deprecated)_
 
 #### Permitted roles
- Role | Notes
+ |
 --- | ---
 Admin |
 Space Developer |
-Space Supporter | Experimental
+Space Supporter |

--- a/docs/v3/source/includes/resources/tasks/_get.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_get.md.erb
@@ -37,4 +37,4 @@ Org Manager | `command` field redacted
 Space Auditor | `command` field redacted
 Space Developer |
 Space Manager | `command` field redacted
-Space Supporter | Experimental, `command` field redacted
+Space Supporter | `command` field redacted

--- a/docs/v3/source/includes/resources/tasks/_list.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_list.md.erb
@@ -40,8 +40,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/tasks/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_list_for_app.md.erb
@@ -39,8 +39,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  Role | Notes
@@ -52,4 +52,4 @@ Org Manager | `command` field redacted
 Space Auditor | `command` field redacted
 Space Developer |
 Space Manager | `command` field redacted
-Space Supporter | Experimental, `command` field redacted
+Space Supporter | `command` field redacted

--- a/docs/v3/source/includes/resources/users/_create.md.erb
+++ b/docs/v3/source/includes/resources/users/_create.md.erb
@@ -44,6 +44,6 @@ Name     | Type     | Description
 
 #### Permitted roles
 
-Role | Notes
------ | ---
+ |
+----- |
 Admin |

--- a/docs/v3/source/includes/resources/users/_delete.md.erb
+++ b/docs/v3/source/includes/resources/users/_delete.md.erb
@@ -26,7 +26,7 @@ Location: https://api.example.org/v3/jobs/[guid]
 
 #### Permitted roles
 
-Role  | Notes
+ |
 --- | ---
 Admin |
 

--- a/docs/v3/source/includes/resources/users/_get.md.erb
+++ b/docs/v3/source/includes/resources/users/_get.md.erb
@@ -36,6 +36,6 @@ Org Manager | Can only view users affiliated with their org
 Space Auditor | Can only view users affiliated with their org
 Space Developer | Can only view users affiliated with their org
 Space Manager | Can only view users affiliated with their org
-Space Supporter | Experimental; Can only view users affiliated with their org
+Space Supporter | Can only view users affiliated with their org
 
 **Note:** A user can always see themselves with this endpoint, regardless of role.

--- a/docs/v3/source/includes/resources/users/_list.md.erb
+++ b/docs/v3/source/includes/resources/users/_list.md.erb
@@ -37,8 +37,8 @@ Name | Type | Description
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at` and `updated_at`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
-**created_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
-**updated_ats** (*experimental*)| _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators-experimental)
+**created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
+**updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 
 #### Permitted roles
  Role | Notes
@@ -52,4 +52,4 @@ Org Manager | Can only view users affiliated with their org
 Space Auditor | Can only view users affiliated with their org
 Space Developer | Can only view users affiliated with their org
 Space Manager | Can only view users affiliated with their org
-Space Supporter | Experimental; Can only view users affiliated with their org
+Space Supporter | Can only view users affiliated with their org

--- a/docs/v3/source/includes/upgrade_guide/conceptual_changes/_resource_summaries.md
+++ b/docs/v3/source/includes/upgrade_guide/conceptual_changes/_resource_summaries.md
@@ -23,11 +23,11 @@ filter by the parent resource. See below for examples of summaries in V3.
   Passing `include=space` will include the space resource in the response body.
 - To fetch all service offerings in a space use `GET
   /v3/service_offerings?space_guids=<space-guid>`. Use the
-  experimental `fields` parameter to include related information in the response
+  `fields` parameter to include related information in the response
   body.
 - To fetch all service instances in a space use `GET
   /v3/service_instances?space_guids=<space-guid>`. Use the
-  experimental `fields` parameter to include related information in the response
+  `fields` parameter to include related information in the response
   body.
   
 ##### Replacing the space summary response for service instances


### PR DESCRIPTION
- Unify role headings to match dominant pattern
  - Use 'Permitted roles' rather than 'Permitted Roles'
  - Remove role table headers unless more than one column is present
- Left a few experimental labels:
  - [potential errors](https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.html#create-an-app): reworking our error codes is still a potential track of work/not complete
  - [route destination weights](https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.html#the-destination-object): I remember having trouble getting this feature through to clients, not sure about the status of the work or whether it's ready to be GA'd
  - [space manifest diffs](https://v3-apidocs.cloudfoundry.org/version/3.113.0/index.html#generate-a-manifest-for-an-app): there are still github issues around them, and while the endpoint is functional I don't believe we completely finished the track of work

I've also gone through and made sure everything still renders/links correctly, should be good to go but let me know if I missed something