### PR TITLE
Install Ruby version inside actions job based on project

### DIFF
--- a/.github/workflows/composite/setup/action.yml
+++ b/.github/workflows/composite/setup/action.yml
@@ -1,0 +1,43 @@
+name: "setup"
+description: "Configure Ubuntu to run Cloud_Controller_NG and its tests"
+
+inputs:
+  BOSH_CLI_VERSION:
+    description: "Bosh CLI Version"
+    required: true
+    default: 6.4.17
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v2
+    - run: |
+        sudo apt-get update && \
+        sudo apt-get -y install \
+        build-essential \
+        curl \
+        debconf-utils \
+        git \
+        libcurl4-openssl-dev \
+        libpq-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        libxml2-dev \
+        libxslt-dev \
+        libyaml-dev \
+        libv8-dev \
+        software-properties-common \
+        unzip \
+        wget \
+        zip \
+        zlib1g-dev
+        
+        sudo wget -O /usr/local/bin/bosh https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${{ inputs.BOSH_CLI_VERSION }}-linux-amd64 && sudo chmod +x /usr/local/bin/bosh
+      shell: bash
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+    - name: Install dependencies
+      run: bundle install
+      shell: bash

--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -1,0 +1,33 @@
+name: Docs Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs_test.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs_test.yml'
+
+jobs:
+  test_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/workflows/composite/setup
+      - name: Install Docs Dependencies
+        run: bundle install
+        working-directory: docs/v3
+      - name: Run docs tests
+        run: bundle exec rake check_doc_links
+      - uses: ravsamhq/notify-slack-action@v1.1
+        if: github.event_name == 'push'
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure' # default is 'success,failure,warnings'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,20 +1,22 @@
 name: Unit Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   rubocop:
     runs-on: ubuntu-latest
-    container:
-      image: "cloudfoundry/capi:ruby-units"
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: bundle install
+    - uses: actions/checkout@v3
+    - uses: ./.github/workflows/composite/setup
     - name: Run Rubocop
       run: bundle exec rake rubocop
     - uses: ravsamhq/notify-slack-action@v1.1
@@ -24,18 +26,29 @@ jobs:
         notify_when: 'failure' # default is 'success,failure,warnings'
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+
   test_postgres:
     runs-on: ubuntu-latest
-    container:
-      image: "cloudfoundry/capi:ruby-units"
+    strategy:
+      matrix:
+        image: ["postgres:10", "postgres:14"]
+    services:
+      postgres:
+        image: ${{ matrix.image }}
+        env:
+          POSTGRES_PASSWORD: rootpassword
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: bundle install
-    - name: Setup PostgreSQL
-      run: service postgresql restart
+    - uses: actions/checkout@v3
+    - uses: ./.github/workflows/composite/setup
     - name: Run tests
-      run: DB=postgres bundle exec rake spec:all
+      run: DB=postgres POSTGRES_CONNECTION_PREFIX="postgres://postgres:rootpassword@localhost:5432" bundle exec rake spec:all
     - uses: ravsamhq/notify-slack-action@v1.1
       if: github.event_name == 'push'
       with:
@@ -43,18 +56,24 @@ jobs:
         notify_when: 'failure' # default is 'success,failure,warnings'
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+
   test_mysql:
     runs-on: ubuntu-latest
-    container:
-      image: "cloudfoundry/capi:ruby-units"
+    strategy:
+      matrix:
+        image: ["mysql:5.7", "mysql:8.0"]
+    services:
+      mysql:
+        image: ${{ matrix.image }}
+        env:
+          MYSQL_DATABASE: cc_test
+          MYSQL_ROOT_PASSWORD: password
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        ports:
+          - 3306:3306
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: bundle install
-    - name: Setup MySQL
-      run: |
-        find /var/lib/mysql/mysql -exec touch -c -a {} +
-        service mysql restart
+    - uses: actions/checkout@v3
+    - uses: ./.github/workflows/composite/setup
     - name: Run tests
       run: DB=mysql bundle exec rake spec:all
     - uses: ravsamhq/notify-slack-action@v1.1
@@ -64,43 +83,3 @@ jobs:
         notify_when: 'failure' # default is 'success,failure,warnings'
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-  test_mysql8:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-    - name: Setup MySQL
-      run: |
-        sudo systemctl start mysql.service
-    - name: Run tests
-      run: DB=mysql MYSQL_CONNECTION_PREFIX=mysql2://root:root@localhost:3306 bundle exec rake spec:all
-    - uses: ravsamhq/notify-slack-action@v1.1
-      if: github.event_name == 'push'
-      with:
-        status: ${{ job.status }}
-        notify_when: 'failure' # default is 'success,failure,warnings'
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-  test_docs:
-    runs-on: ubuntu-latest
-    container:
-      image: "cloudfoundry/capi:rc-docs"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: |
-          bundle install
-          cd docs/v3
-          bundle install
-          cd -
-      - name: Run docs tests
-        run: bundle exec rake check_doc_links
-      - uses: ravsamhq/notify-slack-action@v1.1
-        if: github.event_name == 'push'
-        with:
-          status: ${{ job.status }}
-          notify_when: 'failure' # default is 'success,failure,warnings'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - errors/**/*
     - lib/diego/bbs/models/**/*
     - lib/logcache/v2/**/*
+    - vendor/bundle/**/*
 
 Bundler/DuplicatedGem:
   Enabled: false

--- a/docs/v3/Gemfile.lock
+++ b/docs/v3/Gemfile.lock
@@ -168,4 +168,4 @@ DEPENDENCIES
   sass
 
 BUNDLED WITH
-   2.2.32
+   2.3.5


### PR DESCRIPTION
With this change one does not need to maintain own OCI images for github
actions. Each run is based on a stock ubuntu image which is setup
acordingly at runtime of a job. This makes it possible to run the unit
tests with exactly what is defined in cloud_controller_ng and not have
to sync a OCI image to the state of the cloud_controller_ng project.

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
