### PR TITLE
Update keyword arguments for Ruby 3.0

### DIFF
--- a/app/controllers/v3/service_plan_visibility_controller.rb
+++ b/app/controllers/v3/service_plan_visibility_controller.rb
@@ -67,7 +67,7 @@ class ServicePlanVisibilityController < ApplicationController
     message = ServicePlanVisibilityUpdateMessage.new(hashed_params[:body])
     bad_request!(message.errors.full_messages) unless message.valid?
 
-    updated_service_plan = V3::ServicePlanVisibilityUpdate.new.update(service_plan, message, opts)
+    updated_service_plan = V3::ServicePlanVisibilityUpdate.new.update(service_plan, message, **opts)
     event_repository.record_service_plan_update_visibility_event(service_plan, message.audit_hash)
     updated_service_plan
   rescue V3::ServicePlanVisibilityUpdate::UnprocessableRequest => e

--- a/lib/cloud_controller/blobstore/fog/error_handling_client.rb
+++ b/lib/cloud_controller/blobstore/fog/error_handling_client.rb
@@ -43,7 +43,7 @@ module CloudController
         error_handling { wrapped_client.cp_r_to_blobstore(*args)    }
       end
 
-      def download_from_blobstore(*args)
+      def download_from_blobstore(*args, **kwargs)
         error_handling { wrapped_client.download_from_blobstore(*args) }
       end
 

--- a/lib/cloud_controller/clock/scheduler.rb
+++ b/lib/cloud_controller/clock/scheduler.rb
@@ -57,7 +57,7 @@ module VCAP::CloudController
         interval: @config.get(:diego_sync, :frequency_in_seconds),
         timeout: @timeout_calculator.calculate(:diego_sync),
       }
-      @clock.schedule_frequent_inline_job(clock_opts) do
+      @clock.schedule_frequent_inline_job(**clock_opts) do
         Jobs::Diego::Sync.new
       end
     end
@@ -68,7 +68,7 @@ module VCAP::CloudController
           name: job_config[:name],
           interval: @config.get(job_config[:name].to_sym, :frequency_in_seconds),
         }
-        @clock.schedule_frequent_worker_job(clock_opts) do
+        @clock.schedule_frequent_worker_job(**clock_opts) do
           klass = job_config[:class]
           klass.new(@config.get(job_config[:name].to_sym, :expiration_in_seconds))
         end
@@ -83,7 +83,7 @@ module VCAP::CloudController
           priority: cleanup_config[:priority] || Clock::HIGH_PRIORITY
         }
 
-        @clock.schedule_daily_job(clock_opts) do
+        @clock.schedule_daily_job(**clock_opts) do
           klass = cleanup_config[:class]
 
           if cleanup_config[:arg_from_config]

--- a/lib/cloud_controller/seeds.rb
+++ b/lib/cloud_controller/seeds.rb
@@ -93,7 +93,7 @@ module VCAP::CloudController
               router_group_guid: find_routing_guid(domain),
               internal: domain['internal']
             }
-            SharedDomain.find_or_create(attrs.compact)
+            SharedDomain.find_or_create(**attrs.compact)
           end
 
           if CloudController::DomainDecorator.new(system_domain).has_sub_domain?(test_domains: domains.map { |domain_hash| domain_hash['name'] })

--- a/lib/services/service_brokers/v2/response_parser.rb
+++ b/lib/services/service_brokers/v2/response_parser.rb
@@ -35,7 +35,7 @@ module VCAP::Services
             end
 
           validator = CommonErrorValidator.new(validator)
-          validator.validate(unvalidated_response.to_hash)
+          validator.validate(**unvalidated_response.to_hash)
         end
 
         def parse_bind(path, response, opts={})
@@ -65,7 +65,7 @@ module VCAP::Services
             end
 
           validator = CommonErrorValidator.new(validator)
-          validator.validate(unvalidated_response.to_hash)
+          validator.validate(**unvalidated_response.to_hash)
         end
 
         def parse_unbind(path, response)
@@ -93,7 +93,7 @@ module VCAP::Services
             end
 
           validator = CommonErrorValidator.new(validator)
-          validator.validate(unvalidated_response.to_hash)
+          validator.validate(**unvalidated_response.to_hash)
         end
 
         def parse_deprovision(path, response)
@@ -122,7 +122,7 @@ module VCAP::Services
             end
 
           validator = CommonErrorValidator.new(validator)
-          validator.validate(unvalidated_response.to_hash)
+          validator.validate(**unvalidated_response.to_hash)
         end
 
         def parse_catalog(path, response)
@@ -140,7 +140,7 @@ module VCAP::Services
             end
 
           validator = CommonErrorValidator.new(validator)
-          validator.validate(unvalidated_response.to_hash)
+          validator.validate(**unvalidated_response.to_hash)
         end
 
         def parse_update(path, response)
@@ -167,7 +167,7 @@ module VCAP::Services
             end
 
           validator = CommonErrorValidator.new(validator)
-          validator.validate(unvalidated_response.to_hash)
+          validator.validate(**unvalidated_response.to_hash)
         end
 
         def parse_fetch_state(path, response)
@@ -195,7 +195,7 @@ module VCAP::Services
               CommonErrorValidator.new(FailingValidator.new(Errors::ServiceBrokerBadResponse))
             end
 
-          validator.validate(unvalidated_response.to_hash)
+          validator.validate(**unvalidated_response.to_hash)
         end
 
         def parse_fetch_parameters(path, response, schema)
@@ -211,7 +211,7 @@ module VCAP::Services
 
           validator = CommonErrorValidator.new(validator)
 
-          validator.validate(unvalidated_response.to_hash)
+          validator.validate(**unvalidated_response.to_hash)
         end
 
         def parse_fetch_instance_parameters(path, response)

--- a/middleware/block_v3_only_roles.rb
+++ b/middleware/block_v3_only_roles.rb
@@ -3,9 +3,9 @@ require 'mixins/client_ip'
 module CloudFoundry
   module Middleware
     class BlockV3OnlyRoles
-      def initialize(app, logger:)
+      def initialize(app, opts)
         @app                   = app
-        @logger                = logger
+        @logger                = opts[:logger]
       end
 
       def call(env)

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -49,14 +49,14 @@ module CloudFoundry
     class RateLimiter
       include CloudFoundry::Middleware::ClientIp
 
-      def initialize(app, logger:, per_process_general_limit:, global_general_limit:, per_process_unauthenticated_limit:, global_unauthenticated_limit:, interval:)
+      def initialize(app, opts)
         @app                               = app
-        @logger                            = logger
-        @per_process_general_limit         = per_process_general_limit
-        @global_general_limit              = global_general_limit
-        @per_process_unauthenticated_limit = per_process_unauthenticated_limit
-        @global_unauthenticated_limit      = global_unauthenticated_limit
-        @interval                          = interval
+        @logger                            = opts[:logger]
+        @per_process_general_limit         = opts[:per_process_general_limit]
+        @global_general_limit              = opts[:global_general_limit]
+        @per_process_unauthenticated_limit = opts[:per_process_unauthenticated_limit]
+        @global_unauthenticated_limit      = opts[:global_unauthenticated_limit]
+        @interval                          = opts[:interval]
         @request_counter                   = RequestCounter.instance
       end
 

--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -23,9 +23,9 @@ module CloudFoundry
     end
 
     class ServiceBrokerRateLimiter
-      def initialize(app, logger:)
+      def initialize(app, opts)
         @app                               = app
-        @logger                            = logger
+        @logger                            = opts[:logger]
         @request_counter = ServiceBrokerRequestCounter.instance
       end
 

--- a/spec/api/documentation/buildpack_cache_api_spec.rb
+++ b/spec/api/documentation/buildpack_cache_api_spec.rb
@@ -30,7 +30,7 @@ RSpec.resource 'Blobstores', type: :api do
   end
 
   before do
-    TestConfig.override(blobstore_config)
+    TestConfig.override(**blobstore_config)
   end
 
   after do

--- a/spec/performance/packages_controller_index_spec.rb
+++ b/spec/performance/packages_controller_index_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe PackagesController, type: :controller do # , isolation: :truncati
     let(:n) { 10 }
 
     before do
-      TestConfig.override({
+      TestConfig.override(
         db: {
           log_level: 'debug',
       }
         # logging.level: 'debug2'
-      })
+      )
       allow_user_read_access_for(user, spaces: user_spaces)
       n.times do |i|
         app = VCAP::CloudController::AppModel.make(space: user_spaces.sample, guid: "app-guid-#{i}")

