### PR TITLE
Use x86_64-darwin as platform in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,9 +543,7 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-darwin-14
-  x86_64-darwin-16
-  x86_64-darwin-17
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Maintaining specific Mac OS X versions in the Gemfile.lock is cumbersome, so let's just stick to a generic entry `x86_64-darwin`.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
