### PR TITLE
Exclude /healthz from request logging

### DIFF
--- a/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
@@ -5,7 +5,9 @@ module VCAP::CloudController::Logs
   RSpec.describe RequestLogs do
     let(:request_logs) { RequestLogs.new(logger) }
     let(:logger) { double('logger', info: nil) }
-    let(:fake_request) { double('request', request_method: 'request_method', ip: 'ip', filtered_path: 'filtered_path') }
+    let(:fake_ip) { 'ip' }
+    let(:fake_fullpath) { 'fullpath' }
+    let(:fake_request) { double('request', request_method: 'request_method', ip: fake_ip, filtered_path: 'filtered_path', fullpath: fake_fullpath) }
     let(:request_id) { 'ID' }
     let(:env) { { 'cf.user_guid' => 'user-guid' } }
     let(:status) { 200 }
@@ -15,14 +17,40 @@ module VCAP::CloudController::Logs
         allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
       end
 
-      it 'logs the start of a request' do
-        request_logs.start_request(request_id, env)
-        expect(logger).to have_received(:info).with(/Started.+user: user-guid.+with vcap-request-id: ID/)
+      context '#start_request' do
+        it 'logs the start of the request' do
+          request_logs.start_request(request_id, env)
+          expect(logger).to have_received(:info).with(/Started.+user: user-guid.+with vcap-request-id: ID/)
+        end
+
+        context 'request to /healthz endpoint' do
+          let(:fake_fullpath) { '/healthz' }
+
+          it 'does not log the start of the request' do
+            request_logs.start_request(request_id, env)
+            expect(logger).not_to have_received(:info)
+          end
+        end
       end
 
-      it 'logs the completion of a request' do
-        request_logs.complete_request(request_id, status)
-        expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/)
+      context '#complete_request' do
+        context 'with a matching start request' do
+          before do
+            request_logs.instance_variable_set(:@incomplete_requests, { request_id => {} })
+          end
+
+          it 'logs the completion of the request' do
+            request_logs.complete_request(request_id, status)
+            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/)
+          end
+        end
+
+        context 'without a matching start request' do
+          it 'does not log the completion of the request' do
+            request_logs.complete_request(request_id, status)
+            expect(logger).not_to have_received(:info)
+          end
+        end
       end
 
       context 'anonymize_ips flag is true' do
@@ -37,7 +65,7 @@ module VCAP::CloudController::Logs
       end
 
       context 'request with ipv4 address' do
-        let(:fake_request) { double('request', request_method: 'request_method', ip: '192.168.1.80', filtered_path: 'filtered_path') }
+        let(:fake_ip) { '192.168.1.80' }
 
         context 'anonymize_ips flag is false' do
           it 'logs full ipv4 addresses' do
@@ -59,7 +87,7 @@ module VCAP::CloudController::Logs
       end
 
       context 'request with ipv6 address' do
-        let(:fake_request) { double('request', request_method: 'request_method', ip: '2001:0db8:85a3:1234:0000:8a2e:0370:7334', filtered_path: 'filtered_path') }
+        let(:fake_ip) { '2001:0db8:85a3:1234:0000:8a2e:0370:7334' }
 
         context 'anonymize_ips flag is false' do
           it 'logs canonical and unaltered ipv6 addresses' do
@@ -81,7 +109,7 @@ module VCAP::CloudController::Logs
       end
 
       context 'request with non canonical(shortened) ipv6 address' do
-        let(:fake_request) { double('request', request_method: 'request_method', ip: '2001:db8:85a3:1234::370:0', filtered_path: 'filtered_path') }
+        let(:fake_ip) { '2001:db8:85a3:1234::370:0' }
 
         context 'anonymize_ips flag is false' do
           it 'logs canonical and unaltered ipv6 addresses' do


### PR DESCRIPTION
The logs for requests to `/healthz` do not contain any useful data. The user is always empty, the IP address is 127.0.0.1 and for the VCAP request ID no additinal information can be found as this endpoint does nothing.

We also have the nginx access logs which contain the exact same information (including the upstream HTTP status code).

Closes #3029.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
