### PR TITLE
Allow overwrite of delayed job priorities

### DIFF
--- a/app/jobs/logging_context_job.rb
+++ b/app/jobs/logging_context_job.rb
@@ -50,7 +50,9 @@ module VCAP::CloudController
       end
 
       def deprioritize_job(job)
-        if job.priority == 0
+        if job.priority < 0
+          job.priority = 0
+        elsif job.priority == 0
           job.priority = 1
         else
           job.priority *= 2

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -317,6 +317,7 @@ module VCAP::CloudController
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
+              optional(:priorities) => Hash,
             },
 
             # perm settings no longer have any effect but are preserved here

--- a/lib/cloud_controller/config_schemas/base/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/clock_schema.rb
@@ -180,6 +180,7 @@ module VCAP::CloudController
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
+              optional(:priorities) => Hash,
             },
 
             max_labels_per_resource: Integer,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -173,6 +173,7 @@ module VCAP::CloudController
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
+              optional(:priorities) => Hash,
             },
 
             volume_services_enabled: bool,

--- a/lib/cloud_controller/job/job_priority_overwriter.rb
+++ b/lib/cloud_controller/job/job_priority_overwriter.rb
@@ -5,14 +5,14 @@ module VCAP::CloudController
     end
 
     def get(job_display_name)
-      if is_overwritten(job_display_name)
+      if overwritten?(job_display_name)
         @overwritten_job_priorities[job_display_name.to_sym]
       end
     end
 
     private
 
-    def is_overwritten(job_display_name)
+    def overwritten?(job_display_name)
       return false if @overwritten_job_priorities.nil? || job_display_name.nil?
 
       @overwritten_job_priorities.key?(job_display_name.to_sym)

--- a/lib/cloud_controller/job/job_priority_overwriter.rb
+++ b/lib/cloud_controller/job/job_priority_overwriter.rb
@@ -1,0 +1,23 @@
+module VCAP::CloudController
+  class JobPriorityOverwriter
+    def initialize(config)
+      @overwritten_job_priorities = config.get(:jobs, :priorities)
+    end
+
+    def get(job_display_name)
+      if is_overwritten(job_display_name)
+        @overwritten_job_priorities[job_display_name.to_sym]
+      end
+    end
+
+    private
+
+    def is_overwritten(job_display_name)
+      return false if @overwritten_job_priorities.nil? || job_display_name.nil?
+
+      @overwritten_job_priorities.key?(job_display_name.to_sym)
+    end
+
+    attr_reader :config
+  end
+end

--- a/spec/unit/jobs/enqueuer_spec.rb
+++ b/spec/unit/jobs/enqueuer_spec.rb
@@ -12,12 +12,12 @@ module VCAP::CloudController::Jobs
           global: {
             timeout_in_seconds: global_timeout,
           },
-          priorities: job_display_name
+          **priorities
         }
       }
     end
     let(:global_timeout) { 5.hours }
-    let(:job_display_name) { nil }
+    let(:priorities) { {} }
 
     before do
       TestConfig.override(**config_override)
@@ -130,7 +130,7 @@ module VCAP::CloudController::Jobs
       end
 
       context 'priority from config' do
-        let(:job_display_name) { { wrapped_job.display_name.to_sym => 1899 } }
+        let(:priorities) { { priorities: { wrapped_job.display_name.to_sym => 1899 } } }
         it 'uses the configured priority' do
           original_enqueue = Delayed::Job.method(:enqueue)
           expect(Delayed::Job).to receive(:enqueue) do |enqueued_job, opts|

--- a/spec/unit/jobs/enqueuer_spec.rb
+++ b/spec/unit/jobs/enqueuer_spec.rb
@@ -11,11 +11,13 @@ module VCAP::CloudController::Jobs
         jobs: {
           global: {
             timeout_in_seconds: global_timeout,
-          }
+          },
+          priorities: job_display_name
         }
       }
     end
     let(:global_timeout) { 5.hours }
+    let(:job_display_name) { nil }
 
     before do
       TestConfig.override(**config_override)
@@ -50,6 +52,15 @@ module VCAP::CloudController::Jobs
         end
         Enqueuer.new(wrapped_job, opts).public_send(method_name)
         expect(timeout_calculator).to have_received(:calculate).with(wrapped_job.job_name_in_configuration)
