### PR TITLE
Docs: Add missing `guids` query parameter of list service instances

### DIFF
--- a/docs/v3/source/includes/resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list.md.erb
@@ -30,6 +30,7 @@ This endpoint retrieves the service instances the user has access to, including 
 Name | Type | Description
 ---- | ---- | ------------
 **names** | _list of strings_ | Comma-delimited list of service instance names to filter by
+**guids** | _list of strings_ | Comma-delimited list of service instance guids to filter by
 **type** | _string_ | Filter by type; valid values are `managed` and `user-provided`
 **space_guids** | _list of strings_ | Comma-delimited list of space guids to filter by
 **organization_guids** | _list of strings_ | Comma-delimited list of organization guids to filter by


### PR DESCRIPTION
Add missing `guids` query parameter of service instance list endpoint to docs