### PR TITLE
Add permissions check to service instances purge

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -109,7 +109,7 @@ class ServiceInstancesV3Controller < ApplicationController
     purge = params['purge'] == 'true'
 
     if purge
-      unauthorized! unless admin? || writable_space_scoped?(service_instance.service.service_broker.space)
+      unauthorized! unless service_instance.is_a?(UserProvidedServiceInstance) || current_user_can_write?(service_instance.service)
       ServiceInstancePurge.new(service_event_repository).purge(service_instance)
       return [:no_content, nil]
     end

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -109,6 +109,7 @@ class ServiceInstancesV3Controller < ApplicationController
     purge = params['purge'] == 'true'
 
     if purge
+      unauthorized! unless admin? || writable_space_scoped?(service_instance.service.service_broker.space)
       ServiceInstancePurge.new(service_event_repository).purge(service_instance)
       return [:no_content, nil]
     end

--- a/docs/v3/source/includes/resources/service_instances/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_delete.md.erb
@@ -53,4 +53,4 @@ Name | Type | Description
  |
 --- | ---
 Admin |
-Space Developer |
+Space Developer | Purge only allowed for space-scoped brokers

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -3322,29 +3322,88 @@ RSpec.describe 'V3 service instances' do
 
       context 'when purge is true' do
         let(:query_params) { 'purge=true' }
-        let(:service_offering) { VCAP::CloudController::Service.make(requires: %w(route_forwarding)) }
-        let(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service_offering) }
-        let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan) }
-        before(:each) do
-          @binding = VCAP::CloudController::ServiceBinding.make(service_instance: instance)
-          @key = VCAP::CloudController::ServiceKey.make(service_instance: instance)
-          @route = VCAP::CloudController::RouteBinding.make(service_instance: instance)
 
-          api_call.call(admin_headers)
+        context 'when broker is space scoped' do
+          let!(:service_broker) { VCAP::CloudController::ServiceBroker.make(space: space) }
+          let(:service_offering) { VCAP::CloudController::Service.make(requires: %w(route_forwarding), service_broker: service_broker) }
+          let(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service_offering) }
+          let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan) }
+
+          before(:each) do
+            @binding = VCAP::CloudController::ServiceBinding.make(service_instance: instance)
+            @key = VCAP::CloudController::ServiceKey.make(service_instance: instance)
+            @route = VCAP::CloudController::RouteBinding.make(service_instance: instance)
+          end
+
+          context 'as developer' do
+            let(:space_dev_headers) do
+              org.add_user(user)
+              space.add_developer(user)
+              headers_for(user)
+            end
+
+            it 'deletes the service instance' do
+              api_call.call(space_dev_headers)
+
+              expect(last_response).to have_status_code(204)
+              expect { instance.reload }.to raise_error Sequel::NoExistingObject
+            end
+          end
+
+          context 'as admin' do
+            it 'deletes the service instance' do
+              api_call.call(admin_headers)
+
+              expect(last_response).to have_status_code(204)
+              expect { instance.reload }.to raise_error Sequel::NoExistingObject
+            end
+          end
         end
 
-        it 'removes all associations' do
-          expect { @binding.reload }.to raise_error Sequel::NoExistingObject
-          expect { @key.reload }.to raise_error Sequel::NoExistingObject
-          expect { @route.reload }.to raise_error Sequel::NoExistingObject
-        end
+        context 'when broker is global' do
+          let(:service_offering) { VCAP::CloudController::Service.make(requires: %w(route_forwarding)) }
+          let(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service_offering) }
+          let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan) }
 
-        it 'deletes the service instance' do
-          expect { instance.reload }.to raise_error Sequel::NoExistingObject
-        end
+          before(:each) do
+            @binding = VCAP::CloudController::ServiceBinding.make(service_instance: instance)
+            @key = VCAP::CloudController::ServiceKey.make(service_instance: instance)
+            @route = VCAP::CloudController::RouteBinding.make(service_instance: instance)
+          end
 
-        it 'responds with 204' do
-          expect(last_response).to have_status_code(204)
+          context 'as developer' do
+            let(:space_dev_headers) do
+              org.add_user(user)
+              space.add_developer(user)
+              headers_for(user)
+            end
+
+            it 'responds with 403' do
+              api_call.call(space_dev_headers)
+
+              expect(last_response).to have_status_code(403)
+            end
+          end
+
+          context 'as admin' do
+            before(:each) do
+              api_call.call(admin_headers)
+            end
+
+            it 'removes all associations' do
+              expect { @binding.reload }.to raise_error Sequel::NoExistingObject
+              expect { @key.reload }.to raise_error Sequel::NoExistingObject
+              expect { @route.reload }.to raise_error Sequel::NoExistingObject
+            end
+
+            it 'deletes the service instance' do
+              expect { instance.reload }.to raise_error Sequel::NoExistingObject
+            end
+
+            it 'responds with 204' do
+              expect(last_response).to have_status_code(204)
+            end
+          end
         end
       end
 

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -2827,7 +2827,7 @@ RSpec.describe 'V3 service instances' do
 
       context 'with purge' do
         let(:query_params) { 'purge=true' }
