### PR TITLE
Optionally overwrite timeout for Logcache::Client

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -211,6 +211,7 @@ module VCAP::CloudController
             logcache: {
               host: String,
               port: Integer,
+              optional(:timeout_in_seconds) => Integer,
             },
 
             optional(:logcache_tls) => {

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -516,6 +516,7 @@ module CloudController
       Logcache::Client.new(
         host: config.get(:logcache, :host),
         port: config.get(:logcache, :port),
+        timeout: config.get(:logcache, :timeout_in_seconds),
         client_ca_path: config.get(:logcache_tls, :ca_file),
         client_cert_path: config.get(:logcache_tls, :cert_file),
         client_key_path: config.get(:logcache_tls, :key_file),

--- a/lib/logcache/client.rb
+++ b/lib/logcache/client.rb
@@ -6,7 +6,9 @@ module Logcache
     MAX_LIMIT = 1000
     DEFAULT_LIMIT = 100
 
-    def initialize(host:, port:, client_ca_path:, client_cert_path:, client_key_path:, tls_subject_name:)
+    def initialize(host:, port:, timeout:, client_ca_path:, client_cert_path:, client_key_path:, tls_subject_name:)
+      timeout ||= 250
+
       if client_ca_path
         client_ca = IO.read(client_ca_path)
         client_key = IO.read(client_key_path)
@@ -16,13 +18,13 @@ module Logcache
           "#{host}:#{port}",
           GRPC::Core::ChannelCredentials.new(client_ca, client_key, client_cert),
           channel_args: { GRPC::Core::Channel::SSL_TARGET => tls_subject_name },
-          timeout: 250
+          timeout: timeout
         )
       else
         @service = Logcache::V1::Egress::Stub.new(
           "#{host}:#{port}",
           :this_channel_is_insecure,
-          timeout: 250
+          timeout: timeout
         )
       end
     end

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -489,14 +489,16 @@ RSpec.describe CloudController::DependencyLocator do
       allow(Logcache::Client).to receive(:new).and_return(logcache_client)
     end
 
-    it 'returns the tc-decorated client without TLS' do
+    it 'returns the tc-decorated client without TLS and default timeout' do
       TestConfig.override(
-        logcache_tls: nil
+        logcache_tls: nil,
+        timeout_in_seconds: nil,
       )
       expect(locator.traffic_controller_compatible_logcache_client).to be_an_instance_of(Logcache::TrafficControllerDecorator)
       expect(Logcache::Client).to have_received(:new).with(
         host: 'http://doppler.service.cf.internal',
         port: 8080,
+        timeout: nil,
         client_ca_path: nil,
         client_cert_path: nil,
         client_key_path: nil,
@@ -504,11 +506,12 @@ RSpec.describe CloudController::DependencyLocator do
       )
     end
 
-    it 'returns the tc-decorated client with TLS certificates' do
+    it 'returns the tc-decorated client with TLS certificates and custom timeout' do
       TestConfig.override(
         logcache: {
           host: 'some-logcache-host',
           port: 1234,
+          timeout_in_seconds: 10,
         },
         logcache_tls: {
           ca_file: 'logcache-ca',
@@ -521,6 +524,7 @@ RSpec.describe CloudController::DependencyLocator do
       expect(Logcache::Client).to have_received(:new).with(
         host: 'some-logcache-host',
         port: 1234,
+        timeout: 10,
         client_ca_path: 'logcache-ca',
         client_cert_path: 'logcache-client-ca',
         client_key_path: 'logcache-client-key',


### PR DESCRIPTION
The timeout used for the Logcache GRPC client was hard-coded to 250 seconds. With this change the timeout can be (optionally) configured to a different value.

Running "cf push" results in requests to `/v3/processes/:guid/stats`. But in case Logcache is unavailable, "cf push" can actually continue/succeed without showing the requested data. The default timeout resulted in long-running requests without adding much value.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
