### PR TITLE
Refactor common functionality into ServiceCredentialBindingMixin

### DIFF
--- a/app/models/runtime/helpers/service_credential_binding_mixin.rb
+++ b/app/models/runtime/helpers/service_credential_binding_mixin.rb
@@ -1,0 +1,23 @@
+module VCAP::CloudController
+  module ServiceCredentialBindingMixin
+    def terminal_state?
+      !last_operation || (%w(succeeded failed).include? last_operation.state)
+    end
+
+    def operation_in_progress?
+      !!last_operation && last_operation.state == 'in progress'
+    end
+
+    def create_failed?
+      return true if last_operation&.type == 'create' && last_operation.state == 'failed'
+
+      false
+    end
+
+    def create_in_progress?
+      return true if last_operation&.type == 'create' && last_operation.state == 'in progress'
+
+      false
+    end
+  end
+end

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -1,5 +1,7 @@
 module VCAP::CloudController
   class ServiceKey < Sequel::Model
+    include ServiceCredentialBindingMixin
+
     class InvalidAppAndServiceRelation < StandardError; end
 
     many_to_one :service_instance
@@ -89,26 +91,6 @@ module VCAP::CloudController
 
     def last_operation
       service_key_operation
-    end
-
-    def create_failed?
-      return true if last_operation&.type == 'create' && last_operation.state == 'failed'
-
-      false
-    end
-
-    def create_in_progress?
-      return true if last_operation&.type == 'create' && last_operation.state == 'in progress'
-
-      false
-    end
-
-    def terminal_state?
-      !service_key_operation || (%w(succeeded failed).include? service_key_operation.state)
-    end
-
-    def operation_in_progress?
-      !!service_key_operation && service_key_operation.state == 'in progress'
     end
 
     def save_with_attributes_and_new_operation(attributes, operation)

--- a/spec/unit/models/services/service_binding_spec.rb
+++ b/spec/unit/models/services/service_binding_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require_relative 'service_credential_binding_shared'
 
 module VCAP::CloudController
   RSpec.describe VCAP::CloudController::ServiceBinding, type: :model do
@@ -536,90 +537,7 @@ module VCAP::CloudController
       end
     end
 
-    describe '#terminal_state?' do
-      let(:service_binding) { ServiceBinding.make }
-      let(:operation) { ServiceBindingOperation.make(state: state) }
-
-      before do
-        service_binding.service_binding_operation = operation
-      end
-
-      context 'when state is succeeded' do
-        let(:state) { 'succeeded' }
-
-        it 'returns true' do
-          expect(service_binding.terminal_state?).to be true
-        end
-      end
-
-      context 'when state is failed' do
-        let(:state) { 'failed' }
-
-        it 'returns true when state is `failed`' do
-          expect(service_binding.terminal_state?).to be true
-        end
-      end
-
-      context 'when state is something else' do
-        let(:state) { 'in progress' }
-
-        it 'returns false' do
-          expect(service_binding.terminal_state?).to be false
-        end
-      end
-
-      context 'when binding operation is missing' do
-        let(:operation) { nil }
-
-        it 'returns true' do
-          expect(service_binding.terminal_state?).to be true
-        end
-      end
-    end
-
-    describe 'operation_in_progress?' do
-      let(:service_instance) { ManagedServiceInstance.make }
-      let(:service_binding) { ServiceBinding.make(service_instance: service_instance) }
-
-      context 'when the service binding has been created synchronously' do
-        it 'returns false' do
-          expect(service_binding.operation_in_progress?).to be false
-        end
-      end
-
-      context 'when the service binding is being created asynchronously' do
-        let(:state) {}
-        let(:operation) { ServiceBindingOperation.make(state: state) }
-
-        before do
-          service_binding.service_binding_operation = operation
-        end
-
-        context 'and the operation is in progress' do
-          let(:state) { 'in progress' }
-
-          it 'returns true' do
-            expect(service_binding.operation_in_progress?).to be true
-          end
-        end
-
-        context 'and the operation has failed' do
-          let(:state) { 'failed' }
-
-          it 'returns false' do
-            expect(service_binding.operation_in_progress?).to be false
-          end
-        end
-
-        context 'and the operation has succeeded' do
-          let(:state) { 'succeeded' }
-
-          it 'returns false' do
-            expect(service_binding.operation_in_progress?).to be false
-          end
-        end
-      end
-    end
+    it_behaves_like 'a model including the ServiceCredentialBindingMixin', ServiceBinding, ServiceBindingOperation, :service_binding_operation
 
     describe '#destroy' do
       it 'cascades deletion of related dependencies' do

