### PR TITLE
WIP/RFC: parameterize roles by org

### DIFF
--- a/app/fetchers/role_list_fetcher.rb
+++ b/app/fetchers/role_list_fetcher.rb
@@ -17,7 +17,7 @@ module VCAP::CloudController
         end
         if message.requested?(:organization_guids)
           org_ids = Organization.dataset.where(guid: message.organization_guids).select(:id)
-          dataset = dataset.where(organization_id: org_ids)
+          dataset = dataset.for_organization(organization_id: org_ids)
         end
         if message.requested?(:user_guids)
           user_ids = User.dataset.where(guid: message.user_guids).select(:id)

--- a/app/models/runtime/role.rb
+++ b/app/models/runtime/role.rb
@@ -5,98 +5,198 @@ module VCAP::CloudController
 
   # Sequel allows to create models based on datasets. The following is a dataset that unions all the individual roles
   # tables and labels each row with a `type` column based on which table it came from
-  class Role < Sequel::Model(
-    OrganizationUser.select(
-      Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_USER, :type),
-      Sequel.as(:role_guid, :guid),
-      :user_id,
-      :organization_id,
-      Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
-      :created_at,
-      :updated_at
-    ).union(
-      OrganizationManager.select(
-        Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_MANAGER, :type),
+
+  def self.role_dataset(organization_id=false)
+    if organization_id
+      spaces_in_org = Space.where(organization_id: organization_id).map(&:id)
+      OrganizationUser.select(
+        Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_USER, :type),
         Sequel.as(:role_guid, :guid),
         :user_id,
         :organization_id,
         Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
         :created_at,
-        :updated_at),
-      all: true,
-      from_self: false
-    ).union(
-      OrganizationBillingManager.select(
-        Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_BILLING_MANAGER, :type),
-        Sequel.as(:role_guid, :guid),
-        :user_id,
-        :organization_id,
-        Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
-        :created_at,
-        :updated_at),
-      all: true,
-      from_self: false
-    ).union(
-      OrganizationAuditor.select(
-        Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_AUDITOR, :type),
-        Sequel.as(:role_guid, :guid),
-        :user_id,
-        :organization_id,
-        Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
-        :created_at,
-        :updated_at),
-      all: true,
-      from_self: false
-    ).union(
-      SpaceDeveloper.select(
-        Sequel.as(VCAP::CloudController::RoleTypes::SPACE_DEVELOPER, :type),
-        Sequel.as(:role_guid, :guid),
-        :user_id,
-        Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
-        :space_id,
-        :created_at,
-        :updated_at),
-      all: true,
-      from_self: false
-    ).union(
-      SpaceAuditor.select(
-        Sequel.as(VCAP::CloudController::RoleTypes::SPACE_AUDITOR, :type),
-        Sequel.as(:role_guid, :guid),
-        :user_id,
-        Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
-        :space_id,
-        :created_at,
-        :updated_at),
-      all: true,
-      from_self: false
-    ).union(
-      SpaceSupporter.select(
-        Sequel.as(VCAP::CloudController::RoleTypes::SPACE_SUPPORTER, :type),
-      Sequel.as(:role_guid, :guid),
-      :user_id,
-      Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
-      :space_id,
-      :created_at,
-      :updated_at),
+        :updated_at
+      ).where(organization_id: organization_id).union(
+        OrganizationManager.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_MANAGER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          :organization_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
+          :created_at,
+          :updated_at).where(organization_id: organization_id),
         all: true,
         from_self: false
-    ).union(
-      SpaceManager.select(
-        Sequel.as(VCAP::CloudController::RoleTypes::SPACE_MANAGER, :type),
+      ).union(
+        OrganizationBillingManager.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_BILLING_MANAGER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          :organization_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
+          :created_at,
+          :updated_at).where(organization_id: organization_id),
+        all: true,
+        from_self: false
+      ).union(
+        OrganizationAuditor.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_AUDITOR, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          :organization_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
+          :created_at,
+          :updated_at).where(organization_id: organization_id),
+        all: true,
+        from_self: false
+      ).union(
+        SpaceDeveloper.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::SPACE_DEVELOPER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
+          :space_id,
+          :created_at,
+          :updated_at).where(space_id: spaces_in_org),
+          all: true,
+          from_self: false
+      ).union(
+        SpaceAuditor.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::SPACE_AUDITOR, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
+          :space_id,
+          :created_at,
+          :updated_at).where(space_id: spaces_in_org),
+          all: true,
+          from_self: false
+      ).union(
+        SpaceSupporter.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::SPACE_SUPPORTER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
+          :space_id,
+          :created_at,
+          :updated_at).where(space_id: spaces_in_org),
+          all: true,
+          from_self: false
+      ).union(
+        SpaceManager.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::SPACE_MANAGER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
+          :space_id,
+          :created_at,
+          :updated_at).where(space_id: spaces_in_org),
+          all: true,
+          from_self: false
+      ).from_self
+    else
+      OrganizationUser.select(
+        Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_USER, :type),
         Sequel.as(:role_guid, :guid),
         :user_id,
