### PR TITLE
Replace usage of Digest with OpenSSL::Digest

### DIFF
--- a/app/controllers/runtime/stagings_controller.rb
+++ b/app/controllers/runtime/stagings_controller.rb
@@ -153,7 +153,7 @@ module VCAP::CloudController
     def check_file_md5
       return if Rails.env.local?
 
-      digester = Digester.new(algorithm: Digest::MD5, type: :base64digest)
+      digester = Digester.new(algorithm: OpenSSL::Digest::MD5, type: :base64digest)
       file_md5 = digester.digest_path(upload_path)
       header_md5 = env['HTTP_CONTENT_MD5']
 

--- a/app/jobs/v3/buildpack_cache_upload.rb
+++ b/app/jobs/v3/buildpack_cache_upload.rb
@@ -15,7 +15,7 @@ module VCAP::CloudController
           app = AppModel.find(guid: @app_guid)
 
           if app
-            sha256_digest = Digester.new(algorithm: Digest::SHA256).digest_path(@local_path)
+            sha256_digest = Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_path(@local_path)
             blobstore_key = Presenters::V3::CacheKeyPresenter.cache_key(guid: @app_guid, stack_name: @stack_name)
 
             FileUtils.chmod('u=wr', @local_path) if blobstore.local?

--- a/app/jobs/v3/droplet_upload.rb
+++ b/app/jobs/v3/droplet_upload.rb
@@ -17,7 +17,7 @@ module VCAP::CloudController
 
           if droplet
             sha1_digest = Digester.new.digest_path(@local_path)
-            sha256_digest = Digester.new(algorithm: Digest::SHA256).digest_path(@local_path)
+            sha256_digest = Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_path(@local_path)
 
             blobstore.cp_to_blobstore(
               @local_path,

--- a/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
@@ -75,7 +75,7 @@ module VCAP::CloudController
             layer = {
               name:              buildpack[:name],
               url:               buildpack[:url],
-              destination_path:  "/tmp/buildpacks/#{Digest::MD5.hexdigest(buildpack[:key])}",
+              destination_path:  "/tmp/buildpacks/#{OpenSSL::Digest::MD5.hexdigest(buildpack[:key])}",
               layer_type:        ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
               media_type:        ::Diego::Bbs::Models::ImageLayer::MediaType::ZIP,
             }
@@ -107,7 +107,7 @@ module VCAP::CloudController
             buildpack_dependency = {
               name:               buildpack[:name],
               from:               buildpack[:url],
-              to:                 "/tmp/buildpacks/#{Digest::MD5.hexdigest(buildpack[:key])}",
+              to:                 "/tmp/buildpacks/#{OpenSSL::Digest::MD5.hexdigest(buildpack[:key])}",
               cache_key:          buildpack[:key],
             }
             if buildpack[:sha256]

--- a/lib/cloud_controller/packager/local_bits_packer.rb
+++ b/lib/cloud_controller/packager/local_bits_packer.rb
@@ -16,7 +16,7 @@ module CloudController
 
           {
             sha1:   Digester.new.digest_path(complete_package_path),
-            sha256: Digester.new(algorithm: Digest::SHA256).digest_path(complete_package_path),
+            sha256: Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_path(complete_package_path),
           }
         end
       end

--- a/lib/cloud_controller/telemetry_logger.rb
+++ b/lib/cloud_controller/telemetry_logger.rb
@@ -1,5 +1,5 @@
-require 'digest'
 require 'json'
+require 'openssl'
 
 module VCAP::CloudController
   class TelemetryLogger
@@ -41,7 +41,7 @@ module VCAP::CloudController
       end
 
       def anonymize(entries)
-        entries.transform_values { |v| Digest::SHA256.hexdigest(v) }
+        entries.transform_values { |v| OpenSSL::Digest::SHA256.hexdigest(v) }
       end
     end
   end

--- a/lib/cloud_controller/upload_buildpack.rb
+++ b/lib/cloud_controller/upload_buildpack.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
     def upload_buildpack(buildpack, bits_file_path, new_filename)
       return false if buildpack.locked
 
-      sha256 = Digester.new(algorithm: Digest::SHA256).digest_path(bits_file_path)
+      sha256 = Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_path(bits_file_path)
       new_key = "#{buildpack.guid}_#{sha256}"
       missing_bits = buildpack.key && !buildpack_blobstore.exists?(buildpack.key)
 

--- a/lib/vcap/digester.rb
+++ b/lib/vcap/digester.rb
@@ -1,5 +1,7 @@
+require 'openssl'
+
 class Digester
-  ALGORITHM = Digest::SHA1
+  ALGORITHM = OpenSSL::Digest::SHA1
   TYPE = :hexdigest
 
   def initialize(algorithm: ALGORITHM, type: TYPE)

--- a/middleware/mixins/user_reset_interval.rb
+++ b/middleware/mixins/user_reset_interval.rb
@@ -3,7 +3,7 @@ module CloudFoundry
     module UserResetInterval
       def next_reset_interval(user_guid, reset_interval_in_minutes)
         interval = reset_interval_in_minutes.minutes.to_i
-        offset = Digest::MD5.hexdigest(user_guid).hex.remainder(interval)
+        offset = OpenSSL::Digest::MD5.hexdigest(user_guid).hex.remainder(interval)
 
         no_of_intervals = ((Time.now.utc - offset).to_f / interval).floor + 1
 

--- a/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
+++ b/spec/acceptance/broker_api_compatibility/broker_api_versions_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Broker API Versions' do
       'broker_api_v2.15_spec.rb' => 'c575fd37bc6dc8df4f773719ccef3288',
     }
   end
