### PR TITLE
Fix state handling for POST /v3/service_instances/:guid/relationships/shared_spaces

### DIFF
--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -89,11 +89,13 @@ module VCAP::CloudController
     end
 
     def validate_service_instance_state!(service_instance)
-      raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceNotFound', service_instance.name) if service_instance.create_failed?
-
-      error!('The service instance is getting deleted or its deletion failed.') if service_instance.delete_in_progress? ||
-        service_instance.delete_failed?
-      error!('Service instance is currently being created. It can be shared after its creation succeeded.') if service_instance.create_in_progress?
+      if service_instance.create_failed?
+        raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceNotFound', service_instance.name)
+      elsif service_instance.create_in_progress?
+        error!('Service instance is currently being created. It can be shared after its creation succeeded.')
+      elsif service_instance.delete_in_progress?
+        error!('The service instance is getting deleted.')
+      end
     end
   end
 end

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -327,7 +327,7 @@ module VCAP::CloudController
         it 'raises' do
           expect {
             service_instance_share.create(service_instance, [target_space1], user_audit_info)
-          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'The service instance is getting deleted or its deletion failed.')
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'The service instance is getting deleted.')
         end
       end
 
@@ -336,10 +336,9 @@ module VCAP::CloudController
           service_instance.save_with_new_operation({}, { type: 'delete', state: 'failed' })
         end
 
-        it 'raises' do
-          expect {
-            service_instance_share.create(service_instance, [target_space1], user_audit_info)
-          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'The service instance is getting deleted or its deletion failed.')
+        it 'creates the share' do
+          shared_instance = service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          expect(shared_instance.shared_spaces.length).to eq 1
         end
       end
     end

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -248,6 +248,100 @@ module VCAP::CloudController
           end
         end
       end
+
+      context 'when the last operation state of the service instance is create in progress' do
+        before do
+          service_instance.save_with_new_operation({}, { type: 'create', state: 'in progress' })
+        end
+
+        it 'raises' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'Service instance is currently being created. It can be shared after its creation succeeded.')
+        end
+      end
+
+      context 'when the last operation state of the service instance is create succeeded' do
+        before do
+          service_instance.save_with_new_operation({}, { type: 'create', state: 'succeeded' })
+        end
+
+        it 'creates the share' do
+          shared_instance = service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          expect(shared_instance.shared_spaces.length).to eq 1
+        end
+      end
+
+      context 'when the last operation state of the service instance is create failed' do
+        before do
+          service_instance.save_with_new_operation({}, { type: 'create', state: 'failed' })
+        end
+
+        it 'raises' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          }.to raise_error CloudController::Errors::ApiError do |err|
+            expect(err.name).to eq('ServiceInstanceNotFound')
+          end
+        end
+      end
+
+      context 'when the last operation state of the service instance is update in progress' do
+        before do
+          service_instance.save_with_new_operation({}, { type: 'update', state: 'in progress' })
+        end
+
+        it 'creates the share' do
+          shared_instance = service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          expect(shared_instance.shared_spaces.length).to eq 1
+        end
+      end
+
+      context 'when the last operation state of the service instance is update succeeded' do
+        before do
+          service_instance.save_with_new_operation({}, { type: 'update', state: 'succeeded' })
+        end
+
+        it 'creates the share' do
+          shared_instance = service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          expect(shared_instance.shared_spaces.length).to eq 1
+        end
+      end
+
+      context 'when the last operation state of the service instance is update failed' do
+        before do
+          service_instance.save_with_new_operation({}, { type: 'update', state: 'failed' })
+        end
+
+        it 'creates the share' do
+          shared_instance = service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          expect(shared_instance.shared_spaces.length).to eq 1
+        end
+      end
+
+      context 'when the last operation state of the service instance is delete in progress' do
+        before do
+          service_instance.save_with_new_operation({}, { type: 'delete', state: 'in progress' })
+        end
+
+        it 'raises' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'The service instance is getting deleted or its deletion failed.')
+        end
+      end
+
+      context 'when the last operation state of the service instance is delete failed' do
+        before do
+          service_instance.save_with_new_operation({}, { type: 'delete', state: 'failed' })
+        end
+
+        it 'raises' do
+          expect {
+            service_instance_share.create(service_instance, [target_space1], user_audit_info)
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'The service instance is getting deleted or its deletion failed.')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

A short explanation of the proposed change:
* Reject request when state of service instance is `create in progress`, `create failed`, `delete in progress`

Links to any other associated PRs
* This PR solves the described issues according to #2713

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
