### PR TITLE
Ensure route destinations have consistent order

### DIFF
--- a/app/presenters/v3/route_destinations_presenter.rb
+++ b/app/presenters/v3/route_destinations_presenter.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController::Presenters::V3
     end
 
     def presented_destinations
-      destinations.map do |route_mapping|
+      destinations.sort_by { |d| [d.created_at, d.guid] }.map do |route_mapping|
         RouteDestinationPresenter.new(route_mapping).destination_hash
       end
     end

--- a/spec/unit/presenters/v3/route_destinations_presenter_spec.rb
+++ b/spec/unit/presenters/v3/route_destinations_presenter_spec.rb
@@ -16,7 +16,8 @@ module VCAP::CloudController::Presenters::V3
         app_port: 1234,
         route: route,
         process_type: process.type,
-        weight: 55
+        weight: 55,
+        created_at: 10.minutes.ago
       )
     end
 
@@ -26,7 +27,8 @@ module VCAP::CloudController::Presenters::V3
         app_port: 5678,
         route: route,
         process_type: 'other-process',
-        weight: 45
+        weight: 45,
+        created_at: 5.minutes.ago
       )
     end
 
@@ -57,6 +59,14 @@ module VCAP::CloudController::Presenters::V3
         expect(result[:destinations][1][:port]).to eq(route_mapping2.app_port)
         expect(result[:destinations][1][:weight]).to eq(route_mapping2.weight)
         expect(result[:destinations][1][:protocol]).to eq(route_mapping2.protocol)
+      end
+
+      context 'ordering' do
+        subject(:presenter) { RouteDestinationsPresenter.new(route.route_mappings.reverse, route: route) }
+        it 'orders the destinations by guid' do
+          expect(result[:destinations][0][:guid]).to eq(route_mapping.guid)
+          expect(result[:destinations][1][:guid]).to eq(route_mapping2.guid)
+        end
       end
 
       context 'links' do


### PR DESCRIPTION
A lot of our route destinations assume consistent ordering from the DB, but no code actually enforces it, resulting in lots of flakes like this: https://ci.cake.capi.land/teams/main/pipelines/capi/jobs/cc-unit-tests/builds/740

This does a simple in-memory sort on the presenter.


* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
