### PR TITLE
Service instance permissions

### DIFF
--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -163,16 +163,20 @@ class ApplicationController < ActionController::Base
     !READ_SCOPE_HTTP_METHODS.include?(request.method)
   end
 
-  def check_read_permissions!
-    read_scope = SecurityContext.scopes.include?('cloud_controller.read')
-    admin_read_only_scope = SecurityContext.scopes.include?('cloud_controller.admin_read_only')
-    global_auditor_scope = SecurityContext.scopes.include?('cloud_controller.global_auditor')
+  def read_scope
+    roles.cloud_controller_reader?
+  end
 
-    raise CloudController::Errors::ApiError.new_from_details('NotAuthorized') if !roles.admin? && !read_scope && !admin_read_only_scope && !global_auditor_scope
+  def write_scope
+    roles.cloud_controller_writer?
+  end
+
+  def check_read_permissions!
+    raise CloudController::Errors::ApiError.new_from_details('NotAuthorized') if !roles.admin? && !roles.admin_read_only? && !roles.global_auditor? && !read_scope
   end
 
   def check_write_permissions!
-    write_scope = SecurityContext.scopes.include?('cloud_controller.write')
+    roles.cloud_controller_writer?
     raise CloudController::Errors::ApiError.new_from_details('NotAuthorized') if !roles.admin? && !write_scope
   end
 

--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -176,7 +176,6 @@ class ApplicationController < ActionController::Base
   end
 
   def check_write_permissions!
-    roles.cloud_controller_writer?
     raise CloudController::Errors::ApiError.new_from_details('NotAuthorized') if !roles.admin? && !write_scope
   end
 

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -222,7 +222,7 @@ class ServiceInstancesV3Controller < ApplicationController
     service_instance_not_found! unless service_instance
 
     render status: :ok, json: {
-      manage: is_space_active?(service_instance.space) ? can_write_to_active_space?(service_instance.space) : permission_queryer.can_write_globally?,
+      manage: is_space_active?(service_instance.space) ? can_write_to_active_space?(service_instance.space) : admin?,
       read: can_read_service_instance?(service_instance),
     }
   end

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -217,6 +217,16 @@ class ServiceInstancesV3Controller < ApplicationController
     end
   end
 
+  def show_permissions
+    service_instance = ServiceInstance.first(guid: hashed_params[:guid])
+    service_instance_not_found! unless service_instance
+
+    render status: :ok, json: {
+      manage: is_space_active?(service_instance.space) ? can_write_to_active_space?(service_instance.space) : permission_queryer.can_write_globally?,
+      read: can_read_service_instance?(service_instance),
+    }
+  end
+
   private
 
   DECORATORS = [
@@ -423,5 +433,9 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def operation_in_progress!
     unprocessable!('There is an operation in progress for the service instance.')
+  end
+
+  def read_scope
+    %w(show_permissions).include?(action_name) && roles.cloud_controller_service_permissions_reader? ? true : super
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,6 +240,7 @@ Rails.application.routes.draw do
   get '/service_instances/:guid/relationships/shared_spaces/usage_summary', to: 'service_instances_v3#shared_spaces_usage_summary'
   get '/service_instances/:guid/credentials', to: 'service_instances_v3#credentials'
   get '/service_instances/:guid/parameters', to: 'service_instances_v3#parameters'
+  get '/service_instances/:guid/permissions', to: 'service_instances_v3#show_permissions'
   post '/service_instances', to: 'service_instances_v3#create'
   post '/service_instances/:guid/relationships/shared_spaces', to: 'service_instances_v3#share_service_instance'
   patch '/service_instances/:guid', to: 'service_instances_v3#update'

--- a/docs/v3/source/includes/api_resources/_service_instances.erb
+++ b/docs/v3/source/includes/api_resources/_service_instances.erb
@@ -293,3 +293,10 @@
   }
 }
 <% end %>
+
+<% content_for :service_instance_permissions do %>
+{
+  "read": true,
+  "manage": false
+}
+<% end %>

