### PR TITLE
Implements sharing a route across spaces

### DIFF
--- a/app/actions/route_share.rb
+++ b/app/actions/route_share.rb
@@ -1,0 +1,38 @@
+require 'repositories/route_event_repository'
+
+module VCAP::CloudController
+  class RouteShare
+    class Error < ::StandardError
+    end
+
+    def create(route, target_spaces, user_audit_info)
+      validate_target_spaces!(route, target_spaces)
+
+      Route.db.transaction do
+        target_spaces.each do |space|
+          route.add_shared_space(space)
+        end
+      end
+      Repositories::RouteEventRepository.new.record_route_share(
+        route, user_audit_info, target_spaces.map(&:guid)
+      )
+      route
+    end
+
+    private
+
+    def error!(message)
+      raise Error.new(message)
+    end
+
+    def validate_target_spaces!(route, target_spaces)
+      validate_not_sharing_to_self!(route, target_spaces)
+    end
+
+    def validate_not_sharing_to_self!(route, spaces)
+      if spaces.include?(route.space)
+        error!("Unable to share route '#{route.uri}' with space '#{route.space.guid}'. Routes cannot be shared into the space where they were created.")
+      end
+    end
+  end
+end

--- a/app/actions/service_instance_share.rb
+++ b/app/actions/service_instance_share.rb
@@ -66,7 +66,8 @@ module VCAP::CloudController
 
     def validate_not_sharing_to_self!(service_instance, spaces)
       if spaces.include?(service_instance.space)
-        error!('Service instances cannot be shared into the space where they were created.')
+        error!("Unable to share service instance '#{service_instance.name}' with space '#{service_instance.space.guid}'. "\
+        'Service instances cannot be shared into the space where they were created.')
       end
     end
 

--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -27,6 +27,14 @@ module VCAP::CloudController
                         order:                   Sequel.asc(:id),
                         conditions:              { type: ProcessTypes::WEB }
 
+    many_to_many :shared_spaces,
+          left_key:          :route_guid,
+          left_primary_key:  :guid,
+          right_key:         :target_space_guid,
+          right_primary_key: :guid,
+          join_table:        :route_shares,
+          class: VCAP::CloudController::Space
+
     one_to_one :route_binding
     one_through_one :service_instance, join_table: :route_bindings
 
@@ -37,6 +45,10 @@ module VCAP::CloudController
 
     add_association_dependencies labels: :destroy
     add_association_dependencies annotations: :destroy
+
+    def shared?
+      return VCAP::CloudController::Space.where(routes_shared_from_other_spaces: self).empty? == false
+    end
 
     def fqdn
       host.empty? ? domain.name : "#{host}.#{domain.name}"

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -58,6 +58,14 @@ module VCAP::CloudController
           join_table:        :service_instance_shares,
           class: 'VCAP::CloudController::ServiceInstance'
 
+    many_to_many :routes_shared_from_other_spaces,
+          left_key:          :target_space_guid,
+          left_primary_key:  :guid,
+          right_key:         :route_guid,
+          right_primary_key: :guid,
+          join_table:        :route_shares,
+          class: 'VCAP::CloudController::Route'
+
     one_to_many :service_brokers
     one_to_many :routes
     one_to_many :tasks,

--- a/app/repositories/route_event_repository.rb
+++ b/app/repositories/route_event_repository.rb
@@ -41,6 +41,24 @@ module VCAP::CloudController
         )
       end
 
