### PR TITLE
Prevent deployment creation while previous deployment is being canceled

### DIFF
--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -125,6 +125,10 @@ module VCAP::CloudController
       deployments.any?(&:deploying?)
     end
 
+    def canceling?
+      deployments.any?(&:canceling?)
+    end
+
     def self.user_visibility_filter(user)
       space_guids = Space.join(:spaces_developers, space_id: :id, user_id: user.id).select(:spaces__guid).
                     union(Space.join(:spaces_managers, space_id: :id, user_id: user.id).select(:spaces__guid)).

--- a/app/models/runtime/deployment_model.rb
+++ b/app/models/runtime/deployment_model.rb
@@ -71,6 +71,10 @@ module VCAP::CloudController
       state == DEPLOYING_STATE
     end
 
+    def canceling?
+      state == CANCELING_STATE
+    end
+
     def cancelable?
       valid_states_for_cancel = [DeploymentModel::DEPLOYING_STATE,
                                  DeploymentModel::CANCELING_STATE]

--- a/spec/unit/actions/deployment_create_spec.rb
+++ b/spec/unit/actions/deployment_create_spec.rb
@@ -956,6 +956,18 @@ module VCAP::CloudController
           end
         end
       end
+
+      context 'when the previous deployment is in the CANCELING state' do
+        before do
+          DeploymentModel.make(app: app, state: DeploymentModel::CANCELING_STATE)
+        end
+
+        it 'raises an error' do
+          expect {
+            DeploymentCreate.create(app: app, message: message, user_audit_info: user_audit_info)
+          }.to raise_error(DeploymentCreate::InvalidStatus, 'Cannot create deployment while previous deployment is being cancelled.')
+        end
+      end
     end
   end
 end

--- a/spec/unit/models/runtime/app_model_spec.rb
+++ b/spec/unit/models/runtime/app_model_spec.rb
@@ -495,12 +495,35 @@ module VCAP::CloudController
       end
 
       it 'returns true when the app has a deployment that is being deployed' do
+        VCAP::CloudController::DeploymentModel.make(state: 'DEPLOYING', app: app_model)
         VCAP::CloudController::DeploymentModel.make(state: 'DEPLOYED', app: app_model)
         VCAP::CloudController::DeploymentModel.make(state: 'CANCELING', app: app_model)
-        VCAP::CloudController::DeploymentModel.make(state: 'DEPLOYING', app: app_model)
         VCAP::CloudController::DeploymentModel.make(state: 'CANCELED', app: app_model)
 
         expect(app_model.deploying?).to be(true)
+      end
+    end
+
+    describe '#canceling?' do
+      it 'returns false when the app has no deployments' do
+        expect(app_model.canceling?).to be(false)
+      end
+
+      it 'returns false when the app has no deployments that are being canceled' do
+        VCAP::CloudController::DeploymentModel.make(state: 'DEPLOYING', app: app_model)
+        VCAP::CloudController::DeploymentModel.make(state: 'DEPLOYED', app: app_model)
+        VCAP::CloudController::DeploymentModel.make(state: 'CANCELED', app: app_model)
+
+        expect(app_model.canceling?).to be(false)
+      end
+
+      it 'returns true when the app has a deployment that is being canceled' do
+        VCAP::CloudController::DeploymentModel.make(state: 'DEPLOYING', app: app_model)
+        VCAP::CloudController::DeploymentModel.make(state: 'DEPLOYED', app: app_model)
+        VCAP::CloudController::DeploymentModel.make(state: 'CANCELING', app: app_model)
+        VCAP::CloudController::DeploymentModel.make(state: 'CANCELED', app: app_model)
+
+        expect(app_model.canceling?).to be(true)
       end
     end
 

--- a/spec/unit/models/runtime/deployment_model_spec.rb
+++ b/spec/unit/models/runtime/deployment_model_spec.rb
@@ -55,26 +55,36 @@ module VCAP::CloudController
     describe '#deploying?' do
       it 'returns true if the deployment is deploying' do
         deployment.state = 'DEPLOYING'
-
         expect(deployment.deploying?).to be(true)
       end
 
-      it 'returns false if the deployment has been deployed' do
+      it 'returns false otherwise' do
         deployment.state = 'DEPLOYED'
-
         expect(deployment.deploying?).to be(false)
-      end
 
-      it 'returns false if the deployment is canceling' do
         deployment.state = 'CANCELING'
+        expect(deployment.deploying?).to be(false)
 
+        deployment.state = 'CANCELED'
         expect(deployment.deploying?).to be(false)
       end
+    end
 
-      it 'returns false if the deployment has been canceled' do
+    describe '#canceling?' do
+      it 'returns true if the deployment is canceling' do
+        deployment.state = 'CANCELING'
+        expect(deployment.canceling?).to be(true)
+      end
+
+      it 'returns false otherwise' do
         deployment.state = 'CANCELED'
+        expect(deployment.canceling?).to be(false)
 
-        expect(deployment.deploying?).to be(false)
+        deployment.state = 'DEPLOYING'
+        expect(deployment.canceling?).to be(false)
+
+        deployment.state = 'DEPLOYED'
+        expect(deployment.canceling?).to be(false)
       end
     end
 


### PR DESCRIPTION
Having a `CANCELING` and a (newer) `DEPLOYING` deployment in parallel results in unexpected and potentially non-deterministic results.

Mitigates issue #3019.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
