### PR TITLE
Diego::Client targets active bbs instance with id from locket

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -401,6 +401,7 @@ locket:
   ca_file: 'spec/fixtures/certs/bbs_ca.crt'
   cert_file: 'spec/fixtures/certs/bbs_client.crt'
   key_file: 'spec/fixtures/certs/bbs_client.key'
+  diego_client_timeout: 5
 
 threadpool_size: 20
 webserver: thin

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -68,6 +68,15 @@ module VCAP::CloudController
               },
             },
 
+            locket: {
+              host: String,
+              port: Integer,
+              ca_file: String,
+              cert_file: String,
+              key_file: String,
+              diego_client_timeout: Integer
+            },
+
             log_audit_events: bool,
 
             optional(:telemetry_log_path) => String, # path to log telemetry to, omit to disable

--- a/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
@@ -70,7 +70,7 @@ module VCAP::CloudController
               optional(:lock_owner) => String
             },
 
-            optional(:locket) => {
+            locket: {
               host: String,
               port: Integer,
               ca_file: String,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -77,6 +77,15 @@ module VCAP::CloudController
               fog_aws_storage_options: Hash
             },
 
+            locket: {
+              host: String,
+              port: Integer,
+              ca_file: String,
+              cert_file: String,
+              key_file: String,
+              diego_client_timeout: Integer
+            },
+
             packages: {
               max_package_size: Integer,
               app_package_directory_key: String,

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -477,6 +477,7 @@ module CloudController
         connect_timeout: config.get(:diego, :bbs, :connect_timeout),
         send_timeout: config.get(:diego, :bbs, :send_timeout),
         receive_timeout: config.get(:diego, :bbs, :receive_timeout),
+        locket_config: config.get(:locket),
       )
     end
 

--- a/lib/cloud_controller/deployment_updater/scheduler.rb
+++ b/lib/cloud_controller/deployment_updater/scheduler.rb
@@ -19,20 +19,14 @@ module VCAP::CloudController
             )
             }
 
