### PR TITLE
Transfer Owner returns  a 422 when value for data is not an object

### DIFF
--- a/app/messages/route_transfer_owner_message.rb
+++ b/app/messages/route_transfer_owner_message.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     validates_with NoAdditionalKeysValidator
     validates :data, presence: true, hash: true, allow_nil: false
-    validate :data_content
+    validate :data_content, if: -> { data.is_a?(Hash) }
 
     def space_guid
       HashUtils.dig(data, :guid)

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -3419,6 +3419,26 @@ RSpec.describe 'Routes Request' do
           )
         end
       end
+      context 'when data is not a hash' do
+        let(:request_body) do
+          {
+            data: [{ 'guid' => target_space.guid }]
+          }
+        end
+
+        it 'should respond with 422' do
+          api_call.call(space_dev_headers)
+
+          expect(last_response.status).to eq(422)
+          expect(parsed_response['errors']).to include(
+            include(
+              {
+                'detail' => 'Data must be an object',
+                'title' => 'CF-UnprocessableEntity'
+              })
+          )
+        end
+      end
     end
 
     describe 'when route_sharing flag is disabled' do


### PR DESCRIPTION
Co-authored-by: David Alvarado <alvaradoda@vmware.com>
Co-authored-by: Michael Oleske <moleske@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Transfer Owner endpoint was returning a 500 when the value for data was an array.  We do validate that it is a hash, but weren't returning the error correctly

* An explanation of the use cases your change solves
A user passing in an incorrect array value for data will get a useful error message

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
