### PR TITLE
Add partial search by usernames to GET /organizations/:guid/users

### DIFF
--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -168,7 +168,7 @@ class OrganizationsV3Controller < ApplicationController
 
   def list_members
     message = UsersListMessage.from_params(query_params)
-    invalid_param!(message.errors.full_messages) unless message.valid
+    invalid_param!(message.errors.full_messages) unless message.valid?
 
     org = fetch_org(hashed_params[:guid])
     org_not_found! unless org && permission_queryer.can_read_from_org?(org.guid)

--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -168,7 +168,7 @@ class OrganizationsV3Controller < ApplicationController
 
   def list_members
     message = UsersListMessage.from_params(query_params)
-    invalid_param!(message.errors.full_messages) unless message.valid?
+    invalid_param!(message.errors.full_messages) unless message.valid
 
     org = fetch_org(hashed_params[:guid])
     org_not_found! unless org && permission_queryer.can_read_from_org?(org.guid)

--- a/app/fetchers/user_list_fetcher.rb
+++ b/app/fetchers/user_list_fetcher.rb
@@ -17,6 +17,11 @@ module VCAP::CloudController
           dataset = dataset.where(guid: guids)
         end
 
+        if message.requested?(:partial_usernames)
+          guids = uaa_client.ids_for_usernames_and_origins(message.partial_usernames, message.origins, false)
+          dataset = dataset.where(guid: guids)
+        end
+
         if message.requested?(:label_selector)
           dataset = LabelSelectorQueryGenerator.add_selector_queries(
             label_klass: UserLabelModel,

--- a/app/messages/users_list_message.rb
+++ b/app/messages/users_list_message.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
 
     validates_with NoAdditionalParamsValidator
 
-    validate :origin_requires_username
+    validate :origin_requires_username_or_partial_usernames
     validate :usernames_or_partial_usernames
 
     validates :usernames, allow_nil: true, array: true
@@ -21,7 +21,7 @@ module VCAP::CloudController
       super(params, %w(usernames partial_usernames origins))
     end
 
-    def origin_requires_username
+    def origin_requires_username_or_partial_usernames
       if @origins
         unless @usernames || @partial_usernames
           errors.add(:origins, 'filter cannot be provided without usernames or partial_usernames filter.')

--- a/app/messages/users_list_message.rb
+++ b/app/messages/users_list_message.rb
@@ -4,25 +4,34 @@ module VCAP::CloudController
   class UsersListMessage < MetadataListMessage
     register_allowed_keys [
       :usernames,
+      :partial_usernames,
       :origins
     ]
 
     validates_with NoAdditionalParamsValidator
 
     validate :origin_requires_username
+    validate :usernames_or_partial_usernames
 
     validates :usernames, allow_nil: true, array: true
+    validates :partial_usernames, allow_nil: true, array: true
     validates :origins, allow_nil: true, array: true
 
     def self.from_params(params)
-      super(params, %w(usernames origins))
+      super(params, %w(usernames partial_usernames origins))
     end
 
     def origin_requires_username
       if @origins
-        unless @usernames
-          errors.add(:origins, 'filter cannot be provided without usernames filter.')
+        unless @usernames || @partial_usernames
+          errors.add(:origins, 'filter cannot be provided without usernames or partial_usernames filter.')
         end
+      end
+    end
+
+    def usernames_or_partial_usernames
+      if @usernames && @partial_usernames
+        errors.add(:usernames, 'filter cannot be provided with both usernames and partial_usernames filter.')
       end
     end
   end

--- a/docs/v3/source/includes/resources/organizations/_list_users.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_list_users.md.erb
@@ -31,7 +31,8 @@ Retrieve all users with a role in the specified organization.
 Name | Type | Description
 ---- | ---- | ------------
 **guids** | _list of strings_ | Comma-delimited list of user guids to filter by
-**usernames** | _list of strings_ | Comma-delimited list of usernames to filter by
+**usernames** | _list of strings_ | Comma-delimited list of usernames to filter by. Mutually exclusive with **partial_usernames**
+**partial_usernames** | _list of strings_ | Comma-delimited list of strings to search by. When using this query parameter, all the users that contain the string provided in their username will be returned. Mutually exclusive with **usernames**
 **origins** | _list of strings_ | Comma-delimited list of user origins (user stores) to filter by, for example, users authenticated by UAA have the origin "uaa"; users authenticated by an LDAP provider have the origin "ldap"; when filtering by origins, usernames must be included
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/spaces/_list_users.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_list_users.md.erb
@@ -31,7 +31,8 @@ Retrieve all users with a role in the specified space.
 Name | Type | Description
 ---- | ---- | ------------
 **guids** | _list of strings_ | Comma-delimited list of user guids to filter by
-**usernames** | _list of strings_ | Comma-delimited list of usernames to filter by
+**usernames** | _list of strings_ | Comma-delimited list of usernames to filter by. Mutually exclusive with **partial_usernames**
+**partial_usernames** | _list of strings_ | Comma-delimited list of strings to search by. When using this query parameter, all the users that contain the string provided in their username will be returned. Mutually exclusive with **usernames**
 **origins** | _list of strings_ | Comma-delimited list of user origins (user stores) to filter by, for example, users authenticated by UAA have the origin "uaa"; users authenticated by an LDAP provider have the origin "ldap"; when filtering by origins, usernames must be included
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/users/_list.md.erb
+++ b/docs/v3/source/includes/resources/users/_list.md.erb
@@ -31,7 +31,8 @@ Retrieve all users that the current user can see.
 Name | Type | Description
 ---- | ---- | ------------
 **guids** | _list of strings_ | Comma-delimited list of user guids to filter by
-**usernames** | _list of strings_ | Comma-delimited list of usernames to filter by
+**usernames** | _list of strings_ | Comma-delimited list of usernames to filter by. Mutually exclusive with **partial_usernames**
+**partial_usernames** | _list of strings_ | Comma-delimited list of strings to search by. When using this query parameter, all the users that contain the string provided in their username will be returned. Mutually exclusive with **usernames**
 **origins** | _list of strings_ | Comma-delimited list of user origins (user stores) to filter by, for example, users authenticated by UAA have the origin "uaa"; users authenticated by an LDAP provider have the origin "ldap"; when filtering by origins, usernames must be included
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/lib/cloud_controller/uaa/uaa_client.rb
+++ b/lib/cloud_controller/uaa/uaa_client.rb
@@ -62,21 +62,31 @@ module VCAP::CloudController
       raise UaaEndpointDisabled
     end
 
-    def ids_for_usernames_and_origins(usernames, origins)
-      username_filter_string = usernames&.map { |u| "username eq \"#{u}\"" }&.join(' or ')
+    def ids_for_usernames_and_origins(usernames, origins, precise_username_match=true)
+      operator = precise_username_match ? 'eq' : 'co'
+      username_filter_string = usernames&.map { |u| "username #{operator} \"#{u}\"" }&.join(' or ')
       origin_filter_string = origins&.map { |o| "origin eq \"#{o}\"" }&.join(' or ')
 
+      filter_string = construct_filter_string(username_filter_string, origin_filter_string)
+
+      if precise_username_match
+        results = query(:user_id, includeInactive: true, filter: filter_string)
+      else
+        results = query(:user, filter: filter_string, attributes: 'id')
+      end
+
+      results['resources'].map { |r| r['id'] }
+    rescue CF::UAA::TargetError, CF::UAA::BadTarget
+      raise UaaEndpointDisabled
+    end
+
+    def construct_filter_string(username_filter_string, origin_filter_string)
       filter_string = username_filter_string || origin_filter_string
 
       if username_filter_string && origin_filter_string
         filter_string = "( #{username_filter_string} ) and ( #{origin_filter_string} )"
       end
-
-      results = query(:user_id, includeInactive: true, filter: filter_string)
-
-      results['resources'].map { |r| r['id'] }
-    rescue CF::UAA::TargetError, CF::UAA::BadTarget
-      raise UaaEndpointDisabled
+      return filter_string
     end
 
     def origins_for_username(username)

--- a/lib/cloud_controller/uaa/uaa_client.rb
+++ b/lib/cloud_controller/uaa/uaa_client.rb
@@ -81,12 +81,11 @@ module VCAP::CloudController
     end
 
     def construct_filter_string(username_filter_string, origin_filter_string)
-      filter_string = username_filter_string || origin_filter_string
-
       if username_filter_string && origin_filter_string
-        filter_string = "( #{username_filter_string} ) and ( #{origin_filter_string} )"
+        "( #{username_filter_string} ) and ( #{origin_filter_string} )"
+      else
+        username_filter_string || origin_filter_string
       end
-      return filter_string
     end
 
     def origins_for_username(username)

--- a/spec/request/organizations_spec.rb
+++ b/spec/request/organizations_spec.rb
@@ -1468,28 +1468,30 @@ module VCAP::CloudController
           end
         end
 
-        it_behaves_like 'list query endpoint' do
-          before do
-            allow(uaa_client).to receive(:ids_for_usernames_and_origins).and_return([])
-          end
+        context 'uses partial_usernames' do
+          it_behaves_like 'list query endpoint' do
+            before do
+              allow(uaa_client).to receive(:ids_for_usernames_and_origins).and_return([])
+            end
 
-          let(:excluded_params) { [:usernames] }
-          let(:request) { "/v3/organizations/#{organization1.guid}/users" }
-          let(:message) { VCAP::CloudController::UsersListMessage }
-          let(:user_header) { admin_header }
+            let(:excluded_params) { [:usernames] }
+            let(:request) { "/v3/organizations/#{organization1.guid}/users" }
+            let(:message) { VCAP::CloudController::UsersListMessage }
+            let(:user_header) { admin_header }
 
-          let(:params) do
-            {
-              guids: ['foo', 'bar'],
-              partial_usernames: ['foo', 'bar'],
-              origins: ['foo', 'bar'],
-              page:   '2',
-              per_page:   '10',
-              order_by:   'updated_at',
-              label_selector:   'foo,bar',
-              created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
-              updated_ats: { gt: Time.now.utc.iso8601 },
-            }
+            let(:params) do
+              {
+                guids: ['foo', 'bar'],
+                partial_usernames: ['foo', 'bar'],
+                origins: ['foo', 'bar'],
+                page:   '2',
+                per_page:   '10',
+                order_by:   'updated_at',
+                label_selector:   'foo,bar',
+                created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
+                updated_ats: { gt: Time.now.utc.iso8601 },
+              }
+            end
           end
         end
 
@@ -1543,7 +1545,7 @@ module VCAP::CloudController
         context 'by partial_usernames and origins' do
           before do
             allow(uaa_client).to receive(:users_for_ids).with([org_manager.guid]).and_return({
-              org_manager.guid => { 'username' => 'b-mcjam', 'origin' => 'Okta' },
+              org_manager.guid => { 'username' => 'rob-mcjam', 'origin' => 'Okta' },
             })
             allow(uaa_client).to receive(:ids_for_usernames_and_origins).with(['b-mcjam'], ['Okta'], false).and_return([org_manager.guid])
           end

--- a/spec/request/organizations_spec.rb
+++ b/spec/request/organizations_spec.rb
@@ -1448,6 +1448,7 @@ module VCAP::CloudController
             allow(uaa_client).to receive(:ids_for_usernames_and_origins).and_return([])
           end
 
+          let(:excluded_params) { [:partial_usernames] }
           let(:request) { "/v3/organizations/#{organization1.guid}/users" }
           let(:message) { VCAP::CloudController::UsersListMessage }
           let(:user_header) { admin_header }
@@ -1456,6 +1457,31 @@ module VCAP::CloudController
             {
               guids: ['foo', 'bar'],
               usernames: ['foo', 'bar'],
+              origins: ['foo', 'bar'],
+              page:   '2',
+              per_page:   '10',
+              order_by:   'updated_at',
+              label_selector:   'foo,bar',
+              created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
+              updated_ats: { gt: Time.now.utc.iso8601 },
+            }
+          end
+        end
+
+        it_behaves_like 'list query endpoint' do
+          before do
+            allow(uaa_client).to receive(:ids_for_usernames_and_origins).and_return([])
+          end
+
+          let(:excluded_params) { [:usernames] }
+          let(:request) { "/v3/organizations/#{organization1.guid}/users" }
+          let(:message) { VCAP::CloudController::UsersListMessage }
+          let(:user_header) { admin_header }
+
+          let(:params) do
+            {
+              guids: ['foo', 'bar'],
+              partial_usernames: ['foo', 'bar'],
               origins: ['foo', 'bar'],
               page:   '2',
               per_page:   '10',
@@ -1504,6 +1530,33 @@ module VCAP::CloudController
               'total_pages' => 1,
               'first' => { 'href' => "#{link_prefix}/v3/organizations/#{organization1.guid}/users?origins=Okta&page=1&per_page=50&usernames=rob-mcjames" },
               'last' => { 'href' => "#{link_prefix}/v3/organizations/#{organization1.guid}/users?origins=Okta&page=1&per_page=50&usernames=rob-mcjames" },
+              'next' => nil,
+              'previous' => nil
+            }
+
+            expect(last_response).to have_status_code(200)
+            expect(parsed_response['resources'].map { |r| r['guid'] }).to contain_exactly(org_manager.guid)
+            expect(parsed_response['pagination']).to eq(expected_pagination)
+          end
+        end
+
+        context 'by partial_usernames and origins' do
+          before do
+            allow(uaa_client).to receive(:users_for_ids).with([org_manager.guid]).and_return({
+              org_manager.guid => { 'username' => 'b-mcjam', 'origin' => 'Okta' },
+            })
+            allow(uaa_client).to receive(:ids_for_usernames_and_origins).with(['b-mcjam'], ['Okta'], false).and_return([org_manager.guid])
+          end
+
+          it 'returns 200 and the filtered users' do
+            get "/v3/organizations/#{organization1.guid}/users?partial_usernames=b-mcjam&origins=Okta", nil, admin_header
+
+            parsed_response = MultiJson.load(last_response.body)
+            expected_pagination = {
+              'total_results' => 1,
+              'total_pages' => 1,
+              'first' => { 'href' => "#{link_prefix}/v3/organizations/#{organization1.guid}/users?origins=Okta&page=1&partial_usernames=b-mcjam&per_page=50" },
+              'last' => { 'href' => "#{link_prefix}/v3/organizations/#{organization1.guid}/users?origins=Okta&page=1&partial_usernames=b-mcjam&per_page=50" },
               'next' => nil,
               'previous' => nil
             }

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -1293,6 +1293,7 @@ RSpec.describe 'Spaces' do
           allow(uaa_client).to receive(:ids_for_usernames_and_origins).and_return([])
         end
 
+        let(:excluded_params) { [:partial_usernames] }
         let(:request) { "/v3/spaces/#{space1.guid}/users" }
         let(:message) { VCAP::CloudController::UsersListMessage }
         let(:user_header) { admin_header }

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -1313,6 +1313,33 @@ RSpec.describe 'Spaces' do
         end
       end
 
+      context 'uses partial_username' do
+        it_behaves_like 'list query endpoint' do
+          before do
+            allow(uaa_client).to receive(:ids_for_usernames_and_origins).and_return([])
+          end
+
+          let(:excluded_params) { [:usernames] }
+          let(:request) { "/v3/spaces/#{space1.guid}/users" }
+          let(:message) { VCAP::CloudController::UsersListMessage }
+          let(:user_header) { admin_header }
+
+          let(:params) do
+            {
+              guids: ['foo', 'bar'],
+              partial_usernames: ['foo', 'bar'],
+              origins: ['foo', 'bar'],
+              page:   '2',
+              per_page:   '10',
+              order_by:   'updated_at',
+              label_selector:   'foo,bar',
+              created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
+              updated_ats: { gt: Time.now.utc.iso8601 },
+            }
+          end
+        end
+      end
+
       context 'by guid' do
         it 'returns 200 and the filtered users' do
           get "/v3/spaces/#{space1.guid}/users?guids=#{user.guid}", nil, admin_header

--- a/spec/request/users_spec.rb
+++ b/spec/request/users_spec.rb
@@ -122,6 +122,33 @@ RSpec.describe 'Users Request' do
           }
         end
       end
