### PR TITLE
Make telemetry_log_path config optional

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -70,7 +70,7 @@ module VCAP::CloudController
 
             log_audit_events: bool,
 
-            telemetry_log_path: String, # path to log telemetry to, /dev/null to disable
+            optional(:telemetry_log_path) => String, # path to log telemetry to, omit to disable
 
             pid_filename: String, # Pid filename to use
 

--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -156,8 +156,9 @@ module VCAP::CloudController
       return if @setup_telemetry_logging
 
       @setup_telemetry_logging = true
-      logger = ActiveSupport::Logger.new(@config.get(:telemetry_log_path))
-      TelemetryLogger.init(logger)
+
+      telemetry_log_path = @config.get(:telemetry_log_path)
+      TelemetryLogger.init(ActiveSupport::Logger.new(telemetry_log_path)) unless telemetry_log_path.nil?
     end
 
     def setup_db

--- a/lib/cloud_controller/telemetry_logger.rb
+++ b/lib/cloud_controller/telemetry_logger.rb
@@ -26,6 +26,8 @@ module VCAP::CloudController
       attr_reader :logger
 
       def emit(event_name, entries, raw_entries={})
+        return if logger.nil?
+
         converted_entries = raw_entries.merge(raw_entries.select { |k, v|
           INTEGER_FIELDS.include?(k)
         }.transform_values(&:to_i))

--- a/spec/unit/lib/cloud_controller/telemetry_logger_spec.rb
+++ b/spec/unit/lib/cloud_controller/telemetry_logger_spec.rb
@@ -9,6 +9,20 @@ module VCAP::CloudController
       TelemetryLogger.init(ActiveSupport::Logger.new(file.path))
     end
 
+    context 'telemetry logging disabled' do
+      # To test an uninitialized TelemetryLogger we use a dedicated subclass here.
+      class DisabledTelemetryLogger < TelemetryLogger; end
+
+      it 'still allows emit to be called without failing' do
+        expect {
+          DisabledTelemetryLogger.internal_emit(
+            'some-event',
+            { 'key' => 'value' },
+          )
+        }.not_to raise_error
+      end
+    end
+
     it 'logs job name, timestamp, and event, anonymizing by default' do
       TelemetryLogger.v3_emit(
         'some-event',


### PR DESCRIPTION
- Setting the path to `/dev/null` is inefficient as log data is still prepared and formatted.
- Create the `ActiveSupport::Logger` only when path is provided.
- When no logger is set in `TelemetryLogger`, immediately return inside the `emit` method.

See also cloudfoundry/capi-release#233

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
