### PR TITLE
Implement exponential backoff for SB operations (CC v3 API)

### DIFF
--- a/app/jobs/reoccurring_job.rb
+++ b/app/jobs/reoccurring_job.rb
@@ -3,7 +3,7 @@ require 'jobs/cc_job'
 module VCAP::CloudController
   module Jobs
     class ReoccurringJob < VCAP::CloudController::Jobs::CCJob
-      attr_reader :finished, :start_time
+      attr_reader :finished, :start_time, :retry_number
 
       def success(current_delayed_job)
         pollable_job = PollableJobModel.find_by_delayed_job(current_delayed_job)
@@ -49,6 +49,7 @@ module VCAP::CloudController
       def initialize
         @start_time = Time.now
         @finished = false
+        @retry_number = 0
       end
 
       def default_maximum_duration_seconds
@@ -59,8 +60,16 @@ module VCAP::CloudController
         Config.config.get(:broker_client_default_async_poll_interval_seconds)
       end
 
+      def default_polling_exponential_backoff
+        Config.config.get(:broker_client_async_poll_exponential_backoff_rate)
+      end
+
+      def next_execution_in
+        polling_interval_seconds * default_polling_exponential_backoff**retry_number
+      end
+
       def next_enqueue_would_exceed_maximum_duration?
-        Time.now + polling_interval_seconds > start_time + maximum_duration_seconds
+        Time.now + next_execution_in > start_time + maximum_duration_seconds
       end
 
       def finish
@@ -75,9 +84,10 @@ module VCAP::CloudController
       def enqueue_next_job(pollable_job)
         opts = {
           queue: Jobs::Queues.generic,
-          run_at: Delayed::Job.db_time_now + polling_interval_seconds
+          run_at: Delayed::Job.db_time_now + next_execution_in
         }
 
+        @retry_number += 1
         Jobs::Enqueuer.new(self, opts).enqueue_pollable(existing_guid: pollable_job.guid)
       end
     end

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -60,6 +60,7 @@ max_retained_revisions_per_app: 100
 
 broker_client_default_async_poll_interval_seconds: 60
 broker_client_max_async_poll_duration_minutes: 10080
+broker_client_async_poll_exponential_backoff_rate: 1.0
 
 shared_isolation_segment_name: 'shared'
 

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -184,6 +184,7 @@ module VCAP::CloudController
             broker_client_timeout_seconds: Integer,
             broker_client_default_async_poll_interval_seconds: Integer,
             broker_client_max_async_poll_duration_minutes: Integer,
+            broker_client_async_poll_exponential_backoff_rate: Float,
             optional(:uaa_client_name) => String,
             optional(:uaa_client_secret) => String,
             optional(:uaa_client_scope) => String,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -111,6 +111,7 @@ module VCAP::CloudController
             broker_client_timeout_seconds: Integer,
             broker_client_default_async_poll_interval_seconds: Integer,
             broker_client_max_async_poll_duration_minutes: Integer,
+            broker_client_async_poll_exponential_backoff_rate: Float,
             optional(:uaa_client_name) => String,
             optional(:uaa_client_secret) => String,
             optional(:uaa_client_scope) => String,

--- a/spec/unit/jobs/reoccurring_job_spec.rb
+++ b/spec/unit/jobs/reoccurring_job_spec.rb
@@ -75,10 +75,13 @@ module VCAP
         job.polling_interval_seconds = 95
         expect(job.polling_interval_seconds).to eq(95)
 
-        enqueued_time = Time.now
+        enqueued_time = 0
 
-        Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
-        execute_all_jobs(expected_successes: 1, expected_failures: 0)
+        Timecop.freeze do
+          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
+          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          enqueued_time = Time.now
+        end
 
         Timecop.freeze(94.seconds.after(enqueued_time)) do
           execute_all_jobs(expected_successes: 0, expected_failures: 0)
@@ -103,10 +106,13 @@ module VCAP
           it 'when changing exponential backoff rate only' do
             TestConfig.config[:broker_client_async_poll_exponential_backoff_rate] = 2.0
 
-            enqueued_time = Time.now
+            enqueued_time = 0
 
-            Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
-            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+            Timecop.freeze do
+              Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+              execute_all_jobs(expected_successes: 1, expected_failures: 0)
+              enqueued_time = Time.now
+            end
 
             [60, 180, 420, 900, 1860].each do |seconds|
               Timecop.freeze((seconds - 1).seconds.after(enqueued_time)) do
@@ -122,30 +128,35 @@ module VCAP
             TestConfig.config[:broker_client_async_poll_exponential_backoff_rate] = 1.3
             TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
 
-            enqueued_time = Time.now
+            enqueued_time = 0
 
