### PR TITLE
Return correct docker port

### DIFF
--- a/app/models/runtime/process_model.rb
+++ b/app/models/runtime/process_model.rb
@@ -559,7 +559,7 @@ module VCAP::CloudController
     end
 
     def docker_ports
-      if !self.needs_staging? && desired_droplet.present?
+      if desired_droplet.present? && desired_droplet.staged?
         return desired_droplet.docker_ports
       end
 


### PR DESCRIPTION
As outlined in #2976 the correct docker port from the desired droplet is only returned if *the process does not need staging*.

I've found the story "API should support docker apps not listening on port 8080" in PivotalTracker [1] and the corresponding commit in ccng [2]. The commit message contains a table which I'm repeating here in a simplified form:

| App Lifecycle | Staged | Display |
|--|--|--|
| buildpack | anything | 8080 |
| docker | false | 8080 |
| docker | true | execution metadata 1st port OR 8080 |

According to this table the custom port from the Dockerfile (i.e. execution metadata) should only be returned if the docker app *is staged*. This PR changes the condition from "*the process does not need staging*" to "*the desired droplet is staged*" and thus prevents the wrong package state calculation for aborted deployments outlined in #2975.

Closes #2976

[1] https://www.pivotaltracker.com/n/projects/2196383/stories/167149569
[2] https://github.com/cloudfoundry/cloud_controller_ng/commit/e1a87d7baf6d8a12efb3ad8f9ed89fd49692e6aa

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
