### PR TITLE
Check arguments encoding before dispatching to controller (v2)

### DIFF
--- a/spec/unit/controllers/base/base_controller_spec.rb
+++ b/spec/unit/controllers/base/base_controller_spec.rb
@@ -70,6 +70,11 @@ module VCAP::CloudController
       end
       define_route :get, '/test_warnings', :test_warnings
 
+      def test_arguments(arg)
+        "arg = #{arg}"
+      end
+      define_route :get, '/test_arguments/:arg', :test_arguments
+
       def self.translate_validation_exception(error, attrs)
         RuntimeError.new('validation failed')
       end
@@ -133,6 +138,11 @@ module VCAP::CloudController
         it 'returns InvalidRelation when an Invalid Relation error occurs' do
           get '/test_invalid_relation_error'
           expect(decoded_response['code']).to eq(1002)
+        end
+
+        it 'returns InvalidRequest when arguments have invalid encoding' do
+          get '/test_arguments/%a5'
+          expect(decoded_response['code']).to eq(10004)
         end
       end
 


### PR DESCRIPTION
Whereas Rails (`/v3`) validates the encoding of path parameters and responds with the error message `Invalid path parameters: Invalid encoding for parameter: ...` in case of an invalid encoding, Sinatra (`/v2`) simply passes the arguments on to the controller.

With this change all arguments that implement `valid_encoding?` are checked and if this validation fails an `InvalidRequest` error is returned.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
