### PR TITLE
Replace .any? with more efficient SQL statements

### DIFF
--- a/app/actions/domain_delete_shared_org.rb
+++ b/app/actions/domain_delete_shared_org.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
       Domain.db.transaction do
         raise OrgError.new if org_error(domain, shared_organization)
 
-        raise RouteError.new if routes?(domain, shared_organization.guid)
+        raise RouteError.new if routes?(domain, shared_organization)
 
         domain.remove_shared_organization(shared_organization)
       end
@@ -22,10 +22,11 @@ module VCAP::CloudController
       !(domain.shared_organizations.include?(shared_organization) && domain.owning_organization) || domain.owning_organization.guid == shared_organization.guid
     end
 
-    def self.routes?(domain, org_guid)
-      domain.routes.any? do |route|
-        route.space.organization_guid == org_guid
-      end
+    def self.routes?(domain, shared_organization)
+      domain.routes_dataset.
+        join(:spaces, id: :space_id).
+        where(spaces__organization_id: shared_organization.id).
+        any?
     end
   end
 end

--- a/app/models/runtime/process_model.rb
+++ b/app/models/runtime/process_model.rb
@@ -570,7 +570,7 @@ module VCAP::CloudController
       open_ports = ports || []
 
       if docker?
-        has_mapping_without_port = route_mappings.any? { |mapping| !mapping.has_app_port_specified? }
+        has_mapping_without_port = route_mappings_dataset.where(app_port: ProcessModel::NO_APP_PORT_SPECIFIED).any?
         needs_docker_ports = docker_ports.present? && (has_mapping_without_port || open_ports.empty?)
 
         if needs_docker_ports

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -204,7 +204,7 @@ module VCAP::CloudController
     end
 
     def shared?
-      shared_spaces.any?
+      shared_spaces_dataset.any?
     end
 
     def has_bindings?


### PR DESCRIPTION
For each change some corresponding specs have been identified and executed with logging of database queries enabled. The changes in `app/models/runtime/process_model.rb` and `app/models/services/service_instance.rb` resulted in the same overall number of `SELECT`s, but the number of (more efficient) `SELECT 1`s increased. The change in `app/actions/domain_delete_shared_org.rb` also resulted in more `SELECT 1`s and also less `SELECT`s overall.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
