### PR TITLE
Adapt presenter_args function for /v3/security_groups and /v3/space_quotas as in /v3/domains

### DIFF
--- a/app/controllers/v3/security_groups_controller.rb
+++ b/app/controllers/v3/security_groups_controller.rb
@@ -21,7 +21,7 @@ class SecurityGroupsController < ApplicationController
 
     render status: :created, json: Presenters::V3::SecurityGroupPresenter.new(
       security_group,
-      visible_space_guids: visible_space_guids
+      **presenter_args
     )
   rescue SecurityGroupCreate::Error => e
     unprocessable!(e)
@@ -40,7 +40,7 @@ class SecurityGroupsController < ApplicationController
     end
     unauthorized! if unwritable_space_guids.any?
 
-    SecurityGroupApply.apply_running(security_group, message, visible_space_guids)
+    SecurityGroupApply.apply_running(security_group, message, **presenter_args)
 
     render status: :ok, json: Presenters::V3::ToManyRelationshipPresenter.new(
       "security_groups/#{security_group.guid}",
@@ -65,7 +65,7 @@ class SecurityGroupsController < ApplicationController
     end
     unauthorized! if unwritable_space_guids.any?
 
-    SecurityGroupApply.apply_staging(security_group, message, visible_space_guids)
+    SecurityGroupApply.apply_staging(security_group, message, **presenter_args)
 
     render status: :ok, json: Presenters::V3::ToManyRelationshipPresenter.new(
       "security_groups/#{security_group.guid}",
@@ -83,7 +83,7 @@ class SecurityGroupsController < ApplicationController
 
     render status: :ok, json: Presenters::V3::SecurityGroupPresenter.new(
       security_group,
-      visible_space_guids: visible_space_guids
+      **presenter_args
     )
   end
 
@@ -102,7 +102,7 @@ class SecurityGroupsController < ApplicationController
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
       path: '/v3/security_groups',
       message: message,
-      extra_presenter_args: { visible_space_guids: visible_space_guids },
+      extra_presenter_args: presenter_args,
     )
   end
 
@@ -119,7 +119,7 @@ class SecurityGroupsController < ApplicationController
 
     render status: :ok, json: Presenters::V3::SecurityGroupPresenter.new(
       updated_security_group,
-      visible_space_guids: visible_space_guids
+      **presenter_args
     )
   rescue SecurityGroupUpdate::Error => e
     unprocessable!(e)
@@ -176,11 +176,11 @@ class SecurityGroupsController < ApplicationController
 
   private
 
-  def visible_space_guids
+  def presenter_args
     if permission_queryer.can_read_globally?
-      :all
+      { all_spaces_visible: true }
     else
-      permission_queryer.readable_space_guids
+      { visible_space_guids: permission_queryer.readable_space_guids }
     end
   end
 end

--- a/app/controllers/v3/space_quotas_controller.rb
+++ b/app/controllers/v3/space_quotas_controller.rb
@@ -24,7 +24,7 @@ class SpaceQuotasController < ApplicationController
 
     render status: :created, json: Presenters::V3::SpaceQuotaPresenter.new(
       space_quota,
-      visible_space_guids: visible_space_guids
+      **presenter_args
     )
   rescue SpaceQuotasCreate::Error => e
     unprocessable!(e.message)
@@ -36,7 +36,7 @@ class SpaceQuotasController < ApplicationController
 
     render status: :ok, json: Presenters::V3::SpaceQuotaPresenter.new(
       space_quota,
-      visible_space_guids: visible_space_guids
+      **presenter_args
     )
   end
 
@@ -51,7 +51,7 @@ class SpaceQuotasController < ApplicationController
       paginated_result: SequelPaginator.new.get_page(dataset, message.try(:pagination_options)),
       path: '/v3/space_quotas',
       message: message,
-      extra_presenter_args: { visible_space_guids: visible_space_guids },
+      extra_presenter_args: presenter_args,
     )
   end
 
@@ -71,7 +71,7 @@ class SpaceQuotasController < ApplicationController
 
     render status: :ok, json: Presenters::V3::SpaceQuotaPresenter.new(
       space_quota,
-      visible_space_guids: visible_space_guids
+      **presenter_args
     )
   rescue SpaceQuotaUpdate::Error => e
     unprocessable!(e.message)
@@ -89,7 +89,7 @@ class SpaceQuotasController < ApplicationController
     message = SpaceQuotaApplyMessage.new(hashed_params[:body])
     unprocessable!(message.errors.full_messages) unless message.valid?
 
-    SpaceQuotaApply.new.apply(space_quota, message, visible_space_guids)
+    SpaceQuotaApply.new.apply(space_quota, message, **presenter_args)
 
     render status: :ok, json: Presenters::V3::ToManyRelationshipPresenter.new(
       "space_quotas/#{space_quota.guid}",
@@ -151,11 +151,11 @@ class SpaceQuotasController < ApplicationController
     permission_queryer.readable_space_quota_guids
   end
 
-  def visible_space_guids
+  def presenter_args
     if permission_queryer.can_read_globally?
-      :all
+      { all_spaces_visible: true }
     else
-      permission_queryer.readable_space_guids
+      { visible_space_guids: permission_queryer.readable_space_guids }
     end
   end
 end

--- a/app/presenters/v3/security_group_presenter.rb
+++ b/app/presenters/v3/security_group_presenter.rb
@@ -6,10 +6,12 @@ module VCAP::CloudController::Presenters::V3
       resource,
       show_secrets: false,
       censored_message: VCAP::CloudController::Presenters::Censorship::REDACTED_CREDENTIAL,
-      visible_space_guids:
+      all_spaces_visible: false,
+      visible_space_guids: []
     )
       super(resource, show_secrets: show_secrets, censored_message: censored_message)
       @visible_space_guids = visible_space_guids
