### PR TITLE
Increase the webdav receive_timeout to 120 seconds

### DIFF
--- a/lib/cloud_controller/blobstore/webdav/dav_client.rb
+++ b/lib/cloud_controller/blobstore/webdav/dav_client.rb
@@ -40,7 +40,7 @@ module CloudController
       def self.build(options, directory_key, root_dir=nil, min_size=nil, max_size=nil)
         new(
           directory_key: directory_key,
-          httpclient:    HTTPClientProvider.provide(ca_cert_path: options[:ca_cert_path], connect_timeout: options[:blobstore_timeout]),
+          httpclient:    HTTPClientProvider.provide(ca_cert_path: options[:ca_cert_path], connect_timeout: options[:blobstore_timeout], receive_timeout: 120),
           signer:        NginxSecureLinkSigner.build(options: options, directory_key: directory_key),
           endpoint:      options[:private_endpoint],
           user:          options[:username],

--- a/lib/cloud_controller/blobstore/webdav/http_client_provider.rb
+++ b/lib/cloud_controller/blobstore/webdav/http_client_provider.rb
@@ -1,9 +1,10 @@
 module CloudController
   module Blobstore
     class HTTPClientProvider
-      def self.provide(ca_cert_path: nil, connect_timeout: nil)
+      def self.provide(ca_cert_path: nil, connect_timeout: nil, receive_timeout: nil)
         client = HTTPClient.new
         client.connect_timeout = connect_timeout if connect_timeout
+        client.receive_timeout = receive_timeout if receive_timeout
         client.ssl_config.verify_mode = VCAP::CloudController::Config.config.get(:skip_cert_verify) ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
         client.ssl_config.set_default_paths
 


### PR DESCRIPTION
* A short explanation of the proposed change:
We were hitting the 60 second default timeout when uploading a large app. This timeout is used after the PUT to the blobstore when the httpclient is trying to read the headers for the response. Since the blobstore is busy processing the large upload, it was taking longer than 60 seconds to start the response.

Currently not configurable but should be easy to thread it through the config if that becomes needed later.

* Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/pull/274