### PR TITLE
Fix v3 upgrade guide for audit_events

### DIFF
--- a/docs/v3/source/includes/upgrade_guide/changed_resources/_audit_events_in_v3.md
+++ b/docs/v3/source/includes/upgrade_guide/changed_resources/_audit_events_in_v3.md
@@ -18,11 +18,6 @@ contained in V2, but the JSON is structured a little differently. In particular:
 - Actee-related fields have been grouped under the `target` key (e.g.
   `target.type` instead of `actee_type`).
 
-At the time of this writing, V3 does not support greater-than or less-than
-filtering for the `created_at` field. In V2, this was supported via
-`/v2/events?q=timestamp>some_timestamp`. There are plans support this in the
-future.
-
 V3 endpoints attempt to report audit events in the same way as V2 endpoints did.
 A notable case where this was not possible is for the `audit.app.restage` event.
 Read more about [restaging](#restage) in V3.


### PR DESCRIPTION
V3 meanwhile supports greater-than or less-than filtering for the created_at field.
See V3 Concepts > Filters > Relational Operators

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Just a small documentation fix for the v3 upgrade guide.

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
