### PR TITLE
Simplify the mother of all queries

### DIFF
--- a/app/models/services/service_plan_visibility.rb
+++ b/app/models/services/service_plan_visibility.rb
@@ -14,13 +14,11 @@ module VCAP::CloudController
     end
 
     def self.visible_private_plan_ids_for_user(user)
-      user.organizations.map { |org|
-        visible_private_plan_ids_for_organization(org)
-      }.flatten.uniq
+      visible_private_plan_ids_for_organization(user.membership_org_ids).distinct
     end
 
-    def self.visible_private_plan_ids_for_organization(organization)
-      organization.service_plan_visibilities.map(&:service_plan_id)
+    def self.visible_private_plan_ids_for_organization(org_id)
+      dataset.where(organization_id: org_id).select(:service_plan_id)
     end
 
     private

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -193,7 +193,7 @@ module VCAP::CloudController
       end
 
       it 'returns plans from private service brokers in all the spaces the user has roles in' do
-        expect(ServicePlan.plan_ids_from_private_brokers(user)).to(match_array([service_plan_1.id, service_plan_2.id]))
+        expect(ServicePlan.plan_ids_from_private_brokers(user).select_map(:service_plans__id)).to(match_array([service_plan_1.id, service_plan_2.id]))
       end
 
       it "doesn't return plans for private services in spaces the user doesn't have roles in" do
@@ -201,7 +201,7 @@ module VCAP::CloudController
         service = Service.make(service_broker: broker)
         plan = ServicePlan.make(service: service, public: false)
 
-        expect(ServicePlan.plan_ids_from_private_brokers(user)).not_to include plan
+        expect(ServicePlan.plan_ids_from_private_brokers(user).select_map(:service_plans__id)).not_to include plan
       end
     end
 
@@ -230,14 +230,14 @@ module VCAP::CloudController
 
         context 'when the service instances are in spaces that the user has a role in' do
           it 'returns all plans regardless of active or public' do
-            expect(ServicePlan.plan_ids_for_visible_service_instances(user)).
+            expect(ServicePlan.plan_ids_for_visible_service_instances(user).select_map(:service_plans__id)).
               to match_array([service_plan.id, non_public_plan.id, inactive_plan.id])
           end
         end
 
         context 'when the service instances are in spaces that the user does NOT have a role in' do
           it 'does not return service plans associated with that service instance' do
-            expect(ServicePlan.plan_ids_for_visible_service_instances(user)).not_to include(other_plan.id)
+            expect(ServicePlan.plan_ids_for_visible_service_instances(user).select_map(:service_plans__id)).not_to include(other_plan.id)
           end
         end
       end

--- a/spec/unit/models/services/service_plan_visibility_spec.rb
+++ b/spec/unit/models/services/service_plan_visibility_spec.rb
@@ -57,7 +57,7 @@ module VCAP::CloudController
       end
 
       it "returns the list of ids for plans the user's orgs can see" do
-        expect(ServicePlanVisibility.visible_private_plan_ids_for_user(user)).to match_array([
+        expect(ServicePlanVisibility.visible_private_plan_ids_for_user(user).select_map(:service_plan_id)).to match_array([
           plan_visible_to_both.id, plan_visible_to_org1.id, plan_visible_to_org2.id
         ])
       end
@@ -73,7 +73,7 @@ module VCAP::CloudController
       end
 
       it "returns the list of ids for plans the user's orgs can see" do
-        expect(ServicePlanVisibility.visible_private_plan_ids_for_organization(organization)).to match_array([visible_plan.id])
+        expect(ServicePlanVisibility.visible_private_plan_ids_for_organization(organization.id).select_map(:service_plan_id)).to match_array([visible_plan.id])
       end
     end
   end


### PR DESCRIPTION
**A short explanation of the proposed change:**

Optimizes the DB queries made when checking user permissions for service plans.

**An explanation of the use cases your change solves**

While playing with Kibana visualizations analyzing a week's worth of logs on one of our larger foundations, I came to the crazy realization that 5.8 billion logs - representing fully _62%_ of all queries and 9% of all querytime - had a single caller: [`app/models/services/service_plan.rb:147`](https://github.com/cloudfoundry/cloud_controller_ng/blob/c9a2ca978fef70cd2c634fc5415f4faaeade8d34/app/models/services/service_plan.rb#L143-L151):

```ruby
def self.plan_ids_for_visible_service_instances(user)
  plan_ids = []
  user.spaces.each do |space|
    space.service_instances.select(&:managed_instance?).each do |service_instance|
      plan_ids << service_instance.service_plan_id
    end
  end
  plan_ids.uniq
end
```

So we retrieve and loop over the user's spaces, and then _for each one_ make a separate query to the `service_instances` table, before looping over those in turn to get their IDs. We average 6,821 queries per vcap request solely on these lines - a rate 45 times higher than the next most prolific caller underneath it. _No me gusta esto_.

This is ultimately called by `user_visibility_for_read` in both the `ServicePlan` and the `Service` models. I _think_ it's only used for calls in v2, which I know we generally don't touch, but even so I reckon the numbers make this a special case that justifies a fix.

Here's a table to illustrate the speed improvement to `self.plan_ids_for_visible_service_instances`, which is now 559x faster. I took a sample request from a foundation with 20k service plans and 200k service instances, and then ran the [new query](https://gist.github.com/will-gant/70e2d9a9e1a1a5300114d457c518c69f) with the same user's id (analysis [here](https://gist.github.com/will-gant/a1f1a8d28dc87fcea757e77af4e25ff4)):

|        | Number of queries | Total querytime(s) |
|:------:|:-----------------:|:------------------:|
| Before | 10621             | 28.446             |
| After  | 1                 | 0.050806           |

**Links to any other associated PRs**

n/a

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
  *_Run against the following cf-acceptance-test suites with the PR branch swapped into CAPI 1.140.0: apps, container_networking, detect, docker, internet_dependent, routing, service_instance_sharing, services, ssh, sso, tasks, v3_
