### PR TITLE
Attempt to refactor service_instance_list_fetcher perm logic

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -37,19 +37,12 @@ class ServiceInstancesV3Controller < ApplicationController
     message = ServiceInstancesListMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?
 
-    dataset = if permission_queryer.can_read_globally?
-                ServiceInstanceListFetcher.fetch(
-                  message,
-                  eager_loaded_associations: Presenters::V3::ServiceInstancePresenter.associated_resources,
-                  omniscient: true,
-                )
-              else
-                ServiceInstanceListFetcher.fetch(
-                  message,
-                  eager_loaded_associations: Presenters::V3::ServiceInstancePresenter.associated_resources,
-                  readable_space_guids: permission_queryer.readable_space_guids,
-                )
-              end
+    dataset = ServiceInstanceListFetcher.fetch(
+      message,
+      eager_loaded_associations: Presenters::V3::ServiceInstancePresenter.associated_resources,
+      omniscient: permission_queryer.can_read_globally?,
+      readable_spaces_dataset: permission_queryer.readable_space_guids_query,
+    )
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::ServiceInstancePresenter,

--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -4,15 +4,15 @@ require 'fetchers/label_selector_query_generator'
 module VCAP::CloudController
   class ServiceInstanceListFetcher < BaseListFetcher
     class << self
-      def fetch(message, omniscient: false, readable_space_guids: [], eager_loaded_associations: [])
+      def fetch(message, omniscient: false, readable_spaces_dataset: nil, eager_loaded_associations: [])
         dataset = ServiceInstance.dataset.eager(eager_loaded_associations).
                   join(:spaces, id: Sequel[:service_instances][:space_id]).
                   left_join(:service_instance_shares, service_instance_guid: Sequel[:service_instances][:guid])
 
         unless omniscient
           dataset = dataset.where do
-            (Sequel[:spaces][:guid] =~ readable_space_guids) |
-              (Sequel[:service_instance_shares][:target_space_guid] =~ readable_space_guids)
+            (Sequel[:spaces][:guid] =~ readable_spaces_dataset) |
+              (Sequel[:service_instance_shares][:target_space_guid] =~ readable_spaces_dataset)
           end
         end
 

--- a/spec/unit/fetchers/service_instance_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_instance_list_fetcher_spec.rb
@@ -27,16 +27,16 @@ module VCAP::CloudController
       end
 
       it 'fetches nothing for users who cannot see any spaces' do
-        expect(fetcher.fetch(message).all).to be_empty
+        expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: -1).select(:guid)).all).to be_empty
       end
 
       it 'fetches the instances owned by readable spaces' do
-        dataset = fetcher.fetch(message, readable_space_guids: [space_1.guid, space_3.guid])
+        dataset = fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_1.id, space_3.id]).select(:guid))
         expect(dataset.all).to contain_exactly(msi_1, msi_3, upsi, ssi)
       end
 
       it 'fetches the instances shared to readable spaces' do
-        dataset = fetcher.fetch(message, readable_space_guids: [space_2.guid])
+        dataset = fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_2.id]).select(:guid))
         expect(dataset.all).to contain_exactly(msi_2, ssi)
       end
 
@@ -53,7 +53,7 @@ module VCAP::CloudController
 
           it 'returns instances with matching name' do
             expect(fetcher.fetch(message, omniscient: true)).to contain_exactly(msi_1, ssi)
-            expect(fetcher.fetch(message, readable_space_guids: [space_1.guid])).to contain_exactly(msi_1)
+            expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_1.id]).select(:guid))).to contain_exactly(msi_1)
           end
         end
 
@@ -62,7 +62,7 @@ module VCAP::CloudController
 
           it 'returns instances with matching space guids' do
             expect(fetcher.fetch(message, omniscient: true)).to contain_exactly(msi_1, upsi)
-            expect(fetcher.fetch(message, readable_space_guids: [space_1.guid, space_2.guid])).to contain_exactly(msi_1, upsi)
+            expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_1.id, space_2.id]).select(:guid))).to contain_exactly(msi_1, upsi)
           end
         end
 
@@ -71,7 +71,7 @@ module VCAP::CloudController
 
           it 'returns instances with matching org guids' do
             expect(fetcher.fetch(message, omniscient: true).map(&:guid)).to contain_exactly(*[msi_1, upsi, msi_2, ssi].map(&:guid))
-            expect(fetcher.fetch(message, readable_space_guids: [space_1.guid, space_3.guid])).to contain_exactly(msi_1, ssi, upsi)
+            expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_1.id, space_3.id]).select(:guid))).to contain_exactly(msi_1, ssi, upsi)
           end
         end
 
@@ -83,7 +83,7 @@ module VCAP::CloudController
 
           it 'returns instances with matching labels' do
             expect(fetcher.fetch(message, omniscient: true)).to contain_exactly(msi_2)
-            expect(fetcher.fetch(message, readable_space_guids: [space_1.guid, space_2.guid])).to contain_exactly(msi_2)
+            expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_1.id, space_2.id]).select(:guid))).to contain_exactly(msi_2)
           end
         end
 
