### PR TITLE
Prevent inconsistencies when cancelling service binding/instance creations

### DIFF
--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -38,7 +38,7 @@ module VCAP::CloudController
             binding.destroy if binding
             b.save_with_attributes_and_new_operation(
               binding_details,
-              CREATE_IN_PROGRESS_OPERATION
+              CREATE_INITIAL_OPERATION
             )
             MetadataUpdate.update(b, message)
           end

--- a/app/actions/service_credential_binding_key_create.rb
+++ b/app/actions/service_credential_binding_key_create.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
             key.destroy if key
             b.save_with_attributes_and_new_operation(
               binding_details,
-              CREATE_IN_PROGRESS_OPERATION
+              CREATE_INITIAL_OPERATION
             )
             MetadataUpdate.update(b, message)
           end

--- a/app/actions/service_route_binding_create.rb
+++ b/app/actions/service_route_binding_create.rb
@@ -26,7 +26,7 @@ module VCAP::CloudController
           RouteBinding.db.transaction do
             b.save_with_attributes_and_new_operation(
               binding_details,
-              CREATE_IN_PROGRESS_OPERATION
+              CREATE_INITIAL_OPERATION
             )
             MetadataUpdate.update(b, message)
           end

--- a/app/actions/v3/service_binding_create.rb
+++ b/app/actions/v3/service_binding_create.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
       PollingFinished = PollingStatus.new(true, nil).freeze
       ContinuePolling = ->(retry_after) { PollingStatus.new(false, retry_after) }
 
-      CREATE_IN_PROGRESS_OPERATION = { type: 'create', state: 'in progress' }.freeze
+      CREATE_INITIAL_OPERATION = { type: 'create', state: 'initial' }.freeze
 
       def bind(binding, parameters: {}, accepts_incomplete: false)
         client = VCAP::Services::ServiceClientProvider.provide(instance: binding.service_instance)

--- a/app/actions/v3/service_binding_delete.rb
+++ b/app/actions/v3/service_binding_delete.rb
@@ -18,7 +18,8 @@ module VCAP::CloudController
       ContinuePolling = ->(retry_after) { PollingStatus.new(false, retry_after) }
 
       def blocking_operation_in_progress?(binding)
-        binding.operation_in_progress? && binding.last_operation.type != 'create'
+        binding.operation_in_progress? &&
+          (binding.create_initial? || binding.delete_in_progress?)
       end
 
       def delete(binding)

--- a/app/actions/v3/service_instance_create_managed.rb
+++ b/app/actions/v3/service_instance_create_managed.rb
@@ -35,7 +35,7 @@ module VCAP::CloudController
 
         last_operation = {
           type: 'create',
-          state: ManagedServiceInstance::IN_PROGRESS_STRING
+          state: ManagedServiceInstance::INITIAL_STRING
         }
 
         ManagedServiceInstance.new.tap do |i|

--- a/app/actions/v3/service_instance_delete.rb
+++ b/app/actions/v3/service_instance_delete.rb
@@ -30,7 +30,8 @@ module VCAP::CloudController
       end
 
       def blocking_operation_in_progress?
-        service_instance.operation_in_progress? && service_instance.last_operation.type != 'create'
+        service_instance.operation_in_progress? &&
+          (service_instance.create_initial? || service_instance.update_in_progress? || service_instance.delete_in_progress?)
       end
 
       def delete

--- a/app/models/runtime/helpers/service_operation_mixin.rb
+++ b/app/models/runtime/helpers/service_operation_mixin.rb
@@ -1,19 +1,24 @@
 module VCAP::CloudController
   module ServiceOperationMixin
+    INITIAL = 'initial'.freeze
     IN_PROGRESS = 'in progress'.freeze
     SUCCEEDED = 'succeeded'.freeze
     FAILED = 'failed'.freeze
 
     def operation_in_progress?
-      last_operation? && last_operation.state == IN_PROGRESS
+      last_operation? && [INITIAL, IN_PROGRESS].include?(last_operation.state)
     end
 
     def terminal_state?
       !last_operation? || [SUCCEEDED, FAILED].include?(last_operation.state)
     end
 
