### PR TITLE
Remove ruby-debug-ide and debase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,10 +96,8 @@ end
 
 group :development do
   gem 'byebug'
-  gem 'debase', '>= 0.2.2.beta14'
   gem 'listen'
   gem 'roodi'
-  gem 'ruby-debug-ide', '>= 0.7.0.beta4'
   gem 'solargraph'
   gem 'spork', git: 'https://github.com/sporkrb/spork', ref: '224df49' # '~> 1.0rc'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,9 +125,6 @@ GEM
       rexml
     crass (1.0.6)
     daemons (1.4.1)
-    debase (0.2.5.beta2)
-      debase-ruby_core_source (>= 0.10.12)
-    debase-ruby_core_source (0.10.12)
     declarative (0.0.20)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)
@@ -447,8 +444,6 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
-    ruby-debug-ide (0.7.3)
-      rake (>= 0.8.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     ruby_parser (3.8.3)
@@ -557,7 +552,6 @@ DEPENDENCIES
   clockwork
   cloudfront-signer
   codeclimate-test-reporter (>= 1.0.8)
-  debase (>= 0.2.2.beta14)
   em-http-request (~> 1.1)
   eventmachine (~> 1.2.7)
   fluent-logger
@@ -612,7 +606,6 @@ DEPENDENCIES
   rspec-wait
   rspec_api_documentation (>= 6.1.0)
   rubocop (~> 1.44.1)
-  ruby-debug-ide (>= 0.7.0.beta4)
   rubyzip (>= 1.3.0)
   sequel (~> 5.64)
   sequel_pg


### PR DESCRIPTION
This PR removes `ruby-debug-ide`.  We face an issue where, when bundling for the first time on a new env, the first attempt at installing `ruby-debug-ide` fails and bundling a second time magically works.

We're opening this PR because we aren't sure anyone is using it--we think IDEs like RubyMine should work fine without this gem.  As far as we can gather, we think this was added to debug running instances of CCNG.  We think breakpoints in tests run from RubyMine should work.

Alternatively we can add this to a separate gem group (e.g. `ide`) and exclude that when installing if others are using this.