### PR TITLE
Remove unnecessary db query as admin user for update_route_destinations

### DIFF
--- a/app/controllers/v3/routes_controller.rb
+++ b/app/controllers/v3/routes_controller.rb
@@ -332,9 +332,13 @@ class RoutesController < ApplicationController
   def validate_app_guids!(apps_hash, desired_app_guids)
     existing_app_guids = apps_hash.keys
 
-    missing_app_guids = desired_app_guids - (existing_app_guids & permission_queryer.readable_app_guids)
+    not_existing_app_guids = desired_app_guids - existing_app_guids
+    unprocessable!("App(s) with guid(s) \"#{not_existing_app_guids.join('", "')}\" do not exist.") unless not_existing_app_guids.empty?
 
-    unprocessable!("App(s) with guid(s) \"#{missing_app_guids.join('", "')}\" do not exist or you do not have access.") unless missing_app_guids.empty?
+    unless permission_queryer.can_read_globally?
+      unauthorized_app_guids = desired_app_guids - permission_queryer.readable_app_guids
+      unprocessable!("App(s) with guid(s) \"#{unauthorized_app_guids.join('", "')}\" you do not have access.") unless unauthorized_app_guids.empty?
+    end
   end
 
   def validate_app_spaces!(apps_hash, route)

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -298,7 +298,7 @@ class VCAP::CloudController::Permissions
   end
 
   def readable_app_guids
-    VCAP::CloudController::AppModel.where(space_guid: readable_space_guids).select(:guid).map(&:guid)
+    VCAP::CloudController::AppModel.user_visible(@user, can_read_globally?).select(:guid).map(&:guid)
   end
 
   def readable_route_mapping_guids

--- a/spec/request/route_destinations_spec.rb
+++ b/spec/request/route_destinations_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe 'Route Destinations Request' do
             post "/v3/routes/#{route.guid}/destinations", params.to_json, user_header
             expect(last_response.status).to eq(422)
 
-            expect(parsed_response['errors'][0]['detail']).to match('App(s) with guid(s) "whoops" do not exist or you do not have access.')
+            expect(parsed_response['errors'][0]['detail']).to match('App(s) with guid(s) "whoops" do not exist.')
           end
         end
 
@@ -499,7 +499,7 @@ RSpec.describe 'Route Destinations Request' do
             post "/v3/routes/#{route.guid}/destinations", params.to_json, user_header
             expect(last_response.status).to eq(422)
 
-            expect(parsed_response['errors'][0]['detail']).to match('App(s) with guid(s) "whoops-1", "whoops-2" do not exist or you do not have access.')
+            expect(parsed_response['errors'][0]['detail']).to match('App(s) with guid(s) "whoops-1", "whoops-2" do not exist.')
           end
         end
 
@@ -524,7 +524,7 @@ RSpec.describe 'Route Destinations Request' do
           it 'returns a ' do
             post "/v3/routes/#{route.guid}/destinations", params.to_json, user_header
             expect(last_response.status).to eq(422)
-            expect(parsed_response['errors'][0]['detail']).to match("App(s) with guid(s) \"#{app_model.guid}\" do not exist or you do not have access.")
+            expect(parsed_response['errors'][0]['detail']).to match("App(s) with guid(s) \"#{app_model.guid}\" you do not have access.")
           end
         end
       end
@@ -909,7 +909,7 @@ RSpec.describe 'Route Destinations Request' do
             patch "/v3/routes/#{route.guid}/destinations", params.to_json, user_header
             expect(last_response.status).to eq(422)
 
-            expect(parsed_response['errors'][0]['detail']).to match('App(s) with guid(s) "whoops" do not exist or you do not have access.')
+            expect(parsed_response['errors'][0]['detail']).to match('App(s) with guid(s) "whoops" do not exist.')
           end
         end
 
@@ -965,7 +965,7 @@ RSpec.describe 'Route Destinations Request' do
             patch "/v3/routes/#{route.guid}/destinations", params.to_json, user_header
             expect(last_response.status).to eq(422)
 
-            expect(parsed_response['errors'][0]['detail']).to match('App(s) with guid(s) "whoops-1", "whoops-2" do not exist or you do not have access.')
+            expect(parsed_response['errors'][0]['detail']).to match('App(s) with guid(s) "whoops-1", "whoops-2" do not exist.')
           end
         end
 
@@ -990,7 +990,7 @@ RSpec.describe 'Route Destinations Request' do
           it 'returns a ' do
             patch "/v3/routes/#{route.guid}/destinations", params.to_json, user_header
             expect(last_response.status).to eq(422)
-            expect(parsed_response['errors'][0]['detail']).to match("App(s) with guid(s) \"#{app_model.guid}\" do not exist or you do not have access.")
+            expect(parsed_response['errors'][0]['detail']).to match("App(s) with guid(s) \"#{app_model.guid}\" you do not have access.")
           end
         end
       end


### PR DESCRIPTION
- Improve cases for admin user in `lib/cloud_controller/permissions.rb: 'readable_app_guids'` and `app/controllers/v3/routes_controller.rb: 'validate_app_guids!'` to avoid unnecessary SELECT statements without condition (`SELECT guid FROM spaces`, `SELECT guid FROM apps`).
- Adapting the route_destinations_spec to the changes.

In one of our dashboards we saw a lot of `SELECT guid FROM spaces` queries without any filter. We found out that this query was originally triggered by readable_app_guids which used to call readable_space_guids  in permissions.rb for the case when the user is an admin. To remove the unnecessary db query for admins, we replaced the readable_space_guids 
part in readable_app_guids with: `VCAP::CloudController::AppModel.user_visible(@user, can_read_globally?).select(:guid).map(&:guid)` which is already done similar in other functions. With this change we make use of the user_visibility_filter of the sequel_plugin vcap_user_visibility, which is possible because this filter is implemented in the app_model.

The above change showed in the dashboards another db query without filter, `SELECT guid FROM apps`, triggered in routes_controller.rb where readable_app_guids is called in validate_app_guids! for the case when the user is admin. In validate_app_guids we splitted the original unprocessable! case up into two scenarios:
- check if the given app guids include non existing guids
- if the user is not an admin user, check for unauthorized app guids 

With this change the unnecessary db query for admin users can be avoided.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
