### PR TITLE
Prevent quota updates or assignment with finite log rates

### DIFF
--- a/app/actions/organization_quota_apply.rb
+++ b/app/actions/organization_quota_apply.rb
@@ -4,8 +4,20 @@ module VCAP::CloudController
     end
 
     def apply(org_quota, message)
+      orgs = valid_orgs(message.organization_guids)
+
+      if org_quota.log_rate_limit != QuotaDefinition::UNLIMITED
+        affected_processes = Organization.where(Sequel[:organizations][:id] => orgs.map(&:id)).
+                             join(:spaces, organization_id: :id).
+                             join(:apps, space_guid: :guid).
+                             join(:processes, app_guid: :guid)
+
+        unless affected_processes.where(log_rate_limit: ProcessModel::UNLIMITED_LOG_RATE).empty?
+          error!('Current usage exceeds new quota values. The org(s) being assigned this quota contain apps running with an unlimited log rate limit.')
+        end
+      end
+
       QuotaDefinition.db.transaction do
-        orgs = valid_orgs(message.organization_guids)
         orgs.each { |org| org_quota.add_organization(org) }
       end
     rescue Sequel::ValidationFailed => e

--- a/app/actions/organization_quotas_update.rb
+++ b/app/actions/organization_quotas_update.rb
@@ -109,14 +109,15 @@ module VCAP::CloudController
 
     def self.unlimited_processes_exist_error!(orgs)
       named_orgs = orgs.take(MAX_ORGS_TO_LIST_ON_FAILURE).map(&:name).join("', '")
-      message = if orgs.size == 1
-                  "Org '#{named_orgs}' assigned this quota contains"
-                elsif orgs.size > MAX_ORGS_TO_LIST_ON_FAILURE
-                  "Orgs '#{named_orgs}' and #{orgs.drop(MAX_ORGS_TO_LIST_ON_FAILURE).size}" \
-                  ' other orgs assigned this quota contain'
-                else
-                  "Orgs '#{named_orgs}' assigned this quota contain"
-                end + ' apps running with an unlimited log rate limit.'
+      message = 'This quota is applied to ' +
+        if orgs.size == 1
+          "org '#{named_orgs}' which contains"
+        elsif orgs.size > MAX_ORGS_TO_LIST_ON_FAILURE
+          "orgs '#{named_orgs}' and #{orgs.drop(MAX_ORGS_TO_LIST_ON_FAILURE).size}" \
+          ' other orgs which contain'
+        else
+          "orgs '#{named_orgs}' which contain"
+        end + ' apps running with an unlimited log rate limit.'
 
       raise Error.new("Current usage exceeds new quota values. #{message}")
     end

--- a/app/actions/organization_quotas_update.rb
+++ b/app/actions/organization_quotas_update.rb
@@ -2,8 +2,18 @@ module VCAP::CloudController
   class OrganizationQuotasUpdate
     class Error < ::StandardError
     end
+
+    MAX_ORGS_TO_LIST_ON_FAILURE = 2
+
     # rubocop:disable Metrics/CyclomaticComplexity
     def self.update(quota, message)
+      if log_rate_limit(message) != QuotaDefinition::UNLIMITED
+        orgs = orgs_with_unlimited_processes(quota)
+        if orgs.any?
+          unlimited_processes_exist_error!(orgs)
+        end
+      end
+
       quota.db.transaction do
         quota.lock!
 
@@ -84,5 +94,34 @@ module VCAP::CloudController
     def self.total_private_domains(message)
       default_if_nil(message.total_domains, QuotaDefinition::UNLIMITED)
     end
