### PR TITLE
Raise `UaaUnavailable` instead of `UaaEndpointDisabled`

### DIFF
--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -197,8 +197,6 @@ module VCAP::CloudController
           user_id = @uaa_client.id_for_username(username, origin: origin.presence)
         rescue UaaUnavailable
           raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
-        rescue UaaEndpointDisabled
-          raise CloudController::Errors::ApiError.new_from_details('UaaEndpointDisabled')
         end
         raise CloudController::Errors::ApiError.new_from_details('UserNotFound', username) unless user_id
 
@@ -232,8 +230,6 @@ module VCAP::CloudController
           user_id = @uaa_client.id_for_username(username, origin: origin.presence)
         rescue UaaUnavailable
           raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
-        rescue UaaEndpointDisabled
-          raise CloudController::Errors::ApiError.new_from_details('UaaEndpointDisabled')
         end
         raise CloudController::Errors::ApiError.new_from_details('UserNotFound', username) unless user_id
 

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -202,8 +202,6 @@ module VCAP::CloudController
           user_id = @uaa_client.id_for_username(username, origin: origin.presence)
         rescue UaaUnavailable
           raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
-        rescue UaaEndpointDisabled
-          raise CloudController::Errors::ApiError.new_from_details('UaaEndpointDisabled')
         end
         raise CloudController::Errors::ApiError.new_from_details('UserNotFound', username) unless user_id
 
@@ -237,8 +235,6 @@ module VCAP::CloudController
           user_id = @uaa_client.id_for_username(username, origin: origin.presence)
         rescue UaaUnavailable
           raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
-        rescue UaaEndpointDisabled
-          raise CloudController::Errors::ApiError.new_from_details('UaaEndpointDisabled')
         end
         raise CloudController::Errors::ApiError.new_from_details('UserNotFound', username) unless user_id
 

--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -185,7 +185,7 @@ class OrganizationsV3Controller < ApplicationController
       message: message,
       extra_presenter_args: { uaa_users: User.uaa_users_info(user_guids) },
     )
-  rescue VCAP::CloudController::UaaEndpointDisabled
+  rescue VCAP::CloudController::UaaUnavailable
     raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
   end
 

--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -207,7 +207,7 @@ class SpacesV3Controller < ApplicationController
       message: message,
       extra_presenter_args: { uaa_users: User.uaa_users_info(user_guids) },
     )
-  rescue VCAP::CloudController::UaaEndpointDisabled
+  rescue VCAP::CloudController::UaaUnavailable
     raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
   end
 

--- a/app/controllers/v3/users_controller.rb
+++ b/app/controllers/v3/users_controller.rb
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
       message: message,
       extra_presenter_args: { uaa_users: User.uaa_users_info(user_guids) },
     )
-  rescue VCAP::CloudController::UaaEndpointDisabled
+  rescue VCAP::CloudController::UaaUnavailable
     raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
   end
 

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -138,11 +138,6 @@
   http_code: 503
   message: "The UAA service is currently unavailable"
 
-20005:
-  name: UaaEndpointDisabled
-  http_code: 501
-  message: "The UAA endpoint needed is disabled"
-
 20006:
   name: UserIsInMultipleOrigins
   http_code: 400

--- a/lib/cloud_controller/uaa/errors.rb
+++ b/lib/cloud_controller/uaa/errors.rb
@@ -30,10 +30,4 @@ module VCAP::CloudController
       'The UAA returned an unexpected error'
     end
   end
-
-  class UaaEndpointDisabled < UaaError
-    def message
-      'The UAA endpoint is disabled'
-    end
-  end
 end

--- a/spec/request/organizations_spec.rb
+++ b/spec/request/organizations_spec.rb
@@ -1683,9 +1683,9 @@ module VCAP::CloudController
         it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
       end
 
-      context 'when UAA is disabled' do
+      context 'when UAA is unavailable' do
         before do
-          allow(uaa_client).to receive(:users_for_ids).and_raise(VCAP::CloudController::UaaEndpointDisabled)
+          allow(uaa_client).to receive(:users_for_ids).and_raise(VCAP::CloudController::UaaUnavailable)
         end
 
         it 'returns an error indicating UAA is unavailable' do

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -1569,10 +1569,10 @@ RSpec.describe 'Spaces' do
       it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
     end
 
-    context 'when UAA is disabled' do
+    context 'when UAA is unavailable' do
       before do
         allow(VCAP::CloudController::UaaClient).to receive(:new).and_return(uaa_client)
-        allow(uaa_client).to receive(:users_for_ids).and_raise(VCAP::CloudController::UaaEndpointDisabled)
+        allow(uaa_client).to receive(:users_for_ids).and_raise(VCAP::CloudController::UaaUnavailable)
       end
 
       it 'returns an error indicating UAA is unavailable' do

--- a/spec/request/users_spec.rb
+++ b/spec/request/users_spec.rb
@@ -335,10 +335,10 @@ RSpec.describe 'Users Request' do
 
         it_behaves_like 'permissions for list endpoint', ALL_PERMISSIONS
 
-        context 'when UAA is disabled' do
+        context 'when UAA is unavailable' do
           before do
             allow(uaa_client).to receive(:ids_for_usernames_and_origins).with(['bob-mcjames'], nil).
-              and_raise(VCAP::CloudController::UaaEndpointDisabled)
+              and_raise(VCAP::CloudController::UaaUnavailable)
           end
 
           it 'returns an error indicating UAA is unavailable' do

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -1875,13 +1875,13 @@ module VCAP::CloudController
                 expect(decoded_response['code']).to eq(20004)
               end
 
