### PR TITLE
Fix state handling for POST /v3/spaces/:guid/actions/apply_manifest

### DIFF
--- a/app/actions/app_apply_manifest.rb
+++ b/app/actions/app_apply_manifest.rb
@@ -195,9 +195,9 @@ module VCAP::CloudController
     def validate_service_instance!(service_instance)
       service_instance_not_found!(manifest_service_binding.name) unless service_instance
 
-      if service_instance.type == 'managed_service_instance'
+      if service_instance.managed_instance?
         service_instance_not_found!(service_instance.name) if service_instance.create_failed?
-        delete_in_progress_or_failed!(service_instance) if service_instance.last_operation_is_delete?
+        delete_in_progress!(service_instance) if service_instance.delete_in_progress?
       end
     end
 
@@ -224,8 +224,8 @@ module VCAP::CloudController
       raise CloudController::Errors::NotFound.new_from_details('ResourceNotFound', "Service instance '#{name}' not found")
     end
 
-    def delete_in_progress_or_failed!(service_instance)
-      error_message = 'The service instance is getting deleted or its deletion failed. Therefore, no binding can be created.'
+    def delete_in_progress!(service_instance)
+      error_message = 'The service instance is getting deleted. Therefore, no binding can be created.'
       raise_binding_error!(service_instance, error_message)
     end
 

--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -56,6 +56,7 @@ module VCAP::CloudController
           service_not_bindable! unless service_instance.service_plan.bindable?
           service_not_available! unless service_instance.service_plan.active?
           volume_mount_not_enabled! if service_instance.volume_service? && !volume_mount_services_enabled
+          service_instance_not_found! if service_instance.create_failed?
           operation_in_progress! if service_instance.operation_in_progress?
         end
       end
@@ -82,6 +83,10 @@ module VCAP::CloudController
 
       def operation_in_progress!
         raise UnprocessableCreate.new('There is an operation in progress for the service instance')
+      end
+
+      def service_instance_not_found!
+        raise UnprocessableCreate.new('Service instance not found')
       end
 
       def app_is_required!

--- a/spec/unit/actions/app_apply_manifest_spec.rb
+++ b/spec/unit/actions/app_apply_manifest_spec.rb
@@ -931,8 +931,31 @@ module VCAP::CloudController
 /For service 'si-name': A binding failed to be deleted. Resolve the issue with this binding before retrying this operation./)
                 end
               end
+            end
 
-              context 'when the last operation state of the service instance is create failed' do
+            context 'different service instance states' do
+              context 'when the last operation state is create succeeded' do
+                before do
+                  service_instance.save_with_new_operation({}, { type: 'create', state: 'succeeded' })
+                end
+
+                it 'creates the binding' do
+                  service_binding_1 = instance_double(ServiceBinding)
+                  service_binding_2 = instance_double(ServiceBinding)
+
+                  allow(service_cred_binding_create).to receive(:precursor).and_return(
+                    service_binding_1,
+                    service_binding_2,
+                    )
+
+                  app_apply_manifest.apply(app.guid, message)
+
+                  expect(service_cred_binding_create).to have_received(:bind).with(service_binding_1, parameters: nil)
+                  expect(service_cred_binding_create).to have_received(:bind).with(service_binding_2, parameters: { 'foo' => 'bar' })
+                end
+              end
+
+              context 'when the last operation state is create failed' do
                 before do
                   service_instance.save_with_new_operation({}, { type: 'create', state: 'failed' })
                 end
@@ -941,11 +964,53 @@ module VCAP::CloudController
                   expect {
                     app_apply_manifest.apply(app.guid, message)
                   }.to raise_error(CloudController::Errors::NotFound,
-                                   "Service instance '#{service_instance.name}' not found")
+                     "Service instance '#{service_instance.name}' not found")
                 end
               end
 
