### PR TITLE
Fix issue with docker port on strategy rolling

### DIFF
--- a/app/models/runtime/process_model.rb
+++ b/app/models/runtime/process_model.rb
@@ -33,6 +33,7 @@ module VCAP::CloudController
 
     NO_APP_PORT_SPECIFIED = -1
     DEFAULT_HTTP_PORT     = 8080
+    DEFAULT_DOCKER_PORT   = 3000
     DEFAULT_PORTS         = [DEFAULT_HTTP_PORT].freeze
 
     many_to_one :app, class: 'VCAP::CloudController::AppModel', key: :app_guid, primary_key: :guid, without_guid_generation: true

--- a/lib/cloud_controller/diego/protocol/routing_info.rb
+++ b/lib/cloud_controller/diego/protocol/routing_info.rb
@@ -69,6 +69,7 @@ module VCAP::CloudController
           return route_mapping.app_port if route_mapping.has_app_port_specified?
           return process.docker_ports.first if process.docker? && process.docker_ports.present?
           return process.ports.first if process.ports.present?
+          return VCAP::CloudController::ProcessModel::DEFAULT_DOCKER_PORT if process.docker?
 
           VCAP::CloudController::ProcessModel::DEFAULT_HTTP_PORT
         end

--- a/spec/unit/lib/cloud_controller/diego/protocol/routing_info_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/routing_info_spec.rb
@@ -107,10 +107,10 @@ module VCAP::CloudController
                 context 'when the app has no docker ports' do
                   let(:execution_metadata) { '{}' }
 
-                  it 'uses 8080 as a default' do
+                  it 'uses 3000 as a default' do
                     expected_http = [
-                      { 'hostname' => route_with_service.uri, 'route_service_url' => route_with_service.route_service_url, 'port' => 8080, 'protocol' => 'http1' },
-                      { 'hostname' => route_without_service.uri, 'port' => 8080, 'protocol' => 'http1' }
+                      { 'hostname' => route_with_service.uri, 'route_service_url' => route_with_service.route_service_url, 'port' => 3000, 'protocol' => 'http1' },
+                      { 'hostname' => route_without_service.uri, 'port' => 3000, 'protocol' => 'http1' }
                     ]
 
                     expect(ri.keys).to match_array ['http_routes', 'internal_routes']


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Fixes a problem, that when a docker app is pushed with --strategy-rolling the default HTTP-Port is used if the push gets aborted at the right time. Since Docker apps do not use the default HTTP-Port this is not the desired behaviour.

* An explanation of the use cases your change solves

Docker app gets pushed with --strategy-rolling and gets aborted in the staging phase.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
