### PR TITLE
Revert "build(deps-dev): bump parallel_tests from 4.0.0 to 4.1.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,7 @@ GEM
     os (1.1.4)
     palm_civet (1.1.0)
     parallel (1.22.1)
-    parallel_tests (4.1.0)
+    parallel_tests (4.0.0)
       parallel
     parser (3.2.0.0)
       ast (~> 2.4.1)


### PR DESCRIPTION
Reverts cloudfoundry/cloud_controller_ng#3143

Could cause issues in the concourse pipeline