-        Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
-        :space_id,
+        :organization_id,
+        Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
         :created_at,
-        :updated_at),
-      all: true,
-      from_self: false
-    ).from_self
-  )
+        :updated_at
+      ).union(
+        OrganizationManager.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_MANAGER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          :organization_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
+          :created_at,
+          :updated_at),
+          all: true,
+          from_self: false
+      ).union(
+        OrganizationBillingManager.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_BILLING_MANAGER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          :organization_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
+          :created_at,
+          :updated_at),
+          all: true,
+          from_self: false
+      ).union(
+        OrganizationAuditor.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::ORGANIZATION_AUDITOR, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          :organization_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :space_id),
+          :created_at,
+          :updated_at),
+          all: true,
+          from_self: false
+      ).union(
+        SpaceDeveloper.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::SPACE_DEVELOPER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
+          :space_id,
+          :created_at,
+          :updated_at),
+          all: true,
+          from_self: false
+      ).union(
+        SpaceAuditor.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::SPACE_AUDITOR, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
+          :space_id,
+          :created_at,
+          :updated_at),
+          all: true,
+          from_self: false
+      ).union(
+        SpaceSupporter.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::SPACE_SUPPORTER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
+          :space_id,
+          :created_at,
+          :updated_at),
+          all: true,
+          from_self: false
+      ).union(
+        SpaceManager.select(
+          Sequel.as(VCAP::CloudController::RoleTypes::SPACE_MANAGER, :type),
+          Sequel.as(:role_guid, :guid),
+          :user_id,
+          Sequel.as(SPACE_OR_ORGANIZATION_NOT_SPECIFIED, :organization_id),
+          :space_id,
+          :created_at,
+          :updated_at),
+          all: true,
+          from_self: false
+      ).from_self
+    end
+  end
 
+  class Role < Sequel::Model(role_dataset)
     many_to_one :user, key: :user_id
     many_to_one :organization, key: :organization_id
     many_to_one :space, key: :space_id
+
+    class << self
+      def for_organization(organization_id)
+        self.from do |o|
+          VCAP::CloudController.role_dataset(organization_id)
+        end
+      end
+    end
 
     def user_guid
       user.guid


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

If `/v3/roles` is filtered by `organization_guids`, the role join models (`organizations_managers`, `spaces_developers` etc) are all `UNION`ed into a single unfiltered virtual table and a filter is applied. If the role tables are filtered by the organization *first* then it was found to speed up the query by about 2 orders of magnitude (probably depends on the user base of the org vs the user base of _all_ orgs in the Foundry install).

Thanks to @pivotal-Josh-Gainey for finding this optimization (he had a pair too but I can't find his github).

* An explanation of the use cases your change solves

In many of VMware's usages of the roles endpoint, we are allowing a user to edit the roles for a space or an org in a GUI. It ends up calling `/v3/roles` with an `organization_guids` or `space_guids` filter for the organization or space that the user is editing. This is a WIP that only solves for organization_guids and has no tests, but I also plan to extend it to `space_guids` and look for other datasets that `UNION` these join models because they also might need this optimization.

This is particularly important to Cloud Foundry installs with many users given access to many orgs/spaces. For example, given a CC database on mysql with 50 orgs, 50 spaces in each org, and 25 users who all have access to every org and space the `Role` model will have 255000 records. We then approximated the roles endpoint as such and timed it:
```ruby
rlm = RolesListMessage.from_params({organization_guids: [org.guid], page: 1, user_guids: org.users[0..50].map(&:guid), per_page: 50})
RoleListFetcher.fetch(rlm, Role, eager_loaded_associations: Presenters::V3::RolePresenter.associated_resources).all
```
Before this change : **0.9s**
After this change: **0.004s**

* Links to any other associated PRs

Don't know of any PRs but I am sure `Role` has some optimizations recently that are related but didn't have this impact on this scale of data.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement
(I have signed a great many of these CF CLAs but I probably need to sign the latest one)

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake` (currently failing on RoleListFetcher test, will resolve)

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
