### PR TITLE
Add upgrade documentation for /v3/info endpoint

### DIFF
--- a/docs/v3/source/includes/upgrade_guide/changed_resources/_header.md
+++ b/docs/v3/source/includes/upgrade_guide/changed_resources/_header.md
@@ -10,6 +10,7 @@ This table shows how V2 resources map to their respective V3 counterparts. Note 
 |Environment Variable Groups|Environment Variable Groups|
 |Events|Audit Events|[Audit Events in V3](#audit-events-in-v3)|
 |Feature Flags|Feature Flags|
+|Info|Info|[Info in V3](#info-in-v3)
 |Jobs|Jobs|
 |Organizations|Organizations|
 |Quota Definitions|Organization Quotas|[Organization Quotas in V3](#organization-quotas-in-v3)

--- a/docs/v3/source/includes/upgrade_guide/changed_resources/_info_in_v3.md
+++ b/docs/v3/source/includes/upgrade_guide/changed_resources/_info_in_v3.md
@@ -1,0 +1,5 @@
+### Info in V3
+
+In V2, `info` provided links to external APIs, such as the authorization endpoint
+
+In V3, use `/` to get external APIs as these links have been removed from `v3/info`

--- a/docs/v3/source/includes/upgrade_guide/changed_resources/_info_in_v3.md
+++ b/docs/v3/source/includes/upgrade_guide/changed_resources/_info_in_v3.md
@@ -1,5 +1,7 @@
 ### Info in V3
 
-In V2, `info` provided links to external APIs, such as the authorization endpoint
+In V2, `/v2/info` provides descriptive information about the system and endpoints to external APIs.
 
-In V3, use `/` to get external APIs as these links have been removed from `v3/info`
+In V3, `/v3/info` only provides descriptive information about the system.
+
+To access the external APIs in V3, use the root (`/`).

--- a/docs/v3/source/index.html.md
+++ b/docs/v3/source/index.html.md
@@ -415,6 +415,7 @@ includes:
   - upgrade_guide/changed_resources/header
   - upgrade_guide/changed_resources/audit_events_in_v3
   - upgrade_guide/changed_resources/domains_in_v3
+  - upgrade_guide/changed_resources/info_in_v3
   - upgrade_guide/changed_resources/organization_quotas_in_v3
   - upgrade_guide/changed_resources/routes_in_v3
   - upgrade_guide/changed_resources/security_groups_in_v3


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Update upgrade docs to note that external api endpoints can be retrieved by hitting `/` as they have been removed from `v3/info`

* An explanation of the use cases your change solves
Will help folks such as in this [cloud foundry slack question](https://cloudfoundry.slack.com/archives/C07C04W4Q/p1659546990342019)

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