+
+      context 'uses partial_usernames' do
+        it_behaves_like 'list query endpoint' do
+          before do
+            allow(uaa_client).to receive(:ids_for_usernames_and_origins).and_return([])
+          end
+
+          let(:excluded_params) { [:usernames] }
+          let(:request) { '/v3/users' }
+          let(:message) { VCAP::CloudController::UsersListMessage }
+          let(:user_header) { admin_header }
+
+          let(:params) do
+            {
+              guids: ['foo', 'bar'],
+              partial_usernames: ['foo', 'bar'],
+              origins: ['foo', 'bar'],
+              page:   '2',
+              per_page:   '10',
+              order_by:   'updated_at',
+              label_selector:   'foo,bar',
+              created_ats:  "#{Time.now.utc.iso8601},#{Time.now.utc.iso8601}",
+              updated_ats: { gt: Time.now.utc.iso8601 },
+            }
+          end
+        end
+      end
     end
 
     describe 'without filters' do

--- a/spec/request/users_spec.rb
+++ b/spec/request/users_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe 'Users Request' do
       end
 
       it_behaves_like 'list query endpoint' do
+        let(:excluded_params) { [:partial_usernames] }
         let(:request) { 'v3/users' }
         let(:message) { VCAP::CloudController::UsersListMessage }
         let(:user_header) { admin_header }
