### PR TITLE
Use event_presenter for audit events in syslogs

### DIFF
--- a/app/models/runtime/event.rb
+++ b/app/models/runtime/event.rb
@@ -51,7 +51,7 @@ module VCAP::CloudController
       super
       if Config.config.get(:log_audit_events)
         logger = Steno.logger('cc.model.event')
-        logger.info "Audit event: #{type} enacted by #{actor_type} #{actor_username || actor_name} on #{actee_type} #{actee_name}"
+        logger.info Presenters::V3::EventPresenter.new(self).body.to_json
       end
     end
 

--- a/app/presenters/v3/event_presenter.rb
+++ b/app/presenters/v3/event_presenter.rb
@@ -3,6 +3,10 @@ require 'presenters/v3/base_presenter'
 module VCAP::CloudController::Presenters::V3
   class EventPresenter < BasePresenter
     def to_hash
+      body.merge!({ links: build_links })
+    end
+
+    def body
       {
         guid: event.guid,
         created_at: event.timestamp,
@@ -13,7 +17,6 @@ module VCAP::CloudController::Presenters::V3
         data: event.data || {},
         space: space,
         organization: org,
-        links: build_links
       }
     end
 

--- a/spec/unit/models/runtime/event_spec.rb
+++ b/spec/unit/models/runtime/event_spec.rb
@@ -110,11 +110,16 @@ module VCAP::CloudController
           actee: 'nimoy',
           actee_type: 'vulcan',
           actee_name: 'Mr. Spock',
-          space_guid: space.guid
+          space: space
+
         }
-        e = Event.new(required_attrs)
-        expect(fake_logger).to receive(:info).with('Audit event: audit.test enacted by pork chop on vulcan Mr. Spock')
-        e.save
+        event = Event.new(required_attrs)
+        allow(fake_logger).to receive(:info)
+
+        event.save
+
+        expect(fake_logger).to have_received(:info).with(/audit.test/)
+        expect(fake_logger).to have_received(:info).with(/#{event.guid}/)
       end
     end
 


### PR DESCRIPTION
Co-authored-by: Joseph Palermo <jpalermo@pivotal.io>
Co-authored-by: Merric de Launey <mdelauney@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