-  let(:digester) { Digester.new(algorithm: Digest::MD5) }
+  let(:digester) { Digester.new(algorithm: OpenSSL::Digest::MD5) }
 
   it 'verifies that there is a broker API test for each minor version' do
     stub_request(:get, 'http://broker-url/v2/catalog').

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -233,8 +233,8 @@ RSpec.describe 'Apps' do
               'telemetry-time' => Time.now.to_datetime.rfc3339,
               'create-app' => {
                 'api-version' => 'v3',
-                'app-id' => Digest::SHA256.hexdigest(app_guid),
-                'user-id' => Digest::SHA256.hexdigest(user.guid),
+                'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_guid),
+                'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
               }
             }.to_json
             expect(logger_spy).to have_received(:info).with(expected_json)
@@ -2260,8 +2260,8 @@ RSpec.describe 'Apps' do
             'telemetry-time' => Time.now.to_datetime.rfc3339,
             'update-app' => {
               'api-version' => 'v3',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
@@ -2568,8 +2568,8 @@ RSpec.describe 'Apps' do
               'telemetry-time' => Time.now.to_datetime.rfc3339,
               'start-app' => {
                 'api-version' => 'v3',
-                'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-                'user-id' => Digest::SHA256.hexdigest(user.guid),
+                'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+                'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
               }
             }
             expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
@@ -2846,8 +2846,8 @@ RSpec.describe 'Apps' do
             'telemetry-time' => Time.now.to_datetime.rfc3339,
             'stop-app' => {
               'api-version' => 'v3',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
@@ -2983,8 +2983,8 @@ RSpec.describe 'Apps' do
               'telemetry-time' => Time.now.to_datetime.rfc3339,
               'restart-app' => {
                 'api-version' => 'v3',
-                'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-                'user-id' => Digest::SHA256.hexdigest(user.guid),
+                'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+                'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
               }
             }
             expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
@@ -3399,7 +3399,7 @@ RSpec.describe 'Apps' do
               'origin' => 'buildpack',
               'memory-in-mb' => 300,
               'process-types' => ['web'],
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))

--- a/spec/request/builds_spec.rb
+++ b/spec/request/builds_spec.rb
@@ -325,9 +325,9 @@ RSpec.describe 'Builds' do
               'lifecycle' => 'buildpack',
               'buildpacks' => ['http://github.com/myorg/awesome-buildpack'],
               'stack' => 'cflinuxfs3',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'build-id' => Digest::SHA256.hexdigest(created_build.guid),