-            if config.get(:locket).nil?
-              loop(&update_step)
-              return
-            end
-
-            client = Locket::Client.new(
+            locket_client = Locket::Client.new(
               host: config.get(:locket, :host),
               port: config.get(:locket, :port),
               client_ca_path: config.get(:locket, :ca_file),
               client_key_path: config.get(:locket, :key_file),
               client_cert_path: config.get(:locket, :cert_file),
             )
-            lock_worker = Locket::LockWorker.new(client)
-
+            lock_worker = Locket::LockWorker.new(locket_client)
             lock_worker.acquire_lock_and_repeatedly_call(
               owner: config.get(:deployment_updater, :lock_owner),
               key: config.get(:deployment_updater, :lock_key),

--- a/lib/diego/client.rb
+++ b/lib/diego/client.rb
@@ -189,7 +189,6 @@ module Diego
     private
 
     attr_reader :client, :base_url, :locket_config
-    attr_accessor :cached_active_bbs_id
 
     def protobuf_encode!(hash, protobuf_message_class)
       # See below link to understand proto3 message encoding

--- a/lib/locket/client.rb
+++ b/lib/locket/client.rb
@@ -2,11 +2,11 @@ require 'steno'
 require 'locket/locket_services_pb'
 
 module Locket
-  class LockRunner
+  class Client
     class Error < StandardError
     end
 
-    def initialize(key:, owner:, host:, port:, client_ca_path:, client_cert_path:, client_key_path:)
+    def initialize(host:, port:, client_ca_path:, client_cert_path:, client_key_path:)
       client_ca = File.open(client_ca_path).read
       client_key = File.open(client_key_path).read
       client_cert = File.open(client_cert_path).read
@@ -16,18 +16,15 @@ module Locket
         GRPC::Core::ChannelCredentials.new(client_ca, client_key, client_cert)
       )
       @lock_acquired = false
-
-      @key = key
-      @owner = owner
     end
 
-    def start
+    def start(owner:, key:)
       raise Error.new('Cannot start more than once') if @thread
 
       @thread = Thread.new do
         loop do
           begin
-            service.lock(build_lock_request)
+            service.lock(build_lock_request(owner: owner, key: key))
             logger.debug("Acquired lock '#{key}' for owner '#{owner}'")
             @lock_acquired = true
           rescue GRPC::BadStatus => e
@@ -52,7 +49,7 @@ module Locket
 
     attr_reader :service, :lock_acquired, :key, :owner
 
-    def build_lock_request
+    def build_lock_request(owner:, key:)
       Models::LockRequest.new(
         {
           resource: {

--- a/lib/locket/lock_worker.rb
+++ b/lib/locket/lock_worker.rb
@@ -1,13 +1,13 @@
 module Locket
   class LockWorker
-    def initialize(lock_runner)
-      @lock_runner = lock_runner
+    def initialize(client)
+      @client = client
     end
 
-    def acquire_lock_and_repeatedly_call(&block)
-      @lock_runner.start
+    def acquire_lock_and_repeatedly_call(owner:, key:, &block)
+      @client.start(owner: owner, key: key)
       loop do
-        if @lock_runner.lock_acquired?
+        if @client.lock_acquired?
           yield block
         else
           sleep 1

--- a/spec/diego/client_spec.rb
+++ b/spec/diego/client_spec.rb
@@ -12,13 +12,6 @@ module Diego
     let(:test_config) { TestConfig.config_instance }
     let(:locket_config) { test_config.get(:locket) }
     let(:key) { 'bbs' }
-    let(:fetch_request) do
-      Models::FetchRequest.new(
-        {
-          key: key,
-        }
-      )
-    end
     let(:fetch_response) do
       Models::FetchResponse.new(
         {
@@ -683,7 +676,7 @@ module Diego
           end
           stub_request(:post, 'https://bbs-1.bbs.example.com:4443/v1/ping').to_timeout
           stub_request(:post, 'https://bbs-2.bbs.example.com:4443/v1/ping').to_return(status: 200,
-body: Bbs::Models::PingResponse.encode(Bbs::Models::PingResponse.new(available: true)).to_s)
+          body: Bbs::Models::PingResponse.encode(Bbs::Models::PingResponse.new(available: true)).to_s)
         end
 
         it 'tries locket again to get the new active bbs id' do

--- a/spec/unit/lib/locket/client_spec.rb
+++ b/spec/unit/lib/locket/client_spec.rb
@@ -20,6 +20,20 @@ RSpec.describe Locket::Client do
       }
     )
   end
+  let(:fetch_request) do
+    Models::FetchRequest.new(
+      {
+        key: key,
+      }
+    )
+  end
+  let(:fetch_response) do
+    Models::FetchResponse.new(
+      {
+        resource: { owner: owner },
+      }
+    )
+  end
 
   let(:client) do
     Locket::Client.new(
@@ -41,12 +55,22 @@ RSpec.describe Locket::Client do
       and_return(credentials)
 
     allow(Models::Locket::Stub).to receive(:new).
-      with("#{host}:#{port}", credentials).
+      with("#{host}:#{port}", credentials, timeout: nil).
       and_return(locket_service)
   end
 
   after do
     client.stop
+  end
+
+  describe '#fetch' do
+    it 'fetches a single lock by key' do
+      allow(locket_service).to receive(:fetch).and_return(fetch_response)
+      response = client.fetch(key: key)
+
+      expect(locket_service).to have_received(:fetch).with(fetch_request)
+      expect(response).to eq(fetch_response)
+    end
   end
 
   describe '#start' do

--- a/spec/unit/lib/locket/lock_worker_spec.rb
+++ b/spec/unit/lib/locket/lock_worker_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Locket::LockWorker do
     end
 
     describe 'when it does not have the lock' do
-      it 'does not yield to the block if it does not have the lock' do
+      it 'does not yield to the block' do
         allow(client).to receive(:lock_acquired?).and_return(false)
 
         expect { |b| lock_worker.acquire_lock_and_repeatedly_call(owner: owner, key: key, &b) }.not_to yield_control
@@ -36,8 +36,8 @@ RSpec.describe Locket::LockWorker do
       end
     end
 
-    describe 'when it does not have the lock' do
-      it 'yields to the block if it does have the lock' do
+    describe 'when it does have the lock' do
+      it 'yields to the block' do
         allow(client).to receive(:lock_acquired?).and_return(true)
 
         expect { |b| lock_worker.acquire_lock_and_repeatedly_call(owner: owner, key: key, &b) }.to yield_control

--- a/spec/unit/lib/locket/lock_worker_spec.rb
+++ b/spec/unit/lib/locket/lock_worker_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 require 'locket/lock_worker'
-require 'locket/lock_runner'
+require 'locket/client'
 
 RSpec.describe Locket::LockWorker do
-  let(:lock_runner) { instance_double(Locket::LockRunner, start: nil, lock_acquired?: nil) }
-  subject(:lock_worker) { Locket::LockWorker.new(lock_runner) }
+  let(:client) { instance_double(Locket::Client, start: nil, lock_acquired?: nil) }
+  let(:key) { 'lock-key' }
+  let(:owner) { 'lock-owner' }
+  subject(:lock_worker) { Locket::LockWorker.new(client) }
 
   describe '#acquire_lock_and' do
     before do
@@ -13,32 +15,32 @@ RSpec.describe Locket::LockWorker do
       allow(lock_worker).to receive(:sleep) # dont use real time please
     end
 
-    it 'should start the LockRunner' do
-      lock_worker.acquire_lock_and_repeatedly_call {}
+    it 'should start the Client' do
+      lock_worker.acquire_lock_and_repeatedly_call(owner: owner, key: key, &{})
 
-      expect(lock_runner).to have_received(:start)
+      expect(client).to have_received(:start)
     end
 
     describe 'when it does not have the lock' do
       it 'does not yield to the block if it does not have the lock' do
-        allow(lock_runner).to receive(:lock_acquired?).and_return(false)
+        allow(client).to receive(:lock_acquired?).and_return(false)
 
-        expect { |b| lock_worker.acquire_lock_and_repeatedly_call(&b) }.not_to yield_control
+        expect { |b| lock_worker.acquire_lock_and_repeatedly_call(owner: owner, key: key, &b) }.not_to yield_control
       end
 
       it 'sleeps before attempting to check the lock status again' do
-        allow(lock_runner).to receive(:lock_acquired?).and_return(false)
+        allow(client).to receive(:lock_acquired?).and_return(false)
 
-        lock_worker.acquire_lock_and_repeatedly_call {}
+        lock_worker.acquire_lock_and_repeatedly_call(owner: owner, key: key, &{})
         expect(lock_worker).to have_received(:sleep).with(1)
       end
     end
 
     describe 'when it does not have the lock' do
       it 'yields to the block if it does have the lock' do
-        allow(lock_runner).to receive(:lock_acquired?).and_return(true)
+        allow(client).to receive(:lock_acquired?).and_return(true)
 
-        expect { |b| lock_worker.acquire_lock_and_repeatedly_call(&b) }.to yield_control
+        expect { |b| lock_worker.acquire_lock_and_repeatedly_call(owner: owner, key: key, &b) }.to yield_control
       end
     end
   end

--- a/spec/unit/lib/locket/lock_worker_spec.rb
+++ b/spec/unit/lib/locket/lock_worker_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Locket::LockWorker do
     it 'should start the Client' do
       lock_worker.acquire_lock_and_repeatedly_call(owner: owner, key: key, &{})
 
-      expect(client).to have_received(:start)
+      expect(client).to have_received(:start).with(owner: owner, key: key)
     end
 
     describe 'when it does not have the lock' do


### PR DESCRIPTION
* **A short explanation of the proposed change:**

Get the bosh instance id for the currently-active `bbs` process from `locket`, so that [Diego::Client](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/lib/diego/client.rb) can use an instance-specific bosh-dns URL instead of one that resolves to all IPs in the instance group (i.e. `fd0458bf-71f9-4df2-9ab1-5fb523a92e56.bbs.service.cf.internal`, not `bbs.service.cf.internal`).

* **An explanation of the use cases your change solves**

Mitigates the risk of `Runner is unavailable` errors during a `cf push` when the client is unable to reach a `bbs` instance.

`bbs` operates as a cluster. At any one time one instance is 'active', and able to serve responses to API calls, while others are inactive. An active instance holds the `bbs` lock from `locket`.

At present, whenever the Diego::Client needs to communicate with `bbs` it hits the URL passed in from [config.diego.bbs.url](https://github.com/cloudfoundry/cloud_controller_ng/blob/cce461e7c3fb97161bf7501d6ab2d51953d95f89/config/cloud_controller.yml#L294-L295). The [default value](https://github.com/cloudfoundry/capi-release/blob/282227c144b19b0c88839555aadf10b5182d0f71/jobs/cloud_controller_ng/spec#L1083-L1085) passed in for this from the capi-release is `https://bbs.service.cf.internal:8889`. This domain is [defined by cf-deployment](https://github.com/cloudfoundry/cf-deployment/blob/6ec2aca405f23a2eb32ec4108d3385edcfdb9b22/cf-deployment.yml#L209-L215) as a bosh-dns alias for the `diego-api` instance group with query [q-s4](https://bosh.io/docs/dns/#constructing-queries) (i.e. resolving to all instances, whether healthy or unhealthy, in a random order).

When all `bbs` instances are reachable, you either hit the active instance first, or you hit an inactive one (`connection refused`) and the http client (implicitly) tries the next IP in the list. But if the first IP in the list is unreachable, the request hangs until it times out ([by default](https://github.com/cloudfoundry/capi-release/blob/282227c144b19b0c88839555aadf10b5182d0f71/jobs/cloud_controller_ng/spec#L1089-L1091) after 10s) and then fails. The Diego::Client [makes three attempts](https://github.com/cloudfoundry/cloud_controller_ng/blob/cce461e7c3fb97161bf7501d6ab2d51953d95f89/lib/diego/client.rb#L163-L169) to reach the active `bbs` instance before giving up and raising an error, with our [`httpclient`](https://www.rubydoc.info/gems/httpclient) re-resolving DNS each time. 

Say you've got two `diego-api` instances, and a network issue makes one of them unreachable. In such a case, every API call currently has a 1/8 chance of that the first IP in the list is the unreachable one three times in a row, which will cause `cf push` and some other commands to fail.

Note:
* We considered switching to a `q-s3` bosh-dns query (healthy instances only) but decided against this. If some process other than `bbs` was failing on an active bbs instance clients would be stuck unable to reach the Diego API (DNS would resolve only to inactive instances, while nothing would trigger a new leadership election).
* `locket` is colocated with `bbs` on the `diego-api` instance. Retries are handled automatically by gRPC (and with a shorter 5-second timeout).

* **Links to any other associated PRs**

cloudfoundry/capi-release#275 (should be merged before this PR)

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)*
    \* Run against the following cf-acceptance-test suites: apps, container_networking, detect, docker, internet_dependent, routing, service_instance_sharing, services, ssh, sso, tasks, v3
