### PR TITLE
Exclude events table from using window function for pagination

### DIFF
--- a/app/models/runtime/event.rb
+++ b/app/models/runtime/event.rb
@@ -81,5 +81,13 @@ module VCAP::CloudController
         [:organization_guid, Organization.dataset.where(auditors: user).select_map(:guid)]
       ])
     end
+
+    Event.dataset_module do
+      # Don't use window function for the 'events' table as this table might contain millions of rows
+      # which can lead to a performance degradation.
+      def supports_window_functions?
+        false
+      end
+    end
   end
 end

--- a/lib/cloud_controller/paging/sequel_paginator.rb
+++ b/lib/cloud_controller/paging/sequel_paginator.rb
@@ -2,9 +2,6 @@ require 'cloud_controller/paging/paginated_result'
 
 module VCAP::CloudController
   class SequelPaginator
-    # Don't use window function for the 'events' table as this table might contain millions of rows
-    # which can lead to a performance degradation.
-    EXCLUDE_FROM_PAGINATION_WITH_WINDOW_FUNCTION = [:events].freeze
     def get_page(sequel_dataset, pagination_options)
       page = pagination_options.page
       per_page = pagination_options.per_page
@@ -17,7 +14,7 @@ module VCAP::CloudController
 
       sequel_dataset = sequel_dataset.order(sequel_order)
       sequel_dataset = sequel_dataset.order_append(Sequel.asc(Sequel.qualify(table_name, :guid))) if sequel_dataset.model.columns.include?(:guid)
-      records, count = if !EXCLUDE_FROM_PAGINATION_WITH_WINDOW_FUNCTION.include?(table_name) && can_paginate_with_window_function?(sequel_dataset)
+      records, count = if can_paginate_with_window_function?(sequel_dataset)
                          paginate_with_window_function(sequel_dataset, per_page, page, table_name)
                        else
                          paginate_with_extension(sequel_dataset, per_page, page)

--- a/lib/cloud_controller/paging/sequel_paginator.rb
+++ b/lib/cloud_controller/paging/sequel_paginator.rb
@@ -2,6 +2,9 @@ require 'cloud_controller/paging/paginated_result'
 
 module VCAP::CloudController
   class SequelPaginator
+    # Don't use window function for the 'events' table as this table might contain millions of rows
+    # which can lead to a performance degradation.
+    EXCLUDE_FROM_PAGINATION_WITH_WINDOW_FUNCTION = [:events].freeze
     def get_page(sequel_dataset, pagination_options)
       page = pagination_options.page
       per_page = pagination_options.per_page
@@ -14,8 +17,7 @@ module VCAP::CloudController
 
       sequel_dataset = sequel_dataset.order(sequel_order)
       sequel_dataset = sequel_dataset.order_append(Sequel.asc(Sequel.qualify(table_name, :guid))) if sequel_dataset.model.columns.include?(:guid)
-
-      records, count = if can_paginate_with_window_function?(sequel_dataset)
+      records, count = if !EXCLUDE_FROM_PAGINATION_WITH_WINDOW_FUNCTION.include?(table_name) && can_paginate_with_window_function?(sequel_dataset)
                          paginate_with_window_function(sequel_dataset, per_page, page, table_name)
                        else
                          paginate_with_extension(sequel_dataset, per_page, page)

--- a/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
+++ b/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
@@ -129,14 +129,14 @@ module VCAP::CloudController
         expect(paginated_result.total).to be > 1
       end
 