-            Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
-            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+            Timecop.freeze do
+              Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+              execute_all_jobs(expected_successes: 1, expected_failures: 0)
+              enqueued_time = Time.now
+            end
 
             [10, 23, 39.9, 61.8, 90.4].each do |seconds|
               Timecop.freeze((seconds - 1).seconds.after(enqueued_time)) do
                 execute_all_jobs(expected_successes: 0, expected_failures: 0)
               end
 
-              Timecop.freeze((seconds + 1).seconds.after(enqueued_time)) do
+              Timecop.freeze((seconds.ceil + 1).seconds.after(enqueued_time)) do
                 execute_all_jobs(expected_successes: 1, expected_failures: 0)
               end
             end
           end
           it 'when changing exponential backoff rate and retry_after from the job' do
-            job = FakeJob.new(retry_after: [20, 30])
             TestConfig.config[:broker_client_async_poll_exponential_backoff_rate] = 1.3
             TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
 
-            enqueued_time = Time.now
+            enqueued_time = 0
 
-            Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
-            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+            Timecop.freeze do
+              Jobs::Enqueuer.new(FakeJob.new(retry_after: [20, 30]), queue: Jobs::Queues.generic).enqueue_pollable
+              execute_all_jobs(expected_successes: 1, expected_failures: 0)
+              enqueued_time = Time.now
+            end
 
             # the job should run after 20s * 1.3^0 = 20 seconds
             Timecop.freeze(19.seconds.after(enqueued_time)) do
@@ -176,8 +187,12 @@ module VCAP
           # With a backoff rate of 1.3, 11 jobs could have been executed in 60 minutes (initial run + 10 retries).
           job.instance_variable_set(:@retry_number, 10)
 
-          enqueued_time = Time.now
-          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
+          enqueued_time = 0
+
+          Timecop.freeze do
+            Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
+            enqueued_time = Time.now
+          end
 
           # The calculated backoff for the 11th retry would be 3384.321 seconds.
           Timecop.freeze(enqueued_time + 3384.321.ceil.seconds) do
@@ -194,13 +209,15 @@ module VCAP
 
       context 'updates the polling interval if config changes' do
         it 'when changed from the job only' do
-          job = FakeJob.new(retry_after: [20, 30])
           TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
 
-          enqueued_time = Time.now
+          enqueued_time = 0
 
-          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
-          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          Timecop.freeze do
+            Jobs::Enqueuer.new(FakeJob.new(retry_after: [20, 30]), queue: Jobs::Queues.generic).enqueue_pollable
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+            enqueued_time = Time.now
+          end
 
           Timecop.freeze(19.seconds.after(enqueued_time)) do
             execute_all_jobs(expected_successes: 0, expected_failures: 0)
@@ -221,13 +238,15 @@ module VCAP
         end
 
         it 'when default changed after changing from the job' do
-          job = FakeJob.new(retry_after: [20])
           TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
 
-          enqueued_time = Time.now
+          enqueued_time = 0
 
-          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
-          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          Timecop.freeze do
+            Jobs::Enqueuer.new(FakeJob.new(retry_after: [20]), queue: Jobs::Queues.generic).enqueue_pollable
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+            enqueued_time = Time.now
+          end
 
           Timecop.freeze(19.seconds.after(enqueued_time)) do
             execute_all_jobs(expected_successes: 0, expected_failures: 0)
@@ -249,13 +268,15 @@ module VCAP
         end
 
         it 'when changing default only' do
-          job = FakeJob.new
           TestConfig.config[:broker_client_default_async_poll_interval_seconds] = 10
 
-          enqueued_time = Time.now
+          enqueued_time = 0
 
-          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
-          execute_all_jobs(expected_successes: 1, expected_failures: 0)
+          Timecop.freeze do
+            Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+            execute_all_jobs(expected_successes: 1, expected_failures: 0)
+            enqueued_time = Time.now
+          end
 
           Timecop.freeze(9.seconds.after(enqueued_time)) do
             execute_all_jobs(expected_successes: 0, expected_failures: 0)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Introduce a new parameter `broker_client_async_poll_exponential_backoff_rate` which lets users configure exponential backoff for service related polling jobs. This includes the creation, update and deletion of service instances and the creation and deletion of service credential bindings. 

* An explanation of the use cases your change solves
The CC already offers two parameters with which the polling interval `broker_client_default_async_poll_interval_seconds` and the polling duration `broker_client_max_async_poll_duration_minutes` can be configured. Though, this is not enough to prevent that the CC can be overloaded by a single user e.g. by creating many service instances, while the broker needs a lot of time to handle the request. This will result in many polling jobs, which overload the worker processes.

The newly introduced parameter `broker_client_async_poll_exponential_backoff_rate`, by default, does not change the current behaviour as it is set to 1.0, which means there is no exponential backoff. When set to a higher number, the time until each re-enqueued job will be run will increase and therefore lead to much less polling jobs, which need to be run by the worker processes. 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
