### PR TITLE
Remove vestigial pretty option passed to Oj json encoder

### DIFF
--- a/config/initializers/json.rb
+++ b/config/initializers/json.rb
@@ -26,7 +26,7 @@ module CCInitializers
         if Rails.env.test?
           Oj.dump(v, time_format: :ruby)
         else
-          Oj.dump(v, options.merge(pretty: true, time_format: :ruby))
+          Oj.dump(v, options.merge(time_format: :ruby))
         end
       end
     end


### PR DESCRIPTION
* This option worked with MultiJson/yajl, but is not supported by Oj and
  does nothing.

Co-authored-by: Seth Boyles <sboyles@pivotal.io>
Co-authored-by: Alex Rocha <alexr1@vmware.com>

With #2930, we switched to only using Oj due to a memory leak with MultiJson.  This had the side-effect of no longer returning 'pretty' JSON responses, i.e no spaces or newlines.  This option being left is misleading as it doesn't actually do anything