### PR TITLE
Remove unnecessary db query as admin user for organization_quotas

### DIFF
--- a/app/controllers/v3/organization_quotas_controller.rb
+++ b/app/controllers/v3/organization_quotas_controller.rb
@@ -52,7 +52,11 @@ class OrganizationQuotasController < ApplicationController
     message = OrganizationQuotasListMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?
 
-    dataset = OrganizationQuotaListFetcher.fetch(message: message, readable_org_guids: permission_queryer.readable_org_guids)
+    if permission_queryer.can_read_globally?
+      dataset = OrganizationQuotaListFetcher.fetch_all(message: message)
+    else
+      dataset = OrganizationQuotaListFetcher.fetch(message: message, readable_org_guids: permission_queryer.readable_org_guids)
+    end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::OrganizationQuotaPresenter,

--- a/app/fetchers/organization_quota_list_fetcher.rb
+++ b/app/fetchers/organization_quota_list_fetcher.rb
@@ -10,6 +10,11 @@ module VCAP::CloudController
         filter(message, dataset, readable_org_guids)
       end
 
+      def fetch_all(message:)
+        dataset = QuotaDefinition.dataset
+        filter(message, dataset, nil)
+      end
+
       private
 
       def filter(message, dataset, readable_org_guids)
@@ -18,9 +23,15 @@ module VCAP::CloudController
         end
 
         if message.requested? :organization_guids
+          if readable_org_guids
+            guids = message.organization_guids & readable_org_guids
+          else
+            guids = message.organization_guids
+          end
+
           dataset = dataset.
                     join(:organizations, quota_definition_id: :id).
-                    where(Sequel[:organizations][:guid] => message.organization_guids & readable_org_guids).distinct.
+                    where(Sequel[:organizations][:guid] => guids).distinct.
                     qualify(:quota_definitions)
         end
 


### PR DESCRIPTION
Improve cases for admin user when fetching organization_quotas. Before this triggered a "SELECT guids FROM organizations" without condition. To avoid this unnecessary db query for admin users we distinguish now between admin or not admin and only in the non-admin case the query for the organization guids is done.

With this change, if an admin user calls /v3/organization_quotas?organization_guids=some_guids, there won't be any more a "SELECT guids FROM organizations" db query, which returned a huge dataset. For admin users now just all org guids are used, because as an admin you can see all organizations.


* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
