### PR TITLE
Adds delete shared routes endpoint

### DIFF
--- a/app/actions/route_share.rb
+++ b/app/actions/route_share.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
     end
 
     def create(route, target_spaces, user_audit_info)
-      validate_target_spaces!(route, target_spaces)
+      validate_not_sharing_to_self!(route, target_spaces)
 
       Route.db.transaction do
         target_spaces.each do |space|
@@ -23,10 +23,6 @@ module VCAP::CloudController
 
     def error!(message)
       raise Error.new(message)
-    end
-
-    def validate_target_spaces!(route, target_spaces)
-      validate_not_sharing_to_self!(route, target_spaces)
     end
 
     def validate_not_sharing_to_self!(route, spaces)

--- a/app/actions/route_unshare.rb
+++ b/app/actions/route_unshare.rb
@@ -1,0 +1,32 @@
+require 'repositories/route_event_repository'
+
+module VCAP::CloudController
+  class RouteUnshare
+    class Error < ::StandardError
+    end
+
+    def delete(route, target_space, user_audit_info)
+      validate_not_unsharing_from_owner!(route, target_space)
+
+      Route.db.transaction do
+        route.remove_shared_space(target_space)
+      end
+      Repositories::RouteEventRepository.new.record_route_unshare(
+        route, user_audit_info, target_space.guid
+      )
+      route
+    end
+
+    private
+
+    def error!(message)
+      raise Error.new(message)
+    end
+
+    def validate_not_unsharing_from_owner!(route, space)
+      if space == route.space
+        error!("Unable to unshare route '#{route.uri}' from space '#{route.space.guid}'. Routes cannot be removed from the space that owns them.")
+      end
+    end
+  end
+end

--- a/app/actions/route_unshare.rb
+++ b/app/actions/route_unshare.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
     class Error < ::StandardError
     end
 
-    def delete(route, target_space, user_audit_info)
+    def unshare(route, target_space, user_audit_info)
       validate_not_unsharing_from_owner!(route, target_space)
 
       Route.db.transaction do

--- a/app/controllers/v3/routes_controller.rb
+++ b/app/controllers/v3/routes_controller.rb
@@ -131,7 +131,7 @@ class RoutesController < ApplicationController
     unprocessable!(e.message)
   end
 
-  def unshare_routes
+  def unshare_route
     FeatureFlag.raise_unless_enabled!(:route_sharing)
     unauthorized! unless permission_queryer.can_manage_apps_in_space?(route.space.guid)
 
@@ -145,7 +145,7 @@ class RoutesController < ApplicationController
     end
 
     unshare = RouteUnshare.new
-    unshare.delete(route, target_space, user_audit_info)
+    unshare.unshare(route, target_space, user_audit_info)
 
     head :no_content
   rescue VCAP::CloudController::RouteUnshare::Error => e

--- a/app/repositories/route_event_repository.rb
+++ b/app/repositories/route_event_repository.rb
@@ -59,6 +59,24 @@ module VCAP::CloudController
         )
       end
 
