### PR TITLE
Return 503 in case of database connection errors

### DIFF
--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -76,6 +76,7 @@ class ApplicationController < ActionController::Base
   rescue_from CloudController::Errors::ApiError, with: :handle_api_error
   rescue_from CloudController::Errors::CompoundError, with: :handle_compound_error
   rescue_from ActionDispatch::Http::Parameters::ParseError, with: :handle_invalid_request_body
+  rescue_from Sequel::DatabaseConnectionError, Sequel::DatabaseDisconnectError, with: :handle_db_connection_error
 
   def configuration
     Config.config
@@ -196,6 +197,11 @@ class ApplicationController < ActionController::Base
 
   def handle_invalid_request_body(_error)
     error = CloudController::Errors::ApiError.new_from_details('MessageParseError', 'invalid request body')
+    handle_api_error(error)
+  end
+
+  def handle_db_connection_error(_)
+    error = CloudController::Errors::ApiError.new_from_details('ServiceUnavailable', 'Database connection failure')
     handle_api_error(error)
   end
 


### PR DESCRIPTION
An unhandled `Sequel::DatabaseDisconnectError` results in a 500 error response (Internal Server Error). Instead a 503 (Service Unavailable) is correct as the problem is not caused by internal Cloud Controller coding.

The `DatabaseDisconnectError` has been seen on a foundation; the `Sequel::DatabaseConnectionError` has been added as it is a similar error type.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
