### PR TITLE
Remove more inefficient counting

### DIFF
--- a/app/access/base_access.rb
+++ b/app/access/base_access.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
     end
 
     def object_is_visible_to_user?(object, user)
-      object.class.user_visible(user, false).where(guid: object.guid).count > 0
+      object.class.user_visible(user, false).where(guid: object.guid).any?
     end
 
     def admin_user?

--- a/app/access/managed_service_instance_access.rb
+++ b/app/access/managed_service_instance_access.rb
@@ -58,7 +58,7 @@ module VCAP::CloudController
       return true if admin_user?
 
       if service_instance.new? || service_instance.changed_columns.include?(:service_plan_id)
-        return ServicePlan.user_visible(context.user, admin_user?).filter(guid: service_instance.service_plan.guid).count > 0
+        return ServicePlan.user_visible(context.user, admin_user?).filter(guid: service_instance.service_plan.guid).any?
       end
 
       true

--- a/app/access/service_plan_access.rb
+++ b/app/access/service_plan_access.rb
@@ -71,7 +71,7 @@ module VCAP::CloudController
     end
 
     def object_is_visible_to_user?(service_plan, user)
-      VCAP::CloudController::ServicePlan.user_visible(user, false, :read).where(guid: service_plan.guid).count > 0
+      VCAP::CloudController::ServicePlan.user_visible(user, false, :read).where(guid: service_plan.guid).any?
     end
   end
 end

--- a/app/actions/service_offering_delete.rb
+++ b/app/actions/service_offering_delete.rb
@@ -3,7 +3,7 @@ module VCAP::CloudController
     class AssociationNotEmptyError < StandardError; end
 
     def delete(service_offering_model)
-      association_not_empty! unless service_offering_model.service_plans.empty?
+      association_not_empty! unless ServicePlan.where(service_id: service_offering_model.id).empty?
       service_offering_model.destroy
     end
 

--- a/app/actions/service_offering_delete.rb
+++ b/app/actions/service_offering_delete.rb
@@ -3,7 +3,7 @@ module VCAP::CloudController
     class AssociationNotEmptyError < StandardError; end
 
     def delete(service_offering_model)
-      association_not_empty! unless ServicePlan.where(service_id: service_offering_model.id).empty?
+      association_not_empty! if ServicePlan.where(service_id: service_offering_model.id).any?
       service_offering_model.destroy
     end
 

--- a/app/actions/space_delete.rb
+++ b/app/actions/space_delete.rb
@@ -82,7 +82,7 @@ module VCAP::CloudController
     def delete_service_brokers(space_model)
       broker_remover = service_broker_remover(@services_event_repository)
       private_service_brokers = space_model.service_brokers
-      deletable_brokers = private_service_brokers.reject { |broker| broker.service_plans.map(&:service_instances).flatten.any? }
+      deletable_brokers = private_service_brokers.reject { |broker| broker.service_plans.map { |plan| plan.service_instances_dataset.any? }.flatten.any? }
 
       deletable_brokers.each do |broker|
         broker_remover.remove(broker)

--- a/app/actions/space_delete.rb
+++ b/app/actions/space_delete.rb
@@ -82,7 +82,13 @@ module VCAP::CloudController
     def delete_service_brokers(space_model)
       broker_remover = service_broker_remover(@services_event_repository)
       private_service_brokers = space_model.service_brokers
-      deletable_brokers = private_service_brokers.reject { |broker| broker.service_plans.map { |plan| plan.service_instances_dataset.any? }.flatten.any? }
+      deletable_brokers = private_service_brokers.reject do |broker|
+        ServiceInstance.
+          join(:service_plans, id: :service_instances__service_plan_id).
+          join(:services, id: :service_plans__service_id).
+          where(services__service_broker_id: broker.id).
+          any?
+      end
 
       deletable_brokers.each do |broker|
         broker_remover.remove(broker)

--- a/app/controllers/runtime/routes_controller.rb
+++ b/app/controllers/runtime/routes_controller.rb
@@ -370,7 +370,7 @@ module VCAP::CloudController
         routes = routes.where(path: path) if path
         routes = routes.where(port: port) if port
 
-        return [HTTP::NO_CONTENT, nil] if routes.count > 0
+        return [HTTP::NO_CONTENT, nil] if routes.any?
       end
       [HTTP::NOT_FOUND, nil]
     end

--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -106,7 +106,7 @@ module VCAP::CloudController
     end
 
     def staging_in_progress?
-      builds.any?(&:staging?)
+      builds_dataset.where(state: BuildModel::STAGING_STATE).any?
     end
 
     def docker?
@@ -122,7 +122,7 @@ module VCAP::CloudController
     end
 
     def deploying?
-      deployments.any?(&:deploying?)
+      deployments_dataset.where(state: DeploymentModel::DEPLOYING_STATE).any?
     end
 
     def self.user_visibility_filter(user)

--- a/lib/database/batch_delete.rb
+++ b/lib/database/batch_delete.rb
@@ -12,7 +12,7 @@ module Database
 
       loop do
         set = dataset.limit(amount)
-        break if set.count == 0
+        break if set.empty?
 
         total_count += delete_batch(set)
       end

--- a/lib/services/service_brokers/v2/catalog.rb
+++ b/lib/services/service_brokers/v2/catalog.rb
@@ -122,7 +122,10 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     def can_delete_service?(service)
-      service.service_plans_dataset.all? { |plan| plan.service_instances_dataset.empty? }
+      VCAP::CloudController::ServiceInstance.
+        join(:service_plans, id: :service_instances__service_plan_id).
+        where(service_plans__service_id: service.id).
+        empty?
     end
 
     def updating_service?(new_service, old_service)

--- a/lib/services/service_brokers/v2/catalog.rb
+++ b/lib/services/service_brokers/v2/catalog.rb
@@ -122,7 +122,7 @@ module VCAP::Services::ServiceBrokers::V2
     end
 
     def can_delete_service?(service)
-      service.service_plans_dataset.map(&:service_instances_dataset).map(&:count).all?(0)
+      service.service_plans_dataset.all? { |plan| plan.service_instances_dataset.empty? }
     end
 
     def updating_service?(new_service, old_service)


### PR DESCRIPTION
 **A short explanation of the proposed change:**

Small optimizations to a few DB queries related to counting.

**An explanation of the use cases your change solves**

Two small things:
1. In a few more places, switches to use `Sequel`'s `any?` and `empty?` methods instead of `count` when all we want to know is whether a non-zero number of matching records exist. Essentially a follow-up to #3052
2. In a few places we use formulations like `resource.associated_resources.map(&:other_associated_resources)`, which results in a single query to fetch `associated_resources` and then, for each one found, a separate query to count its `other_associated_resources`. This can be replaced with a single query with a join and `empty?`\\`any?`.

**Links to any other associated PRs**

n/a

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