+    def create_initial?
+      create? && initial?
+    end
+
     def create_in_progress?
-      create? && in_progress?
+      create? && (initial? || in_progress?)
     end
 
     def create_succeeded?
@@ -60,6 +65,10 @@ module VCAP::CloudController
 
     def delete?
       last_operation&.type == 'delete'
+    end
+
+    def initial?
+      last_operation&.state == INITIAL
     end
 
     def in_progress?

--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -5,6 +5,7 @@ module VCAP::CloudController
   class ManagedServiceInstance < ServiceInstance
     include ServiceOperationMixin
 
+    INITIAL_STRING = 'initial'.freeze
     IN_PROGRESS_STRING = 'in progress'.freeze
 
     many_to_one :service_plan

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1813,6 +1813,22 @@ RSpec.describe 'v3 service credential bindings' do
         end
       end
 
+      context 'when the service credential binding creation request has not been responded to by the broker' do
+        before do
+          binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'initial' })
+        end
+
+        it 'responds with 422' do
+          api_call.call admin_headers
+          expect(last_response).to have_status_code(422)
+          expect(parsed_response['errors']).to include(include({
+            'detail' => include('There is an operation in progress for the service binding.'),
+            'title' => 'CF-UnprocessableEntity',
+            'code' => 10008,
+          }))
+        end
+      end
+
       context 'when the service credential binding is still creating' do
         before do
           binding.save_with_attributes_and_new_operation(

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -1465,6 +1465,22 @@ RSpec.describe 'v3 service route bindings' do
           end
         end
 
+        context 'when the route binding creation request has not been responded to by the broker' do
+          before do
+            binding.save_with_new_operation({}, { type: 'create', state: 'initial' })
+          end
+
+          it 'responds with 422' do
+            api_call.call admin_headers
+            expect(last_response).to have_status_code(422)
+            expect(parsed_response['errors']).to include(include({
+              'detail' => include('There is an operation in progress for the service binding.'),
+              'title' => 'CF-UnprocessableEntity',
+              'code' => 10008,
+            }))
+          end
+        end
+
         context 'when the route binding is still creating' do
           before do
             binding.save_with_new_operation(

--- a/spec/support/shared_examples/request/bindings_create.rb
+++ b/spec/support/shared_examples/request/bindings_create.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'service credential binding create endpoint' do |klass, ch
         expect(binding.app).to eq(app_to_bind_to) if check_app
         expect(binding.service_instance).to eq(service_instance)
 
-        expect(binding.last_operation.state).to eq('in progress')
+        expect(binding.last_operation.state).to eq('initial')
         expect(binding.last_operation.type).to eq('create')
 
         expect(binding).to have_labels({ prefix: nil, key: 'foo', value: 'bar' })

--- a/spec/unit/actions/service_credential_binding_app_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_app_create_spec.rb
@@ -53,7 +53,7 @@ module VCAP::CloudController
             expect(binding.credentials).to be_empty
             expect(binding.syslog_drain_url).to be_nil
             expect(binding.last_operation.type).to eq('create')
-            expect(binding.last_operation.state).to eq('in progress')
+            expect(binding.last_operation.state).to eq('initial')
             expect(binding).to have_labels({ prefix: nil, key: 'release', value: 'stable' })
             expect(binding).to have_annotations({ prefix: 'seriouseats.com', key: 'potato', value: 'fried' })
           end

--- a/spec/unit/actions/service_credential_binding_delete_spec.rb
+++ b/spec/unit/actions/service_credential_binding_delete_spec.rb
@@ -155,6 +155,15 @@ module VCAP::CloudController
       end
 
       RSpec.shared_examples 'blocking operation in progress' do
+        describe 'create initial' do
+          let(:last_operation_type) { 'create' }
+          let(:last_operation_state) { 'initial' }
+
+          it 'is blocking' do
+            expect(action.blocking_operation_in_progress?(binding)).to be_truthy
+          end
+        end
+
         describe 'delete in progress' do
           let(:last_operation_type) { 'delete' }
           let(:last_operation_state) { 'in progress' }

--- a/spec/unit/actions/service_credential_binding_key_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_key_create_spec.rb
@@ -49,7 +49,7 @@ module VCAP::CloudController
             expect(binding.name).to eq(name)
             expect(binding.credentials).to be_empty
             expect(binding.last_operation.type).to eq('create')
-            expect(binding.last_operation.state).to eq('in progress')
+            expect(binding.last_operation.state).to eq('initial')
             expect(binding).to have_labels({ prefix: nil, key: 'release', value: 'stable' })
             expect(binding).to have_annotations({ prefix: 'seriouseats.com', key: 'potato', value: 'fried' })
           end

--- a/spec/unit/actions/service_route_binding_create_spec.rb
+++ b/spec/unit/actions/service_route_binding_create_spec.rb
@@ -48,7 +48,7 @@ module VCAP::CloudController
             )
             expect(precursor.route_service_url).to be_nil
             expect(precursor.last_operation.type).to eq('create')
-            expect(precursor.last_operation.state).to eq('in progress')
+            expect(precursor.last_operation.state).to eq('initial')
           end
 
           context 'route is internal' do

--- a/spec/unit/actions/v3/service_instance_create_managed_spec.rb
+++ b/spec/unit/actions/v3/service_instance_create_managed_spec.rb
@@ -74,7 +74,7 @@ module VCAP::CloudController
           expect(instance.maintenance_info).to eq(maintenance_info)
 
           expect(instance.last_operation.type).to eq('create')
-          expect(instance.last_operation.state).to eq('in progress')
+          expect(instance.last_operation.state).to eq('initial')
 
           expect(instance).to have_annotations({ prefix: 'seriouseats.com', key: 'potato', value: 'fried' })
           expect(instance).to have_labels({ prefix: nil, key: 'release', value: 'stable' })

--- a/spec/unit/actions/v3/service_instance_delete_spec.rb
+++ b/spec/unit/actions/v3/service_instance_delete_spec.rb
@@ -24,6 +24,15 @@ module VCAP::CloudController
             end
           end
 
+          describe 'create initial' do
+            let(:last_operation_type) { 'create' }
+            let(:last_operation_state) { 'initial' }
+
+            it 'is blocking' do
+              expect(action.blocking_operation_in_progress?).to be_truthy
+            end
+          end
+
           describe 'delete in progress' do
             let(:last_operation_type) { 'delete' }
             let(:last_operation_state) { 'in progress' }

--- a/spec/unit/models/services/service_operation_shared.rb
+++ b/spec/unit/models/services/service_operation_shared.rb
@@ -24,6 +24,7 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     context 'when there is an operation' do
       it "returns true for 'succeeded' and 'failed' states" do
         [
+          { type: 'create', state: 'initial',     result: false },
           { type: 'create', state: 'in progress', result: false },
           { type: 'create', state: 'succeeded',   result: true },
           { type: 'create', state: 'failed',      result: true },
@@ -48,8 +49,9 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     end
 
     context 'when there is an operation' do
-      it "returns true only for 'in progress' states" do
+      it "returns true for 'initial' and 'in progress' states" do
         [
+          { type: 'create', state: 'initial',     result: true },
           { type: 'create', state: 'in progress', result: true },
           { type: 'create', state: 'succeeded',   result: false },
           { type: 'create', state: 'failed',      result: false },
@@ -66,6 +68,33 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     end
   end
 
+  describe '#create_initial?' do
+    context 'when there is no operation' do
+      it 'returns false' do
+        expect(service.create_initial?).to be false
+      end
+    end
+
+    context 'when there is an operation' do
+      it "returns true only for the 'create initial' state" do
+        [
+          { type: 'create', state: 'initial',     result: true },
+          { type: 'create', state: 'in progress', result: false },
+          { type: 'create', state: 'succeeded',   result: false },
+          { type: 'create', state: 'failed',      result: false },
+          { type: 'update', state: 'in progress', result: false },
+          { type: 'update', state: 'succeeded',   result: false },
+          { type: 'update', state: 'failed',      result: false },
+          { type: 'delete', state: 'in progress', result: false },
+          { type: 'delete', state: 'failed',      result: false },
+        ].each do |test|
+          update_operation(test[:type], test[:state])
+          expect(service.create_initial?).to be test[:result]
+        end
+      end
+    end
+  end
+
   describe '#create_in_progress?' do
     context 'when there is no operation' do
       it 'returns false' do
@@ -74,8 +103,9 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     end
 
     context 'when there is an operation' do
-      it "returns true only for the 'create in progress' state" do
+      it "returns true for the 'create initial' and 'create in progress' states" do
         [
+          { type: 'create', state: 'initial',     result: true },
           { type: 'create', state: 'in progress', result: true },
           { type: 'create', state: 'succeeded',   result: false },
           { type: 'create', state: 'failed',      result: false },
@@ -102,6 +132,7 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     context 'when there is an operation' do
       it "returns true only for the 'create succeeded' state" do
         [
+          { type: 'create', state: 'initial',     result: false },
           { type: 'create', state: 'in progress', result: false },
           { type: 'create', state: 'succeeded',   result: true },
           { type: 'create', state: 'failed',      result: false },
@@ -128,6 +159,7 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     context 'when there is an operation' do
       it "returns true only for the 'create failed' state" do
         [
+          { type: 'create', state: 'initial',     result: false },
           { type: 'create', state: 'in progress', result: false },
           { type: 'create', state: 'succeeded',   result: false },
           { type: 'create', state: 'failed',      result: true },
@@ -154,6 +186,7 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     context 'when there is an operation' do
       it "returns true only for the 'update in progress' state" do
         [
+          { type: 'create', state: 'initial',     result: false },
           { type: 'create', state: 'in progress', result: false },
           { type: 'create', state: 'succeeded',   result: false },
           { type: 'create', state: 'failed',      result: false },
@@ -180,6 +213,7 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     context 'when there is an operation' do
       it "returns true only for the 'update succeeded' state" do
         [
+          { type: 'create', state: 'initial',     result: false },
           { type: 'create', state: 'in progress', result: false },
           { type: 'create', state: 'succeeded',   result: false },
           { type: 'create', state: 'failed',      result: false },
@@ -206,6 +240,7 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     context 'when there is an operation' do
       it "returns true only for the 'update failed' state" do
         [
+          { type: 'create', state: 'initial',     result: false },
           { type: 'create', state: 'in progress', result: false },
           { type: 'create', state: 'succeeded',   result: false },
           { type: 'create', state: 'failed',      result: false },
@@ -232,6 +267,7 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     context 'when there is an operation' do
       it "returns true only for the 'delete in progress' state" do
         [
+          { type: 'create', state: 'initial',     result: false },
           { type: 'create', state: 'in progress', result: false },
           { type: 'create', state: 'succeeded',   result: false },
           { type: 'create', state: 'failed',      result: false },
@@ -258,6 +294,7 @@ RSpec.shared_examples 'a model including the ServiceOperationMixin' do |service_
     context 'when there is an operation' do
       it "returns true only for the 'delete failed' state" do
         [
+          { type: 'create', state: 'initial',     result: false },
           { type: 'create', state: 'in progress', result: false },
           { type: 'create', state: 'succeeded',   result: false },
           { type: 'create', state: 'failed',      result: false },


### PR DESCRIPTION
This change adds a new 'create initial' state to service operations to distinguish between requests that have not been responded to and operations that are being processed asynchronously by the broker.

The reasoning for this change is the following scenario:
```mermaid
sequenceDiagram
  participant Client
  participant Cloud Controller
  participant CCDB
  participant Some Routing Component
  participant Service Broker

  Client->>+Cloud Controller: create
  Cloud Controller->>CCDB: insert
  activate CCDB
  Cloud Controller->>+Some Routing Component: provision
  Note over Some Routing Component: some delay

  rect rgba(255, 0, 0, .2)
    Client->>+Cloud Controller: delete
    Cloud Controller->>+Some Routing Component: deprovision
    Some Routing Component->>Service Broker: #
    Service Broker-->>Some Routing Component: 410 Gone
    Some Routing Component-->>-Cloud Controller: #
    Cloud Controller->>-CCDB: delete
    deactivate CCDB
  end

  Some Routing Component->>Service Broker: provision (cont.)
  Service Broker-->>Some Routing Component: 201 Created
  Some Routing Component-->>-Cloud Controller: #
  Cloud Controller->>-CCDB: update
  Note over CCDB: already deleted!
```

When a creation is delayed for some reason (up to 60 seconds until the request times out), it is possible that an impatient client issues a deletion request in parallel that might lead to a situation where an instance is created by the service broker, but the Cloud Controller already removed it from its database. To mitigate this inconsistency, the Cloud Controller would need to trigger an orphan mitigation; but this is solely done within the [service client implementation](/cloudfoundry/cloud_controller_ng/blob/main/lib/services/service_brokers/v2/client.rb), i.e. only as a result of communication errors, not based on state inconsistencies.

The alternative approach implemented in this PR is the introduction of a new 'create initial' state that is set in `ServiceCredentialBindingAppCreate`, `ServiceCredentialBindingKeyCreate`, `ServiceRouteBindingCreate` and `ServiceInstanceCreateManaged`. In most cases the 'initial' state is semantically treated as 'in progress', but when checking for a blocking operation before accepting a delete request, it is treated as such and results in an error being reported to the client:
```mermaid
sequenceDiagram
  participant Client
  participant Cloud Controller
  participant CCDB
  participant Some Routing Component
  participant Service Broker

  Client->>+Cloud Controller: create
  Cloud Controller->>CCDB: insert
  activate CCDB
  Cloud Controller->>+Some Routing Component: provision
  Note over Some Routing Component: some delay

  rect rgba(255, 0, 0, .2)
    Client->>+Cloud Controller: delete
    Cloud Controller-->>-Client: 422 Unprocessable
  end

  Some Routing Component->>Service Broker: provision (cont.)
  Service Broker-->>Some Routing Component: 201 Created
  Some Routing Component-->>-Cloud Controller: #
  Cloud Controller->>-CCDB: update
  deactivate CCDB
```

The Open Service Broker API specification allows for delete requests being processed in parallel to create requests (which should semantically be treated as a cancel operation). This requirement is still fulfilled, but limited to create requests already accepted and asynchronously processed by the broker. So this change has no effect on the following scenario:
```mermaid
sequenceDiagram
  participant Client
  participant Cloud Controller
  participant CCDB
  participant Some Routing Component
  participant Service Broker

  Client->>+Cloud Controller: create
  Cloud Controller->>CCDB: insert
  activate CCDB
  Cloud Controller->>+Some Routing Component: provision
  Some Routing Component->>Service Broker: #
  Service Broker-->>Some Routing Component: 202 Accepted
  Some Routing Component-->>-Cloud Controller: #
  Cloud Controller->>+Some Routing Component: poll
  Note over Some Routing Component: some delay

  rect rgba(255, 0, 0, .2)
    Client->>+Cloud Controller: delete
    Cloud Controller->>+Some Routing Component: deprovision
    Some Routing Component->>Service Broker: #
    Service Broker-->>Some Routing Component: 202 Accepted
    Some Routing Component-->>-Cloud Controller: #
    Cloud Controller->>-CCDB: update
  end

  Some Routing Component->>Service Broker: poll (cont.)
  Note over Service Broker: last_operation now<br/>indicates the state of<br/>the deprovision request
  Service Broker-->>Some Routing Component: 200 OK
  Some Routing Component-->>-Cloud Controller: #
  Cloud Controller->>-CCDB: delete
  deactivate CCDB
```

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
