### PR TITLE
Fix state handling for GET /v3/service_instances/:guid/parameters

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -204,10 +204,7 @@ class ServiceInstancesV3Controller < ApplicationController
     service_instance_not_found! unless service_instance && can_read_service_instance?(service_instance)
     unauthorized! unless can_read_space?(service_instance.space)
 
-    if service_instance.managed_instance?
-      service_instance_not_found! if service_instance.create_failed?
-      delete_in_progress! if service_instance.delete_in_progress?
-    end
+    service_instance_not_found! if service_instance.managed_instance? && service_instance.create_failed?
 
     begin
       render status: :ok, json: ServiceInstanceRead.new.fetch_parameters(service_instance)
@@ -416,9 +413,5 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def operation_in_progress!
     unprocessable!('There is an operation in progress for the service instance.')
-  end
-
-  def delete_in_progress!
-    unprocessable!('The service instance is getting deleted.')
   end
 end

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -204,6 +204,11 @@ class ServiceInstancesV3Controller < ApplicationController
     service_instance_not_found! unless service_instance && can_read_service_instance?(service_instance)
     unauthorized! unless can_read_space?(service_instance.space)
 
+    if service_instance.managed_instance?
+      service_instance_not_found! if service_instance.create_failed?
+      delete_in_progress! if service_instance.delete_in_progress?
+    end
+
     begin
       render status: :ok, json: ServiceInstanceRead.new.fetch_parameters(service_instance)
     rescue ServiceInstanceRead::NotSupportedError
@@ -411,5 +416,9 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def operation_in_progress!
     unprocessable!('There is an operation in progress for the service instance.')
+  end
+
+  def delete_in_progress!
+    unprocessable!('The service instance is getting deleted.')
   end
 end

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -686,6 +686,111 @@ RSpec.describe 'V3 service instances' do
       end
     end
 
+    context 'when the last operation state of the service instance is create in progress' do
+      before do
+        instance.save_with_new_operation({}, { type: 'create', state: 'in progress' })
+      end
+
+      it 'fails with an explanatory error' do
+        get "/v3/service_instances/#{instance.guid}/parameters", nil, admin_headers
+        expect(last_response).to have_status_code(409)
+        expect(parsed_response['errors']).to include(include({
+           'title' => 'CF-AsyncServiceInstanceOperationInProgress',
+           'code' => 60016,
+         }))
+      end
+    end
+
+    context 'when the last operation state of the service instance is create succeeded' do
+      before do
+        instance.save_with_new_operation({}, { type: 'create', state: 'succeeded' })
+      end
+
+      it 'returns the parameters' do
+        get "/v3/service_instances/#{instance.guid}/parameters", nil, admin_headers
+        expect(last_response).to have_status_code(200)
+      end
+    end
+
+    context 'when the last operation state of the service instance is create failed' do
+      before do
+        instance.save_with_new_operation({}, { type: 'create', state: 'failed' })
+      end
+
+      it 'fails with an explanatory error' do
+        get "/v3/service_instances/#{instance.guid}/parameters", nil, admin_headers
+        expect(last_response).to have_status_code(404)
+        expect(parsed_response['errors']).to include(include({
+           'title' => 'CF-ResourceNotFound',
+           'code' => 10010,
+         }))
+      end
+    end
+
+    context 'when the last operation state of the service instance is update in progress' do
+      before do
+        instance.save_with_new_operation({}, { type: 'update', state: 'in progress' })
+      end
+
+      it 'fails with an explanatory error' do
+        get "/v3/service_instances/#{instance.guid}/parameters", nil, admin_headers
+        expect(last_response).to have_status_code(409)
+        expect(parsed_response['errors']).to include(include({
+           'title' => 'CF-AsyncServiceInstanceOperationInProgress',
+           'code' => 60016,
+         }))
+      end
+    end
+
+    context 'when the last operation state of the service instance is update succeeded' do
+      before do
+        instance.save_with_new_operation({}, { type: 'update', state: 'succeeded' })
+      end
+
+      it 'returns the parameters' do
+        get "/v3/service_instances/#{instance.guid}/parameters", nil, admin_headers
+        expect(last_response).to have_status_code(200)
+      end
+    end
+
+    context 'when the last operation state of the service instance is update failed' do
+      before do
+        instance.save_with_new_operation({}, { type: 'update', state: 'failed' })
+      end
+
+      it 'returns the parameters' do
+        get "/v3/service_instances/#{instance.guid}/parameters", nil, admin_headers
+        expect(last_response).to have_status_code(200)
+      end
+    end
+
+    context 'when the last operation state of the service instance is delete in progress' do
+      before do
+        instance.save_with_new_operation({}, { type: 'delete', state: 'in progress' })
+      end
+
+      it 'fails with an explanatory error' do
+        get "/v3/service_instances/#{instance.guid}/parameters", nil, admin_headers
+        expect(last_response).to have_status_code(422)
+        expect(parsed_response['errors']).to include(include({
+           'title' => 'CF-UnprocessableEntity',
+           'code' => 10008,
+           'detail' => 'The service instance is getting deleted.'
+         }))
+      end
+    end
+
+    context 'when the last operation state of the service instance is delete failed' do
+      before do
+        instance.save_with_new_operation({}, { type: 'delete', state: 'failed' })
+      end
+
+      it 'returns the parameters' do
+        get "/v3/service_instances/#{instance.guid}/parameters", nil, admin_headers
+        expect(last_response).to have_status_code(200)
+      end
+    end
+
     context 'when the instance is user-provided' do
       it 'responds with 404' do
         upsi = VCAP::CloudController::UserProvidedServiceInstance.make(space: space)

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -771,11 +771,10 @@ RSpec.describe 'V3 service instances' do
 
       it 'fails with an explanatory error' do
         get "/v3/service_instances/#{instance.guid}/parameters", nil, admin_headers
-        expect(last_response).to have_status_code(422)
+        expect(last_response).to have_status_code(409)
         expect(parsed_response['errors']).to include(include({
-           'title' => 'CF-UnprocessableEntity',
-           'code' => 10008,
-           'detail' => 'The service instance is getting deleted.'
+           'title' => 'CF-AsyncServiceInstanceOperationInProgress',
+           'code' => 60016,
          }))
       end
     end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

A short explanation of the proposed change:
- Return `ServiceInstanceNotFound` when service instance state is `create failed`

An explanation of the use cases your change solves
* This PR solves the described issues according to https://github.com/cloudfoundry/cloud_controller_ng/issues/2713

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
