### PR TITLE
Use foreign keys more to avoid DB queries

### DIFF
--- a/app/access/route_access.rb
+++ b/app/access/route_access.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
     end
 
     def read?(route)
-      context.queryer.can_read_route?(route.space.guid)
+      context.queryer.can_read_route?(route.space_id)
     end
 
     def read_for_update?(route, params=nil)

--- a/app/actions/droplet_create.rb
+++ b/app/actions/droplet_create.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController
         droplet,
         user_audit_info,
         app.name,
-        app.space.guid,
+        app.space_guid,
         app.organization.guid
       )
 
@@ -81,8 +81,8 @@ module VCAP::CloudController
 
     def droplet_from_build(build)
       DropletModel.new(
-        app_guid:             build.app.guid,
-        package_guid:         build.package.guid,
+        app_guid:             build.app_guid,
+        package_guid:         build.package_guid,
         state:                DropletModel::STAGING_STATE,
         build:                build,
       )

--- a/app/actions/manifest_route_update.rb
+++ b/app/actions/manifest_route_update.rb
@@ -94,7 +94,7 @@ module VCAP::CloudController
               domain: existing_domain,
               manifest_triggered: true,
             )
-          elsif route.space.guid != app.space.guid
+          elsif route.space.guid != app.space_guid
             raise InvalidRoute.new('Routes cannot be mapped to destinations in different spaces')
           end
 

--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -48,7 +48,7 @@ module VCAP::CloudController
 
       def validate_service_instance!(app, service_instance, volume_mount_services_enabled)
         app_is_required! unless app.present?
-        space_mismatch! unless all_space_guids(service_instance).include? app.space.guid
+        space_mismatch! unless all_space_guids(service_instance).include? app.space_guid
         if service_instance.managed_instance?
           service_not_bindable! unless service_instance.service_plan.bindable?
           volume_mount_not_enabled! if service_instance.volume_service? && !volume_mount_services_enabled

