### PR TITLE
Downgrade mysql container

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["mysql:5.7", "mysql:8.0"]
+        image: ["mysql:5.7", "mysql:8.0.29"]
     services:
       mysql:
         image: ${{ matrix.image }}


### PR DESCRIPTION
Currently the cc does not start on mysql `8.0.30`. This also cause the unit test github action to fails.
It fails with the following error: 
```
Referencing column 'app_guid' and referenced column 'guid' in foreign key constraint 'route_mappings_ibfk_1' are incompatible.
```


Seems to be related to this change:

> Important Change: A previous change renamed character sets having deprecated names prefixed with utf8_ to use utf8mb3_ instead. In this release, we rename the utf8_ collations as well, using the utf8mb3_ prefix; this is to make the collation names consistent with those of the character sets, not to rely any longer on the deprecated collation names, and to clarify the distinction between utf8mb3 and utf8mb4. The names using the utf8mb3_ prefix are now used exclusively for these collations in the output of SHOW statements such as SHOW CREATE TABLE, as well as in the values displayed in the columns of Information Schema tables including the COLLATIONS and COLUMNS tables. (Bug #33787300)
[Source](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-30.html)


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
