### PR TITLE
Misc db optimizations

### DIFF
--- a/app/actions/process_create.rb
+++ b/app/actions/process_create.rb
@@ -26,9 +26,7 @@ module VCAP::CloudController
       app.class.db.transaction do
         process = app.add_process(attrs)
         route_mappings = process.route_mappings
-        if route_mappings.count > 0
-          process.update(ports: route_mappings.map(&:app_port))
-        end
+        process.update(ports: route_mappings.map(&:app_port)) unless route_mappings.empty?
         Repositories::ProcessEventRepository.record_create(process, @user_audit_info, manifest_triggered: @manifest_triggered)
       end
 

--- a/app/actions/process_create_from_app_droplet.rb
+++ b/app/actions/process_create_from_app_droplet.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController
     end
 
     def create_process(app, type)
-      if app.processes_dataset.where(type: type).count == 0
+      if app.processes_dataset.where(type: type).empty?
         ProcessCreate.new(@user_audit_info).create(app, { type: type })
       end
     end

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -541,7 +541,7 @@ module VCAP::CloudController
     end
 
     def plan_visible_to_org?(organization, service_plan)
-      ServicePlan.organization_visible(organization).filter(guid: service_plan.guid).count > 0
+      !ServicePlan.organization_visible(organization).filter(guid: service_plan.guid).empty?
     end
 
     def has_routes?(service_instance)

--- a/app/controllers/services/validators/service_update_validator.rb
+++ b/app/controllers/services/validators/service_update_validator.rb
@@ -22,7 +22,7 @@ module VCAP::CloudController
         return unless parameters
         return if SecurityContext.admin?
 
-        if ServicePlan.user_visible(SecurityContext.current_user).filter(guid: service_instance.service_plan.guid).count == 0
+        if ServicePlan.user_visible(SecurityContext.current_user).filter(guid: service_instance.service_plan.guid).empty?
           raise CloudController::Errors::ApiError.new_from_details('ServiceInstanceWithInaccessiblePlanNotUpdateable', 'parameters')
         end
       end

--- a/app/controllers/services/validators/service_update_validator.rb
+++ b/app/controllers/services/validators/service_update_validator.rb
@@ -89,7 +89,7 @@ module VCAP::CloudController
       end
 
       def plan_in_different_service?(service_plan, service)
-        service_plan.service.guid != service.guid
+        service_plan.service_guid != service.guid
       end
 
       def plan_update_requested?(requested_plan_guid, old_plan)

