### PR TITLE
Don't filter out quota metrics

### DIFF
--- a/lib/logcache/traffic_controller_decorator.rb
+++ b/lib/logcache/traffic_controller_decorator.rb
@@ -64,7 +64,9 @@ module Logcache
       # rubocop:disable Style/PreferredHashMethods
       envelope.gauge.metrics.has_key?('cpu') ||
       envelope.gauge.metrics.has_key?('memory') ||
-      envelope.gauge.metrics.has_key?('disk')
+      envelope.gauge.metrics.has_key?('memory_quota') ||
+      envelope.gauge.metrics.has_key?('disk') ||
+      envelope.gauge.metrics.has_key?('disk_quota')
       # rubocop:enable Style/PreferredHashMethods
     end
 


### PR DESCRIPTION
Allows app quota retrieval when metrics are delivered in separate envelopes, which occurs when syslog ingress to log cache is turned on.

Closes #2669.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
