### PR TITLE
Add 'initial' to the list of values for the state of a service operation

### DIFF
--- a/docs/v3/source/includes/resources/service_credential_bindings/_object.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_object.md.erb
@@ -33,7 +33,7 @@ Name | Type | Description
 Name | Type | Description
 ---- | ---- | -----------
 **type** | _string_ | Either `create` or `delete`
-**state** | _string_ | Either `in progress`, `succeeded`, or `failed`
+**state** | _string_ | Either `initial`, `in progress`, `succeeded`, or `failed`<br>_Note: The `initial` state indicates that no response from the service broker has been received yet._
 **description** | _string_ | A textual explanation associated with this state
 **created_at** | _[timestamp](#timestamps)_ | The time with zone when the operation started
 **updated_at** | _[timestamp](#timestamps)_ | The time with zone when the operation was last updated

--- a/docs/v3/source/includes/resources/service_instances/_object.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_object.md.erb
@@ -48,7 +48,7 @@ Name | Type | Description
 Name | Type | Description
 ---- | ---- | -----------
 **type** | _string_ | Either `create`, `update`, or `delete`
-**state** | _string_ | Either `in progress`, `succeeded`, or `failed`
+**state** | _string_ | Either `initial`, `in progress`, `succeeded`, or `failed`<br>_Note: The `initial` state indicates that no response from the service broker has been received yet._
 **description** | _string_ | A textual explanation associated with this state
 **created_at** | _[timestamp](#timestamps)_ | The time with zone when the operation started
 **updated_at** | _[timestamp](#timestamps)_ | The time with zone when the operation was last updated


### PR DESCRIPTION
This state was added before (see #2697), but not documented.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
