### PR TITLE
Add validation for credentials in SB update to be not blank

### DIFF
--- a/app/messages/basic_credentials_message.rb
+++ b/app/messages/basic_credentials_message.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
 
     validates_with NoAdditionalKeysValidator
 
-    validates :username, string: true
-    validates :password, string: true
+    validates :username, string: true, presence: true
+    validates :password, string: true, presence: true
   end
 end

--- a/spec/unit/messages/service_broker_create_message_spec.rb
+++ b/spec/unit/messages/service_broker_create_message_spec.rb
@@ -119,18 +119,37 @@ module VCAP::CloudController
 
         context 'when authentication is not valid' do
           let(:request_body) do
+            valid_body[:authentication] = valid_body[:authentication].except(:type)
             valid_body
-          end
-
-          before do
-            allow_any_instance_of(VCAP::CloudController::Validators::AuthenticationValidator).to receive(:validate) do |_, record|
-              record.errors.add(:authentication, 'this authentication is not valid!')
-            end
           end
 
           it 'is not valid' do
             expect(message).not_to be_valid
-            expect(message.errors_on(:authentication)).to include('this authentication is not valid!')
+            expect(message.errors_on(:authentication)).to include('authentication.type must be one of ["basic"]')
+          end
+        end
+
+        context 'when username is an empty string' do
+          let(:request_body) do
+            valid_body[:authentication][:credentials][:username] = ''
+            valid_body
+          end
+
+          it 'is not valid' do
+            expect(message).not_to be_valid
+            expect(message.errors_on(:authentication)).to include(/Username can't be blank/)
+          end
+        end
+
+        context 'when password is an empty string' do
+          let(:request_body) do
+            valid_body[:authentication][:credentials][:password] = ''
+            valid_body
+          end
+
+          it 'is not valid' do
+            expect(message).not_to be_valid
+            expect(message.errors_on(:authentication)).to include(/Password can't be blank/)
           end
         end
       end

--- a/spec/unit/messages/service_broker_update_message_spec.rb
+++ b/spec/unit/messages/service_broker_update_message_spec.rb
@@ -149,18 +149,37 @@ module VCAP::CloudController
 
         context 'when authentication is not valid' do
           let(:request_body) do
+            valid_body[:authentication] = valid_body[:authentication].except(:type)
             valid_body
-          end
-
-          before do
-            allow_any_instance_of(VCAP::CloudController::Validators::AuthenticationValidator).to receive(:validate) do |_, record|
-              record.errors.add(:authentication, 'this authentication is not valid!')
-            end
           end
 
           it 'is not valid' do
             expect(message).not_to be_valid
-            expect(message.errors_on(:authentication)).to include('this authentication is not valid!')
+            expect(message.errors_on(:authentication)).to include('authentication.type must be one of ["basic"]')
+          end
+        end
+
+        context 'when username is an empty string' do
+          let(:request_body) do
+            valid_body[:authentication][:credentials][:username] = ''
+            valid_body
+          end
+
+          it 'is not valid' do
+            expect(message).not_to be_valid
+            expect(message.errors_on(:authentication)).to include(/Username can't be blank/)
+          end
+        end
+
+        context 'when password is an empty string' do
+          let(:request_body) do
+            valid_body[:authentication][:credentials][:password] = ''
+            valid_body
+          end
+
+          it 'is not valid' do
+            expect(message).not_to be_valid
+            expect(message.errors_on(:authentication)).to include(/Password can't be blank/)
           end
         end
       end

--- a/spec/unit/messages/validators/authentication_validator_spec.rb
+++ b/spec/unit/messages/validators/authentication_validator_spec.rb
@@ -118,5 +118,37 @@ module VCAP::CloudController::Validators
         expect(message.errors_on(:authentication)).to include(/Field\(s\) \["password"\] must be valid/)
       end
     end
+
+    context 'when username is an empty string' do
+      let(:authentication) do
+        {
+          credentials: {
+            username: '',
+            password: 'pass'
+          },
+        }
+      end
+
+      it 'is not valid' do
+        expect(message).not_to be_valid
+        expect(message.errors_on(:authentication)).to include(/Username can't be blank/)
+      end
+    end
+
+    context 'when password is an empty string' do
+      let(:authentication) do
+        {
+          credentials: {
+            username: 'user',
+            password: ''
+          },
+        }
+      end
+
+      it 'is not valid' do
+        expect(message).not_to be_valid
+        expect(message.errors_on(:authentication)).to include(/Password can't be blank/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

This PR consists of two fixes.
One is adding a validation check to make sure that credentials, which have been sent with a SB update request, are not empty strings. From now on `username` and `password` must be non-empty strings, otherwise the validation will fail. This coding is executed by the API processes.

The other ensures that after a model layer validation error, the SB can be reset to its previous state. This coding is executed by the CC worker processes and is run during the delayed job execution of the broker.update job.

* An explanation of the use cases your change solves

The issue is explained in #2937.

Registering a broker in CF with empty credentials never worked. In V2 and V3 an error will be returned. So it is okay to make non-empty credentials obligatory. The OSBAPI Spec says "While the communication between a Platform and Service Broker MAY be unsecure, it is RECOMMENDED that all communications between a Platform and a Service Broker are secured via TLS and authenticated."([source](https://github.com/openservicebrokerapi/servicebroker/blob/v2.15/spec.md#platform-to-service-broker-authentication:~:text=While%20the%20communication%20between%20a%20Platform%20and%20Service%20Broker%20MAY%20be%20unsecure%2C%20it%20is%20RECOMMENDED%20that%20all%20communications%20between%20a%20Platform%20and%20a%20Service%20Broker%20are%20secured%20via%20TLS%20and%20authenticated.))

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