+      end
+
+      it 'uses the default priority' do
+        original_enqueue = Delayed::Job.method(:enqueue)
+        expect(Delayed::Job).to receive(:enqueue) do |enqueued_job, opts|
+          expect(opts).not_to include(:priority)
+          original_enqueue.call(enqueued_job, opts)
+        end
+        Enqueuer.new(wrapped_job, opts).public_send(method_name)
       end
     end
 
@@ -115,6 +126,18 @@ module VCAP::CloudController::Jobs
           Enqueuer.new(wrapped_job, opts).enqueue_pollable do |pollable_job|
             ErrorTranslatorJob.new(pollable_job)
           end
+        end
+      end
+
+      context 'priority from config' do
+        let(:job_display_name) { { wrapped_job.display_name.to_sym => 1899 } }
+        it 'uses the configured priority' do
+          original_enqueue = Delayed::Job.method(:enqueue)
+          expect(Delayed::Job).to receive(:enqueue) do |enqueued_job, opts|
+            expect(opts).to include({ priority: 1899 })
+            original_enqueue.call(enqueued_job, opts)
+          end
+          Enqueuer.new(wrapped_job, opts).enqueue_pollable
         end
       end
     end

--- a/spec/unit/jobs/logging_context_job_spec.rb
+++ b/spec/unit/jobs/logging_context_job_spec.rb
@@ -171,6 +171,19 @@ module VCAP::CloudController
         end
 
         describe 'job priority' do
+          context 'when the job priority starts at -10' do
+            before do
+              allow(job).to receive(:priority).and_return(-10)
+            end
+
+            it 'deprioritizes the job to priority 0' do
+              logging_context_job.error(job, 'exception')
+
+              expect(job).to have_received(:priority=).with(0).ordered
+              expect(job).to have_received(:save).ordered
+            end
+          end
+
           context 'when the job priority starts at 0' do
             before do
               allow(job).to receive(:priority).and_return(0)

--- a/spec/unit/lib/cloud_controller/job/job_priority_overwriter_spec.rb
+++ b/spec/unit/lib/cloud_controller/job/job_priority_overwriter_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'cloud_controller/job/job_priority_overwriter'
+
+module VCAP::CloudController
+  RSpec.describe JobPriorityOverwriter do
+    let(:config) do
+      Config.new({
+                   jobs: {
+                     priorities: {
+                       "resource1.create": -20,
+                       "resource2.delete": 10
+                     },
+                   }
+                 })
+    end
+
+    context 'when a job is specified in the config' do
+      it 'returns the job priority from the config' do
+        expect(JobPriorityOverwriter.new(config).get(:"resource1.create")).to eq(-20)
+        expect(JobPriorityOverwriter.new(config).get(:"resource2.delete")).to eq(10)
+      end
+    end
+
+    context 'when a job is NOT specified in the config' do
+      it 'returns nil' do
+        expect(JobPriorityOverwriter.new(config).get(:"res1.bommel")).to eq(nil)
+      end
+    end
+
+    context 'when the job_name is nil' do
+      it 'returns nil' do
+        expect(JobPriorityOverwriter.new(config).get(nil)).to eq(nil)
+      end
+    end
+
+    context 'when the config is empty' do
+      it 'returns nil' do
+        expect(JobPriorityOverwriter.new(Config.new({})).get(:"res1.bommel")).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* A short explanation of the proposed change:
With this change the job priority can be overwritten in the cloud controller config. This allows operators to prioritize e.g. cf push over service broker operations.
* An explanation of the use cases your change solves:
It is implemented by an optional 'priorities' config parameter thus it does not change the current behavior/ priorities. The parameter is a hash which contains the jobs display_name and its overwritten priority (int).
An example configuration could look like this:
  ```  
  jobs:
      global:
        timeout_in_seconds: 14400
      priorities:
        space.apply_manifest: -10
        buildpack.delete: 10
  ```
* Links to any other associated PRs
cloudfoundry/capi-release/pull/227

* Related doc PRs
https://github.com/cloudfoundry/docs-cf-admin/pull/214
https://github.com/cloudfoundry/docs-book-cloudfoundry/pull/118

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
