### PR TITLE
Prefer Numerics in schema config over Floats

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -184,7 +184,7 @@ module VCAP::CloudController
             broker_client_timeout_seconds: Integer,
             broker_client_default_async_poll_interval_seconds: Integer,
             broker_client_max_async_poll_duration_minutes: Integer,
-            broker_client_async_poll_exponential_backoff_rate: Float,
+            broker_client_async_poll_exponential_backoff_rate: Numeric,
             optional(:uaa_client_name) => String,
             optional(:uaa_client_secret) => String,
             optional(:uaa_client_scope) => String,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -111,7 +111,7 @@ module VCAP::CloudController
             broker_client_timeout_seconds: Integer,
             broker_client_default_async_poll_interval_seconds: Integer,
             broker_client_max_async_poll_duration_minutes: Integer,
-            broker_client_async_poll_exponential_backoff_rate: Float,
+            broker_client_async_poll_exponential_backoff_rate: Numeric,
             optional(:uaa_client_name) => String,
             optional(:uaa_client_secret) => String,
             optional(:uaa_client_scope) => String,

--- a/spec/unit/lib/cloud_controller/config_spec.rb
+++ b/spec/unit/lib/cloud_controller/config_spec.rb
@@ -585,6 +585,60 @@ module VCAP::CloudController
       end
     end
 
+    describe 'broker_client_async_poll_exponential_backoff_rate' do
+      let(:cc_config_file) do
+        config = YAMLConfig.safe_load_file('config/cloud_controller.yml')
+        config['broker_client_async_poll_exponential_backoff_rate'] = backoff_rate
+
+        file = Tempfile.new('cc_config.yml')
+        file.write(YAML.dump(config))
+        file.close
+        file
+      end
+
+      let(:config) do
+        Config.load_from_file(cc_config_file, context: schema_context)
+      end
+
+      context 'worker schema' do
+        let(:schema_context) { :worker }
+        context 'when given an Integer' do
+          let(:backoff_rate) { 1 }
+
+          it 'succeeds' do
+            expect(config.get(:broker_client_async_poll_exponential_backoff_rate)).to eq 1
+          end
+        end
+
+        context 'when given a Float' do
+          let(:backoff_rate) { 1.0 }
+
+          it 'succeeds' do
+            expect(config.get(:broker_client_async_poll_exponential_backoff_rate)).to eq 1
+          end
+        end
+      end
+
+      context 'api schema' do
+        let(:schema_context) { :api }
+        context 'when given an Integer' do
+          let(:backoff_rate) { 1 }
+
+          it 'succeeds' do
+            expect(config.get(:broker_client_async_poll_exponential_backoff_rate)).to eq 1
+          end
+        end
+
+        context 'when given a Float' do
+          let(:backoff_rate) { 1.0 }
+
+          it 'succeeds' do
+            expect(config.get(:broker_client_async_poll_exponential_backoff_rate)).to eq 1
+          end
+        end
+      end
+    end
+
     describe '#kubernetes_ca_cert' do
       subject(:config_instance) { Config.new(test_config_hash.merge(k8s_config_hash)) }
 


### PR DESCRIPTION
* 'Float' will throw errors if an Integer is given to the config

Authored-by: Seth Boyles <sboyles@pivotal.io>

Passing an integer (e.g. 1) to the config results in a validation error.  See thread here: https://cloudfoundry.slack.com/archives/C07C04W4Q/p1647454358000839

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
