### PR TITLE
Fix flakey test in droplets.spec

### DIFF
--- a/spec/request/droplets_spec.rb
+++ b/spec/request/droplets_spec.rb
@@ -404,7 +404,10 @@ RSpec.describe 'Droplets' do
       it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
 
       it 'downloads the bit(s) for a droplet' do
-        get "/v3/droplets/#{guid}/download", nil, developer_headers
+        Timecop.freeze do
+          get "/v3/droplets/#{guid}/download", nil, developer_headers
+          bits_download_url
+        end
 
         expect(last_response.status).to eq(302)
         expect(last_response.headers['Location']).to eq(bits_download_url)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

The test failed (https://github.com/cloudfoundry/cloud_controller_ng/runs/7670613025?check_suite_focus=true) because the generated expected droplet URL is based on the current timestamp. Depending on the test execution speed, it can differ from the timestamp in the URL, which was generated during the request.

Fixed by using Timecop.freeze, which ensures that both URLs will have the same timestamp.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
