### PR TITLE
Treat failed service-credential-binding and service-credential-key as non-existent / Do not cleanup failed bindings in apply_manifest

### DIFF
--- a/app/actions/app_apply_manifest.rb
+++ b/app/actions/app_apply_manifest.rb
@@ -201,7 +201,8 @@ module VCAP::CloudController
     end
 
     def binding_exists?(service_instance, app)
-      ServiceBinding.where(service_instance: service_instance, app: app).present?
+      binding = ServiceBinding.first(service_instance: service_instance, app: app)
+      binding && !binding.create_failed?
     end
 
     def binding_being_deleted!(service_instance, app)

--- a/app/actions/app_apply_manifest.rb
+++ b/app/actions/app_apply_manifest.rb
@@ -1,4 +1,3 @@
-require 'actions/mixins/bindings_delete'
 require 'actions/process_create'
 require 'actions/process_scale'
 require 'actions/process_update'
@@ -11,8 +10,6 @@ require 'cloud_controller/random_route_generator'
 
 module VCAP::CloudController
   class AppApplyManifest
-    include V3::BindingsDeleteMixin
-
     class Error < StandardError; end
     class NoDefaultDomain < StandardError; end
     class ServiceBindingError < StandardError; end
@@ -166,10 +163,6 @@ module VCAP::CloudController
             raise ServiceBrokerRespondedAsyncWhenNotAllowed.new('The service broker responded asynchronously, but async bindings are not supported.')
           end
         rescue => e
-          if binding
-            delete_bindings([binding], user_audit_info: @user_audit_info)
-          end
-
           raise_binding_error!(service_instance, e.message)
         end
       end

--- a/app/actions/service_credential_binding_key_create.rb
+++ b/app/actions/service_credential_binding_key_create.rb
@@ -26,7 +26,10 @@ module VCAP::CloudController
           credentials: {}
         }
 