+
+    def self.orgs_with_unlimited_processes(quota)
+      quota.organizations_dataset.
+        distinct.
+        select(Sequel[:organizations][:name]).
+        join(:spaces, organization_id: :id).
+        join(:apps, space_guid: :guid).
+        join(:processes, app_guid: :guid).
+        where(log_rate_limit: QuotaDefinition::UNLIMITED).
+        order(:name).
+        all
+    end
+
+    def self.unlimited_processes_exist_error!(orgs)
+      named_orgs = orgs.take(MAX_ORGS_TO_LIST_ON_FAILURE).map(&:name).join("', '")
+      message = if orgs.size == 1
+                  "Org '#{named_orgs}' assigned this quota contains"
+                elsif orgs.size > MAX_ORGS_TO_LIST_ON_FAILURE
+                  "Orgs '#{named_orgs}' and #{orgs.drop(MAX_ORGS_TO_LIST_ON_FAILURE).size}" \
+                  ' other orgs assigned this quota contain'
+                else
+                  "Orgs '#{named_orgs}' assigned this quota contain"
+                end + ' apps running with an unlimited log rate limit.'
+
+      raise Error.new("Current usage exceeds new quota values. #{message}")
+    end
+
+    private_class_method :orgs_with_unlimited_processes,
+                         :unlimited_processes_exist_error!
   end
 end

--- a/app/actions/space_quota_update.rb
+++ b/app/actions/space_quota_update.rb
@@ -102,14 +102,15 @@ module VCAP::CloudController
 
     def self.unlimited_processes_exist_error!(spaces)
       named_spaces = spaces.take(MAX_SPACES_TO_LIST_ON_FAILURE).map(&:name).join("', '")
-      message = if spaces.size == 1
-                  "Space '#{named_spaces}' assigned this quota contains"
-                elsif spaces.size > MAX_SPACES_TO_LIST_ON_FAILURE
-                  "Spaces '#{named_spaces}' and #{spaces.drop(MAX_SPACES_TO_LIST_ON_FAILURE).size}" \
-                  ' other spaces assigned this quota contain'
-                else
-                  "Spaces '#{named_spaces}' assigned this quota contain"
-                end + ' apps running with an unlimited log rate limit.'
+      message = 'This quota is applied to ' +
+        if spaces.size == 1
+          "space '#{named_spaces}' which contains"
+        elsif spaces.size > MAX_SPACES_TO_LIST_ON_FAILURE
+          "spaces '#{named_spaces}' and #{spaces.drop(MAX_SPACES_TO_LIST_ON_FAILURE).size}" \
+          ' other spaces which contain'
+        else
+          "spaces '#{named_spaces}' which contain"
+        end + ' apps running with an unlimited log rate limit.'
 
       raise Error.new("Current usage exceeds new quota values. #{message}")
     end

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -73,6 +73,18 @@ module VCAP::CloudController
         end
       end
 
+      if request_attrs['quota_definition_guid']
+        quota = QuotaDefinition.first(guid: request_attrs['quota_definition_guid'])
+        if quota.log_rate_limit != QuotaDefinition::UNLIMITED
+          affected_processes = org.processes_dataset
+          unless affected_processes.where(log_rate_limit: ProcessModel::UNLIMITED_LOG_RATE).empty?
+            raise CloudController::Errors::ApiError.new_from_details(
+              'UnprocessableEntity',
+              'Current usage exceeds new quota values. This org currently contains apps running with an unlimited log rate limit.')
+          end
+        end
+      end
+
       super(org)
     end
 

--- a/app/models/runtime/process_model.rb
+++ b/app/models/runtime/process_model.rb
@@ -34,6 +34,7 @@ module VCAP::CloudController
     NO_APP_PORT_SPECIFIED = -1
     DEFAULT_HTTP_PORT     = 8080
     DEFAULT_PORTS         = [DEFAULT_HTTP_PORT].freeze
+    UNLIMITED_LOG_RATE    = -1
 
     many_to_one :app, class: 'VCAP::CloudController::AppModel', key: :app_guid, primary_key: :guid, without_guid_generation: true
     many_to_one :revision, class: 'VCAP::CloudController::RevisionModel', key: :revision_guid, primary_key: :guid, without_guid_generation: true

--- a/spec/request/organization_quotas_spec.rb
+++ b/spec/request/organization_quotas_spec.rb
@@ -462,6 +462,20 @@ module VCAP::CloudController
           expect(last_response).to include_error_message("Organization Quota '#{organization_quota.name}' already exists.")
         end
       end
