### PR TITLE
Finalize only deployments with 'STATUS_VALUE' 'ACTIVE'

### DIFF
--- a/lib/cloud_controller/deployment_updater/dispatcher.rb
+++ b/lib/cloud_controller/deployment_updater/dispatcher.rb
@@ -39,8 +39,8 @@ module VCAP::CloudController
         def finalize_degenerate_deployments(logger)
           deployments_without_deploying_web_process = DeploymentModel.qualify.
                                                       left_join(:processes, guid: :deploying_web_process_guid).
-                                                      exclude(status_reason: DeploymentModel::DEGENERATE_STATUS_REASON).
-                                                      where(processes__id: nil)
+                                                      where(processes__id: nil).
+                                                      where(status_value: DeploymentModel::ACTIVE_STATUS_VALUE)
           deployments_without_deploying_web_process.each do |d|
             d.update(
               state: DeploymentModel::DEPLOYED_STATE,

--- a/spec/unit/lib/cloud_controller/deployment_updater/dispatcher_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/dispatcher_spec.rb
@@ -87,6 +87,26 @@ module VCAP::CloudController
         it_behaves_like 'a degenerated deployment'
       end
 
+      context 'when the deploying_web_process_guid is nil and state is DEPLOYED' do
+        let!(:scaling_deployment) {
+          DeploymentModel.make(state: DeploymentModel::DEPLOYED_STATE,
+                               status_value: DeploymentModel::FINALIZED_STATUS_VALUE,
+                               status_reason: DeploymentModel::DEPLOYED_STATUS_REASON,
+         deploying_web_process: nil)
+        }
+
+        before do
+          allow(DeploymentUpdater::Updater).to receive(:new).with(scaling_deployment, logger).and_return(updater)
+        end
+
+        it 'does not change the status_reason to DEGENERATED' do
+          subject.dispatch
+          deployment = scaling_deployment.reload
+
+          expect(deployment.status_reason).to eq(DeploymentModel::DEPLOYED_STATUS_REASON)
+        end
+      end
+
       context 'when the deploying_web_process_guid references a non-existent process' do
         let!(:scaling_deployment) do
           deployment = DeploymentModel.make(state: DeploymentModel::DEPLOYING_STATE)

--- a/spec/unit/lib/cloud_controller/deployment_updater/dispatcher_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/dispatcher_spec.rb
@@ -88,12 +88,12 @@ module VCAP::CloudController
       end
 
       context 'when the deploying_web_process_guid is nil and state is DEPLOYED' do
-        let!(:scaling_deployment) {
+        let!(:scaling_deployment) do
           DeploymentModel.make(state: DeploymentModel::DEPLOYED_STATE,
                                status_value: DeploymentModel::FINALIZED_STATUS_VALUE,
                                status_reason: DeploymentModel::DEPLOYED_STATUS_REASON,
-         deploying_web_process: nil)
-        }
+                               deploying_web_process: nil)
+        end
 
         before do
           allow(DeploymentUpdater::Updater).to receive(:new).with(scaling_deployment, logger).and_return(updater)

--- a/spec/unit/lib/cloud_controller/deployment_updater/dispatcher_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/dispatcher_spec.rb
@@ -99,7 +99,7 @@ module VCAP::CloudController
           allow(DeploymentUpdater::Updater).to receive(:new).with(scaling_deployment, logger).and_return(updater)
         end
 
-        it 'does not change the status_reason to DEGENERATED' do
+        it 'does not change the status_reason to DEGENERATE' do
           subject.dispatch
           deployment = scaling_deployment.reload
 


### PR DESCRIPTION
In case a deployment of a new or stopped app is triggered the deployments table entry will look like this:
```
  id                                  | 43
  guid                                | 79165acb-420b-4c46-bc2f-79d5b05b4f0d
  state                               | DEPLOYED
  deploying_web_process_guid          |
  ...
  status_value                        | FINALIZED
  status_reason                       | DEPLOYED
  strategy                            | rolling
```

As `deploying_web_process_guid` is empty the `finalize_degenerate_deployments` jobs will eventually set the `status_reason` to `DEGENERATE`.
If this happens at a bad moment it can cause a `Cannot cancel a deployment with status: FINALIZED and reason: DEGENERATE` cf push error.
Because the deployment is already `FINALIZED` it does not make sense to change its status. Therefore this change makes sure that `finalize_degenerate_deployments` only considers active deployments.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