@@ -326,7 +327,7 @@ RSpec.describe 'Users Request' do
           get '/v3/users', 'origins=uaa', admin_header
           expect(last_response).to have_status_code(422)
           expect(parsed_response['errors'].first['detail']).to eq(
-            'Origins filter cannot be provided without usernames filter.')
+            'Origins filter cannot be provided without usernames or partial_usernames filter.')
         end
       end
 

--- a/spec/unit/lib/uaa/uaa_client_spec.rb
+++ b/spec/unit/lib/uaa/uaa_client_spec.rb
@@ -527,6 +527,7 @@ module VCAP::CloudController
     describe '#ids_for_usernames_and_origins' do
       let(:username1) { 'user1@example.com' }
       let(:username2) { 'user2@example.com' }
+      let(:partial_username) { 'user' }
 
       context 'with usernames but no origins' do
         it 'returns the ids for the usernames' do
@@ -552,6 +553,31 @@ module VCAP::CloudController
         end
       end
 
+      context 'with partial_usernames but no origin' do
+        it 'returns the ids for the usernames' do
+          response_body = {
+            'resources' => [
+              { 'id' => '123' },
+              { 'id' => '456' },
+              { 'id' => '789' },
+            ],
+            'schemas' => ['urn:scim:schemas:core:1.0'],
+            'startindex' => 1,
+            'itemsperpage' => 100,
+            'totalresults' => 1 }
+
+          WebMock::API.stub_request(:get, "#{url}/Users").
+            with(query: { 'filter' => "username co \"#{partial_username}\"",
+                          'attributes' => "id" }).
+            to_return(
+              status: 200,
+              headers: { 'content-type' => 'application/json' },
+              body: response_body.to_json)
+
+          expect(uaa_client.ids_for_usernames_and_origins([partial_username], nil, false)).to eq(%w(123 456 789))
+        end
+      end
+
       context 'with usernames and origins' do
         it 'returns the intersection of the usernames and the origins' do
           response_body = {
@@ -572,6 +598,30 @@ module VCAP::CloudController
               body: response_body.to_json)
 
           uaa_client.ids_for_usernames_and_origins([username1, username2], ['Okta'])
