### PR TITLE
Remove redundant locks and transactions

### DIFF
--- a/app/actions/services/locks/deleter_lock.rb
+++ b/app/actions/services/locks/deleter_lock.rb
@@ -15,7 +15,6 @@ module VCAP::CloudController
     def lock!
       ManagedServiceInstance.db.transaction do
         service_instance.lock!
-        service_instance.last_operation.lock! if service_instance.last_operation
 
         try_to_cancel_last_operation!
 

--- a/app/actions/services/locks/updater_lock.rb
+++ b/app/actions/services/locks/updater_lock.rb
@@ -15,7 +15,6 @@ module VCAP::CloudController
     def lock!
       ManagedServiceInstance.db.transaction do
         service_instance.lock!
-        service_instance.last_operation.lock! if service_instance.last_operation
 
         raise_if_instance_locked(service_instance)
 

--- a/app/actions/v3/service_instance_create_managed.rb
+++ b/app/actions/v3/service_instance_create_managed.rb
@@ -148,14 +148,10 @@ module VCAP::CloudController
       end
 
       def save_instance(broker_response, instance)
-        ManagedServiceInstance.db.transaction do
-          instance.lock!
-          instance.last_operation.lock! if instance.last_operation
-          instance.save_with_new_operation(
-            broker_response[:instance] || {},
-            broker_response[:last_operation] || {}
-          )
-        end
+        instance.save_with_new_operation(
+          broker_response[:instance] || {},
+          broker_response[:last_operation] || {}
+        )
       end
 
       def fetch_service_instance(client, instance)

--- a/app/actions/v3/service_instance_update_managed.rb
+++ b/app/actions/v3/service_instance_update_managed.rb
@@ -143,14 +143,10 @@ module VCAP::CloudController
         attributes_to_update = {}
         attributes_to_update[:dashboard_url] = broker_response[:dashboard_url] if broker_response.key?(:dashboard_url)
 
-        ManagedServiceInstance.db.transaction do
-          instance.lock!
-          instance.last_operation.lock! if instance.last_operation
-          instance.save_with_new_operation(
-            attributes_to_update,
-            broker_response[:last_operation] || {}
-          )
-        end
+        instance.save_with_new_operation(
+          attributes_to_update,
+          broker_response[:last_operation] || {}
+        )
 
         event_repository.record_service_instance_event(:start_update, instance, @audit_hash)
       end


### PR DESCRIPTION
- When locking an instance, there is no need to explicitly lock its corresponding operation (dependent 1:1 association).
- As `save_with_new_operation` (`ServiceInstance`) now locks the instance and updates itself and the associated operation in a transaction (see [1]), there is no need to wrap it into another transaction in the calling code.

[1] https://github.com/cloudfoundry/cloud_controller_ng/pull/2916

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