@@ -93,7 +93,7 @@ module VCAP::CloudController
 
             it 'returns instances with matching type' do
               expect(fetcher.fetch(message, omniscient: true)).to contain_exactly(msi_1, msi_2, msi_3, ssi)
-              expect(fetcher.fetch(message, readable_space_guids: [space_1.guid])).to contain_exactly(msi_1)
+              expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_1.id]).select(:guid))).to contain_exactly(msi_1)
             end
           end
 
@@ -102,7 +102,7 @@ module VCAP::CloudController
 
             it 'returns instances with matching type' do
               expect(fetcher.fetch(message, omniscient: true)).to contain_exactly(upsi)
-              expect(fetcher.fetch(message, readable_space_guids: [space_1.guid])).to contain_exactly(upsi)
+              expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_1.id]).select(:guid))).to contain_exactly(upsi)
             end
           end
         end
@@ -113,7 +113,7 @@ module VCAP::CloudController
 
           it 'returns instances with matching service plan names' do
             expect(fetcher.fetch(message, omniscient: true)).to contain_exactly(msi_1, msi_2, msi_4)
-            expect(fetcher.fetch(message, readable_space_guids: [space_1.guid])).to contain_exactly(msi_1, msi_4)
+            expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_1.id]).select(:guid))).to contain_exactly(msi_1, msi_4)
           end
         end
 
@@ -123,7 +123,7 @@ module VCAP::CloudController
 
           it 'returns instances with matching service plan guids' do
             expect(fetcher.fetch(message, omniscient: true)).to contain_exactly(msi_1, msi_2, msi_4)
-            expect(fetcher.fetch(message, readable_space_guids: [space_1.guid])).to contain_exactly(msi_1, msi_4)
+            expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: [space_1.id]).select(:guid))).to contain_exactly(msi_1, msi_4)
           end
         end
       end


### PR DESCRIPTION
Rather than passing the list of space ids, pass a dataset that is properly scoped

* A short explanation of the proposed change:
While working on allowing api endpoints to properly return shared routes, we found service instances already have a pattern for this. However they also pass space ids around rather than the datasets as most v3 controllers do.

The space visibility queries are rather complex though, so using it as a subquery concerned us. 

To see if this is an acceptable change, we used the [cf-performance-tests](https://github.com/cloudfoundry/cf-performance-tests) and wrote a quick test to benchmark the service instances list endpoint.

The results are below. In every case, using the dataset is slightly slower. So the choice is now: Do we want performance? or: Do we want consistency?

---
Number of Spaces: 20  
Service Instance Per Space: 500
#### New Code:
```
  Begin Report Entries >>
      individually::as regular user::GET /v3/service_instances
      Name                                 | N | Min     | Median  | Mean    | StdDev | Max    
      =========================================================================================
      GET /v3/service_instances [duration] | 5 | 382.2ms | 397.3ms | 403.1ms | 15.8ms | 429.8ms
  << End Report Entries
```
#### Old Code:
```
  Begin Report Entries >>
      individually::as regular user::GET /v3/service_instances
      Name                                 | N | Min     | Median  | Mean    | StdDev | Max    
      =========================================================================================
      GET /v3/service_instances [duration] | 5 | 375.8ms | 410.3ms | 407.5ms | 25.1ms | 439.6ms
  << End Report Entries
```
---
Number of Spaces: 20000  
Service Instance Per Space: 5
#### New Code:
```
  Begin Report Entries >>
      individually::as regular user::GET /v3/service_instances
      Name                                 | N | Min     | Median  | Mean    | StdDev | Max    
      =========================================================================================
      GET /v3/service_instances [duration] | 5 | 1.4303s | 1.4915s | 1.4852s | 30.3ms | 1.5233s
  << End Report Entries
```
#### Old Code:
```
  Begin Report Entries >>
      individually::as regular user::GET /v3/service_instances
      Name                                 | N | Min     | Median  | Mean    | StdDev | Max    
      =========================================================================================
      GET /v3/service_instances [duration] | 5 | 1.3077s | 1.3323s | 1.3378s | 21.4ms | 1.3664s
  << End Report Entries
```
---
Number of Spaces: 200  
Service Instance Per Space: 5000
#### New Code:
```
  Begin Report Entries >>
      individually::as regular user::GET /v3/service_instances
      Name                                 | N | Min    | Median  | Mean    | StdDev | Max     
      =========================================================================================
      GET /v3/service_instances [duration] | 5 | 9.808s | 9.8519s | 9.8814s | 82.6ms | 10.0384s
  << End Report Entries
```
#### Old Code:
```
  Begin Report Entries >>
      individually::as regular user::GET /v3/service_instances
      Name                                 | N | Min     | Median  | Mean    | StdDev | Max    
      =========================================================================================
      GET /v3/service_instances [duration] | 5 | 9.0863s | 9.1712s | 9.1931s | 75ms   | 9.2905s
  << End Report Entries
```