+
+      context 'when trying to set a log rate limit and there are apps with unlimited log rates' do
+        let!(:app_model) { VCAP::CloudController::AppModel.make(name: 'name1', space: space) }
+        let!(:process_model) { VCAP::CloudController::ProcessModel.make(app: app_model, log_rate_limit: -1) }
+
+        it 'returns 422' do
+          patch "/v3/organization_quotas/#{organization_quota.guid}", params.to_json, admin_header
+
+          expect(last_response).to have_status_code(422)
+          expect(last_response).to include_error_message(
+            'Current usage exceeds new quota values. ' \
+            "Org '#{org.name}' assigned this quota contains apps running with an unlimited log rate limit.")
+        end
+      end
     end
 
     describe 'POST /v3/organization_quotas/:guid/relationships/organizations' do
@@ -522,6 +536,19 @@ module VCAP::CloudController
           post "/v3/organization_quotas/#{org_quota.guid}/relationships/organizations", params.to_json, admin_header
           expect(last_response).to have_status_code(422)
           expect(parsed_response['errors'][0]['detail']).to eq('Invalid data type: Data[0] guid should be a string.')
+        end
+      end
+
+      context 'when the quota has a finite log rate limit and there are apps with unlimited log rates' do
+        let(:org_quota) { VCAP::CloudController::QuotaDefinition.make(log_rate_limit: 100) }
+        let!(:app_model) { VCAP::CloudController::AppModel.make(name: 'name1', space: space) }
+        let!(:process_model) { VCAP::CloudController::ProcessModel.make(app: app_model, log_rate_limit: -1) }
+
+        it 'returns 422' do
+          post "/v3/organization_quotas/#{org_quota.guid}/relationships/organizations", params.to_json, admin_header
+          expect(last_response).to have_status_code(422)
+          expect(last_response).to include_error_message(
+            'Current usage exceeds new quota values. The org(s) being assigned this quota contain apps running with an unlimited log rate limit.')
         end
       end
     end

--- a/spec/request/organization_quotas_spec.rb
+++ b/spec/request/organization_quotas_spec.rb
@@ -473,7 +473,7 @@ module VCAP::CloudController
           expect(last_response).to have_status_code(422)
           expect(last_response).to include_error_message(
             'Current usage exceeds new quota values. ' \
-            "Org '#{org.name}' assigned this quota contains apps running with an unlimited log rate limit.")
+            "This quota is applied to org '#{org.name}' which contains apps running with an unlimited log rate limit.")
         end
       end
     end

--- a/spec/request/space_quotas_spec.rb
+++ b/spec/request/space_quotas_spec.rb
@@ -269,7 +269,7 @@ module VCAP::CloudController
 
           expect(last_response).to have_status_code(422)
           expect(last_response).to include_error_message(
-            "Current usage exceeds new quota values. Space '#{space.name}' assigned this quota contains apps running with an unlimited log rate limit.")
+            "Current usage exceeds new quota values. This quota is applied to space '#{space.name}' which contains apps running with an unlimited log rate limit.")
         end
       end
     end

--- a/spec/request/v2/organizations_spec.rb
+++ b/spec/request/v2/organizations_spec.rb
@@ -99,4 +99,28 @@ RSpec.describe 'Organizations' do
       )
     end
   end
+
+  describe 'PUT /v2/organizations/:guid' do
+    context 'when the quota has a finite log rate limit and there are apps with unlimited log rates' do
+      let(:admin_header) { headers_for(user, scopes: %w(cloud_controller.admin)) }
+      let(:org_quota) { VCAP::CloudController::QuotaDefinition.make(log_rate_limit: 100) }
+
+      let(:params) do
+        {
+          quota_definition_guid: org_quota.guid
+        }
+      end
+
+      let!(:space) { VCAP::CloudController::Space.make(organization: org) }
+      let!(:app_model) { VCAP::CloudController::AppModel.make(name: 'name1', space: space) }
+      let!(:process_model) { VCAP::CloudController::ProcessModel.make(app: app_model, log_rate_limit: -1) }
+
+      it 'returns 422' do
+        put "/v2/organizations/#{org.guid}", params.to_json, admin_header
+        expect(last_response).to have_status_code(422)
+        expect(decoded_response['error_code']).to eq('CF-UnprocessableEntity')
+        expect(decoded_response['description']).to eq('Current usage exceeds new quota values. This org currently contains apps running with an unlimited log rate limit.')
+      end
+    end
+  end
 end

