### PR TITLE
Stop logging noisy copilot-related config errors

### DIFF
--- a/lib/cloud_controller/copilot/adapter.rb
+++ b/lib/cloud_controller/copilot/adapter.rb
@@ -76,7 +76,7 @@ module VCAP::CloudController
         end
 
         def with_guardrails(route: nil)
-          return unless Config.config.get(:copilot, :enabled)
+          return unless copilot_enabled?
 
           if route
             return unless Config.config.get(:copilot, :temporary_istio_domains).include?(route.domain.name)
@@ -89,6 +89,12 @@ module VCAP::CloudController
 
         def logger
           Steno.logger('copilot_adapter')
+        end
+
+        def copilot_enabled?
+          Config.config.get(:copilot, :enabled)
+        rescue Config::InvalidConfigPath
+          false
         end
       end
     end

--- a/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
+++ b/spec/unit/lib/cloud_controller/copilot/adapter_spec.rb
@@ -101,6 +101,18 @@ module VCAP::CloudController
           expect(copilot_client).not_to have_received(:upsert_route)
         end
       end
+
+      context 'when copilot is not present in the config', job_context: :worker do
+        it 'does not log an error' do
+          adapter.create_route(route)
+          expect(fake_logger).not_to have_received(:error)
+        end
+
+        it 'does not actually talk to copilot' do
+          adapter.create_route(route)
+          expect(copilot_client).not_to have_received(:upsert_route)
+        end
+      end
     end
 
     describe '#map_route' do


### PR DESCRIPTION
Prior to this change workers would log errors like the following since they do not have the necessary config to talk to Copilot:

```
"failed communicating with copilot backend: \"copilot.enabled\" is not a valid config key"
```

Long term Copilot is deprecated and this codepath should be removed, but in the short term this will cut down on noisy errors being logged by the workers. I made a separate issue that captures some of that context, https://github.com/cloudfoundry/cloud_controller_ng/issues/2942.

This PR addresses https://github.com/cloudfoundry/cloud_controller_ng/issues/1883 for @reidmit.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