-      context 'calls DB twice if table is in exclude-from-window-function-with-pagination list' do
-        let(:dataset) { VCAP::CloudController.const_get(VCAP::CloudController::Event.to_s.classify).dataset }
-        let!(:event_1) { VCAP::CloudController.const_get(VCAP::CloudController::Event.to_s.classify).make(guid: '1', created_at: '2022-12-20T10:47:01Z') }
-        let!(:event_2) { VCAP::CloudController.const_get(VCAP::CloudController::Event.to_s.classify).make(guid: '2', created_at: '2022-12-20T10:47:02Z') }
-        let!(:event_3) { VCAP::CloudController.const_get(VCAP::CloudController::Event.to_s.classify).make(guid: '3', created_at: '2022-12-20T10:47:03Z') }
-        let!(:event_4) { VCAP::CloudController.const_get(VCAP::CloudController::Event.to_s.classify).make(guid: '4', created_at: '2022-12-20T10:47:04Z') }
+      context 'events table' do
+        let(:dataset) { Event.dataset }
+        let!(:event_1) { Event.make(guid: '1', created_at: '2022-12-20T10:47:01Z') }
+        let!(:event_2) { Event.make(guid: '2', created_at: '2022-12-20T10:47:02Z') }
+        let!(:event_3) { Event.make(guid: '3', created_at: '2022-12-20T10:47:03Z') }
+        let!(:event_4) { Event.make(guid: '4', created_at: '2022-12-20T10:47:04Z') }
 
-        it 'does not use window function for events table' do
+        it 'does not use window function' do
           options = { page: page, per_page: per_page }
           pagination_options = PaginationOptions.new(options)
 


### PR DESCRIPTION
The events table is one of the biggest tables. We saw slow queries on big landscapes like:
```
cf curl "/v3/audit_events?types=audit.user.organization_user_add%2Caudit.user.organization_billing_manager_remove%2Caudit.user.space_developer_add%2Caudit.user.organization_auditor_remove%2Caudit.user.space_developer_remove%2Caudit.user.space_auditor_remove%2Caudit.user.space_auditor_add%2Caudit.user.space_manager_add%2Caudit.user.organization_billing_manager_add%2Caudit.user.organization_manager_remove%2Caudit.user.organization_auditor_add%2Caudit.user.space_manager_remove%2Caudit.user.organization_manager_add%2Caudit.user.organization_user_remove&per_page=500&order_by=-created_at" 
```
We experimented and discovered using v2 for audit_events is much faster. The difference between v2 and v3 is that for v3 pagination is done via window function. 
```
SELECT *, count(*) OVER () AS "pagination_total_results" FROM "events" WHERE ("type" IN ('audit.user.organization_user_add', 'audit.user.organization_billing_manager_remove', 'audit.user.space_developer_add', 'audit.user.organization_auditor_remove', 'audit.user.space_developer_remove', 'audit.user.space_auditor_remove', 'audit.user.space_auditor_add', 'audit.user.space_manager_add', 'audit.user.organization_billing_manager_add', 'audit.user.organization_manager_remove', 'audit.user.organization_auditor_add', 'audit.user.space_manager_remove', 'audit.user.organization_manager_add', 'audit.user.organization_user_remove')) ORDER BY "events"."created_at" DESC, "events"."guid" ASC LIMIT 500 OFFSET 0
```
In v2 it was done with 2 queries.
```
SELECT * FROM "events" WHERE (type  IN  ('audit.user.organization_user_add', 'audit.user.organization_billing_manager_remove', 'audit.user.space_developer_add', 'audit.user.organization_auditor_remove', 'audit.user.space_developer_remove', 'audit.user.space_auditor_remove', 'audit.user.space_auditor_add', 'audit.user.space_manager_add', 'audit.user.organization_billing_manager_add', 'audit.user.organization_manager_remove', 'audit.user.organization_auditor_add', 'audit.user.space_manager_remove', 'audit.user.organization_manager_add', 'audit.user.organization_user_remove')) ORDER BY "timestamp" DESC, "id" DESC LIMIT 500 OFFSET 0

SELECT count(*) AS "count" FROM "events" WHERE (type  IN  ('audit.user.organization_user_add', 'audit.user.organization_billing_manager_remove', 'audit.user.space_developer_add', 'audit.user.organization_auditor_remove', 'audit.user.space_developer_remove', 'audit.user.space_auditor_remove', 'audit.user.space_auditor_add', 'audit.user.space_manager_add', 'audit.user.organization_billing_manager_add', 'audit.user.organization_manager_remove', 'audit.user.organization_auditor_add', 'audit.user.space_manager_remove', 'audit.user.organization_manager_add', 'audit.user.organization_user_remove')) LIMIT 1
```
For big tables like the events table using pagination with window function seems not to be the best choice. 
With this PR we change it so that the events table is excluded from window function for pagiantion
The query for the /v3/audit_events call would look like following with current change:
(no more window function)
```
SELECT * FROM "events" WHERE (type  IN  ('audit.user.organization_user_add', 'audit.user.organization_billing_manager_remove', 'audit.user.space_developer_add', 'audit.user.organization_auditor_remove', 'audit.user.space_developer_remove', 'audit.user.space_auditor_remove', 'audit.user.space_auditor_add', 'audit.user.space_manager_add', 'audit.user.organization_billing_manager_add', 'audit.user.organization_manager_remove', 'audit.user.organization_auditor_add', 'audit.user.space_manager_remove', 'audit.user.organization_manager_add', 'audit.user.organization_user_remove')) ORDER BY "events"."created_at" DESC, "events"."guid" ASC LIMIT 500 OFFSET 0

SELECT count(*) AS "count" FROM "events" WHERE (type  IN  ('audit.user.organization_user_add', 'audit.user.organization_billing_manager_remove', 'audit.user.space_developer_add', 'audit.user.organization_auditor_remove', 'audit.user.space_developer_remove', 'audit.user.space_auditor_remove', 'audit.user.space_auditor_add', 'audit.user.space_manager_add', 'audit.user.organization_billing_manager_add', 'audit.user.organization_manager_remove', 'audit.user.organization_auditor_add', 'audit.user.space_manager_remove', 'audit.user.organization_manager_add', 'audit.user.organization_user_remove')) LIMIT 1
```
Excluding the events table from using the pagination with window function and do 2 queries like it was in v2 improves query time extremely.

