### PR TITLE
Ensure that delayed_job workers handle `SIGQUIT`

### DIFF
--- a/lib/delayed_job/quit_trap.rb
+++ b/lib/delayed_job/quit_trap.rb
@@ -1,0 +1,20 @@
+# Class 'Worker' in the 'delayed_job' gem only handles SIGTERM & SIGINT which result in a graceful shutdown
+# This monkey patch extends `start()` to also handle SIGQUIT.
+# Could be replaced by https://github.com/collectiveidea/delayed_job/pull/900
+
+module QuitTrap
+  def start
+    trap('QUIT') do
+      Thread.new { say 'Exiting...' }
+      stop
+    end
+
+    super
+  end
+end
+
+module Delayed
+  class Worker
+    prepend QuitTrap
+  end
+end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -1,3 +1,5 @@
+require 'delayed_job/quit_trap'
+
 namespace :jobs do
   desc 'Clear the delayed_job queue.'
   task :clear do

--- a/spec/unit/lib/delayed_job/delayed_job_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_job_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe 'delayed_job' do
+  describe 'version' do
+    it 'should not be updated' do
+      expect(Gem.loaded_specs['delayed_job'].version).to eq('4.1.9'), 'revisit monkey patch in lib/delayed_job/quit_trap.rb'
+    end
+  end
+end


### PR DESCRIPTION
Adds a monkey patches to delayed_job workers to gracefully shutdown in case of a `QUIT` signal. So far delayed_job only considers `INT` & `TERM` signals for graceful shutdown.
This might become obsolete once the following change is merged into delayed_job: https://github.com/collectiveidea/delayed_job/pull/900

To ensure that a version bump of delayed_job does not break the monkey patch a test will fail in case the version number changes. In case of a version bump it needs to be manually verified if the monkey patch is still working.

Co-authored-by: Philipp Thun <philipp.thun@sap.com>
Co-authored-by: Sven Krieger <37476281+svkrieger@users.noreply.github.com>
Co-authored-by: Johannes Haass <johannes.haass@sap.com>

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
