### PR TITLE
Add delete on cascade to fk_svc_inst_op_svc_instance_id

### DIFF
--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -24,7 +24,6 @@ module VCAP::CloudController
     serialize_attributes :json, :tags
 
     one_to_one :service_instance_operation
-    add_association_dependencies service_instance_operation: :destroy
 
     one_to_many :service_bindings, before_add: :validate_service_binding, key: :service_instance_guid, primary_key: :guid
     one_to_many :service_keys

--- a/db/migrations/20220805145100_add_delete_on_cascade_to_fk_svc_inst_op_svc_instance_id.rb
+++ b/db/migrations/20220805145100_add_delete_on_cascade_to_fk_svc_inst_op_svc_instance_id.rb
@@ -1,6 +1,6 @@
 Sequel.migration do
-  # Add delete cascade to fk_svc_inst_op_svc_instance_id, without there won't be cleaned up all ocurrencies in
-  # the service_instance_operations table
+  # Add DELETE CASCADE to foreign key fk_svc_inst_op_svc_instance_id to ensure that 'service instance operations'
+  # are deleted together with the referenced 'service instance'.
 
   up do
     alter_table :service_instance_operations do

--- a/db/migrations/20220805145100_add_delete_on_cascade_to_fk_svc_inst_op_svc_instance_id.rb
+++ b/db/migrations/20220805145100_add_delete_on_cascade_to_fk_svc_inst_op_svc_instance_id.rb
@@ -1,0 +1,18 @@
+Sequel.migration do
+  # Add delete cascade to fk_svc_inst_op_svc_instance_id, without there won't be cleaned up all ocurrencies in
+  # the service_instance_operations table
+
+  up do
+    alter_table :service_instance_operations do
+      drop_constraint :fk_svc_inst_op_svc_instance_id, type: :foreign_key
+      add_foreign_key [:service_instance_id], :service_instances, key: :id, name: :fk_svc_inst_op_svc_instance_id, on_delete: :cascade
+    end
+  end
+
+  down do
+    alter_table :service_instance_operations do
+      drop_constraint :fk_svc_inst_op_svc_instance_id, type: :foreign_key
+      add_foreign_key [:service_instance_id], :service_instances, key: :id, name: :fk_svc_inst_op_svc_instance_id
+    end
+  end
+end

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -183,29 +183,14 @@ module VCAP::CloudController
         expect(ServiceInstanceAnnotationModel.where(id: annotation.id)).to be_empty
       end
 
-      it 'cascade deletes all ServiceInstanceOperations for this instance' do
+      it 'cascade deletes the related ServiceInstanceOperation for this instance' do
         last_operation = ServiceInstanceOperation.make
         service_instance.service_instance_operation = last_operation
 
         service_instance.destroy
 
-        expect(ServiceInstance.find(guid: service_instance.guid)).to be_nil
-        expect(ServiceInstanceOperation.find(guid: last_operation.guid)).to be_nil
-      end
-
-      it 'cascades deletion of related dependencies' do
-        binding = ServiceInstance.make
-        ServiceInstanceLabelModel.make(key_name: 'foo', value: 'bar', service_instance: binding)
-        ServiceInstanceAnnotationModel.make(key_name: 'baz', value: 'wow', service_instance: binding)
-        last_operation = ServiceInstanceOperation.make
-        binding.service_instance_operation = last_operation
-
-        binding.destroy
-
-        expect(ServiceInstance.find(guid: binding.guid)).to be_nil
+        expect(ServiceInstance.find(id: service_instance.id)).to be_nil
         expect(ServiceInstanceOperation.find(id: last_operation.id)).to be_nil
-        expect(ServiceInstanceLabelModel.find(resource_guid: binding.guid)).to be_nil
-        expect(ServiceInstanceAnnotationModel.find(resource_guid: binding.guid)).to be_nil
       end
 
       it 'creates a DELETED service usage event' do


### PR DESCRIPTION
We can see double entries for the same service_instance_id
in the service_instance_operations table. This leads to:
PG::ForeignKeyViolation: ERROR:  update or delete on table
"service_instances" violates foreign key constraint
"fk_svc_inst_op_svc_instance_id" on table "service_instance_operations"

For service bindings, service keys and route bindings the foreign
key constraint from operation to resource contains ON DELETE CASCADE;
for service instances this is missing.

Adding ON DELETE CASCADE to FK fk_svc_inst_op_svc_instance_id in
service_instance_operations


* Links to any other associated PRs
The root cause is fixed in this PR: #2916
#2929

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
