### PR TITLE
Prevent binding creation when instance is in state 'create failed'

### DIFF
--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -5,9 +5,6 @@ require 'actions/v3/service_binding_create'
 module VCAP::CloudController
   module V3
     class ServiceCredentialBindingAppCreate < V3::ServiceBindingCreate
-      class UnprocessableCreate < StandardError
-      end
-
       class Unimplemented < StandardError
       end
 
@@ -79,14 +76,6 @@ module VCAP::CloudController
       def event_repository
         @event_repository ||= Repositories::ServiceGenericBindingEventRepository.new(
           Repositories::ServiceGenericBindingEventRepository::SERVICE_APP_CREDENTIAL_BINDING)
-      end
-
-      def operation_in_progress!
-        raise UnprocessableCreate.new('There is an operation in progress for the service instance')
-      end
-
-      def service_instance_not_found!
-        raise UnprocessableCreate.new('Service instance not found')
       end
 
       def app_is_required!

--- a/app/actions/v3/service_binding_create.rb
+++ b/app/actions/v3/service_binding_create.rb
@@ -6,6 +6,9 @@ module VCAP::CloudController
     end
 
     class ServiceBindingCreate
+      class UnprocessableCreate < StandardError
+      end
+
       PollingStatus = Struct.new(:finished, :retry_after).freeze
       PollingFinished = PollingStatus.new(true, nil).freeze
       ContinuePolling = ->(retry_after) { PollingStatus.new(false, retry_after) }
@@ -123,6 +126,14 @@ module VCAP::CloudController
 
       def not_retrievable!
         raise BindingNotRetrievable.new('The broker responded asynchronously but does not support fetching binding data')
+      end
+
+      def service_instance_not_found!
+        raise UnprocessableCreate.new('Service instance not found')
+      end
+
+      def operation_in_progress!
+        raise UnprocessableCreate.new('There is an operation in progress for the service instance')
       end
     end
   end

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -2748,7 +2748,7 @@ RSpec.describe 'V3 service instances' do
         end
       end
 
-      context 'and it is an delete operation' do
+      context 'and it is a delete operation' do
         before do
           service_instance.save_with_new_operation({}, { type: 'delete', state: 'in progress', description: 'almost there, I promise' })
         end

--- a/spec/unit/actions/service_credential_binding_key_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_key_create_spec.rb
@@ -185,7 +185,20 @@ module VCAP::CloudController
                   action.precursor(service_instance, message: message)
                 }.to raise_error(
                   ServiceCredentialBindingKeyCreate::UnprocessableCreate,
-                  'There is an operation in progress for the service instance.'
+                  'There is an operation in progress for the service instance'
+                )
+              end
+            end
+
+            context "when the service instance is in state 'create failed'" do
+              it 'raises an error' do
+                service_instance.save_with_new_operation({}, { type: 'create', state: 'failed' })
+
+                expect {
+                  action.precursor(service_instance, message: message)
+                }.to raise_error(
+                  ServiceCredentialBindingKeyCreate::UnprocessableCreate,
+                  'Service instance not found'
                 )
               end
             end

--- a/spec/unit/actions/service_route_binding_create_spec.rb
+++ b/spec/unit/actions/service_route_binding_create_spec.rb
@@ -155,6 +155,19 @@ module VCAP::CloudController
               )
             end
           end
+
+          context "when the service instance is in state 'create failed'" do
+            it 'raises an error' do
+              service_instance.save_with_new_operation({}, { type: 'create', state: 'failed' })
+
+              expect {
+                action.precursor(service_instance, route, message: message)
+              }.to raise_error(
+                ServiceRouteBindingCreate::UnprocessableCreate,
+                'Service instance not found'
+              )
+            end
+          end
         end
 
         context 'user-provided service instance' do


### PR DESCRIPTION
- Apply changes done in `ServiceCredentialBindingAppCreate` [1] also to `ServiceCredentialBindingKeyCreate` and `ServiceRouteBindingCreate`.
- Move common code into `ServiceBindingCreate`.

[1] #2756

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
