### PR TITLE
Remove Azure_branch_merge timebomb test

### DIFF
--- a/spec/unit/lib/cloud_controller/blobstore/client_spec.rb
+++ b/spec/unit/lib/cloud_controller/blobstore/client_spec.rb
@@ -10,14 +10,5 @@ module CloudController
 
       it_behaves_like 'a blobstore client'
     end
-
-    RSpec.describe '#Azure_branch_merge' do
-      it_should_be_removed(
-        by: '2022/5/1',
-        explanation: 'It\'s been ~3 months since we made this PR https://github.com/Azure/azure-storage-ruby/pull/212. '\
-        'If its not already been accepted its time for a new solution. '\
-        'See https://docs.google.com/document/d/1s4-64mDqif31K5hkCJf6QW86rad2hYV7W17AqZyHhWE/edit#heading=h.nnrp172sw8k1 for more context',
-      )
-    end
   end
 end


### PR DESCRIPTION
Removing this timebomb because we don't have the resources to fix this
atm and its slowing down dev process. Replacing this test with a story
in our backlog: https://www.pivotaltracker.com/story/show/182054248 to backlog

Authored-by: Merric de Launey <mdelauney@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
