### PR TITLE
Patch HTTPClient to accept socket_connect_timeout

### DIFF
--- a/lib/http/httpclient.rb
+++ b/lib/http/httpclient.rb
@@ -1,0 +1,41 @@
+require 'httpclient'
+
+module HTTPClientMonkeyPatch
+  module SocketConnectTimeout
+    attr_reader :socket_connect_timeout
+
+    def socket_connect_timeout=(timeout)
+      @socket_connect_timeout = timeout
+    end
+  end
+
+  module TCPSocketWithConnectTimeout
+    def create_socket(host, port)
+      @debug_dev << "! CONNECT TO #{host}:#{port}\n" if @debug_dev
+      clean_host = host.delete('[]')
+      if @socket_local == HTTPClient::Site::EMPTY
+        socket = TCPSocket.new(clean_host, port, connect_timeout: @client.socket_connect_timeout)
+      else
+        clean_local = @socket_local.host.delete('[]')
+        socket = TCPSocket.new(clean_host, port, clean_local, @socket_local.port, connect_timeout: @client.socket_connect_timeout)
+      end
+      socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if @tcp_keepalive
+      if @debug_dev
+        @debug_dev << "! CONNECTION ESTABLISHED\n"
+        socket.extend(HTTPClient::DebugSocket)
+        socket.debug_dev = @debug_dev
+      end
+      socket
+    rescue SystemCallError, SocketError => e
+      raise e.new(e.message + " (#{host}:#{port})")
+    end
+  end
+end
+
+class HTTPClient
+  prepend HTTPClientMonkeyPatch::SocketConnectTimeout
+end
+
+class HTTPClient::Session
+  prepend HTTPClientMonkeyPatch::TCPSocketWithConnectTimeout
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,14 +127,14 @@ each_run_block = proc do
 
     rspec_config.include SpaceRestrictedResponseGenerators
 
-    rspec_config.before(:all) { WebMock.disable_net_connect!(allow: 'codeclimate.com') }
+    rspec_config.before(:all) { WebMock.disable_net_connect!(allow: %w[codeclimate.com fake.bbs]) }
     rspec_config.before(:all, type: :integration) do
       WebMock.allow_net_connect!
       @uaa_server = FakeUAAServer.new(6789)
       @uaa_server.start
     end
     rspec_config.after(:all, type: :integration) do
-      WebMock.disable_net_connect!(allow: 'codeclimate.com')
+      WebMock.disable_net_connect!(allow: %w[codeclimate.com fake.bbs])
       @uaa_server.stop
     end
 

--- a/spec/unit/lib/http/httpclient_spec.rb
+++ b/spec/unit/lib/http/httpclient_spec.rb
@@ -1,0 +1,9 @@
+require 'httpclient'
+
+RSpec.describe HTTPClient do
+  describe 'version' do
+    it 'should not be updated' do
+      expect(HTTPClient::VERSION).to eq('2.8.3'), 'revisit monkey patch in lib/http/httpclient.rb'
+    end
+  end
+end


### PR DESCRIPTION
Monkey patch `HTTPClient` to accept `socket_connect_timeout` as optional configuration. If set, it is used as `connect_timeout` parameter when creating a `TCPSocket`.

Set the `socket_connect_timeout` in `Diego::Client` to (overall) `connect_timeout` / 2.

Add test to ensure that the `httpclient` version is not updated without revisiting the monkey patch.

### Background information

:information_source: **Use case**: Mitigates the risk of `Runner is unavailable` and `Stager is unavailable` errors during a cf push when the client is unable to reach a bbs instance.

---

:x: First, **discarded** solution proposal: #3002

---

:heavy_check_mark: Second, **merged** solution proposal: #3048

:boom: Issues caused by #3048
- #3109
- #3112
- sporadically failing `sync-integration-tests`

:information_source: **Root cause**: `Net::HTTP` and altered `Diego::Client` implementations are not thread-safe.

:arrows_counterclockwise: Revert PR: #3113

---

:heavy_check_mark: Third, **merged** solution proposal: #3170

:poop: Issues caused by #3170
- `cc-unit-tests` failing (Concourse)

:information_source: **Root cause**: Concourse executes the unit tests with Ruby 3.1.3 (as opposed to the version 3.1.2 specified in `.ruby-version`) which includes a newer Net::HTTP version that reverted the usage of the `Socket.tcp`'s `connect_timeout` option (see https://github.com/ruby/net-http/pull/74).

:arrows_counterclockwise: Revert PR: #3171

---

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
