### PR TITLE
Clarify docs for updating route destinations

### DIFF
--- a/docs/v3/source/includes/resources/routes/_update_destination.md.erb
+++ b/docs/v3/source/includes/resources/routes/_update_destination.md.erb
@@ -1,4 +1,4 @@
-### Update a destination for a route
+### Update a destination protocol for a route
 
 ```
 Example Request
@@ -42,8 +42,10 @@ Content-Type: application/json
 }
 ```
 
+This endpoint updates the protocol of a route destination (app, port and weight cannot be updated)
+
 #### Definition
-`PATCH /v3/routes/:guid/destinations`
+`PATCH /v3/routes/:guid/destinations/:guid`
 
 #### Optional parameters
 


### PR DESCRIPTION
* A short explanation of the proposed change:

Updates docs

* An explanation of the use cases your change solves

Corrects the request path for updating a route destination (which was missing the destination guid). Also emphasizes (as hinted at in the existing code example) that _only_ a protocol can be updated. All other fields must be omitted from your payload:

```bash
$ cf curl -X PATCH /v3/routes/dafd5952-3c58-4ec0-9ca8-da8ac7004a46/destinations/237a50d1-cca5-4437-9f6b-2fb00ec87b80 -d '{
  "app": {
    "guid": "b0fdafaa-525c-4c9b-8c7f-e44b71410eaf",
    "process": {
      "type": "web"
    }
  },
  "weight": null,
  "port": 7777,
  "protocol": "http1"
}'

{
  "errors": [
    {
      "detail": "Unknown field(s): 'app', 'weight', 'port'",
      "title": "CF-UnprocessableEntity",
      "code": 10008
    }
  ]
}
```

Whereas this works:

```bash
$ cf curl -X PATCH /v3/routes/dafd5952-3c58-4ec0-9ca8-da8ac7004a46/destinations/237a50d1-cca5-4437-9f6b-2fb00ec87b80 -d '{"protocol":"http1"}'
```

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
