### PR TITLE
Implement additional rate limiter for v2 API calls

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -264,6 +264,14 @@ rate_limiter:
   global_unauthenticated_limit: 1000
   reset_interval_in_minutes: 60
 
+rate_limiter_v2_api:
+  enabled: false
+  per_process_general_limit: 1000
+  global_general_limit: 10000
+  per_process_admin_limit: 2000
+  global_admin_limit: 20000
+  reset_interval_in_minutes: 60
+
 max_concurrent_service_broker_requests: 0
 
 diego:

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -113,6 +113,11 @@
   http_code: 403
   message: "The organization is suspended"
 
+10018:
+  name: RateLimitV2APIExceeded
+  http_code: 429
+  message: "Rate Limit of V2 API Exceeded. Please consider to use V3 API"
+
 20001:
   name: UserInvalid
   http_code: 400

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -295,7 +295,7 @@ module VCAP::CloudController
             max_concurrent_service_broker_requests: Integer,
             shared_isolation_segment_name: String,
 
-            rate_limiter_v2_api: {
+            optional(:rate_limiter_v2_api) => {
               enabled: bool,
               per_process_general_limit: Integer,
               global_general_limit: Integer,

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -295,6 +295,15 @@ module VCAP::CloudController
             max_concurrent_service_broker_requests: Integer,
             shared_isolation_segment_name: String,
 
+            rate_limiter_v2_api: {
+              enabled: bool,
+              per_process_general_limit: Integer,
+              global_general_limit: Integer,
+              per_process_admin_limit: Integer,
+              global_admin_limit: Integer,
+              reset_interval_in_minutes: Integer,
+            },
+
             opi: {
               enabled: bool,
               url: String,

--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -7,6 +7,7 @@ require 'cef_logs'
 require 'security_context_setter'
 require 'rate_limiter'
 require 'service_broker_rate_limiter'
+require 'rate_limiter_v2_api'
 require 'new_relic_custom_attributes'
 require 'zipkin'
 require 'block_v3_only_roles'
@@ -43,6 +44,16 @@ module VCAP::CloudController
           use CloudFoundry::Middleware::ServiceBrokerRateLimiter, {
             logger: Steno.logger('cc.service_broker_rate_limiter'),
             broker_timeout_seconds: config.get(:broker_client_timeout_seconds),
+          }
+        end
+        if config.get(:rate_limiter_v2_api, :enabled)
+          use CloudFoundry::Middleware::RateLimiterV2API, {
+            logger: Steno.logger('cc.rate_limiter_v2_api'),
+            per_process_general_limit: config.get(:rate_limiter_v2_api, :per_process_general_limit),
+            global_general_limit: config.get(:rate_limiter_v2_api, :global_general_limit),
+            per_process_admin_limit: config.get(:rate_limiter_v2_api, :per_process_admin_limit),
+            global_admin_limit: config.get(:rate_limiter_v2_api, :global_admin_limit),
+            interval: config.get(:rate_limiter_v2_api, :reset_interval_in_minutes),
           }
         end
 

--- a/middleware/base_rate_limiter.rb
+++ b/middleware/base_rate_limiter.rb
@@ -1,0 +1,152 @@
+module CloudFoundry
+  module Middleware
+    RequestCount = Struct.new(:requests, :valid_until)
+
+    class BaseRequestCounter
+      include CloudFoundry::Middleware::UserResetInterval
+
+      def initialize
+        reset
+      end
+
+      # needed for testing
+      def reset
+        @mutex = Mutex.new
+        @data = {}
+      end
+
+      def get(user_guid, reset_interval_in_minutes, logger)
+        @mutex.synchronize do
+          return create_new_request_count(user_guid, reset_interval_in_minutes) unless @data.key? user_guid
+
+          request_count = @data[user_guid]
+          if request_count.valid_until < Time.now.utc
+            logger.info("Resetting request count of #{request_count.requests} for user '#{user_guid}'")
+            return create_new_request_count(user_guid, reset_interval_in_minutes)
+          end
+
+          [request_count.requests, request_count.valid_until]
+        end
+      end
+
+      def increment(user_guid)
+        @mutex.synchronize do
+          request_count = @data[user_guid]
+          request_count.requests += 1
+          @data[user_guid] = request_count
+        end
+      end
+
+      private
+
+      def create_new_request_count(user_guid, reset_interval_in_minutes)
+        requests = 0
+        valid_until = next_reset_interval(user_guid, reset_interval_in_minutes)
+        @data[user_guid] = RequestCount.new(requests, valid_until)
+        [requests, valid_until]
+      end
+    end
+
+    class RateLimitHeaders
+      attr_accessor :limit, :reset, :remaining
+
+      def initialize(suffix)
+        @prefix = 'X-RateLimit'
+        @suffix = suffix.nil? ? nil : '-' + suffix
+        @limit = nil
+        @reset = nil
+        @remaining = nil
+      end
+
+      def as_hash
+        return {} if [@limit, @reset, @remaining].all?(&:nil?)
+
+        { "#{@prefix}-Limit#{@suffix}" => @limit, "#{@prefix}-Reset#{@suffix}" => @reset, "#{@prefix}-Remaining#{@suffix}" => @remaining }
+      end
+    end
+
+    class BaseRateLimiter
+      include CloudFoundry::Middleware::ClientIp
+
+      def initialize(app, logger, request_counter, reset_interval, header_suffix=nil)
+        @app = app
+        @logger = logger
+        @request_counter = request_counter
+        @reset_interval = reset_interval
+        @header_suffix = header_suffix
+      end
+
+      def call(env)
+        rate_limit_headers = RateLimitHeaders.new(@header_suffix)
+
+        request = ActionDispatch::Request.new(env)
+
+        unless skip_rate_limiting?(env, request)
+          user_guid = user_token?(env) ? env['cf.user_guid'] : client_ip(request)
+
+          count, valid_until = @request_counter.get(user_guid, @reset_interval, @logger)
+          new_request_count = count + 1
+
+          rate_limit_headers.limit = global_request_limit(env).to_s
+          rate_limit_headers.reset = valid_until.to_i.to_s
+          rate_limit_headers.remaining = estimate_remaining(env, new_request_count)
+
+          return too_many_requests!(env, rate_limit_headers) if exceeded_rate_limit(new_request_count, env)
+
+          @request_counter.increment(user_guid)
+        end
+
+        status, headers, body = @app.call(env)
+        [status, headers.merge(rate_limit_headers.as_hash), body]
+      end
+
+      private
+
+      def skip_rate_limiting?(env, request)
+        raise NotImplementedError
+      end
+
+      def global_request_limit(env)
+        raise NotImplementedError
+      end
+
+      def rate_limit_error(env)
+        raise NotImplementedError
+      end
+
+      def exceeded_rate_limit(count, env)
+        count > per_process_request_limit(env)
+      end
+
+      def estimate_remaining(env, new_count)
+        global_limit = global_request_limit(env)
+        limit = per_process_request_limit(env)
+        return '0' unless limit > 0
+
+        estimate = ((limit - new_count).to_f / limit).floor(1) * global_limit
+        [0, estimate].max.to_i.to_s
+      end
+
+      def user_token?(env)
+        !!env['cf.user_guid']
+      end
+
+      def basic_auth?(auth)
+        (auth.provided? && auth.basic?)
+      end
+
+      def admin?
+        VCAP::CloudController::SecurityContext.admin? || VCAP::CloudController::SecurityContext.admin_read_only?
+      end
+
+      def too_many_requests!(env, rate_limit_headers)
+        headers = {}
+        headers['Retry-After'] = rate_limit_headers.reset
+        headers['Content-Type'] = 'text/plain; charset=utf-8'
+        message = rate_limit_error(env).to_json
+        headers['Content-Length'] = message.length.to_s
+        [429, rate_limit_headers.as_hash.merge(headers), [message]]
+      end
+    end
+  end
+end

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -1,87 +1,18 @@
 require 'mixins/client_ip'
 require 'mixins/user_reset_interval'
+require 'base_rate_limiter'
 
 module CloudFoundry
   module Middleware
-    RequestCount = Struct.new(:requests, :valid_until)
+    REQUEST_COUNTER = BaseRequestCounter.new
 
-    class RequestCounter
-      include Singleton
-      include CloudFoundry::Middleware::UserResetInterval
-
-      def initialize
-        @mutex = Mutex.new
-        @data = {}
-      end
-
-      def get(user_guid, reset_interval_in_minutes, logger)
-        @mutex.synchronize do
-          return create_new_request_count(user_guid, reset_interval_in_minutes) unless @data.key? user_guid
-
-          request_count = @data[user_guid]
-          if request_count.valid_until < Time.now.utc
-            logger.info("Resetting request count of #{request_count.requests} for user '#{user_guid}'")
-            return create_new_request_count(user_guid, reset_interval_in_minutes)
-          end
-
-          [request_count.requests, request_count.valid_until]
-        end
-      end
-
-      def increment(user_guid)
-        @mutex.synchronize do
-          request_count = @data[user_guid]
-          request_count.requests += 1
-          @data[user_guid] = request_count
-        end
-      end
-
-      private
-
-      def create_new_request_count(user_guid, reset_interval_in_minutes)
-        requests = 0
-        valid_until = next_reset_interval(user_guid, reset_interval_in_minutes)
-        @data[user_guid] = RequestCount.new(requests, valid_until)
-        [requests, valid_until]
-      end
-    end
-
-    class RateLimiter
-      include CloudFoundry::Middleware::ClientIp
-
+    class RateLimiter < BaseRateLimiter
       def initialize(app, opts)
-        @app                               = app
-        @logger                            = opts[:logger]
         @per_process_general_limit         = opts[:per_process_general_limit]
         @global_general_limit              = opts[:global_general_limit]
         @per_process_unauthenticated_limit = opts[:per_process_unauthenticated_limit]
         @global_unauthenticated_limit      = opts[:global_unauthenticated_limit]
-        @interval                          = opts[:interval]
-        @request_counter                   = RequestCounter.instance
-      end
-
-      def call(env)
-        rate_limit_headers = {}
-
-        request = ActionDispatch::Request.new(env)
-
-        unless skip_rate_limiting?(env, request)
-          user_guid = user_token?(env) ? env['cf.user_guid'] : client_ip(request)
-
-          count, valid_until = @request_counter.get(user_guid, @interval, @logger)
-          new_count = count + 1
-
-          rate_limit_headers['X-RateLimit-Limit']     = global_request_limit(env).to_s
-          rate_limit_headers['X-RateLimit-Reset']     = valid_until.to_i.to_s
-          rate_limit_headers['X-RateLimit-Remaining'] = estimate_remaining(env, new_count)
-
-          return too_many_requests!(env, rate_limit_headers) if exceeded_rate_limit(new_count, env)
-
-          @request_counter.increment(user_guid)
-        end
-
-        status, headers, body = @app.call(env)
-        [status, headers.merge(rate_limit_headers), body]
+        super(app, opts[:logger], REQUEST_COUNTER, opts[:interval])
       end
 
       private
@@ -99,37 +30,12 @@ module CloudFoundry
         request.fullpath.match(%r{\A/internal})
       end
 
-      def basic_auth?(auth)
-        (auth.provided? && auth.basic?)
-      end
-
-      def user_token?(env)
-        !!env['cf.user_guid']
-      end
-
       def global_request_limit(env)
         user_token?(env) ? @global_general_limit : @global_unauthenticated_limit
       end
 
       def per_process_request_limit(env)
         user_token?(env) ? @per_process_general_limit : @per_process_unauthenticated_limit
-      end
-
-      def estimate_remaining(env, new_count)
-        global_limit = global_request_limit(env)
-        limit = per_process_request_limit(env)
-        return '0' unless limit > 0
-
-        estimate = ((limit - new_count).to_f / limit).floor(1) * global_limit
-        [0, estimate].max.to_i.to_s
-      end
-
-      def too_many_requests!(env, rate_limit_headers)
-        rate_limit_headers['Retry-After']    = rate_limit_headers['X-RateLimit-Reset']
-        rate_limit_headers['Content-Type']   = 'text/plain; charset=utf-8'
-        message                              = rate_limit_error(env).to_json
-        rate_limit_headers['Content-Length'] = message.length.to_s
-        [429, rate_limit_headers, [message]]
       end
 
       def rate_limit_error(env)
@@ -141,14 +47,6 @@ module CloudFoundry
         elsif version == '/v3'
           ErrorPresenter.new(api_error, Rails.env.test?, V3ErrorHasher.new(api_error)).to_hash
         end
-      end
-
-      def exceeded_rate_limit(count, env)
-        count > per_process_request_limit(env)
-      end
-
-      def admin?
-        VCAP::CloudController::SecurityContext.admin? || VCAP::CloudController::SecurityContext.admin_read_only?
       end
     end
   end

--- a/middleware/rate_limiter_v2_api.rb
+++ b/middleware/rate_limiter_v2_api.rb
@@ -1,0 +1,40 @@
+require 'mixins/client_ip'
+require 'mixins/user_reset_interval'
+require 'base_rate_limiter'
+
+module CloudFoundry
+  module Middleware
+    REQUEST_COUNTER_V2_API = BaseRequestCounter.new
+
+    class RateLimiterV2API < BaseRateLimiter
+      def initialize(app, opts)
+        @per_process_general_limit = opts[:per_process_general_limit]
+        @global_general_limit      = opts[:global_general_limit]
+        @per_process_admin_limit   = opts[:per_process_admin_limit]
+        @global_admin_limit        = opts[:global_admin_limit]
+        super(app, opts[:logger], REQUEST_COUNTER_V2_API, opts[:interval], 'V2-API')
+      end
+
+      private
+
+      def skip_rate_limiting?(env, request)
+        auth = Rack::Auth::Basic::Request.new(env)
+        basic_auth?(auth) || !request.fullpath.match(%r{\A/v2/(?!(info)).+})
+      end
+
+      def global_request_limit(env)
+        admin? ? @global_admin_limit : @global_general_limit
+      end
+
+      def per_process_request_limit(env)
+        admin? ? @per_process_admin_limit : @per_process_general_limit
+      end
+
+      def rate_limit_error(env)
+        error_name = 'RateLimitV2APIExceeded'
+        api_error = CloudController::Errors::ApiError.new_from_details(error_name)
+        ErrorPresenter.new(api_error, Rails.env.test?, V2ErrorHasher.new(api_error)).to_hash
+      end
+    end
+  end
+end

--- a/middleware/rate_limiter_v2_api.rb
+++ b/middleware/rate_limiter_v2_api.rb
@@ -1,25 +1,27 @@
-require 'mixins/client_ip'
-require 'mixins/user_reset_interval'
 require 'base_rate_limiter'
 
 module CloudFoundry
   module Middleware
-    REQUEST_COUNTER_V2_API = BaseRequestCounter.new
-
     class RateLimiterV2API < BaseRateLimiter
+      REQUEST_COUNTER = RequestCounter.new
+
       def initialize(app, opts)
         @per_process_general_limit = opts[:per_process_general_limit]
         @global_general_limit      = opts[:global_general_limit]
         @per_process_admin_limit   = opts[:per_process_admin_limit]
         @global_admin_limit        = opts[:global_admin_limit]
-        super(app, opts[:logger], REQUEST_COUNTER_V2_API, opts[:interval], 'V2-API')
+        super(app, opts[:logger], REQUEST_COUNTER, opts[:interval], 'V2-API')
       end
 
       private
 
-      def skip_rate_limiting?(env, request)
-        auth = Rack::Auth::Basic::Request.new(env)
-        basic_auth?(auth) || !request.fullpath.match(%r{\A/v2/(?!(info)).+})
+      def apply_rate_limiting?(env)
+        !basic_auth?(env) && v2_api?(env)
+      end
+
+      def v2_api?(env)
+        request = ActionDispatch::Request.new(env)
+        request.fullpath.match(%r{\A/v2/(?!(info)).+})
       end
 
       def global_request_limit(env)
@@ -31,8 +33,7 @@ module CloudFoundry
       end
 
       def rate_limit_error(env)
-        error_name = 'RateLimitV2APIExceeded'
-        api_error = CloudController::Errors::ApiError.new_from_details(error_name)
+        api_error = CloudController::Errors::ApiError.new_from_details('RateLimitV2APIExceeded')
         ErrorPresenter.new(api_error, Rails.env.test?, V2ErrorHasher.new(api_error)).to_hash
       end
     end

--- a/spec/support/shared_examples/middleware/rate_limiting.rb
+++ b/spec/support/shared_examples/middleware/rate_limiting.rb
@@ -1,0 +1,11 @@
+RSpec.shared_examples_for 'endpoint exempts from rate limiting' do |header_suffix=''|
+  it 'exempts them from rate limiting' do
+    allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+    _, response_headers, _ = middleware.call(env)
+    expect(request_counter).not_to have_received(:get)
+    expect(request_counter).not_to have_received(:increment)
+    expect(response_headers["X-RateLimit-Limit#{header_suffix}"]).to be_nil
+    expect(response_headers["X-RateLimit-Remaining#{header_suffix}"]).to be_nil
+    expect(response_headers["X-RateLimit-Reset#{header_suffix}"]).to be_nil
+  end
+end

--- a/spec/unit/middleware/rate_limiter_spec.rb
+++ b/spec/unit/middleware/rate_limiter_spec.rb
@@ -16,12 +16,11 @@ module CloudFoundry
           }
         )
       end
-      let(:REQUEST_COUNTER) { double }
+      let(:request_counter) { double }
       before(:each) {
-        middleware.instance_variable_set('@REQUEST_COUNTER', REQUEST_COUNTER)
-        REQUEST_COUNTER.reset
-        allow(REQUEST_COUNTER).to receive(:get).and_return([0, Time.now.utc])
-        allow(REQUEST_COUNTER).to receive(:increment)
+        middleware.instance_variable_set('@request_counter', request_counter)
+        allow(request_counter).to receive(:get).and_return([0, Time.now.utc])
+        allow(request_counter).to receive(:increment)
       }
 
       let(:app) { double(:app, call: [200, {}, 'a body']) }
@@ -52,18 +51,18 @@ module CloudFoundry
 
         describe 'X-RateLimit-Remaining' do
           it 'shows the user the number of remaining requests rounded down to nearest 10%' do
-            allow(REQUEST_COUNTER).to receive(:get).and_return([0, Time.now.utc])
+            allow(request_counter).to receive(:get).and_return([0, Time.now.utc])
             _, response_headers, _ = middleware.call(user_1_env)
             expect(response_headers['X-RateLimit-Remaining']).to eq('900')
 
-            allow(REQUEST_COUNTER).to receive(:get).and_return([10, Time.now.utc])
+            allow(request_counter).to receive(:get).and_return([10, Time.now.utc])
             _, response_headers, _ = middleware.call(user_1_env)
             expect(response_headers['X-RateLimit-Remaining']).to eq('800')
           end
 
-          it 'tracks user\'s remaining requests independently' do
-            expect(REQUEST_COUNTER).to receive(:get).with(user_1_guid, interval, logger).and_return([0, Time.now.utc])
-            expect(REQUEST_COUNTER).to receive(:get).with(user_2_guid, interval, logger).and_return([10, Time.now.utc])
+          it "tracks user's remaining requests independently" do
+            expect(request_counter).to receive(:get).with(user_1_guid, interval, logger).and_return([0, Time.now.utc])
+            expect(request_counter).to receive(:get).with(user_2_guid, interval, logger).and_return([10, Time.now.utc])
 
             _, response_headers, _ = middleware.call(user_1_env)
             expect(response_headers['X-RateLimit-Remaining']).to eq('900')
@@ -76,7 +75,7 @@ module CloudFoundry
         describe 'X-RateLimit-Reset' do
           it 'shows the user when the interval will expire' do
             valid_until = Time.now.utc.beginning_of_hour + interval.minutes
-            allow(REQUEST_COUNTER).to receive(:get).and_return([0, valid_until])
+            allow(request_counter).to receive(:get).and_return([0, valid_until])
             _, response_headers, _ = middleware.call(user_1_env)
             expect(response_headers['X-RateLimit-Reset'].to_i).to eq(valid_until.utc.to_i)
           end
@@ -85,7 +84,7 @@ module CloudFoundry
 
       it 'increments the counter and allows the request to continue' do
         _, _, _ = middleware.call(user_1_env)
-        expect(REQUEST_COUNTER).to have_received(:increment).with(user_1_guid)
+        expect(request_counter).to have_received(:increment).with(user_1_guid)
         expect(app).to have_received(:call)
       end
 
@@ -99,8 +98,8 @@ module CloudFoundry
         describe 'when the user has basic auth credentials' do
           it 'exempts them from rate limiting' do
             _, response_headers, _ = middleware.call(basic_auth_env)
-            expect(REQUEST_COUNTER).not_to have_received(:get)
-            expect(REQUEST_COUNTER).not_to have_received(:increment)
+            expect(request_counter).not_to have_received(:get)
+            expect(request_counter).not_to have_received(:increment)
             expect(response_headers['X-RateLimit-Limit']).to be_nil
             expect(response_headers['X-RateLimit-Remaining']).to be_nil
             expect(response_headers['X-RateLimit-Reset']).to be_nil
@@ -111,14 +110,8 @@ module CloudFoundry
           context 'when the user is hitting a path starting with "/internal"' do
             let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/internal/pants/1234') }
 
-            it 'exempts them from rate limiting' do
-              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-              _, response_headers, _ = middleware.call(unauthenticated_env)
-              expect(REQUEST_COUNTER).not_to have_received(:get)
-              expect(REQUEST_COUNTER).not_to have_received(:increment)
-              expect(response_headers['X-RateLimit-Limit']).to be_nil
-              expect(response_headers['X-RateLimit-Remaining']).to be_nil
-              expect(response_headers['X-RateLimit-Reset']).to be_nil
+            it_behaves_like 'endpoint exempts from rate limiting' do
+              let(:env) { unauthenticated_env }
             end
           end
 
@@ -128,8 +121,8 @@ module CloudFoundry
 
             it 'rate limits them' do
               allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-              expect(REQUEST_COUNTER).to receive(:get).with('forwarded_ip', interval, logger).and_return([0, Time.now.utc])
-              expect(REQUEST_COUNTER).to receive(:increment).with('forwarded_ip')
+              expect(request_counter).to receive(:get).with('forwarded_ip', interval, logger).and_return([0, Time.now.utc])
+              expect(request_counter).to receive(:increment).with('forwarded_ip')
               _, response_headers, _ = middleware.call(unauthenticated_env)
               expect(response_headers['X-RateLimit-Limit']).to_not be_nil
               expect(response_headers['X-RateLimit-Remaining']).to_not be_nil
@@ -142,56 +135,32 @@ module CloudFoundry
           context 'when the user is hitting a root path /' do
             let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/') }
 
-            it 'exempts them from rate limiting' do
-              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-              _, response_headers, _ = middleware.call(unauthenticated_env)
-              expect(REQUEST_COUNTER).not_to have_received(:get)
-              expect(REQUEST_COUNTER).not_to have_received(:increment)
-              expect(response_headers['X-RateLimit-Limit']).to be_nil
-              expect(response_headers['X-RateLimit-Remaining']).to be_nil
-              expect(response_headers['X-RateLimit-Reset']).to be_nil
+            it_behaves_like 'endpoint exempts from rate limiting' do
+              let(:env) { unauthenticated_env }
             end
           end
 
           context 'when the user is hitting a root path /v2/info' do
             let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v2/info') }
 
-            it 'exempts them from rate limiting' do
-              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-              _, response_headers, _ = middleware.call(unauthenticated_env)
-              expect(REQUEST_COUNTER).not_to have_received(:get)
-              expect(REQUEST_COUNTER).not_to have_received(:increment)
-              expect(response_headers['X-RateLimit-Limit']).to be_nil
-              expect(response_headers['X-RateLimit-Remaining']).to be_nil
-              expect(response_headers['X-RateLimit-Reset']).to be_nil
+            it_behaves_like 'endpoint exempts from rate limiting' do
+              let(:env) { unauthenticated_env }
             end
           end
 
           context 'when the user is hitting a root path /v3' do
             let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3') }
 
-            it 'exempts them from rate limiting' do
-              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-              _, response_headers, _ = middleware.call(unauthenticated_env)
-              expect(REQUEST_COUNTER).not_to have_received(:get)
-              expect(REQUEST_COUNTER).not_to have_received(:increment)
-              expect(response_headers['X-RateLimit-Limit']).to be_nil
-              expect(response_headers['X-RateLimit-Remaining']).to be_nil
-              expect(response_headers['X-RateLimit-Reset']).to be_nil
+            it_behaves_like 'endpoint exempts from rate limiting' do
+              let(:env) { unauthenticated_env }
             end
           end
 
           context 'when the user is hitting a root path /healthz' do
             let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/healthz') }
 
-            it 'exempts them from rate limiting' do
-              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-              _, response_headers, _ = middleware.call(unauthenticated_env)
-              expect(REQUEST_COUNTER).not_to have_received(:get)
-              expect(REQUEST_COUNTER).not_to have_received(:increment)
-              expect(response_headers['X-RateLimit-Limit']).to be_nil
-              expect(response_headers['X-RateLimit-Remaining']).to be_nil
-              expect(response_headers['X-RateLimit-Reset']).to be_nil
+            it_behaves_like 'endpoint exempts from rate limiting' do
+              let(:env) { unauthenticated_env }
             end
           end
         end
@@ -220,15 +189,15 @@ module CloudFoundry
             valid_until_2 = Time.now.utc
 
             allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-            expect(REQUEST_COUNTER).to receive(:get).with(forwarded_ip, interval, logger).and_return([0, valid_until])
-            expect(REQUEST_COUNTER).to receive(:increment).with(forwarded_ip)
+            expect(request_counter).to receive(:get).with(forwarded_ip, interval, logger).and_return([0, valid_until])
+            expect(request_counter).to receive(:increment).with(forwarded_ip)
             _, response_headers, _ = middleware.call(unauthenticated_env)
             expect(response_headers['X-RateLimit-Remaining']).to eq('90')
             expect(response_headers['X-RateLimit-Reset']).to eq(valid_until.to_i.to_s)
 
             allow(ActionDispatch::Request).to receive(:new).and_return(fake_request_2)
-            expect(REQUEST_COUNTER).to receive(:get).with(forwarded_ip_2, interval, logger).and_return([2, valid_until_2])
-            expect(REQUEST_COUNTER).to receive(:increment).with(forwarded_ip_2)
+            expect(request_counter).to receive(:get).with(forwarded_ip_2, interval, logger).and_return([2, valid_until_2])
+            expect(request_counter).to receive(:increment).with(forwarded_ip_2)
             _, response_headers, _ = middleware.call(unauthenticated_env)
             expect(response_headers['X-RateLimit-Remaining']).to eq('70')
             expect(response_headers['X-RateLimit-Reset']).to eq(valid_until_2.to_i.to_s)
@@ -251,18 +220,18 @@ module CloudFoundry
           it 'identifies them by the request ip' do
             valid_until = Time.now.utc.beginning_of_hour
             valid_until_2 = Time.now.utc.beginning_of_hour + 5.minutes
-            allow(REQUEST_COUNTER).to receive(:get).with(ip, interval, logger).and_return([0, valid_until])
-            allow(REQUEST_COUNTER).to receive(:get).with(ip_2, interval, logger).and_return([2, valid_until_2])
+            allow(request_counter).to receive(:get).with(ip, interval, logger).and_return([0, valid_until])
+            allow(request_counter).to receive(:get).with(ip_2, interval, logger).and_return([2, valid_until_2])
 
             allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
             _, response_headers, _ = middleware.call(unauthenticated_env)
-            expect(REQUEST_COUNTER).to have_received(:increment).with(ip)
+            expect(request_counter).to have_received(:increment).with(ip)
             expect(response_headers['X-RateLimit-Remaining']).to eq('90')
             expect(response_headers['X-RateLimit-Reset']).to eq(valid_until.utc.to_i.to_s)
 
             allow(ActionDispatch::Request).to receive(:new).and_return(fake_request_2)
             _, response_headers, _ = middleware.call(unauthenticated_env)
-            expect(REQUEST_COUNTER).to have_received(:increment).with(ip_2)
+            expect(request_counter).to have_received(:increment).with(ip_2)
             expect(response_headers['X-RateLimit-Remaining']).to eq('70')
             expect(response_headers['X-RateLimit-Reset']).to eq(valid_until_2.utc.to_i.to_s)
           end
@@ -282,8 +251,8 @@ module CloudFoundry
           expect(response_headers).not_to include('X-RateLimit-Remaining')
           expect(status).to eq(200)
           expect(app).to have_received(:call).at_least(:once)
-          expect(REQUEST_COUNTER).to_not have_received(:get)
-          expect(REQUEST_COUNTER).to_not have_received(:increment)
+          expect(request_counter).to_not have_received(:get)
+          expect(request_counter).to_not have_received(:increment)
         end
       end
 
@@ -292,7 +261,7 @@ module CloudFoundry
         let(:middleware_env) do
           { 'cf.user_guid' => 'user-id-1', 'PATH_INFO' => path_info }
         end
-        before(:each) { allow(REQUEST_COUNTER).to receive(:get).and_return([per_process_general_limit + 1, Time.now.utc]) }
+        before(:each) { allow(request_counter).to receive(:get).and_return([per_process_general_limit + 1, Time.now.utc]) }
 
         it 'returns 429 response' do
           status, _, _ = middleware.call(middleware_env)
@@ -301,18 +270,18 @@ module CloudFoundry
 
         it 'does not increment the request counter' do
           _, _, _ = middleware.call(middleware_env)
-          expect(REQUEST_COUNTER).to_not have_received(:increment)
+          expect(request_counter).to_not have_received(:increment)
         end
 
         it 'prevents "X-RateLimit-Remaining" from going lower than zero' do
-          allow(REQUEST_COUNTER).to receive(:get).and_return([per_process_general_limit + 100, Time.now.utc])
+          allow(request_counter).to receive(:get).and_return([per_process_general_limit + 100, Time.now.utc])
           _, response_headers, _ = middleware.call(middleware_env)
           expect(response_headers['X-RateLimit-Remaining']).to eq('0')
         end
 
         it 'contains the correct headers' do
           valid_until = Time.now.utc
-          allow(REQUEST_COUNTER).to receive(:get).and_return([per_process_general_limit + 1, valid_until])
+          allow(request_counter).to receive(:get).and_return([per_process_general_limit + 1, valid_until])
           error_presenter = instance_double(ErrorPresenter, to_hash: { foo: 'bar' })
           allow(ErrorPresenter).to receive(:new).and_return(error_presenter)
 
@@ -358,7 +327,7 @@ module CloudFoundry
           let(:unauthenticated_env) { { 'some' => 'env', 'PATH_INFO' => path_info } }
 
           it 'suggests they log in' do
-            allow(REQUEST_COUNTER).to receive(:get).and_return([per_process_unauthenticated_limit + 1, Time.now.utc])
+            allow(request_counter).to receive(:get).and_return([per_process_unauthenticated_limit + 1, Time.now.utc])
             _, response_headers, body = middleware.call(unauthenticated_env)
             expect(response_headers['X-RateLimit-Remaining']).to eq('0')
             json_body = JSON.parse(body.first)
@@ -372,7 +341,8 @@ module CloudFoundry
       end
     end
 
-    RSpec.describe REQUEST_COUNTER do
+    RSpec.describe RequestCounter do
+      let(:request_counter) { RequestCounter.new }
       let(:reset_interval_in_minutes) { 60 }
       let(:logger) { double('logger', info: nil) }
       let(:user_guid) { 'user-id' }
@@ -381,52 +351,51 @@ module CloudFoundry
       describe 'get' do
         before(:each) do
           Timecop.freeze
-          REQUEST_COUNTER.reset
         end
         after(:each) do Timecop.return end
 
         it 'should return next offset valid until interval and 0 requests for a new user' do
           new_valid_until = Time.now.utc.beginning_of_hour + reset_interval_in_minutes.minutes
-          expect(REQUEST_COUNTER).to receive(:next_reset_interval).and_return(new_valid_until)
+          expect(request_counter).to receive(:next_reset_interval).and_return(new_valid_until)
 
-          count, valid_until = REQUEST_COUNTER.get(user_guid, reset_interval_in_minutes, logger)
+          count, valid_until = request_counter.get(user_guid, reset_interval_in_minutes, logger)
           expect(count).to eq(0)
           expect(valid_until).to eq(new_valid_until)
         end
 
         it 'should return offset valid untils for different users' do
           new_valid_until_1 = Time.now.utc.beginning_of_hour + reset_interval_in_minutes.minutes
-          expect(REQUEST_COUNTER).to receive(:next_reset_interval).with(user_guid, reset_interval_in_minutes).and_return(new_valid_until_1)
-          _, valid_until = REQUEST_COUNTER.get(user_guid, reset_interval_in_minutes, logger)
+          expect(request_counter).to receive(:next_reset_interval).with(user_guid, reset_interval_in_minutes).and_return(new_valid_until_1)
+          _, valid_until = request_counter.get(user_guid, reset_interval_in_minutes, logger)
           expect(valid_until).to eq(new_valid_until_1)
 
           new_valid_until_2 = Time.now.utc.beginning_of_hour + reset_interval_in_minutes.minutes - 5.minutes
-          expect(REQUEST_COUNTER).to receive(:next_reset_interval).with(user_guid_2, reset_interval_in_minutes).and_return(new_valid_until_2)
-          _, valid_until = REQUEST_COUNTER.get(user_guid_2, reset_interval_in_minutes, logger)
+          expect(request_counter).to receive(:next_reset_interval).with(user_guid_2, reset_interval_in_minutes).and_return(new_valid_until_2)
+          _, valid_until = request_counter.get(user_guid_2, reset_interval_in_minutes, logger)
           expect(valid_until).to eq(new_valid_until_2)
         end
 
         it 'should return valid until and requests for an existing user' do
-          expect(REQUEST_COUNTER).to receive(:next_reset_interval).and_return(Time.now.utc.beginning_of_hour + reset_interval_in_minutes.minutes)
-          _, original_valid_until = REQUEST_COUNTER.get(user_guid, reset_interval_in_minutes, logger)
-          REQUEST_COUNTER.increment(user_guid)
+          expect(request_counter).to receive(:next_reset_interval).and_return(Time.now.utc.beginning_of_hour + reset_interval_in_minutes.minutes)
+          _, original_valid_until = request_counter.get(user_guid, reset_interval_in_minutes, logger)
+          request_counter.increment(user_guid)
 
           Timecop.travel(original_valid_until - 1.minutes) do
-            count, valid_until = REQUEST_COUNTER.get(user_guid, reset_interval_in_minutes, logger)
+            count, valid_until = request_counter.get(user_guid, reset_interval_in_minutes, logger)
             expect(count).to eq(1)
             expect(valid_until).to eq(original_valid_until)
           end
         end
 
         it 'should return new valid until and 0 requests for an existing user with expired rate limit' do
-          expect(REQUEST_COUNTER).to receive(:next_reset_interval).and_return(Time.now.utc.beginning_of_hour + reset_interval_in_minutes.minutes)
-          _, original_valid_until = REQUEST_COUNTER.get(user_guid, reset_interval_in_minutes, logger)
-          REQUEST_COUNTER.increment(user_guid)
+          expect(request_counter).to receive(:next_reset_interval).and_return(Time.now.utc.beginning_of_hour + reset_interval_in_minutes.minutes)
+          _, original_valid_until = request_counter.get(user_guid, reset_interval_in_minutes, logger)
+          request_counter.increment(user_guid)
 
           Timecop.travel(original_valid_until + 1.minutes) do
             new_valid_until = Time.now.utc.beginning_of_hour + reset_interval_in_minutes.minutes
-            expect(REQUEST_COUNTER).to receive(:next_reset_interval).and_return(new_valid_until)
-            count, valid_until = REQUEST_COUNTER.get(user_guid, reset_interval_in_minutes, logger)
+            expect(request_counter).to receive(:next_reset_interval).and_return(new_valid_until)
+            count, valid_until = request_counter.get(user_guid, reset_interval_in_minutes, logger)
             expect(count).to eq(0)
             expect(valid_until).to eq(new_valid_until)
             expect(logger).to have_received(:info).with "Resetting request count of 1 for user 'user-id'"

--- a/spec/unit/middleware/rate_limiter_v2_api_spec.rb
+++ b/spec/unit/middleware/rate_limiter_v2_api_spec.rb
@@ -1,0 +1,373 @@
+require 'spec_helper'
+
+module CloudFoundry
+  module Middleware
+    RSpec.describe RateLimiterV2API do
+      let(:middleware) do
+        RateLimiterV2API.new(
+          app,
+          {
+            logger:                            logger,
+            per_process_general_limit:         per_process_general_limit,
+            global_general_limit:              global_general_limit,
+            per_process_admin_limit: per_process_admin_limit,
+            global_admin_limit:      global_admin_limit,
+            interval:                          interval,
+          }
+        )
+      end
+      let(:REQUEST_COUNTER_V2_API) { double }
+      before(:each) {
+        middleware.instance_variable_set('@V2_API_REQUEST_COUNTER', REQUEST_COUNTER_V2_API)
+        allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([0, Time.now.utc])
+        allow(REQUEST_COUNTER_V2_API).to receive(:increment)
+      }
+
+      let(:app) { double(:app, call: [200, {}, 'a body']) }
+      let(:per_process_general_limit) { 20 }
+      let(:global_general_limit) { 200 }
+      let(:per_process_admin_limit) { 100 }
+      let(:global_admin_limit) { 1000 }
+      let(:interval) { 60 }
+      let(:logger) { double('logger', info: nil) }
+
+      let(:path_info) { '/v2/service_instances' }
+      let(:default_env) { { some: 'env' } }
+      let(:basic_auth_env) { { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('user', 'pass'), 'PATH_INFO' => path_info } }
+      let(:user_1_guid) { 'user-id-1' }
+      let(:user_2_guid) { 'user-id-2' }
+      let(:user_1_env) { { 'cf.user_guid' => user_1_guid, 'PATH_INFO' => path_info } }
+      let(:user_2_env) { { 'cf.user_guid' => user_2_guid, 'PATH_INFO' => path_info } }
+
+      describe 'headers as regular user' do
+        describe 'X-RateLimit-Limit-V2-API' do
+          it 'shows the user the total request limit' do
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Limit-V2-API']).to eq(global_general_limit.to_s)
+          end
+        end
+
+        describe 'X-RateLimit-Remaining-V2-API' do
+          it 'shows the user the number of remaining requests rounded down to nearest 10%' do
+            allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([0, Time.now.utc])
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('180')
+
+            allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([10, Time.now.utc])
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('80')
+          end
+
+          it 'tracks user\'s remaining requests independently' do
+            expect(REQUEST_COUNTER_V2_API).to receive(:get).with(user_1_guid, interval, logger).and_return([0, Time.now.utc])
+            expect(REQUEST_COUNTER_V2_API).to receive(:get).with(user_2_guid, interval, logger).and_return([10, Time.now.utc])
+
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('180')
+
+            _, response_headers, _ = middleware.call(user_2_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('80')
+          end
+        end
+
+        describe 'X-RateLimit-Reset-V2-API' do
+          it 'shows the user when the interval will expire' do
+            valid_until = Time.now.utc.beginning_of_hour + interval.minutes
+            allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([0, valid_until])
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Reset-V2-API'].to_i).to eq(valid_until.utc.to_i)
+          end
+        end
+      end
+
+      describe 'headers as admin user' do
+        before do
+          allow(VCAP::CloudController::SecurityContext).to receive(:admin_read_only?).and_return(true)
+        end
+        describe 'X-RateLimit-Limit-V2-API' do
+          it 'shows the user the total request limit' do
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Limit-V2-API']).to eq(global_admin_limit.to_s)
+          end
+        end
+
+        describe 'X-RateLimit-Remaining-V2-API' do
+          it 'shows the user the number of remaining requests rounded down to nearest 10%' do
+            allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([0, Time.now.utc])
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('900')
+
+            allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([10, Time.now.utc])
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('800')
+          end
+        end
+
+        describe 'X-RateLimit-Reset-V2-API' do
+          it 'shows the user when the interval will expire' do
+            valid_until = Time.now.utc.beginning_of_hour + interval.minutes
+            allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([0, valid_until])
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Reset-V2-API'].to_i).to eq(valid_until.utc.to_i)
+          end
+        end
+      end
+
+      it 'increments the counter and allows the request to continue' do
+        _, _, _ = middleware.call(user_1_env)
+        expect(REQUEST_COUNTER_V2_API).to have_received(:increment).with(user_1_guid)
+        expect(app).to have_received(:call)
+      end
+
+      it 'does not drop headers created in next middleware' do
+        allow(app).to receive(:call).and_return([200, { 'from' => 'wrapped-app' }, 'a body'])
+        _, headers, _ = middleware.call({})
+        expect(headers).to match(hash_including('from' => 'wrapped-app'))
+      end
+
+      describe 'exempting non v2/* endpoints' do
+        describe 'exempting internal endpoints' do
+          context 'when the user is hitting a path starting with "/internal"' do
+            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/internal/pants/1234') }
+
+            it 'exempts them from rate limiting' do
+              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+              _, response_headers, _ = middleware.call(default_env)
+              expect(REQUEST_COUNTER_V2_API).not_to have_received(:get)
+              expect(REQUEST_COUNTER_V2_API).not_to have_received(:increment)
+              expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
+              expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
+              expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
+            end
+          end
+
+          context 'when the user is hitting containing, but NOT starting with "/internal"' do
+            let(:headers) { ActionDispatch::Http::Headers.from_hash({ 'HTTP_X_FORWARDED_FOR' => 'forwarded_ip' }) }
+            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v2/pants/internal/1234', headers: headers) }
+
+            it 'rate limits them' do
+              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+              expect(REQUEST_COUNTER_V2_API).to receive(:get).with('forwarded_ip', interval, logger).and_return([0, Time.now.utc])
+              expect(REQUEST_COUNTER_V2_API).to receive(:increment).with('forwarded_ip')
+              _, response_headers, _ = middleware.call(default_env)
+              expect(response_headers['X-RateLimit-Limit-V2-API']).to_not be_nil
+              expect(response_headers['X-RateLimit-Remaining-V2-API']).to_not be_nil
+              expect(response_headers['X-RateLimit-Reset-V2-API']).to_not be_nil
+            end
+          end
+        end
+
+        context 'when the user is hitting a root path /' do
+          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/') }
+
+          it 'exempts them from rate limiting' do
+            allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+            _, response_headers, _ = middleware.call(default_env)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:get)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:increment)
+            expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
+          end
+        end
+
+        context 'when the user is hitting a root path /v2/info' do
+          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v2/info') }
+
+          it 'exempts them from rate limiting' do
+            allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+            _, response_headers, _ = middleware.call(default_env)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:get)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:increment)
+            expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
+          end
+        end
+
+        context 'when the user is hitting a root path /v3' do
+          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3') }
+
+          it 'exempts them from rate limiting' do
+            allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+            _, response_headers, _ = middleware.call(default_env)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:get)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:increment)
+            expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
+          end
+        end
+
+        context 'when the user is hitting a root path /v3/services' do
+          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/services') }
+
+          it 'exempts them from rate limiting' do
+            allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+            _, response_headers, _ = middleware.call(default_env)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:get)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:increment)
+            expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
+          end
+        end
+
+        context 'when the user is hitting a root path /healthz' do
+          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/healthz') }
+
+          it 'exempts them from rate limiting' do
+            allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+            _, response_headers, _ = middleware.call(default_env)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:get)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:increment)
+            expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
+          end
+        end
+      end
+
+      describe 'when the user is not logged in' do
+        describe 'when the user has basic auth credentials' do
+          it 'exempts them from rate limiting' do
+            _, response_headers, _ = middleware.call(basic_auth_env)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:get)
+            expect(REQUEST_COUNTER_V2_API).not_to have_received(:increment)
+            expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
+          end
+        end
+
+        describe 'when the user has a "HTTP_X_FORWARDED_FOR" header from proxy' do
+          let(:forwarded_ip) { 'forwarded_ip' }
+          let(:forwarded_ip_2) { 'forwarded_ip_2' }
+          let(:headers) { ActionDispatch::Http::Headers.from_hash({ 'HTTP_X_FORWARDED_FOR' => forwarded_ip }) }
+          let(:headers_2) { ActionDispatch::Http::Headers.from_hash({ 'HTTP_X_FORWARDED_FOR' => forwarded_ip_2 }) }
+          let(:fake_request) { instance_double(ActionDispatch::Request, headers: headers, ip: 'proxy-ip', fullpath: '/v2/some/path') }
+          let(:fake_request_2) { instance_double(ActionDispatch::Request, headers: headers_2, ip: 'proxy-ip', fullpath: '/v2/some/path') }
+
+          before do
+            allow(fake_request).to receive(:fetch_header).with('HTTP_X_FORWARDED_FOR').and_return(forwarded_ip)
+            allow(fake_request_2).to receive(:fetch_header).with('HTTP_X_FORWARDED_FOR').and_return(forwarded_ip_2)
+          end
+
+          it 'identifies them by the "HTTP_X_FORWARDED_FOR" header' do
+            valid_until = Time.now.utc
+            valid_until_2 = Time.now.utc
+
+            allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+            expect(REQUEST_COUNTER_V2_API).to receive(:get).with(forwarded_ip, interval, logger).and_return([0, valid_until])
+            expect(REQUEST_COUNTER_V2_API).to receive(:increment).with(forwarded_ip)
+            _, response_headers, _ = middleware.call(default_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('180')
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq(valid_until.to_i.to_s)
+
+            allow(ActionDispatch::Request).to receive(:new).and_return(fake_request_2)
+            expect(REQUEST_COUNTER_V2_API).to receive(:get).with(forwarded_ip_2, interval, logger).and_return([2, valid_until_2])
+            expect(REQUEST_COUNTER_V2_API).to receive(:increment).with(forwarded_ip_2)
+            _, response_headers, _ = middleware.call(default_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('160')
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq(valid_until_2.to_i.to_s)
+          end
+        end
+
+        describe 'when the there is no "HTTP_X_FORWARDED_FOR" header' do
+          let(:headers) { ActionDispatch::Http::Headers.from_hash({ 'X_HEADER' => 'nope' }) }
+          let(:ip) { 'some-ip' }
+          let(:ip_2) { 'some-ip-2' }
+          let(:fake_request) { instance_double(ActionDispatch::Request, headers: headers, ip: ip, fullpath: '/v2/some/path') }
+          let(:fake_request_2) { instance_double(ActionDispatch::Request, headers: headers, ip: ip_2, fullpath: '/v2/some/path') }
+
+          it 'identifies them by the request ip' do
+            valid_until = Time.now.utc.beginning_of_hour
+            valid_until_2 = Time.now.utc.beginning_of_hour + 5.minutes
+            allow(REQUEST_COUNTER_V2_API).to receive(:get).with(ip, interval, logger).and_return([0, valid_until])
+            allow(REQUEST_COUNTER_V2_API).to receive(:get).with(ip_2, interval, logger).and_return([2, valid_until_2])
+
+            allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+            _, response_headers, _ = middleware.call(default_env)
+            expect(REQUEST_COUNTER_V2_API).to have_received(:increment).with(ip)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('180')
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq(valid_until.utc.to_i.to_s)
+
+            allow(ActionDispatch::Request).to receive(:new).and_return(fake_request_2)
+            _, response_headers, _ = middleware.call(default_env)
+            expect(REQUEST_COUNTER_V2_API).to have_received(:increment).with(ip_2)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('160')
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq(valid_until_2.utc.to_i.to_s)
+          end
+        end
+      end
+
+      context 'when limit has exceeded' do
+        let(:path_info) { '/v2/foo' }
+        let(:middleware_env) do
+          { 'cf.user_guid' => 'user-id-1', 'PATH_INFO' => path_info }
+        end
+        before(:each) { allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([per_process_general_limit + 1, Time.now.utc]) }
+
+        it 'returns 429 response' do
+          status, _, _ = middleware.call(middleware_env)
+          expect(status).to eq(429)
+        end
+
+        it 'does not increment the request counter' do
+          _, _, _ = middleware.call(middleware_env)
+          expect(REQUEST_COUNTER_V2_API).to_not have_received(:increment)
+        end
+
+        it 'prevents "X-RateLimit-Remaining-V2-API" from going lower than zero' do
+          allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([per_process_general_limit + 100, Time.now.utc])
+          _, response_headers, _ = middleware.call(middleware_env)
+          expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('0')
+        end
+
+        it 'contains the correct headers' do
+          valid_until = Time.now.utc
+          allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([per_process_general_limit + 1, valid_until])
+          error_presenter = instance_double(ErrorPresenter, to_hash: { foo: 'bar' })
+          allow(ErrorPresenter).to receive(:new).and_return(error_presenter)
+
+          _, response_headers, _ = middleware.call(middleware_env)
+          expect(response_headers['Retry-After']).to eq(valid_until.utc.to_i.to_s)
+          expect(response_headers['Content-Type']).to eq('text/plain; charset=utf-8')
+          expect(response_headers['Content-Length']).to eq({ foo: 'bar' }.to_json.length.to_s)
+        end
+
+        it 'ends the request' do
+          _, _, _ = middleware.call(middleware_env)
+          expect(app).not_to have_received(:call)
+        end
+
+        it 'formats the response error in v2 format' do
+          _, _, body = middleware.call(middleware_env)
+          json_body = JSON.parse(body.first)
+          expect(json_body).to include(
+            'code' => 10018,
+            'description' => 'Rate Limit of V2 API Exceeded. Please consider to use V3 API',
+            'error_code' => 'CF-RateLimitV2APIExceeded',
+                                 )
+        end
+
+        context 'when the user is admin' do
+          let(:path_info) { '/v2/foo' }
+          let(:default_env) { { 'some' => 'env', 'PATH_INFO' => path_info } }
+
+          it 'contains the correct headers' do
+            valid_until = Time.now.utc
+            allow(REQUEST_COUNTER_V2_API).to receive(:get).and_return([per_process_admin_limit + 1, valid_until])
+            error_presenter = instance_double(ErrorPresenter, to_hash: { foo: 'bar' })
+            allow(ErrorPresenter).to receive(:new).and_return(error_presenter)
+
+            _, response_headers, _ = middleware.call(middleware_env)
+            expect(response_headers['Retry-After']).to eq(valid_until.utc.to_i.to_s)
+            expect(response_headers['Content-Type']).to eq('text/plain; charset=utf-8')
+            expect(response_headers['Content-Length']).to eq({ foo: 'bar' }.to_json.length.to_s)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* A explanation of the proposed change:
  
  As v2 API is deprecated and v3 API has in general a better performance (at least on big foundations) we want to motivate users to migrate to v3 API.
  We want to add a rate limiter for v2 API calls as an additional 'motivator'. This rate limiter distinguishes between requests from admin and regular  users. It is disabled per default and can be configured by operators.
  
  The v2 rate limiter reuses the logic of the general rate limiter. Main differences are the paths on which the rate limit will be skipped and the error messages.
  To improve reuse between the general rate limiter and v2 rate limiter we introduced a base rate limiter which contains most of the logic (move over from general rate limiter).
  This will also make it easier to implement further requests limiter.

  If enabled users will see the following additional headers
  ```
  X-Ratelimit-Limit-V2-Api: 100
  X-Ratelimit-Remaining-V2-Api: 0
  X-Ratelimit-Reset-V2-Api: 1658755978
  ```



* An explanation of the use cases your change solves
  As an operator I want to rate limit v2 API calls for regular (incl. unauthenticated) and admin users


* Links to any other associated PRs
  - https://github.com/cloudfoundry/capi-release/pull/254

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