-        ServiceKey.new.tap do |b|
+        key = ServiceKey.first(service_instance: service_instance, name: message.name)
+        key_already_exists!(message.name) if key && !key.create_failed?
+
+        (key || ServiceKey.new).tap do |b|
           ServiceKey.db.transaction do
             b.save_with_attributes_and_new_operation(
               binding_details,

--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -121,6 +121,9 @@ class ServiceCredentialBindingsController < ApplicationController
   def details
     ensure_service_credential_binding_is_accessible!
     not_found! unless can_read_secrets_in_the_binding_space?
+    if service_credential_binding.create_in_progress? || service_credential_binding.create_failed?
+      not_found_with_message!(service_credential_binding)
+    end
 
     credentials = if service_credential_binding[:type] == 'key' && service_credential_binding.credhub_reference?
                     fetch_credentials_value(service_credential_binding.credhub_reference)
@@ -384,6 +387,12 @@ class ServiceCredentialBindingsController < ApplicationController
 
   def binding_operation_in_progress!
     unprocessable!('There is an operation in progress for the service binding.')
+  end
+
+  def not_found_with_message!(service_credential_binding)
+    type = service_credential_binding.is_a?(ServiceKey) ? 'key' : 'binding'
+    state = service_credential_binding.last_operation.state
+    resource_not_found_with_message!("Creation of service #{type} #{state}")
   end
 
   def not_found!

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -131,6 +131,12 @@ module VCAP::CloudController
       true
     end
 
+    def create_failed?
+      return true if service_binding_operation&.type == 'create' && service_binding_operation.state == 'failed'
+
+      false
+    end
+
     def terminal_state?
       !service_binding_operation || (%w(succeeded failed).include? service_binding_operation.state)
     end

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -132,7 +132,13 @@ module VCAP::CloudController
     end
 
     def create_failed?
-      return true if service_binding_operation&.type == 'create' && service_binding_operation.state == 'failed'
+      return true if last_operation&.type == 'create' && last_operation.state == 'failed'
+
+      false
+    end
+
+    def create_in_progress?
+      return true if last_operation&.type == 'create' && last_operation.state == 'in progress'
 
       false
     end

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -91,6 +91,18 @@ module VCAP::CloudController
       service_key_operation
     end
 
+    def create_failed?
+      return true if last_operation&.type == 'create' && last_operation.state == 'failed'
+
+      false
+    end
+
+    def create_in_progress?
+      return true if last_operation&.type == 'create' && last_operation.state == 'in progress'
+
+      false
+    end
+
     def terminal_state?
       !service_key_operation || (%w(succeeded failed).include? service_key_operation.state)
     end

--- a/spec/request/space_manifests_spec.rb
+++ b/spec/request/space_manifests_spec.rb
@@ -218,7 +218,6 @@ RSpec.describe 'Space Manifests' do
         get job_location, nil, user_header
         parsed_response = MultiJson.load(last_response.body)
 
-        expect(VCAP::CloudController::ServiceBinding.count).to eq(0)
         expect(parsed_response['errors'].first['detail']).to eq("For application '#{app1_model.name}': For service '#{service_instance_1.name}': Failed")
       end
     end

--- a/spec/unit/actions/app_apply_manifest_spec.rb
+++ b/spec/unit/actions/app_apply_manifest_spec.rb
@@ -13,7 +13,6 @@ module VCAP::CloudController
       let(:process_update) { instance_double(ProcessUpdate) }
       let(:process_create) { instance_double(ProcessCreate) }
       let(:service_cred_binding_create) { instance_double(V3::ServiceCredentialBindingAppCreate) }
-      let(:service_cred_binding_delete) { instance_double(V3::ServiceCredentialBindingDelete) }
       let(:random_route_generator) { instance_double(RandomRouteGenerator, route: 'spiffy/donut') }
 
       describe '#apply' do
@@ -49,10 +48,6 @@ module VCAP::CloudController
             to receive(:new).and_return(service_cred_binding_create)
           allow(service_cred_binding_create).to receive(:precursor)
           allow(service_cred_binding_create).to receive(:bind)
-
-          allow(V3::ServiceCredentialBindingDelete).
-            to receive(:new).and_return(service_cred_binding_delete)
-          allow(service_cred_binding_delete).to receive(:delete)
 
           allow(AppPatchEnvironmentVariables).
             to receive(:new).and_return(app_patch_env)
@@ -858,48 +853,26 @@ module VCAP::CloudController
                 context 'action starts async binding' do
                   before do
                     allow(service_cred_binding_create).to receive(:bind).and_return({ async: true })
-                    allow(service_cred_binding_delete).to receive(:delete).and_return({ finished: true })
                   end
 
-                  it 'raises an error and requests unbind' do
+                  it 'raises an error' do
                     expect {
                       app_apply_manifest.apply(app.guid, message)
                     }.to raise_error(AppApplyManifest::ServiceBindingError,
 /For service 'si-name': The service broker responded asynchronously, but async bindings are not supported./)
-
-                    expect(service_cred_binding_delete).to have_received(:delete)
                   end
-
-                  context 'delete happens async' do
-                    before do
-                      allow(service_cred_binding_delete).to receive(:delete).and_return({ finished: false })
-                    end
-
-                    it 'creates a job to follow up' do
-                      expect {
-                        app_apply_manifest.apply(app.guid, message)
-                      }.to raise_error(AppApplyManifest::ServiceBindingError,
-/For service 'si-name': The service broker responded asynchronously, but async bindings are not supported./)
-
-                      expect(service_cred_binding_delete).to have_received(:delete)
-                      expect(Delayed::Job.all).to have(1).job
-                    end
-                  end
-
-                  context
                 end
 
                 context 'bind fails with BindingNotRetrievable' do
                   before do
                     allow(service_cred_binding_create).to receive(:bind).and_raise(V3::ServiceBindingCreate::BindingNotRetrievable)
                   end
-                  it 'fails with async error and attempt delete' do
+
+                  it 'fails with async error' do
                     expect {
                       app_apply_manifest.apply(app.guid, message)
                     }.to raise_error(AppApplyManifest::ServiceBindingError,
 /For service 'si-name': The service broker responded asynchronously, but async bindings are not supported./)
-
-                    expect(service_cred_binding_delete).to have_received(:delete)
                   end
                 end
               end
@@ -909,12 +882,10 @@ module VCAP::CloudController
                   allow(service_cred_binding_create).to receive(:bind).and_raise('fake binding error')
                 end
 
-                it 'decorates the error with the name of the service instancev and delete the binding' do
+                it 'decorates the error with the name of the service instance' do
                   expect {
                     app_apply_manifest.apply(app.guid, message)
                   }.to raise_error(AppApplyManifest::ServiceBindingError, /For service 'si-name': fake binding error/)
-
-                  expect(service_cred_binding_delete).to have_received(:delete)
                 end
               end
             end
@@ -930,8 +901,6 @@ module VCAP::CloudController
                 expect {
                   app_apply_manifest.apply(app.guid, message)
                 }.to raise_error(AppApplyManifest::ServiceBindingError, /For service 'si-name': An existing binding is being deleted. Try recreating the binding later./)
-
-                expect(service_cred_binding_delete).to_not have_received(:delete)
               end
             end
           end

--- a/spec/unit/actions/app_apply_manifest_spec.rb
+++ b/spec/unit/actions/app_apply_manifest_spec.rb
@@ -822,6 +822,20 @@ module VCAP::CloudController
 
                 expect(service_cred_binding_create).to_not have_received(:bind)
               end
+
+              context "last binding operation is 'create failed'" do
+                before do
+                  binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })
+                end
+
+                it 'recreates the binding' do
+                  allow(service_cred_binding_create).to receive(:precursor).and_return(binding)
+
+                  app_apply_manifest.apply(app.guid, message)
+
+                  expect(service_cred_binding_create).to have_received(:bind).with(binding, parameters: nil)
+                end
+              end
             end
 
             context 'volume_services_enabled' do