--- a/spec/request/v2/space_quota_definitions_spec.rb
+++ b/spec/request/v2/space_quota_definitions_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe 'SpaceQuotaDefinitions' do
+  let(:user) { VCAP::CloudController::User.make }
+  let(:org) { VCAP::CloudController::Organization.make }
+
+  describe 'PUT /v2/space_quota_definitions/guid/spaces/space_guid' do
+    context 'when the quota has a finite log rate limit and there are apps with unlimited log rates' do
+      let(:admin_header) { headers_for(user, scopes: %w(cloud_controller.admin)) }
+      let(:space_quota) { VCAP::CloudController::SpaceQuotaDefinition.make(organization: org, log_rate_limit: 100) }
+
+      let!(:space) { VCAP::CloudController::Space.make(organization: org) }
+      let!(:app_model) { VCAP::CloudController::AppModel.make(name: 'name1', space: space) }
+      let!(:process_model) { VCAP::CloudController::ProcessModel.make(app: app_model, log_rate_limit: -1) }
+
+      it 'returns 422' do
+        put "/v2/space_quota_definitions/#{space_quota.guid}/spaces/#{space.guid}", nil, admin_header
+        expect(last_response).to have_status_code(422)
+        expect(decoded_response['error_code']).to eq('CF-UnprocessableEntity')
+        expect(decoded_response['description']).to eq('Current usage exceeds new quota values. This space currently contains apps running with an unlimited log rate limit.')
+      end
+    end
+  end
+end

--- a/spec/unit/actions/organization_quotas_update_spec.rb
+++ b/spec/unit/actions/organization_quotas_update_spec.rb
@@ -121,8 +121,8 @@ module VCAP::CloudController
             it 'errors with a message telling the user the affected org' do
               expect do
                 OrganizationQuotasUpdate.update(org_quota, message)
-              end.to raise_error(OrganizationQuotasUpdate::Error, "Current usage exceeds new quota values. Org 'org-name-1' " \
-                                 'assigned this quota contains apps running with an unlimited log rate limit.')
+              end.to raise_error(OrganizationQuotasUpdate::Error, 'Current usage exceeds new quota values. This quota is applied to org ' \
+                                 "'org-name-1' which contains apps running with an unlimited log rate limit.")
             end
           end
           context 'and they are in two orgs' do
@@ -132,8 +132,8 @@ module VCAP::CloudController
             it 'errors with a message telling the user the affected orgs' do
               expect do
                 OrganizationQuotasUpdate.update(org_quota, message)
-              end.to raise_error(OrganizationQuotasUpdate::Error, "Current usage exceeds new quota values. Orgs 'org-name-1', 'org-name-2' " \
-                                 'assigned this quota contain apps running with an unlimited log rate limit.')
+              end.to raise_error(OrganizationQuotasUpdate::Error, 'Current usage exceeds new quota values. This quota is applied to orgs ' \
+                                 "'org-name-1', 'org-name-2' which contain apps running with an unlimited log rate limit.")
             end
           end
 
@@ -144,8 +144,8 @@ module VCAP::CloudController
             it 'errors with a message telling the user some of the affected orgs and a total count' do
               expect do
                 OrganizationQuotasUpdate.update(org_quota, message)
-              end.to raise_error(OrganizationQuotasUpdate::Error, "Current usage exceeds new quota values. Orgs 'org-name-1', 'org-name-2' and 3 other orgs " \
-                                 'assigned this quota contain apps running with an unlimited log rate limit.')
+              end.to raise_error(OrganizationQuotasUpdate::Error, 'Current usage exceeds new quota values. This quota is applied to orgs ' \
+                                 "'org-name-1', 'org-name-2' and 3 other orgs which contain apps running with an unlimited log rate limit.")
             end
           end
 
@@ -159,8 +159,8 @@ module VCAP::CloudController
             it 'only names the org once in the error message' do
               expect do
                 OrganizationQuotasUpdate.update(org_quota, message)