-              context 'when the last operation state of the service instance is delete in progress' do
+              context 'when the last operation state is update succeeded' do
+                before do
+                  service_instance.save_with_new_operation({}, { type: 'update', state: 'succeeded' })
+                end
+
+                it 'creates the binding' do
+                  service_binding_1 = instance_double(ServiceBinding)
+                  service_binding_2 = instance_double(ServiceBinding)
+
+                  allow(service_cred_binding_create).to receive(:precursor).and_return(
+                    service_binding_1,
+                    service_binding_2,
+                    )
+
+                  app_apply_manifest.apply(app.guid, message)
+
+                  expect(service_cred_binding_create).to have_received(:bind).with(service_binding_1, parameters: nil)
+                  expect(service_cred_binding_create).to have_received(:bind).with(service_binding_2, parameters: { 'foo' => 'bar' })
+                end
+              end
+
+              context 'when the last operation state is update failed' do
+                before do
+                  service_instance.save_with_new_operation({}, { type: 'update', state: 'failed' })
+                end
+
+                it 'creates the binding' do
+                  service_binding_1 = instance_double(ServiceBinding)
+                  service_binding_2 = instance_double(ServiceBinding)
+
+                  allow(service_cred_binding_create).to receive(:precursor).and_return(
+                    service_binding_1,
+                    service_binding_2,
+                    )
+
+                  app_apply_manifest.apply(app.guid, message)
+
+                  expect(service_cred_binding_create).to have_received(:bind).with(service_binding_1, parameters: nil)
+                  expect(service_cred_binding_create).to have_received(:bind).with(service_binding_2, parameters: { 'foo' => 'bar' })
+                end
+              end
+
+              context 'when the last operation state is delete in progress' do
                 before do
                   service_instance.save_with_new_operation({}, { type: 'delete', state: 'in progress' })
                 end
@@ -954,20 +1019,28 @@ module VCAP::CloudController
                   expect {
                     app_apply_manifest.apply(app.guid, message)
                   }.to raise_error(AppApplyManifest::ServiceBindingError,
-                                   "For service '#{service_instance.name}': The service instance is getting deleted or its deletion failed. Therefore, no binding can be created.")
+                     "For service '#{service_instance.name}': The service instance is getting deleted. Therefore, no binding can be created.")
                 end
               end
 
-              context 'when the last operation state of the service instance is delete failed' do
+              context 'when the last operation state is delete failed' do
                 before do
                   service_instance.save_with_new_operation({}, { type: 'delete', state: 'failed' })
                 end
 
-                it 'fails with a service binding error' do
-                  expect {
-                    app_apply_manifest.apply(app.guid, message)
-                  }.to raise_error(AppApplyManifest::ServiceBindingError,
-                                   "For service '#{service_instance.name}': The service instance is getting deleted or its deletion failed. Therefore, no binding can be created.")
+                it 'creates the binding' do
+                  service_binding_1 = instance_double(ServiceBinding)
+                  service_binding_2 = instance_double(ServiceBinding)
+
+                  allow(service_cred_binding_create).to receive(:precursor).and_return(
+                    service_binding_1,
+                    service_binding_2,
+                    )
+
+                  app_apply_manifest.apply(app.guid, message)
+
+                  expect(service_cred_binding_create).to have_received(:bind).with(service_binding_1, parameters: nil)
+                  expect(service_cred_binding_create).to have_received(:bind).with(service_binding_2, parameters: { 'foo' => 'bar' })
                 end
               end
             end

--- a/spec/unit/actions/app_apply_manifest_spec.rb
+++ b/spec/unit/actions/app_apply_manifest_spec.rb
@@ -934,6 +934,21 @@ module VCAP::CloudController
             end
 
             context 'different service instance states' do
