### PR TITLE
Fix sporadic test errors due to serialization of GUIDs

### DIFF
--- a/spec/unit/actions/buildpack_delete_spec.rb
+++ b/spec/unit/actions/buildpack_delete_spec.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController
 
           job = Delayed::Job.last
           expect(job.handler).to include('VCAP::CloudController::Jobs::Runtime::BlobstoreDelete')
-          expect(job.handler).to include("key: #{buildpack.key}")
+          expect(job.handler).to match(/key: ['"]?#{buildpack.key}/)
           expect(job.handler).to include('buildpack_blobstore')
           expect(job.queue).to eq(Jobs::Queues.generic)
           expect(job.guid).not_to be_nil

--- a/spec/unit/actions/package_delete_spec.rb
+++ b/spec/unit/actions/package_delete_spec.rb
@@ -63,7 +63,7 @@ module VCAP::CloudController
 
             job = Delayed::Job.last
             expect(job.handler).to include('VCAP::CloudController::Jobs::Runtime::BlobstoreDelete')
-            expect(job.handler).to include("key: #{package.guid}")
+            expect(job.handler).to match(/key: ['"]?#{package.guid}/)
             expect(job.handler).to include('package_blobstore')
             expect(job.queue).to eq(Jobs::Queues.generic)
             expect(job.guid).not_to be_nil


### PR DESCRIPTION
A GUID with a leading zero is serialized as `'GUID'`, a GUID with any other character at the beginning is serialized as `GUID`.

This led to sporadic test errors, with e.g. the following message:
```
expected "<...>key: '09a609b0-9d4d-4ca8-bac7-6c28278d5e85'<...>" to
include "key: 09a609b0-9d4d-4ca8-bac7-6c28278d5e85"
```

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
