### PR TITLE
Prepare rack-test 2.x bump

### DIFF
--- a/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
@@ -79,6 +79,10 @@ module VCAP::CloudController
           context 'with an empty request' do
             let(:req_body) { {} }
 
+            before do
+              # rack_test overrides 'CONTENT_TYPE' header with 'boundary' which causes errors when the request does not contain an application
+              headers[:multipart] = false
+            end
             it 'fails to upload' do
               make_request
 
@@ -94,6 +98,10 @@ module VCAP::CloudController
           context 'with empty resources and no application' do
             let(:req_body) { { resources: '[]' } }
 
+            before do
+              # rack_test overrides 'CONTENT_TYPE' header with 'boundary' which causes errors when the request does not contain an application
+              headers[:multipart] = false
+            end
             it 'fails to upload' do
               make_request
 
@@ -108,6 +116,11 @@ module VCAP::CloudController
 
           context 'with at least one resource and no application' do
             let(:req_body) { { resources: JSON.dump([{ 'fn' => 'lol', 'sha1' => 'abc', 'size' => 2048 }]) } }
+
+            before do
+              # rack_test overrides 'CONTENT_TYPE' header with 'boundary' which causes errors when the request does not contain an application
+              headers[:multipart] = false
+            end
 
             it 'succeeds to upload' do
               make_request
@@ -328,7 +341,7 @@ module VCAP::CloudController
 
         describe 'resources' do
           context 'with a bad file path' do
-            let(:req_body) { { resources: JSON.dump([{ 'fn' => '../../lol', 'sha1' => 'abc', 'size' => 2048 }]) } }
+            let(:req_body) { { resources: JSON.dump([{ 'fn' => '../../lol', 'sha1' => 'abc', 'size' => 2048 }]), application: valid_zip } }
 
             it 'fails to upload' do
               expect {
@@ -347,7 +360,7 @@ module VCAP::CloudController
 
           context 'with a bad file mode' do
             context 'when the file is not readable by owner' do
-              let(:req_body) { { resources: JSON.dump([{ 'fn' => 'lol', 'sha1' => 'abc', 'size' => 2048, 'mode' => '300' }]) } }
+              let(:req_body) { { resources: JSON.dump([{ 'fn' => 'lol', 'sha1' => 'abc', 'size' => 2048, 'mode' => '300' }]), application: valid_zip } }
 
               before do
                 FeatureFlag.make(name: 'app_bits_upload', enabled: true)
@@ -369,7 +382,7 @@ module VCAP::CloudController
             end
 
             context 'when the file is not writable by owner' do
-              let(:req_body) { { resources: JSON.dump([{ 'fn' => 'lol', 'sha1' => 'abc', 'size' => 2048, 'mode' => '577' }]) } }
+              let(:req_body) { { resources: JSON.dump([{ 'fn' => 'lol', 'sha1' => 'abc', 'size' => 2048, 'mode' => '577' }]), application: valid_zip } }
 
               it 'fails to upload' do
                 expect {


### PR DESCRIPTION
* A short explanation of the proposed change:

  rack-test 2.x overrides `CONTENT_TYPE` header with `boundary` which causes errors when the request does not contain an application.
  To prevent tests to fail it is necessary to add `application` to requests where it was missing and to override `multipart` in empty requests.


* Links to any other associated PRs:
  Related to rack-test bump PR: https://github.com/cloudfoundry/cloud_controller_ng/pull/2848
  Rack-test changes: https://github.com/rack/rack-test/blob/main/History.md#200--2022-06-24

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
