### PR TITLE
Add /v3/service_instance/:guid/permissions endpoint

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -216,6 +216,18 @@ class ServiceInstancesV3Controller < ApplicationController
     end
   end
 
+  def show_permissions
+    service_instance = ServiceInstance.first(guid: hashed_params[:guid])
+    service_instance_not_found! unless service_instance && can_read_service_instance?(service_instance)
+    service_instance_not_found! if service_instance.managed_instance? && service_instance.create_failed?
+    unauthorized! unless can_read_from_space?(service_instance.space)
+
+    render status: :ok, json: {
+      "manage": current_user_can_write?(service_instance),
+      "read": can_read_service_instance?(service: service_instance),
+    }
+  end
+
   private
 
   DECORATORS = [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -239,6 +239,7 @@ Rails.application.routes.draw do
   get '/service_instances/:guid/relationships/shared_spaces/usage_summary', to: 'service_instances_v3#shared_spaces_usage_summary'
   get '/service_instances/:guid/credentials', to: 'service_instances_v3#credentials'
   get '/service_instances/:guid/parameters', to: 'service_instances_v3#parameters'
+  get '/service_instances/:guid/permissions', to: 'service_instances_v3#show_permissions'
   post '/service_instances', to: 'service_instances_v3#create'
   post '/service_instances/:guid/relationships/shared_spaces', to: 'service_instances_v3#share_service_instance'
   patch '/service_instances/:guid', to: 'service_instances_v3#update'


### PR DESCRIPTION
* A short explanation of the proposed change:

Add the `/v3/service_instance/:guid/permissions` endpoint that enables service_instance dashboard functionality with the V3 API

* An explanation of the use cases your change solves

As a service developer there is a functionality called service dashboards (https://docs.cloudfoundry.org/services/dashboard-sso.html#checking-user-permissions). These dashboards call the CF API to check if a user is allowed to alter or read the service_instance. This is done via `/v2/service_instance/:guid/permissions`.
A corresponding V3 endpoint does not exist which means this functionality wont work anymore when V2 is disabled.

This PR adds this endpoint also in V3.

See also https://cloudfoundry.slack.com/archives/C07C04W4Q/p1657878898740599 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
