### PR TITLE
Don't reuse GUIDs when recreating bindings

### DIFF
--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -33,13 +33,13 @@ module VCAP::CloudController
           credentials: {}
         }
 
-        (binding || ServiceBinding.new).tap do |b|
+        ServiceBinding.new.tap do |b|
           ServiceBinding.db.transaction do
+            binding.destroy if binding
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_IN_PROGRESS_OPERATION
             )
-
             MetadataUpdate.update(b, message)
           end
         end

--- a/app/actions/service_credential_binding_key_create.rb
+++ b/app/actions/service_credential_binding_key_create.rb
@@ -28,8 +28,9 @@ module VCAP::CloudController
           credentials: {}
         }
 
-        (key || ServiceKey.new).tap do |b|
+        ServiceKey.new.tap do |b|
           ServiceKey.db.transaction do
+            key.destroy if key
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_IN_PROGRESS_OPERATION

--- a/spec/unit/actions/service_credential_binding_app_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_app_create_spec.rb
@@ -82,11 +82,12 @@ module VCAP::CloudController
                 binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })
               end
 
-              it 'updates and returns the existing binding' do
+              it 'deletes the existing binding and creates a new one' do
                 b = action.precursor(service_instance, app: app, message: message)
 
-                expect(b.id).to eq(binding.id)
+                expect(b.guid).not_to eq(binding.guid)
                 expect(b.create_in_progress?).to be_truthy
+                expect { binding.reload }.to raise_error Sequel::NoExistingObject
               end
             end
 

--- a/spec/unit/actions/service_credential_binding_key_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_key_create_spec.rb
@@ -71,11 +71,12 @@ module VCAP::CloudController
                 binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })
               end
 
-              it 'updates and returns the existing key' do
+              it 'deletes the existing key and creates a new one' do
                 b = action.precursor(service_instance, message: message)
 
-                expect(b.id).to eq(binding.id)
+                expect(b.guid).not_to eq(binding.guid)
                 expect(b.create_in_progress?).to be_truthy
+                expect { binding.reload }.to raise_error Sequel::NoExistingObject
               end
             end
 


### PR DESCRIPTION
When a service credential binding or key is in state `create failed`, subsequent POST requests treat them as non-existent and issue another create request to the service broker. But instead of reusing the previously created GUID, delete the existing binding / key (and its GUID) and create a new one.

Closes #2666.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