-              it 'returns an error when UAA endpoint is disabled' do
-                expect(uaa_client).to receive(:id_for_username).and_raise(UaaEndpointDisabled)
+              it 'returns an error when UAA is unavailable' do
+                expect(uaa_client).to receive(:id_for_username).and_raise(UaaUnavailable)
 
                 put "/v2/organizations/#{org.guid}/#{plural_role}", MultiJson.dump({ username: user.username })
 
-                expect(last_response.status).to eq(501)
-                expect(decoded_response['code']).to eq(20005)
+                expect(last_response.status).to eq(503)
+                expect(decoded_response['code']).to eq(20004)
               end
 
               it 'creates an audit.user.organization_role_add when a role is associated to a space' do
@@ -2059,13 +2059,13 @@ module VCAP::CloudController
             expect(decoded_response['code']).to eq(20004)
           end
 
-          it 'returns an error when UAA endpoint is disabled' do
-            expect(uaa_client).to receive(:id_for_username).and_raise(UaaEndpointDisabled)
+          it 'returns an error when UAA is unavailable' do
+            expect(uaa_client).to receive(:id_for_username).and_raise(UaaUnavailable)
 
             delete "/v2/organizations/#{org.guid}/#{plural_role}", MultiJson.dump({ username: user.username })
 
-            expect(last_response.status).to eq(501)
-            expect(decoded_response['code']).to eq(20005)
+            expect(last_response.status).to eq(503)
+            expect(decoded_response['code']).to eq(20004)
           end
 
           it 'creates an event of type audit.user.organization_role_remove when a user-role association is removed from the organization' do

--- a/spec/unit/controllers/runtime/spaces_controller_spec.rb
+++ b/spec/unit/controllers/runtime/spaces_controller_spec.rb
@@ -2321,13 +2321,13 @@ module VCAP::CloudController
               expect(decoded_response['code']).to eq(20004)
             end
 
-            it 'returns an error when UAA endpoint is disabled' do
-              expect(uaa_client).to receive(:id_for_username).and_raise(UaaEndpointDisabled)
+            it 'returns an error when UAA is unavailable' do
+              expect(uaa_client).to receive(:id_for_username).and_raise(UaaUnavailable)
 
               put "/v2/spaces/#{space_one.guid}/#{plural_role}", MultiJson.dump({ username: user.username })
 
-              expect(last_response.status).to eq(501)
-              expect(decoded_response['code']).to eq(20005)
+              expect(last_response.status).to eq(503)
+              expect(decoded_response['code']).to eq(20004)
             end
 
             it 'logs audit.space.role.add when a role is associated to a space' do
@@ -2506,13 +2506,13 @@ module VCAP::CloudController
               expect(decoded_response['code']).to eq(20004)
             end
 
-            it 'returns an error when UAA endpoint is disabled' do
-              expect(uaa_client).to receive(:id_for_username).and_raise(UaaEndpointDisabled)
+            it 'returns an error when UAA is unavailable' do
+              expect(uaa_client).to receive(:id_for_username).and_raise(UaaUnavailable)
 
               delete "/v2/spaces/#{space_one.guid}/#{plural_role}", MultiJson.dump({ username: user.username })
 
-              expect(last_response.status).to eq(501)
-              expect(decoded_response['code']).to eq(20005)
+              expect(last_response.status).to eq(503)
+              expect(decoded_response['code']).to eq(20004)
             end
 
             it 'logs audit.space.role.remove when a user-role association is removed from a space' do

--- a/spec/unit/lib/uaa/uaa_client_spec.rb
+++ b/spec/unit/lib/uaa/uaa_client_spec.rb
@@ -519,7 +519,7 @@ module VCAP::CloudController
         it 'raises UaaUnavailable' do
           expect {
             uaa_client.id_for_username(username)
-          }.to raise_error(UaaEndpointDisabled)
+          }.to raise_error(UaaUnavailable)
         end
       end
     end
@@ -655,17 +655,17 @@ module VCAP::CloudController
         end
       end
 
-      context 'when the endpoint is disabled' do
+      context 'when the endpoint is unavailable' do
         before do
           scim = double('scim')
           allow(scim).to receive(:query).and_raise(CF::UAA::TargetError)
           allow(uaa_client).to receive(:scim).and_return(scim)
         end
 
-        it 'raises UaaEndpointDisabled' do
+        it 'raises UaaUnavailable' do
           expect {
             uaa_client.ids_for_usernames_and_origins([username1], nil)
-          }.to raise_error(UaaEndpointDisabled)
+          }.to raise_error(UaaUnavailable)
         end
       end
 
@@ -676,10 +676,10 @@ module VCAP::CloudController
           allow(uaa_client).to receive(:scim).and_return(scim)
         end
 
-        it 'raises UaaEndpointDisabled' do
+        it 'raises UaaUnavailable' do
           expect {
             uaa_client.ids_for_usernames_and_origins([username1], nil)
-          }.to raise_error(UaaEndpointDisabled)
+          }.to raise_error(UaaUnavailable)
         end
       end
     end


### PR DESCRIPTION
* A short explanation of the proposed change:
  In case of errors while using `uaa_client` the error `UaaUnavailable` is better suited than `UaaEndpointDisabled`. This can happen e.g. when a wrong or outdated uaa secret is used.


* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