-              'user-id' => Digest::SHA256.hexdigest(developer.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+              'build-id' => OpenSSL::Digest::SHA256.hexdigest(created_build.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(developer.guid),
             }
           }
           expect(logger_spy).to have_received(:info).with(JSON.generate(expected_json))

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -586,8 +586,8 @@ RSpec.describe 'Deployments' do
             'create-deployment' => {
               'api-version' => 'v3',
               'strategy' => 'rolling',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
@@ -605,9 +605,9 @@ RSpec.describe 'Deployments' do
             'rolled-back-app' => {
               'api-version' => 'v3',
               'strategy' => 'rolling',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
-              'revision-id' => Digest::SHA256.hexdigest(revision.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
+              'revision-id' => OpenSSL::Digest::SHA256.hexdigest(revision.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).twice

--- a/spec/request/droplets_spec.rb
+++ b/spec/request/droplets_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe 'Droplets' do
         buildpack_receipt_buildpack: 'http://buildpack.git.url.com',
         error_description: 'example error',
         execution_metadata: 'some-data',
-        droplet_hash: Digest::SHA1.hexdigest(worlds_smallest_tgz_file),
+        droplet_hash: OpenSSL::Digest::SHA1.hexdigest(worlds_smallest_tgz_file),
         sha256_checksum: 'some-sha-256',
         process_types: { 'web' => 'start-command' },
       )

--- a/spec/request/packages_spec.rb
+++ b/spec/request/packages_spec.rb
@@ -949,8 +949,8 @@ RSpec.describe 'Packages' do
             'telemetry-time' => Time.now.to_datetime.rfc3339,
             'upload-package' => {
               'api-version' => 'v3',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -996,8 +996,8 @@ RSpec.describe 'Processes' do
               'disk-in-mb' => 20,
               'log-rate-in-bytes-per-second' => 40,
               'process-type' => 'web',
-              'app-id' => Digest::SHA256.hexdigest(process.app.guid),
-              'user-id' => Digest::SHA256.hexdigest(developer.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(developer.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
@@ -1628,8 +1628,8 @@ RSpec.describe 'Processes' do
               'disk-in-mb' => 20,
               'log-rate-in-bytes-per-second' => 40,
               'process-type' => 'web',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'user-id' => Digest::SHA256.hexdigest(developer.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(developer.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1276,10 +1276,10 @@ RSpec.describe 'v3 service credential bindings' do
               'telemetry-time' => Time.now.to_datetime.rfc3339,
               'bind-service' => {
                 'api-version' => 'v3',
-                'service-id' => Digest::SHA256.hexdigest('user-provided'),
-                'service-instance-id' => Digest::SHA256.hexdigest(service_instance.guid),
-                'app-id' => Digest::SHA256.hexdigest(app_guid),
-                'user-id' => Digest::SHA256.hexdigest(user.guid),
+                'service-id' => OpenSSL::Digest.hexdigest('SHA256', 'user-provided'),
+                'service-instance-id' => OpenSSL::Digest::SHA256.hexdigest(service_instance.guid),
+                'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_guid),
+                'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
               }
             }
             expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
@@ -1399,10 +1399,10 @@ RSpec.describe 'v3 service credential bindings' do
               'telemetry-time' => Time.now.to_datetime.rfc3339,
               'bind-service' => {
                 'api-version' => 'v3',
-                'service-id' => Digest::SHA256.hexdigest(service_instance.service_plan.service.guid),
-                'service-instance-id' => Digest::SHA256.hexdigest(service_instance.guid),
-                'app-id' => Digest::SHA256.hexdigest(app_guid),
-                'user-id' => Digest::SHA256.hexdigest(user.guid),
+                'service-id' => OpenSSL::Digest::SHA256.hexdigest(service_instance.service_plan.service.guid),
+                'service-instance-id' => OpenSSL::Digest::SHA256.hexdigest(service_instance.guid),
+                'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_guid),
+                'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
               }
             }
             expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))

--- a/spec/request/sidecars_spec.rb
+++ b/spec/request/sidecars_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe 'Sidecars' do
             'origin' => 'user',
             'memory-in-mb' => 300,
             'process-types' => ['other_worker', 'web'],
-            'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-            'user-id' => Digest::SHA256.hexdigest(user.guid),
+            'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+            'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
           }
         }
         expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))