--- a/docs/v3/source/includes/concepts/_authorization.md.erb
+++ b/docs/v3/source/includes/concepts/_authorization.md.erb
@@ -12,6 +12,7 @@ Scope | Description
 `cloud_controller.read` | This scope provides read access to resources based on user roles
 `cloud_controller.write` | This scope provides write access to resources based on user roles
 `cloud_controller.update_build_state` | This scope allows its bearer to update the state of a build; currently only used when [updating builds](#update-a-build)
+`cloud_controller_service_permissions.read` | This scope provides read only access for [service instance permissions](#get-permissions-for-a-service-instance)
 
 #### Cloud Foundry user roles
 

--- a/docs/v3/source/includes/resources/apps/_permissions.md.erb
+++ b/docs/v3/source/includes/resources/apps/_permissions.md.erb
@@ -1,4 +1,4 @@
-### Get permissions
+### Get permissions for an app
 
 ```
 Example Request

--- a/docs/v3/source/includes/resources/service_instances/_permissions.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_permissions.md.erb
@@ -1,0 +1,34 @@
+### Get permissions for a service instance
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/service_instances/[guid]/permissions" \
+  -X GET \
+  -H "Authorization: bearer [token]"
+```
+
+```
+Example Response
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+<%= yield_content :service_instance_permissions %>
+```
+
+Get the current user's permissions for the given service instance. If a user can get a service instance then they can 'read' it. Users who can update a service instance can 'manage' it.
+
+This endpoint's primary purpose is to enable third-party service dashboards to determine the permissions of a given Cloud Foundry user that has authenticated with the dashboard via single sign-on (SSO). For more information, see the Cloud Foundry documentation on [Dashboard Single Sign-On](https://docs.cloudfoundry.org/services/dashboard-sso.html).
+
+#### Definition
+`GET /v3/service_instances/:guid/permissions`
+
+#### Permitted roles
+ |
+--- | ---
+All Roles |

--- a/docs/v3/source/index.html.md
+++ b/docs/v3/source/index.html.md
@@ -301,16 +301,17 @@ includes:
   - resources/service_instances/header
   - resources/service_instances/object
   - resources/service_instances/create
-  - resources/service_instances/list
   - resources/service_instances/get
-  - resources/service_instances/credentials
-  - resources/service_instances/parameters
-  - resources/service_instances/update
+  - resources/service_instances/list
   - resources/service_instances/delete
+  - resources/service_instances/update
+  - resources/service_instances/credentials
+  - resources/service_instances/get_shared_spaces_usage_summary
   - resources/service_instances/list_shared_spaces
+  - resources/service_instances/parameters
+  - resources/service_instances/permissions
   - resources/service_instances/share_to_space
   - resources/service_instances/unshare_from_space
-  - resources/service_instances/get_shared_spaces_usage_summary
   - resources/service_credential_bindings/header
   - resources/service_credential_bindings/object
   - resources/service_credential_bindings/create

--- a/lib/cloud_controller/roles.rb
+++ b/lib/cloud_controller/roles.rb
@@ -6,6 +6,9 @@ module VCAP::CloudController
     CLOUD_CONTROLLER_ADMIN_READ_ONLY_SCOPE = 'cloud_controller.admin_read_only'.freeze
     CLOUD_CONTROLLER_GLOBAL_AUDITOR = 'cloud_controller.global_auditor'.freeze
     CLOUD_CONTROLLER_BUILD_STATE_UPDATER = 'cloud_controller.update_build_state'.freeze
+    CLOUD_CONTROLLER_READER_SCOPE = 'cloud_controller.read'.freeze
+    CLOUD_CONTROLLER_WRITER_SCOPE = 'cloud_controller.write'.freeze
+    CLOUD_CONTROLLER_SERVICE_PERMISSIONS_READER = 'cloud_controller_service_permissions.read'.freeze
 
     ORG_ROLE_NAMES = [:user, :manager, :billing_manager, :auditor].freeze
     SPACE_ROLE_NAMES = [:manager, :developer, :auditor].freeze
@@ -24,6 +27,18 @@ module VCAP::CloudController
 
     def global_auditor?
       @scopes.include?(CLOUD_CONTROLLER_GLOBAL_AUDITOR)
+    end
+
+    def cloud_controller_reader?
+      @scopes.include?(CLOUD_CONTROLLER_READER_SCOPE)
+    end
+
+    def cloud_controller_writer?
+      @scopes.include?(CLOUD_CONTROLLER_WRITER_SCOPE)
+    end
+
+    def cloud_controller_service_permissions_reader?
+      @scopes.include?(CLOUD_CONTROLLER_SERVICE_PERMISSIONS_READER)
     end
 
     def admin=(flag)

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -4138,13 +4138,13 @@ RSpec.describe 'V3 service instances' do
 
       before do
         org.add_user(user)
-        space.add_developer(user)
       end
 
-      it 'returns a 200' do
+      it 'succeeds' do
         get "/v3/service_instances/#{guid}/permissions", nil, user_headers
-        expect(last_response.status).to eq(200)
-        expect(JSON.parse(last_response.body)).to eq(read_and_write)
+        expect(last_response).to have_status_code(200)
+        parsed_response = MultiJson.load(last_response.body)
+        expect(parsed_response).to match_json_response(no_permissions[:response_object])
       end
     end
 

--- a/spec/support/user_header_helpers.rb
+++ b/spec/support/user_header_helpers.rb
@@ -38,13 +38,6 @@ module UserHeaderHelpers
   end
 
   # rubocop:disable all
-  def set_user_with_header_as_cloud_controller_service_permissions_reader(opts = {})
-    # rubocop:enable all
-    user = opts.delete(:user) || VCAP::CloudController::User.make
-    set_user_with_header(user, { cloud_controller_service_permissions_reader: true }.merge(opts))
-  end
-
-  # rubocop:disable all
   def set_user_with_header_as_unauthenticated(opts = {})
     # rubocop:enable all
     set_user_with_header(nil, opts)
@@ -75,11 +68,19 @@ module UserHeaderHelpers
   end
 
   # rubocop:disable all
+  def set_user_with_header_as_service_permissions_reader(opts = {})
+    # rubocop:enable all
+    user = opts.delete(:user) || VCAP::CloudController::User.make
+    scopes = { scopes: %w(cloud_controller_service_permissions.read) }
+    set_user_with_header(user, scopes.merge(opts))
+  end
+
+  # rubocop:disable all
   def set_user_with_header_as_role(role:, org: nil, space: nil, user: nil, scopes: nil, user_name: nil, email: nil)
     # rubocop:enable all
     current_user = user || VCAP::CloudController::User.make
 
-    scope_roles = %w(admin admin_read_only global_auditor reader_and_writer reader writer)
+    scope_roles = %w(admin admin_read_only global_auditor reader_and_writer reader writer service_permissions_reader)
     if org && !scope_roles.include?(role) && role.to_s != 'no_role'
       org.add_user(current_user)
     end
@@ -92,9 +93,6 @@ module UserHeaderHelpers
       set_user_with_header_as_admin_read_only(user: current_user, scopes: scopes || ['cloud_controller.write'], user_name: user_name, email: email)
     when 'global_auditor'
       set_user_with_header_as_global_auditor(user: current_user, scopes: scopes || ['cloud_controller.write'], user_name: user_name, email: email)
-    when 'cloud_controller_service_permissions_reader'
-      set_user_with_header_as_cloud_controller_service_permissions_reader(user: current_user, scopes: ['cloud_controller_service_permissions.read'], user_name: user_name,
-email: email)
     when 'space_developer'
       space.add_developer(current_user)
       set_user_with_header_as_reader_and_writer(user: current_user, user_name: user_name, email: email)
@@ -126,6 +124,8 @@ email: email)
       set_user_with_header_as_reader(user: current_user, user_name: user_name, email: email)
     when 'writer'
       set_user_with_header_as_writer(user: current_user, user_name: user_name, email: email)
+    when 'service_permissions_reader'
+      set_user_with_header_as_service_permissions_reader(user: current_user, user_name: user_name, email: email)
     when 'no_role' # not a real role - added for testing
       set_user_with_header(user, user_name: user_name, email: email)
     else

--- a/spec/support/user_header_helpers.rb
+++ b/spec/support/user_header_helpers.rb
@@ -38,6 +38,13 @@ module UserHeaderHelpers
   end
 
   # rubocop:disable all
+  def set_user_with_header_as_cloud_controller_service_permissions_reader(opts = {})
+    # rubocop:enable all
+    user = opts.delete(:user) || VCAP::CloudController::User.make
+    set_user_with_header(user, { cloud_controller_service_permissions_reader: true }.merge(opts))
+  end
+
+  # rubocop:disable all
   def set_user_with_header_as_unauthenticated(opts = {})
     # rubocop:enable all
     set_user_with_header(nil, opts)
@@ -85,6 +92,9 @@ module UserHeaderHelpers
       set_user_with_header_as_admin_read_only(user: current_user, scopes: scopes || ['cloud_controller.write'], user_name: user_name, email: email)
     when 'global_auditor'
       set_user_with_header_as_global_auditor(user: current_user, scopes: scopes || ['cloud_controller.write'], user_name: user_name, email: email)
+    when 'cloud_controller_service_permissions_reader'
+      set_user_with_header_as_cloud_controller_service_permissions_reader(user: current_user, scopes: ['cloud_controller_service_permissions.read'], user_name: user_name,
+email: email)
     when 'space_developer'
       space.add_developer(current_user)
       set_user_with_header_as_reader_and_writer(user: current_user, user_name: user_name, email: email)

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -59,12 +59,20 @@ module UserHelpers
   end
 
   # rubocop:disable all
+  def set_current_user_as_service_permissions_reader(opts = {})
+    # rubocop:enable all
+    user = opts.delete(:user) || VCAP::CloudController::User.make
+    scopes = { scopes: %w(cloud_controller_service_permissions.read) }
+    set_current_user(user, scopes.merge(opts))
+  end
+
+  # rubocop:disable all
   def set_current_user_as_role(role:, org: nil, space: nil, user: nil, scopes: nil)
     # rubocop:enable all
     current_user = user || VCAP::CloudController::User.make
     current_user = set_current_user(current_user, scopes: scopes)
 
-    scope_roles = %w(admin admin_read_only global_auditor reader_and_writer reader writer)
+    scope_roles = %w(admin admin_read_only global_auditor reader_and_writer reader writer service_permissions_reader)
     if org && !scope_roles.include?(role)
       org.add_user(current_user)
     end
@@ -108,6 +116,8 @@ module UserHelpers
       set_current_user_as_reader(user: current_user)
     when 'writer'
       set_current_user_as_writer(user: current_user)
+    when 'service_permissions_reader'
+      set_current_user_as_service_permissions_reader(user: current_user)
     when 'no_role'
       nil
     else

--- a/spec/unit/controllers/v3/application_controller_spec.rb
+++ b/spec/unit/controllers/v3/application_controller_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe ApplicationController, type: :controller do
       head 201
     end
 
+    def destroy
+      head 202
+    end
+
+    def update
+      head 200
+    end
+
     def api_explode
       raise CloudController::Errors::ApiError.new_from_details('InvalidRequest', 'omg no!')
     end
@@ -118,6 +126,42 @@ RSpec.describe ApplicationController, type: :controller do
       it 'should show a specific item' do
         get :show, params: { id: 1 }
         expect(response.status).to eq(204)
+      end
+    end
+
+    context 'cloud_controller_service_permissions.read' do
+      let(:name) { before do
+        set_current_user(VCAP::CloudController::User.new(guid: 'some-guid'), scopes: ['cloud_controller_service_permissions.read'])
+      end
+      }
+
+      let(:name) do
+        get :show, params: { id: 1 }
+      end
+
+      it 'cannot show' do
+        name
+        expect(response.status).to eq(403)
+      end
+
+      it 'cannot index' do
+        get :index
+        expect(response.status).to eq(403)
+      end
+
+      it 'cannot create' do
+        post :create
+        expect(response.status).to eq(403)
+      end
+
+      it 'cannot update' do
+        patch :update, params: { id: 1 }, as: :json
+        expect(response.status).to eq(403)
+      end
+
+      it 'cannot delete' do
+        delete :destroy, params: { id: 1 }, as: :json
+        expect(response.status).to eq(403)
       end
     end
 


### PR DESCRIPTION
* A short explanation of the proposed change:

Adds a `/v3/service_instance/:guid/permissions` endpoint that enables service_instance dashboard functionality with the V3 API

* An explanation of the use cases your change solves

As a service developer there is a functionality called service dashboards (https://docs.cloudfoundry.org/services/dashboard-sso.html#checking-user-permissions). Users can manage their service instances via these dashboards, which call the CF API to check if a user is allowed to alter or read a given service instance. This can currently only be done via `/v2/service_instance/:guid/permissions`.

A corresponding V3 endpoint does not exist, which means this functionality won't work when V2 is disabled.

This PR adds an equivalent endpoint to V3.

See also:
https://cloudfoundry.slack.com/archives/C07C04W4Q/p1657878898740599
https://github.com/cloudfoundry/cf-acceptance-tests/issues/565

* Links to any other associated PRs

cloudfoundry/cf-acceptance-tests#593

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
