### PR TITLE
Reset VCAP::Request.current_id after tests modifying it

### DIFF
--- a/spec/unit/jobs/enqueuer_spec.rb
+++ b/spec/unit/jobs/enqueuer_spec.rb
@@ -32,6 +32,10 @@ module VCAP::CloudController::Jobs
         allow(timeout_calculator).to receive(:calculate).and_return(job_timeout)
       end
 
+      after do
+        ::VCAP::Request.current_id = nil
+      end
+
       it "populates LoggingContextJob's ID with the one from the thread-local Request" do
         original_enqueue = Delayed::Job.method(:enqueue)
         expect(Delayed::Job).to receive(:enqueue) do |logging_context_job, opts|

--- a/spec/unit/jobs/logging_context_job_spec.rb
+++ b/spec/unit/jobs/logging_context_job_spec.rb
@@ -15,6 +15,10 @@ module VCAP::CloudController
         allow(Steno).to receive(:logger).and_return(background_logger)
       end
 
+      after do
+        ::VCAP::Request.current_id = nil
+      end
+
       context '#perform' do
         it 'delegates to the handler' do
           expect(logging_context_job.perform).to eq('fake-perform')


### PR DESCRIPTION
This prevents other specs from randomly erroring.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
