### PR TITLE
Use dedicated semaphore per user

### DIFF
--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -10,15 +10,16 @@ module CloudFoundry
       end
 
       def limit=(limit)
-        @data.default = Concurrent::Semaphore.new(limit)
+        @limit = limit
       end
 
       def try_acquire?(user_guid)
-        return @data[user_guid].try_acquire
+        @data[user_guid] = Concurrent::Semaphore.new(@limit) unless @data.key?(user_guid)
+        @data[user_guid].try_acquire
       end
 
       def release(user_guid)
-        @data[user_guid].release
+        @data[user_guid].release if @data.key?(user_guid)
       end
     end
 


### PR DESCRIPTION
By setting the default value for the hash to an instance of `Concurrent::Semaphore`, all hash entries shared the same semaphore. This change ensures that for every entry a dedicated instance is created.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
