### PR TITLE
Enable CC to process large manifests

### DIFF
--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -89,8 +89,11 @@ class ApplicationController < ActionController::Base
   def parsed_yaml
     return @parsed_yaml if @parsed_yaml
 
+    bad_request!('Manifest size is too large. The maximum supported size is 1MB.') if request.body.size > 1.megabyte
+
     allow_yaml_aliases = false
-    yaml = Psych.safe_load(request.body.string, permitted_classes: [], permitted_symbols: [], aliases: allow_yaml_aliases, strict_integer: true)
+    yaml = Psych.safe_load(request.body.read, permitted_classes: [], permitted_symbols: [], aliases: allow_yaml_aliases, strict_integer: true)
+
     message_parse_error!('invalid request body') if !yaml.is_a? Hash
     @parsed_yaml = yaml
   rescue Psych::BadAlias


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Enable the CC to process large requests (caused by large manifests) up to 1MB.

* An explanation of the use cases your change solves
Until now, when a user does a cf push with an app manifest larger than ~130KB, the CC will error with a 500 - unknown error. This is due to Thin ([see here](https://github.com/macournoyer/thin/blob/02f0a3a72620313c69a1d797671cc522399d9b4c/lib/thin/request.rb#L12))  which outsources large request bodies/headers into Tempfiles, instead of in-memory StreamIOs (Puma does the same [see here](https://github.com/puma/puma/blob/32d999708d7019b85b0518c8e0693773b0bd4ff4/lib/puma/const.rb#L147)). Currently the CC coding calls a `.string` method on the request body, which is not present for Tempfile objects. This commit changes to the `.read` method, which is available on both classes.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