+              context 'when the last operation state is create in progress' do
+                before do
+                  service_instance.save_with_new_operation({}, { type: 'create', state: 'in progress' })
+                  allow(service_cred_binding_create).to receive(:precursor).and_raise(V3::ServiceCredentialBindingAppCreate::UnprocessableCreate,
+'There is an operation in progress for the service instance')
+                end
+
+                it 'fails with a service binding error' do
+                  expect {
+                    app_apply_manifest.apply(app.guid, message)
+                  }.to raise_error(AppApplyManifest::ServiceBindingError,
+                     "For service '#{service_instance.name}': There is an operation in progress for the service instance")
+                end
+              end
+
               context 'when the last operation state is create succeeded' do
                 before do
                   service_instance.save_with_new_operation({}, { type: 'create', state: 'succeeded' })
@@ -958,13 +973,29 @@ module VCAP::CloudController
               context 'when the last operation state is create failed' do
                 before do
                   service_instance.save_with_new_operation({}, { type: 'create', state: 'failed' })
+                  allow(service_cred_binding_create).to receive(:precursor).and_raise(V3::ServiceCredentialBindingAppCreate::UnprocessableCreate, 'Service instance not found')
                 end
 
                 it 'fails with a service binding error' do
                   expect {
                     app_apply_manifest.apply(app.guid, message)
-                  }.to raise_error(CloudController::Errors::NotFound,
-                     "Service instance '#{service_instance.name}' not found")
+                  }.to raise_error(AppApplyManifest::ServiceBindingError,
+                     "For service '#{service_instance.name}': Service instance not found")
+                end
+              end
+
+              context 'when the last operation state is update in progress' do
+                before do
+                  service_instance.save_with_new_operation({}, { type: 'update', state: 'in progress' })
+                  allow(service_cred_binding_create).to receive(:precursor).and_raise(V3::ServiceCredentialBindingAppCreate::UnprocessableCreate,
+'There is an operation in progress for the service instance')
+                end
+
+                it 'fails with a service binding error' do
+                  expect {
+                    app_apply_manifest.apply(app.guid, message)
+                  }.to raise_error(AppApplyManifest::ServiceBindingError,
+                     "For service '#{service_instance.name}': There is an operation in progress for the service instance")
                 end
               end
 
@@ -1013,13 +1044,15 @@ module VCAP::CloudController
               context 'when the last operation state is delete in progress' do
                 before do
                   service_instance.save_with_new_operation({}, { type: 'delete', state: 'in progress' })
+                  allow(service_cred_binding_create).to receive(:precursor).and_raise(V3::ServiceCredentialBindingAppCreate::UnprocessableCreate,
+'There is an operation in progress for the service instance')
                 end
 
                 it 'fails with a service binding error' do
                   expect {
                     app_apply_manifest.apply(app.guid, message)
                   }.to raise_error(AppApplyManifest::ServiceBindingError,
-                     "For service '#{service_instance.name}': The service instance is getting deleted. Therefore, no binding can be created.")
+                     "For service '#{service_instance.name}': There is an operation in progress for the service instance")
                 end
               end
 

--- a/spec/unit/actions/service_credential_binding_app_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_app_create_spec.rb
@@ -230,6 +230,19 @@ module VCAP::CloudController
               end
             end
 
+            context "when the service instance is in state 'create failed'" do
+              it 'raises an error' do
+                service_instance.save_with_new_operation({}, { type: 'create', state: 'failed' })
+
+                expect {
+                  action.precursor(service_instance, app: app, volume_mount_services_enabled: false, message: message)
+                }.to raise_error(
+                  ServiceCredentialBindingAppCreate::UnprocessableCreate,
+                       'Service instance not found'
+                     )
+              end
+            end
+
             context 'when the service is a volume service and service volume mounting is enabled' do
               let(:service_instance) { ManagedServiceInstance.make(:volume_mount, **si_details) }
 


### PR DESCRIPTION
A short explanation of the proposed change:
* Return an error when service instance is in state `create failed`

An explanation of the use cases your change solves
* This PR solves the described issues according to https://github.com/cloudfoundry/cloud_controller_ng/issues/2713

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
