### PR TITLE
Make console compatible to Ruby 3

### DIFF
--- a/lib/cloud_controller/console.rb
+++ b/lib/cloud_controller/console.rb
@@ -28,7 +28,7 @@ if ENV['CLOUD_CONTROLLER_NG_SECRETS']
   config_kwargs.merge!(secrets_hash: secrets_hash)
 end
 
-@config = VCAP::CloudController::Config.load_from_file(@config_file, config_kwargs)
+@config = VCAP::CloudController::Config.load_from_file(@config_file, **config_kwargs)
 logger = Logger.new($stdout)
 
 db_config = @config.set(:db, @config.get(:db).merge(log_level: :debug))


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This change uses double splat operator to pass keywords instead hash object as described in the document see https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

* An explanation of the use cases your change solves
Changing Ruby to 3.x broke running the console and it exited with
```bash
/var/vcap/data/packages/cloud_controller_ng/0a31baf8d49ab27d49fe206acd7f6b6f34d49b7a/cloud_controller_ng/lib/cloud_controller/config.rb:32:in `load_from_file': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /var/vcap/data/packages/cloud_controller_ng/0a31baf8d49ab27d49fe206acd7f6b6f34d49b7a/cloud_controller_ng/lib/cloud_controller/console.rb:31:in `<top (required)>'
	from bin/console:15:in `require'
	from bin/console:15:in `<main>'
```

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
No, because this link is broken...