--- a/spec/request/tasks_spec.rb
+++ b/spec/request/tasks_spec.rb
@@ -1267,8 +1267,8 @@ RSpec.describe 'Tasks' do
             'telemetry-time' => Time.now.to_datetime.rfc3339,
             'create-task' => {
               'api-version' => 'v3',
-              'app-id' => Digest::SHA256.hexdigest(app_model.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
 

--- a/spec/request/v2/apps_spec.rb
+++ b/spec/request/v2/apps_spec.rb
@@ -629,8 +629,8 @@ RSpec.describe 'Apps' do
             'telemetry-time' => Time.now.to_datetime.rfc3339,
             'create-app' => {
               'api-version' => 'v2',
-              'app-id' => Digest::SHA256.hexdigest(app_guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
           expect(last_response.status).to eq(201), last_response.body
@@ -797,8 +797,8 @@ RSpec.describe 'Apps' do
               'telemetry-time' => Time.now.to_datetime.rfc3339,
               'update-app' => {
                 'api-version' => 'v2',
-                'app-id' => Digest::SHA256.hexdigest(process.app.guid),
-                'user-id' => Digest::SHA256.hexdigest(user.guid),
+                'app-id' => OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+                'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
               }
             }
             # start-app telemetry will be logged because of the 'state:STARTED' update param. skip checking this.
@@ -826,8 +826,8 @@ RSpec.describe 'Apps' do
               'memory-in-mb'   => memory,
               'disk-in-mb'     => disk_quota,
               'process-type'   => 'web',
-              'app-id'         => Digest::SHA256.hexdigest(process.app.guid),
-              'user-id'        => Digest::SHA256.hexdigest(user.guid),
+              'app-id'         => OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+              'user-id'        => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
         end
@@ -894,8 +894,8 @@ RSpec.describe 'Apps' do
             'telemetry-time'   => Time.now.to_datetime.rfc3339,
             'start-app' => {
               'api-version'    => 'v2',
-              'app-id'         => Digest::SHA256.hexdigest(process.app.guid),
-              'user-id'        => Digest::SHA256.hexdigest(user.guid),
+              'app-id'         => OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+              'user-id'        => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
         end
@@ -922,8 +922,8 @@ RSpec.describe 'Apps' do
             'telemetry-time'   => Time.now.to_datetime.rfc3339,
             'stop-app' => {
               'api-version'    => 'v2',
-              'app-id'         => Digest::SHA256.hexdigest(process.app.guid),
-              'user-id'        => Digest::SHA256.hexdigest(user.guid),
+              'app-id'         => OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+              'user-id'        => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
         end
@@ -1162,8 +1162,8 @@ RSpec.describe 'Apps' do
             'telemetry-time' => Time.now.to_datetime.rfc3339,
             'delete-app' => {
               'api-version' => 'v2',
-              'app-id' => Digest::SHA256.hexdigest(process.app.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))
@@ -1545,8 +1545,8 @@ RSpec.describe 'Apps' do
               'lifecycle' => 'buildpack',
               'buildpacks' => process.app.buildpack_lifecycle_data.buildpacks,
               'stack' => process.app.buildpack_lifecycle_data.stack,
-              'app-id' => Digest::SHA256.hexdigest(process.app.guid),
-              'user-id' => Digest::SHA256.hexdigest(user.guid),
+              'app-id' => OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+              'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
             }
           }
           expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(anything).once
@@ -1571,8 +1571,8 @@ RSpec.describe 'Apps' do
                 'lifecycle' => 'docker',
                 'buildpacks' => [],
                 'stack' => nil,
-                'app-id' => Digest::SHA256.hexdigest(process.app.guid),
-                'user-id' => Digest::SHA256.hexdigest(user.guid),
+                'app-id' => OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+                'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
               }
             }
             expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(anything).once
@@ -1625,8 +1625,8 @@ RSpec.describe 'Apps' do
           'telemetry-time'   => Time.now.to_datetime.rfc3339,
           'upload-package' => {
             'api-version'    => 'v2',
-            'app-id'         => Digest::SHA256.hexdigest(process.app.guid),
-            'user-id'        => Digest::SHA256.hexdigest(user.guid),
+            'app-id'         => OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+            'user-id'        => OpenSSL::Digest::SHA256.hexdigest(user.guid),
           }
         }
       end

--- a/spec/unit/actions/v2/app_stage_spec.rb
+++ b/spec/unit/actions/v2/app_stage_spec.rb
@@ -206,9 +206,9 @@ module VCAP::CloudController
                   'lifecycle' =>  'buildpack',
                   'buildpacks' =>  ['http://github.com/myorg/awesome-buildpack'],
                   'stack' =>  'my_stack',
