### PR TITLE
Allow bound routes to be moved if the route sharing flag is enabled

### DIFF
--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -167,7 +167,9 @@ module VCAP::CloudController
     end
 
     def validate_changed_space(new_space)
-      raise CloudController::Errors::InvalidAppRelation.new('Route and apps not in same space') if apps.any? { |app| app.space.id != space.id }
+      unless FeatureFlag.enabled? :route_sharing
+        raise CloudController::Errors::InvalidAppRelation.new('Route and apps not in same space') if apps.any? { |app| app.space.id != space.id }
+      end
       raise InvalidOrganizationRelation.new("Organization cannot use domain #{domain.name}") if domain && !domain.usable_by_organization?(new_space.organization)
     end
 

--- a/spec/unit/models/runtime/route_spec.rb
+++ b/spec/unit/models/runtime/route_spec.rb
@@ -150,7 +150,26 @@ module VCAP::CloudController
       end
 
       context 'changing space' do
-        context 'apps' do
+        context 'when the route sharing flag is enabled' do
+          let!(:feature_flag) { VCAP::CloudController::FeatureFlag.make(name: 'route_sharing', enabled: true, error_message: nil) }
+
+          it 'succeeds with no mapped apps' do
+            route = Route.make(space: ProcessModelFactory.make.space, domain: SharedDomain.make)
+
+            expect { route.space = Space.make }.not_to raise_error
+          end
+
+          it 'succeeds when there are apps mapped to it' do
+            process = ProcessModelFactory.make
+            route = Route.make(space: process.space, domain: SharedDomain.make)
+            RouteMappingModel.make(app: process.app, route: route, process_type: process.type)
+
+            expect { route.space = Space.make }.not_to raise_error
+          end
+        end
+        context 'when the route sharing flag is disabled' do
+          let!(:feature_flag) { VCAP::CloudController::FeatureFlag.make(name: 'route_sharing', enabled: false, error_message: nil) }
+
           it 'succeeds with no mapped apps' do
             route = Route.make(space: ProcessModelFactory.make.space, domain: SharedDomain.make)
 


### PR DESCRIPTION
This validation comes from v2 where we allowed users to move a routes
space as long as the route wasnt bound. This will change v2 behavior IF
the user enabled route_sharing. However Route sharing is a v3 feature
disabled by default so I belive this to be acceptable.

Authored-by: Merric de Launey <mdelauney@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