+      @all_spaces_visible = all_spaces_visible
     end
 
     def to_hash
@@ -42,7 +44,7 @@ module VCAP::CloudController::Presenters::V3
     end
 
     def space_guid_hash_for(spaces)
-      visible_spaces = if @visible_space_guids == :all
+      visible_spaces = if @all_spaces_visible
                          spaces
                        else
                          spaces.select { |space| @visible_space_guids.include? space.guid }

--- a/app/presenters/v3/space_quota_presenter.rb
+++ b/app/presenters/v3/space_quota_presenter.rb
@@ -7,10 +7,12 @@ module VCAP::CloudController::Presenters::V3
       resource,
       show_secrets: false,
       censored_message: VCAP::CloudController::Presenters::Censorship::REDACTED_CREDENTIAL,
-      visible_space_guids:
+      all_spaces_visible: false,
+      visible_space_guids: []
     )
       super(resource, show_secrets: show_secrets, censored_message: censored_message)
       @visible_space_guids = visible_space_guids
+      @all_spaces_visible = all_spaces_visible
     end
 
     def to_hash
@@ -53,7 +55,7 @@ module VCAP::CloudController::Presenters::V3
     end
 
     def filtered_visible_spaces
-      visible_spaces = if @visible_space_guids == :all
+      visible_spaces = if @all_spaces_visible
                          space_quota.spaces
                        else
                          space_quota.spaces.select { |space| @visible_space_guids.include? space.guid }

--- a/spec/unit/presenters/v3/security_group_presenter_spec.rb
+++ b/spec/unit/presenters/v3/security_group_presenter_spec.rb
@@ -24,11 +24,12 @@ module VCAP::CloudController::Presenters::V3
     end
 
     describe '#to_hash' do
-      let(:result) { SecurityGroupPresenter.new(security_group, visible_space_guids: visible_space_guids).to_hash }
+      let(:result) { SecurityGroupPresenter.new(security_group, visible_space_guids: visible_space_guids, all_spaces_visible: all_spaces_visible).to_hash }
 
       let(:space1) { VCAP::CloudController::Space.make(guid: 'guid1') }
       let(:space2) { VCAP::CloudController::Space.make(guid: 'guid2') }
       let(:visible_space_guids) { [space1.guid, space2.guid] }
+      let(:all_spaces_visible) { false }
 
       it 'presents the security group as json' do
         expect(result[:guid]).to eq(security_group.guid)
@@ -61,7 +62,8 @@ module VCAP::CloudController::Presenters::V3
       end
 
       describe 'when user is admin' do
-        let(:visible_space_guids) { :all }
+        let(:all_spaces_visible) { true }
+        let(:visible_space_guids) { [] }
 
         it 'displays all spaces' do
           expect(result[:relationships][:running_spaces][:data].length).to eq(1)

--- a/spec/unit/presenters/v3/space_quota_presenter_spec.rb
+++ b/spec/unit/presenters/v3/space_quota_presenter_spec.rb
@@ -7,6 +7,7 @@ module VCAP::CloudController::Presenters::V3
     let(:space_1) { VCAP::CloudController::Space.make(organization: org) }
     let(:space_2) { VCAP::CloudController::Space.make(organization: org) }
     let(:visible_space_guids) { [space_1.guid, space_2.guid] }
+    let(:all_spaces_visible) { false }
 
     let(:space_quota) do
       VCAP::CloudController::SpaceQuotaDefinition.make(
@@ -30,7 +31,7 @@ module VCAP::CloudController::Presenters::V3
     end
 
     describe '#to_hash' do
-      let(:result) { SpaceQuotaPresenter.new(space_quota, visible_space_guids: visible_space_guids).to_hash }
+      let(:result) { SpaceQuotaPresenter.new(space_quota, visible_space_guids: visible_space_guids, all_spaces_visible: all_spaces_visible).to_hash }
 
       it 'presents the org as json' do
         expect(result[:guid]).to eq(space_quota.guid)
@@ -86,7 +87,8 @@ module VCAP::CloudController::Presenters::V3
       end
 
       context 'when user is admin' do
-        let(:visible_space_guids) { :all }
+        let(:all_spaces_visible) { true }
+        let(:visible_space_guids) { [] }
 
         it 'displays all spaces' do
           expect(result[:relationships][:spaces][:data]).to match_array([


### PR DESCRIPTION
* add consistency and use in the former changed /v3/space_quotas and
  /v3/security-groups (#2624) files the same presenter_args function as for the
  /v3/domains changement (#2638) so that instead of selecting all space guids for admin user, all_spaces_visible is set to true and if so no filtering is done, just return all space guids

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
