### PR TITLE
Fix synchronous bind is successfull

### DIFF
--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -62,7 +62,7 @@ module VCAP::CloudController
 
       def validate_binding!(binding)
         if binding
-          already_bound! if binding.create_succeeded? || binding.create_in_progress? || binding.last_operation.nil?
+          already_bound! if binding.create_succeeded? || binding.create_in_progress?
           incomplete_deletion! if binding.delete_failed? || binding.delete_in_progress?
         end
       end

--- a/app/actions/service_credential_binding_key_create.rb
+++ b/app/actions/service_credential_binding_key_create.rb
@@ -59,7 +59,7 @@ module VCAP::CloudController
 
       def validate_key!(key, message_name)
         if key
-          key_already_exists!(message_name) if key.create_succeeded? || key.create_in_progress? || key.last_operation.nil?
+          key_already_exists!(message_name) if key.create_succeeded? || key.create_in_progress?
           key_incomplete_deletion!(message_name) if key.delete_failed? || key.delete_in_progress?
         end
       end

--- a/app/models/runtime/helpers/service_credential_binding_mixin.rb
+++ b/app/models/runtime/helpers/service_credential_binding_mixin.rb
@@ -9,6 +9,7 @@ module VCAP::CloudController
     end
 
     def create_succeeded?
+      return true unless last_operation
       return true if last_operation&.type == 'create' && last_operation.state == 'succeeded'
 
       false

--- a/spec/unit/models/services/service_credential_binding_shared.rb
+++ b/spec/unit/models/services/service_credential_binding_shared.rb
@@ -76,6 +76,33 @@ RSpec.shared_examples 'a model including the ServiceCredentialBindingMixin' do |
     end
   end
 
+  describe '#create_succeeded?' do
+    let(:operation) { nil }
+
+    context 'when there is no binding operation' do
+      it 'returns true' do
+        expect(service_credential_binding.create_succeeded?).to be true
+      end
+    end
+
+    context 'when there is a binding operation' do
+      it "returns true only for the 'create succeeded' state" do
+        [
+          { type: 'create', state: 'failed',      result: false },
+          { type: 'create', state: 'in progress', result: false },
+          { type: 'create', state: 'succeeded',   result: true },
+          { type: 'delete', state: 'in progress', result: false },
+          { type: 'delete', state: 'failed',      result: false },
+          { type: 'delete', state: 'succeeded',   result: false },
+        ].each do |test|
+          service_credential_binding.save_with_attributes_and_new_operation({}, { type: test[:type], state: test[:state] })
+
+          expect(service_credential_binding.create_succeeded?).to be test[:result]
+        end
+      end
+    end
+  end
+
   describe '#create_failed?' do
     let(:operation) { nil }
 


### PR DESCRIPTION
In case of a synchronous bind, last_operation is nil but we should consider this a succesfull binding.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
