### PR TITLE
Introducing a new syslog drain endpoint

### DIFF
--- a/app/controllers/internal/syslog_drain_urls_controller.rb
+++ b/app/controllers/internal/syslog_drain_urls_controller.rb
@@ -52,13 +52,13 @@ module VCAP::CloudController
       prepare_aggregate_function
 
       syslog_drain_urls_query = ServiceBinding.
-                          distinct.
-                          exclude(syslog_drain_url: nil).
-                          exclude(syslog_drain_url: '').
-                          select(:syslog_drain_url).
-                          order(:syslog_drain_url).
-                          limit(batch_size).
-                          offset(last_id)
+                                distinct.
+                                exclude(syslog_drain_url: nil).
+                                exclude(syslog_drain_url: '').
+                                select(:syslog_drain_url).
+                                order(:syslog_drain_url).
+                                limit(batch_size).
+                                offset(last_id)
 
       bindings = ServiceBinding.
                  join(:apps, guid: :app_guid).

--- a/db/migrations/20220802160500_index_syslog_drain_url.rb
+++ b/db/migrations/20220802160500_index_syslog_drain_url.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :service_bindings do
+      add_full_text_index :syslog_drain_url, name: :service_bindings_syslog_drain_url_index, unique: false
+    end
+  end
+
+  down do
+    alter_table :service_bindings do
+      drop_index :syslog_drain_url, name: :service_bindings_syslog_drain_url_index
+    end
+  end
+end

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-CC's internal API is a patchwork of endpoints used by internal components. 
-They evolved over time and were individually designed for specific purposes. 
-We do not recommend using internal API endpoints for anything other than their intended purposes. 
+CC's internal API is a patchwork of endpoints used by internal components.
+They evolved over time and were individually designed for specific purposes.
+We do not recommend using internal API endpoints for anything other than their intended purposes.
 
 ## Endpoints
 
@@ -94,6 +94,13 @@ We do not recommend using internal API endpoints for anything other than their i
 
 ### GET /internal/v4/syslog_drain_urls
 **Description:** Return list of syslog drain urls from logging services
+
+**Intended Consumer:** Loggregator
+
+**Auth Mechanism:** MTLS
+
+### GET /internal/v5/syslog_drain_urls
+**Description:** Return list of syslog drain urls from logging services. Intends to replace v4 version. 
 
 **Intended Consumer:** Loggregator
 

--- a/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
+++ b/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
@@ -300,7 +300,7 @@ module VCAP::CloudController
         expect(decoded_results.count).to eq(3)
 
         foobar = decoded_results.select { |result| result['url'] == 'foobar' }.first
-        expect(foobar["apps"]).to include(
+        expect(foobar['apps']).to include(
           { 'app_id' => app_obj2.guid,
             'hostname' => 'org-1.space-1.app-2' },
           { 'app_id' => app_obj.guid,

--- a/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
+++ b/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
@@ -296,11 +296,17 @@ module VCAP::CloudController
       it 'returns a list of syslog drain urls and their credentials' do
         get '/internal/v5/syslog_drain_urls', '{}'
         expect(last_response).to be_successful
+
+        decoded_results.select { |result| result['url'] == 'foobar' }.
+          first['apps'].
+          sort! { |x, y| x['hostname'] <=> y['hostname'] }
+
         expect(decoded_results.count).to eq(3)
+
         expect(decoded_results).to include(
           { 'apps' =>
              [{ 'app_id' => app_obj2.guid,
-               'hostname' => 'org-1.space-1.app-2' },
+                'hostname' => 'org-1.space-1.app-2' },
               { 'app_id' => app_obj.guid,
                 'hostname' => 'org-1.space-1.app-1' }],
             'cert' => '',

--- a/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
+++ b/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
@@ -299,10 +299,10 @@ module VCAP::CloudController
         expect(decoded_results.count).to eq(3)
         expect(decoded_results).to include(
           { 'apps' =>
-             [{ 'app_id' => app_obj.guid,
-               'hostname' => 'org-1.space-1.app-1' },
-              { 'app_id' => app_obj2.guid,
-               'hostname' => 'org-1.space-1.app-2' }],
+             [{ 'app_id' => app_obj2.guid,
+               'hostname' => 'org-1.space-1.app-2' },
+              { 'app_id' => app_obj.guid,
+                'hostname' => 'org-1.space-1.app-1' }],
             'cert' => '',
             'key' => '',
             'url' => 'foobar' }

--- a/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
+++ b/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
@@ -297,22 +297,16 @@ module VCAP::CloudController
         get '/internal/v5/syslog_drain_urls', '{}'
         expect(last_response).to be_successful
 
-        decoded_results.select { |result| result['url'] == 'foobar' }.
-          first['apps'].
-          sort! { |x, y| x['hostname'] <=> y['hostname'] }
-
         expect(decoded_results.count).to eq(3)
 
-        expect(decoded_results).to include(
-          { 'apps' =>
-             [{ 'app_id' => app_obj2.guid,
-                'hostname' => 'org-1.space-1.app-2' },
-              { 'app_id' => app_obj.guid,
-                'hostname' => 'org-1.space-1.app-1' }],
-            'cert' => '',
-            'key' => '',
-            'url' => 'foobar' }
+        foobar = decoded_results.select { |result| result['url'] == 'foobar' }.first
+        expect(foobar["apps"]).to include(
+          { 'app_id' => app_obj2.guid,
+            'hostname' => 'org-1.space-1.app-2' },
+          { 'app_id' => app_obj.guid,
+            'hostname' => 'org-1.space-1.app-1' }
         )
+
         expect(decoded_results).to include(
           { 'apps' =>
              [{ 'app_id' => app_obj.guid,


### PR DESCRIPTION
We are working against a feature supporting mTLS on syslog-agent. To make it possible the pair of keys/certificates for each mTLS drain are required. Unfortunately the existing endpoint `/internal/v4/syslog_drain_urls` was not exposing the payload of such credentials.

The easiest way to provide those credentials would be to attach them on the existing syslog-drain payload.
That would produce a lot of credential duplication as the existing response is app centric.
A new response was required to efficiently deliver what we needed. This new response is drain centric to avoid the aforementioned duplication.

This change would break the api contract with `syslog-agent's binding-cache` and would require a lot of synchronisation between the two projects. Therefore we decided to publish a new endpoint `/internal/v5/syslog_drain_urls` offering this feature.

The proposal can be found in [this document](https://docs.google.com/document/d/1TkieqfYw9hrNw1xgtoPo6CYTjvEDnsIWt00ctzV57zw/edit#). Additionally there is an ongoing [PR with the loggregator-agent-release](https://github.com/cloudfoundry/loggregator-agent-release/pull/119).

Panagiotis Xynos <panagiotis.xynos@sap.com> & Felix Hambrecht <felix.hambrecht@sap.com>

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
