### PR TITLE
Add includes of route, domain, process for show app endpoint

### DIFF
--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -13,6 +13,9 @@ require 'actions/app_assign_droplet'
 require 'decorators/include_space_decorator'
 require 'decorators/include_organization_decorator'
 require 'decorators/include_space_organization_decorator'
+require 'decorators/include_app_route_decorator'
+require 'decorators/include_app_process_decorator'
+require 'decorators/include_app_domain_decorator'
 require 'messages/apps_list_message'
 require 'messages/app_show_message'
 require 'messages/app_update_message'
@@ -73,6 +76,9 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
     decorators = []
     decorators << IncludeSpaceDecorator if IncludeSpaceDecorator.match?(message.include)
     decorators << IncludeOrganizationDecorator if IncludeOrganizationDecorator.match?(message.include)
+    decorators << IncludeAppRouteDecorator if IncludeAppRouteDecorator.match?(message.include)
+    decorators << IncludeAppProcessDecorator if IncludeAppProcessDecorator.match?(message.include)
+    decorators << IncludeAppDomainDecorator if IncludeAppDomainDecorator.match?(message.include)
 
     render status: :ok, json: Presenters::V3::AppPresenter.new(
       app,

--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -78,7 +78,7 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
     decorators << IncludeOrganizationDecorator if IncludeOrganizationDecorator.match?(message.include)
     decorators << IncludeAppRouteDecorator if IncludeAppRouteDecorator.match?(message.include)
     decorators << IncludeAppProcessDecorator if IncludeAppProcessDecorator.match?(message.include)
-    decorators << IncludeAppDomainDecorator if IncludeAppDomainDecorator.match?(message.include)
+    decorators << IncludeAppDomainDecorator.new(presenter_args) if IncludeAppDomainDecorator.match?(message.include)
 
     render status: :ok, json: Presenters::V3::AppPresenter.new(
       app,
@@ -403,5 +403,13 @@ eager_loaded_associations: Presenters::V3::AppPresenter.associated_resources)
 
   def instances_reporters
     CloudController::DependencyLocator.instance.instances_reporters
+  end
+
+  def presenter_args
+    if permission_queryer.can_read_globally?
+      { all_orgs_visible: true }
+    else
+      { visible_org_guids: permission_queryer.readable_org_guids }
+    end
   end
 end

--- a/app/decorators/include_app_domain_decorator.rb
+++ b/app/decorators/include_app_domain_decorator.rb
@@ -10,12 +10,12 @@ module VCAP::CloudController
 
         app_guids = apps.map(&:guid)
         domains = Domain.select_all(:domains).distinct.
-          join(:routes, domain_id: :id).
-          join(:route_mappings, route_guid: :routes__guid).
-          where(route_mappings__app_guid: app_guids).
-          order(:domains__created_at).
-          eager(Presenters::V3::DomainPresenter.associated_resources).
-          all
+                  join(:routes, domain_id: :id).
+                  join(:route_mappings, route_guid: :routes__guid).
+                  where(route_mappings__app_guid: app_guids).
+                  order(:domains__created_at).
+                  eager(Presenters::V3::DomainPresenter.associated_resources).
+                  all
 
         hash[:included][:domains] = domains.map { |domain| Presenters::V3::DomainPresenter.new(domain).to_hash }
         hash

--- a/app/decorators/include_app_domain_decorator.rb
+++ b/app/decorators/include_app_domain_decorator.rb
@@ -1,0 +1,21 @@
+module VCAP::CloudController
+  class IncludeAppDomainDecorator
+    class << self
+      def match?(include)
+        include&.any? { |i| %w(domain).include?(i) }
+      end
+
+      def decorate(hash, apps)
+        hash[:included] ||= {}
+        routes = apps.map(&:routes).flatten
+        domain_ids = routes.map(&:domain_id).uniq
+
+        domains = Domain.where(id: domain_ids).order(:created_at).
+          eager(Presenters::V3::DomainPresenter.associated_resources).all
+
+        hash[:included][:domains] = domains.map { |domain| Presenters::V3::DomainPresenter.new(domain).to_hash }
+        hash
+      end
+    end
+  end
+end

--- a/app/decorators/include_app_process_decorator.rb
+++ b/app/decorators/include_app_process_decorator.rb
@@ -8,7 +8,8 @@ module VCAP::CloudController
       def decorate(hash, apps)
         hash[:included] ||= {}
 
-        processes = ProcessModel.where(app: apps).order(:created_at).
+        processes = ProcessModel.where(app: apps).
+                    order(Sequel.asc(:created_at), Sequel.asc(:id)).
                     eager(Presenters::V3::ProcessPresenter.associated_resources).all
 
         hash[:included][:processes] = processes.map { |process| Presenters::V3::ProcessPresenter.new(process).to_hash }

--- a/app/decorators/include_app_process_decorator.rb
+++ b/app/decorators/include_app_process_decorator.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
       def decorate(hash, apps)
         hash[:included] ||= {}
 
-        processes = ProcessModel.distinct.where(app: apps).order(:created_at).
+        processes = ProcessModel.where(app: apps).order(:created_at).
                     eager(Presenters::V3::ProcessPresenter.associated_resources).all
 
         hash[:included][:processes] = processes.map { |process| Presenters::V3::ProcessPresenter.new(process).to_hash }

--- a/app/decorators/include_app_process_decorator.rb
+++ b/app/decorators/include_app_process_decorator.rb
@@ -1,0 +1,20 @@
+module VCAP::CloudController
+  class IncludeAppProcessDecorator
+    class << self
+      def match?(include)
+        include&.any? { |i| %w(process).include?(i) }
+      end
+
+      def decorate(hash, apps)
+        hash[:included] ||= {}
+        process_guids = apps.map(&:process_guids).uniq
+
+        processes = ProcessModel.where(guid: process_guids).order(:created_at).
+          eager(Presenters::V3::ProcessPresenter.associated_resources).all
+
+        hash[:included][:processes] = processes.map { |process| Presenters::V3::ProcessPresenter.new(process).to_hash }
+        hash
+      end
+    end
+  end
+end

--- a/app/decorators/include_app_process_decorator.rb
+++ b/app/decorators/include_app_process_decorator.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
         hash[:included] ||= {}
 
         processes = ProcessModel.distinct.where(app: apps).order(:created_at).
-          eager(Presenters::V3::ProcessPresenter.associated_resources).all
+                    eager(Presenters::V3::ProcessPresenter.associated_resources).all
 
         hash[:included][:processes] = processes.map { |process| Presenters::V3::ProcessPresenter.new(process).to_hash }
         hash

--- a/app/decorators/include_app_process_decorator.rb
+++ b/app/decorators/include_app_process_decorator.rb
@@ -7,9 +7,8 @@ module VCAP::CloudController
 
       def decorate(hash, apps)
         hash[:included] ||= {}
-        process_guids = apps.map(&:process_guids).uniq
 
-        processes = ProcessModel.where(guid: process_guids).order(:created_at).
+        processes = ProcessModel.distinct.where(app: apps).order(:created_at).
           eager(Presenters::V3::ProcessPresenter.associated_resources).all
 
         hash[:included][:processes] = processes.map { |process| Presenters::V3::ProcessPresenter.new(process).to_hash }

--- a/app/decorators/include_app_route_decorator.rb
+++ b/app/decorators/include_app_route_decorator.rb
@@ -10,9 +10,10 @@ module VCAP::CloudController
 
         app_guids = apps.map(&:guid)
 
-        routes = Route.inner_join(:route_mappings, route_guid: :guid).
-          where(route_mappings__app_guid: app_guids).
-          order(:created_at).all
+        routes = Route.select_all(:routes).
+                 inner_join(:route_mappings, route_guid: :guid).
+                 where(route_mappings__app_guid: app_guids).
+                 order(:routes__created_at).all
 
         hash[:included][:routes] = routes.map { |route| Presenters::V3::RoutePresenter.new(route).to_hash }
         hash

--- a/app/decorators/include_app_route_decorator.rb
+++ b/app/decorators/include_app_route_decorator.rb
@@ -1,0 +1,20 @@
+module VCAP::CloudController
+  class IncludeAppRouteDecorator
+    class << self
+      def match?(include)
+        include&.any? { |i| %w(route).include?(i) }
+      end
+
+      def decorate(hash, apps)
+        hash[:included] ||= {}
+        route_guids = apps.map(&:route_guids).flatten.uniq
+
+        routes = Route.where(guid: route_guids).order(:created_at).
+          eager(Presenters::V3::RoutePresenter.associated_resources).all
+
+        hash[:included][:routes] = routes.map { |route| Presenters::V3::RoutePresenter.new(route).to_hash }
+        hash
+      end
+    end
+  end
+end

--- a/app/decorators/include_app_route_decorator.rb
+++ b/app/decorators/include_app_route_decorator.rb
@@ -7,10 +7,12 @@ module VCAP::CloudController
 
       def decorate(hash, apps)
         hash[:included] ||= {}
-        route_guids = apps.map(&:route_guids).flatten.uniq
 
-        routes = Route.where(guid: route_guids).order(:created_at).
-          eager(Presenters::V3::RoutePresenter.associated_resources).all
+        app_guids = apps.map(&:guid)
+
+        routes = Route.inner_join(:route_mappings, route_guid: :guid).
+          where(route_mappings__app_guid: app_guids).
+          order(:created_at).all
 
         hash[:included][:routes] = routes.map { |route| Presenters::V3::RoutePresenter.new(route).to_hash }
         hash

--- a/app/messages/app_show_message.rb
+++ b/app/messages/app_show_message.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
     register_allowed_keys [:include]
 
     validates_with NoAdditionalParamsValidator
-    validates_with IncludeParamValidator, valid_values: ['space', 'org', 'space.organization']
+    validates_with IncludeParamValidator, valid_values: ['space', 'org', 'space.organization', 'route', 'process', 'domain']
 
     def self.from_params(params)
       super(params, %w(include))

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -1931,8 +1931,7 @@ RSpec.describe 'Apps' do
         get "/v3/apps/#{app_model.guid}?include=process", nil, user_header
         expect(last_response.status).to eq(200)
 
-        process_1 = app_model.processes[0]
-        process_2 = app_model.processes[1]
+        process_1, process_2 = app_model.processes[0..1]
 
         parsed_response = MultiJson.load(last_response.body)
         processes = parsed_response['included']['processes']


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add includes for route, domain and process to the /v3/apps/:guid endpoint.

* An explanation of the use cases your change solves
The V2 app summary endpoint (/v2/apps/:guid/summary) is no longer available in V3. For a detailed problem description see https://github.com/cloudfoundry/cloud_controller_ng/issues/1990

This PR implements the first step mentioned in the above issue and makes it easier to retrieve domains, routes and processes associated with an app.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