--- a/app/actions/sidecar_synchronize_from_app_droplet.rb
+++ b/app/actions/sidecar_synchronize_from_app_droplet.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
             TelemetryLogger.v3_emit(
               'create-sidecar',
               {
-                'app-id' => sidecar.app.guid,
+                'app-id' => sidecar.app_guid,
               },
               {
                 'api-version' => 'v3',

--- a/app/actions/sidecar_update.rb
+++ b/app/actions/sidecar_update.rb
@@ -46,7 +46,7 @@ module VCAP::CloudController
                  end
 
         processes = ProcessModel.where(
-          app_guid: sidecar.app.guid,
+          app_guid: sidecar.app_guid,
           type: process_types,
         )
         policy = SidecarMemoryLessThanProcessMemoryPolicy.new(processes, memory)

--- a/app/actions/v2/route_mapping_create.rb
+++ b/app/actions/v2/route_mapping_create.rb
@@ -109,7 +109,7 @@ module VCAP::CloudController
       end
 
       def validate_space!
-        raise SpaceMismatch.new(INVALID_SPACE_MESSAGE) unless app.space.guid == route.space.guid
+        raise SpaceMismatch.new(INVALID_SPACE_MESSAGE) unless app.space_guid == route.space.guid
       end
 
       def app_event_repository

--- a/app/controllers/runtime/app_bits_upload_controller.rb
+++ b/app/controllers/runtime/app_bits_upload_controller.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
 
       raise CloudController::Errors::ApiError.new_from_details('UnprocessableEntity', 'cannot upload bits to a docker app') if process.docker?
 
-      relationships  = { app: { data: { guid: process.app.guid } } }
+      relationships  = { app: { data: { guid: process.app_guid } } }
       create_message = PackageCreateMessage.new({ type: 'bits', relationships: relationships })
       package        = PackageCreate.create_without_event(create_message)
 
@@ -66,7 +66,7 @@ module VCAP::CloudController
       TelemetryLogger.v2_emit(
         'upload-package',
         {
-          'app-id' => process.app.guid,
+          'app-id' => process.app_guid,
           'user-id' => current_user.guid,
         })
       result
@@ -84,7 +84,7 @@ module VCAP::CloudController
       dest_process = find_guid_and_validate_access(:upload, dest_app_guid)
 
       copier = PackageCopy.new
-      copier.copy_without_event(dest_process.app.guid, src_process.latest_package)
+      copier.copy_without_event(dest_process.app_guid, src_process.latest_package)
 
       @app_event_repository.record_src_copy_bits(dest_process.app, src_process.app, UserAuditInfo.from_context(SecurityContext))
       @app_event_repository.record_dest_copy_bits(dest_process.app, src_process.app, UserAuditInfo.from_context(SecurityContext))

--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -161,7 +161,7 @@ module VCAP::CloudController
       TelemetryLogger.v2_emit(
         'delete-app',
         {
-          'app-id' => process.app.guid,
+          'app-id' => process.app_guid,
           'user-id' => current_user.guid,
         }
       )
@@ -300,7 +300,7 @@ module VCAP::CloudController
       TelemetryLogger.v2_emit(
         'update-app',
         {
-          'app-id' => process.app.guid,
+          'app-id' => process.app_guid,
           'user-id' => current_user.guid,
         }
       )
@@ -309,7 +309,7 @@ module VCAP::CloudController
         TelemetryLogger.v2_emit(
           'scale-app',
           {
-            'app-id' => process.app.guid,
+            'app-id' => process.app_guid,
             'user-id' => current_user.guid,
           },
           {
@@ -326,7 +326,7 @@ module VCAP::CloudController
           TelemetryLogger.v2_emit(
             'start-app',
             {
-              'app-id' => process.app.guid,
+              'app-id' => process.app_guid,
               'user-id' => current_user.guid,
             }
           )
@@ -335,7 +335,7 @@ module VCAP::CloudController
           TelemetryLogger.v2_emit(
             'stop-app',
             {
-              'app-id' => process.app.guid,
+              'app-id' => process.app_guid,
               'user-id' => current_user.guid,
             }
           )
@@ -366,7 +366,7 @@ module VCAP::CloudController
       TelemetryLogger.v2_emit(
         'create-app',
         {
-          'app-id' => process.app.guid,
+          'app-id' => process.app_guid,
           'user-id' => current_user.guid,
         }
       )

--- a/app/controllers/runtime/restages_controller.rb
+++ b/app/controllers/runtime/restages_controller.rb
@@ -42,7 +42,7 @@ module VCAP::CloudController
       TelemetryLogger.v2_emit(
         'restage-app',
         {
-          'app-id' => process.app.guid,
+          'app-id' => process.app_guid,
           'user-id' => current_user.guid,
         }, {
         'lifecycle' => process.app.lifecycle_type,

--- a/app/controllers/v3/builds_controller.rb
+++ b/app/controllers/v3/builds_controller.rb
@@ -45,7 +45,7 @@ class BuildsController < ApplicationController
     TelemetryLogger.v3_emit(
       'create-build',
       {
-        'app-id' => package.app.guid,
+        'app-id' => package.app_guid,
         'build-id' => build.guid,
         'user-id' => current_user.guid,
       },

--- a/app/controllers/v3/processes_controller.rb
+++ b/app/controllers/v3/processes_controller.rb
@@ -83,7 +83,7 @@ class ProcessesController < ApplicationController
     TelemetryLogger.v3_emit(
       'scale-app',
       {
-        'app-id' => @process.app.guid,
+        'app-id' => @process.app_guid,
         'user-id' => current_user.guid
       },
       {

--- a/app/controllers/v3/routes_controller.rb
+++ b/app/controllers/v3/routes_controller.rb
@@ -229,7 +229,7 @@ class RoutesController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     route = Route.find(guid: hashed_params[:guid])
-    route_not_found! unless route && permission_queryer.can_read_route?(route.space.guid)
+    route_not_found! unless route && permission_queryer.can_read_route?(route.space_id)
     unauthorized! unless permission_queryer.can_manage_apps_in_active_space?(route.space_id)
     suspended! unless permission_queryer.is_space_active?(route.space_id)
 
@@ -246,7 +246,7 @@ class RoutesController < ApplicationController
   def route
     @route || begin
       @route = Route.find(guid: hashed_params[:guid])
-      route_not_found! unless @route && permission_queryer.can_read_route?(@route.space.guid)
+      route_not_found! unless @route && permission_queryer.can_read_route?(@route.space_id)
       @route
     end
   end
@@ -266,7 +266,7 @@ class RoutesController < ApplicationController
     route = Route.find(guid: hashed_params[:guid])
     route_not_found! unless route
 
-    route_not_found! unless permission_queryer.can_read_route?(route.space.guid)
+    route_not_found! unless permission_queryer.can_read_route?(route.space_id)
     unauthorized! unless permission_queryer.can_manage_apps_in_active_space?(route.space_id)
     suspended! unless permission_queryer.is_space_active?(route.space_id)
 

--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -227,7 +227,7 @@ class ServiceCredentialBindingsController < ApplicationController
       {
         'service-id' =>  binding.service_instance.managed_instance? ? binding.service_instance.service_plan.service.guid : 'user-provided',
         'service-instance-id' => binding.service_instance.guid,
-        'app-id' => binding.app.guid,
+        'app-id' => binding.app_guid,
         'user-id' => user_audit_info.user_guid,
       }
     )

--- a/app/fetchers/droplet_list_fetcher.rb
+++ b/app/fetchers/droplet_list_fetcher.rb
@@ -34,7 +34,7 @@ module VCAP::CloudController
           dataset = dataset.extension(:null_dataset)
           return dataset.nullify unless app.droplet
 
-          dataset = dataset.where(guid: app.droplet.guid)
+          dataset = dataset.where(guid: app.droplet_guid)
         end
 
         if message.requested?(:app_guids)

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -229,7 +229,7 @@ module VCAP::CloudController
       validates_unique [:organization_id, :name]
       validates_format SPACE_NAME_REGEX, :name
 
-      if space_quota_definition && space_quota_definition.organization.guid != organization.guid
+      if space_quota_definition && space_quota_definition.organization_id != organization.id
         errors.add(:space_quota_definition, :invalid_organization)
       end
 

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -144,7 +144,7 @@ module VCAP::CloudController
       plan_ids = []
       user.spaces.each do |space|
         space.service_instances.select(&:managed_instance?).each do |service_instance|
-          plan_ids << service_instance.service_plan.id
+          plan_ids << service_instance.service_plan_id
         end
       end
       plan_ids.uniq

--- a/app/presenters/v3/build_presenter.rb
+++ b/app/presenters/v3/build_presenter.rb
@@ -66,7 +66,7 @@ module VCAP::CloudController
         def build_links
           {
             self: { href: url_builder.build_url(path: "/v3/builds/#{build.guid}") },
-            app: { href: url_builder.build_url(path: "/v3/apps/#{build.app.guid}") }
+            app: { href: url_builder.build_url(path: "/v3/apps/#{build.app_guid}") }
           }.tap do |links|
             links[:droplet] = { href: url_builder.build_url(path: "/v3/droplets/#{build.droplet.guid}") } if droplet
           end

--- a/app/presenters/v3/deployment_presenter.rb
+++ b/app/presenters/v3/deployment_presenter.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController::Presenters::V3
         relationships: {
           app: {
             data: {
-              guid: deployment.app.guid
+              guid: deployment.app_guid
             }
           }
         },
@@ -66,7 +66,7 @@ module VCAP::CloudController::Presenters::V3
           href: url_builder.build_url(path: "/v3/deployments/#{deployment.guid}")
         },
         app: {
-          href: url_builder.build_url(path: "/v3/apps/#{deployment.app.guid}")
+          href: url_builder.build_url(path: "/v3/apps/#{deployment.app_guid}")
         },
       }.tap do |links|
         if deployment.cancelable?

--- a/app/presenters/v3/revision_environment_variables_presenter.rb
+++ b/app/presenters/v3/revision_environment_variables_presenter.rb
@@ -34,7 +34,7 @@ module VCAP::CloudController
           {
             self: { href: url_builder.build_url(path: "/v3/revisions/#{revision.guid}/environment_variables") },
             revision: { href: url_builder.build_url(path: "/v3/revisions/#{revision.guid}") },
-            app:  { href: url_builder.build_url(path: "/v3/apps/#{revision.app.guid}") }
+            app:  { href: url_builder.build_url(path: "/v3/apps/#{revision.app_guid}") }
           }
         end
       end

--- a/app/presenters/v3/shared_spaces_usage_summary_presenter.rb
+++ b/app/presenters/v3/shared_spaces_usage_summary_presenter.rb
@@ -20,7 +20,7 @@ module VCAP::CloudController
         def build_usage_summary
           count = Hash.new(0).tap do |h|
             service_instance.service_bindings.each do |binding|
-              h[binding.app.space.guid] += 1
+              h[binding.app.space_guid] += 1
             end
           end
 

--- a/app/presenters/v3/task_presenter.rb
+++ b/app/presenters/v3/task_presenter.rb
@@ -39,7 +39,7 @@ module VCAP::CloudController
         def build_links
           {
             self:    { href: url_builder.build_url(path: "/v3/tasks/#{task.guid}") },
-            app:     { href: url_builder.build_url(path: "/v3/apps/#{task.app.guid}") },
+            app:     { href: url_builder.build_url(path: "/v3/apps/#{task.app_guid}") },
             cancel:  { href: url_builder.build_url(path: "/v3/tasks/#{task.guid}/actions/cancel"), method: 'POST' },
             droplet: { href: url_builder.build_url(path: "/v3/droplets/#{task.droplet_guid}") },
           }

--- a/app/repositories/app_usage_event_repository.rb
+++ b/app/repositories/app_usage_event_repository.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
           space_name:                         process.space.name,
           buildpack_guid:                     process.detected_buildpack_guid,
           buildpack_name:                     buildpack_name_for_app(process),
-          parent_app_guid:                    process.app.guid,
+          parent_app_guid:                    process.app_guid,
           parent_app_name:                    process.app.name,
           process_type:                       process.type
         )
@@ -48,7 +48,7 @@ module VCAP::CloudController
           space_name:                         task.space.name,
           buildpack_guid:                     nil,
           buildpack_name:                     nil,
-          parent_app_guid:                    task.app.guid,
+          parent_app_guid:                    task.app_guid,
           parent_app_name:                    task.app.name,
           process_type:                       nil,
           task_guid:                          task.guid,
@@ -67,7 +67,7 @@ module VCAP::CloudController
           org_guid:                           build.space.organization.guid,
           space_guid:                         build.space.guid,
           space_name:                         build.space.name,
-          parent_app_guid:                    build.app.guid,
+          parent_app_guid:                    build.app_guid,
           parent_app_name:                    build.app.name,
           package_guid:                       build.package_guid,
           app_guid:                           '',

--- a/app/repositories/build_event_repository.rb
+++ b/app/repositories/build_event_repository.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
         metadata = {
           build_guid: build.guid,
-          package_guid: build.package.guid,
+          package_guid: build.package_guid,
         }
 
         Event.create(

--- a/app/repositories/droplet_event_repository.rb
+++ b/app/repositories/droplet_event_repository.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
         metadata = {
           droplet_guid: droplet.guid,
-          package_guid: droplet.package.guid
+          package_guid: droplet.package_guid
         }
 
         Event.create(

--- a/app/repositories/package_event_repository.rb
+++ b/app/repositories/package_event_repository.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController
       end
 
       def self.record_app_package_upload(package, user_audit_info)
-        VCAP::AppLogEmitter.emit(package.app.guid, "Uploading app package for app with guid #{package.app.guid}")
+        VCAP::AppLogEmitter.emit(package.app_guid, "Uploading app package for app with guid #{package.app_guid}")
         metadata = { package_guid: package.guid }
         type     = 'audit.app.package.upload'
 
@@ -37,7 +37,7 @@ module VCAP::CloudController
       end
 
       def self.record_app_upload_bits(package, user_audit_info)
-        VCAP::AppLogEmitter.emit(package.app.guid, "Uploading bits for app with guid #{package.app.guid}")
+        VCAP::AppLogEmitter.emit(package.app_guid, "Uploading bits for app with guid #{package.app_guid}")
         metadata = { package_guid: package.guid }
         type     = 'audit.app.upload-bits'
 
@@ -45,7 +45,7 @@ module VCAP::CloudController
       end
 
       def self.record_app_package_delete(package, user_audit_info)
-        VCAP::AppLogEmitter.emit(package.app.guid, "Deleting app package for app with guid #{package.app.guid}")
+        VCAP::AppLogEmitter.emit(package.app_guid, "Deleting app package for app with guid #{package.app_guid}")
         metadata = { package_guid: package.guid }
         type     = 'audit.app.package.delete'
 
@@ -53,7 +53,7 @@ module VCAP::CloudController
       end
 
       def self.record_app_package_download(package, user_audit_info)
-        VCAP::AppLogEmitter.emit(package.app.guid, "Downloading app package for app with guid #{package.app.guid}")
+        VCAP::AppLogEmitter.emit(package.app_guid, "Downloading app package for app with guid #{package.app_guid}")
         metadata = { package_guid: package.guid }
         type     = 'audit.app.package.download'
 

--- a/app/repositories/process_event_repository.rb
+++ b/app/repositories/process_event_repository.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
       extend TruncationMixin
 
       def self.record_create(process, user_audit_info, manifest_triggered: false)
-        VCAP::AppLogEmitter.emit(process.app.guid, "Added process: \"#{process.type}\"")
+        VCAP::AppLogEmitter.emit(process.app_guid, "Added process: \"#{process.type}\"")
 
         metadata = add_manifest_triggered(manifest_triggered, {
           process_guid: process.guid,
@@ -26,7 +26,7 @@ module VCAP::CloudController
       end
 
       def self.record_delete(process, user_audit_info)
-        VCAP::AppLogEmitter.emit(process.app.guid, "Deleting process: \"#{process.type}\"")
+        VCAP::AppLogEmitter.emit(process.app_guid, "Deleting process: \"#{process.type}\"")
 
         create_event(
           process:        process,
@@ -42,7 +42,7 @@ module VCAP::CloudController
       end
 
       def self.record_update(process, user_audit_info, request, manifest_triggered: false)
-        VCAP::AppLogEmitter.emit(process.app.guid, "Updating process: \"#{process.type}\"")
+        VCAP::AppLogEmitter.emit(process.app_guid, "Updating process: \"#{process.type}\"")
 
         request           = request.dup.symbolize_keys
         request[:command] = Presenters::Censorship::PRIVATE_DATA_HIDDEN if request.key?(:command)
@@ -63,7 +63,7 @@ module VCAP::CloudController
       end
 
       def self.record_scale(process, user_audit_info, request, manifest_triggered: false)
-        VCAP::AppLogEmitter.emit(process.app.guid, "Scaling process: \"#{process.type}\"")
+        VCAP::AppLogEmitter.emit(process.app_guid, "Scaling process: \"#{process.type}\"")
 
         metadata = add_manifest_triggered(manifest_triggered, {
           process_guid: process.guid,
@@ -82,7 +82,7 @@ module VCAP::CloudController
       end
 
       def self.record_terminate(process, user_audit_info, index)
-        VCAP::AppLogEmitter.emit(process.app.guid, "Terminating process: \"#{process.type}\", index: \"#{index}\"")
+        VCAP::AppLogEmitter.emit(process.app_guid, "Terminating process: \"#{process.type}\", index: \"#{index}\"")
 
         create_event(
           process:        process,
@@ -99,7 +99,7 @@ module VCAP::CloudController
       end
 
       def self.record_crash(process, crash_payload)
-        VCAP::AppLogEmitter.emit(process.app.guid, "Process has crashed with type: \"#{process.type}\"")
+        VCAP::AppLogEmitter.emit(process.app_guid, "Process has crashed with type: \"#{process.type}\"")
         crash_payload['exit_description'] = truncate(crash_payload['exit_description'])
 
         create_event(
@@ -113,7 +113,7 @@ module VCAP::CloudController
       end
 
       def self.record_rescheduling(process, rescheduling_payload)
-        VCAP::AppLogEmitter.emit(process.app.guid, 'Process is being rescheduled')
+        VCAP::AppLogEmitter.emit(process.app_guid, 'Process is being rescheduled')
 
         create_event(
           process:    process,

--- a/app/repositories/route_event_repository.rb
+++ b/app/repositories/route_event_repository.rb
@@ -117,7 +117,7 @@ module VCAP::CloudController
       def record_route_map(route_mapping, actor_audit_info)
         Event.create(
           type:              'audit.app.map-route',
-          actee:             route_mapping.app.guid,
+          actee:             route_mapping.app_guid,
           actee_type:        'app',
           actee_name:        route_mapping.app.name,
           actor:             actor_audit_info.user_guid,
@@ -128,7 +128,7 @@ module VCAP::CloudController
           space_guid:        route_mapping.space.guid,
           organization_guid: route_mapping.space.organization.guid,
           metadata:          {
-            route_guid:       route_mapping.route.guid,
+            route_guid:       route_mapping.route_guid,
             app_port:         route_mapping.app_port,
             destination_guid: route_mapping.guid,
             process_type:     route_mapping.process_type,
@@ -140,7 +140,7 @@ module VCAP::CloudController
       def record_route_unmap(route_mapping, actor_audit_info)
         Event.create(
           type:              'audit.app.unmap-route',
-          actee:             route_mapping.app.guid,
+          actee:             route_mapping.app_guid,
           actee_type:        'app',
           actee_name:        route_mapping.app.name,
           actor:             actor_audit_info.user_guid,
@@ -151,7 +151,7 @@ module VCAP::CloudController
           space_guid:        route_mapping.space.guid,
           organization_guid: route_mapping.space.organization.guid,
           metadata:          {
-            route_guid:       route_mapping.route.guid,
+            route_guid:       route_mapping.route_guid,
             app_port:         route_mapping.app_port,
             destination_guid: route_mapping.guid,
             process_type:     route_mapping.process_type,

--- a/app/repositories/task_event_repository.rb
+++ b/app/repositories/task_event_repository.rb
@@ -19,7 +19,7 @@ module VCAP
             actor_type:        'user',
             actor_name:        user_audit_info.user_email,
             actor_username:    user_audit_info.user_name,
-            actee:             task.app.guid,
+            actee:             task.app_guid,
             actee_type:        'app',
             actee_name:        task.app.name,
             timestamp:         Sequel::CURRENT_TIMESTAMP,

--- a/lib/cloud_controller/deployments/deployment_target_state.rb
+++ b/lib/cloud_controller/deployments/deployment_target_state.rb
@@ -55,7 +55,7 @@ module VCAP::CloudController
     # if this needs to be called from somewhere else, we should move it to the revision sidecar model
     def rehydrate(revision_sidecar)
       sidecar = SidecarModel.create(
-        app_guid: revision_sidecar.revision.app.guid,
+        app_guid: revision_sidecar.revision.app_guid,
         name: revision_sidecar.name,
         command: revision_sidecar.command,
         memory: revision_sidecar.memory,

--- a/lib/cloud_controller/diego/app_recipe_builder.rb
+++ b/lib/cloud_controller/diego/app_recipe_builder.rb
@@ -72,8 +72,8 @@ module VCAP::CloudController
           privileged:                       desired_lrp_builder.privileged?,
           ports:                            ports,
           log_source:                       LRP_LOG_SOURCE,
-          log_guid:                         process.app.guid,
-          metrics_guid:                     process.app.guid,
+          log_guid:                         process.app_guid,
+          metrics_guid:                     process.app_guid,
           metric_tags:                      metric_tags(process),
           annotation:                       process.updated_at.to_f.to_s,
           egress_rules:                     Diego::EgressRules.new.running_protobuf_rules(process),
@@ -94,7 +94,7 @@ module VCAP::CloudController
           routes:                           ::Diego::Bbs::Models::ProtoRoutes.new(routes: routes),
           max_pids:                         @config.get(:diego, :pid_limit),
           certificate_properties:           ::Diego::Bbs::Models::CertificateProperties.new(
-            organizational_unit: ["organization:#{process.organization.guid}", "space:#{process.space.guid}", "app:#{process.app.guid}"]
+            organizational_unit: ["organization:#{process.organization.guid}", "space:#{process.space.guid}", "app:#{process.app_guid}"]
           ),
           image_username:                   process.desired_droplet.docker_receipt_username,
           image_password:                   process.desired_droplet.docker_receipt_password,
@@ -103,14 +103,14 @@ module VCAP::CloudController
 
       def metric_tags(process)
         tags = {
-          'source_id' => METRIC_TAG_VALUE.new(static: process.app.guid),
+          'source_id' => METRIC_TAG_VALUE.new(static: process.app_guid),
           'process_id' => METRIC_TAG_VALUE.new(static: process.guid),
           'process_type' => METRIC_TAG_VALUE.new(static: process.type),
           'process_instance_id' => METRIC_TAG_VALUE.new(dynamic: METRIC_TAG_VALUE::DynamicValue::INSTANCE_GUID),
           'instance_id' => METRIC_TAG_VALUE.new(dynamic: METRIC_TAG_VALUE::DynamicValue::INDEX),
           'organization_id' => METRIC_TAG_VALUE.new(static: process.organization.guid),
           'space_id' => METRIC_TAG_VALUE.new(static: process.space.guid),
-          'app_id' => METRIC_TAG_VALUE.new(static: process.app.guid),
+          'app_id' => METRIC_TAG_VALUE.new(static: process.app_guid),
           'organization_name' => METRIC_TAG_VALUE.new(static: process.organization.name),
           'space_name' => METRIC_TAG_VALUE.new(static: process.space.name),
           'app_name' => METRIC_TAG_VALUE.new(static: process.app.name),

--- a/lib/cloud_controller/diego/buildpack/lifecycle_protocol.rb
+++ b/lib/cloud_controller/diego/buildpack/lifecycle_protocol.rb
@@ -84,7 +84,7 @@ module VCAP
 
           def droplet_download_uri(task)
             download_url = @blobstore_url_generator.droplet_download_url(task.droplet)
-            raise InvalidDownloadUri.new("Failed to get blobstore download url for droplet #{task.droplet.guid}") unless download_url
+            raise InvalidDownloadUri.new("Failed to get blobstore download url for droplet #{task.droplet_guid}") unless download_url
 
             download_url
           end

--- a/lib/cloud_controller/diego/protocol/container_network_info.rb
+++ b/lib/cloud_controller/diego/protocol/container_network_info.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
             'properties' => {
               'policy_group_id' => app.guid,
               'app_id' => app.guid,
-              'space_id' => app.space.guid,
+              'space_id' => app.space_guid,
               'org_id' => app.organization.guid,
               'ports' => app.processes.map(&:open_ports).flatten.sort.uniq.join(','),
               'container_workload' => container_workload,

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -117,7 +117,7 @@ module VCAP::CloudController
       def envelopes(desired_lrp, process)
         if desired_lrp.metric_tags['process_id']
           filter = ->(envelope) { envelope.tags.any? { |key, value| key == 'process_id' && value == process.guid } }
-          source_guid = process.app.guid
+          source_guid = process.app_guid
         else
           filter = ->(_) { true }
           source_guid = process.guid

--- a/lib/cloud_controller/diego/task_recipe_builder.rb
+++ b/lib/cloud_controller/diego/task_recipe_builder.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
           cpu_weight:                       cpu_weight(task),
           disk_mb:                          task.disk_in_mb,
           egress_rules:                     @egress_rules.running_protobuf_rules(task.app),
-          log_guid:                         task.app.guid,
+          log_guid:                         task.app_guid,
           log_rate_limit:                   ::Diego::Bbs::Models::LogRateLimit.new(bytes_per_second: task.log_rate_limit),
           log_source:                       TASK_LOG_SOURCE,
           max_pids:                         config.get(:diego, :pid_limit),
@@ -44,8 +44,8 @@ module VCAP::CloudController
           certificate_properties:           ::Diego::Bbs::Models::CertificateProperties.new(
             organizational_unit: [
               "organization:#{task.app.organization.guid}",
-              "space:#{task.app.space.guid}",
-              "app:#{task.app.guid}"
+              "space:#{task.app.space_guid}",
+              "app:#{task.app_guid}"
             ]
           ),
           image_username:                   task.droplet.docker_receipt_username,
@@ -81,7 +81,7 @@ module VCAP::CloudController
           certificate_properties:           ::Diego::Bbs::Models::CertificateProperties.new(
             organizational_unit: [
               "organization:#{staging_details.package.app.organization.guid}",
-              "space:#{staging_details.package.app.space.guid}",
+              "space:#{staging_details.package.app.space_guid}",
               "app:#{staging_details.package.app_guid}"
             ]
           ),

--- a/lib/cloud_controller/kpack/stager.rb
+++ b/lib/cloud_controller/kpack/stager.rb
@@ -19,7 +19,7 @@ module Kpack
 
     def stage(staging_details)
       builder_reference = find_or_create_builder_reference(staging_details)
-      image_resource_name = staging_details.package.app.guid
+      image_resource_name = staging_details.package.app_guid
 
       unless client.get_image(image_resource_name, builder_namespace).present?
         return client.create_image(image_resource(staging_details, builder_reference))
@@ -67,10 +67,10 @@ module Kpack
     def image_resource(staging_details, builder_spec)
       Kubeclient::Resource.new({
         metadata: {
-          name: staging_details.package.app.guid,
+          name: staging_details.package.app_guid,
           namespace: builder_namespace,
           labels: {
-            APP_GUID_LABEL_KEY.to_sym => staging_details.package.app.guid,
+            APP_GUID_LABEL_KEY.to_sym => staging_details.package.app_guid,
             BUILD_GUID_LABEL_KEY.to_sym => staging_details.staging_guid,
             DROPLET_GUID_LABEL_KEY.to_sym => create_droplet_and_get_guid(staging_details),
             STAGING_SOURCE_LABEL_KEY.to_sym => 'STG'
@@ -82,7 +82,7 @@ module Kpack
         spec: {
           serviceAccount: registry_service_account_name,
           builder: builder_spec,
-          tag: "#{registry_tag_base}/#{staging_details.package.app.guid}",
+          tag: "#{registry_tag_base}/#{staging_details.package.app_guid}",
           source: configure_source(staging_details),
           build: {
             env: get_environment_variables(staging_details),
@@ -108,7 +108,7 @@ module Kpack
     def find_or_create_builder_reference(staging_details)
       return CF_DEFAULT_BUILDER_REFERENCE unless staging_details.lifecycle.buildpack_infos.present?
 
-      builder_name = "app-#{staging_details.package.app.guid}"
+      builder_name = "app-#{staging_details.package.app_guid}"
       create_or_update_builder(builder_name, staging_details)
 
       {
@@ -139,7 +139,7 @@ module Kpack
           name: name,
           namespace: builder_namespace,
           labels: {
-            APP_GUID_LABEL_KEY.to_sym => staging_details.package.app.guid,
+            APP_GUID_LABEL_KEY.to_sym => staging_details.package.app_guid,
             BUILD_GUID_LABEL_KEY.to_sym => staging_details.staging_guid,
             STAGING_SOURCE_LABEL_KEY.to_sym => 'STG'
           },
@@ -148,7 +148,7 @@ module Kpack
           serviceAccount: default_builder.spec.serviceAccount,
           stack: default_builder.spec.stack,
           store: default_builder.spec.store,
-          tag: "#{registry_tag_base}/#{staging_details.package.app.guid}-builder",
+          tag: "#{registry_tag_base}/#{staging_details.package.app_guid}-builder",
           order: [
             { group: staging_details.lifecycle.buildpack_infos.map { |buildpack| { id: buildpack } } }
           ]

--- a/lib/cloud_controller/opi/apps_client.rb
+++ b/lib/cloud_controller/opi/apps_client.rb
@@ -57,7 +57,7 @@ module OPI
             GUID: process.guid,
             version: process.version,
             processType: process.type,
-            appGUID: process.app.guid,
+            appGUID: process.app_guid,
             appName: process.app.name,
             spaceGUID: process.space.guid,
             spaceName: process.space.name,

--- a/lib/cloud_controller/opi/apps_rest_client.rb
+++ b/lib/cloud_controller/opi/apps_rest_client.rb
@@ -73,7 +73,7 @@ module OPI
         version: process.version,
         process_guid: OPI.process_guid(process),
         process_type: process.type,
-        app_guid: process.app.guid,
+        app_guid: process.app_guid,
         app_name: process.app.name,
         space_guid: process.space.guid,
         space_name: process.space.name,

--- a/lib/cloud_controller/opi/stager_client.rb
+++ b/lib/cloud_controller/opi/stager_client.rb
@@ -97,7 +97,7 @@ module OPI
           org_name: staging_details.package.app.organization.name,
           org_guid: staging_details.package.app.organization.guid,
           space_name: staging_details.package.app.space.name,
-          space_guid: staging_details.package.app.space.guid,
+          space_guid: staging_details.package.app.space_guid,
           environment: build_env(staging_details.environment_variables) + action_builder.task_environment_variables.to_a,
           completion_callback: staging_completion_callback(staging_details),
           lifecycle: lifecycle,

--- a/lib/cloud_controller/opi/task_client.rb
+++ b/lib/cloud_controller/opi/task_client.rb
@@ -72,7 +72,7 @@ module OPI
         {
           buildpack_lifecycle: {
             droplet_hash: task.droplet.droplet_hash,
-            droplet_guid: task.droplet.guid,
+            droplet_guid: task.droplet_guid,
             start_command: task.command
           }
         }

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -267,15 +267,14 @@ class VCAP::CloudController::Permissions
     end
   end
 
-  def can_read_route?(space_guid)
+  def can_read_route?(space_id)
     return true if can_read_globally?
 
-    space = VCAP::CloudController::Space.where(guid: space_guid).first
-    org = space.organization
+    space = VCAP::CloudController::Space.where(id: space_id).first
 
     space.has_member?(@user) || space.has_supporter?(@user) ||
-      @user.managed_organizations.include?(org) ||
-      @user.audited_organizations.include?(org)
+      @user.managed_organizations.map(&:id).include?(space.organization_id) ||
+      @user.audited_organizations.map(&:id).include?(space.organization_id)
   end
 
   def can_read_app_environment_variables?(space_id, org_id)

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -315,7 +315,7 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     def fetch_service_binding(service_binding, user_guid: nil)
-      path = service_binding_resource_path(service_binding.guid, service_binding.service_instance.guid)
+      path = service_binding_resource_path(service_binding.guid, service_binding.service_instance_guid)
       response = @http_client.get(path, user_guid: user_guid)
       @response_parser.parse_fetch_binding_parameters(path, response).deep_symbolize_keys
     end
@@ -407,7 +407,7 @@ module VCAP::Services::ServiceBrokers::V2
       if service_binding.last_operation.broker_provided_operation
         query_params['operation'] = service_binding.last_operation.broker_provided_operation
       end
-      "#{service_binding_resource_path(service_binding.guid, service_binding.service_instance.guid)}/last_operation?#{query_params.to_query}"
+      "#{service_binding_resource_path(service_binding.guid, service_binding.service_instance_guid)}/last_operation?#{query_params.to_query}"
     end
 
     def service_instance_resource_path(instance, opts={})

--- a/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/opi/task_client_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe(OPI::TaskClient) do
           droplet_hash: 'DROPLET_HASH',
           guid: 'DROPLET_GUID'
         ),
+        droplet_guid: 'DROPLET_GUID',
         space: double(
           guid: 'SPACE_GUID',
           name: 'SPACE_NAME',

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -1127,152 +1127,152 @@ module VCAP::CloudController
     describe '#can_read_route?' do
       it 'returns true if user is an admin' do
         set_current_user(user, { admin: true })
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true if user is a read-only admin' do
         set_current_user(user, { admin_read_only: true })
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true if user is a global auditor' do
         set_current_user_as_global_auditor
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for space developer' do
         org.add_user(user)
         space.add_developer(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for space manager' do
         org.add_user(user)
         space.add_manager(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for space auditor' do
         org.add_user(user)
         space.add_auditor(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for org manager' do
         org.add_user(user)
         org.add_manager(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for org auditor' do
         org.add_user(user)
         org.add_auditor(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for space supporter' do
         org.add_user(user)
         space.add_supporter(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns false for org billing manager' do
         org.add_user(user)
         org.add_billing_manager(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be false
+        expect(permissions.can_read_route?(space.id)).to be false
       end
 
       it 'returns false for regular org user' do
         org.add_user(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be false
+        expect(permissions.can_read_route?(space.id)).to be false
       end
 
       it 'returns false for other user' do
-        expect(permissions.can_read_route?(space_guid)).to be false
+        expect(permissions.can_read_route?(space.id)).to be false
       end
     end
 
     describe '#can_read_route?' do
       it 'returns true if user is an admin' do
         set_current_user(user, { admin: true })
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true if user is a read-only admin' do
         set_current_user(user, { admin_read_only: true })
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true if user is a global auditor' do
         set_current_user_as_global_auditor
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for space developer' do
         org.add_user(user)
         space.add_developer(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for space manager' do
         org.add_user(user)
         space.add_manager(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for space auditor' do
         org.add_user(user)
         space.add_auditor(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for space supporter' do
         org.add_user(user)
         space.add_supporter(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for org manager' do
         org.add_user(user)
         org.add_manager(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns true for org auditor' do
         org.add_user(user)
         org.add_auditor(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be true
+        expect(permissions.can_read_route?(space.id)).to be true
       end
 
       it 'returns false for org billing manager' do
         org.add_user(user)
         org.add_billing_manager(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be false
+        expect(permissions.can_read_route?(space.id)).to be false
       end
 
       it 'returns false for regular org user' do
         org.add_user(user)
 
-        expect(permissions.can_read_route?(space_guid)).to be false
+        expect(permissions.can_read_route?(space.id)).to be false
       end
 
       it 'returns false for other user' do
-        expect(permissions.can_read_route?(space_guid)).to be false
+        expect(permissions.can_read_route?(space.id)).to be false
       end
     end
 


### PR DESCRIPTION
* **A short explanation of the proposed change:**

This PR ensures that where an id or guid of an associated resource is present in a DB row we've already retrieved, we get that from memory instead of making a separate query to the table for the associated resource.

Many database tables contain foreign keys linking them to associated resources - for example, the `processes` table has an `app_guid` column, and the `service_instances` table has `space_id`.

`process.app.guid` = two queries
`process.app_guid` = one query

* **An explanation of the use cases your change solves**

Optimization for speed

* **Links to any other associated PRs**

n/a

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
