### PR TITLE
Remove unnecessary checks in create|update service instance jobs

### DIFF
--- a/app/jobs/v3/create_service_instance_job.rb
+++ b/app/jobs/v3/create_service_instance_job.rb
@@ -124,8 +124,6 @@ module VCAP::CloudController
       def raise_if_other_operations_in_progress!
         last_operation_type = service_instance.last_operation&.type
 
-        return if operation_type == 'delete' && last_operation_type == 'create'
-
         if service_instance.operation_in_progress? && last_operation_type != operation_type
           cancelled!(last_operation_type)
         end

--- a/app/jobs/v3/update_service_instance_job.rb
+++ b/app/jobs/v3/update_service_instance_job.rb
@@ -124,8 +124,6 @@ module VCAP::CloudController
       def raise_if_other_operations_in_progress!
         last_operation_type = service_instance.last_operation&.type
 
-        return if operation_type == 'delete' && last_operation_type == 'create'
-
         if service_instance.operation_in_progress? && last_operation_type != operation_type
           cancelled!(last_operation_type)
         end


### PR DESCRIPTION
The `operation_type` is hard-coded to either `create` or `update` and thus cannot be `delete`.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
