### PR TITLE
Raise specific OrgSuspended error instead of generic NotAuthorized

### DIFF
--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -22,6 +22,10 @@ module V3ErrorsHelper
     raise CloudController::Errors::ApiError.new_from_details('NotAuthorized')
   end
 
+  def suspended!
+    raise CloudController::Errors::ApiError.new_from_details('OrgSuspended')
+  end
+
   def resource_not_found_with_message!(message)
     raise CloudController::Errors::ApiError.new_from_details('ResourceNotFound', message)
   end

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -108,6 +108,11 @@
   http_code: 429
   message: "Service broker concurrent request limit exceeded"
 
+10017:
+  name: OrgSuspended
+  http_code: 403
+  message: "You are not authorized to perform the requested action on a suspended organization"
+
 20001:
   name: UserInvalid
   http_code: 400

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -158,6 +158,10 @@ class VCAP::CloudController::Permissions
     return true if can_write_globally?
     return false unless membership.has_any_roles?(ROLES_FOR_ORG_WRITING, nil, org_guid)
 
+    is_org_active?(org_guid)
+  end
+
+  def is_org_active?(org_guid)
     VCAP::CloudController::Organization.find(guid: org_guid)&.active?
   end
 

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -303,7 +303,7 @@ module VCAP::CloudController
         context 'and user is an admin' do
           it 'returns true' do
             set_current_user(user, { admin: true })
-            expect(permissions.can_read_from_org?(org_guid)).to be true
+            expect(permissions.can_write_to_org?(org_guid)).to be true
           end
         end
 
@@ -356,6 +356,21 @@ module VCAP::CloudController
             org.update(status: Organization::SUSPENDED)
             expect(permissions.can_write_to_org?(org_guid)).to be_falsey
           end
+        end
+      end
+    end
+
+    describe '#is_org_active?' do
+      context 'the org is active' do
+        it 'returns true' do
+          expect(permissions.is_org_active?(org_guid)).to be_truthy
+        end
+      end
+
+      context 'the org is suspended' do
+        it 'returns false' do
+          org.update(status: Organization::SUSPENDED)
+          expect(permissions.is_org_active?(org_guid)).to be_falsey
         end
       end
     end


### PR DESCRIPTION
With this change a new method `is_org_active?` is added to allow controllers to return a more precise error message in case the user is unauthorized due to the fact that the organization is suspended.

The `SpacesV3Controller` has been adapted to raise an `OrgSuspended` error if appropriate.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