-              end.to raise_error(OrganizationQuotasUpdate::Error, "Current usage exceeds new quota values. Org 'org-name' assigned this quota contains apps " \
-                                                                  'running with an unlimited log rate limit.')
+              end.to raise_error(OrganizationQuotasUpdate::Error, 'Current usage exceeds new quota values. This quota is applied to org ' \
+                                 "'org-name' which contains apps running with an unlimited log rate limit.")
             end
           end
         end

--- a/spec/unit/actions/space_quota_update_spec.rb
+++ b/spec/unit/actions/space_quota_update_spec.rb
@@ -109,8 +109,8 @@ module VCAP::CloudController
             it 'errors with a message telling the user the affected space' do
               expect do
                 SpaceQuotaUpdate.update(space_quota, message)
-              end.to raise_error(SpaceQuotaUpdate::Error, "Current usage exceeds new quota values. Space 'space-name-1' " \
-                                 'assigned this quota contains apps running with an unlimited log rate limit.')
+              end.to raise_error(SpaceQuotaUpdate::Error, 'Current usage exceeds new quota values. This quota is applied to space ' \
+                                 "'space-name-1' which contains apps running with an unlimited log rate limit.")
             end
           end
 
@@ -121,8 +121,8 @@ module VCAP::CloudController
             it 'errors with a message telling the user the affected spaces' do
               expect do
                 SpaceQuotaUpdate.update(space_quota, message)
-              end.to raise_error(SpaceQuotaUpdate::Error, "Current usage exceeds new quota values. Spaces 'space-name-1', 'space-name-2' " \
-                                 'assigned this quota contain apps running with an unlimited log rate limit.')
+              end.to raise_error(SpaceQuotaUpdate::Error, 'Current usage exceeds new quota values. This quota is applied to spaces ' \
+                                 "'space-name-1', 'space-name-2' which contain apps running with an unlimited log rate limit.")
             end
           end
 
@@ -133,8 +133,8 @@ module VCAP::CloudController
             it 'errors with a message telling the user some of the affected spaces and a total count' do
               expect do
                 SpaceQuotaUpdate.update(space_quota, message)
-              end.to raise_error(SpaceQuotaUpdate::Error, "Current usage exceeds new quota values. Spaces 'space-name-1', 'space-name-2' and 3 other spaces " \
-                                 'assigned this quota contain apps running with an unlimited log rate limit.')
+              end.to raise_error(SpaceQuotaUpdate::Error, 'Current usage exceeds new quota values. This quota is applied to spaces ' \
+                                 "'space-name-1', 'space-name-2' and 3 other spaces which contain apps running with an unlimited log rate limit.")
             end
           end
 
@@ -148,8 +148,8 @@ module VCAP::CloudController
             it 'only names the space once in the error message' do
               expect do
                 SpaceQuotaUpdate.update(space_quota, message)
-              end.to raise_error(SpaceQuotaUpdate::Error, "Current usage exceeds new quota values. Space 'space-name' assigned this quota contains apps " \
-                                                          'running with an unlimited log rate limit.')
+              end.to raise_error(SpaceQuotaUpdate::Error, 'Current usage exceeds new quota values. This quota is applied to space ' \
+                                 "'space-name' which contains apps running with an unlimited log rate limit.")
             end
           end
         end


### PR DESCRIPTION
This PR builds on #2900 to prevent updates to or assignment of org and space quotas with a finite log rate limit where they would apply to orgs or spaces that contain processes with unlimited log rate limits.

- If an existing deployment is upgraded to gain log rate limiting support then existing application processes will default to -1 (unlimited).
- If an org or space quota is subsequently updated to include a finite log rate limit then processes in the affected orgs or spaces will be unable to restart without having their log rate limit changed.
- Block org and space quota finite log rate limit updates until processes under the affected orgs or spaces have been updated with a finite log rate limit. Specify the names of the first two orgs or spaces and a total count in the error.
- Block assignment of org or space quotas with finite log rate limits to orgs or spaces that contain processes with unlimited log rate limits.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