--- a/spec/request/domains_spec.rb
+++ b/spec/request/domains_spec.rb
@@ -1073,7 +1073,7 @@ RSpec.describe 'Domains Request' do
 
         context 'when the domain is in the list of reserved private domains' do
           before do
-            TestConfig.override({ reserved_private_domains: File.join(Paths::FIXTURES, 'config/reserved_private_domains.dat') })
+            TestConfig.override(reserved_private_domains: File.join(Paths::FIXTURES, 'config/reserved_private_domains.dat'))
           end
 
           it 'returns a 422 with a error message about reserved domains' do

--- a/spec/request/knowledge_bombs/verify_old_lrps_can_download_assets_spec.rb
+++ b/spec/request/knowledge_bombs/verify_old_lrps_can_download_assets_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'BuildpackBitsController download endpoint exists:' do
       end
 
       before do
-        TestConfig.override(staging_config)
+        TestConfig.override(**staging_config)
         allow(VCAP::CloudController::BlobDispatcher).to receive(:new).and_return(blob_dispatcher)
       end
 

--- a/spec/request/packages_spec.rb
+++ b/spec/request/packages_spec.rb
@@ -822,7 +822,7 @@ RSpec.describe 'Packages' do
     before do
       space.organization.add_user(user)
       space.add_developer(user)
-      TestConfig.override(test_config_overrides)
+      TestConfig.override(**test_config_overrides)
     end
 
     shared_examples :upload_bits_successfully do

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -704,7 +704,7 @@ RSpec.describe 'V3 service brokers' do
       context 'when job succeeds with warnings' do
         context 'when warning is a UAA problem' do
           let(:broker) do
-            TestConfig.override({ uaa_client_name: nil, uaa_client_secret: nil })
+            TestConfig.override(uaa_client_name: nil, uaa_client_secret: nil)
             create_broker_successfully(global_broker_request_body, with: admin_headers, execute_all_jobs: true)
           end
 
@@ -729,7 +729,7 @@ RSpec.describe 'V3 service brokers' do
 
         context 'when warning is a catalog problem (deactivated plan, but there is a service instance)' do
           let!(:broker) do
-            TestConfig.override({})
+            TestConfig.override
             create_broker_successfully(global_broker_request_body, with: admin_headers, execute_all_jobs: true)
           end
 
@@ -1138,7 +1138,7 @@ RSpec.describe 'V3 service brokers' do
     context 'when job succeeds with warnings' do
       context 'when warning is a UAA problem' do
         before do
-          TestConfig.override({ uaa_client_name: nil, uaa_client_secret: nil })
+          TestConfig.override(uaa_client_name: nil, uaa_client_secret: nil)
           create_broker_successfully(global_broker_request_body, with: admin_headers)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
         end

--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -103,7 +103,7 @@ RSpec.shared_examples 'permissions for single object endpoint' do |roles|
       it 'returns the correct response status and resources' do
         email = Sham.email
         user_name = Sham.name
-        headers = set_user_with_header_as_role({
+        headers = set_user_with_header_as_role(
           role: role,
           org: org,
           space: space,
@@ -111,7 +111,7 @@ RSpec.shared_examples 'permissions for single object endpoint' do |roles|
           scopes: expected_codes_and_responses[role][:scopes],
           user_name: user_name,
           email: email,
-        })
+        )
 
         api_call.call(headers)
 

--- a/spec/support/bootstrap/test_config.rb
+++ b/spec/support/bootstrap/test_config.rb
@@ -19,7 +19,7 @@ module TestConfig
     end
 
     def reset
-      override({})
+      override
     end
 
     def config

--- a/spec/support/shared_examples/controllers/resource_pool.rb
+++ b/spec/support/shared_examples/controllers/resource_pool.rb
@@ -59,7 +59,7 @@ shared_context 'resource pool' do
 
   before do
     @resource_pool = VCAP::CloudController::ResourcePool.new(
-      VCAP::CloudController::Config.new(resource_pool: resource_pool_config)
+      VCAP::CloudController::Config.new({ resource_pool: resource_pool_config })
     )
     allow(VCAP::CloudController::ResourcePool).to receive(:instance).and_return(@resource_pool)
   end

--- a/spec/support/shared_examples/jobs/create_binding_job.rb
+++ b/spec/support/shared_examples/jobs/create_binding_job.rb
@@ -58,9 +58,9 @@ RSpec.shared_examples 'create binding job' do |binding_type|
       context 'asynchronous response' do
         context 'computes the maximum duration' do
           before do
-            TestConfig.override({
+            TestConfig.override(
               broker_client_max_async_poll_duration_minutes: 90009
-            })
+            )
             subject.perform
           end
 
@@ -141,7 +141,7 @@ RSpec.shared_examples 'create binding job' do |binding_type|
       context 'the maximum duration' do
         it 'recomputes the value' do
           subject.maximum_duration_seconds = 90009
-          TestConfig.override({ broker_client_max_async_poll_duration_minutes: 8088 })
+          TestConfig.override(broker_client_max_async_poll_duration_minutes: 8088)
           subject.perform
           expect(subject.maximum_duration_seconds).to eq(8088.minutes)
         end

--- a/spec/support/shared_examples/jobs/delete_binding_job.rb
+++ b/spec/support/shared_examples/jobs/delete_binding_job.rb
@@ -58,9 +58,9 @@ RSpec.shared_examples 'delete binding job' do |binding_type|
 
         context 'computes the maximum duration' do
           before do
-            TestConfig.override({
+            TestConfig.override(
               broker_client_max_async_poll_duration_minutes: 90009
-            })
+            )
             subject.perform
           end
 
@@ -130,7 +130,7 @@ RSpec.shared_examples 'delete binding job' do |binding_type|
       context 'the maximum duration' do
         it 'recomputes the value' do
           subject.maximum_duration_seconds = 90009
-          TestConfig.override({ broker_client_max_async_poll_duration_minutes: 8088 })
+          TestConfig.override(broker_client_max_async_poll_duration_minutes: 8088)
           subject.perform
           expect(subject.maximum_duration_seconds).to eq(8088.minutes)
         end

--- a/spec/unit/actions/task_create_spec.rb
+++ b/spec/unit/actions/task_create_spec.rb
@@ -5,11 +5,11 @@ module VCAP::CloudController
   RSpec.describe TaskCreate do
     subject(:task_create_action) { TaskCreate.new(config) }
     let(:config) do
-      Config.new(
+      Config.new({
         maximum_app_disk_in_mb: 4096,
         default_app_memory: 1024,
         default_app_disk_in_mb: 1024
-      )
+      })
     end
 
     describe '#create' do

--- a/spec/unit/controllers/internal/download_droplets_controller_spec.rb
+++ b/spec/unit/controllers/internal/download_droplets_controller_spec.rb
@@ -35,7 +35,7 @@ module VCAP::CloudController
 
       before do
         Fog.unmock!
-        TestConfig.override(staging_config)
+        TestConfig.override(**staging_config)
       end
       after { FileUtils.rm_rf(workspace) }
 
@@ -152,7 +152,7 @@ module VCAP::CloudController
 
       before do
         Fog.unmock!
-        TestConfig.override(staging_config)
+        TestConfig.override(**staging_config)
       end
       after { FileUtils.rm_rf(workspace) }
 

--- a/spec/unit/controllers/internal/staging_completion_controller_spec.rb
+++ b/spec/unit/controllers/internal/staging_completion_controller_spec.rb
@@ -41,7 +41,7 @@ module VCAP::CloudController
     let(:one_hour_in_nanoseconds) { (1.hour.to_i * 1e9).to_i }
 
     before do
-      TestConfig.override({ kubernetes: nil })
+      TestConfig.override(kubernetes: nil)
 
       allow(VCAP::CloudController::Metrics::StatsdUpdater).to receive(:new).and_return(statsd_updater)
     end
@@ -190,7 +190,7 @@ module VCAP::CloudController
       describe 'authentication' do
         context 'when running in Kubernetes' do
           before do
-            TestConfig.override({ kubernetes: { host_url: 'example.com' } })
+            TestConfig.override(kubernetes: { host_url: 'example.com' })
           end
 
           context 'when missing authentication' do

