### PR TITLE
Exclude app usage events table from using window function

### DIFF
--- a/app/models/runtime/app_usage_event.rb
+++ b/app/models/runtime/app_usage_event.rb
@@ -9,5 +9,10 @@ module VCAP::CloudController
       :buildpack_guid, :buildpack_name,
       :package_state, :previous_package_state, :parent_app_guid,
       :parent_app_name, :process_type, :task_name, :task_guid
+    AppUsageEvent.dataset_module do
+      def supports_window_functions?
+        false
+      end
+    end
   end
 end

--- a/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
+++ b/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
@@ -148,6 +148,26 @@ module VCAP::CloudController
         end
       end
 
+      context 'AppUsageEvents table' do
+        before do
+          AppUsageEvent.make(guid: '1', created_at: '2022-12-20T10:47:01Z')
+          AppUsageEvent.make(guid: '2', created_at: '2022-12-20T10:47:02Z')
+          AppUsageEvent.make(guid: '3', created_at: '2022-12-20T10:47:03Z')
+          AppUsageEvent.make(guid: '4', created_at: '2022-12-20T10:47:04Z')
+        end
+
+        it 'does not use window function' do
+          options = { page: page, per_page: per_page }
+          pagination_options = PaginationOptions.new(options)
+
+          paginated_result = nil
+          expect {
+            paginated_result = paginator.get_page(AppUsageEvent.dataset, pagination_options)
+          }.to have_queried_db_times(/over/i, 0)
+          expect(paginated_result.total).to be > 1
+        end
+      end
+
       it 'returns correct total results for distinct result' do
         options = { page: page, per_page: per_page, order_by: :key_name }
         pagination_options = PaginationOptions.new(options)


### PR DESCRIPTION
Similar to the issue reported in https://github.com/cloudfoundry/cloud_controller_ng/pull/3117, we have noticed performance degradation when using the OVER window function with `app_usage_events` when the tables has a large-ish number of row (around 150,000).  This PR disables use of the window function for `app_usage_events`, just as we have disabled it for `events`.

@kathap @philippthun , since you both worked on the previous PR--are you concerned that this might be a trend with several of our tables?  We don't have a lot of context on the performance benefits of the use of the OVER window function, and it feels like its use may be high risk.  We were wondering if it might be worth disabling the OVER window for more models, or even all of them.  Perhaps a configuration value in capi-release?



* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