+      def record_route_unshare(route, actor_audit_info, target_space_guid)
+        Event.create(
+          space:          route.space,
+          type:           'audit.route.unshare',
+          actee:          route.guid,
+          actee_type:     'route',
+          actee_name:     route.host,
+          actor:          actor_audit_info.user_guid,
+          actor_type:     'user',
+          actor_name:     actor_audit_info.user_email,
+          actor_username: actor_audit_info.user_name,
+          timestamp:      Sequel::CURRENT_TIMESTAMP,
+          metadata:       {
+            target_space_guid: target_space_guid
+          }
+        )
+      end
+
       def record_route_delete_request(route, actor_audit_info, recursive)
         Event.create(
           type:              'audit.route.delete-request',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,7 @@ Rails.application.routes.draw do
   get '/routes/:guid', to: 'routes#show'
   post '/routes', to: 'routes#create'
   post '/routes/:guid/relationships/shared_spaces', to: 'routes#share_routes'
+  delete '/routes/:guid/relationships/shared_spaces/:space_guid', to: 'routes#unshare_routes'
   patch '/routes/:guid', to: 'routes#update'
   delete '/routes/:guid', to: 'routes#destroy'
   get '/apps/:guid/routes', to: 'routes#index_by_app'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,7 +158,7 @@ Rails.application.routes.draw do
   get '/routes/:guid', to: 'routes#show'
   post '/routes', to: 'routes#create'
   post '/routes/:guid/relationships/shared_spaces', to: 'routes#share_routes'
-  delete '/routes/:guid/relationships/shared_spaces/:space_guid', to: 'routes#unshare_routes'
+  delete '/routes/:guid/relationships/shared_spaces/:space_guid', to: 'routes#unshare_route'
   patch '/routes/:guid', to: 'routes#update'
   delete '/routes/:guid', to: 'routes#destroy'
   get '/apps/:guid/routes', to: 'routes#index_by_app'

--- a/docs/v3/source/includes/experimental_resources/_share_routes.md.erb
+++ b/docs/v3/source/includes/experimental_resources/_share_routes.md.erb
@@ -43,3 +43,31 @@ Content-Type: application/json
 Admin |
 Space Developer |
 Space Supporter |
+
+
+## Unshare a route that was shared with another space (experimental)
+
+Unshares a route that was shared with another space.
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/routes/[guid]/relationships/shared_spaces/[space_guid]" \
+  -X DELETE \
+  -H "Authorization: bearer [token]" \
+  -H "Content-type: application/json"
+```
+
+```http
+HTTP/1.1 204 No Content
+```
+
+#### Permitted roles
+
+ |
+--- |
+Admin |
+Space Developer |
+Space Supporter |

--- a/spec/unit/actions/route_unshare_spec.rb
+++ b/spec/unit/actions/route_unshare_spec.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
     let(:target_space2) { Space.make }
     let(:user_audit_info) { UserAuditInfo.new(user_guid: 'user-guid-1', user_email: 'user@email.com') }
 
-    describe '#delete' do
+    describe '#unshare' do
       let(:target_space3) { Space.make }
       before do
         allow_any_instance_of(Repositories::RouteEventRepository).to receive(:record_route_unshare)
@@ -27,7 +27,7 @@ module VCAP::CloudController
         expect(target_space2.routes_shared_from_other_spaces[0]).to eq route
         expect(target_space3.routes_shared_from_other_spaces[0]).to eq route
 
-        modified_route = route_unshare.delete(route, target_space2, user_audit_info)
+        modified_route = route_unshare.unshare(route, target_space2, user_audit_info)
         # The target_space variable will not refresh its routes anymore after we added a call to grab the shared routes with the space to the
         # Validation of shared routes. If we just reload the objects we can get the new version of thh spaces shared routes.
         target_space1.reload
@@ -48,7 +48,7 @@ module VCAP::CloudController
         expect_any_instance_of(Repositories::RouteEventRepository).to receive(:record_route_unshare).with(
           route, user_audit_info, target_space2.guid)
 
-        route_unshare.delete(route, target_space2, user_audit_info)
+        route_unshare.unshare(route, target_space2, user_audit_info)
       end
 
       context 'when unsharing a space fails' do
@@ -60,7 +60,7 @@ module VCAP::CloudController
           expect(route.shared_spaces.length).to eq 3
 
           expect {
-            route_unshare.delete(route, target_space1, user_audit_info)
+            route_unshare.unshare(route, target_space1, user_audit_info)
           }.to raise_error('db failure')
 
           route.reload
@@ -71,7 +71,7 @@ module VCAP::CloudController
       context 'when attempting to unshare the owning space' do
         it 'does not permit you to unshare that space' do
           expect {
-            route_unshare.delete(route, route.space, user_audit_info)
+            route_unshare.unshare(route, route.space, user_audit_info)
           }.to raise_error(VCAP::CloudController::RouteUnshare::Error,
                            "Unable to unshare route '#{route.uri}' from space '#{route.space.guid}'. Routes cannot be removed from the space that owns them.")
 

--- a/spec/unit/actions/route_unshare_spec.rb
+++ b/spec/unit/actions/route_unshare_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'actions/route_unshare'
+
+module VCAP::CloudController
+  RSpec.describe RouteUnshare do
+    let(:route_share) { RouteShare.new }
+    let(:route_unshare) { RouteUnshare.new }
+    let(:route) { Route.make }
+    let(:target_space1) { Space.make }
+    let(:target_space2) { Space.make }
+    let(:user_audit_info) { UserAuditInfo.new(user_guid: 'user-guid-1', user_email: 'user@email.com') }
+
+    describe '#delete' do
+      let(:target_space3) { Space.make }
+      before do
+        allow_any_instance_of(Repositories::RouteEventRepository).to receive(:record_route_unshare)
+        route_share.create(route, [target_space1, target_space2, target_space3], user_audit_info)
+      end
+
+      it 'deletes share' do
+        expect(route.shared_spaces.length).to eq 3
+        expect(target_space1.routes_shared_from_other_spaces.length).to eq 1
+        expect(target_space2.routes_shared_from_other_spaces.length).to eq 1
+        expect(target_space3.routes_shared_from_other_spaces.length).to eq 1
+
+        expect(target_space1.routes_shared_from_other_spaces[0]).to eq route
+        expect(target_space2.routes_shared_from_other_spaces[0]).to eq route
+        expect(target_space3.routes_shared_from_other_spaces[0]).to eq route
+
+        modified_route = route_unshare.delete(route, target_space2, user_audit_info)
+        # The target_space variable will not refresh its routes anymore after we added a call to grab the shared routes with the space to the
+        # Validation of shared routes. If we just reload the objects we can get the new version of thh spaces shared routes.
+        target_space1.reload
+        target_space2.reload
+        target_space3.reload
+        expect(modified_route.shared_spaces.length).to eq 2
+
+        expect(target_space1.routes_shared_from_other_spaces.length).to eq 1
+        expect(target_space2.routes_shared_from_other_spaces.length).to eq 0
+        expect(target_space3.routes_shared_from_other_spaces.length).to eq 1
+
+        expect(target_space1.routes_shared_from_other_spaces[0]).to eq route
+        expect(target_space2.routes_shared_from_other_spaces[0]).to be_nil
+        expect(target_space3.routes_shared_from_other_spaces[0]).to eq route
+      end
+
+      it 'records a share event' do
+        expect_any_instance_of(Repositories::RouteEventRepository).to receive(:record_route_unshare).with(
+          route, user_audit_info, target_space2.guid)
+
+        route_unshare.delete(route, target_space2, user_audit_info)
+      end
+
+      context 'when unsharing a space fails' do
+        before do
+          allow(route).to receive(:remove_shared_space).with(target_space1).and_raise('db failure')
+        end
+
+        it 'does not unshare the space' do
+          expect(route.shared_spaces.length).to eq 3
+
+          expect {
+            route_unshare.delete(route, target_space1, user_audit_info)
+          }.to raise_error('db failure')
+
+          route.reload
+          expect(route.shared_spaces.length).to eq 3
+        end
+      end
+
+      context 'when attempting to unshare the owning space' do
+        it 'does not permit you to unshare that space' do
+          expect {
+            route_unshare.delete(route, route.space, user_audit_info)
+          }.to raise_error(VCAP::CloudController::RouteUnshare::Error,
+                           "Unable to unshare route '#{route.uri}' from space '#{route.space.guid}'. Routes cannot be removed from the space that owns them.")
+
+          route.reload
+
+          expect(route.shared_spaces.length).to eq 3
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/route_event_repository_spec.rb
+++ b/spec/unit/repositories/route_event_repository_spec.rb
@@ -70,7 +70,27 @@ module VCAP::CloudController
           expect(event.actor_name).to eq(user_email)
           expect(event.actor_username).to eq(user_name)
           expect(event.space_guid).to eq(route.space.guid)
-          expect(event.metadata['target_space_guids']).to eq(['space-guid', 'another-guid'])
+          expect(event.metadata['target_space_guids']).to eq(target_space_guids)
+        end
+      end
+
+      describe '#record_route_unshare' do
+        let(:target_space_guid) { 'space-guid' }
+
+        it 'records event correctly' do
+          event = route_event_repository.record_route_unshare(route, actor_audit_info, target_space_guid)
+          event.reload
+          expect(event.space).to eq(route.space)
+          expect(event.type).to eq('audit.route.unshare')
+          expect(event.actee).to eq(route.guid)
+          expect(event.actee_type).to eq('route')
+          expect(event.actee_name).to eq(route.host)
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(user_email)
+          expect(event.actor_username).to eq(user_name)
+          expect(event.space_guid).to eq(route.space.guid)
+          expect(event.metadata['target_space_guid']).to eq(target_space_guid)
         end
       end
 


### PR DESCRIPTION
NOTE: This PR depends on PR #2803. It would be a bad idea to merge this before that. I have marked it as a Draft PR to maybe help prevent it from getting accidentally merged.

This PR adds the endpoint required to delete any routes shared by the endpoint in PR #2803, as well as the tests and documentation related to this delete endpoint. 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
