### PR TITLE
Add display name for service instance/binding state fetch jobs

### DIFF
--- a/app/jobs/v2/services/service_binding_state_fetch.rb
+++ b/app/jobs/v2/services/service_binding_state_fetch.rb
@@ -47,6 +47,10 @@ module VCAP::CloudController
           retry_job
         end
 
+        def display_name
+          'service_binding.state_fetch'
+        end
+
         def max_attempts
           1
         end

--- a/app/jobs/v2/services/service_instance_state_fetch.rb
+++ b/app/jobs/v2/services/service_instance_state_fetch.rb
@@ -40,6 +40,10 @@ module VCAP::CloudController
           :service_instance_state_fetch
         end
 
+        def display_name
+          'service_instance.state_fetch'
+        end
+
         def max_attempts
           1
         end

--- a/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
@@ -790,6 +790,14 @@ module VCAP::CloudController
 
           include_examples 'when brokers return Retry-After header', :fetch_service_binding_last_operation
         end
+
+        describe '#display_name' do
+          let(:job) { VCAP::CloudController::Jobs::Services::ServiceBindingStateFetch.new(service_binding.guid, user_info, request_attrs) }
+
+          it 'returns a display name for this action' do
+            expect(job.display_name).to eq('service_binding.state_fetch')
+          end
+        end
       end
     end
   end

--- a/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
@@ -581,6 +581,12 @@ module VCAP::CloudController
           end
         end
 
+        describe '#display_name' do
+          it 'returns a display name for this action' do
+            expect(job.display_name).to eq('service_instance.state_fetch')
+          end
+        end
+
         describe '#end_timestamp' do
           let(:max_poll_duration) { VCAP::CloudController::Config.config.get(:broker_client_max_async_poll_duration_minutes) }
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This change adds display_names to two jobs, allowing users to change the priority of the `service_instance` and  `service_binding` state fetch jobs in their bosh manifest.

* An explanation of the use cases your change solves
Gives operators the ability to change job priorities in order to improve performance. For example, you could de-prioritise these two jobs to ensure a CF push can succeed.

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have made this pull request to the `main` branch
* [ ] I have viewed, signed, and submitted the Contributor License Agreement


* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
