### PR TITLE
Raise specific OrgSuspended error instead of generic NotAuthorized

### DIFF
--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -22,6 +22,10 @@ module V3ErrorsHelper
     raise CloudController::Errors::ApiError.new_from_details('NotAuthorized')
   end
 
+  def suspended!
+    raise CloudController::Errors::ApiError.new_from_details('OrgSuspended')
+  end
+
   def resource_not_found_with_message!(message)
     raise CloudController::Errors::ApiError.new_from_details('ResourceNotFound', message)
   end

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -108,6 +108,11 @@
   http_code: 429
   message: "Service broker concurrent request limit exceeded"
 
+10017:
+  name: OrgSuspended
+  http_code: 403
+  message: "You are not authorized to perform the requested action on a suspended organization"
+
 20001:
   name: UserInvalid
   http_code: 400


### PR DESCRIPTION
With this change a new method `can_write_to_org_checks` is added to `VCAP::CloudController::Permissions` that returns a boolean similar to `can_write_to_org?` and the reason for a successful or failed check.

The following results are possible:
- `true, :global_check`
- `true, :role_check`
- `false, :role_check`
- `false, :org_active_check`

The `SpacesV3Controller` has been adapted to use this method and raise a more specific error in case the org is suspended.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
