### PR TITLE
Cut DB query complexity in permissions/visibility checks

### DIFF
--- a/app/controllers/internal/log_access_controller.rb
+++ b/app/controllers/internal/log_access_controller.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
       if roles.admin? || roles.admin_read_only? || roles.global_auditor?
         found = LogAccessFetcher.new.app_exists?(guid)
       else
-        allowed_space_guids = membership.space_guids_for_roles_subquery(Permissions::ROLES_FOR_SPACE_READING)
+        allowed_space_guids = membership.authorized_space_guids_subquery(Permissions::ROLES_FOR_SPACE_READING)
         found = LogAccessFetcher.new.app_exists_by_space?(guid, allowed_space_guids)
       end
 

--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -475,7 +475,7 @@ module VCAP::CloudController
         ]
 
         raise e unless SecurityContext.global_auditor? ||
-          membership.has_any_roles?(basic_access, process.space.id, process.organization.id)
+          membership.role_applies?(basic_access, process.space.id, process.organization.id)
 
         [HTTP::OK, JSON.generate({
           read_sensitive_data: false,

--- a/app/models/runtime/organization.rb
+++ b/app/models/runtime/organization.rb
@@ -164,7 +164,7 @@ module VCAP::CloudController
 
     def self.user_visibility_filter(user)
       {
-        id: OrganizationRole.where(user_id: user.id).select(Sequel.as(:organization_id, :id))
+        id: user.membership_org_ids
       }
     end
 

--- a/app/models/runtime/organization.rb
+++ b/app/models/runtime/organization.rb
@@ -164,13 +164,7 @@ module VCAP::CloudController
 
     def self.user_visibility_filter(user)
       {
-        id: dataset.join_table(:inner, :organizations_managers, organization_id: :id, user_id: user.id).select(:organizations__id).union(
-          dataset.join_table(:inner, :organizations_users, organization_id: :id, user_id: user.id).select(:organizations__id)
-        ).union(
-          dataset.join_table(:inner, :organizations_billing_managers, organization_id: :id, user_id: user.id).select(:organizations__id)
-        ).union(
-          dataset.join_table(:inner, :organizations_auditors, organization_id: :id, user_id: user.id).select(:organizations__id)
-        ).select(:id)
+        id: OrganizationRole.where(user_id: user.id).select(Sequel.as(:organization_id, :id))
       }
     end
 

--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -175,17 +175,13 @@ module VCAP::CloudController
 
     def self.user_visibility_filter(user)
       {
-         space_id: Space.dataset.join_table(:inner, :spaces_developers, space_id: :id, user_id: user.id).select(:spaces__id).union(
-           Space.dataset.join_table(:inner, :spaces_managers, space_id: :id, user_id: user.id).select(:spaces__id)
-           ).union(
-             Space.dataset.join_table(:inner, :spaces_auditors, space_id: :id, user_id: user.id).select(:spaces__id)
-           ).union(
-             Space.dataset.join_table(:inner, :spaces_supporters, space_id: :id, user_id: user.id).select(:spaces__id)
-           ).union(
-             Space.dataset.join_table(:inner, :organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__id)
-           ).union(
-             Space.dataset.join_table(:inner, :organizations_auditors, organization_id: :organization_id, user_id: user.id).select(:spaces__id)
-           ).select(:id)
+         space_id: user.space_developer_space_ids.
+           union(user.space_manager_space_ids, from_self: false).
+           union(user.space_auditor_space_ids, from_self: false).
+           union(user.space_supporter_space_ids, from_self: false).
+           union(Space.join(user.org_manager_org_ids, organization_id: :organization_id).select(:spaces__id)).
+           union(Space.join(user.org_auditor_org_ids, organization_id: :organization_id).select(:spaces__id)).
+           select(:space_id)
        }
     end
 

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -271,8 +271,12 @@ module VCAP::CloudController
 
     def self.user_visibility_filter(user)
       {
-        spaces__id: dataset.join(:organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__id).
-          union(SpaceRole.where(user_id: user.id).select(:space_id)).select(:id)
+        spaces__id: user.space_developer_space_ids.
+          union(user.space_manager_space_ids, from_self: false).
+          union(user.space_auditor_space_ids, from_self: false).
+          union(user.space_supporter_space_ids, from_self: false).
+          union(dataset.join(user.org_manager_org_ids, organization_id: :organization_id).select(:spaces__id), from_self: false).
+          select(:space_id)
       }
     end
 

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -271,12 +271,8 @@ module VCAP::CloudController
 
     def self.user_visibility_filter(user)
       {
-        spaces__id: dataset.join_table(:inner, :spaces_developers, space_id: :id, user_id: user.id).select(:spaces__id).
-          union(dataset.join_table(:inner, :spaces_managers, space_id: :id, user_id: user.id).select(:spaces__id)).
-          union(dataset.join_table(:inner, :spaces_auditors, space_id: :id, user_id: user.id).select(:spaces__id)).
-          union(dataset.join_table(:inner, :spaces_supporters, space_id: :id, user_id: user.id).select(:spaces__id)).
-          union(dataset.join_table(:inner, :organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__id)).
-          select(:id)
+        spaces__id: dataset.join(:organizations_managers, organization_id: :organization_id, user_id: user.id).select(:spaces__id).
+          union(SpaceRole.where(user_id: user.id).select(:space_id)).select(:id)
       }
     end
 

--- a/app/models/runtime/space_quota_definition.rb
+++ b/app/models/runtime/space_quota_definition.rb
@@ -49,12 +49,15 @@ module VCAP::CloudController
     end
 
     def self.user_visibility_filter(user)
+      visible_space_ids = user.space_developer_space_ids.
+                          union(user.space_manager_space_ids, from_self: false).
+                          union(user.space_auditor_space_ids, from_self: false).
+                          union(user.space_supporter_space_ids, from_self: false).
+                          select_map(:space_id)
+
       Sequel.or([
-        [:organization, user.managed_organizations_dataset],
-        [:spaces, user.spaces_dataset],
-        [:spaces, user.supported_spaces_dataset],
-        [:spaces, user.managed_spaces_dataset],
-        [:spaces, user.audited_spaces_dataset]
+        [:id, Space.where(id: visible_space_ids).select(:space_quota_definition_id)],
+        [:organization_id, user.org_manager_org_ids]
       ])
     end
 

--- a/app/models/runtime/user.rb
+++ b/app/models/runtime/user.rb
@@ -177,11 +177,19 @@ module VCAP::CloudController
     end
 
     def membership_space_ids
-      SpaceRole.where(user_id: id).select_map(:space_id)
+      space_developer_space_ids.
+        union(space_manager_space_ids, from_self: false).
+        union(space_auditor_space_ids, from_self: false).
+        union(space_supporter_space_ids, from_self: false).
+        select_map(:space_id)
     end
 
     def membership_org_ids
-      OrganizationRole.where(user_id: id).select_map(:organization_id)
+      org_manager_org_ids.
+        union(org_user_org_ids, from_self: false).
+        union(org_billing_manager_org_ids, from_self: false).
+        union(org_auditor_org_ids, from_self: false).
+        select_map(:organization_id)
     end
 
     def org_user_org_ids
@@ -216,15 +224,19 @@ module VCAP::CloudController
       SpaceManager.where(user_id: id).select(:space_id)
     end
 
-    def visible_users_in_my_orgs
-      OrganizationRole.where(organization_id: membership_organizations).select_map(:user_id)
+    def visible_user_ids_in_my_orgs
+      OrganizationUser.where(organization_id: membership_org_ids).select(:user_id).
+        union(OrganizationManager.where(organization_id: membership_org_ids).select(:user_id), from_self: false).
+        union(OrganizationAuditor.where(organization_id: membership_org_ids).select(:user_id), from_self: false).
+        union(OrganizationBillingManager.where(organization_id: membership_org_ids).select(:user_id), from_self: false).
+        select_map(:user_id)
     end
 
     def readable_users(can_read_globally)
       if can_read_globally
         User.dataset
       else
-        User.where(id: visible_users_in_my_orgs).or(id: id)
+        User.where(id: visible_user_ids_in_my_orgs).or(id: id)
       end
     end
 

--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -127,7 +127,7 @@ module VCAP::CloudController
     end
 
     def self.plan_ids_from_private_brokers(user)
-      plan_ids_from_brokers(user.membership_spaces.join(:service_brokers, space_id: :id))
+      plan_ids_from_brokers(ServiceBroker.where(space_id: user.membership_space_ids))
     end
 
     def self.plan_ids_from_private_brokers_by_space(space)

--- a/lib/cloud_controller/membership.rb
+++ b/lib/cloud_controller/membership.rb
@@ -71,13 +71,13 @@ module VCAP::CloudController
     private
 
     def role_applies_to_space?(roles, space_id)
-      return false unless space_id && space_role_sufficient?(roles)
+      return false unless space_id && contains_space_role?(roles)
 
       member_space_ids(roles).include?(space_id)
     end
 
     def role_applies_to_org?(roles, org_id)
-      return false unless org_id && org_role_sufficient?(roles)
+      return false unless org_id && contains_org_role?(roles)
 
       member_org_ids(roles).include?(org_id)
     end
@@ -86,11 +86,11 @@ module VCAP::CloudController
       Array(roles).intersection(filter)
     end
 
-    def space_role_sufficient?(roles)
+    def contains_space_role?(roles)
       roles_filter(roles, SPACE_ROLES).any?
     end
 
-    def org_role_sufficient?(roles)
+    def contains_org_role?(roles)
       roles_filter(roles, ORG_ROLES).any?
     end
 

--- a/lib/cloud_controller/membership.rb
+++ b/lib/cloud_controller/membership.rb
@@ -16,77 +16,112 @@ module VCAP::CloudController
       @user = user
     end
 
-    def has_any_roles?(roles, space_id=nil, org_id=nil)
-      if space_id && space_role?(roles)
-        return true unless SpaceRole.where(type: space_roles(roles), user_id: @user.id, space_id: space_id).empty?
+    def role_applies?(roles, space_id=nil, org_id=nil)
+      role_applies_to_space?(roles, space_id) || role_applies_to_org?(roles, org_id)
+    end
+
+    def authorized_org_guids(roles)
+      authorized_org_guids_subquery(roles).select_map(:guid)
+    end
+
+    def authorized_org_guids_subquery(roles)
+      authorized_orgs_subquery(roles).select(:guid)
+    end
+
+    def authorized_orgs_subquery(roles)
+      space_ids = member_space_ids(roles)
+      org_ids_from_space_roles = Space.where(id: space_ids).select(:organization_id) if space_ids
+
+      if org_ids_from_space_roles
+        Organization.where(id: member_org_ids(roles)).or(id: org_ids_from_space_roles)
+      else
+        Organization.where(id: member_org_ids(roles))
       end
+    end
 
-      if org_id && org_role?(roles)
-        return true unless OrganizationRole.where(type: org_roles(roles), user_id: @user.id, organization_id: org_id).empty?
+    def authorized_space_guids(roles)
+      authorized_space_guids_subquery(roles).select_map(:guid)
+    end
+
+    def authorized_space_guids_subquery(roles)
+      authorized_spaces_subquery(roles).select(:guid)
+    end
+
+    def authorized_spaces_subquery(roles)
+      org_ids = member_org_ids(roles)
+      if org_ids
+        Space.where(id: member_space_ids(roles)).or(organization_id: org_ids).select(:id, :guid)
+      else
+        Space.where(id: member_space_ids(roles)).select(:id, :guid)
       end
-
-      false
     end
 
-    def org_guids_for_roles(roles)
-      org_guids_for_roles_subquery(roles).select_map(:guid)
+    def member_space_ids(roles)
+      space_role_subqueries(roles).reduce do |query, subquery|
+        query.union(subquery, from_self: false)
+      end&.select_map(:space_id)
     end
 
-    def org_guids_for_roles_subquery(roles)
-      orgs_for_roles_subquery(roles).select(:guid)
-    end
-
-    def orgs_for_roles_subquery(roles)
-      org_ids = org_ids_for_org_roles(roles)
-      space_ids = space_ids_for_space_roles(roles)
-      org_ids_from_space_roles = if space_ids
-                                   Space.where(id: space_ids).select(:organization_id)
-                                 end
-      Organization.where(id: org_ids).or(id: org_ids_from_space_roles).select(:id, :guid)
-    end
-
-    def space_guids_for_roles(roles)
-      space_guids_for_roles_subquery(roles).select_map(:guid)
-    end
-
-    def space_guids_for_roles_subquery(roles)
-      spaces_for_roles_subquery(roles).select(:guid)
-    end
-
-    def spaces_for_roles_subquery(roles)
-      space_ids = space_ids_for_space_roles(roles)
-      org_ids = org_ids_for_org_roles(roles)
-      Space.where(id: space_ids).or(organization_id: org_ids).select(:id, :guid)
+    def member_org_ids(roles)
+      org_role_subqueries(roles).reduce do |query, subquery|
+        query.union(subquery, from_self: false)
+      end&.select_map(:organization_id)
     end
 
     private
 
-    def space_roles(roles)
-      Array(roles) & SPACE_ROLES
+    def role_applies_to_space?(roles, space_id)
+      return false unless space_id && space_role_sufficient?(roles)
+
+      member_space_ids(roles).include?(space_id)
     end
 
-    def org_roles(roles)
-      Array(roles) & ORG_ROLES
+    def role_applies_to_org?(roles, org_id)
+      return false unless org_id && org_role_sufficient?(roles)
+
+      member_org_ids(roles).include?(org_id)
     end
 
-    def space_role?(roles)
-      space_roles(roles).any?
+    def roles_filter(roles, filter)
+      Array(roles).intersection(filter)
     end
 
-    def org_role?(roles)
-      org_roles(roles).any?
+    def space_role_sufficient?(roles)
+      roles_filter(roles, SPACE_ROLES).any?
     end
 
-    def space_ids_for_space_roles(roles)
-      if space_role?(roles)
-        SpaceRole.where(type: space_roles(roles), user_id: @user.id).select(:space_id)
-      end
+    def org_role_sufficient?(roles)
+      roles_filter(roles, ORG_ROLES).any?
     end
 
-    def org_ids_for_org_roles(roles)
-      if org_role?(roles)
-        OrganizationRole.where(type: org_roles(roles), user_id: @user.id).select(:organization_id)
-      end
+    def space_role_subqueries(roles)
+      roles_filter(roles, SPACE_ROLES).map do |space_role|
+        case space_role
+        when SPACE_DEVELOPER
+          SpaceDeveloper.select(:space_id).where(user_id: @user.id)
+        when SPACE_MANAGER
+          SpaceManager.select(:space_id).where(user_id: @user.id)
+        when SPACE_AUDITOR
+          SpaceAuditor.select(:space_id).where(user_id: @user.id)
+        when SPACE_SUPPORTER
+          SpaceSupporter.select(:space_id).where(user_id: @user.id)
+        end
+      end.compact
+    end
+
+    def org_role_subqueries(roles)
+      roles_filter(roles, ORG_ROLES).map do |org_role|
+        case org_role
+        when ORG_MANAGER
+          OrganizationManager.where(user_id: @user.id).select(:organization_id)
+        when ORG_AUDITOR
+          OrganizationAuditor.where(user_id: @user.id).select(:organization_id)
+        when ORG_BILLING_MANAGER
+          OrganizationBillingManager.where(user_id: @user.id).select(:organization_id)
+        when ORG_USER
+          OrganizationUser.where(user_id: @user.id).select(:organization_id)
+        end
+      end.compact
     end
   end
 end

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -101,7 +101,7 @@ class VCAP::CloudController::Permissions
     if can_read_globally?
       raise 'must not be called for users that can read globally'
     else
-      membership.org_guids_for_roles_subquery(ROLES_FOR_ORG_READING)
+      membership.authorized_org_guids_subquery(ROLES_FOR_ORG_READING)
     end
   end
 
@@ -109,7 +109,7 @@ class VCAP::CloudController::Permissions
     if can_read_globally?
       VCAP::CloudController::Organization.select(:id, :guid)
     else
-      membership.orgs_for_roles_subquery(ROLES_FOR_ORG_READING)
+      membership.authorized_orgs_subquery(ROLES_FOR_ORG_READING)
     end
   end
 
@@ -117,18 +117,18 @@ class VCAP::CloudController::Permissions
     if can_read_globally?
       VCAP::CloudController::Organization.select(:guid)
     else
-      membership.org_guids_for_roles_subquery(ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + SPACE_ROLES)
+      membership.authorized_org_guids_subquery(ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + SPACE_ROLES)
     end
   end
 
   def can_read_from_org?(org_id)
-    can_read_globally? || membership.has_any_roles?(ROLES_FOR_ORG_READING, nil, org_id)
+    can_read_globally? || membership.role_applies?(ROLES_FOR_ORG_READING, nil, org_id)
   end
 
   def can_write_to_active_org?(org_id)
     return true if can_write_globally?
 
-    membership.has_any_roles?(ROLES_FOR_ORG_WRITING, nil, org_id)
+    membership.role_applies?(ROLES_FOR_ORG_WRITING, nil, org_id)
   end
 
   def is_org_active?(org_id)
@@ -156,43 +156,43 @@ class VCAP::CloudController::Permissions
     if can_read_globally?
       raise 'must not be called for users that can read globally'
     else
-      membership.space_guids_for_roles_subquery(ROLES_FOR_SPACE_READING)
+      membership.authorized_space_guids_subquery(ROLES_FOR_SPACE_READING)
     end
   end
 
   def can_read_from_space?(space_id, org_id)
-    can_read_globally? || membership.has_any_roles?(ROLES_FOR_SPACE_READING, space_id, org_id)
+    can_read_globally? || membership.role_applies?(ROLES_FOR_SPACE_READING, space_id, org_id)
   end
 
   def can_download_droplet?(space_id, org_id)
-    can_read_globally? || membership.has_any_roles?(ROLES_FOR_DROPLET_DOWLOAD, space_id, org_id)
+    can_read_globally? || membership.role_applies?(ROLES_FOR_DROPLET_DOWLOAD, space_id, org_id)
   end
 
   def can_read_secrets_in_space?(space_id, org_id)
     can_read_secrets_globally? ||
-      membership.has_any_roles?(ROLES_FOR_SPACE_SECRETS_READING, space_id, org_id)
+      membership.role_applies?(ROLES_FOR_SPACE_SECRETS_READING, space_id, org_id)
   end
 
   def can_read_services_in_space?(space_id, org_id)
-    can_read_globally? || membership.has_any_roles?(ROLES_FOR_SPACE_SERVICES_READING, space_id, org_id)
+    can_read_globally? || membership.role_applies?(ROLES_FOR_SPACE_SERVICES_READING, space_id, org_id)
   end
 
   def can_write_to_active_space?(space_id)
     return true if can_write_globally?
 
-    membership.has_any_roles?(ROLES_FOR_SPACE_WRITING, space_id)
+    membership.role_applies?(ROLES_FOR_SPACE_WRITING, space_id)
   end
 
   def can_manage_apps_in_active_space?(space_id)
     return true if can_write_globally?
 
-    membership.has_any_roles?(ROLES_FOR_APP_MANAGING, space_id)
+    membership.role_applies?(ROLES_FOR_APP_MANAGING, space_id)
   end
 
   def can_update_active_space?(space_id, org_id)
     return true if can_write_globally?
 
-    membership.has_any_roles?(ROLES_FOR_SPACE_UPDATING, space_id, org_id)
+    membership.role_applies?(ROLES_FOR_SPACE_UPDATING, space_id, org_id)
   end
 
   def can_read_from_isolation_segment?(isolation_segment)
@@ -211,7 +211,7 @@ class VCAP::CloudController::Permissions
     if can_read_secrets_globally?
       VCAP::CloudController::Space.select_map(:guid)
     else
-      membership.space_guids_for_roles(ROLES_FOR_SPACE_SERVICES_READING)
+      membership.authorized_space_guids(ROLES_FOR_SPACE_SERVICES_READING)
     end
   end
 
@@ -223,7 +223,7 @@ class VCAP::CloudController::Permissions
     if can_read_globally?
       VCAP::CloudController::Space.select(:id, :guid)
     else
-      membership.spaces_for_roles_subquery(SPACE_ROLES)
+      membership.authorized_spaces_subquery(SPACE_ROLES)
     end
   end
 
@@ -239,12 +239,12 @@ class VCAP::CloudController::Permissions
 
   def can_read_app_environment_variables?(space_id, org_id)
     can_read_secrets_globally? ||
-      membership.has_any_roles?(ROLES_FOR_APP_ENVIRONMENT_VARIABLES_READING, space_id, org_id)
+      membership.role_applies?(ROLES_FOR_APP_ENVIRONMENT_VARIABLES_READING, space_id, org_id)
   end
 
   def can_read_system_environment_variables?(space_id, org_id)
     can_read_secrets_globally? ||
-      membership.has_any_roles?(ROLES_FOR_SPACE_SECRETS_READING, space_id, org_id)
+      membership.role_applies?(ROLES_FOR_SPACE_SECRETS_READING, space_id, org_id)
   end
 
   def readable_app_guids
@@ -270,8 +270,8 @@ class VCAP::CloudController::Permissions
   def readable_event_dataset
     return VCAP::CloudController::Event.dataset if can_read_globally?
 
-    spaces_with_permitted_roles = membership.space_guids_for_roles(SPACE_ROLES_FOR_EVENTS)
-    orgs_with_permitted_roles = membership.org_guids_for_roles(VCAP::CloudController::Membership::ORG_AUDITOR)
+    spaces_with_permitted_roles = membership.authorized_space_guids(SPACE_ROLES_FOR_EVENTS)
+    orgs_with_permitted_roles = membership.authorized_org_guids(VCAP::CloudController::Membership::ORG_AUDITOR)
     VCAP::CloudController::Event.dataset.filter(Sequel.or([
       [:space_guid, spaces_with_permitted_roles],
       [:organization_guid, orgs_with_permitted_roles]

--- a/spec/unit/lib/cloud_controller/membership_spec.rb
+++ b/spec/unit/lib/cloud_controller/membership_spec.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
 
     let(:membership) { Membership.new(user) }
 
-    describe '#has_any_roles?' do
+    describe '#role_applies?' do
       context 'when space roles are provided' do
         before do
           organization.add_user(user)
@@ -21,7 +21,7 @@ module VCAP::CloudController
             end
 
             it 'returns true' do
-              result = membership.has_any_roles?(Membership::SPACE_DEVELOPER, space.id)
+              result = membership.role_applies?(Membership::SPACE_DEVELOPER, space.id)
               expect(result).to be_truthy
             end
           end
@@ -32,7 +32,31 @@ module VCAP::CloudController
             end
 
             it 'returns false' do
-              result = membership.has_any_roles?(Membership::SPACE_DEVELOPER, space.id)
+              result = membership.role_applies?(Membership::SPACE_DEVELOPER, space.id)
+              expect(result).to be_falsey
+            end
+          end
+        end
+
+        describe 'SPACE_SUPPORTER' do
+          context 'when the user has the role' do
+            before do
+              space.add_supporter(user)
+            end
+
+            it 'returns true' do
+              result = membership.role_applies?(Membership::SPACE_SUPPORTER, space.id)
+              expect(result).to be_truthy
+            end
+          end
+
+          context 'when the user does not have the role' do
+            before do
+              space.remove_supporter(user)
+            end
+
+            it 'returns false' do
+              result = membership.role_applies?(Membership::SPACE_SUPPORTER, space.id)
               expect(result).to be_falsey
             end
           end
@@ -45,7 +69,7 @@ module VCAP::CloudController
             end
 
             it 'returns true' do
-              result = membership.has_any_roles?(Membership::SPACE_MANAGER, space.id)
+              result = membership.role_applies?(Membership::SPACE_MANAGER, space.id)
               expect(result).to be_truthy
             end
           end
@@ -56,7 +80,7 @@ module VCAP::CloudController
             end
 
             it 'returns false' do
-              result = membership.has_any_roles?(Membership::SPACE_MANAGER, space.id)
+              result = membership.role_applies?(Membership::SPACE_MANAGER, space.id)
               expect(result).to be_falsey
             end
           end
@@ -69,7 +93,7 @@ module VCAP::CloudController
             end
 
             it 'returns true' do
-              result = membership.has_any_roles?(Membership::SPACE_AUDITOR, space.id)
+              result = membership.role_applies?(Membership::SPACE_AUDITOR, space.id)
               expect(result).to be_truthy
             end
           end
@@ -80,7 +104,7 @@ module VCAP::CloudController
             end
 
             it 'returns false' do
-              result = membership.has_any_roles?(Membership::SPACE_AUDITOR, space.id)
+              result = membership.role_applies?(Membership::SPACE_AUDITOR, space.id)
               expect(result).to be_falsey
             end
           end
@@ -94,7 +118,7 @@ module VCAP::CloudController
           end
 
           it 'returns true' do
-            result = membership.has_any_roles?([
+            result = membership.role_applies?([
               Membership::SPACE_MANAGER,
               Membership::SPACE_DEVELOPER,
               Membership::SPACE_AUDITOR], space.id)
@@ -111,7 +135,7 @@ module VCAP::CloudController
           end
 
           it 'returns false' do
-            result = membership.has_any_roles?([
+            result = membership.role_applies?([
               Membership::SPACE_MANAGER,
               Membership::SPACE_DEVELOPER,
               Membership::SPACE_AUDITOR], space.id)
@@ -122,7 +146,7 @@ module VCAP::CloudController
 
         context 'when the space id is nil' do
           it 'returns false' do
-            result = membership.has_any_roles?(Membership::SPACE_DEVELOPER)
+            result = membership.role_applies?(Membership::SPACE_DEVELOPER)
             expect(result).to be_falsey
           end
         end
@@ -138,7 +162,7 @@ module VCAP::CloudController
           end
 
           it 'returns true' do
-            result = membership.has_any_roles?([
+            result = membership.role_applies?([
               Membership::SPACE_DEVELOPER,
               Membership::SPACE_MANAGER,
               Membership::SPACE_AUDITOR],
@@ -164,7 +188,7 @@ module VCAP::CloudController
             end
 
             it 'returns true' do
-              result = membership.has_any_roles?(Membership::ORG_USER, nil, organization.id)
+              result = membership.role_applies?(Membership::ORG_USER, nil, organization.id)
               expect(result).to be_truthy
             end
           end
@@ -175,7 +199,7 @@ module VCAP::CloudController
             end
 
             it 'returns false' do
-              result = membership.has_any_roles?(Membership::ORG_USER, nil, organization.id)
+              result = membership.role_applies?(Membership::ORG_USER, nil, organization.id)
               expect(result).to be_falsey
             end
           end
@@ -188,7 +212,7 @@ module VCAP::CloudController
             end
 
             it 'returns true' do
-              result = membership.has_any_roles?(Membership::ORG_MANAGER, nil, organization.id)
+              result = membership.role_applies?(Membership::ORG_MANAGER, nil, organization.id)
               expect(result).to be_truthy
             end
           end
@@ -199,7 +223,7 @@ module VCAP::CloudController
             end
 
             it 'returns false' do
-              result = membership.has_any_roles?(Membership::ORG_MANAGER, nil, organization.id)
+              result = membership.role_applies?(Membership::ORG_MANAGER, nil, organization.id)
               expect(result).to be_falsey
             end
           end
@@ -212,7 +236,7 @@ module VCAP::CloudController
             end
 
             it 'returns true' do
-              result = membership.has_any_roles?(Membership::ORG_AUDITOR, nil, organization.id)
+              result = membership.role_applies?(Membership::ORG_AUDITOR, nil, organization.id)
               expect(result).to be_truthy
             end
           end
@@ -223,7 +247,7 @@ module VCAP::CloudController
             end
 
             it 'returns false' do
-              result = membership.has_any_roles?(Membership::ORG_AUDITOR, nil, organization.id)
+              result = membership.role_applies?(Membership::ORG_AUDITOR, nil, organization.id)
               expect(result).to be_falsey
             end
           end
@@ -236,7 +260,7 @@ module VCAP::CloudController
             end
 
             it 'returns true' do
-              result = membership.has_any_roles?(Membership::ORG_BILLING_MANAGER, nil, organization.id)
+              result = membership.role_applies?(Membership::ORG_BILLING_MANAGER, nil, organization.id)
               expect(result).to be_truthy
             end
           end
@@ -247,7 +271,7 @@ module VCAP::CloudController
             end
 
             it 'returns false' do
-              result = membership.has_any_roles?(Membership::ORG_BILLING_MANAGER, nil, organization.id)
+              result = membership.role_applies?(Membership::ORG_BILLING_MANAGER, nil, organization.id)
               expect(result).to be_falsey
             end
           end
@@ -261,7 +285,7 @@ module VCAP::CloudController
           end
 
           it 'returns true' do
-            result = membership.has_any_roles?([
+            result = membership.role_applies?([
               Membership::ORG_MANAGER,
               Membership::ORG_BILLING_MANAGER,
               Membership::ORG_AUDITOR], nil, organization.id)
@@ -278,7 +302,7 @@ module VCAP::CloudController
           end
 
           it 'returns false' do
-            result = membership.has_any_roles?([
+            result = membership.role_applies?([
               Membership::ORG_MANAGER,
               Membership::ORG_BILLING_MANAGER,
               Membership::ORG_AUDITOR], nil, organization.id)
@@ -293,7 +317,7 @@ module VCAP::CloudController
           end
 
           it 'returns false' do
-            result = membership.has_any_roles?(Membership::ORG_USER, space.id, nil)
+            result = membership.role_applies?(Membership::ORG_USER, space.id, nil)
             expect(result).to be_falsey
           end
         end
@@ -310,7 +334,7 @@ module VCAP::CloudController
           end
 
           it 'returns true' do
-            result = membership.has_any_roles?([
+            result = membership.role_applies?([
               Membership::ORG_USER,
               Membership::ORG_MANAGER,
               Membership::ORG_AUDITOR,
@@ -335,7 +359,7 @@ module VCAP::CloudController
           end
 
           it 'returns true' do
-            result = membership.has_any_roles?([
+            result = membership.role_applies?([
               Membership::ORG_MANAGER,
               Membership::SPACE_MANAGER,
               Membership::SPACE_DEVELOPER,
@@ -356,7 +380,7 @@ module VCAP::CloudController
           end
 
           it 'returns false' do
-            result = membership.has_any_roles?([
+            result = membership.role_applies?([
               Membership::ORG_MANAGER,
               Membership::SPACE_MANAGER,
               Membership::SPACE_DEVELOPER,
@@ -370,12 +394,12 @@ module VCAP::CloudController
       end
     end
 
-    describe '#org_guids_for_roles' do
+    describe '#authorized_org_guids' do
       context 'when the user has a role in the organization' do
         context 'for org users' do
           it 'returns all orgs in which the user is a member' do
             organization.add_user(user)
-            guids = membership.org_guids_for_roles(Membership::ORG_USER)
+            guids = membership.authorized_org_guids(Membership::ORG_USER)
             expect(guids).to eq([organization.guid])
           end
         end
@@ -383,7 +407,7 @@ module VCAP::CloudController
         context 'for org auditors' do
           it 'returns all orgs in which the user is an auditor' do
             organization.add_auditor(user)
-            guids = membership.org_guids_for_roles(Membership::ORG_AUDITOR)
+            guids = membership.authorized_org_guids(Membership::ORG_AUDITOR)
             expect(guids).to eq([organization.guid])
           end
         end
@@ -391,7 +415,7 @@ module VCAP::CloudController
         context 'for org managers' do
           it 'returns all orgs in which the user is a manager' do
             organization.add_manager(user)
-            guids = membership.org_guids_for_roles(Membership::ORG_MANAGER)
+            guids = membership.authorized_org_guids(Membership::ORG_MANAGER)
             expect(guids).to eq([organization.guid])
           end
         end
@@ -399,7 +423,7 @@ module VCAP::CloudController
         context 'for org billing managers' do
           it 'returns all orgs in which the user is a billing manager' do
             organization.add_billing_manager(user)
-            guids = membership.org_guids_for_roles(Membership::ORG_BILLING_MANAGER)
+            guids = membership.authorized_org_guids(Membership::ORG_BILLING_MANAGER)
             expect(guids).to eq([organization.guid])
           end
         end
@@ -407,7 +431,7 @@ module VCAP::CloudController
         context 'for space managers' do
           it 'returns all orgs for spaces in which the user is a space manager' do
             SpaceManager.create(user: user, space: space)
-            guids = membership.org_guids_for_roles(Membership::SPACE_MANAGER)
+            guids = membership.authorized_org_guids(Membership::SPACE_MANAGER)
             expect(guids).to eq([organization.guid])
           end
         end
@@ -415,7 +439,7 @@ module VCAP::CloudController
         context 'for space developers' do
           it 'returns all orgs for spaces in which the user is a space developer' do
             SpaceDeveloper.create(user: user, space: space)
-            guids = membership.org_guids_for_roles(Membership::SPACE_DEVELOPER)
+            guids = membership.authorized_org_guids(Membership::SPACE_DEVELOPER)
             expect(guids).to eq([organization.guid])
           end
         end
@@ -423,7 +447,7 @@ module VCAP::CloudController
         context 'for space supporters' do
           it 'returns all orgs for spaces in which the user is a space supporters' do
             SpaceSupporter.create(user: user, space: space)
-            guids = membership.org_guids_for_roles(Membership::SPACE_SUPPORTER)
+            guids = membership.authorized_org_guids(Membership::SPACE_SUPPORTER)
             expect(guids).to eq([organization.guid])
           end
         end
@@ -431,7 +455,7 @@ module VCAP::CloudController
         context 'for space auditors' do
           it 'returns all orgs for spaces in which the user is a space auditor' do
             SpaceAuditor.create(user: user, space: space)
-            guids = membership.org_guids_for_roles(Membership::SPACE_AUDITOR)
+            guids = membership.authorized_org_guids(Membership::SPACE_AUDITOR)
             expect(guids).to eq([organization.guid])
           end
         end
@@ -441,7 +465,7 @@ module VCAP::CloudController
             organization.add_auditor(user)
             organization.add_billing_manager(user)
 
-            guids = membership.org_guids_for_roles([Membership::ORG_BILLING_MANAGER, Membership::ORG_AUDITOR])
+            guids = membership.authorized_org_guids([Membership::ORG_BILLING_MANAGER, Membership::ORG_AUDITOR])
 
             expect(guids).to eq([organization.guid])
           end
@@ -450,16 +474,16 @@ module VCAP::CloudController
 
       context 'when the user has no role in any organization' do
         it 'should return an empty list' do
-          guids = membership.org_guids_for_roles([Membership::ORG_USER,
-                                                  Membership::ORG_AUDITOR,
-                                                  Membership::ORG_BILLING_MANAGER,
-                                                  Membership::ORG_MANAGER])
+          guids = membership.authorized_org_guids([Membership::ORG_USER,
+                                                   Membership::ORG_AUDITOR,
+                                                   Membership::ORG_BILLING_MANAGER,
+                                                   Membership::ORG_MANAGER])
           expect(guids).to be_empty
         end
       end
     end
 
-    describe '#space_guids_for_roles' do
+    describe '#authorized_space_guids' do
       let(:user) { User.make }
 
       before do
@@ -472,7 +496,7 @@ module VCAP::CloudController
         end
 
         it 'returns all spaces in which the user develops' do
-          guids = membership.space_guids_for_roles(Membership::SPACE_DEVELOPER)
+          guids = membership.authorized_space_guids(Membership::SPACE_DEVELOPER)
 
           expect(guids).to eq([space.guid])
         end
@@ -484,7 +508,7 @@ module VCAP::CloudController
         end
 
         it 'returns all spaces that the user managers' do
-          guids = membership.space_guids_for_roles(Membership::SPACE_MANAGER)
+          guids = membership.authorized_space_guids(Membership::SPACE_MANAGER)
 
           expect(guids).to eq([space.guid])
         end
@@ -496,7 +520,7 @@ module VCAP::CloudController
         end
 
         it 'returns all spaces that the user audits' do
-          guids = membership.space_guids_for_roles(Membership::SPACE_AUDITOR)
+          guids = membership.authorized_space_guids(Membership::SPACE_AUDITOR)
 
           expect(guids).to eq([space.guid])
         end
@@ -508,7 +532,7 @@ module VCAP::CloudController
         end
 
         it 'returns all spaces in which the user supports applications' do
-          guids = membership.space_guids_for_roles(Membership::SPACE_SUPPORTER)
+          guids = membership.authorized_space_guids(Membership::SPACE_SUPPORTER)
 
           expect(guids).to eq([space.guid])
         end
@@ -516,7 +540,7 @@ module VCAP::CloudController
 
       context 'org user' do
         it 'returns all spaces that the user is in the org' do
-          guids = membership.space_guids_for_roles(Membership::ORG_USER)
+          guids = membership.authorized_space_guids(Membership::ORG_USER)
 
           expect(guids).to eq([space.guid])
         end
@@ -528,7 +552,7 @@ module VCAP::CloudController
         end
 
         it 'returns all spaces that the user org manages' do
-          guids = membership.space_guids_for_roles(Membership::ORG_MANAGER)
+          guids = membership.authorized_space_guids(Membership::ORG_MANAGER)
 
           expect(guids).to eq([space.guid])
         end
@@ -540,7 +564,7 @@ module VCAP::CloudController
         end
 
         it 'returns all spaces that the user org billing manages' do
-          guids = membership.space_guids_for_roles(Membership::ORG_BILLING_MANAGER)
+          guids = membership.authorized_space_guids(Membership::ORG_BILLING_MANAGER)
 
           expect(guids).to eq([space.guid])
         end
@@ -552,7 +576,7 @@ module VCAP::CloudController
         end
 
         it 'returns all spaces that the user org audits' do
-          guids = membership.space_guids_for_roles(Membership::ORG_AUDITOR)
+          guids = membership.authorized_space_guids(Membership::ORG_AUDITOR)
 
           expect(guids).to eq([space.guid])
         end
@@ -574,7 +598,7 @@ module VCAP::CloudController
         end
 
         it 'returns the correct space guids without duplicates' do
-          guids = membership.space_guids_for_roles([Membership::ORG_MANAGER, Membership::SPACE_DEVELOPER, Membership::SPACE_AUDITOR])
+          guids = membership.authorized_space_guids([Membership::ORG_MANAGER, Membership::SPACE_DEVELOPER, Membership::SPACE_AUDITOR])
 
           expect(guids).to contain_exactly(space1_in_managed_org.guid, space2_in_managed_org.guid, space.guid)
         end

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -137,7 +137,7 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         subquery = instance_double(Sequel::Dataset)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(membership).to receive(:org_guids_for_roles_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
+        expect(membership).to receive(:authorized_org_guids_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
         expect(subquery).to receive(:select_map).and_return(org_guid_records)
         expect(permissions.readable_org_guids).to eq([guid1, guid2])
       end
@@ -148,7 +148,7 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         subquery = instance_double(Sequel::Dataset)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(membership).to receive(:org_guids_for_roles_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
+        expect(membership).to receive(:authorized_org_guids_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
         expect(permissions.readable_org_guids_query).to be(subquery)
       end
     end
@@ -158,7 +158,7 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         subquery = instance_double(Sequel::Dataset)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(membership).to receive(:orgs_for_roles_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
+        expect(membership).to receive(:authorized_orgs_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
         expect(permissions.readable_orgs_query).to be(subquery)
       end
     end
@@ -172,14 +172,14 @@ module VCAP::CloudController
         let(:second_org_guid) { double(:second_org_guid) }
 
         before do
-          allow(membership).to receive(:org_guids_for_roles_subquery).
+          allow(membership).to receive(:authorized_org_guids_subquery).
             with(Permissions::ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + Permissions::SPACE_ROLES).
             and_return(subquery)
           allow(Membership).to receive(:new).with(user).and_return(membership)
         end
 
         it 'combines readable orgs for both org-scoped and space-scoped roles' do
-          allow(membership).to receive(:space_guids_for_roles).
+          allow(membership).to receive(:authorized_space_guids).
             with(Permissions::SPACE_ROLES).
             and_return([space_guid])
 
@@ -372,7 +372,7 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         subquery = instance_double(Sequel::Dataset)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(membership).to receive(:space_guids_for_roles_subquery).with(Permissions::ROLES_FOR_SPACE_READING).and_return(subquery)
+        expect(membership).to receive(:authorized_space_guids_subquery).with(Permissions::ROLES_FOR_SPACE_READING).and_return(subquery)
         expect(subquery).to receive(:select_map).and_return(space_guid_records)
         expect(permissions.readable_space_guids).to eq([guid1, guid2])
       end
@@ -383,7 +383,7 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         subquery = instance_double(Sequel::Dataset)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(membership).to receive(:space_guids_for_roles_subquery).with(Permissions::ROLES_FOR_SPACE_READING).and_return(subquery)
+        expect(membership).to receive(:authorized_space_guids_subquery).with(Permissions::ROLES_FOR_SPACE_READING).and_return(subquery)
         expect(permissions.readable_space_guids_query).to be(subquery)
       end
     end
@@ -517,7 +517,7 @@ module VCAP::CloudController
         membership = instance_double(Membership)
         subquery = instance_double(Sequel::Dataset)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(membership).to receive(:spaces_for_roles_subquery).with(Permissions::SPACE_ROLES).and_return(subquery)
+        expect(membership).to receive(:authorized_spaces_subquery).with(Permissions::SPACE_ROLES).and_return(subquery)
         expect(permissions.readable_space_scoped_spaces_query).to be(subquery)
       end
     end
@@ -728,10 +728,10 @@ module VCAP::CloudController
       it 'returns event datasets from space membership' do
         membership = instance_double(Membership)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(membership).to receive(:space_guids_for_roles).
+        expect(membership).to receive(:authorized_space_guids).
           with(Permissions::SPACE_ROLES_FOR_EVENTS).
           and_return([space_guid])
-        expect(membership).to receive(:org_guids_for_roles).with(Membership::ORG_AUDITOR).and_return([])
+        expect(membership).to receive(:authorized_org_guids).with(Membership::ORG_AUDITOR).and_return([])
         event_guids = Permissions.new(user).readable_event_dataset.map(&:guid)
 
         expect(event_guids).to contain_exactly(space_scoped_event.guid)
@@ -740,10 +740,10 @@ module VCAP::CloudController
       it 'returns event datasets from org membership' do
         membership = instance_double(Membership)
         expect(Membership).to receive(:new).with(user).and_return(membership)
-        expect(membership).to receive(:space_guids_for_roles).
+        expect(membership).to receive(:authorized_space_guids).
           with(Permissions::SPACE_ROLES_FOR_EVENTS).
           and_return([])
-        expect(membership).to receive(:org_guids_for_roles).with(Membership::ORG_AUDITOR).and_return(org_guid)
+        expect(membership).to receive(:authorized_org_guids).with(Membership::ORG_AUDITOR).and_return(org_guid)
         event_guids = Permissions.new(user).readable_event_dataset.map(&:guid)
 
         expect(event_guids).to contain_exactly(org_scoped_event.guid)

--- a/spec/unit/models/runtime/user_spec.rb
+++ b/spec/unit/models/runtime/user_spec.rb
@@ -492,7 +492,7 @@ module VCAP::CloudController
       end
     end
 
-    describe '#visible_users_in_my_orgs' do
+    describe '#visible_user_ids_in_my_orgs' do
       let(:user_organization) { Organization.make }
       let(:manager_organization) { Organization.make }
       let(:auditor_organization) { Organization.make }
@@ -525,9 +525,9 @@ module VCAP::CloudController
         auditor_organization.add_auditor(org_auditor)
         billing_manager_organization.add_billing_manager(org_billing_manager)
 
-        user_result = user.visible_users_in_my_orgs
+        user_result = user.visible_user_ids_in_my_orgs
         expect(user_result).to match_array([user.id, other_user1.id])
-        manager_result = org_manager.visible_users_in_my_orgs
+        manager_result = org_manager.visible_user_ids_in_my_orgs
         expect(manager_result).to match_array(
           [
             org_manager.id,
@@ -535,14 +535,14 @@ module VCAP::CloudController
             other_user2.id,
           ],
         )
-        auditor_result = org_auditor.visible_users_in_my_orgs
+        auditor_result = org_auditor.visible_user_ids_in_my_orgs
         expect(auditor_result).to match_array(
           [
             org_auditor.id,
             other_user3.id,
           ],
         )
-        billing_manager_result = org_billing_manager.visible_users_in_my_orgs
+        billing_manager_result = org_billing_manager.visible_user_ids_in_my_orgs
         expect(billing_manager_result).to match_array(
           [
             org_billing_manager.id,

--- a/spec/unit/models/runtime/user_spec.rb
+++ b/spec/unit/models/runtime/user_spec.rb
@@ -514,7 +514,7 @@ module VCAP::CloudController
         outside_organization.add_billing_manager(outside_other_user)
       end
 
-      it 'returns a list of users in orgs that the user is a member of' do
+      it 'returns a list of ids for users in the same orgs that the user is a member of' do
         user = User.make
         org_manager = User.make
         org_auditor = User.make
@@ -525,9 +525,9 @@ module VCAP::CloudController
         auditor_organization.add_auditor(org_auditor)
         billing_manager_organization.add_billing_manager(org_billing_manager)
 
-        user_result = user.visible_users_in_my_orgs.select_map(:id)
+        user_result = user.visible_users_in_my_orgs
         expect(user_result).to match_array([user.id, other_user1.id])
-        manager_result = org_manager.visible_users_in_my_orgs.select_map(:id)
+        manager_result = org_manager.visible_users_in_my_orgs
         expect(manager_result).to match_array(
           [
             org_manager.id,
@@ -535,14 +535,14 @@ module VCAP::CloudController
             other_user2.id,
           ],
         )
-        auditor_result = org_auditor.visible_users_in_my_orgs.select_map(:id)
+        auditor_result = org_auditor.visible_users_in_my_orgs
         expect(auditor_result).to match_array(
           [
             org_auditor.id,
             other_user3.id,
           ],
         )
-        billing_manager_result = org_billing_manager.visible_users_in_my_orgs.select_map(:id)
+        billing_manager_result = org_billing_manager.visible_users_in_my_orgs
         expect(billing_manager_result).to match_array(
           [
             org_billing_manager.id,


### PR DESCRIPTION
* **A short explanation of the proposed change:**

Reduces the complexity of queries checking for user permissions and resource visibility, in particular by removing unnecessary table unions and joins, and by making greater use of role tables when retrieving space and organization ids.

This includes a reversal of changes to `membership.rb` introduced by #2502, which has resulted in inefficient unions of role tables that are unnecessary for most requests. Where an endpoint is authorized only for, say, space developers and org managers, our existing logic will union all eight role tables. This PR reverts to making a union only of the tables for roles that are actually authorized for the specific endpoint being hit.

* **An explanation of the use cases your change solves**

n/a

* **Links to any other associated PRs**

n/a

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
  *_Run against the following cf-acceptance-test suites with the PR branch swapped into CAPI 1.140.0: apps, container_networking, detect, docker, internet_dependent, routing, service_instance_sharing, services, ssh, sso, tasks, v3_