+        end
+      end
+
+      context 'with partial_usernames and origin' do
+        it 'returns the ids for the usernames' do
+          response_body = {
+            'resources' => [
+              { 'id' => '456' },
+              { 'id' => '789' },
+            ],
+            'schemas' => ['urn:scim:schemas:core:1.0'],
+            'startindex' => 1,
+            'itemsperpage' => 100,
+            'totalresults' => 1 }
+
+          WebMock::API.stub_request(:get, "#{url}/Users").
+            with(query: { 'filter' => "( username co \"#{partial_username}\" ) and ( origin eq \"Okta\" )",
+                          'attributes' => 'id' }).
+            to_return(
+              status: 200,
+              headers: { 'content-type' => 'application/json' },
+              body: response_body.to_json)
+
+          expect(uaa_client.ids_for_usernames_and_origins([partial_username], ['Okta'], false)).to eq(%w(456 789))
         end
       end
 
@@ -632,6 +682,26 @@ module VCAP::CloudController
           }.to raise_error(UaaEndpointDisabled)
         end
       end
+    end
+
+    describe '#construct_filter_string' do
+      let(:username_filter_string) {'username eq \"someone\"'}
+      let(:origin_filter_string) {'origin eq \"Okta\"'}
+
+      context 'when username_filter_string and origin_filter string are provided' do
+        it 'returns a new string with the two filter strings combined' do
+          filter_string = uaa_client.construct_filter_string(username_filter_string, origin_filter_string)
+          expect(filter_string).to eq("( #{username_filter_string} ) and ( #{origin_filter_string} )")
+        end
+      end
+
+      context 'when only username_filter_string is provided' do
+        it 'returns just username_filter_string' do
+          filter_string = uaa_client.construct_filter_string(username_filter_string, nil)
+          expect(filter_string).to eq(username_filter_string)
+        end
+      end
+
     end
 
     describe '#origins_for_username' do