-                  'app-id' =>  Digest::SHA256.hexdigest(process.app.guid),
-                  'build-id' =>  Digest::SHA256.hexdigest(process.latest_build.guid),
-                  'user-id' =>  Digest::SHA256.hexdigest('userguid'),
+                  'app-id' =>  OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+                  'build-id' =>  OpenSSL::Digest::SHA256.hexdigest(process.latest_build.guid),
+                  'user-id' =>  OpenSSL::Digest.hexdigest('SHA256', 'userguid'),
                 }
               }
               expect(logger_spy).to have_received(:info).with(JSON.generate(expected_json))
@@ -246,9 +246,9 @@ module VCAP::CloudController
                     'lifecycle' =>  'kpack',
                     'buildpacks' =>  [],
                     'stack' =>  nil,
-                    'app-id' =>  Digest::SHA256.hexdigest(process.app.guid),
-                    'build-id' =>  Digest::SHA256.hexdigest(process.latest_build.guid),
-                    'user-id' =>  Digest::SHA256.hexdigest('userguid'),
+                    'app-id' =>  OpenSSL::Digest::SHA256.hexdigest(process.app.guid),
+                    'build-id' =>  OpenSSL::Digest::SHA256.hexdigest(process.latest_build.guid),
+                    'user-id' =>  OpenSSL::Digest.hexdigest('SHA256', 'userguid'),
                   }
                 }
                 expect(logger_spy).to have_received(:info).with(JSON.generate(expected_json))

--- a/spec/unit/controllers/internal/staging_completion_controller_spec.rb
+++ b/spec/unit/controllers/internal/staging_completion_controller_spec.rb
@@ -351,8 +351,8 @@ module VCAP::CloudController
                 'lifecycle' =>  'buildpack',
                 'buildpacks' =>  %w(the-pleasant-buildpack),
                 'stack' =>  'cflinuxfs3',
-                'app-id' =>  Digest::SHA256.hexdigest(staged_app.guid),
-                'build-id' =>  Digest::SHA256.hexdigest(build.guid),
+                'app-id' =>  OpenSSL::Digest::SHA256.hexdigest(staged_app.guid),
+                'build-id' =>  OpenSSL::Digest::SHA256.hexdigest(build.guid),
               }
             }
             expect_any_instance_of(ActiveSupport::Logger).to receive(:info).with(JSON.generate(expected_json))

--- a/spec/unit/controllers/runtime/buildpack_bits_controller_spec.rb
+++ b/spec/unit/controllers/runtime/buildpack_bits_controller_spec.rb
@@ -6,9 +6,9 @@ module VCAP::CloudController
   RSpec.describe VCAP::CloudController::BuildpackBitsController do
     let(:user) { make_user }
     let(:filename) { 'file.zip' }
-    let(:sha_valid_zip) { Digester.new(algorithm: Digest::SHA256).digest_file(valid_zip) }
-    let(:sha_valid_zip2) { Digester.new(algorithm: Digest::SHA256).digest_file(valid_zip2) }
-    let(:sha_valid_tar_gz) { Digester.new(algorithm: Digest::SHA256).digest_file(valid_tar_gz) }
+    let(:sha_valid_zip) { Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_file(valid_zip) }
+    let(:sha_valid_zip2) { Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_file(valid_zip2) }
+    let(:sha_valid_tar_gz) { Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_file(valid_tar_gz) }
 
     let(:valid_zip_manifest_tmpdir) { Dir.mktmpdir }
     let(:valid_zip_manifest) do

--- a/spec/unit/controllers/runtime/stagings_controller_spec.rb
+++ b/spec/unit/controllers/runtime/stagings_controller_spec.rb
@@ -123,7 +123,7 @@ module VCAP::CloudController
     let(:blobstore) do
       CloudController::DependencyLocator.instance.droplet_blobstore
     end
-    let(:digester) { Digester.new(algorithm: Digest::MD5, type: :base64digest) }
+    let(:digester) { Digester.new(algorithm: OpenSSL::Digest::MD5, type: :base64digest) }
 
     let(:buildpack_cache_blobstore) do
       CloudController::DependencyLocator.instance.buildpack_cache_blobstore

--- a/spec/unit/jobs/v3/buildpack_cache_upload_spec.rb
+++ b/spec/unit/jobs/v3/buildpack_cache_upload_spec.rb
@@ -40,7 +40,7 @@ module VCAP::CloudController
         end
 
         it 'updates the buildpack cache checksum' do
