### PR TITLE
Don't check org quota visibility if user reads globally

### DIFF
--- a/app/actions/organization_quota_apply.rb
+++ b/app/actions/organization_quota_apply.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
       return orgs if orgs.length == org_guids.length
 
       invalid_org_guids = org_guids - orgs.map(&:guid)
-      error!("Organizations with guids #{invalid_org_guids} do not exist, or you do not have access to them.")
+      error!("Organizations with guids #{invalid_org_guids} do not exist")
     end
 
     def error!(message)

--- a/spec/request/organization_quotas_spec.rb
+++ b/spec/request/organization_quotas_spec.rb
@@ -500,7 +500,7 @@ module VCAP::CloudController
         it 'returns a 422 with a helpful message' do
           post "/v3/organization_quotas/#{org_quota.guid}/relationships/organizations", params.to_json, admin_header
           expect(last_response).to have_status_code(422)
-          expect(last_response).to have_error_message('Organizations with guids ["not a real guid"] do not exist, or you do not have access to them.')
+          expect(last_response).to have_error_message('Organizations with guids ["not a real guid"] do not exist')
         end
       end
 

--- a/spec/unit/actions/organization_quota_apply_spec.rb
+++ b/spec/unit/actions/organization_quota_apply_spec.rb
@@ -50,7 +50,7 @@ module VCAP::CloudController
         it 'raises a human-friendly error' do
           expect {
             subject.apply(org_quota, message_with_invalid_org_guid)
-          }.to raise_error(OrganizationQuotaApply::Error, "Organizations with guids [\"#{invalid_org_guid}\"] do not exist, or you do not have access to them.")
+          }.to raise_error(OrganizationQuotaApply::Error, "Organizations with guids [\"#{invalid_org_guid}\"] do not exist")
         end
       end
     end


### PR DESCRIPTION
* A short explanation of the proposed change:

Adopts the approach taken in #2650 and #2638 to eliminate the need for DB queries in the org quotas presenter when the user is a global reader.

* An explanation of the use cases your change solves

This noticeably speeds up [GET /v3/organization_quotas](https://v3-apidocs.cloudfoundry.org/version/3.121.0/index.html#list-organization-quotas) for global readers, which currently drags when constructing the relationships block of each response object. On foundations with thousands of orgs constructing the relationships block currently take a very long time (I measured an average of 117 seconds on one foundation with 65,000 orgs, and that's with `per_page=50` (versus 0.035 seconds for the [equivalent v2 endpoint](https://apidocs.cloudfoundry.org/16.22.0/organization_quota_definitions/creating_a_organization_quota_definition.html))). Currently, a separate DB query is made for each org that org quotas have a relationship with in order to determine whether it is visible to the user - even when we know the user is a global reader.

This change skips these expensive queries for users with an admin, admin read-only or global auditor role, and in a test environment with 20,000 orgs, each assigned its own org quota, `/v3/organization_quotas?per_page=50` now takes 0.533 seconds.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
