### PR TITLE
Loggregator: add flag to deprecate v4 bindings endpoint

### DIFF
--- a/app/controllers/internal/syslog_drain_urls_controller.rb
+++ b/app/controllers/internal/syslog_drain_urls_controller.rb
@@ -43,7 +43,7 @@ module VCAP::CloudController
 
       next_page_token = last_id + batch_size unless guid_to_drain_maps.empty?
 
-      [HTTP::OK, MultiJson.dump({ results: drain_urls, next_id: next_page_token }, pretty: true)]
+      [HTTP::OK, MultiJson.dump({ results: drain_urls, next_id: next_page_token, v5_available: true }, pretty: true)]
     end
 
     get '/internal/v5/syslog_drain_urls', :listv5

--- a/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
+++ b/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
@@ -17,6 +17,7 @@ module VCAP::CloudController
         get '/internal/v4/syslog_drain_urls', '{}'
         expect(last_response).to be_successful
         expect(decoded_results.count).to eq(1)
+        expect(decoded_v5_available).to eq(true)
         expect(decoded_results).to include(
           {
             app_obj.guid => { 'drains'   => match_array(['fish%2cfinger', 'foobar']),
@@ -34,6 +35,7 @@ module VCAP::CloudController
           get '/internal/v4/syslog_drain_urls', '{}'
           expect(last_response).to be_successful
           expect(decoded_results.count).to eq(1)
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_results).to include(
             {
               app_obj.guid => { 'drains'   => match_array(['fish%2cfinger', 'foobar']),
@@ -52,6 +54,7 @@ module VCAP::CloudController
           get '/internal/v4/syslog_drain_urls', '{}'
           expect(last_response).to be_successful
           expect(decoded_results.count).to eq(1)
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_results).to include(
             {
               app_obj.guid => { 'drains'   => match_array(['fish%2cfinger', 'foobar']),
@@ -70,6 +73,7 @@ module VCAP::CloudController
           get '/internal/v4/syslog_drain_urls', '{}'
           expect(last_response).to be_successful
           expect(decoded_results.count).to eq(1)
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_results).to include(
             {
               app_obj.guid => { 'drains'   => match_array(['fish%2cfinger', 'foobar']),
@@ -94,6 +98,7 @@ module VCAP::CloudController
           get '/internal/v4/syslog_drain_urls', '{}'
           expect(last_response).to be_successful
           expect(decoded_results.count).to eq(1)
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_results).to include(
             {
               app_obj.guid => { 'drains'   => match_array(['fish%2cfinger', 'foobar']),
@@ -116,6 +121,7 @@ module VCAP::CloudController
           get '/internal/v4/syslog_drain_urls', '{}'
           expect(last_response).to be_successful
           expect(decoded_results.count).to eq(1)
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_results).to include(
             {
               app_obj.guid => { 'drains'   => match_array(['fish%2cfinger', 'foobar']),
@@ -132,6 +138,7 @@ module VCAP::CloudController
         it 'does not include that app' do
           get '/internal/v4/syslog_drain_urls', '{}'
           expect(last_response).to be_successful
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_results).not_to have_key(app_no_binding.guid)
         end
       end
@@ -142,6 +149,7 @@ module VCAP::CloudController
         it 'does not include that app' do
           get '/internal/v4/syslog_drain_urls', '{}'
           expect(last_response).to be_successful
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_results).not_to have_key(app_no_drain.guid)
         end
       end
@@ -152,6 +160,7 @@ module VCAP::CloudController
         it 'includes the app without the empty syslog_drain_urls' do
           get '/internal/v4/syslog_drain_urls', '{}'
           expect(last_response).to be_successful
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_results).not_to have_key(app_empty_drain.guid)
         end
       end
@@ -170,6 +179,7 @@ module VCAP::CloudController
         it 'includes all of the syslog_drain_urls for that app' do
           get '/internal/v4/syslog_drain_urls', '{}'
           expect(last_response).to be_successful
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_results[app_obj.guid]['drains'].length).to eq(52)
         end
       end
@@ -187,6 +197,7 @@ module VCAP::CloudController
           [1, 3].each do |size|
             get '/internal/v4/syslog_drain_urls', { 'batch_size' => size }
             expect(last_response).to be_successful
+            expect(decoded_v5_available).to eq(true)
             expect(decoded_results.size).to eq(size)
           end
         end
@@ -235,6 +246,7 @@ module VCAP::CloudController
             'next_id'    => token,
           }
           expect(decoded_results.size).to eq(0)
+          expect(decoded_v5_available).to eq(true)
           expect(decoded_response['next_id']).to be_nil
         end
 
@@ -251,6 +263,7 @@ module VCAP::CloudController
 
             saved_results = decoded_results.dup
             expect(saved_results.size).to eq(2)
+            expect(decoded_v5_available).to eq(true)
           end
         end
 
@@ -268,6 +281,7 @@ module VCAP::CloudController
 
             saved_results = decoded_results.dup
             expect(saved_results.size).to eq(2)
+            expect(decoded_v5_available).to eq(true)
           end
         end
       end
@@ -444,6 +458,10 @@ module VCAP::CloudController
 
     def decoded_next_id
       decoded_response.fetch('next_id')
+    end
+
+    def decoded_v5_available
+      decoded_response.fetch('v5_available')
     end
   end
 end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
The PR adds a flag to allow the syslog-binding-cache to check if the new  v5 endpoint is already available

* An explanation of the use cases your change solves
The change solves the issue of using a fallback from v5 to v4 endpoints during the next update while ensuring a fallback does not happen in case of a malfunctioning cloud controller.

* Links to any other associated PRs
https://github.com/cloudfoundry/loggregator-agent-release/pull/119

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
