### PR TITLE
Fix two typos in API docs

### DIFF
--- a/docs/v3/source/includes/concepts/_metadata.md.erb
+++ b/docs/v3/source/includes/concepts/_metadata.md.erb
@@ -97,7 +97,7 @@ They are queryable, identifying attributes of a resource, but they do not affect
 For example, an app may be assigned a label with key `sensitive` and possible values `true` or `false`.
 
 Users could then find all sensitive apps with a selector for `sensitive=true`, resulting in a response containing
-only apps having the label key `sensitive` with a label value of `false`.
+only apps having the label key `sensitive` with a label value of `true`.
 
 #### Labels
 

--- a/docs/v3/source/includes/resources/apps/_list.md.erb
+++ b/docs/v3/source/includes/resources/apps/_list.md.erb
@@ -40,7 +40,7 @@ Name | Type | Description
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. Valid values are `created_at`, `updated_at`, `name`, `state`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **lifecycle_type** | _string_ | [Lifecycle](#lifecycles) type to filter by; valid values are `buildpack`, `docker`
-**include**| _list of strings_ | Optionally include a list of unique related resources in the response; valid values are `space` and `spaceorganization`
+**include**| _list of strings_ | Optionally include a list of unique related resources in the response; valid values are `space` and `space.organization`
 **created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 **updated_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Just fixing two typos in the API docs.