### PR TITLE
Add user_guid to request logs

### DIFF
--- a/lib/vcap/request.rb
+++ b/lib/vcap/request.rb
@@ -22,6 +22,14 @@ module VCAP
         Thread.current[:vcap_request_id]
       end
 
+      def user_guid=(user_guid)
+        if user_guid.nil?
+          Steno.config.context.data.delete('user_guid')
+        else
+          Steno.config.context.data['user_guid'] = user_guid
+        end
+      end
+
       def b3_trace_id=(trace_id)
         Thread.current[:b3_trace_id] = trace_id
         if trace_id.nil?

--- a/middleware/vcap_request_id.rb
+++ b/middleware/vcap_request_id.rb
@@ -12,9 +12,12 @@ module CloudFoundry
         env['cf.request_id'] = external_request_id(env) || internal_request_id
         ::VCAP::Request.current_id = env['cf.request_id']
 
-        status, headers, body = @app.call(env)
+        begin
+          status, headers, body = @app.call(env)
+        ensure
+          ::VCAP::Request.current_id = nil
+        end
 
-        ::VCAP::Request.current_id = nil
         headers['X-VCAP-Request-ID'] = env['cf.request_id']
         [status, headers, body]
       end

--- a/middleware/zipkin.rb
+++ b/middleware/zipkin.rb
@@ -18,10 +18,12 @@ module CloudFoundry
           'X-B3-SpanId'  => env['HTTP_X_B3_SPANID']
         }
 
-        status, headers, body = @app.call(env)
-
-        ::VCAP::Request.b3_trace_id = nil
-        ::VCAP::Request.b3_span_id = nil
+        begin
+          status, headers, body = @app.call(env)
+        ensure
+          ::VCAP::Request.b3_trace_id = nil
+          ::VCAP::Request.b3_span_id = nil
+        end
 
         [status, headers.merge(zipkin_headers), body]
       end

--- a/spec/unit/lib/vcap/request_spec.rb
+++ b/spec/unit/lib/vcap/request_spec.rb
@@ -106,5 +106,19 @@ module VCAP
         expect(Thread.current[:b3_span_id]).to eq(span_id)
       end
     end
+
+    describe '.user_guid' do
+      after do
+        Request.user_guid = nil
+      end
+
+      let(:user_guid) { SecureRandom.uuid }
+
+      it 'sets the new user_guid on the Steno logger context' do
+        Request.user_guid = user_guid
+
+        expect(Steno.config.context.data['user_guid']).to eq user_guid
+      end
+    end
   end
 end

--- a/spec/unit/middleware/vcap_request_id_spec.rb
+++ b/spec/unit/middleware/vcap_request_id_spec.rb
@@ -32,6 +32,27 @@ module CloudFoundry
           end
         end
 
+        context 'clearing the request id' do
+          context 'and an error is raised when the request is passed' do
+            let(:error) { RuntimeError.new('oops') }
+            before do
+              allow(app).to receive(:call).and_raise(error)
+            end
+
+            it 'sets the request id to nil' do
+              expect { middleware.call('HTTP_X_VCAP_REQUEST_ID' => 'specific-request-id') }.to raise_error(error)
+              expect(::VCAP::Request.current_id).to eq(nil)
+            end
+          end
+
+          context 'and no error is raised when the request is passed' do
+            it 'sets the request id to nil' do
+              middleware.call('HTTP_X_VCAP_REQUEST_ID' => 'specific-request-id')
+              expect(::VCAP::Request.current_id).to eq(nil)
+            end
+          end
+        end
+
         context 'when HTTP_X_VCAP_REQUEST_ID is passed in from outside' do
           it 'includes it in cf.request_id and appends a uuid to ensure uniqueness' do
             middleware.call('HTTP_X_VCAP_REQUEST_ID' => 'request-id')


### PR DESCRIPTION
**A short explanation of the proposed change:**

Add the field `user_guid` to request logs in `CloudFoundry::Middleware::SecurityContextSetter`.

**An explanation of the use cases your change solves**

Currently the only Cloud Controller logs which include `user_guid` as a field are `nginx_access` logs. The values of user guids appear incidentally in the log message itself in a handful of cases (about 0.6% of all logs), generally in SQL statements and errors.

The Steno logging library always adds [eight fields](https://github.com/cloudfoundry/steno/blob/e2c9408c1d255ff4a9952bdced9684bec666d4d6/lib/steno/record.rb#L28-L39) to request logs (including the log message itself), and at present our middleware adds another three: the `request_guid`, `b3_trace_id` and `b3_span_id`. The latter two are added by [CloudFoundry::Middleware::Zipkin](https://github.com/cloudfoundry/cloud_controller_ng/blob/bcbfc98cdc68639f2260eab300635b6202f79190/middleware/zipkin.rb#L13-L14), and the former by [CloudFoundry::Middleware::VcapRequestId](https://github.com/cloudfoundry/cloud_controller_ng/blob/bcbfc98cdc68639f2260eab300635b6202f79190/middleware/vcap_request_id.rb#L13).

We think having access to the `user_guid` in all request logs could make it easier to debug certain kinds of issues. If you're interested in a single request, it's already possible (though a bit laborious) to trace your way back from some downstream request log to the nginx log that gives you the `user_guid`. But if you're seeing a _pattern_ across many requests, there's currently no convenient way to know if they're all coming from one particular user. If every log carried the `user_guid`, it'd be pretty easy with tools like Kibana to do that sort of analysis.

**Links to any other associated PRs**

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
