### PR TITLE
Raise an exception if user can read globally

### DIFF
--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -116,7 +116,7 @@ class VCAP::CloudController::Permissions
 
   def readable_org_guids_query
     if can_read_globally?
-      VCAP::CloudController::Organization.select(:guid)
+      raise 'must not be called for users that can read globally'
     else
       membership.org_guids_for_roles_subquery(ROLES_FOR_ORG_READING)
     end
@@ -183,7 +183,7 @@ class VCAP::CloudController::Permissions
 
   def readable_space_guids_query
     if can_read_globally?
-      VCAP::CloudController::Space.select(:guid)
+      raise 'must not be called for users that can read globally'
     else
       membership.space_guids_for_roles_subquery(ROLES_FOR_SPACE_READING)
     end

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -107,43 +107,28 @@ module VCAP::CloudController
     end
 
     describe '#readable_org_guids' do
-      it 'returns all the org guids for admins' do
+      it 'raises exception and does not SELECT all gudis for admins' do
         user = set_current_user_as_admin
         subject = Permissions.new(user)
-
-        org1_guid = Organization.make.guid
-        org2_guid = Organization.make.guid
-
-        org_guids = subject.readable_org_guids
-
-        expect(org_guids).to include(org1_guid)
-        expect(org_guids).to include(org2_guid)
+        expect {
+          subject.readable_org_guids
+        }.to raise_error('must not be called for users that can read globally')
       end
 
-      it 'returns all the org guids for read-only admins' do
-        user = set_current_user_as_admin_read_only
+      it 'raises exception and does not SELECT all gudis for read-only admins' do
+        user = set_current_user_as_admin
         subject = Permissions.new(user)
-
-        org1_guid = Organization.make.guid
-        org2_guid = Organization.make.guid
-
-        org_guids = subject.readable_org_guids
-
-        expect(org_guids).to include(org1_guid)
-        expect(org_guids).to include(org2_guid)
+        expect {
+          subject.readable_org_guids
+        }.to raise_error('must not be called for users that can read globally')
       end
 
-      it 'returns all the org guids for global auditors' do
+      it 'raises exception and does not SELECT all gudis for global auditors' do
         user = set_current_user_as_global_auditor
         subject = Permissions.new(user)
-
-        org1_guid = Organization.make.guid
-        org2_guid = Organization.make.guid
-
-        org_guids = subject.readable_org_guids
-
-        expect(org_guids).to include(org1_guid)
-        expect(org_guids).to include(org2_guid)
+        expect {
+          subject.readable_org_guids
+        }.to raise_error('must not be called for users that can read globally')
       end
 
       it 'returns org guids from membership via subquery' do
@@ -397,49 +382,28 @@ module VCAP::CloudController
     end
 
     describe '#readable_space_guids' do
-      it 'returns all the space guids for admins' do
+      it 'raises exception and does not SELECT all gudis for admins' do
         user = set_current_user_as_admin
         subject = Permissions.new(user)
-
-        org1 = Organization.make
-        space1 = Space.make(organization: org1)
-        org2 = Organization.make
-        space2 = Space.make(organization: org2)
-
-        space_guids = subject.readable_space_guids
-
-        expect(space_guids).to include(space1.guid)
-        expect(space_guids).to include(space2.guid)
+        expect {
+          subject.readable_space_guids
+        }.to raise_error('must not be called for users that can read globally')
       end
 
-      it 'returns all the space guids for read-only admins' do
+      it 'raises exception and does not SELECT all gudis for read-only admins' do
         user = set_current_user_as_admin_read_only
         subject = Permissions.new(user)
-
-        org1 = Organization.make
-        space1 = Space.make(organization: org1)
-        org2 = Organization.make
-        space2 = Space.make(organization: org2)
-
-        space_guids = subject.readable_space_guids
-
-        expect(space_guids).to include(space1.guid)
-        expect(space_guids).to include(space2.guid)
+        expect {
+          subject.readable_space_guids
+        }.to raise_error('must not be called for users that can read globally')
       end
 
-      it 'returns all the space guids for global auditors' do
+      it 'raises exception and does not SELECT all gudis for global auditors' do
         user = set_current_user_as_global_auditor
         subject = Permissions.new(user)
-
-        org1 = Organization.make
-        space1 = Space.make(organization: org1)
-        org2 = Organization.make
-        space2 = Space.make(organization: org2)
-
-        space_guids = subject.readable_space_guids
-
-        expect(space_guids).to include(space1.guid)
-        expect(space_guids).to include(space2.guid)
+        expect {
+          subject.readable_space_guids
+        }.to raise_error('must not be called for users that can read globally')
       end
 
       it 'returns space guids from membership via subquery' do

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -107,7 +107,7 @@ module VCAP::CloudController
     end
 
     describe '#readable_org_guids' do
-      it 'raises exception and does not SELECT all gudis for admins' do
+      it 'raises exception and does not SELECT all guids for admins' do
         user = set_current_user_as_admin
         subject = Permissions.new(user)
         expect {
@@ -115,15 +115,15 @@ module VCAP::CloudController
         }.to raise_error('must not be called for users that can read globally')
       end
 
-      it 'raises exception and does not SELECT all gudis for read-only admins' do
-        user = set_current_user_as_admin
+      it 'raises exception and does not SELECT all guids for read-only admins' do
+        user = set_current_user_as_admin_read_only
         subject = Permissions.new(user)
         expect {
           subject.readable_org_guids
         }.to raise_error('must not be called for users that can read globally')
       end
 
-      it 'raises exception and does not SELECT all gudis for global auditors' do
+      it 'raises exception and does not SELECT all guids for global auditors' do
         user = set_current_user_as_global_auditor
         subject = Permissions.new(user)
         expect {
@@ -382,7 +382,7 @@ module VCAP::CloudController
     end
 
     describe '#readable_space_guids' do
-      it 'raises exception and does not SELECT all gudis for admins' do
+      it 'raises exception and does not SELECT all guids for admins' do
         user = set_current_user_as_admin
         subject = Permissions.new(user)
         expect {
@@ -390,7 +390,7 @@ module VCAP::CloudController
         }.to raise_error('must not be called for users that can read globally')
       end
 
-      it 'raises exception and does not SELECT all gudis for read-only admins' do
+      it 'raises exception and does not SELECT all guids for read-only admins' do
         user = set_current_user_as_admin_read_only
         subject = Permissions.new(user)
         expect {
@@ -398,7 +398,7 @@ module VCAP::CloudController
         }.to raise_error('must not be called for users that can read globally')
       end
 
-      it 'raises exception and does not SELECT all gudis for global auditors' do
+      it 'raises exception and does not SELECT all guids for global auditors' do
         user = set_current_user_as_global_auditor
         subject = Permissions.new(user)
         expect {


### PR DESCRIPTION
With #2986, #2995, #2997 no case is left where
readable_space_guids_query or readable_org_guids_query (permissions.rb) is called in an admin use case. 

Therefore the select for all guids as admin user is not needed any more. Instead raise an exception if this query is called for admin users.


* Links to any other associated PRs
#2986, #2995, #2997

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
