### PR TITLE
POST /v3/service_credential_bindings can now bind inactive service plans

### DIFF
--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -51,7 +51,6 @@ module VCAP::CloudController
         space_mismatch! unless all_space_guids(service_instance).include? app.space.guid
         if service_instance.managed_instance?
           service_not_bindable! unless service_instance.service_plan.bindable?
-          service_not_available! unless service_instance.service_plan.active?
           volume_mount_not_enabled! if service_instance.volume_service? && !volume_mount_services_enabled
           service_instance_not_found! if service_instance.create_failed?
           operation_in_progress! if service_instance.operation_in_progress?

--- a/app/actions/service_credential_binding_key_create.rb
+++ b/app/actions/service_credential_binding_key_create.rb
@@ -48,7 +48,6 @@ module VCAP::CloudController
       def validate_service_instance!(service_instance)
         if service_instance.managed_instance?
           service_not_bindable! unless service_instance.service_plan.bindable?
-          service_not_available! unless service_instance.service_plan.active?
           service_instance_not_found! if service_instance.create_failed?
           operation_in_progress! if service_instance.operation_in_progress?
         else

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1373,18 +1373,6 @@ RSpec.describe 'v3 service credential bindings' do
             }))
           end
 
-          it 'returns a 422 when the plan is no longer available' do
-            service_instance.service_plan.update(active: false)
-
-            api_call.call admin_headers
-            expect(last_response).to have_status_code(422)
-            expect(parsed_response['errors']).to include(include({
-              'detail' => include('Service plan is not available'),
-              'title' => 'CF-UnprocessableEntity',
-              'code' => 10008,
-            }))
-          end
-
           it 'responds with 422 when there is an operation in progress for the service instance' do
             service_instance.save_with_new_operation({}, { type: 'guacamole', state: 'in progress' })
             api_call.call admin_headers
@@ -1581,22 +1569,6 @@ RSpec.describe 'v3 service credential bindings' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(include({
               'detail' => include('Service plan does not allow bindings.'),
-              'title' => 'CF-UnprocessableEntity',
-              'code' => 10008,
-            }))
-          end
-        end
-
-        context 'when the service instance is from unavailable plan' do
-          let(:plan) { VCAP::CloudController::ServicePlan.make(active: false) }
-          let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space, service_plan: plan) }
-
-          it 'returns a 422' do
-            api_call.call admin_headers
-
-            expect(last_response).to have_status_code(422)
-            expect(parsed_response['errors']).to include(include({
-              'detail' => include('Service plan is not available.'),
               'title' => 'CF-UnprocessableEntity',
               'code' => 10008,
             }))

--- a/spec/unit/actions/service_credential_binding_app_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_app_create_spec.rb
@@ -196,11 +196,10 @@ module VCAP::CloudController
                 service_instance.service_plan.update(active: false)
               end
 
-              it 'raises an error' do
-                expect { action.precursor(service_instance, app: app, message: message) }.to raise_error(
-                  ServiceCredentialBindingAppCreate::UnprocessableCreate,
-                  'Service plan is not available'
-                )
+              it 'does not raise an error' do
+                expect {
+                  action.precursor(service_instance, app: app, volume_mount_services_enabled: true, message: message)
+                }.not_to raise_error
               end
             end
 

--- a/spec/unit/actions/service_credential_binding_key_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_key_create_spec.rb
@@ -169,11 +169,8 @@ module VCAP::CloudController
                 service_instance.service_plan.update(active: false)
               end
 
-              it 'raises an error' do
-                expect { action.precursor(service_instance, message: message) }.to raise_error(
-                  ServiceCredentialBindingKeyCreate::UnprocessableCreate,
-                  'Service plan is not available.'
-                )
+              it 'does not raise an error' do
+                expect { action.precursor(service_instance, message: message) }.to_not raise_error
               end
             end
 


### PR DESCRIPTION
[finishes #183267128]

Co-authored-by: Joseph Palermo <jpalermo@pivotal.io>
Co-authored-by: Merric de Launey <mdelauney@pivotal.io>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
