### PR TITLE
Canceling deployment is superseded by new deployment

### DIFF
--- a/lib/cloud_controller/deployment_updater/updater.rb
+++ b/lib/cloud_controller/deployment_updater/updater.rb
@@ -39,9 +39,9 @@ module VCAP::CloudController
 
       def cancel_deployment
         deployment.db.transaction do
-          deployment.lock!
-
           app.lock!
+          return unless deployment.lock!.state == DeploymentModel::CANCELING_STATE
+
           deploying_web_process.lock!
 
           prior_web_process = web_processes.
@@ -63,10 +63,10 @@ module VCAP::CloudController
 
       def scale_deployment
         deployment.db.transaction do
-          deployment.lock!
+          app.lock!
+          return unless deployment.lock!.state == DeploymentModel::DEPLOYING_STATE
 
           oldest_web_process_with_instances.lock!
-          app.lock!
           deploying_web_process.lock!
 
           return unless ready_to_scale?

--- a/spec/unit/actions/deployment_create_spec.rb
+++ b/spec/unit/actions/deployment_create_spec.rb
@@ -416,6 +416,19 @@ module VCAP::CloudController
                 expect(existing_deployment.status_reason).to eq(DeploymentModel::SUPERSEDED_STATUS_REASON)
               end
             end
+
+            context 'when the existing deployment is CANCELING' do
+              let(:existing_state) { DeploymentModel::CANCELING_STATE }
+
+              it 'sets the existing deployment to CANCELED, with reason SUPERSEDED' do
+                DeploymentCreate.create(app: app, message: message, user_audit_info: user_audit_info)
+                existing_deployment.reload
+
+                expect(existing_deployment.state).to eq(DeploymentModel::CANCELED_STATE)
+                expect(existing_deployment.status_value).to eq(DeploymentModel::FINALIZED_STATUS_VALUE)
+                expect(existing_deployment.status_reason).to eq(DeploymentModel::SUPERSEDED_STATUS_REASON)
+              end
+            end
           end
 
           context 'when the message specifies metadata' do


### PR DESCRIPTION
There are two active states for deployments (`DEPLOYING, CANCELING`) and two corresponding actions (`DeploymentCreate`, `DeploymentCancel`). This results in the following possible scenarios:

| | state | + action | = updated state | (new deployment) |
|--|--|--|--|--|
| 1 | DEPLOYING | create | SUPERSEDED | DEPLOYING |
| 2 | DEPLOYING | cancel | CANCELING | - |
| 3 | CANCELING | cancel | CANCELING | - |
| 4 | CANCELING | create | CANCELING | DEPLOYING |

Scenario 4 (`CANCELING` + `create`) currently leads to two active deployments for an app (`CANCELING` + `DEPLOYING`). As the `Dispatcher` and `Updater` (module `DeploymentUpdater`) are not designed to handle two active deployments concurrently, the result for this scenario has been changed:

| | state | + action | = updated state | (new deployment) |
|--|--|--|--|--|
| 4 | CANCELING | create | SUPERSEDED | DEPLOYING |

This means that the `create` action now sets a `CANCELING` deployment to `SUPERSEDED` (`CANCELED`) and during the next run of the `DeploymentUpdater`, the new `DEPLOYING` deployment will be processed.

Furthermore the `Updater` (module `DeploymentUpdater`) now checks that the deployment being processed is still in the expected state.

### Skip interim web processes from SUPERSEDED (CANCELED) deployments

When a deployment train is canceled, the latest interim web process is scaled up. The introduction of a `SUPERSEDED` (`CANCELED`) state requires a change to how this latest interim web process is determined.

Let's assume the following sequence of actions:
- create
- create
- cancel
- create
- cancel

This would result in the following states (after each action):
- `DEPLOYING`
- `SUPERSEDED` (`DEPLOYED`) + `DEPLOYING`
- `SUPERSEDED` (`DEPLOYED`) + `CANCELING`
- `SUPERSEDED` (`DEPLOYED`) + `SUPERSEDED` (`CANCELED`) + `DEPLOYING`
- `SUPERSEDED` (`DEPLOYED`) + `SUPERSEDED` (`CANCELED`) + `CANCELING`

And this should result in the web process from the `SUPERSEDED` (`CANCELED`) deployment to be skipped and the one from the `SUPERSEDED` (`DEPLOYED`) deployment to be scaled up.

### Scale canceled web processes to zero

The introduction of a `SUPERSEDED` (`CANCELED`) state requires the `Updater` (module `DeploymentUpdater`) to handle the interim web process belonging to such a `SUPERSEDED` (`CANCELED`) deployment.

The cleanup of unused web processes happens at the end of a (successful or canceled) deployment. But as the canceled interim web process should not be used anymore, it is now immediately scaled to zero instances.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