--- a/spec/unit/lib/uaa/uaa_client_spec.rb
+++ b/spec/unit/lib/uaa/uaa_client_spec.rb
@@ -568,7 +568,7 @@ module VCAP::CloudController
 
           WebMock::API.stub_request(:get, "#{url}/Users").
             with(query: { 'filter' => "username co \"#{partial_username}\"",
-                          'attributes' => "id" }).
+                          'attributes' => 'id' }).
             to_return(
               status: 200,
               headers: { 'content-type' => 'application/json' },
@@ -685,8 +685,8 @@ module VCAP::CloudController
     end
 
     describe '#construct_filter_string' do
-      let(:username_filter_string) {'username eq \"someone\"'}
-      let(:origin_filter_string) {'origin eq \"Okta\"'}
+      let(:username_filter_string) { 'username eq \"someone\"' }
+      let(:origin_filter_string) { 'origin eq \"Okta\"' }
 
       context 'when username_filter_string and origin_filter string are provided' do
         it 'returns a new string with the two filter strings combined' do
@@ -701,7 +701,6 @@ module VCAP::CloudController
           expect(filter_string).to eq(username_filter_string)
         end
       end
-
     end
 
     describe '#origins_for_username' do

--- a/spec/unit/messages/users_list_message_spec.rb
+++ b/spec/unit/messages/users_list_message_spec.rb
@@ -9,6 +9,7 @@ module VCAP::CloudController
           'page' => 1,
           'per_page' => 5,
           'guids' => 'user1-guid,user2-guid',
+          'partial_usernames' => 'user',
           'usernames' => 'user1-name,user2-name',
           'origins' => 'user1-origin,user2-origin',
         }