--- a/spec/unit/models/services/service_credential_binding_shared.rb
+++ b/spec/unit/models/services/service_credential_binding_shared.rb
@@ -1,0 +1,132 @@
+RSpec.shared_examples 'a model including the ServiceCredentialBindingMixin' do |service_credential_binding_class, operation_class, operation_association|
+  let(:service_credential_binding) { service_credential_binding_class.make }
+  let(:operation) { operation_class.make(state: state) }
+
+  before do
+    service_credential_binding.associations[operation_association] = operation
+  end
+
+  describe '#terminal_state?' do
+    context 'when state is succeeded' do
+      let(:state) { 'succeeded' }
+
+      it 'returns true' do
+        expect(service_credential_binding.terminal_state?).to be true
+      end
+    end
+
+    context 'when state is failed' do
+      let(:state) { 'failed' }
+
+      it 'returns true' do
+        expect(service_credential_binding.terminal_state?).to be true
+      end
+    end
+
+    context 'when state is something else' do
+      let(:state) { 'in progress' }
+
+      it 'returns false' do
+        expect(service_credential_binding.terminal_state?).to be false
+      end
+    end
+
+    context 'when binding operation is missing' do
+      let(:operation) { nil }
+
+      it 'returns true' do
+        expect(service_credential_binding.terminal_state?).to be true
+      end
+    end
+  end
+
+  describe '#operation_in_progress?' do
+    context 'when the service credential binding has been created synchronously' do
+      let(:operation) { nil }
+
+      it 'returns false' do
+        expect(service_credential_binding.operation_in_progress?).to be false
+      end
+    end
+
+    context 'when the service credential binding is being created asynchronously' do
+      context 'and the operation is in progress' do
+        let(:state) { 'in progress' }
+
+        it 'returns true' do
+          expect(service_credential_binding.operation_in_progress?).to be true
+        end
+      end
+
+      context 'and the operation has failed' do
+        let(:state) { 'failed' }
+
+        it 'returns false' do
+          expect(service_credential_binding.operation_in_progress?).to be false
+        end
+      end
+
+      context 'and the operation has succeeded' do
+        let(:state) { 'succeeded' }
+
+        it 'returns false' do
+          expect(service_credential_binding.operation_in_progress?).to be false
+        end
+      end
+    end
+  end
+
+  describe '#create_failed?' do
+    let(:operation) { nil }
+
+    context 'when there is no binding operation' do
+      it 'returns false' do
+        expect(service_credential_binding.create_failed?).to be false
+      end
+    end
+
+    context 'when there is a binding operation' do
+      it "returns true only for the 'create failed' state" do
+        [
+          { type: 'create', state: 'failed',      result: true },
+          { type: 'create', state: 'in progress', result: false },
+          { type: 'create', state: 'succeeded',   result: false },
+          { type: 'delete', state: 'in progress', result: false },
+          { type: 'delete', state: 'failed',      result: false },
+          { type: 'delete', state: 'succeeded',   result: false },
+        ].each do |test|
+          service_credential_binding.save_with_attributes_and_new_operation({}, { type: test[:type], state: test[:state] })
+
+          expect(service_credential_binding.create_failed?).to be test[:result]
+        end
+      end
+    end
+  end
+
+  describe '#create_in_progress?' do
+    let(:operation) { nil }
+
+    context 'when there is no binding operation' do
+      it 'returns false' do
+        expect(service_credential_binding.create_in_progress?).to be false
+      end
+    end
+
+    context 'when there is a binding operation' do
+      it "returns true only for the 'create in progress' state" do
+        [
+          { type: 'create', state: 'in progress', result: true },
+          { type: 'create', state: 'failed',      result: false },
+          { type: 'create', state: 'succeeded',   result: false },
+          { type: 'delete', state: 'in progress', result: false },
+          { type: 'delete', state: 'failed',      result: false },
+          { type: 'delete', state: 'succeeded',   result: false },
+        ].each do |test|
+          service_credential_binding.save_with_attributes_and_new_operation({}, { type: test[:type], state: test[:state] })
+
+          expect(service_credential_binding.create_in_progress?).to be test[:result]
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/models/services/service_key_spec.rb
+++ b/spec/unit/models/services/service_key_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require_relative 'service_credential_binding_shared'
 
 RSpec::Matchers.define :existing_service_key_count do |c|
   match { |arg| arg.is_a?(Sequel::Dataset) && arg.count == c }
