### PR TITLE
Optimize space supporter filter for v2 calls

### DIFF
--- a/middleware/block_v3_only_roles.rb
+++ b/middleware/block_v3_only_roles.rb
@@ -36,21 +36,21 @@ module CloudFoundry
       end
 
       def space_supporter_and_only_space_supporter?(current_user)
-        return false if VCAP::CloudController::User.
+        return false if VCAP::CloudController::User.db.select(1).
                         where do
                           Sequel.or(
                             [
-                              [VCAP::CloudController::SpaceDeveloper.select(1).where(user_id: current_user.id).exists, true],
-                              [VCAP::CloudController::OrganizationManager.select(1).where(user_id: current_user.id).exists, true],
-                              [VCAP::CloudController::SpaceManager.select(1).where(user_id: current_user.id).exists, true],
-                              [VCAP::CloudController::SpaceAuditor.select(1).where(user_id: current_user.id).exists, true],
-                              [VCAP::CloudController::OrganizationAuditor.select(1).where(user_id: current_user.id).exists, true],
-                              [VCAP::CloudController::OrganizationBillingManager.select(1).where(user_id: current_user.id).exists, true]
+                              [VCAP::CloudController::SpaceDeveloper.limit(1).select(1).where(user_id: current_user.id).exists, true],
+                              [VCAP::CloudController::OrganizationManager.limit(1).select(1).where(user_id: current_user.id).exists, true],
+                              [VCAP::CloudController::SpaceManager.limit(1).select(1).where(user_id: current_user.id).exists, true],
+                              [VCAP::CloudController::SpaceAuditor.limit(1).select(1).where(user_id: current_user.id).exists, true],
+                              [VCAP::CloudController::OrganizationAuditor.limit(1).select(1).where(user_id: current_user.id).exists, true],
+                              [VCAP::CloudController::OrganizationBillingManager.limit(1).select(1).where(user_id: current_user.id).exists, true]
                             ]
                           )
                         end.any?
 
-        VCAP::CloudController::SpaceSupporter.select(1).where(user_id: current_user.id).any?
+        VCAP::CloudController::SpaceSupporter.where(user_id: current_user.id).any?
       end
 
       def roles

--- a/middleware/block_v3_only_roles.rb
+++ b/middleware/block_v3_only_roles.rb
@@ -36,7 +36,7 @@ module CloudFoundry
       end
 
       def space_supporter_and_only_space_supporter?(current_user)
-        return false if VCAP::CloudController::User.db.select(1).
+        return false if VCAP::CloudController::User.
                         where do
                           Sequel.or(
                             [


### PR DESCRIPTION
_**UPDATE: I've completely changed this optimization since first opening the PR so this description is out of date (I'm leaving it as a record of how this has progressed) - see comments below for latest details**_

A short explanation of the proposed change:

Optimizes the checks that prevent users with only a space supporter role from accessing the v2 API, cutting around 7% off the overall querytime when there are large tables.

This PR uses Sequel's [`any?`](https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/any_not_empty_rb.html) method instead of the existing check, which retrieves [`.all`](https://www.rubydoc.info/github/jeremyevans/sequel/Sequel%2FDataset:all) of a given user's roles and then, in the CC's ruby code, counts them to see whether the user has exactly 1 space supporter role and zero of all other role types.

The method will also now return false right away, without querying the space supporters table, if the user has any non-supporter role.

An explanation of the use cases your change solves

The existing check currently adds a pretty significant delay to every v2 call on large foundations, and this change slightly mitigates that.

I've run the [old](https://gist.github.com/will-gant/2d38d02bd16b1e016e931cda60d0fdef) and the [new](https://gist.github.com/will-gant/b3dda4513ced76c45dc4176892c9199c) queries in postgres with `EXPLAIN ANALYZE` 100 times each on a foundation with about 75k users and 646k roles. Averages from the results are presented in the table below (times in ms):

|                | Old      | New      |
|----------------|----------|----------|
| Planning time  |  1.50904 |  1.06917 |
| Execution time | 36.42587 |   34.286 |
| Overall time   | 37.93491 | 35.35517 |

If the user lacks any non-supporter role, we then have to separately check the supporters table. That [little query](https://gist.github.com/will-gant/df8d92d7df34b565e5e26dd934201419) has a planning time of 0.186ms, and execution 1.366ms. So we're still a smidgen faster even for the minority of requests that also need to execute that.

So it's a pretty modest improvement, but given that this is middleware that gets executed for all v2 calls, I think cumulatively it should be a useful saving.

Links to any other associated PRs

n/a

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