### PR DESCRIPTION
### Treat failed binding as non-existent 

When the last operation for a service binding is `create failed`:
- accept request to `POST /v3/service_credential_bindings` instead of rejecting it with "The app is already bound to the service instance"; this allows users to retry the creation without the need to explicitly unbind the service
- create binding in `POST /v3/spaces/:guid/actions/apply_manifest` instead of skipping it; the old behavior resulted in apps using a failed binding

### Treat failed key creation as non-existent 

When the last operation for a service key is `create failed`:
- accept request to `POST /v3/service_credential_bindings` instead of rejecting it with "The service instance already has a key binding with name 'mykey'"; this allows users to retry the creation without the need to explicitly delete the key

When the last operation for a service key is `create in progress` or `create failed`:
- raise an error when `GET /v3/service_credential_bindings/:guid/details` is called instead of showing empty key data

### Do not delete bindings in case of bind errors during apply_manifest

The current implementation has the following drawbacks:
- If the automatically triggered deletion succeeded, the original binding error was not shown anymore (e.g. in `cf service myservice`).
- If also the deletion failed, this status was persisted.
  - A subsequent `cf push` treated this as an existing binding and continued.
  - The app's environment variables contained empty credentials.

The changed implementation has the following advantages:
- `VCAP::Services::ServiceClientProvider` already performs the orphan mitigation.
- There is no need anymore to delete a failed binding as bindings in state `create failed` are treated as non-existent and `cf push` can be re-run without any manual cleanup being necessary.
- Users can still see the state of the 'last operation' (e.g. in `cf service myservice`).
- For a binding in state `create failed` no data is added to the app's environment variables.
- The behavior is consistent with `cf bind-service`.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
