### PR TITLE
Use more efficient 'select' in place of 'select_map'

### DIFF
--- a/app/models/runtime/security_group.rb
+++ b/app/models/runtime/security_group.rb
@@ -34,8 +34,7 @@ module VCAP::CloudController
                           union(user.space_manager_space_ids, from_self: false).
                           union(user.space_auditor_space_ids, from_self: false).
                           union(user.space_supporter_space_ids, from_self: false).
-                          union(Space.join(user.org_manager_org_ids, organization_id: :organization_id).select(:spaces__id), from_self: false).
-                          select_map(:space_id)
+                          union(Space.join(user.org_manager_org_ids, organization_id: :organization_id).select(:spaces__id), from_self: false)
 
       Sequel.or([
         [:running_default, true],

--- a/app/models/runtime/space_quota_definition.rb
+++ b/app/models/runtime/space_quota_definition.rb
@@ -52,8 +52,7 @@ module VCAP::CloudController
       visible_space_ids = user.space_developer_space_ids.
                           union(user.space_manager_space_ids, from_self: false).
                           union(user.space_auditor_space_ids, from_self: false).
-                          union(user.space_supporter_space_ids, from_self: false).
-                          select_map(:space_id)
+                          union(user.space_supporter_space_ids, from_self: false)
 
       Sequel.or([
         [:id, Space.where(id: visible_space_ids).select(:space_quota_definition_id)],

--- a/app/models/runtime/user.rb
+++ b/app/models/runtime/user.rb
@@ -180,16 +180,14 @@ module VCAP::CloudController
       space_developer_space_ids.
         union(space_manager_space_ids, from_self: false).
         union(space_auditor_space_ids, from_self: false).
-        union(space_supporter_space_ids, from_self: false).
-        select_map(:space_id)
+        union(space_supporter_space_ids, from_self: false)
     end
 
     def membership_org_ids
       org_manager_org_ids.
         union(org_user_org_ids, from_self: false).
         union(org_billing_manager_org_ids, from_self: false).
-        union(org_auditor_org_ids, from_self: false).
-        select_map(:organization_id)
+        union(org_auditor_org_ids, from_self: false)
     end
 
     def org_user_org_ids
@@ -224,19 +222,19 @@ module VCAP::CloudController
       SpaceManager.where(user_id: id).select(:space_id)
     end
 
-    def visible_user_ids_in_my_orgs
+    def visible_users_in_my_orgs
       OrganizationUser.where(organization_id: membership_org_ids).select(:user_id).
         union(OrganizationManager.where(organization_id: membership_org_ids).select(:user_id), from_self: false).
         union(OrganizationAuditor.where(organization_id: membership_org_ids).select(:user_id), from_self: false).
         union(OrganizationBillingManager.where(organization_id: membership_org_ids).select(:user_id), from_self: false).
-        select_map(:user_id)
+        select(:user_id)
     end
 
     def readable_users(can_read_globally)
       if can_read_globally
         User.dataset
       else
-        User.where(id: visible_user_ids_in_my_orgs).or(id: id)
+        User.where(id: visible_users_in_my_orgs).or(id: id)
       end
     end
 

--- a/lib/cloud_controller/membership.rb
+++ b/lib/cloud_controller/membership.rb
@@ -73,13 +73,13 @@ module VCAP::CloudController
     def role_applies_to_space?(roles, space_id)
       return false unless space_id && contains_space_role?(roles)
 
-      member_space_ids(roles).select_map(:space_id).include?(space_id)
+      member_space_ids(roles).where(space_id: space_id).any?
     end
 
     def role_applies_to_org?(roles, org_id)
       return false unless org_id && contains_org_role?(roles)
 
-      member_org_ids(roles).select_map(:organization_id).include?(org_id)
+      member_org_ids(roles).where(organization_id: org_id).any?
     end
 
     def roles_filter(roles, filter)

--- a/lib/cloud_controller/membership.rb
+++ b/lib/cloud_controller/membership.rb
@@ -56,14 +56,14 @@ module VCAP::CloudController
       end
     end
 
-    def member_space_ids(roles)
-      space_role_subqueries(roles).reduce do |query, subquery|
+    def member_space_ids(roles, extra_filters={})
+      space_role_subqueries(roles, extra_filters).reduce do |query, subquery|
         query.union(subquery, from_self: false)
       end&.select(:space_id)
     end
 
-    def member_org_ids(roles)
-      org_role_subqueries(roles).reduce do |query, subquery|
+    def member_org_ids(roles, extra_filters={})
+      org_role_subqueries(roles, extra_filters).reduce do |query, subquery|
         query.union(subquery, from_self: false)
       end&.select(:organization_id)
     end
@@ -73,13 +73,13 @@ module VCAP::CloudController
     def role_applies_to_space?(roles, space_id)
       return false unless space_id && contains_space_role?(roles)
 
-      member_space_ids(roles).where(space_id: space_id).any?
+      member_space_ids(roles, space_id: space_id).any?
     end
 
     def role_applies_to_org?(roles, org_id)
       return false unless org_id && contains_org_role?(roles)
 
-      member_org_ids(roles).where(organization_id: org_id).any?
+      member_org_ids(roles, organization_id: org_id).any?
     end
 
     def roles_filter(roles, filter)
@@ -94,32 +94,32 @@ module VCAP::CloudController
       roles_filter(roles, ORG_ROLES).any?
     end
 
-    def space_role_subqueries(roles)
+    def space_role_subqueries(roles, extra_filters={})
       roles_filter(roles, SPACE_ROLES).map do |space_role|
         case space_role
         when SPACE_DEVELOPER
-          SpaceDeveloper.select(:space_id).where(user_id: @user.id)
+          SpaceDeveloper.where(extra_filters.merge(user_id: @user.id)).select(:space_id)
         when SPACE_MANAGER
-          SpaceManager.select(:space_id).where(user_id: @user.id)
+          SpaceManager.where(extra_filters.merge(user_id: @user.id)).select(:space_id)
         when SPACE_AUDITOR
-          SpaceAuditor.select(:space_id).where(user_id: @user.id)
+          SpaceAuditor.where(extra_filters.merge(user_id: @user.id)).select(:space_id)
         when SPACE_SUPPORTER
-          SpaceSupporter.select(:space_id).where(user_id: @user.id)
+          SpaceSupporter.where(extra_filters.merge(user_id: @user.id)).select(:space_id)
         end
       end.compact
     end
 
-    def org_role_subqueries(roles)
+    def org_role_subqueries(roles, extra_filters={})
       roles_filter(roles, ORG_ROLES).map do |org_role|
         case org_role
         when ORG_MANAGER
-          OrganizationManager.where(user_id: @user.id).select(:organization_id)
+          OrganizationManager.where(extra_filters.merge(user_id: @user.id)).select(:organization_id)
         when ORG_AUDITOR
-          OrganizationAuditor.where(user_id: @user.id).select(:organization_id)
+          OrganizationAuditor.where(extra_filters.merge(user_id: @user.id)).select(:organization_id)
         when ORG_BILLING_MANAGER
-          OrganizationBillingManager.where(user_id: @user.id).select(:organization_id)
+          OrganizationBillingManager.where(extra_filters.merge(user_id: @user.id)).select(:organization_id)
         when ORG_USER
-          OrganizationUser.where(user_id: @user.id).select(:organization_id)
+          OrganizationUser.where(extra_filters.merge(user_id: @user.id)).select(:organization_id)
         end
       end.compact
     end

--- a/spec/unit/models/runtime/user_spec.rb
+++ b/spec/unit/models/runtime/user_spec.rb
@@ -492,7 +492,7 @@ module VCAP::CloudController
       end
     end
 
-    describe '#visible_user_ids_in_my_orgs' do
+    describe '#visible_users_in_my_orgs' do
       let(:user_organization) { Organization.make }
       let(:manager_organization) { Organization.make }
       let(:auditor_organization) { Organization.make }
@@ -525,9 +525,9 @@ module VCAP::CloudController
         auditor_organization.add_auditor(org_auditor)
         billing_manager_organization.add_billing_manager(org_billing_manager)
 
-        user_result = user.visible_user_ids_in_my_orgs
+        user_result = user.visible_users_in_my_orgs.select_map(:user_id)
         expect(user_result).to match_array([user.id, other_user1.id])
-        manager_result = org_manager.visible_user_ids_in_my_orgs
+        manager_result = org_manager.visible_users_in_my_orgs.select_map(:user_id)
         expect(manager_result).to match_array(
           [
             org_manager.id,
@@ -535,14 +535,14 @@ module VCAP::CloudController
             other_user2.id,
           ],
         )
-        auditor_result = org_auditor.visible_user_ids_in_my_orgs
+        auditor_result = org_auditor.visible_users_in_my_orgs.select_map(:user_id)
         expect(auditor_result).to match_array(
           [
             org_auditor.id,
             other_user3.id,
           ],
         )
-        billing_manager_result = org_billing_manager.visible_user_ids_in_my_orgs
+        billing_manager_result = org_billing_manager.visible_users_in_my_orgs.select_map(:user_id)
         expect(billing_manager_result).to match_array(
           [
             org_billing_manager.id,


### PR DESCRIPTION
**A short explanation of the proposed change:**

Fixes an anti-optimization introduced by mistake in #3043, whereby several methods that make DB queries were changed from `select` (which returns a `Sequel::Dataset` to be executed later) to `select_map` (which immediately executes a query and returns the result as an array).

```ruby
def foo1
  Foo.select(:id)
end

def foo2
  Foo.select_map(:id)
end
```

In the above example, `foo2` is an efficient way to get a list of ids when our ruby code needs these for something. But it turns out `foo1` is much more efficient when we want to use those ids as part of another Sequel query:

```ruby
Bar.where(foo_ids: foo1)
```

**An explanation of the use cases your change solves**

We noticed that (repeated) runs of the [cf-performance-tests](https://github.com/cloudfoundry/cf-performance-tests) showed the newly-released [CAPI 1.141.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.141.0), which includes the changes from #3043, gave a much slower response to `GET /v3/domains` and `GET /v3/organizations/:guid/domains` (for the former, 8.51 seconds instead of 0.69). 

The tests made requests with a non-admin user and a DB seeded with 20k orgs (in which the user was an org manager in each), plus 400 private domains and 100 shared domains. These screenshots cut off the version numbers way below - but the sudden increase is from 1.141.0:
![Screenshot 2022-11-21 at 15 43 46](https://user-images.githubusercontent.com/20523607/203097272-98bd083d-4ffd-483c-83a8-152e222b676e.png)
![Screenshot 2022-11-21 at 15 43 55](https://user-images.githubusercontent.com/20523607/203097285-2739bdb2-da35-42ce-87de-451a9dc45875.png)

@philippthun correctly surmised that the root cause would be one of the places I'd switched to `select_map`. Here it was `membership.authorized_org_guids_subquery(ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + SPACE_ROLES)`, which #3043 changed so it would call `member_org_ids`:

```ruby
def member_org_ids(roles)
  org_role_subqueries(roles).reduce do |query, subquery|
    query.union(subquery, from_self: false)
  end&.select_map(:organization_id)
end
```

```sql
SELECT     "guid"
FROM       "organizations"
INNER JOIN "organizations_private_domains"
ON         (
                      "organizations_private_domains"."organization_id" = "organizations"."id" )
WHERE      ( (
                                 "organizations_private_domains"."private_domain_id" = 1 )
           AND        (
                                 "guid" IN (xxx) )
           OR         (
                                 "id" IS NULL ) )) ) )
```

#3043 made `xxx` an array of guid strings, retrieved in a separate query, whereas prior to that PR (and in the current PR) it's a subquery that retrieves those guids.

Passing an array of guids was in fact a little faster _in the DB_ than passing a subquery (22.228 ms planning + 0.105 ms execution versus 2.973 ms and 30.199 ms planning before #3043), and in Kibana I observed less querytime overall. But this was outweighed by an enormous, silent gap in time between each query in the logs, leading to a slower request overall. Having played around with these queries locally and frozen my machine a few times, I think that's what comes from the host passing round arrays that hold tens of thousands of strings.

Since the overall request time is more relevant here, here are some speeds for `cf curl /v3/domains` timed from bash:

* c9a2ca978fef70cd2c634fc5415f4faaeade8d34 (pre-#⁠3043): 0.758 seconds
* 0b5e6e38e522da496799479591721a60fb7fef93 (#⁠3043): 8.512 seconds
* b14c6e5dc3d66f80ecbbe558920c4cc65a0c48cb (#⁠3070): 0.692 seconds

*Links to any other associated PRs*

#3043

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
