### PR TITLE
Send retry-after header when ratelimiting service-broker calls

### DIFF
--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -40,7 +40,10 @@ module VCAP::CloudController
         end
         if config.get(:max_concurrent_service_broker_requests) > 0
           CloudFoundry::Middleware::ServiceBrokerRequestCounter.instance.limit = config.get(:max_concurrent_service_broker_requests)
-          use CloudFoundry::Middleware::ServiceBrokerRateLimiter, logger: Steno.logger('cc.service_broker_rate_limiter')
+          use CloudFoundry::Middleware::ServiceBrokerRateLimiter, {
+            logger: Steno.logger('cc.service_broker_rate_limiter'),
+            broker_timeout_seconds: config.get(:broker_client_timeout_seconds),
+          }
         end
 
         if config.get(:security_event_logging, :enabled)

--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -77,10 +77,16 @@ module CloudFoundry
         !!env['cf.user_guid']
       end
 
+      def suggested_retry_time
+        Time.now.utc + rand(30..90).second
+      end
+
       def too_many_requests!(env, user_guid)
+        rate_limit_headers = {}
+        rate_limit_headers['Retry-After'] = suggested_retry_time
         @logger.info("Service broker concurrent rate limit exceeded for user '#{user_guid}'")
         message = rate_limit_error(env).to_json
-        [429, {}, [message]]
+        [429, rate_limit_headers, [message]]
       end
 
       def rate_limit_error(env)

--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -26,6 +26,7 @@ module CloudFoundry
       def initialize(app, opts)
         @app                               = app
         @logger                            = opts[:logger]
+        @broker_timeout_seconds            = opts[:broker_timeout_seconds]
         @request_counter = ServiceBrokerRequestCounter.instance
       end
 
@@ -78,7 +79,8 @@ module CloudFoundry
       end
 
       def suggested_retry_time
-        Time.now.utc + rand(30..90).second
+        delay_range = @broker_timeout_seconds * 0.5..@broker_timeout_seconds * 1.5
+        Time.now.utc + rand(delay_range).to_i.second
       end
 
       def too_many_requests!(env, user_guid)

--- a/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
@@ -105,6 +105,7 @@ module VCAP::CloudController
             expect(CloudFoundry::Middleware::ServiceBrokerRateLimiter).to have_received(:new).with(
               anything,
               logger: instance_of(Steno::Logger),
+              broker_timeout_seconds: TestConfig.config_instance.get(:broker_client_timeout_seconds)
             )
           end
         end

--- a/spec/unit/middleware/service_broker_rate_limiter_spec.rb
+++ b/spec/unit/middleware/service_broker_rate_limiter_spec.rb
@@ -60,13 +60,14 @@ module CloudFoundry
           context 'when the path is /v2/*' do
             let(:path_info) { '/v2/service_instances' }
             it 'formats the response error in v2 format' do
-              _, _, body = middleware.call(user_env)
+              _, response_headers, body = middleware.call(user_env)
               json_body = JSON.parse(body.first)
               expect(json_body).to include(
                 'code' => 10016,
                 'description' => 'Service broker concurrent request limit exceeded',
                 'error_code' => 'CF-ServiceBrokerRateLimitExceeded',
               )
+              expect(response_headers['Retry-After']).to be_within(90.second).of Time.now
             end
           end
 
@@ -74,13 +75,14 @@ module CloudFoundry
             let(:path_info) { '/v3/service_instances' }
 
             it 'formats the response error in v3 format' do
-              _, _, body = middleware.call(user_env)
+              _, response_headers, body = middleware.call(user_env)
               json_body = JSON.parse(body.first)
               expect(json_body['errors'].first).to include(
                 'code' => 10016,
                 'detail' => 'Service broker concurrent request limit exceeded',
                 'title' => 'CF-ServiceBrokerRateLimitExceeded',
               )
+              expect(response_headers['Retry-After']).to be_within(90.second).of Time.now
             end
           end
         end


### PR DESCRIPTION
* A short explanation of the proposed change:

This adds a Retry-After header to responses sent by the `ServiceBrokerRateLimiter`, which already rate limits users who make too many concurrent requests to endpoints associated with the six API resources below:
* v2/service_instances
* v2/service_bindings
* v2/service_keys
* v3/service_instances
* v3/service_credential_bindings
* v3/service_route_binding

The new header suggests an absolute retry time between 30 and 90 seconds in the future (a time within this range is selected at random at the time of the call).

* An explanation of the use cases your change solves

 This addresses an anomaly whereby this rate limiter does not include such a header while other rate limiters in the Cloud Controller do, and will help clients (some of whom immediately attempt retries) to avoid getting themselves rate limited.

* Related pull requests

Docs: https://github.com/cloudfoundry/docs-running-cf/pull/104

* Some background

While working on this change I generated a heatmap showing response times for endpoints for the above resources from a month of from logs from a large CF foundation that is in heavy use. See screenshot below.

![Screenshot 2022-03-22 at 09 42 55](https://user-images.githubusercontent.com/20523607/159452442-119b9b1d-857c-431f-a5e5-2cacf949c7ee.png)

The overwhelming majority of responses occur in less than one second. For three of the API resources responses sometimes take up to 60 seconds, and for one (/v2/service_instances) this exceptionally takes up to 90 seconds (though we're talking about <10 requests out of several million).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