-        before(:each) do
+        before do
           @binding = VCAP::CloudController::ServiceBinding.make(service_instance: instance)
           @route = VCAP::CloudController::RouteBinding.make(service_instance: instance)
         end
@@ -3322,18 +3322,12 @@ RSpec.describe 'V3 service instances' do
 
       context 'when purge is true' do
         let(:query_params) { 'purge=true' }
+        let(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service_offering) }
+        let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan) }
 
         context 'when broker is space scoped' do
-          let!(:service_broker) { VCAP::CloudController::ServiceBroker.make(space: space) }
+          let(:service_broker) { VCAP::CloudController::ServiceBroker.make(space: space) }
           let(:service_offering) { VCAP::CloudController::Service.make(requires: %w(route_forwarding), service_broker: service_broker) }
-          let(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service_offering) }
-          let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan) }
-
-          before(:each) do
-            @binding = VCAP::CloudController::ServiceBinding.make(service_instance: instance)
-            @key = VCAP::CloudController::ServiceKey.make(service_instance: instance)
-            @route = VCAP::CloudController::RouteBinding.make(service_instance: instance)
-          end
 
           context 'as developer' do
             let(:space_dev_headers) do
@@ -3362,10 +3356,8 @@ RSpec.describe 'V3 service instances' do
 
         context 'when broker is global' do
           let(:service_offering) { VCAP::CloudController::Service.make(requires: %w(route_forwarding)) }
-          let(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service_offering) }
-          let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: service_plan) }
 
-          before(:each) do
+          before do
             @binding = VCAP::CloudController::ServiceBinding.make(service_instance: instance)
             @key = VCAP::CloudController::ServiceKey.make(service_instance: instance)
             @route = VCAP::CloudController::RouteBinding.make(service_instance: instance)
@@ -3386,7 +3378,7 @@ RSpec.describe 'V3 service instances' do
           end
 
           context 'as admin' do
-            before(:each) do
+            before do
               api_call.call(admin_headers)
             end
 
@@ -3939,7 +3931,7 @@ RSpec.describe 'V3 service instances' do
     let(:instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
     let(:other_space) { VCAP::CloudController::Space.make }
 
-    before(:each) do
+    before do
       share_service_instance(instance, other_space)
     end
 

--- a/spec/request/service_offerings_spec.rb
+++ b/spec/request/service_offerings_spec.rb
@@ -763,18 +763,14 @@ RSpec.describe 'V3 service offerings' do
 
     context 'when purge=true' do
       context 'when user is a space developer' do
-        let(:user) { VCAP::CloudController::User.make }
-
         before do
           org.add_user(user)
           space.add_developer(user)
         end
 
         context 'when broker is space-scoped' do
-          let!(:org) { VCAP::CloudController::Organization.make }
-          let!(:space) { VCAP::CloudController::Space.make(organization: org) }
-          let!(:service_broker) { VCAP::CloudController::ServiceBroker.make(space: space) }
-          let!(:service_offering) { VCAP::CloudController::Service.make(service_broker: service_broker) }
+          let(:service_broker) { VCAP::CloudController::ServiceBroker.make(space: space) }
+          let(:service_offering) { VCAP::CloudController::Service.make(service_broker: service_broker) }
 
           it 'deletes the service offering and its dependencies' do
             delete "/v3/service_offerings/#{service_offering.guid}?purge=true", nil, headers_for(user)
@@ -790,7 +786,7 @@ RSpec.describe 'V3 service offerings' do
         context 'when broker is global' do
           let(:service_offering) { VCAP::CloudController::ServicePlan.make(public: true, active: true).service }
 
-          it 'deletes the service offering and its dependencies' do
+          it 'responds with 403' do
             delete "/v3/service_offerings/#{service_offering.guid}?purge=true", nil, headers_for(user)
 
             expect(last_response).to have_status_code(403)


### PR DESCRIPTION
Allow purging of service instances only for admins and space developers if broker is space scoped. This replicates the behavior of  `DELETE /v2/service_instances/:guid?purge=true`.
The current implementation allows any space developer to purge their service instances which can result in orphaned resources.

Updated permissions for `DELETE v3/service_instances/:guid`:

| service instance type|purge|Permitted roles|
|---|---|---|
| managed| false | Admin, SpaceDeveloper |
| **managed**| **true** | **Admin only (previously allowed for  SpaceDeveloper)** |
| space-scoped | false | Admin, SpaceDeveloper |
| space-scoped | true | Admin, SpaceDeveloper |
| user-provided | false | Admin, SpaceDeveloper |
| user-provided | true | Admin, SpaceDeveloper |

  

Related to #2878


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
