### PR TITLE
Re-add db table `request_counts`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,6 +135,7 @@ Migration/AddConstraintName:
   Exclude:
     # skip old migration files since we do not want to fix them after they are in the wild
     - !ruby/regexp /db/migrations/201([0-6]|70[1-6]).+\.rb$/
+    - db/migrations/20221125134500_add_request_count_table.rb
 
 Migration/IncludeStringSize:
   Include:
@@ -142,6 +143,7 @@ Migration/IncludeStringSize:
   Exclude:
     # skip old migration files since we do not want to fix them after they are in the wild
     - !ruby/regexp /db/migrations/201([0-6]|70[1-6]|707[01]).+\.rb$/
+    - db/migrations/20221125134500_add_request_count_table.rb
 
 Migration/RequirePrimaryKey:
   Include:

--- a/db/migrations/20221125134500_add_request_count_table.rb
+++ b/db/migrations/20221125134500_add_request_count_table.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  change do
+    create_table? :request_counts do
+      primary_key :id
+
+      String :user_guid
+      index :user_guid
+
+      Integer :count, default: 0
+      Time :valid_until
+    end
+  end
+end


### PR DESCRIPTION
While updating capi from version 1.139.0 to 1.140.0 it can happen that not yet updated cc-workers will fail during a restart with error `relation "request_counts" does not exist`. To avoid this we need to create the table again.
In a future release it can be removed again.

See #3075


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
