### PR TITLE
Print RUBY_DESCRIPTION to stdout on startup

### DIFF
--- a/bin/cloud_controller
+++ b/bin/cloud_controller
@@ -6,6 +6,7 @@ ENV['RAILS_ENV'] ||= 'production'
 ENV['SINATRA_ACTIVESUPPORT_WARNING'] ||= 'false'
 
 require 'cloud_controller'
+puts RUBY_DESCRIPTION
 begin
   VCAP::CloudController::Runner.new(ARGV).run!
 rescue => e

--- a/lib/tasks/clock.rake
+++ b/lib/tasks/clock.rake
@@ -1,6 +1,8 @@
 namespace :clock do
   desc 'Start a recurring tasks'
   task :start do
+    puts RUBY_DESCRIPTION
+
     require 'cloud_controller/clock/scheduler'
 
     RakeConfig.context = :clock

--- a/lib/tasks/deployment_updater.rake
+++ b/lib/tasks/deployment_updater.rake
@@ -1,6 +1,7 @@
 namespace :deployment_updater do
   desc 'Start a recurring process to perform zero downtime deployments'
   task :start do
+    puts RUBY_DESCRIPTION
     require 'cloud_controller/deployment_updater/scheduler'
 
     RakeConfig.context = :deployment_updater

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -11,6 +11,7 @@ namespace :jobs do
   desc 'Start a delayed_job worker that works on jobs that require access to local resources.'
 
   task :local, [:name] do |t, args|
+    puts RUBY_DESCRIPTION
     queue = VCAP::CloudController::Jobs::Queues.local(RakeConfig.config).to_s
     args.with_defaults(name: queue)
 
@@ -22,6 +23,7 @@ namespace :jobs do
 
   desc 'Start a delayed_job worker.'
   task :generic, [:name] do |t, args|
+    puts RUBY_DESCRIPTION
     args.with_defaults(name: ENV['HOSTNAME'])
 
     RakeConfig.context = :worker


### PR DESCRIPTION
Prints RUBY_DESCRIPTION on startup for various jobs.  Added to check that YJIT is successfully enabled (https://github.com/cloudfoundry/capi-release/pull/270)

Prints something like this:

```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) +YJIT [x86_64-linux]
```

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
