### PR TITLE
Use standard library's debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,10 +96,9 @@ end
 
 group :development do
   gem 'byebug'
-  gem 'debase', '>= 0.2.2.beta14'
   gem 'listen'
   gem 'roodi'
-  gem 'ruby-debug-ide', '>= 0.7.0.beta4'
+  gem 'debug'
   gem 'solargraph'
   gem 'spork', git: 'https://github.com/sporkrb/spork', ref: '224df49' # '~> 1.0rc'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,9 +125,9 @@ GEM
       rexml
     crass (1.0.6)
     daemons (1.4.1)
-    debase (0.2.5.beta2)
-      debase-ruby_core_source (>= 0.10.12)
-    debase-ruby_core_source (0.10.12)
+    debug (1.7.0)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     declarative (0.0.20)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)
@@ -268,7 +268,10 @@ GEM
     httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    io-console (0.5.11)
     ipaddress (0.8.3)
+    irb (1.5.1)
+      reline (>= 0.3.0)
     jaro_winkler (1.5.4)
     json (2.6.2)
     json-diff (0.4.1)
@@ -384,6 +387,8 @@ GEM
       ffi (~> 1.0)
     recursive-open-struct (1.1.3)
     regexp_parser (2.6.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -447,8 +452,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.23.0)
       parser (>= 3.1.1.0)
-    ruby-debug-ide (0.7.3)
-      rake (>= 0.8.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     ruby_parser (3.8.3)
@@ -557,7 +560,7 @@ DEPENDENCIES
   clockwork
   cloudfront-signer
   codeclimate-test-reporter (>= 1.0.8)
-  debase (>= 0.2.2.beta14)
+  debug
   em-http-request (~> 1.1)
   eventmachine (~> 1.2.7)
   fluent-logger
@@ -612,7 +615,6 @@ DEPENDENCIES
   rspec-wait
   rspec_api_documentation (>= 6.1.0)
   rubocop (~> 1.39.0)
-  ruby-debug-ide (>= 0.7.0.beta4)
   rubyzip (>= 1.3.0)
   sequel (~> 5.63)
   sequel_pg

--- a/README.md
+++ b/README.md
@@ -144,6 +144,48 @@ By default, `bundle exec rake` will run the unit tests first, and then `rubocop`
 
     RUBOCOP_FIRST=1 bundle exec rake
 
+#### Running unit tests with a debugger
+
+As of ruby 2.6 this can be done with the Standard Library's `debug` gem, which is installed by the Gemfile's development group. The following instructions give an example of how to debug specs with Visual Studio Code.
+
+Copy the following into `.vscode/launch.json` at the root of this git repository (more info [here](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations)):
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+          {
+            "type": "rdbg",
+            "name": "Debug specs file",
+            "request": "launch",
+            "command": "bundle exec rspec",
+            "script": "${file}",
+            "args": [],
+            "askParameters": false,
+            "env": { "DB": "postgres" },
+            "localfs": true
+          },
+          {
+            "type": "rdbg",
+            "name": "Debug specs specific line",
+            "request": "launch",
+            "command": "bundle exec rspec",
+            "script": "${file}:${lineNumber}",
+            "args": [],
+            "askParameters": false,
+            "env": { "DB": "postgres" },
+            "localfs": true
+          }
+  ]
+}
+```
+
+If you're using mysql, swap that in as the value of the `DB` environment variable. If you're using a non-default DB connection string (see [here]((https://github.com/cloudfoundry/cloud_controller_ng#unit-tests))), also add that as an environment variable.
+
+Assuming your database is running, you can now click `Run and Debug` in the left-hand navigation bar. You should have a dropdown menu from which you can select the names of either of the two configurations above. Pick one of these and, after [setting breakpoints](https://code.visualstudio.com/docs/editor/debugging#_breakpoints), navigate to the spec file you want to debug. 
+
+If you've chosen to debug while running an entire spec file, open that file and, while keeping it in focus, hit the 'play' button in `Run and Debug`. If you want to run one part of a spec file - i.e. a specific `Describe`, `Context` or `It` block - then open the file, click with your cursor on the desired line, then choose the `Debug specs specific line` configuration, and hit 'play'.
+
 ## Logs
 
 Cloud Controller uses [Steno](http://github.com/cloudfoundry/steno) to manage its logs.


### PR DESCRIPTION
**A short explanation of the proposed change:**

Use the standard library's `debug` instead of `debase`/`ruby-debug-ide`

**An explanation of the use cases your change solves**

Neither `debase` nor `ruby-debug-ide` seem to support ruby 3.x, and I started getting weird segmentation errors when trying to debug with them after we recently bumped from ruby 2.

**Links to any other associated PRs**

n/a

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
