### PR TITLE
Throw an error on sb bind when in binding status is delete_failed or delete_in_progess

### DIFF
--- a/app/models/runtime/helpers/service_credential_binding_mixin.rb
+++ b/app/models/runtime/helpers/service_credential_binding_mixin.rb
@@ -8,14 +8,32 @@ module VCAP::CloudController
       !!last_operation && last_operation.state == 'in progress'
     end
 
-    def create_failed?
-      return true if last_operation&.type == 'create' && last_operation.state == 'failed'
+    def create_succeeded?
+      return true if last_operation&.type == 'create' && last_operation.state == 'succeeded'
 
       false
     end
 
     def create_in_progress?
       return true if last_operation&.type == 'create' && last_operation.state == 'in progress'
+
+      false
+    end
+
+    def create_failed?
+      return true if last_operation&.type == 'create' && last_operation.state == 'failed'
+
+      false
+    end
+
+    def delete_failed?
+      return true if last_operation&.type == 'delete' && last_operation.state == 'failed'
+
+      false
+    end
+
+    def delete_in_progress?
+      return true if last_operation&.type == 'delete' && last_operation.state == 'in progress'
 
       false
     end

--- a/spec/unit/models/services/service_credential_binding_shared.rb
+++ b/spec/unit/models/services/service_credential_binding_shared.rb
@@ -129,4 +129,58 @@ RSpec.shared_examples 'a model including the ServiceCredentialBindingMixin' do |
       end
     end
   end
+
+  describe '#delete_failed?' do
+    let(:operation) { nil }
+
+    context 'when there is no binding operation' do
+      it 'returns false' do
+        expect(service_credential_binding.delete_failed?).to be false
+      end
+    end
+
+    context 'when there is a binding operation' do
+      it "returns true only for the 'delete failed' state" do
+        [
+          { type: 'create', state: 'failed',      result: false },
+          { type: 'create', state: 'in progress', result: false },
+          { type: 'create', state: 'succeeded',   result: false },
+          { type: 'delete', state: 'in progress', result: false },
+          { type: 'delete', state: 'failed',      result: true },
+          { type: 'delete', state: 'succeeded',   result: false },
+        ].each do |test|
+          service_credential_binding.save_with_attributes_and_new_operation({}, { type: test[:type], state: test[:state] })
+
+          expect(service_credential_binding.delete_failed?).to be test[:result]
+        end
+      end
+    end
+  end
+
+  describe '#delete_in_progress?' do
+    let(:operation) { nil }
+
+    context 'when there is no binding operation' do
+      it 'returns false' do
+        expect(service_credential_binding.delete_in_progress?).to be false
+      end
+    end
+
+    context 'when there is a binding operation' do
+      it "returns true only for the 'delete in progress' state" do
+        [
+          { type: 'create', state: 'in progress', result: false },
+          { type: 'create', state: 'failed',      result: false },
+          { type: 'create', state: 'succeeded',   result: false },
+          { type: 'delete', state: 'in progress', result: true },
+          { type: 'delete', state: 'failed',      result: false },
+          { type: 'delete', state: 'succeeded',   result: false },
+        ].each do |test|
+          service_credential_binding.save_with_attributes_and_new_operation({}, { type: test[:type], state: test[:state] })
+
+          expect(service_credential_binding.delete_in_progress?).to be test[:result]
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a fix as part of #2637. It contains changes in behaviour for:
- POST /v3/service_credential_bindings
For both of its workflows, creating a service-credential-binding and a service-credential-key.


When binding is in state delete_in_progess or delete failed we want an
error different from "binding already exists" to be thrown. Fistly this
might not be true since a orphane mitigation might in the meantime
deleted the binding. Secondly the CF CLI interprets this(rightfully) as
success since this message tells it that what CF CLI wanted to to is
already accomplished. So CF CLI will now fail on
create-credential-binding when a binding exists that is in a failed
deletion or pending deletion state.
Same applies for create-credential-key endpoint.
