### PR TITLE
Use Sequel's any_not_empty extension

### DIFF
--- a/app/models/services/service_broker.rb
+++ b/app/models/services/service_broker.rb
@@ -47,11 +47,11 @@ module VCAP::CloudController
     end
 
     def has_service_instances?
-      !VCAP::CloudController::ServiceInstance.
+      VCAP::CloudController::ServiceInstance.
         join(:service_plans, id: :service_plan_id).
         join(:services, id: :service_id).
         where(services__service_broker_id: id).
-        empty?
+        any?
     end
 
     def self.user_visibility_filter(user)

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -94,6 +94,7 @@ Sequel::Model.plugin :timestamps, update_on_create: true
 Sequel::Model.plugin :validation_helpers
 
 Sequel::Database.extension(:current_datetime_timestamp)
+Sequel::Database.extension(:any_not_empty)
 
 require 'cloud_controller/encryptor'
 Sequel::Model.include VCAP::CloudController::Encryptor::FieldEncryptor

--- a/spec/unit/models/services/service_broker_spec.rb
+++ b/spec/unit/models/services/service_broker_spec.rb
@@ -213,7 +213,7 @@ module VCAP::CloudController
         end
 
         it 'does a single db query' do
-          expect { service_broker.has_service_instances? }.to have_queried_db_times(/select/i, 1)
+          expect { service_broker.has_service_instances? }.to have_queried_db_times(/select 1.*limit 1/i, 1)
         end
       end
 
@@ -223,7 +223,7 @@ module VCAP::CloudController
         end
 
         it 'does a single db query' do
-          expect { service_broker.has_service_instances? }.to have_queried_db_times(/select/i, 1)
+          expect { service_broker.has_service_instances? }.to have_queried_db_times(/select 1.*limit 1/i, 1)
         end
       end
     end


### PR DESCRIPTION
There are already several PRs (see below [1]) that change `dataset.any?` to `!dataset.empty?` or otherwise mention the difference between these two statements. Whereas the first one fetches all data from the database to then check if the resulting array contains at least one element, the second statement does a `select 1 as one from table limit 1` query that has a far better performance.

Fortunately there is a Sequel extension (see [2]) that 'fixes' this misleading behavior; so instead of searching for more places where we could change the implementation, using `dataset.any?` should now be equivalent to `!dataset.empty?` and everyone can choose freely which one to use.

[1]
#2117
#2533
#2803
#2855

[2] https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/any_not_empty_rb.html

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
