### PR TITLE
Revert json-schema to 2.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     json-diff (0.4.1)
-    json-schema (2.8.1)
+    json-schema (2.8.0)
       addressable (>= 2.4)
     json_pure (2.6.1)
     jsonpath (1.1.0)

--- a/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_v2.13_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'Service Broker API integration' do
       end
 
       context 'v6' do
-        let(:version) { 'draft' }
+        let(:version) { 'draft-06' }
 
         context 'when a broker catalog defines a service instance' do
           context 'with a valid create schema' do

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.10_spec.rb' => '27e81c4c540e39a4e4eac70c8efb14ba',
       'broker_api_v2.11_spec.rb' => '99e61dc50ceb635b09b3bd16901a4fa6',
       'broker_api_v2.12_spec.rb' => '4023dffdcaae014556dcdba9f7d206bb',
-      'broker_api_v2.13_spec.rb' => 'ceecc106d1a203002e277a37812b6df3',
+      'broker_api_v2.13_spec.rb' => '573bbe3234c33aeccb1f02399dffdfe5',
       'broker_api_v2.14_spec.rb' => 'a9fbd1d91bcc9c33c054c7854be1ab5a',
       'broker_api_v2.15_spec.rb' => 'c575fd37bc6dc8df4f773719ccef3288',
     }

--- a/spec/unit/lib/services/service_brokers/v2/schema_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/schema_spec.rb
@@ -36,7 +36,7 @@ module VCAP::Services::ServiceBrokers::V2
       end
 
       context 'when the schema is compliant to JSON Schema draft06' do
-        let(:version) { 'draft' }
+        let(:version) { 'draft-06' }
         let(:raw_schema) { { '$schema' => draft_schema } }
 
         it 'should be valid' do


### PR DESCRIPTION
Short term fix for #2677.

By reverting the `json-schema` gem to version 2.8.0, the correct name/link for [Draft 6](https://json-schema.org/specification-links.html#draft-6) will be used again.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
