### PR TITLE
Adapt old migration file to work with MySQL 8.0.30

### DIFF
--- a/db/migrations/20150514190458_fix_mysql_collations.rb
+++ b/db/migrations/20150514190458_fix_mysql_collations.rb
@@ -19,7 +19,7 @@ Sequel.migration do
         columns_to_change = ds.with_sql("SHOW FULL COLUMNS FROM `#{table}`").to_a.select do |column_definition|
           next if case_insensitive_columns[table] && case_insensitive_columns[table].include?(column_definition[:Field].to_sym)
 
-          column_definition[:Collation] == 'utf8_general_ci'
+          %w(utf8_general_ci utf8mb3_general_ci).include?(column_definition[:Collation])
         end
         unless columns_to_change.empty?
           modify_column_strings = columns_to_change.collect do |column_definition|


### PR DESCRIPTION
As collation names have been renamed with MySQL 8.0.30 [1] we have to compare to two different possible names, i.e. utf8_general_ci (old name) and utf8mb3_general_ci (new name).

[1] https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-30.html#mysqld-8-0-30-charset

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
