### PR TITLE
Enhance filter and tests for degenerated deployments

### DIFF
--- a/lib/cloud_controller/deployment_updater/dispatcher.rb
+++ b/lib/cloud_controller/deployment_updater/dispatcher.rb
@@ -37,7 +37,11 @@ module VCAP::CloudController
         end
 
         def finalize_degenerate_deployments(logger)
-          DeploymentModel.qualify.left_join(:processes, guid: :deployments__deploying_web_process_guid).where(processes__id: nil).each do |d|
+          deployments_without_deploying_web_process = DeploymentModel.qualify.
+                                                      left_join(:processes, guid: :deploying_web_process_guid).
+                                                      exclude(status_reason: DeploymentModel::DEGENERATE_STATUS_REASON).
+                                                      where(processes__id: nil)
+          deployments_without_deploying_web_process.each do |d|
             d.update(
               state: DeploymentModel::DEPLOYED_STATE,
               status_value: DeploymentModel::FINALIZED_STATUS_VALUE,

--- a/lib/cloud_controller/deployment_updater/dispatcher.rb
+++ b/lib/cloud_controller/deployment_updater/dispatcher.rb
@@ -37,7 +37,7 @@ module VCAP::CloudController
         end
 
         def finalize_degenerate_deployments(logger)
-          DeploymentModel.where(deploying_web_process_guid: nil).each do |d|
+          DeploymentModel.qualify.left_join(:processes, guid: :deployments__deploying_web_process_guid).where(processes__id: nil).each do |d|
             d.update(
               state: DeploymentModel::DEPLOYED_STATE,
               status_value: DeploymentModel::FINALIZED_STATUS_VALUE,

--- a/lib/cloud_controller/deployment_updater/dispatcher.rb
+++ b/lib/cloud_controller/deployment_updater/dispatcher.rb
@@ -48,7 +48,7 @@ module VCAP::CloudController
               status_reason: DeploymentModel::DEGENERATE_STATUS_REASON
             )
 
-            logger.warn('finalized-degenerate-deployment', { deployment: d.guid, app: d.app.guid })
+            logger.warn('finalized-degenerate-deployment', { deployment: d.guid, app: d.app_guid })
           end
         end
       end

--- a/spec/unit/lib/cloud_controller/deployment_updater/dispatcher_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/dispatcher_spec.rb
@@ -26,6 +26,12 @@ module VCAP::CloudController
       subject.dispatch
       expect(updater).to_not have_received(:scale)
     end
+
+    it 'processes the deployment only once' do
+      subject.dispatch
+      subject.dispatch
+      expect(logger).to have_received(:warn).with('finalized-degenerate-deployment', anything).once
+    end
   end
 
   RSpec.describe DeploymentUpdater::Dispatcher do


### PR DESCRIPTION
Instead of filtering for `deploying_web_process_guid` being `nil`, left join the `processes` table and filter for non-existing processes; this also returns deployments that reference a `deploying_web_process` which does not exist anymore.

Ensure that a degenerated deployment is updated (and logged) only once.

Remove unnecessary select from `apps` table.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