+      def record_route_share(route, actor_audit_info, target_space_guids)
+        Event.create(
+          space:          route.space,
+          type:           'audit.route.share',
+          actee:          route.guid,
+          actee_type:     'route',
+          actee_name:     route.host,
+          actor:          actor_audit_info.user_guid,
+          actor_type:     'user',
+          actor_name:     actor_audit_info.user_email,
+          actor_username: actor_audit_info.user_name,
+          timestamp:      Sequel::CURRENT_TIMESTAMP,
+          metadata:       {
+            target_space_guids: target_space_guids
+          }
+        )
+      end
+
       def record_route_delete_request(route, actor_audit_info, recursive)
         Event.create(
           type:              'audit.route.delete-request',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Rails.application.routes.draw do
   get '/routes', to: 'routes#index'
   get '/routes/:guid', to: 'routes#show'
   post '/routes', to: 'routes#create'
+  post '/routes/:guid/relationships/shared_spaces', to: 'routes#share_routes'
   patch '/routes/:guid', to: 'routes#update'
   delete '/routes/:guid', to: 'routes#destroy'
   get '/apps/:guid/routes', to: 'routes#index_by_app'

--- a/db/migrations/20220502214949_create_route_shares.rb
+++ b/db/migrations/20220502214949_create_route_shares.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  change do
+    create_table :route_shares do
+      String :route_guid, null: false, size: 255
+      String :target_space_guid, null: false, size: 255
+
+      foreign_key [:route_guid], :routes, key: :guid, name: :fk_route_guid, on_delete: :cascade
+      foreign_key [:target_space_guid], :spaces, key: :guid, name: :fk_target_space_guid_route_share, on_delete: :cascade
+      primary_key [:route_guid, :target_space_guid], name: :route_target_space_pk
+    end
+  end
+end

--- a/docs/v3/source/includes/experimental_resources/_share_routes.md.erb
+++ b/docs/v3/source/includes/experimental_resources/_share_routes.md.erb
@@ -1,0 +1,45 @@
+## Share a route with another space (experimental)
+
+Shares a route with another space.
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/routes/[guid]/relationships/shared_spaces" \
+  -X POST \
+  -H "Authorization: bearer [token]" \
+  -H "Content-type: application/json" \
+  -d '{
+    "data": [ { "guid": "space-one-guid" }, { "guid": "space-two-guid" } ]
+    }
+  }'
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": {
+    [
+      "guid": "space-one-guid",
+      "guid": "space-two-guid"
+    ]
+  },
+  "links": {
+    "self": {
+      "href":"http://api.example.com/v3/routes/[guid]/relationships/shared_spaces"
+    },
+  }
+}
+```
+
+#### Permitted roles
+
+ |
+--- |
+Admin |
+Space Developer |
+Space Supporter |

--- a/spec/unit/actions/route_share_spec.rb
+++ b/spec/unit/actions/route_share_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'actions/route_share'
+
+module VCAP::CloudController
+  RSpec.describe RouteShare do
+    let(:route_share) { RouteShare.new }
+    let(:route) { Route.make }
+    let(:target_space1) { Space.make }
+    let(:target_space2) { Space.make }
+    let(:user_audit_info) { UserAuditInfo.new(user_guid: 'user-guid-1', user_email: 'user@email.com') }
+
+    describe '#create' do
+      before do
+        allow_any_instance_of(Repositories::RouteEventRepository).to receive(:record_route_share)
+      end
+
+      it 'creates share' do
+        shared_route = route_share.create(route, [target_space1, target_space2], user_audit_info)
+        # The target_space variable will not refresh its routes anymore after we added a call to grab the shared routes with the space to the
+        # Validation of shared routes. If we just reload the target_space1 object we can get the new version of target_space1 & 2's shared routes.
+        target_space1.reload
+        target_space2.reload
+        expect(shared_route.shared_spaces.length).to eq 2
+
+        expect(target_space1.routes_shared_from_other_spaces.length).to eq 1
+        expect(target_space2.routes_shared_from_other_spaces.length).to eq 1
+
+        expect(target_space1.routes_shared_from_other_spaces[0]).to eq route
+        expect(target_space2.routes_shared_from_other_spaces[0]).to eq route
+      end
+
+      it 'records a share event' do
+        expect_any_instance_of(Repositories::RouteEventRepository).to receive(:record_route_share).with(
+          route, user_audit_info, [target_space1.guid, target_space2.guid])
+
+        route_share.create(route, [target_space1, target_space2], user_audit_info)
+      end
+
+      context 'when sharing one space from the list of spaces fails' do
+        before do
+          allow(route).to receive(:add_shared_space).with(target_space1).and_call_original
+          allow(route).to receive(:add_shared_space).with(target_space2).and_raise('db failure')
+        end
+
+        it 'does not share with any spaces' do
+          expect {
+            route_share.create(route, [target_space1, target_space2], user_audit_info)
+          }.to raise_error('db failure')
+
+          route.reload
+          expect(route.shared_spaces.length).to eq 0
+        end
+      end
+
+      context 'when source space is included in list of target spaces' do
+        it 'does not share with any spaces' do
+          expect {
+            route_share.create(route, [target_space1, route.space], user_audit_info)
+          }.to raise_error(VCAP::CloudController::RouteShare::Error,
+                           "Unable to share route '#{route.uri}' with space '#{route.space.guid}'. Routes cannot be shared into the space where they were created.")
+
+          route.reload
+
+          expect(route.shared_spaces.length).to eq 0
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/actions/service_instance_share_spec.rb
+++ b/spec/unit/actions/service_instance_share_spec.rb
@@ -63,7 +63,9 @@ module VCAP::CloudController
         it 'does not share with any spaces' do
           expect {
             service_instance_share.create(service_instance, [target_space1, service_instance.space], user_audit_info)
-          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'Service instances cannot be shared into the space where they were created.')
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error,
+                           "Unable to share service instance '#{service_instance.name}' with space '#{service_instance.space.guid}'. " \
+                           'Service instances cannot be shared into the space where they were created.')
 
           instance = ServiceInstance.find(guid: service_instance.guid)
 
@@ -75,7 +77,9 @@ module VCAP::CloudController
 
           expect {
             service_instance_share.create(service_instance, [target_space1, service_instance.space], user_audit_info)
-          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error, 'Service instances cannot be shared into the space where they were created.')
+          }.to raise_error(VCAP::CloudController::ServiceInstanceShare::Error,
+                           "Unable to share service instance '#{service_instance.name}' with space '#{service_instance.space.guid}'. " \
+                           'Service instances cannot be shared into the space where they were created.')
         end
       end
 

--- a/spec/unit/repositories/route_event_repository_spec.rb
+++ b/spec/unit/repositories/route_event_repository_spec.rb
@@ -54,6 +54,26 @@ module VCAP::CloudController
         end
       end
 
+      describe '#record_route_share' do
+        let(:target_space_guids) { ['space-guid', 'another-guid'] }
+
+        it 'records event correctly' do
+          event = route_event_repository.record_route_share(route, actor_audit_info, target_space_guids)
+          event.reload
+          expect(event.space).to eq(route.space)
+          expect(event.type).to eq('audit.route.share')
+          expect(event.actee).to eq(route.guid)
+          expect(event.actee_type).to eq('route')
+          expect(event.actee_name).to eq(route.host)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.actor_username).to eq(user_name)
+          expect(event.space_guid).to eq(route.space.guid)
+          expect(event.metadata['target_space_guids']).to eq(['space-guid', 'another-guid'])
+        end
+      end
+
       describe '#record_route_delete' do
         let(:recursive) { true }
 


### PR DESCRIPTION
This commit adds 'POST /v3/routes/:guid/relationships/shared_spaces'.
The endpoint's behavior currently matches service instance sharing behavior.
Route sharing does not handle isolation segments.

This endpoint is currently experimental.

This commit also makes minor changes to the error message transmitted
when you fail to share a Service Instance. The existing message didn't
tell you what instance failed to share, or the space that caused the
failure,  which are both nice things for an operator to know.

Here is a note about some implementation detail for future programmers:

`Route.shared?` does not make use of the class's `shared_spaces`
member variable. This is because `shared_spaces` is an `Array`, which
indicates that -behind the scenes- Sequel will first fetch all of the
data for all of the matching objects in the association, wrap that in
an array, and then hand it to us. Given that we only want to know if
there are more than zero items in that array, this could be a huge
waste on Foundations that have a route shared between many spaces.

So, we explicitly search for `Spaces` associated with the `Route` and tell
the ORM to tell us if there is more than one. The Sequel docs claim that
using `empty?` on a `Dataset` object implicitly adds in a `LIMIT 1`
to the query that the ORM generates, so the code as written should only
ever send us one row at most.

For reference, this Pivotal Tracker story tracks this work, but it may not be accessible for folks who aren't a VMWare employee: <https://www.pivotaltracker.com/story/show/181734583>

Co-authored-by: Alex Rocha <alexr1@vmware.com>
Co-authored-by: Merric de Launey <mdelauney@pivotal.io>
Co-authored-by: Kenneth Lakin <klakin@vmware.com>

==============================================

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
See the description above

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