-          sha256_digest = Digester.new(algorithm: Digest::SHA256).digest_file(local_file)
+          sha256_digest = Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_file(local_file)
 
           expect { job.perform }.to change { app.refresh.buildpack_cache_sha256_checksum }.to(sha256_digest)
         end

--- a/spec/unit/jobs/v3/droplet_upload_spec.rb
+++ b/spec/unit/jobs/v3/droplet_upload_spec.rb
@@ -27,7 +27,7 @@ module VCAP::CloudController
       describe '#perform' do
         it 'updates the droplet checksums' do
           sha1_digest = Digester.new.digest_file(local_file)
-          sha256_digest = Digester.new(algorithm: Digest::SHA256).digest_file(local_file)
+          sha256_digest = Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_file(local_file)
 
           job.perform
           expect(droplet.refresh.droplet_hash).to eq(sha1_digest)

--- a/spec/unit/lib/cloud_controller/blobstore/fog/fog_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/blobstore/fog/fog_client_spec.rb
@@ -806,7 +806,7 @@ module CloudController
           it 'correctly downloads byte streams' do
             source_directory_path = File.expand_path('../../../../../fixtures/', File.dirname(__FILE__))
             source_file_path      = File.join(source_directory_path, 'pa/rt/partitioned_key')
-            source_hexdigest      = Digest::SHA2.file(source_file_path).hexdigest
+            source_hexdigest      = OpenSSL::Digest::SHA256.file(source_file_path).hexdigest
 
             pid = spawn("ruby -rwebrick -e'WEBrick::HTTPServer.new(:Port => #{port}, :DocumentRoot => \"#{source_directory_path}\").start'", out: 'test.out', err: 'test.err')
 
@@ -819,7 +819,7 @@ module CloudController
 
               client.download_from_blobstore('partitioned_key', destination_file_path)
 
-              destination_hexdigest = Digest::SHA2.file(destination_file_path).hexdigest
+              destination_hexdigest = OpenSSL::Digest::SHA256.file(destination_file_path).hexdigest
 
               expect(destination_hexdigest).to eq(source_hexdigest)
             ensure
@@ -843,13 +843,13 @@ module CloudController
             source_directory_path = File.join(local_root, directory_key)
 
             source_file_path = File.join(source_directory_path, 'pa/rt/partitioned_key')
-            source_hexdigest = Digest::SHA2.file(source_file_path).hexdigest
+            source_hexdigest = OpenSSL::Digest::SHA256.file(source_file_path).hexdigest
 
             destination_file_path = File.join(Dir.mktmpdir, 'hard_file.xyz')
 
             client.download_from_blobstore('partitioned_key', destination_file_path)
 
-            destination_hexdigest = Digest::SHA2.file(destination_file_path).hexdigest
+            destination_hexdigest = OpenSSL::Digest::SHA256.file(destination_file_path).hexdigest
 
             expect(destination_hexdigest).to eq(source_hexdigest)
           end

