### PR TITLE
Puma Threads & Local Port

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -248,7 +248,8 @@ module VCAP::CloudController
 
             webserver: String, # thin or puma
             optional(:puma) => {
-              workers: Integer
+              workers: Integer,
+              max_threads: Integer,
             },
 
             install_buildpacks: [

--- a/lib/cloud_controller/runners/puma_runner.rb
+++ b/lib/cloud_controller/runners/puma_runner.rb
@@ -24,7 +24,7 @@ module VCAP::CloudController
         else
           conf.bind "tcp://0.0.0.0:#{config.get(:external_port)}"
         end
-        conf.threads(0, config.get(:puma, :max_threads))
+        conf.threads(0, config.get(:puma, :max_threads)) if config.get(:puma, :max_threads)
         conf.workers config.get(:puma, :workers) if config.get(:puma, :workers)
         conf.app app
         conf.before_fork {

--- a/lib/cloud_controller/runners/puma_runner.rb
+++ b/lib/cloud_controller/runners/puma_runner.rb
@@ -20,7 +20,7 @@ module VCAP::CloudController
           end
         }
         conf.bind "unix://#{config.get(:nginx, :instance_socket)}"
-        conf.threads(0, 5)
+        conf.threads(0, config.get(:puma, :max_threads))
         conf.workers config.get(:puma, :workers) if config.get(:puma, :workers)
         conf.app app
         conf.before_fork {

--- a/lib/cloud_controller/runners/puma_runner.rb
+++ b/lib/cloud_controller/runners/puma_runner.rb
@@ -19,7 +19,11 @@ module VCAP::CloudController
             end
           end
         }
-        conf.bind "unix://#{config.get(:nginx, :instance_socket)}"
+        if config.get(:nginx, :use_nginx)
+          conf.bind "unix://#{config.get(:nginx, :instance_socket)}"
+        else
+          conf.bind "tcp://0.0.0.0:#{config.get(:external_port)}"
+        end
         conf.threads(0, config.get(:puma, :max_threads))
         conf.workers config.get(:puma, :workers) if config.get(:puma, :workers)
         conf.app app

--- a/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
+++ b/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
@@ -5,6 +5,8 @@ module VCAP::CloudController
     let(:valid_config_file_path) { File.join(Paths::CONFIG, 'cloud_controller.yml') }
     let(:config_file) { File.new(valid_config_file_path) }
     let(:unix_socket) { '/path/to/socket' }
+    let(:use_nginx) { true }
+    let(:local_port) { '8181' }
     let(:app) { double(:app, call: nil) }
     let(:periodic_updater) { double(:periodic_updater) }
     let(:logger) { double(:logger) }
@@ -21,6 +23,7 @@ module VCAP::CloudController
       TestConfig.override(
         external_host: 'some_local_ip',
         nginx: {
+          use_nginx:  use_nginx,
           instance_socket: unix_socket
         },
         puma: {
@@ -85,6 +88,17 @@ module VCAP::CloudController
         allow_any_instance_of(Puma::Launcher).to receive(:run).and_raise('we have a problem')
         expect(logger).to receive(:error)
         expect { subject.start! }.to raise_exception('we have a problem')
+      end
+    end
+
+    describe '#start! with local port' do
+      let(:use_nginx) { false }
+
+      it 'binds to the configured local port' do
+        subject.start!
+        puma_launcher = subject.instance_variable_get(:@puma_launcher)
+
+        expect(puma_launcher.config.final_options[:binds]).to include("tcp://0.0.0.0:#{local_port}")
       end
     end
 

--- a/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
+++ b/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
@@ -24,7 +24,8 @@ module VCAP::CloudController
           instance_socket: unix_socket
         },
         puma: {
-          workers: 3
+          workers: 3,
+          max_threads: 4,
         }
       )
       PumaRunner.new(TestConfig.config_instance, app, logger, periodic_updater, request_logs)
@@ -57,7 +58,7 @@ module VCAP::CloudController
         puma_launcher = subject.instance_variable_get(:@puma_launcher)
 
         expect(puma_launcher.config.final_options[:min_threads]).to eq(0)
-        expect(puma_launcher.config.final_options[:max_threads]).to eq(5)
+        expect(puma_launcher.config.final_options[:max_threads]).to eq(4)
         expect(puma_launcher.config.final_options[:workers]).to eq(3)
       end
 


### PR DESCRIPTION
This PR makes the number of Puma threads configurable and allows puma to bind against `external_port` if nginx is not used. This is helpful for local development.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
