### PR TITLE
Fix flaky route destinations tests

### DIFF
--- a/spec/request/route_destinations_spec.rb
+++ b/spec/request/route_destinations_spec.rb
@@ -730,6 +730,21 @@ RSpec.describe 'Route Destinations Request' do
     end
 
     context 'permissions' do
+      let(:params) do
+        {
+          destinations: [
+            {
+              app: {
+                guid: app_model.guid,
+                process: {
+                  type: 'web'
+                }
+              },
+              protocol: 'http2'
+            }
+          ]
+        }
+      end
       let(:api_call) { lambda { |user_headers| patch "/v3/routes/#{route.guid}/destinations", params.to_json, user_headers } }
       let(:response_json) do
         {
@@ -740,18 +755,6 @@ RSpec.describe 'Route Destinations Request' do
                 guid: app_model.guid,
                 process: {
                   type: 'web'
-                }
-              },
-              weight: nil,
-              port: 8080,
-              protocol: 'http1'
-            },
-            {
-              guid: UUID_REGEX,
-              app: {
-                guid: app_model.guid,
-                process: {
-                  type: 'worker'
                 }
               },
               weight: nil,
@@ -806,8 +809,7 @@ RSpec.describe 'Route Destinations Request' do
         it 'replaces all destinations on the route' do
           patch "/v3/routes/#{route.guid}/destinations", params.to_json, admin_header
           expect(last_response.status).to eq(200)
-          expect(parsed_response['destinations'][0]['protocol']).to eq('http1')
-          expect(parsed_response['destinations'][1]['protocol']).to eq('http2')
+          expect(parsed_response['destinations'].map { |d| d['protocol'] }).to contain_exactly('http1', 'http2')
         end
       end
 


### PR DESCRIPTION
These tests would sometimes fail because the DB didn't return the route
destination objects in a deterministic order. Since the ordering isn't
part of the behavior under test, we modified them to not care about
order.

Co-authored-by: Seth Boyles <sboyles@pivotal.io>
Co-authored-by: Tom Viehman <tviehman@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