--- a/spec/unit/lib/cloud_controller/diego/buildpack/staging_action_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/staging_action_builder_spec.rb
@@ -323,7 +323,7 @@ module VCAP::CloudController
               buildpack_entry_1 = ::Diego::Bbs::Models::CachedDependency.new(
                 name:               'buildpack-1',
                 from:               'buildpack-1-url',
-                to:                 "/tmp/buildpacks/#{Digest::MD5.hexdigest('buildpack-1-key')}",
+                to:                 "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'buildpack-1-key')}",
                 cache_key:          'buildpack-1-key',
                 checksum_algorithm: 'sha256',
                 checksum_value:     'checksum',
@@ -331,7 +331,7 @@ module VCAP::CloudController
               buildpack_entry_2 = ::Diego::Bbs::Models::CachedDependency.new(
                 name:               'buildpack-2',
                 from:               'buildpack-2-url',
-                to:                 "/tmp/buildpacks/#{Digest::MD5.hexdigest('buildpack-2-key')}",
+                to:                 "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'buildpack-2-key')}",
                 cache_key:          'buildpack-2-key',
                 checksum_algorithm: 'sha256',
                 checksum_value:     'checksum',
@@ -361,7 +361,7 @@ module VCAP::CloudController
                 buildpack_entry_1 = ::Diego::Bbs::Models::CachedDependency.new(
                   name:               'buildpack-1',
                   from:               'buildpack-1-url',
-                  to:                 "/tmp/buildpacks/#{Digest::MD5.hexdigest('buildpack-1-key')}",
+                  to:                 "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'buildpack-1-key')}",
                   cache_key:          'buildpack-1-key',
                   checksum_algorithm: 'sha256',
                   checksum_value:     'checksum',
@@ -369,7 +369,7 @@ module VCAP::CloudController
                 buildpack_entry_2 = ::Diego::Bbs::Models::CachedDependency.new(
                   name:      'buildpack-2',
                   from:      'buildpack-2-url',
-                  to:        "/tmp/buildpacks/#{Digest::MD5.hexdigest('buildpack-2-key')}",
+                  to:        "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'buildpack-2-key')}",
                   cache_key: 'buildpack-2-key',
                 )
 
@@ -399,7 +399,7 @@ module VCAP::CloudController
               buildpack_entry_1 = ::Diego::Bbs::Models::CachedDependency.new(
                 name:               'buildpack-1',
                 from:               'buildpack-1-url',
-                to:                 "/tmp/buildpacks/#{Digest::MD5.hexdigest('buildpack-1-key')}",
+                to:                 "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'buildpack-1-key')}",
                 cache_key:          'buildpack-1-key',
                 checksum_algorithm: 'sha256',
                 checksum_value:     'checksum',
@@ -407,7 +407,7 @@ module VCAP::CloudController
               buildpack_entry_2 = ::Diego::Bbs::Models::CachedDependency.new(
                 name:      'custom',
                 from:      'custom-url',
-                to:        "/tmp/buildpacks/#{Digest::MD5.hexdigest('custom-key')}",
+                to:        "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'custom-key')}",
                 cache_key: 'custom-key',
               )
 
@@ -510,7 +510,7 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::ImageLayer.new(
                     name:              'buildpack-1',
                     url:               'buildpack-1-url',
-                    destination_path:  "/tmp/buildpacks/#{Digest::MD5.hexdigest('buildpack-1-key')}",
+                    destination_path:  "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'buildpack-1-key')}",
                     digest_algorithm:  ::Diego::Bbs::Models::ImageLayer::DigestAlgorithm::SHA256,
                     digest_value:      'checksum',
                     layer_type:        ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
@@ -521,7 +521,7 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::ImageLayer.new(
                     name:              'buildpack-2',
                     url:               'buildpack-2-url',
-                    destination_path:  "/tmp/buildpacks/#{Digest::MD5.hexdigest('buildpack-2-key')}",
+                    destination_path:  "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'buildpack-2-key')}",
                     digest_algorithm:  ::Diego::Bbs::Models::ImageLayer::DigestAlgorithm::SHA256,
                     digest_value:      'checksum',
                     layer_type:        ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
@@ -543,7 +543,7 @@ module VCAP::CloudController
                     ::Diego::Bbs::Models::ImageLayer.new(
                       name:              'buildpack-2',
                       url:               'buildpack-2-url',
-                      destination_path:  "/tmp/buildpacks/#{Digest::MD5.hexdigest('buildpack-2-key')}",
+                      destination_path:  "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'buildpack-2-key')}",
                       layer_type:        ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
                       media_type:        ::Diego::Bbs::Models::ImageLayer::MediaType::ZIP,
                     )
@@ -565,7 +565,7 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::ImageLayer.new(
                     name:              'custom',
                     url:               'custom-url',
-                    destination_path:  "/tmp/buildpacks/#{Digest::MD5.hexdigest('custom-key')}",
+                    destination_path:  "/tmp/buildpacks/#{OpenSSL::Digest.hexdigest('MD5', 'custom-key')}",
                     layer_type:        ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
                     media_type:        ::Diego::Bbs::Models::ImageLayer::MediaType::ZIP,
                   )

--- a/spec/unit/lib/cloud_controller/packager/local_bits_packer_spec.rb
+++ b/spec/unit/lib/cloud_controller/packager/local_bits_packer_spec.rb
@@ -69,7 +69,7 @@ module CloudController::Packager
         sha256_digester = instance_double(Digester, digest_path: 'expected-sha256')
 
         allow(Digester).to receive(:new).with(no_args).and_return(sha1_digester)
-        allow(Digester).to receive(:new).with(algorithm: Digest::SHA256).and_return(sha256_digester)
+        allow(Digester).to receive(:new).with(algorithm: OpenSSL::Digest::SHA256).and_return(sha256_digester)
 
         result_sha = packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
 

--- a/spec/unit/lib/cloud_controller/telemetry_logger_spec.rb
+++ b/spec/unit/lib/cloud_controller/telemetry_logger_spec.rb
@@ -34,7 +34,7 @@ module VCAP::CloudController
         'telemetry-time' => rfc3339,
         'some-event' => {
           'api-version' => 'v3',
-          'bogus_key' => Digest::SHA256.hexdigest('bogus_value')
+          'bogus_key' => OpenSSL::Digest.hexdigest('SHA256', 'bogus_value')
         }
       })
     end
@@ -51,7 +51,7 @@ module VCAP::CloudController
         'telemetry-time' => rfc3339,
         'some-event' => {
           'api-version' => 'v3',
-          'anonymize_key' => Digest::SHA256.hexdigest('anonymize_value'),
+          'anonymize_key' => OpenSSL::Digest.hexdigest('SHA256', 'anonymize_value'),
           'safe_key' => 'safe-value',
         }
       })
@@ -85,7 +85,7 @@ module VCAP::CloudController
           'telemetry-source' => 'cloud_controller_ng',
           'telemetry-time' => rfc3339,
           'some-event' => {
-            'key' => Digest::SHA256.hexdigest('value'),
+            'key' => OpenSSL::Digest.hexdigest('SHA256', 'value'),
             'api-version' => 'v2',
           }
         })
