### PR TITLE
Override empty_from_sql for MySQL

### DIFF
--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -133,6 +133,10 @@ class Sequel::Dataset
     end
   end
 
+  def empty_from_sql
+    ' FROM DUAL' if self.db.database_type == :mysql
+  end
+
   @unique_names_in_subquery = nil
 
   class << self

--- a/middleware/block_v3_only_roles.rb
+++ b/middleware/block_v3_only_roles.rb
@@ -36,7 +36,7 @@ module CloudFoundry
       end
 
       def space_supporter_and_only_space_supporter?(current_user)
-        return false if VCAP::CloudController::User.
+        return false if VCAP::CloudController::User.db.select(1).
                         where do
                           Sequel.or(
                             [


### PR DESCRIPTION
Specify a dummy table name for situations where no table is referenced. See MySQL 5.7 Reference Manual [1] and suggested workaround [2].

[1] https://dev.mysql.com/doc/refman/5.7/en/select.html
[2] https://github.com/jeremyevans/sequel/issues/1977#issuecomment-1359631724

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