@@ -253,90 +254,7 @@ module VCAP::CloudController
       end
     end
 
-    describe '#terminal_state?' do
-      let(:service_binding) { ServiceKey.make }
-      let(:operation) { ServiceKeyOperation.make(state: state) }
-
-      before do
-        service_binding.service_key_operation = operation
-      end
-
-      context 'when state is succeeded' do
-        let(:state) { 'succeeded' }
-
-        it 'returns true' do
-          expect(service_binding.terminal_state?).to be true
-        end
-      end
-
-      context 'when state is failed' do
-        let(:state) { 'failed' }
-
-        it 'returns true when state is `failed`' do
-          expect(service_binding.terminal_state?).to be true
-        end
-      end
-
-      context 'when state is something else' do
-        let(:state) { 'in progress' }
-
-        it 'returns false' do
-          expect(service_binding.terminal_state?).to be false
-        end
-      end
-
-      context 'when binding operation is missing' do
-        let(:operation) { nil }
-
-        it 'returns true' do
-          expect(service_binding.terminal_state?).to be true
-        end
-      end
-    end
-
-    describe 'operation_in_progress?' do
-      let(:service_instance) { ManagedServiceInstance.make }
-      let(:service_key) { ServiceKey.make(service_instance: service_instance) }
-
-      context 'when the service key has been created synchronously' do
-        it 'returns false' do
-          expect(service_key.operation_in_progress?).to be false
-        end
-      end
-
-      context 'when the service key is being created asynchronously' do
-        let(:state) {}
-        let(:operation) { ServiceKeyOperation.make(state: state) }
-
-        before do
-          service_key.service_key_operation = operation
-        end
-
-        context 'and the operation is in progress' do
-          let(:state) { 'in progress' }
-
-          it 'returns true' do
-            expect(service_key.operation_in_progress?).to be true
-          end
-        end
-
-        context 'and the operation has failed' do
-          let(:state) { 'failed' }
-
-          it 'returns false' do
-            expect(service_key.operation_in_progress?).to be false
-          end
-        end
-
-        context 'and the operation has succeeded' do
-          let(:state) { 'succeeded' }
-
-          it 'returns false' do
-            expect(service_key.operation_in_progress?).to be false
-          end
-        end
-      end
-    end
+    it_behaves_like 'a model including the ServiceCredentialBindingMixin', ServiceKey, ServiceKeyOperation, :service_key_operation
 
     describe '#destroy' do
       it 'cascades deletion of related dependencies' do


### PR DESCRIPTION
- Introduce `ServiceCredentialBindingMixin` containing common methods for `ServiceBinding` and `ServiceKey`.
- Also refactor tests from `models/services/service_binding_spec.rb` and `models/services/service_key_spec.rb` into a shared example (`models/services/service_credential_binding_shared.rb`).
- Add tests for recently introduced methods.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
