### PR TITLE
Transfer Owner returns 422 when route's domain cannot be used by targ…

### DIFF
--- a/app/controllers/v3/routes_controller.rb
+++ b/app/controllers/v3/routes_controller.rb
@@ -176,6 +176,10 @@ class RoutesController < ApplicationController
     target_space_error = check_if_space_is_accessible(target_space)
     unprocessable!("Unable to transfer owner of route '#{route.uri}' to space '#{message.space_guid}'. #{target_space_error}") unless target_space_error.nil?
 
+    if !route.domain.usable_by_organization?(target_space.organization)
+      unprocessable!("Unable to transfer owner of route '#{route.uri}' to space '#{message.space_guid}'. Target space does not have access to route's domain")
+    end
+
     RouteTransferOwner.transfer(route, target_space, user_audit_info)
 
     render status: :ok, json: { status: 'ok' }


### PR DESCRIPTION
…et space

Co-authored-by: David Alvarado <alvaradoda@vmware.com>
Co-authored-by: Michael Oleske <moleske@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Transfer Owner endpoint was returning a 500 when the route's domain was not shared with the target space's organization.

* An explanation of the use cases your change solves
A user attempting to transfer a route who's domain is not shared receives a useful error message

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
