### PR TITLE
Catch AppStart errors in deployment create action

### DIFF
--- a/app/actions/deployment_create.rb
+++ b/app/actions/deployment_create.rb
@@ -74,7 +74,7 @@ module VCAP::CloudController
         end
 
         deployment
-      rescue RevisionResolver::NoUpdateRollback, Sequel::ValidationFailed => e
+      rescue RevisionResolver::NoUpdateRollback, Sequel::ValidationFailed, AppStart::InvalidApp => e
         error = DeploymentCreate::Error.new(e.message)
         error.set_backtrace(e.backtrace)
         raise error

--- a/spec/unit/actions/deployment_create_spec.rb
+++ b/spec/unit/actions/deployment_create_spec.rb
@@ -536,6 +536,16 @@ module VCAP::CloudController
                 )
               end
             end
+
+            context 'when the app fails to start' do
+              before do
+                allow(VCAP::CloudController::AppStart).to receive(:start).and_raise(VCAP::CloudController::AppStart::InvalidApp.new('memory quota_exceeded'))
+              end
+
+              it 'raises a DeploymentCreate::Error' do
+                expect { DeploymentCreate.create(app: app, message: message, user_audit_info: user_audit_info) }.to raise_error(DeploymentCreate::Error, 'memory quota_exceeded')
+              end
+            end
           end
         end
 


### PR DESCRIPTION
**A short explanation of the proposed change:**

Propagates `AppStart` errors in the `DeploymentCreate` action

**An explanation of the use cases your change solves**

These previously weren't being rescued, which led to users getting poorer information about errors when doing a `cf push` with `--strategy rolling` than they did when omitting that flag. For example, prior to this PR a `cf push -i 4 -m 4M` in a space whose quota did not have enough memory remaining for all four instances would results in a CLI error like this:

```console
{
   "errors":[
      {
         "code":10008,
         "detail":"memory space_quota_exceeded",
         "title":"CF-UnprocessableEntity"
      }
   ]
}
```

Whereas if `--strategy rolling` was provided, you'd get:

```console
{
  "errors": [
    {
      "code": 10001,
      "detail": "An unknown error occurred.",
      "title": "UnknownError"
    }
  ]
}
```

This is now consistent:

```console
$ cf target -o no-mem -s test
API endpoint:   https://api.cf.aws-dev19.cfp.sapcloud.io
API version:    3.129.0
user:           provisioned_user_cf_admin
org:            no-mem
space:          test

$ cf create-space-quota no-mem -r -1 -m 4M
Creating space quota no-mem for org no-mem as provisioned_user_cf_admin...
OK

$ cf set-space-quota test no-mem
Setting space quota no-mem to space test as provisioned_user_cf_admin...
OK

$ cf push -i 4 -m 4M --strategy rolling
Pushing app cf-nodejs to org no-mem / space test as provisioned_user_cf_admin...
Applying manifest file /users/c5323189/landscape-aws-dev19/cf-sample-app-nodejs/manifest.yml...

Updating with these attributes...
  ---
  applications:
+ - name: cf-nodejs
+   instances: 4
    memory: 4M
+   random-route: true
Manifest applied
Packaging files to upload...
Uploading files...
 714.95 KiB / 714.95 KiB [==========================================================================================================================================] 100.00% 1s

Waiting for API to complete processing files...

Staging app and tracing logs...
   Downloading binary_buildpack...
   Downloading staticfile_buildpack...
   Downloading java_buildpack...
   Downloading ruby_buildpack...
   Downloading dotnet_core_buildpack...
   Downloaded binary_buildpack
   Downloading nodejs_buildpack...
   Downloaded java_buildpack
   Downloading go_buildpack...
   Downloaded staticfile_buildpack
   Downloading python_buildpack...
   Downloaded ruby_buildpack
   Downloading php_buildpack...
   Downloaded dotnet_core_buildpack
   Downloading nginx_buildpack...
   Downloaded php_buildpack
   Downloading r_buildpack...
   Downloaded nodejs_buildpack
   Downloaded go_buildpack
   Downloaded python_buildpack
   Downloaded nginx_buildpack
   Downloaded r_buildpack
   Cell 31e80889-72ee-4692-826f-0a1930fca0e6 creating container for instance 522eea2c-b0e7-4825-875a-03f92dc6f27f
   Cell 31e80889-72ee-4692-826f-0a1930fca0e6 successfully created container for instance 522eea2c-b0e7-4825-875a-03f92dc6f27f
   Downloading app package...
   Downloaded app package (1.2M)
   -----> Nodejs Buildpack version 1.8.1
   -----> Installing binaries
   engines.node (package.json): unspecified
   engines.npm (package.json): unspecified (use default)
   **WARNING** Node version not specified in package.json or .nvmrc. See: http://docs.cloudfoundry.org/buildpacks/node/node-tips.html
   -----> Installing node 16.17.1
   Copy [/tmp/buildpacks/9f4582700e255ea57d531d56f2ba71a0/dependencies/33da2d39aed1341b8fa53e663d60b54c/node_16.17.1_linux_x64_cflinuxfs3_c74713ec.tgz]
   Using default npm version: 8.15.0
   -----> Installing yarn 1.22.19
   Copy [/tmp/buildpacks/9f4582700e255ea57d531d56f2ba71a0/dependencies/0f06052381cbcef1593bd279ca3d9458/yarn_1.22.19_linux_noarch_any-stack_32d0e82e.tgz]
   Installed yarn 1.22.19
   -----> Creating runtime environment
   PRO TIP: It is recommended to vendor the application's Node.js dependencies
   Visit http://docs.cloudfoundry.org/buildpacks/node/index.html#vendoring
   NODE_ENV=production
   NODE_HOME=/tmp/contents1026953200/deps/0/node
   NODE_MODULES_CACHE=true
   NODE_VERBOSE=false
   NPM_CONFIG_LOGLEVEL=error
   NPM_CONFIG_PRODUCTION=true
   -----> Building dependencies
   Installing node modules (package.json)
   added 103 packages, and audited 104 packages in 5s
   8 packages are looking for funding
   run `npm fund` for details
   5 vulnerabilities (1 low, 4 critical)
   To address all issues (including breaking changes), run:
   npm audit fix --force
   Run `npm audit` for details.
   npm notice
   npm notice New major version of npm available! 8.15.0 -> 9.1.2
   npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.1.2>
   npm notice Run `npm install -g npm@9.1.2` to update!
   npm notice
   **WARNING** Unmet dependencies don't fail npm install but may cause runtime issues
   See: https://github.com/npm/npm/issues/7494
   Contrast Security no credentials found. Will not write environment files.
   inside Sealights hook
   service is not configured to run with Sealights
   Exit status 0
   Uploading droplet, build artifacts cache...
   Uploading droplet...
   Uploading build artifacts cache...
   Uploaded build artifacts cache (3M)
   Uploaded droplet (37.6M)
   Uploading complete
   Cell 31e80889-72ee-4692-826f-0a1930fca0e6 stopping instance 522eea2c-b0e7-4825-875a-03f92dc6f27f
   Cell 31e80889-72ee-4692-826f-0a1930fca0e6 destroying container for instance 522eea2c-b0e7-4825-875a-03f92dc6f27f

Starting deployment for app cf-nodejs...
memory space_quota_exceeded
FAILED
```

**Links to any other associated PRs**

n/a

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