--- a/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
     describe 'PUT /v2/app/:id/bits' do
       before do
         TestConfig.override(
-          config_override.merge(
+          **config_override.merge(
             directories: { tmpdir: File.dirname(valid_zip.path) },
             kubernetes: {}
           )

--- a/spec/unit/controllers/runtime/apps_controller_spec.rb
+++ b/spec/unit/controllers/runtime/apps_controller_spec.rb
@@ -372,7 +372,7 @@ module VCAP::CloudController
 
         context 'when custom buildpacks are disabled and the buildpack attribute is being changed' do
           before do
-            TestConfig.override({ disable_custom_buildpacks: true })
+            TestConfig.override(disable_custom_buildpacks: true)
             set_current_user(admin_user, admin: true)
           end
 
@@ -871,7 +871,7 @@ module VCAP::CloudController
 
       context 'when custom buildpacks are disabled and the buildpack attribute is being changed' do
         before do
-          TestConfig.override({ disable_custom_buildpacks: true })
+          TestConfig.override(disable_custom_buildpacks: true)
           set_current_user(admin_user, admin: true)
           process.app.lifecycle_data.update(buildpacks: [Buildpack.make.name])
         end

--- a/spec/unit/controllers/runtime/buildpack_bits_controller_spec.rb
+++ b/spec/unit/controllers/runtime/buildpack_bits_controller_spec.rb
@@ -301,7 +301,7 @@ module VCAP::CloudController
         end
 
         before do
-          TestConfig.override(staging_config)
+          TestConfig.override(**staging_config)
           VCAP::CloudController::Buildpack.create_from_hash({ name: 'get_binary_buildpack', stack: nil, key: 'xyz', position: 0 })
         end
 

--- a/spec/unit/controllers/runtime/resource_matches_controller_spec.rb
+++ b/spec/unit/controllers/runtime/resource_matches_controller_spec.rb
@@ -104,7 +104,7 @@ module VCAP::CloudController
       let(:resources) { [{ sha1: '12345' }, { sha1: '56789' }] }
 
       before do
-        TestConfig.override(bits_service_config)
+        TestConfig.override(**bits_service_config)
         set_current_user_as_admin
       end
 

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -1007,7 +1007,7 @@ module VCAP::CloudController
 
         context 'when the async job times out' do
           before do
-            TestConfig.override({ jobs: { global: { timeout_in_seconds: 0.1 } } })
+            TestConfig.override(jobs: { global: { timeout_in_seconds: 0.1 } })
             stub_deprovision(service_instance, accepts_incomplete: true) do
               sleep 0.11
               { status: 200, body: {}.to_json }

--- a/spec/unit/controllers/runtime/stagings_controller_spec.rb
+++ b/spec/unit/controllers/runtime/stagings_controller_spec.rb
@@ -181,7 +181,7 @@ module VCAP::CloudController
 
     before do
       Fog.unmock!
-      TestConfig.override(staging_config)
+      TestConfig.override(**staging_config)
       set_current_user_as_admin(user: User.make(guid: '1234'), email: 'joe@joe.com', user_name: 'briggs')
     end
 
@@ -223,7 +223,7 @@ module VCAP::CloudController
 
       context 'when using with nginx' do
         before do
-          TestConfig.override(staging_config)
+          TestConfig.override(**staging_config)
           blob = create_test_blob
           allow(blob).to receive(:internal_download_url).and_return("/cc-packages/gu/id/#{package.guid}")
           package_blobstore = instance_double(CloudController::Blobstore::Client, blob: blob, local?: true)
@@ -240,7 +240,7 @@ module VCAP::CloudController
 
       context 'when not using with nginx' do
         before do
-          TestConfig.override(staging_config.merge(nginx: { use_nginx: false }))
+          TestConfig.override(**staging_config.merge(nginx: { use_nginx: false }))
           package_blobstore = instance_double(CloudController::Blobstore::Client, blob: create_test_blob, local?: true)
           allow(CloudController::DependencyLocator.instance).to receive(:package_blobstore).and_return(package_blobstore)
         end
@@ -480,7 +480,7 @@ module VCAP::CloudController
       end
 
       context 'when using with nginx' do
-        before { TestConfig.override(staging_config) }
+        before { TestConfig.override(**staging_config) }
 
         it 'succeeds for valid droplets' do
           upload_droplet
@@ -494,7 +494,7 @@ module VCAP::CloudController
       end
 
       context 'when not using with nginx' do
-        before { TestConfig.override(staging_config.merge(nginx: { use_nginx: false })) }
+        before { TestConfig.override(**staging_config.merge(nginx: { use_nginx: false })) }
 
         it 'succeeds for valid droplets' do
           encoded_expected_body = Base64.encode64(upload_droplet)

--- a/spec/unit/controllers/services/validators/service_update_validator_spec.rb
+++ b/spec/unit/controllers/services/validators/service_update_validator_spec.rb
@@ -25,14 +25,14 @@ module VCAP::CloudController
 
       context 'when the update to the service instance is valid' do
         it 'returns true' do
-          expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+          expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
         end
 
         context 'and when plan update requested on a service that allows update' do
           let(:update_attrs) { { 'service_plan_guid' => new_service_plan.guid } }
 
           it 'returns true' do
-            expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+            expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
           end
         end
 
@@ -40,7 +40,7 @@ module VCAP::CloudController
           let(:update_attrs) { { 'maintenance_info' => { 'version' => '2.0.0' } } }
 
           it 'returns true' do
-            expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+            expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
           end
         end
 
@@ -57,7 +57,7 @@ module VCAP::CloudController
             end
 
             it 'always allows the update' do
-              expect(ServiceUpdateValidator.validate!(service_instance, args)).to be true
+              expect(ServiceUpdateValidator.validate!(service_instance, **args)).to be true
             end
           end
 
@@ -71,7 +71,7 @@ module VCAP::CloudController
               let(:public) { true }
 
               it 'allows the update' do
-                expect(ServiceUpdateValidator.validate!(service_instance, args)).to be true
+                expect(ServiceUpdateValidator.validate!(service_instance, **args)).to be true
               end
             end
 
@@ -84,7 +84,7 @@ module VCAP::CloudController
               end
 
               it 'allows the update' do
-                expect(ServiceUpdateValidator.validate!(service_instance, args)).to be true
+                expect(ServiceUpdateValidator.validate!(service_instance, **args)).to be true
               end
             end
           end
@@ -97,7 +97,7 @@ module VCAP::CloudController
 
           it 'raises a validation error' do
             expect {
-              ServiceUpdateValidator.validate!(service_instance, args)
+              ServiceUpdateValidator.validate!(service_instance, **args)
             }.to raise_error(CloudController::Errors::ApiError, /Cannot update space/)
           end
         end
@@ -113,7 +113,7 @@ module VCAP::CloudController
 
           it 'raises a validation error with the specific message' do
             expect {
-              ServiceUpdateValidator.validate!(service_instance, args)
+              ServiceUpdateValidator.validate!(service_instance, **args)
             }.to raise_error(CloudController::Errors::ApiError, /You have exceeded your space's services limit./)
           end
         end
@@ -132,14 +132,14 @@ module VCAP::CloudController
 
             it 'raises a validation error' do
               expect {
-                ServiceUpdateValidator.validate!(service_instance, args)
+                ServiceUpdateValidator.validate!(service_instance, **args)
               }.to raise_error(CloudController::Errors::ApiError, /cannot switch to non-bindable/)
             end
           end
 
           context 'and service bindings do not exist' do
             it 'returns true' do
-              expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+              expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
             end
           end
         end
@@ -153,7 +153,7 @@ module VCAP::CloudController
 
           it 'raises a validation error if the plan changes' do
             expect {
-              ServiceUpdateValidator.validate!(service_instance, args)
+              ServiceUpdateValidator.validate!(service_instance, **args)
             }.to raise_error(CloudController::Errors::ApiError, /service does not support changing plans/)
           end
 
@@ -161,7 +161,7 @@ module VCAP::CloudController
             let(:update_attrs) { { 'service_plan_guid' => old_service_plan.guid } }
 
             it 'returns true' do
-              expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+              expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
             end
           end
 
@@ -171,7 +171,7 @@ module VCAP::CloudController
             end
 
             it 'returns true' do
-              expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+              expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
             end
           end
 
@@ -182,7 +182,7 @@ module VCAP::CloudController
 
             it 'raises a validation error' do
               expect {
-                ServiceUpdateValidator.validate!(service_instance, args)
+                ServiceUpdateValidator.validate!(service_instance, **args)
               }.to raise_error(CloudController::Errors::ApiError, /service does not support changing plans/)
             end
           end
@@ -197,7 +197,7 @@ module VCAP::CloudController
 
           it 'raises a validation error' do
             expect {
-              ServiceUpdateValidator.validate!(service_instance, args)
+              ServiceUpdateValidator.validate!(service_instance, **args)
             }.to raise_error(CloudController::Errors::ApiError, /service does not support changing plans/)
           end
         end
@@ -207,7 +207,7 @@ module VCAP::CloudController
 
           it 'raises a validation error' do
             expect {
-              ServiceUpdateValidator.validate!(service_instance, args)
+              ServiceUpdateValidator.validate!(service_instance, **args)
             }.to raise_error(CloudController::Errors::ApiError, /Plan/)
           end
         end
@@ -220,7 +220,7 @@ module VCAP::CloudController
 
           it 'raises a validation error' do
             expect {
-              ServiceUpdateValidator.validate!(service_instance, args)
+              ServiceUpdateValidator.validate!(service_instance, **args)
             }.to raise_error(CloudController::Errors::ApiError, /Plan/)
           end
         end
@@ -237,7 +237,7 @@ module VCAP::CloudController
 
             it 'raises a validation error' do
               expect {
-                ServiceUpdateValidator.validate!(service_instance, args)
+                ServiceUpdateValidator.validate!(service_instance, **args)
               }.to raise_error(CloudController::Errors::ApiError, /shared cannot be renamed/)
             end
           end
@@ -246,7 +246,7 @@ module VCAP::CloudController
             let(:update_attrs) { { 'name' => service_instance.name } }
 
             it 'succeeds' do
-              expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+              expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
             end
           end
         end
@@ -255,7 +255,7 @@ module VCAP::CloudController
           let(:update_attrs) { { 'maintenance_info' => { 'version' => '1.0.0' } } }
 
           it 'succeeds' do
-            expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+            expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
           end
         end
 
@@ -265,7 +265,7 @@ module VCAP::CloudController
 
           it 'errors' do
             expect {
-              ServiceUpdateValidator.validate!(service_instance, args)
+              ServiceUpdateValidator.validate!(service_instance, **args)
             }.to raise_error(
               CloudController::Errors::ApiError,
               'The service broker does not support upgrades for service instances created from this plan.'
@@ -278,7 +278,7 @@ module VCAP::CloudController
 
           it 'errors' do
             expect {
-              ServiceUpdateValidator.validate!(service_instance, args)
+              ServiceUpdateValidator.validate!(service_instance, **args)
             }.to raise_error(
               CloudController::Errors::ApiError,
               'maintenance_info.version should be a semantic version.'
@@ -294,7 +294,7 @@ module VCAP::CloudController
 
           it 'errors' do
             expect {
-              ServiceUpdateValidator.validate!(service_instance, args)
+              ServiceUpdateValidator.validate!(service_instance, **args)
             }.to raise_error(
               CloudController::Errors::ApiError,
               'maintenance_info should not be changed when switching to different plan.'
@@ -329,7 +329,7 @@ module VCAP::CloudController
 
               it 'errors' do
                 expect {
-                  ServiceUpdateValidator.validate!(service_instance, args)
+                  ServiceUpdateValidator.validate!(service_instance, **args)
                 }.to raise_error(CloudController::Errors::ApiError, /paid service plans are not allowed/)
               end
             end
@@ -339,11 +339,11 @@ module VCAP::CloudController
               let(:update_attrs) { { 'service_plan_guid' => new_service_plan.guid } }
 
               it 'succeeds' do
-                expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+                expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
               end
 
               it 'does not update the plan on the service instance' do
-                ServiceUpdateValidator.validate!(service_instance, args)
+                ServiceUpdateValidator.validate!(service_instance, **args)
                 expect(service_instance.service_plan).to eq(old_service_plan)
                 expect(service_instance.reload.service_plan).to eq(old_service_plan)
               end
@@ -355,13 +355,13 @@ module VCAP::CloudController
 
               it 'errors' do
                 expect {
-                  ServiceUpdateValidator.validate!(service_instance, args)
+                  ServiceUpdateValidator.validate!(service_instance, **args)
                 }.to raise_error(CloudController::Errors::ApiError, /paid service plans are not allowed/)
               end
 
               it 'does not update the plan on the service instance' do
                 expect {
-                  ServiceUpdateValidator.validate!(service_instance, args)
+                  ServiceUpdateValidator.validate!(service_instance, **args)
                 }.to raise_error(CloudController::Errors::ApiError)
 
                 expect(service_instance.service_plan).to eq(old_service_plan)
@@ -375,7 +375,7 @@ module VCAP::CloudController
             let(:update_attrs) { { 'service_plan_guid' => new_service_plan.guid } }
 
             it 'succeeds for paid plans' do
-              expect(ServiceUpdateValidator.validate!(service_instance, args)).to eq(true)
+              expect(ServiceUpdateValidator.validate!(service_instance, **args)).to eq(true)
             end
           end
         end
@@ -399,7 +399,7 @@ module VCAP::CloudController
 
               it 'raises a validation error' do
                 expect {
-                  ServiceUpdateValidator.validate!(service_instance, args)
+                  ServiceUpdateValidator.validate!(service_instance, **args)
                 }.to raise_error(CloudController::Errors::ApiError, /Cannot update parameters of a service instance that belongs to inaccessible plan/)
               end
             end
@@ -410,7 +410,7 @@ module VCAP::CloudController
 
               it 'raises a validation error' do
                 expect {
-                  ServiceUpdateValidator.validate!(service_instance, args)
+                  ServiceUpdateValidator.validate!(service_instance, **args)
                 }.to raise_error(CloudController::Errors::ApiError, /Cannot update parameters of a service instance that belongs to inaccessible plan/)
               end
             end

--- a/spec/unit/controllers/v3/builds_controller_spec.rb
+++ b/spec/unit/controllers/v3/builds_controller_spec.rb
@@ -479,13 +479,11 @@ RSpec.describe BuildsController, type: :controller do
 
       before do
         TestConfig.override(
-          {
-            staging: {
-              minimum_staging_memory_mb: 5,
-              minimum_staging_disk_mb: 5,
-            },
-            maximum_app_disk_in_mb: 10,
-          }
+          staging: {
+            minimum_staging_memory_mb: 5,
+            minimum_staging_disk_mb: 5,
+          },
+          maximum_app_disk_in_mb: 10,
         )
       end
 

--- a/spec/unit/controllers/v3/packages_controller_spec.rb
+++ b/spec/unit/controllers/v3/packages_controller_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe PackagesController, type: :controller do
 
     context 'when the package is stored in an image registry' do
       before do
-        TestConfig.override({ packages: { image_registry: { base_path: 'hub.example.com/user' } } })
+        TestConfig.override(packages: { image_registry: { base_path: 'hub.example.com/user' } })
       end
 
       it 'returns 422' do
@@ -1306,7 +1306,7 @@ RSpec.describe PackagesController, type: :controller do
 
       context 'when the package is stored in an image registry' do
         before do
-          TestConfig.override({ packages: { image_registry: { base_path: 'hub.example.com/user' } } })
+          TestConfig.override(packages: { image_registry: { base_path: 'hub.example.com/user' } })
         end
 
         it 'returns 422' do

--- a/spec/unit/jobs/enqueuer_spec.rb
+++ b/spec/unit/jobs/enqueuer_spec.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController::Jobs
     let(:global_timeout) { 5.hours }
 
     before do
-      TestConfig.override(config_override)
+      TestConfig.override(**config_override)
     end
 
     shared_examples_for 'a job enqueueing method' do

--- a/spec/unit/jobs/runtime/buildpack_cache_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/buildpack_cache_cleanup_spec.rb
@@ -35,7 +35,7 @@ module VCAP::CloudController
       end
 
       before do
-        TestConfig.override(blobstore_config)
+        TestConfig.override(**blobstore_config)
       end
 
       let(:blobstore) do

--- a/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
@@ -28,10 +28,10 @@ module VCAP::CloudController
         end
 
         before do
-          TestConfig.override({
+          TestConfig.override(
             broker_client_default_async_poll_interval_seconds: default_polling_interval,
             broker_client_max_async_poll_duration_minutes: max_duration,
-          })
+          )
         end
 
         def run_job(job)
@@ -408,7 +408,7 @@ module VCAP::CloudController
 
               context 'when the last_operation is replaced with delete in progress' do
                 before do
-                  service_binding.save_with_new_operation(type: 'delete', state: 'in progress')
+                  service_binding.save_with_new_operation({ type: 'delete', state: 'in progress' })
                 end
 
                 it 'is able to run the job again' do

--- a/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
@@ -69,7 +69,7 @@ module VCAP::CloudController
               broker_client_default_async_poll_interval_seconds: default_polling_interval,
               broker_client_max_async_poll_duration_minutes: max_duration,
             }
-            TestConfig.override(config_override)
+            TestConfig.override(**config_override)
           end
 
           context 'when the caller does not provide the maximum number of attempts' do

--- a/spec/unit/jobs/v3/buildpack_cache_cleanup_spec.rb
+++ b/spec/unit/jobs/v3/buildpack_cache_cleanup_spec.rb
@@ -35,7 +35,7 @@ module VCAP::CloudController
       end
 
       before do
-        TestConfig.override(blobstore_config)
+        TestConfig.override(**blobstore_config)
       end
 
       let(:blobstore) do

--- a/spec/unit/jobs/v3/create_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/create_service_instance_job_spec.rb
@@ -128,9 +128,9 @@ module VCAP::CloudController
 
           context 'computes the maximum duration' do
             before do
-              TestConfig.override({
+              TestConfig.override(
                 broker_client_max_async_poll_duration_minutes: 90009
-              })
+              )
               job.perform
             end
 
@@ -251,7 +251,7 @@ module VCAP::CloudController
           context 'the maximum duration' do
             it 'recomputes the value' do
               job.maximum_duration_seconds = 90009
-              TestConfig.override({ broker_client_max_async_poll_duration_minutes: 8088 })
+              TestConfig.override(broker_client_max_async_poll_duration_minutes: 8088)
 
               job.perform
 

--- a/spec/unit/jobs/v3/delete_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/delete_service_instance_job_spec.rb
@@ -64,9 +64,9 @@ module VCAP::CloudController
 
             context 'computes the maximum duration' do
               before do
-                TestConfig.override({
+                TestConfig.override(
                   broker_client_max_async_poll_duration_minutes: 90009
-                })
+                )
                 job.perform
               end
 
@@ -124,7 +124,7 @@ module VCAP::CloudController
           context 'the maximum duration' do
             it 'recomputes the value' do
               job.maximum_duration_seconds = 90009
-              TestConfig.override({ broker_client_max_async_poll_duration_minutes: 8088 })
+              TestConfig.override(broker_client_max_async_poll_duration_minutes: 8088)
               job.perform
               expect(job.maximum_duration_seconds).to eq(8088.minutes)
             end

--- a/spec/unit/jobs/v3/update_service_instance_job_spec.rb
+++ b/spec/unit/jobs/v3/update_service_instance_job_spec.rb
@@ -149,9 +149,9 @@ module VCAP::CloudController
 
           context 'computes the maximum duration' do
             before do
-              TestConfig.override({
+              TestConfig.override(
                 broker_client_max_async_poll_duration_minutes: 90009
-              })
+              )
               job.perform
             end
 
@@ -268,7 +268,7 @@ module VCAP::CloudController
           context 'the maximum duration' do
             it 'recomputes the value' do
               job.maximum_duration_seconds = 90009
-              TestConfig.override({ broker_client_max_async_poll_duration_minutes: 8088 })
+              TestConfig.override(broker_client_max_async_poll_duration_minutes: 8088)
 
               job.perform
 

--- a/spec/unit/lib/cloud_controller/bits_expiration_spec.rb
+++ b/spec/unit/lib/cloud_controller/bits_expiration_spec.rb
@@ -12,17 +12,17 @@ module VCAP::CloudController
     end
 
     let(:config) do
-      Config.new(
+      Config.new({
         packages: { max_valid_packages_stored: 5 },
         droplets: { max_staged_droplets_stored: 5 }
-      )
+      })
     end
 
     let(:changed_config) do
-      Config.new(
+      Config.new({
         packages: { max_valid_packages_stored: 10 },
         droplets: { max_staged_droplets_stored: 10 }
-      )
+      })
     end
 
     it 'is configurable' do

--- a/spec/unit/lib/cloud_controller/clock/clock_spec.rb
+++ b/spec/unit/lib/cloud_controller/clock/clock_spec.rb
@@ -37,7 +37,7 @@ module VCAP::CloudController
           at:       time,
           priority: priority
         }
-        clock.schedule_daily_job(clock_opts) { some_job_class.new }
+        clock.schedule_daily_job(**clock_opts) { some_job_class.new }
 
         expected_job_opts = { queue: job_name, priority: 0 }
         expect(Jobs::Enqueuer).to have_received(:new).with(instance_of(some_job_class), expected_job_opts)
@@ -66,7 +66,7 @@ module VCAP::CloudController
             at:       time,
             priority: priority
           }
-          clock.schedule_daily_job(clock_opts) { some_job_class.new }
+          clock.schedule_daily_job(**clock_opts) { some_job_class.new }
 
           expected_job_opts = { queue: job_name, priority: priority }
           expect(Jobs::Enqueuer).to have_received(:new).with(instance_of(some_job_class), expected_job_opts)
@@ -93,7 +93,7 @@ module VCAP::CloudController
           name:     job_name,
           interval: interval,
         }
-        clock.schedule_frequent_worker_job(clock_opts) { some_job_class.new }
+        clock.schedule_frequent_worker_job(**clock_opts) { some_job_class.new }
 
         expected_job_opts = { queue: job_name }
         expect(Jobs::Enqueuer).to have_received(:new).with(instance_of(some_job_class), expected_job_opts)
@@ -123,7 +123,7 @@ module VCAP::CloudController
           interval: interval,
           timeout:  timeout,
         }
-        clock.schedule_frequent_inline_job(clock_opts) { some_job_class.new }
+        clock.schedule_frequent_inline_job(**clock_opts) { some_job_class.new }
 
         expected_job_opts = { queue: job_name }
         expect(Jobs::Enqueuer).to have_received(:new).with(instance_of(some_job_class), expected_job_opts)

--- a/spec/unit/lib/cloud_controller/clock/scheduler_spec.rb
+++ b/spec/unit/lib/cloud_controller/clock/scheduler_spec.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
       before do
         allow(Clock).to receive(:new).with(no_args).and_return(clock)
         allow(Clockwork).to receive(:run)
-        TestConfig.override({
+        TestConfig.override(
           jobs: {
             global: { timeout_in_seconds: global_timeout },
           },
@@ -27,7 +27,7 @@ module VCAP::CloudController
           max_retained_deployments_per_app: 15,
           max_retained_builds_per_app: 15,
           max_retained_revisions_per_app: 15,
-        })
+        )
       end
 
       it 'configures Clockwork with a logger' do
@@ -176,9 +176,9 @@ module VCAP::CloudController
 
       context 'when the diego sync frequency is zero' do
         before do
-          TestConfig.override({
+          TestConfig.override(
             diego_sync: { frequency_in_seconds: 0 },
-          })
+          )
         end
 
         it 'does not run diego sync' do

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe CloudController::DependencyLocator do
 
   describe '#droplet_blobstore' do
     let(:config) do
-      VCAP::CloudController::Config.new(
+      VCAP::CloudController::Config.new({
         droplets: {
           fog_connection: 'fog_connection',
           droplet_directory_key: 'key',
         },
-      )
+      })
     end
 
     it 'creates blob store' do
@@ -33,13 +33,13 @@ RSpec.describe CloudController::DependencyLocator do
     end
 
     context('when bits service is enabled') do
-      let(:config) do VCAP::CloudController::Config.new(
+      let(:config) do VCAP::CloudController::Config.new({
         droplets: {
           fog_connection: 'fog_connection',
           droplet_directory_key: 'key',
         },
         bits_service: bits_service_config
-        )
+      })
       end
 
       it 'creates the client with the right arguments' do
@@ -52,12 +52,12 @@ RSpec.describe CloudController::DependencyLocator do
 
   describe '#buildpack_cache_blobstore' do
     let(:config) do
-      VCAP::CloudController::Config.new(
+      VCAP::CloudController::Config.new({
         droplets: {
           fog_connection: 'fog_connection',
           droplet_directory_key: 'key',
         }
-      )
+      })
     end
 
     it 'creates blob store' do
@@ -71,13 +71,13 @@ RSpec.describe CloudController::DependencyLocator do
 
     context('when bits service is enabled') do
       let(:config) do
-        VCAP::CloudController::Config.new(
+        VCAP::CloudController::Config.new({
           droplets: {
             fog_connection: 'fog_connection',
             droplet_directory_key: 'key',
           },
           bits_service: bits_service_config
-        )
+})
       end
 
       it 'creates the client with the right arguments' do
@@ -90,12 +90,12 @@ RSpec.describe CloudController::DependencyLocator do
 
   describe '#package_blobstore' do
     let(:config) do
-      VCAP::CloudController::Config.new(
+      VCAP::CloudController::Config.new({
         packages: {
           fog_connection: 'fog_connection',
           app_package_directory_key: 'key',
         }
-      )
+      })
     end
 
     it 'creates blob store' do
@@ -106,12 +106,12 @@ RSpec.describe CloudController::DependencyLocator do
 
     context('when bits service is enabled') do
       let(:config) do
-        VCAP::CloudController::Config.new(
+        VCAP::CloudController::Config.new({
           packages: {
             app_package_directory_key: 'key'
           },
           bits_service: bits_service_config
-        )
+        })
       end
 
       it 'creates the client with the right arguments' do
@@ -124,12 +124,12 @@ RSpec.describe CloudController::DependencyLocator do
 
   describe '#legacy_global_app_bits_cache' do
     let(:config) do
-      VCAP::CloudController::Config.new(
+      VCAP::CloudController::Config.new({
         resource_pool: {
           fog_connection: 'fog_connection',
           resource_directory_key: 'key',
         }
-      )
+      })
     end
 
     it 'creates blob store' do
@@ -143,12 +143,12 @@ RSpec.describe CloudController::DependencyLocator do
 
   describe '#global_app_bits_cache' do
     let(:config) do
-      VCAP::CloudController::Config.new(
+      VCAP::CloudController::Config.new({
         resource_pool: {
           fog_connection: 'fog_connection',
           resource_directory_key: 'key',
         }
-      )
+      })
     end
 
     it 'creates blob store with a app_bits_cache as root_dir' do
@@ -178,7 +178,7 @@ RSpec.describe CloudController::DependencyLocator do
     end
 
     before do
-      TestConfig.override(my_config)
+      TestConfig.override(**my_config)
     end
 
     it 'creates blobstore_url_generator with the internal_service_hostname, port, and blobstores' do
@@ -210,7 +210,7 @@ RSpec.describe CloudController::DependencyLocator do
     end
 
     before do
-      TestConfig.override(my_config)
+      TestConfig.override(**my_config)
     end
 
     it 'creates droplet_url_generator with the internal_service_hostname, ports, and diego flag' do
@@ -491,9 +491,7 @@ RSpec.describe CloudController::DependencyLocator do
 
     it 'returns the tc-decorated client without TLS' do
       TestConfig.override(
-        {
-          logcache_tls: nil
-        }
+        logcache_tls: nil
       )
       expect(locator.traffic_controller_compatible_logcache_client).to be_an_instance_of(Logcache::TrafficControllerDecorator)
       expect(Logcache::Client).to have_received(:new).with(
@@ -508,17 +506,15 @@ RSpec.describe CloudController::DependencyLocator do
 
     it 'returns the tc-decorated client with TLS certificates' do
       TestConfig.override(
-        {
-          logcache: {
-            host: 'some-logcache-host',
-            port: 1234,
-          },
-          logcache_tls: {
-            ca_file: 'logcache-ca',
-            cert_file: 'logcache-client-ca',
-            key_file: 'logcache-client-key',
-            subject_name: 'some-tls-cert-san'
-          }
+        logcache: {
+          host: 'some-logcache-host',
+          port: 1234,
+        },
+        logcache_tls: {
+          ca_file: 'logcache-ca',
+          cert_file: 'logcache-client-ca',
+          key_file: 'logcache-client-key',
+          subject_name: 'some-tls-cert-san'
         }
       )
       expect(locator.traffic_controller_compatible_logcache_client).to be_an_instance_of(Logcache::TrafficControllerDecorator)
@@ -538,15 +534,13 @@ RSpec.describe CloudController::DependencyLocator do
 
     before do
       TestConfig.override(
-        {
-          copilot: {
-            enabled: true,
-            host: 'some-host',
-            port: 1234,
-            client_ca_file: 'some-client-ca-file',
-            client_key_file: 'some-client-key-file',
-            client_chain_file: 'some-client-chain-file'
-          }
+        copilot: {
+          enabled: true,
+          host: 'some-host',
+          port: 1234,
+          client_ca_file: 'some-client-ca-file',
+          client_key_file: 'some-client-key-file',
+          client_chain_file: 'some-client-chain-file'
         }
       )
     end
@@ -568,10 +562,10 @@ RSpec.describe CloudController::DependencyLocator do
       host = 'test-host'
       port = 1234
 
-      TestConfig.override({
+      TestConfig.override(
         statsd_host: host,
         statsd_port: port,
-      })
+      )
 
       expected_client = double(Statsd)
 
@@ -599,13 +593,13 @@ RSpec.describe CloudController::DependencyLocator do
 
     context 'opi staging is enabled' do
       before do
-        TestConfig.override({
+        TestConfig.override(
           opi: {
             enabled: true,
             url: 'http://custom-opi-url.service.cf.internal',
             opi_staging: true
           }
-        })
+        )
       end
 
       it 'uses opi' do
@@ -633,7 +627,7 @@ RSpec.describe CloudController::DependencyLocator do
 
     context 'opi is enabled' do
       before do
-        TestConfig.override({
+        TestConfig.override(**{
           opi: {
             enabled: true,
             url: 'http://custom-opi-url.service.cf.internal'
@@ -651,7 +645,7 @@ RSpec.describe CloudController::DependencyLocator do
 
       context 'experimental crds are enabled' do
         before do
-          TestConfig.override({
+          TestConfig.override(**{
             opi: {
               enabled: true,
               experimental_enable_crds: true,
@@ -685,12 +679,12 @@ RSpec.describe CloudController::DependencyLocator do
 
     context 'opi is enabled' do
       before do
-        TestConfig.override({
+        TestConfig.override(
           opi: {
             enabled: true,
             url: 'http://custom-opi-url.service.cf.internal'
           }
-        })
+        )
         allow(::Diego::Client).to receive(:new)
       end
 
@@ -724,12 +718,12 @@ RSpec.describe CloudController::DependencyLocator do
 
     context 'opi is enabled' do
       before do
-        TestConfig.override({
+        TestConfig.override(
           opi: {
             enabled: true,
             url: 'http://custom-opi-url.service.cf.internal'
           }
-        })
+        )
         allow(::Diego::Client).to receive(:new)
       end
 
@@ -758,7 +752,7 @@ RSpec.describe CloudController::DependencyLocator do
       token_file.write('token')
       token_file.close
 
-      TestConfig.override(generate_test_kubeconfig)
+      TestConfig.override(**generate_test_kubeconfig)
     end
 
     it 'creates a k8s client from config' do

--- a/spec/unit/lib/cloud_controller/diego/lifecycle_bundle_uri_generator_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/lifecycle_bundle_uri_generator_spec.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
   module Diego
     RSpec.describe LifecycleBundleUriGenerator do
       before do
-        TestConfig.override({ diego: { file_server_url: 'https://file-server.example.com:1234' } })
+        TestConfig.override(diego: { file_server_url: 'https://file-server.example.com:1234' })
       end
 
       it 'creates a file server url for a bundle path' do

--- a/spec/unit/lib/cloud_controller/diego/task_completion_callback_generator_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_completion_callback_generator_spec.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
         end
 
         before do
-          TestConfig.override(task_config)
+          TestConfig.override(**task_config)
         end
 
         context 'when CC is responsible for syncing with Diego' do

--- a/spec/unit/lib/cloud_controller/install_buildpacks_spec.rb
+++ b/spec/unit/lib/cloud_controller/install_buildpacks_spec.rb
@@ -22,7 +22,7 @@ module VCAP::CloudController
       let(:enqueued_job2) { double(:enqueued_job2, perform: nil) }
 
       before do
-        TestConfig.override(install_buildpack_config)
+        TestConfig.override(**install_buildpack_config)
 
         allow(Buildpacks::StackNameExtractor).to receive(:extract_from_file)
         allow(installer.logger).to receive(:error)

--- a/spec/unit/lib/cloud_controller/seeds_spec.rb
+++ b/spec/unit/lib/cloud_controller/seeds_spec.rb
@@ -42,7 +42,7 @@ module VCAP::CloudController
         context 'and the name changes' do
           it 'sets the name of the shared segment to the new value' do
             expect {
-              Seeds.create_seed_shared_isolation_segment(Config.new(shared_isolation_segment_name: 'original-name'))
+              Seeds.create_seed_shared_isolation_segment(Config.new({ shared_isolation_segment_name: 'original-name' }))
             }.to_not change { IsolationSegmentModel.count }
 
             shared_isolation_segment_model = IsolationSegmentModel.first
@@ -57,7 +57,7 @@ module VCAP::CloudController
             # redeploy with what the old 'shared' isolation segment name
             it 'raises some kind of error TBD' do
               expect {
-                Seeds.create_seed_shared_isolation_segment(Config.new(shared_isolation_segment_name: isolation_segment_model.name))
+                Seeds.create_seed_shared_isolation_segment(Config.new({ shared_isolation_segment_name: isolation_segment_model.name }))
               }.to raise_error(Sequel::ValidationFailed, /must be unique/)
             end
           end
@@ -67,7 +67,7 @@ module VCAP::CloudController
 
     describe '.create_seed_quota_definitions' do
       let(:config) do
-        Config.new(
+        Config.new({
           quota_definitions: {
             'small' => {
               non_basic_services_allowed: false,
@@ -85,7 +85,7 @@ module VCAP::CloudController
             },
           },
           default_quota_definition: 'default',
-        )
+        })
       end
 
       before do
@@ -218,7 +218,7 @@ module VCAP::CloudController
 
     describe '.create_seed_domains' do
       let(:config) do
-        Config.new(
+        Config.new({
           app_domains: app_domains,
           system_domain: system_domain,
           system_domain_organization: 'the-system-org',
@@ -231,7 +231,7 @@ module VCAP::CloudController
             },
           },
           default_quota_definition: 'default'
-        )
+        })
       end
       let(:system_org) { Organization.find(name: 'the-system-org') }
       let(:system_domain) { 'system.example.com' }
@@ -412,7 +412,7 @@ module VCAP::CloudController
 
     describe '.create_seed_security_groups' do
       let(:config) do
-        Config.new(
+        Config.new({
           security_group_definitions: [
             {
               'name' => 'staging_default',
@@ -429,7 +429,7 @@ module VCAP::CloudController
           ],
           default_staging_security_groups: ['staging_default'],
           default_running_security_groups: ['running_default']
-        )
+        })
       end
 
       context 'when there are no security groups configured in the system' do

--- a/spec/unit/lib/kubernetes/kube_client_builder_spec.rb
+++ b/spec/unit/lib/kubernetes/kube_client_builder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Kubernetes::KubeClientBuilder do
   end
 
   it 'loads kubernetes creds from the config' do
-    client = Kubernetes::KubeClientBuilder.build(kubernetes_creds)
+    client = Kubernetes::KubeClientBuilder.build(**kubernetes_creds)
 
     expect(client.ssl_options).to eq({
       ca: 'k8s_node_ca'
@@ -36,7 +36,7 @@ RSpec.describe Kubernetes::KubeClientBuilder do
     }
 
     it 'raises an error' do
-      expect { Kubernetes::KubeClientBuilder.build(kubernetes_creds) }.to raise_error(Kubernetes::KubeClientBuilder::MissingCredentialsError)
+      expect { Kubernetes::KubeClientBuilder.build(**kubernetes_creds) }.to raise_error(Kubernetes::KubeClientBuilder::MissingCredentialsError)
     end
   end
 end

--- a/spec/unit/lib/services/service_brokers/v2/client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/client_spec.rb
@@ -1710,7 +1710,7 @@ module VCAP::Services::ServiceBrokers::V2
 
               it 'propagates the error and does not issue an unbind' do
                 expect {
-                  client.bind(binding, arbitrary_parameters)
+                  client.bind(binding, **arbitrary_parameters)
                 }.to raise_error(Errors::ConcurrencyError)
 
                 expect(orphan_mitigator).not_to have_received(:cleanup_failed_bind)

--- a/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
@@ -118,7 +118,7 @@ module VCAP::Services::ServiceBrokers::V2
           let(:ssl_config) { double(:ssl_config, :verify_mode= => nil) }
 
           before do
-            TestConfig.override(config)
+            TestConfig.override(**config)
             allow(HTTPClient).to receive(:new).and_return(http_client)
             allow(http_client).to receive(http_method)
             allow(ssl_config).to receive(:set_default_paths)
@@ -270,7 +270,7 @@ module VCAP::Services::ServiceBrokers::V2
 
     shared_examples 'timeout behavior' do
       before do
-        TestConfig.override(config)
+        TestConfig.override(**config)
         allow(HTTPClient).to receive(:new).and_return(http_client)
         allow(http_client).to receive(http_method)
       end

--- a/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
@@ -13,7 +13,7 @@ module VCAP::Services
         end
 
         class InnerValidator
-          def validate(_broker_response)
+          def validate(**_broker_response)
             raise NotImpementedError.new('implement this in the spec')
           end
         end
@@ -45,15 +45,15 @@ module VCAP::Services
           context 'when the broker response body is valid' do
             let(:broker_response_body) { '{}' }
             it 'does not raise' do
-              expect { json_validator.validate(broker_response.to_hash) }.not_to raise_error
+              expect { json_validator.validate(**broker_response.to_hash) }.not_to raise_error
             end
 
             it 'returns the inner validator result' do
-              expect(json_validator.validate(broker_response.to_hash)).to eql('inner-validator-result')
+              expect(json_validator.validate(**broker_response.to_hash)).to eql('inner-validator-result')
             end
 
             it 'calls the inner validator with the same parameters it was passed' do
-              json_validator.validate(broker_response.to_hash)
+              json_validator.validate(**broker_response.to_hash)
               expect(inner_validator).to have_received(:validate).with(broker_response.to_hash)
             end
           end
@@ -63,7 +63,7 @@ module VCAP::Services
               context "and the response body is #{body}" do
                 let(:broker_response_body) { body }
                 it 'raises' do
-                  expect { json_validator.validate(broker_response.to_hash) }.to raise_error(Errors::ServiceBrokerResponseMalformed) do |e|
+                  expect { json_validator.validate(**broker_response.to_hash) }.to raise_error(Errors::ServiceBrokerResponseMalformed) do |e|
                     expect(e.to_h['description']).to eq(
                       "The service broker returned an invalid response: expected valid JSON object in body, broker returned '#{body}'")
                     expect(e.response_code).to eq(502)
@@ -78,7 +78,7 @@ module VCAP::Services
               let(:broker_response_body) { 'invalid' }
               it 'logs the error' do
                 begin
-                  json_validator.validate(broker_response.to_hash)
+                  json_validator.validate(**broker_response.to_hash)
                 rescue
                   # this is tested above
                 end
@@ -114,7 +114,7 @@ module VCAP::Services
               }
 
               it 'raises a ServiceBrokerResponseMalformed error' do
-                expect { json_validator.validate(broker_response.to_hash) }.to raise_error(Errors::ServiceBrokerResponseMalformed) do |e|
+                expect { json_validator.validate(**broker_response.to_hash) }.to raise_error(Errors::ServiceBrokerResponseMalformed) do |e|
                   description_lines = e.to_h['description'].split("\n")
                   expect(description_lines[0]).to eq('The service broker returned an invalid response: ')
                   expect(description_lines.drop(1)).to contain_exactly("The property '#/' did not contain a required property of 'prop2'")
@@ -132,7 +132,7 @@ module VCAP::Services
               }
 
               it 'raises a ServiceBrokerResponseMalformed error' do
-                expect { json_validator.validate(broker_response.to_hash) }.to raise_error(Errors::ServiceBrokerResponseMalformed) do |e|
+                expect { json_validator.validate(**broker_response.to_hash) }.to raise_error(Errors::ServiceBrokerResponseMalformed) do |e|
                   description_lines = e.to_h['description'].split("\n")
                   expect(description_lines[0]).to eq('The service broker returned an invalid response: ')
                   expect(description_lines.drop(1)).to contain_exactly(

--- a/spec/unit/middleware/rate_limiter_spec.rb
+++ b/spec/unit/middleware/rate_limiter_spec.rb
@@ -6,12 +6,14 @@ module CloudFoundry
       let(:middleware) do
         RateLimiter.new(
           app,
-          logger:                            logger,
-          per_process_general_limit:         per_process_general_limit,
-          global_general_limit:              global_general_limit,
-          per_process_unauthenticated_limit: per_process_unauthenticated_limit,
-          global_unauthenticated_limit:      global_unauthenticated_limit,
-          interval:                          interval,
+          {
+            logger:                            logger,
+            per_process_general_limit:         per_process_general_limit,
+            global_general_limit:              global_general_limit,
+            per_process_unauthenticated_limit: per_process_unauthenticated_limit,
+            global_unauthenticated_limit:      global_unauthenticated_limit,
+            interval:                          interval,
+          }
         )
       end
       let(:request_counter) { double }

--- a/spec/unit/models/runtime/app_model_spec.rb
+++ b/spec/unit/models/runtime/app_model_spec.rb
@@ -396,7 +396,7 @@ module VCAP::CloudController
 
       context 'when default_app_ssh_access is true' do
         before do
-          TestConfig.override({ default_app_ssh_access: true })
+          TestConfig.override(default_app_ssh_access: true)
         end
 
         it 'sets enable_ssh to true' do
@@ -407,7 +407,7 @@ module VCAP::CloudController
 
       context 'when default_app_ssh_access is false' do
         before do
-          TestConfig.override({ default_app_ssh_access: false })
+          TestConfig.override(default_app_ssh_access: false)
         end
 
         it 'sets enable_ssh to false' do
@@ -507,7 +507,7 @@ module VCAP::CloudController
     describe 'encryption' do
       context 'when not saving any encrypted fields, with db keys' do
         it 'still updates the encryption-key value' do
-          TestConfig.override({ database_encryption: { current_key_label: nil, keys: {} } })
+          TestConfig.override(database_encryption: { current_key_label: nil, keys: {} })
           app = AppModel.create(name: 'jimmy')
           expect(app.encryption_key_label).to be_nil
 
@@ -516,7 +516,7 @@ module VCAP::CloudController
           app.reload
           expect(app.encryption_key_label).to be_nil
 
-          TestConfig.override({ database_encryption: { current_key_label: 'k2', keys: { k1: 'moose' } } })
+          TestConfig.override(database_encryption: { current_key_label: 'k2', keys: { k1: 'moose' } })
           app.environment_variables = app.environment_variables.merge({ 'building' => 'outhouse' })
           app.save
           app.reload

--- a/spec/unit/models/runtime/constraints/health_check_policy_spec.rb
+++ b/spec/unit/models/runtime/constraints/health_check_policy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe HealthCheckPolicy do
 
   describe 'health_check_timeout' do
     before do
-      TestConfig.override({ maximum_health_check_timeout: max_health_check_timeout })
+      TestConfig.override(maximum_health_check_timeout: max_health_check_timeout)
     end
 
     context 'when a health_check_timeout exceeds the maximum' do

--- a/spec/unit/models/runtime/package_model_spec.rb
+++ b/spec/unit/models/runtime/package_model_spec.rb
@@ -28,7 +28,7 @@ module VCAP::CloudController
 
       context 'when using a package registry' do
         before do
-          TestConfig.override({ packages: { image_registry: { base_path: 'hub.example.com/user' } } })
+          TestConfig.override(packages: { image_registry: { base_path: 'hub.example.com/user' } })
         end
 
         it 'returns the image reference for the package' do

--- a/spec/unit/models/runtime/process_model_spec.rb
+++ b/spec/unit/models/runtime/process_model_spec.rb
@@ -10,11 +10,11 @@ module VCAP::CloudController
     let(:route) { Route.make(domain: domain, space: space) }
 
     def enable_custom_buildpacks
-      TestConfig.override({ disable_custom_buildpacks: nil })
+      TestConfig.override(disable_custom_buildpacks: nil)
     end
 
     def disable_custom_buildpacks
-      TestConfig.override({ disable_custom_buildpacks: true })
+      TestConfig.override(disable_custom_buildpacks: true)
     end
 
     def expect_validator(validator_class)
@@ -910,7 +910,7 @@ module VCAP::CloudController
 
     describe 'health_check_timeout' do
       before do
-        TestConfig.override({ maximum_health_check_timeout: 512 })
+        TestConfig.override(maximum_health_check_timeout: 512)
       end
 
       context 'when the health_check_timeout was not specified' do
@@ -1303,7 +1303,7 @@ module VCAP::CloudController
 
       describe 'default_app_memory' do
         before do
-          TestConfig.override({ default_app_memory: 200 })
+          TestConfig.override(default_app_memory: 200)
         end
 
         it 'uses the provided memory' do
@@ -1319,7 +1319,7 @@ module VCAP::CloudController
 
       describe 'default disk_quota' do
         before do
-          TestConfig.override({ default_app_disk_in_mb: 512 })
+          TestConfig.override(default_app_disk_in_mb: 512)
         end
 
         it 'should use the provided quota' do
@@ -1335,7 +1335,7 @@ module VCAP::CloudController
 
       describe 'instance_file_descriptor_limit' do
         before do
-          TestConfig.override({ instance_file_descriptor_limit: 200 })
+          TestConfig.override(instance_file_descriptor_limit: 200)
         end
 
         it 'uses the instance_file_descriptor_limit config variable' do

--- a/spec/unit/models/runtime/shared_domain_spec.rb
+++ b/spec/unit/models/runtime/shared_domain_spec.rb
@@ -223,7 +223,7 @@ module VCAP::CloudController
         context 'and the domain is internal' do
           it 'raises an error' do
             attrs = { name: 'some-domain.com', router_group_guid: 'some-guid', internal: true }
-            expect { SharedDomain.find_or_create(attrs) }.to raise_error do |e|
+            expect { SharedDomain.find_or_create(**attrs) }.to raise_error do |e|
               expect(e).to be_a(StandardError)
               expect(e.message).to eq('Error for shared domain name some-domain.com: router_group_guid cannot be specified for internal domains')
             end
@@ -250,7 +250,7 @@ module VCAP::CloudController
             before_updated_at = existing_domain.updated_at
 
             expect {
-              SharedDomain.find_or_create(attrs.merge(internal: false))
+              SharedDomain.find_or_create(**attrs.merge(internal: false))
             }.not_to change { existing_domain.reload }
             expect(fake_logger).to have_received(:warn).
               with("Domain '#{domain_name}' already exists. Skipping updates of internal status")
@@ -268,7 +268,7 @@ module VCAP::CloudController
             before_updated_at = existing_domain.updated_at
 
             expect {
-              SharedDomain.find_or_create(attrs.merge(internal: true))
+              SharedDomain.find_or_create(**attrs.merge(internal: true))
             }.not_to change { existing_domain.reload }
             expect(fake_logger).to have_received(:warn).
               with("Domain '#{domain_name}' already exists. Skipping updates of internal status")
@@ -284,7 +284,7 @@ module VCAP::CloudController
           before_updated_at = existing_domain.updated_at
 
           expect {
-            SharedDomain.find_or_create(attrs.merge(router_group_guid: 'new rgg'))
+            SharedDomain.find_or_create(**attrs.merge(router_group_guid: 'new rgg'))
           }.not_to change { existing_domain.reload }
           expect(fake_logger).to have_received(:warn).
             with("Domain '#{domain_name}' already exists. Skipping updates of router_group_guid")
@@ -299,7 +299,7 @@ module VCAP::CloudController
           before_updated_at = existing_domain.updated_at
 
           expect {
-            SharedDomain.find_or_create(attrs)
+            SharedDomain.find_or_create(**attrs)
           }.not_to change { existing_domain.reload }
           expect(existing_domain.updated_at).to eq(before_updated_at)
           expect(fake_logger).to have_received(:info).with("reusing default serving domain: #{domain_name}")

--- a/spec/unit/presenters/v3/service_broker_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_broker_presenter_spec.rb
@@ -10,10 +10,8 @@ module VCAP::CloudController
       before do
         StubConfig.prepare(
           self,
-          {
-            external_protocol: 'http',
-            external_domain: 'api.example.org'
-          }
+          external_protocol: 'http',
+          external_domain: 'api.example.org'
         )
       end
 


### PR DESCRIPTION
Pulled this out of #2623 to avoid having long living branches and merge conflicts with them. 

See here for why this needs to be changed: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/