### PR TITLE
Revert "build(deps): bump newrelic_rpm from 8.9.0 to 8.10.0 (#2932)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,7 +334,7 @@ GEM
     net-ssh (7.0.1)
     netaddr (2.0.6)
     netrc (0.11.0)
-    newrelic_rpm (8.10.0)
+    newrelic_rpm (8.9.0)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)


### PR DESCRIPTION
This reverts commit e212164f1c389f962608bba59d945e3c38aead91.

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Revert newrelic bump that breaks the elsa environment in our pipelines.  There is a change to how gRPC works in this minor bump that we're not interested in resolving as we'd like to get another release out soon

I'm going to merge this when the PR checks pass as this is blocking our pipeline

* An explanation of the use cases your change solves
Fixes our Elsa environment that has been failing
* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/2932
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