|cf curl /v3/  on 12813074 events|time in s with window function |time in s without window function |
| ----- | ----- | ----- |
|'/v3/audit_events'	|30,34|1,94|
|'/v3/audit_events?page=1&per_page=5&created_ats[gt]=2022-11-23T15:36:54Z'|	22,10|2,17|
|'/v3/audit_events?types=...&per_page=100&order_by=-created_at'|	1,48|	0,69|
|'/v3/audit_events?space_guids=dd3a8c27-bc6f-4b58-930d-d77865c9a428&page=1&per_page=5&order_by=-created_at'	|54,41|	8,51|

|cf curl /v3/  on 1413076 events|time in s with window function |time in s without window function |
| ----- | ----- | ----- |
|'/v3/audit_events'	|2.324|0.198	|
|'/v3/audit_events?page=1&per_page=5&created_ats[gt]=2022-11-23T15:36:54Z'|	0.651|	0.207|
|'/v3/audit_events?types=...&per_page=100&order_by=-created_at'|	1,48|0.338|
|'/v3/audit_events?space_guids=dd3a8c27-bc6f-4b58-930d-d77865c9a428&page=1&per_page=5&order_by=-created_at'	|4.542|	1.483|

![query-time-v2-vs-v3-audit-events-with-type-filter](https://user-images.githubusercontent.com/30441792/208475439-914563ca-b49a-44ed-9d9f-e5d58f26b4f7.png)
Call that were used for graph creation (for v2 of course equivalent v2 call):
```
cf curl "/v3/audit_events?types=audit.user.organization_user_add%2Caudit.user.organization_billing_manager_remove%2Caudit.user.space_developer_add%2Caudit.user.organization_auditor_remove%2Caudit.user.space_developer_remove%2Caudit.user.space_auditor_remove%2Caudit.user.space_auditor_add%2Caudit.user.space_manager_add%2Caudit.user.organization_billing_manager_add%2Caudit.user.organization_manager_remove%2Caudit.user.organization_auditor_add%2Caudit.user.space_manager_remove%2Caudit.user.organization_manager_add%2Caudit.user.organization_user_remove&per_page=100&order_by=-created_at"
```


Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
