### PR TITLE
Optimisations for /v3/roles API calls

### DIFF
--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -116,7 +116,6 @@ class RolesController < ApplicationController
     user_guid = message.user_guid || lookup_user_guid_in_uaa(message.username, message.user_origin)
 
     user = User.first(guid: user_guid) || create_cc_user(user_guid)
-    unprocessable_user! unless user
 
     RoleCreate.new(message, user_audit_info).create_organization_role(
       type: message.type,
@@ -167,10 +166,6 @@ class RolesController < ApplicationController
 
   def unprocessable_organization!
     unprocessable!('Invalid organization. Ensure that the organization exists and you have access to it.')
-  end
-
-  def unprocessable_user!
-    unprocessable!('Invalid user. Ensure that the user exists and you have access to it.')
   end
 
   def unprocessable_space_user!

--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -94,9 +94,6 @@ class RolesController < ApplicationController
     unprocessable_space! unless space
     org = space.organization
 
-    unprocessable_space! if permission_queryer.can_read_from_org?(org.guid) &&
-      !permission_queryer.can_read_from_space?(message.space_guid, org.guid)
-
     unauthorized! unless permission_queryer.can_update_active_space?(message.space_guid, org.guid)
     suspended! unless permission_queryer.is_space_active?(message.space_guid)
 

--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -65,7 +65,8 @@ class RolesController < ApplicationController
     resource_not_found!(:role) unless role
 
     if role.for_space?
-      org_guid = Space.find(guid: role.space_guid).organization.guid
+      org_guid = Organization.join(:spaces, organization_id: :id).select(:organizations__guid).where(spaces__guid: role.space_guid)
+
       unauthorized! unless permission_queryer.can_update_active_space?(role.space_guid, org_guid)
       suspended! unless permission_queryer.is_space_active?(role.space_guid)
     else

--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -65,9 +65,7 @@ class RolesController < ApplicationController
     resource_not_found!(:role) unless role
 
     if role.for_space?
-      org_guid = Organization.join(:spaces, organization_id: :id).select(:organizations__guid).where(spaces__guid: role.space_guid)
-
-      unauthorized! unless permission_queryer.can_update_active_space?(role.space_guid, org_guid)
+      unauthorized! unless permission_queryer.can_update_active_space?(role.space_guid, role.organization_guid)
       suspended! unless permission_queryer.is_space_active?(role.space_guid)
     else
       unauthorized! unless permission_queryer.can_write_to_active_org?(role.organization_guid)

--- a/app/decorators/include_role_organization_decorator.rb
+++ b/app/decorators/include_role_organization_decorator.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
 
       def decorate(hash, roles)
         hash[:included] ||= {}
-        organization_guids = roles.map(&:organization_guid).uniq
+        organization_guids = roles.map { |role| role.organization_guid if !role.for_space? }.uniq
         organizations = Organization.where(guid: organization_guids).
                         order(:created_at).eager(Presenters::V3::OrganizationPresenter.associated_resources).all
 

--- a/app/decorators/include_role_organization_decorator.rb
+++ b/app/decorators/include_role_organization_decorator.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
 
       def decorate(hash, roles)
         hash[:included] ||= {}
-        organization_guids = roles.map { |role| role.organization_guid if !role.for_space? }.uniq
+        organization_guids = roles.map { |role| role.organization_guid unless role.for_space? }.uniq
         organizations = Organization.where(guid: organization_guids).
                         order(:created_at).eager(Presenters::V3::OrganizationPresenter.associated_resources).all
 

--- a/app/models/runtime/role.rb
+++ b/app/models/runtime/role.rb
@@ -103,11 +103,13 @@ module VCAP::CloudController
     end
 
     def organization_guid
-      organization&.guid
+      return organization.guid unless organization_id == SPACE_OR_ORGANIZATION_NOT_SPECIFIED
+
+      space.organization_guid
     end
 
     def space_guid
-      space&.guid
+      space.guid unless space_id == SPACE_OR_ORGANIZATION_NOT_SPECIFIED
     end
 
     def for_space?

--- a/spec/request/roles_spec.rb
+++ b/spec/request/roles_spec.rb
@@ -79,8 +79,6 @@ RSpec.describe 'Roles Request' do
           code: 201,
           response_object: expected_response
         }
-        h['org_auditor'] = { code: 422 }
-        h['org_billing_manager'] = { code: 422 }
         h
       end
 
@@ -332,8 +330,6 @@ RSpec.describe 'Roles Request' do
             code: 201,
             response_object: expected_response
           }
