### PR TITLE
More counting tweaks

### DIFF
--- a/app/actions/update_route_destinations.rb
+++ b/app/actions/update_route_destinations.rb
@@ -66,7 +66,7 @@ module VCAP::CloudController
             Copilot::Adapter.unmap_route(route_mapping)
             route_mapping.processes.each do |process|
               processes_to_ports_map[process] ||= { to_add: [], to_delete: [] }
-              processes_to_ports_map[process][:to_delete] << route_mapping.app_port unless process.route_mappings.any? do |process_route_mapping|
+              processes_to_ports_map[process][:to_delete] << route_mapping.app_port unless process.route_mappings_dataset.any? do |process_route_mapping|
                 process_route_mapping.guid != route_mapping.guid && process_route_mapping.app_port == route_mapping.app_port
               end
             end

--- a/app/actions/v3/service_instance_update_managed.rb
+++ b/app/actions/v3/service_instance_update_managed.rb
@@ -287,7 +287,7 @@ module VCAP::CloudController
 
       def raise_if_bind_inconsistency!
         return unless message.service_plan_guid
-        return unless service_instance.service_bindings.any?
+        return unless service_instance.service_bindings_dataset.any?
         return if ServicePlan.first(guid: message.service_plan_guid).bindable?
 
         raise UnprocessableUpdate.new_from_details(

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -269,7 +269,7 @@ module VCAP::CloudController
       org = find_guid_and_validate_access(:delete, guid)
       raise_if_has_dependent_associations!(org) unless recursive_delete?
 
-      if !org.spaces.empty? && !recursive_delete?
+      if org.spaces_dataset.any? && !recursive_delete?
         raise CloudController::Errors::ApiError.new_from_details('AssociationNotEmpty', 'spaces', Organization.table_name)
       end
 

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -545,19 +545,19 @@ module VCAP::CloudController
     end
 
     def has_routes?(service_instance)
-      !service_instance.routes.empty?
+      service_instance.routes_dataset.any?
     end
 
     def has_bindings?(service_instance)
-      !service_instance.service_bindings.empty?
+      service_instance.service_bindings_dataset.any?
     end
 
     def has_keys?(service_instance)
-      !service_instance.service_keys.empty?
+      service_instance.service_keys_dataset.any?
     end
 
     def has_shares?(service_instance)
-      !service_instance.shared_spaces.empty?
+      service_instance.shared_spaces_dataset.any?
     end
 
     def status_from_operation_state(service_instance)

--- a/app/controllers/services/validators/service_update_validator.rb
+++ b/app/controllers/services/validators/service_update_validator.rb
@@ -80,7 +80,7 @@ module VCAP::CloudController
           requested_plan = ServicePlan.find(guid: requested_plan_guid)
           invalid_relation!('Plan') if invalid_plan?(requested_plan, service)
 
-          unable_to_update_to_nonbindable_plan! if !requested_plan.bindable? && service_instance.service_bindings.any?
+          unable_to_update_to_nonbindable_plan! if !requested_plan.bindable? && service_instance.service_bindings_dataset.any?
         end
       end
 

--- a/app/controllers/v3/domains_controller.rb
+++ b/app/controllers/v3/domains_controller.rb
@@ -106,7 +106,7 @@ class DomainsController < ApplicationController
     unauthorized! unless can_write_to_active_org?(domain.owning_organization_id)
     suspended! unless org_active?(domain.owning_organization_id)
 
-    unprocessable!('This domain is shared with other organizations. Unshare before deleting.') unless domain.shared_organizations.empty?
+    unprocessable!('This domain is shared with other organizations. Unshare before deleting.') unless domain.shared_organizations_dataset.empty?
 
     delete_action = DomainDelete.new
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Domain, domain.guid, delete_action)

--- a/app/controllers/v3/space_quotas_controller.rb
+++ b/app/controllers/v3/space_quotas_controller.rb
@@ -136,7 +136,7 @@ class SpaceQuotasController < ApplicationController
       (space_quota && permission_queryer.can_write_to_active_org?(space_quota.organization_id))
     suspended! unless space_quota && permission_queryer.is_org_active?(space_quota.organization_id)
 
-    unprocessable!('This quota is applied to one or more spaces. Remove this quota from all spaces before deleting.') unless space_quota.spaces.empty?
+    unprocessable!('This quota is applied to one or more spaces. Remove this quota from all spaces before deleting.') unless space_quota.spaces_dataset.empty?
 
     delete_action = SpaceQuotaDeleteAction.new
 

--- a/lib/cloud_controller/backends/stagers.rb
+++ b/lib/cloud_controller/backends/stagers.rb
@@ -22,7 +22,7 @@ module VCAP::CloudController
         raise CloudController::Errors::ApiError.new_from_details('AppPackageInvalid', 'The app package hash is empty')
       end
 
-      if Buildpack.count == 0 && using_admin_buildpack?(process.app.lifecycle_data.buildpacks)
+      if Buildpack.empty? && using_admin_buildpack?(process.app.lifecycle_data.buildpacks)
         raise CloudController::Errors::ApiError.new_from_details('NoBuildpacksFound')
       end
     end

--- a/lib/cloud_controller/legacy_api/legacy_api_base.rb
+++ b/lib/cloud_controller/legacy_api/legacy_api_base.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
 
     def has_default_space?
       raise CloudController::Errors::ApiError.new_from_details('NotAuthorized') unless user
-      return true if user.default_space || !user.spaces.empty?
+      return true if user.default_space || user.spaces_dataset.any?
 
       false
     end

--- a/lib/cloud_controller/route_validator.rb
+++ b/lib/cloud_controller/route_validator.rb
@@ -93,12 +93,11 @@ module VCAP::CloudController
     end
 
     def port_taken?
-      domains = Route.dataset.select_all(Route.table_name).
-                join(Domain.table_name, id: :domain_id).
-                where("#{Domain.table_name}__router_group_guid": route.domain.router_group_guid,
-                      "#{Route.table_name}__port": route.port)
-
-      domains.count > 0
+      Route.
+        join(:domains, id: :domain_id).
+        where(domains__router_group_guid: route.domain.router_group_guid,
+              routes__port: route.port).
+        any?
     end
   end
 end


### PR DESCRIPTION
**A short explanation of the proposed change:**

Optimizes a few more places where we've been asking Sequel to either count all the rows in a dataset, or to retrieve all rows and return them to us, when all we care about is whether a non-zero number of rows exist.

**An explanation of the use cases your change solves**

n/a

**Links to any other associated PRs**

Similar to #3067 and #3052

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
