### PR TITLE
Use ROLES_FOR_SPACE_READING in check for allowed spaces for log access

### DIFF
--- a/app/controllers/internal/log_access_controller.rb
+++ b/app/controllers/internal/log_access_controller.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
     def lookup(guid)
       check_read_permissions!
 
-      if roles.admin? || roles.admin_read_only?
+      if roles.admin? || roles.admin_read_only? || roles.global_auditor?
         found = LogAccessFetcher.new.app_exists?(guid)
       else
         allowed_space_guids = membership.space_guids_for_roles_subquery(Permissions::ROLES_FOR_SPACE_READING)

--- a/app/controllers/internal/log_access_controller.rb
+++ b/app/controllers/internal/log_access_controller.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
       if roles.admin? || roles.admin_read_only?
         found = LogAccessFetcher.new.app_exists?(guid)
       else
-        allowed_space_guids = membership.space_guids_for_roles([Membership::SPACE_DEVELOPER, Membership::SPACE_MANAGER, Membership::SPACE_AUDITOR, Membership::ORG_MANAGER])
+        allowed_space_guids = membership.space_guids_for_roles_subquery(Permissions::ROLES_FOR_SPACE_READING)
         found = LogAccessFetcher.new.app_exists_by_space?(guid, allowed_space_guids)
       end
 

--- a/app/fetchers/log_access_fetcher.rb
+++ b/app/fetchers/log_access_fetcher.rb
@@ -7,10 +7,8 @@ module VCAP::CloudController
 
     def app_exists_by_space?(guid, space_guids)
       AppModel.where(guid: guid, space_guid: space_guids).count > 0 ||
-        ProcessModel.dataset.select("#{ProcessModel.table_name}__guid".to_sym).
-          where("#{ProcessModel.table_name}__guid".to_sym => guid).
-          join(AppModel.table_name, "#{AppModel.table_name}__guid".to_sym => :app_guid).
-          where("#{AppModel.table_name}__space_guid".to_sym => space_guids).count > 0
+        ProcessModel.join(:apps, guid: :app_guid).
+          where(processes__guid: guid, apps__space_guid: space_guids).count > 0
     end
   end
 end

--- a/middleware/block_v3_only_roles.rb
+++ b/middleware/block_v3_only_roles.rb
@@ -28,7 +28,7 @@ module CloudFoundry
       end
 
       def allowed_path?(path)
-        ['/v2/info', '/'].include?(path)
+        path.match?(%r{^(/|/v2/info|/internal/v4/.*)$})
       end
 
       def globally_authenticated?

--- a/spec/request/internal/log_access_spec.rb
+++ b/spec/request/internal/log_access_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Internal Log Access Endpoint' do
       let(:api_call) { lambda { |user_headers| get "/internal/v4/log_access/#{app_model.guid}", nil, user_headers } }
       let(:expected_codes_and_responses) do
         h = Hash.new(code: 200)
-        %w[no_role global_auditor org_auditor org_billing_manager].each { |r| h[r] = { code: 404 } }
+        %w[no_role org_auditor org_billing_manager].each { |r| h[r] = { code: 404 } }
         h
       end
 

--- a/spec/request/internal/log_access_spec.rb
+++ b/spec/request/internal/log_access_spec.rb
@@ -1,22 +1,22 @@
 require 'spec_helper'
+require 'request_spec_shared_examples'
 
 RSpec.describe 'Internal Log Access Endpoint' do
   let(:user) { VCAP::CloudController::User.make }
-  let(:user_header) { headers_for(user) }
   let(:space) { VCAP::CloudController::Space.make }
+  let(:org) { space.organization }
   let(:app_model) { VCAP::CloudController::AppModel.make(space: space) }
 
-  before do
-    space.organization.add_user(user)
-    space.add_developer(user)
-  end
-
   describe 'GET /internal/v4/log_access/:app_guid' do
-    context 'when the user has access to view the logs for the app' do
-      it 'returns 200' do
-        get "/internal/v4/log_access/#{app_model.guid}", nil, user_header
-        expect(last_response.status).to eq(200)
+    context 'permissions' do
+      let(:api_call) { lambda { |user_headers| get "/internal/v4/log_access/#{app_model.guid}", nil, user_headers } }
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 200)
+        %w[no_role global_auditor org_auditor org_billing_manager].each { |r| h[r] = { code: 404 } }
+        h
       end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
     end
   end
 end

--- a/spec/unit/controllers/internal/log_access_controller_spec.rb
+++ b/spec/unit/controllers/internal/log_access_controller_spec.rb
@@ -44,46 +44,6 @@ module VCAP::CloudController
         end
       end
 
-      context 'permissions' do
-        let(:roles_to_http_responses) do
-          {
-            'admin' => 200,
-            'admin_read_only' => 200,
-            'global_auditor' => 404,
-            'space_developer' => 200,
-            'space_manager' => 200,
-            'space_auditor' => 200,
-            'org_manager' => 200,
-            'org_auditor' => 404,
-            'org_billing_manager' => 404,
-          }
-        end
-
-        roles = [
-          'admin',
-          'admin_read_only',
-          'global_auditor',
-          'space_developer',
-          'space_manager',
-          'space_auditor',
-          'org_manager',
-          'org_auditor',
-          'org_billing_manager',
-        ]
-
-        roles.each do |role|
-          describe "as an #{role}" do
-            it 'returns the correct response status' do
-              expected_return_value = roles_to_http_responses[role]
-              set_current_user_as_role(role: role, org: org, space: space, user: user)
-              response_code = log_access_controller.lookup(app_model.guid)
-
-              expect(response_code).to eq(expected_return_value), "role #{role}: expected  #{expected_return_value}, got: #{response_code}"
-            end
-          end
-        end
-      end
-
       context 'when the app does not exist' do
         before do
           set_current_user_as_admin


### PR DESCRIPTION
- The manually compiled list missed the `space_supporter` role.
- Use subquery instead of guids list.
- Simplify unnecessary complex Sequel statements, e.g.
  ```
  where("#{ProcessModel.table_name}__guid".to_sym => guid)
  ```
  becomes
  ```
  where(processes__guid: guid)
  ```
- Exclude all `/internal/v4/` endpoints from `BlockV3OnlyRoles`.
- Move `log_access` permissions tests from controller spec to request spec and use 'permissions for single object endpoint' shared example with `ALL_PERMISSIONS`.
- The second commit allows log access for the `global_auditor` role. The Log Cache checks permissions by calling `/v3/apps/:guid` [1], whereas Doppler uses `/internal/v4/log_access/:app_guid` [2]. The first endpoint allows the `global_auditor` role to access an app (and logs respectively), the latter endpoint denied access for this role. This inconsistency is resolved with this change.

[1] https://github.com/cloudfoundry/log-cache-release/blob/58fde8a7188a893f209395ec853100c777869797/src/internal/auth/capi_client.go#L100-L111
[2] https://github.com/cloudfoundry/loggregator-release/blob/bf8b344445739e7e1819cf349290ad70944f1083/src/trafficcontroller/internal/auth/log_access_authorizer.go#L32-L51

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