-          h['org_auditor'] = { code: 422 }
-          h['org_billing_manager'] = { code: 422 }
           h
         end
 
@@ -525,8 +521,6 @@ RSpec.describe 'Roles Request' do
           code: 201,
           response_object: expected_response
         }
-        h['org_auditor'] = { code: 422 }
-        h['org_billing_manager'] = { code: 422 }
         h
       end
 
@@ -567,8 +561,6 @@ RSpec.describe 'Roles Request' do
             response_object: expected_response
           }
 
-          h['org_auditor'] = { code: 422 }
-          h['org_billing_manager'] = { code: 422 }
           h
         end
         it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS

--- a/spec/unit/decorators/include_role_organization_decorator_spec.rb
+++ b/spec/unit/decorators/include_role_organization_decorator_spec.rb
@@ -7,10 +7,12 @@ module VCAP::CloudController
 
     let(:organization1) { Organization.make(name: 'first-organization') }
     let(:organization2) { Organization.make(name: 'second-organization') }
+    let(:orguser) { OrganizationUser.make(organization: organization1) }
+    let(:orgauditor) { OrganizationAuditor.make(organization: organization2) }
     let(:roles) do
       [
-        OrganizationUser.make(organization: organization1),
-        OrganizationAuditor.make(organization: organization2)
+        Role.where(user_id: orguser.user_id, organization_id: organization1.id).first,
+        Role.where(user_id: orgauditor.user_id, organization_id: organization2.id).first
       ]
     end
 


### PR DESCRIPTION
This PR optimizes the speed of requests to `/v3/roles` by:
- Removing unnecessary checks when creating space roles, reducing the number of expensive DB queries.
- Avoiding a number of expensive DB queries that were run on all `create` calls by where a user guid was provided, which were aimed at determining whether the assignee user was in the same org as the user trying to assign them a role.
- Retrieving the `org_guid` used in destroying a role more efficiently.

The second commit ([ed19bdbe](https://github.com/sap-contributions/cloud_controller_ng/commit/ed19bdbe7fbfbc27936ba7a0f192bd58cc238c47)) ends an inconsistency whereby org managers received a 201 if they assigned an org role to an unaffiliated user by providing that user's username, but a 422 CF-UnprocessableEntity if they tried to do the same by providing the user's guid. See an example below of the previous behaviour (now corrected).

Org manager setting an org role on a user outside the organizaition when providing the user's guid:

```
$ cf curl -X POST /v3/roles -d '{
>       "type": "organization_auditor",
>       "relationships": {
>         "user": {
>           "data": {
>             "guid": "6823285a-51d3-47de-989b-51d6b9bd834f"
>           }
>         },
>         "organization": {
>           "data": {
>             "guid": "550d3635-3ae8-481e-ad2a-c150ec45d910"
>           }
>         }
>       }
>     }'
{
  "errors": [
    {
      "detail": "Invalid user. Ensure that the user exists and you have access to it.",
      "title": "CF-UnprocessableEntity",
      "code": 10008
    }
  ]
}
```

Org manager setting the same org role on the same user, still outside their org, by providing their username:
```
$ cf curl -X POST /v3/roles -d '{
>       "type": "organization_auditor",
>       "relationships": {
>         "user": {
>           "data": {
>             "username": "lame"
>           }
>         },
>         "organization": {
>           "data": {
>             "guid": "550d3635-3ae8-481e-ad2a-c150ec45d910"
>           }
>         }
>       }
>     }'
{
  "guid": "277ff39c-d8ac-4c1e-a118-32cee054e882",
  "created_at": "2022-09-15T13:54:32Z",
  "updated_at": "2022-09-15T13:54:32Z",
  "type": "organization_auditor",
  "relationships": {
    "user": {
      "data": {
        "guid": "6823285a-51d3-47de-989b-51d6b9bd834f"
      }
    },
    "organization": {
      "data": {
        "guid": "550d3635-3ae8-481e-ad2a-c150ec45d910"
      }
    },
    "space": {
      "data": null
    }
  },
  "links": {
    "self": {
      "href": "https://api.cf.azure-dev24.azure.cfp.sapcloud.io/v3/roles/277ff39c-d8ac-4c1e-a118-32cee054e882"
    },
    "user": {
      "href": "https://api.cf.azure-dev24.azure.cfp.sapcloud.io/v3/users/6823285a-51d3-47de-989b-51d6b9bd834f"
    },
    "organization": {
      "href": "https://api.cf.azure-dev24.azure.cfp.sapcloud.io/v3/organizations/550d3635-3ae8-481e-ad2a-c150ec45d910"
    }
  }
}
```

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
