### PR TITLE
Dont show service credential keys not in state create succeeded

### DIFF
--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -614,6 +614,17 @@ RSpec.describe 'v3 service credential bindings' do
       }
     }
 
+    context "last binding operation is in 'create succeeded' state" do
+      before do
+        app_binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'succeeded' })
+      end
+
+      it 'returns details' do
+        api_call.call(admin_headers)
+        expect(last_response).to have_status_code(200)
+      end
+    end
+
     context "last binding operation is in 'create in progress' state" do
       before do
         app_binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'in progress' })
@@ -643,6 +654,38 @@ RSpec.describe 'v3 service credential bindings' do
           'title' => 'CF-ResourceNotFound',
           'code' => 10010,
         }))
+      end
+    end
+
+    context "last binding operation is in 'delete in progress' state" do
+      before do
+        app_binding.save_with_attributes_and_new_operation({}, { type: 'delete', state: 'in progress' })
+      end
+
+      it 'returns an error' do
+        api_call.call(admin_headers)
+        expect(last_response).to have_status_code(404)
+        expect(parsed_response['errors']).to include(include({
+          'detail' => 'Deletion of service binding in progress',
+          'title' => 'CF-ResourceNotFound',
+          'code' => 10010,
+        }))
+      end
+    end
+
+    context "last binding operation is in 'delete failed' state" do
+      before do
+        app_binding.save_with_attributes_and_new_operation({}, { type: 'delete', state: 'failed' })
+      end
+
+      it 'returns an error' do
+        api_call.call(admin_headers)
+        expect(last_response).to have_status_code(404)
+        expect(parsed_response['errors']).to include(include({
+          'detail' => 'Deletion of service binding failed',
+          'title' => 'CF-ResourceNotFound',
+          'code' => 10010,
+         }))
       end
     end
 


### PR DESCRIPTION
Basically we want not to show any service key whos state is not in
create succeeded. This is due to all other states cannot be certain that
the key still exists/already exists and orphane mitigation hasnt cleaned
it up even after a initial failed delete.
For more information see https://github.com/cloudfoundry/cloud_controller_ng/issues/2637

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