--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -225,7 +225,7 @@ class ServiceCredentialBindingsController < ApplicationController
     TelemetryLogger.v3_emit(
       'bind-service',
       {
-        'service-id' =>  binding.service_instance.managed_instance? ? binding.service_instance.service_plan.service.guid : 'user-provided',
+        'service-id' =>  binding.service_instance.managed_instance? ? binding.service_instance.service_plan.service_guid : 'user-provided',
         'service-instance-id' => binding.service_instance.guid,
         'app-id' => binding.app_guid,
         'user-id' => user_audit_info.user_guid,

--- a/app/decorators/field_service_instance_plan_decorator.rb
+++ b/app/decorators/field_service_instance_plan_decorator.rb
@@ -27,7 +27,7 @@ module VCAP::CloudController
           plan_view[:relationships] = {
             service_offering: {
               data: {
-                guid: plan.service.guid
+                guid: plan.service_guid
               }
             }
           }

--- a/app/fetchers/log_access_fetcher.rb
+++ b/app/fetchers/log_access_fetcher.rb
@@ -1,14 +1,14 @@
 module VCAP::CloudController
   class LogAccessFetcher
     def app_exists?(guid)
-      AppModel.where(guid: guid).count > 0 ||
-        ProcessModel.where(guid: guid).count > 0
+      !AppModel.where(guid: guid).empty? ||
+        !ProcessModel.where(guid: guid).empty?
     end
 
     def app_exists_by_space?(guid, space_guids)
-      AppModel.where(guid: guid, space_guid: space_guids).count > 0 ||
-        ProcessModel.join(:apps, guid: :app_guid).
-          where(processes__guid: guid, apps__space_guid: space_guids).count > 0
+      !AppModel.where(guid: guid, space_guid: space_guids).empty? ||
+        !ProcessModel.join(:apps, guid: :app_guid).
+          where(processes__guid: guid, apps__space_guid: space_guids).empty?
     end
   end
 end

--- a/app/models/runtime/domain.rb
+++ b/app/models/runtime/domain.rb
@@ -190,7 +190,7 @@ module VCAP::CloudController
     end
 
     def matching_route(route_domain, route_host)
-      Route.dataset.filter(host: route_host, domain: route_domain).count > 0
+      !Route.dataset.filter(host: route_host, domain: route_domain).empty?
     end
   end
 end

--- a/app/models/runtime/organization.rb
+++ b/app/models/runtime/organization.rb
@@ -271,7 +271,7 @@ module VCAP::CloudController
     end
 
     def has_user?(user)
-      user.present? && users_dataset.where(user_id: user.id).present?
+      user.present? && !users_dataset.where(user_id: user.id).empty?
     end
 
     def default_domain

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -200,11 +200,11 @@ module VCAP::CloudController
     end
 
     def has_developer?(user)
-      user.present? && developers_dataset.where(user_id: user.id).present?
+      user.present? && !SpaceDeveloper.where(space_id: id, user_id: user.id).empty?
     end
 
     def has_supporter?(user)
-      user.present? && supporters_dataset.where(user_id: user.id).present?
+      user.present? && !SpaceSupporter.where(space_id: id, user_id: user.id).empty?
     end
 
     def has_member?(user)
@@ -331,11 +331,11 @@ module VCAP::CloudController
     private
 
     def has_manager?(user)
-      user.present? && managers_dataset.where(user_id: user.id).present?
+      user.present? && !SpaceManager.where(space_id: id, user_id: user.id).empty?
     end
 
     def has_auditor?(user)
-      user.present? && auditors_dataset.where(user_id: user.id).present?
+      user.present? && !SpaceAuditor.where(space_id: id, user_id: user.id).empty?
     end
 
     def memory_remaining

--- a/app/presenters/v3/service_plan_presenter.rb
+++ b/app/presenters/v3/service_plan_presenter.rb
@@ -120,7 +120,7 @@ module VCAP::CloudController
           relationships = {
             service_offering: {
               data: {
-                guid: service_plan.service.guid
+                guid: service_plan.service_guid
               }
             }
           }
@@ -138,7 +138,7 @@ module VCAP::CloudController
               href: url_builder.build_url(path: "/v3/service_plans/#{service_plan.guid}")
             },
             service_offering: {
-              href: url_builder.build_url(path: "/v3/service_offerings/#{service_plan.service.guid}")
+              href: url_builder.build_url(path: "/v3/service_offerings/#{service_plan.service_guid}")
             },
             visibility: {
               href: url_builder.build_url(path: "/v3/service_plans/#{service_plan.guid}/visibility")

--- a/lib/services/service_brokers/service_manager.rb
+++ b/lib/services/service_brokers/service_manager.rb
@@ -149,7 +149,7 @@ module VCAP::Services::ServiceBrokers
         plan_to_deactivate.active = false
         plan_to_deactivate.save
 
-        deactivated_plans_warning.add(plan_to_deactivate) if plan_to_deactivate.service_instances_dataset.count >= 1
+        deactivated_plans_warning.add(plan_to_deactivate) unless plan_to_deactivate.service_instances_dataset.empty?
       end
 
       @warnings << deactivated_plans_warning.message if deactivated_plans_warning.message
@@ -159,7 +159,7 @@ module VCAP::Services::ServiceBrokers
       plan_ids_in_broker_catalog = catalog.plans.map(&:broker_provided_id)
       plans_in_db_not_in_catalog = catalog.service_broker.service_plans.reject { |p| plan_ids_in_broker_catalog.include?(p.broker_provided_id) }
       plans_in_db_not_in_catalog.each do |plan_to_deactivate|
-        if plan_to_deactivate.service_instances_dataset.count < 1
+        if plan_to_deactivate.service_instances_dataset.empty?
           plan_to_deactivate.destroy
           @services_event_repository.record_service_plan_event(:delete, plan_to_deactivate)
         end
@@ -169,7 +169,7 @@ module VCAP::Services::ServiceBrokers
     def delete_services(catalog)
       services_in_db_not_in_catalog = catalog.service_broker.services_dataset.where(Sequel.lit('unique_id NOT in ?', catalog.services.map(&:broker_provided_id)))
       services_in_db_not_in_catalog.each do |service|
-        if service.service_plans_dataset.count < 1
+        if service.service_plans_dataset.empty?
           service.destroy
           @services_event_repository.record_service_event(:delete, service)
         end


### PR DESCRIPTION
**A short explanation of the proposed change:**

Tiny PR doing two things:
1. Use Sequel's `empty?` to avoid cumbersomely counting all the rows in a table when all we want to know is whether there are _any_ rows.
2. Where we want the guid of a service corresponding to a service_plan, use the latter's `service_guid` column instead of querying the services table.

**An explanation of the use cases your change solves**

n/a - minor optimizations for speed

**Links to any other associated PRs**

n/a

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
