### PR TITLE
Ignore sequel_pg logs

### DIFF
--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -30,7 +30,7 @@ module VCAP::CloudController
         db.logger = logger
         db.sql_log_level = opts[:log_level]
         db.extension :caller_logging
-        db.caller_logging_ignore = /sequel_paginator|query_length_logging/
+        db.caller_logging_ignore = /sequel_paginator|query_length_logging|sequel_pg/
         db.caller_logging_formatter = lambda do |caller|
           "(#{caller.sub(%r{^.*/cloud_controller_ng/}, '')})"
         end


### PR DESCRIPTION
Before we saw many log entries which had as resource sequel_pg, which is not very helpful if you want to find the origin of the sql statement. Ignoring sequel_pg logs in db.rb will skip those entries and make it easier to see where a sql statement comes from.

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