@@ -102,7 +102,7 @@ module VCAP::CloudController
           'telemetry-source' => 'cloud_controller_ng',
           'telemetry-time' => rfc3339,
           'some-event' => {
-            'key' => Digest::SHA256.hexdigest('value'),
+            'key' => OpenSSL::Digest.hexdigest('SHA256', 'value'),
             'api-version' => 'v3',
           }
         })
@@ -119,7 +119,7 @@ module VCAP::CloudController
           'telemetry-source' => 'cloud_controller_ng',
           'telemetry-time' => rfc3339,
           'some-event' => {
-            'key' => Digest::SHA256.hexdigest('value'),
+            'key' => OpenSSL::Digest.hexdigest('SHA256', 'value'),
             'api-version' => 'internal',
           }
         })

--- a/spec/unit/lib/cloud_controller/upload_buildpack_spec.rb
+++ b/spec/unit/lib/cloud_controller/upload_buildpack_spec.rb
@@ -10,8 +10,8 @@ module VCAP::CloudController
     let(:tmpdir) { Dir.mktmpdir }
     let(:filename) { 'file.zip' }
 
-    let(:sha_valid_zip) { Digester.new(algorithm: Digest::SHA256).digest_file(valid_zip) }
-    let(:sha_valid_zip2) { Digester.new(algorithm: Digest::SHA256).digest_file(valid_zip2) }
+    let(:sha_valid_zip) { Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_file(valid_zip) }
+    let(:sha_valid_zip2) { Digester.new(algorithm: OpenSSL::Digest::SHA256).digest_file(valid_zip2) }
 
     let(:valid_zip_manifest_stack) { nil }
     let(:valid_zip) do

--- a/spec/unit/lib/vcap/digester_spec.rb
+++ b/spec/unit/lib/vcap/digester_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Digester do
   end
 
   describe 'changing the algorithm' do
-    subject(:digester) { Digester.new(algorithm: Digest::MD5) }
+    subject(:digester) { Digester.new(algorithm: OpenSSL::Digest::MD5) }
     let(:md5) { '9f3f3f57770f25cb8faa685d7336aa4c' }
 
     it 'uses the given algorithm' do


### PR DESCRIPTION
**A short explanation of the proposed change**:

Replace usage of [Digest](https://ruby-doc.org/stdlib-3.0.1/libdoc/digest/rdoc/Digest.html) with [OpenSSL::Digest](https://ruby-doc.org/stdlib-3.0.0/libdoc/openssl/rdoc/OpenSSL.html) module.

**An explanation of the use cases your change solves**:

Resolves the performance issues when using `Digest` module with Ruby 3, see https://github.com/cloudfoundry/capi-release/issues/285 for a detailed report.

**Links to any other associated PRs**:

n/a

---

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)

---

Resolves cloudfoundry/capi-release#285
