### PR TITLE
Reduce db queries for /organizations/:guid/domains

### DIFF
--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -151,7 +151,7 @@ class OrganizationsV3Controller < ApplicationController
       paginated_result: SequelPaginator.new.get_page(domains, message.try(:pagination_options)),
       path: "/v3/organizations/#{org.guid}/domains",
       message: message,
-      extra_presenter_args: { visible_org_guids_query: permission_queryer.readable_org_guids_query }
+      extra_presenter_args: presenter_args
     )
   end
 
@@ -163,7 +163,7 @@ class OrganizationsV3Controller < ApplicationController
     domain_not_found! unless domain
     domain_not_found! if domain.private? && permission_queryer.readable_org_guids_for_domains_query.where(guid: org.guid).empty?
 
-    render status: :ok, json: Presenters::V3::DomainPresenter.new(domain, visible_org_guids_query: permission_queryer.readable_org_guids_query)
+    render status: :ok, json: Presenters::V3::DomainPresenter.new(domain, **presenter_args)
   end
 
   def list_members
@@ -257,5 +257,13 @@ class OrganizationsV3Controller < ApplicationController
     end
     isolation_segment_not_found! unless isolation_segment && permission_queryer.can_read_from_isolation_segment?(isolation_segment)
     dataset
+  end
+
+  def presenter_args
+    if permission_queryer.can_read_globally?
+      { all_orgs_visible: true }
+    else
+      { visible_org_guids_query: permission_queryer.readable_org_guids_query }
+    end
   end
 end


### PR DESCRIPTION
- calling /organizations/:guid/domains and /organizations/:guid/domains/default calls index_org_domains and 
   show_default_domain in organizations_controller, where permission_queryer.readable_org_guids_query was used which 
   selects all org guids for admin users
- instead of selecting all org guids for admin user, now all_orgs_visible is set to true. If all_orgs_visible is true (=admin 
   user), no filtering is done, just return all org guids

Similar to #2638


* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
