### PR TITLE
Add index for attempts in delayed_jobs table

### DIFF
--- a/db/migrations/20220217141700_add_attempts_index_to_delayed_jobs.rb
+++ b/db/migrations/20220217141700_add_attempts_index_to_delayed_jobs.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :delayed_jobs do
+      add_index :attempts, name: :delayed_jobs_attempts_index
+    end
+  end
+
+  down do
+    alter_table :delayed_jobs do
+      drop_index :attempts, name: :delayed_jobs_attempts_index
+    end
+  end
+end


### PR DESCRIPTION
* With adding an index to attempts, the query time can be improved
significantly.
* This will improve SELECT "queue", count(*) AS "count" FROM
  "delayed_jobs" WHERE ("attempts" = 0) GROUP BY "queue";

Signed-off-by: Philipp Thun <philipp.thun@sap.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
