### PR TITLE
Fix pagination links in "List domains for an org" docs

### DIFF
--- a/docs/v3/source/includes/api_resources/_domains.erb
+++ b/docs/v3/source/includes/api_resources/_domains.erb
@@ -39,19 +39,19 @@
 }
  <% end %>
 
-<% content_for :paginated_list_of_domains do %>
+<% content_for :paginated_list_of_domains do |base_url| %>
 {
   "pagination": {
     "total_results": 3,
     "total_pages": 2,
     "first": {
-      "href": "https://api.example.org/v3/domains?page=1&per_page=2"
+      "href": "https://api.example.org<%= base_url %>?page=1&per_page=2"
     },
     "last": {
-      "href": "https://api.example.org/v3/domains?page=2&per_page=2"
+      "href": "https://api.example.org<%= base_url %>?page=2&per_page=2"
     },
     "next": {
-      "href": "https://api.example.org/v3/domains?page=2&per_page=2"
+      "href": "https://api.example.org<%= base_url %>?page=2&per_page=2"
     },
     "previous": null
   },

--- a/docs/v3/source/includes/resources/domains/_list_domains_for_an_org.md.erb
+++ b/docs/v3/source/includes/resources/domains/_list_domains_for_an_org.md.erb
@@ -18,7 +18,7 @@ Example Response
 HTTP/1.1 200 OK
 Content-Type: application/json
 
-<%= yield_content :paginated_list_of_domains, '/v3/organizations/:org_guid/domains' %>
+<%= yield_content :paginated_list_of_domains, '/v3/organizations/[guid]/domains' %>
 ```
 
 Retrieve all domains available in an organization for the current user. This will return unscoped domains


### PR DESCRIPTION
* A short explanation of the proposed change:
Fixes the pagination links in the docs for http://localhost:8000/#list-domains-for-an-organization.

* An explanation of the use cases your change solves
Helps clients better understand what to expect from this endpoint. 🙂 

* Links to any other associated PRs
N/A

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