@@ -22,6 +23,7 @@ module VCAP::CloudController
         expect(message.per_page).to eq(5)
         expect(message.guids).to eq(%w[user1-guid user2-guid])
         expect(message.usernames).to eq(%w[user1-name user2-name])
+        expect(message.partial_usernames).to eq(%w[user])
         expect(message.origins).to eq(%w[user1-origin user2-origin])
       end
 
@@ -84,18 +86,16 @@ module VCAP::CloudController
       end
     end
 
-    describe 'origin_requires_username' do
-      it 'accepts usernames and origins' do
-        message = UsersListMessage.from_params({ usernames: ['bob'], origins: ['uaa'] })
-        expect(message).to be_valid
-      end
-      it 'accepts no usernames no origins' do
+    describe 'accepts no usernames no origins' do
+      it 'is valid' do
         message = UsersListMessage.from_params({})
         expect(message).to be_valid
       end
+    end
 
-      it 'accepts usernames without origins' do
-        message = UsersListMessage.from_params({ usernames: ['bob'] })
+    describe 'origin_requires_username_or_partial_usernames' do
+      it 'accepts usernames and origins' do
+        message = UsersListMessage.from_params({ usernames: ['bob'], origins: ['uaa'] })
         expect(message).to be_valid
       end
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

### A short explanation of the proposed change:

Add partial search by usernames to GET /organizations/:guid/users

For partial_usernames parameter, we are using UAA /Users endpoint that requires `scim.read` scope. 
### An explanation of the use cases your change solves
This will let us to find usernames by substring e.g. `GET /organizations/:guid/users?partial_usernames=foo`

### Links to any other associated PRs
CF-D [PR](https://github.com/cloudfoundry/cf-deployment/pull/984)

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)

Coauthored by @jdgonzaleza 