### PR TITLE
Log request fields in separate hash

### DIFF
--- a/lib/cloud_controller/logs/request_logs.rb
+++ b/lib/cloud_controller/logs/request_logs.rb
@@ -19,7 +19,9 @@ module VCAP::CloudController
                   user: env['cf.user_guid'],
                   ip: anonymize_ip(request.ip),
                   request_id: request_id,
-                  at: Time.now.utc)
+                  at: Time.now.utc),
+          { request_method: request.request_method,
+            request_fullpath: request.filtered_path }
         )
         @incomplete_requests.store(request_id, env)
       end
@@ -27,7 +29,9 @@ module VCAP::CloudController
       def complete_request(request_id, status)
         return if @incomplete_requests.delete(request_id).nil?
 
-        @logger.info("Completed #{status} vcap-request-id: #{request_id}")
+        @logger.info("Completed #{status} vcap-request-id: #{request_id}",
+                     { cc_status_code: status }
+        )
       end
 
       def log_incomplete_requests
@@ -40,7 +44,9 @@ module VCAP::CloudController
                     path: request.filtered_path,
                     user: env['cf.user_guid'],
                     ip: anonymize_ip(request.ip),
-                    request_id: request_id)
+                    request_id: request_id),
+            { request_method: request.request_method,
+              request_fullpath: request.filtered_path }
           )
         end
       end

--- a/lib/cloud_controller/logs/request_logs.rb
+++ b/lib/cloud_controller/logs/request_logs.rb
@@ -30,7 +30,7 @@ module VCAP::CloudController
         return if @incomplete_requests.delete(request_id).nil?
 
         @logger.info("Completed #{status} vcap-request-id: #{request_id}",
-                     { cc_status_code: status }
+                     { status_code: status }
         )
       end
 

--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -27,8 +27,8 @@ module VCAP::CloudController
         use CloudFoundry::Middleware::NewRelicCustomAttributes if config.get(:newrelic_enabled)
         use Honeycomb::Rack::Middleware, client: Honeycomb.client if config.get(:honeycomb)
         use CloudFoundry::Middleware::SecurityContextSetter, configurer
-        use CloudFoundry::Middleware::RequestLogs, request_logs
         use CloudFoundry::Middleware::Zipkin
+        use CloudFoundry::Middleware::RequestLogs, request_logs
         if config.get(:rate_limiter, :enabled)
           use CloudFoundry::Middleware::RateLimiter, {
             logger: Steno.logger('cc.rate_limiter'),

--- a/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
@@ -4,13 +4,17 @@ require 'cloud_controller/logs/request_logs'
 module VCAP::CloudController::Logs
   RSpec.describe RequestLogs do
     let(:request_logs) { RequestLogs.new(logger) }
-    let(:logger) { double('logger', info: nil) }
+    let(:logger) { double('logger', info: nil, error: nil) }
     let(:fake_ip) { 'ip' }
     let(:fake_fullpath) { 'fullpath' }
     let(:fake_request) { double('request', request_method: 'request_method', ip: fake_ip, filtered_path: 'filtered_path', fullpath: fake_fullpath) }
     let(:request_id) { 'ID' }
     let(:env) { { 'cf.user_guid' => 'user-guid' } }
     let(:status) { 200 }
+
+    let(:additional_fields) { { request_method: 'request_method',
+                                request_fullpath: 'filtered_path' }
+    }
 
     describe 'logging' do
       before do
@@ -20,7 +24,7 @@ module VCAP::CloudController::Logs
       context '#start_request' do
         it 'logs the start of the request' do
           request_logs.start_request(request_id, env)
-          expect(logger).to have_received(:info).with(/Started.+user: user-guid.+with vcap-request-id: ID/)
+          expect(logger).to have_received(:info).with(/Started.+user: user-guid.+with vcap-request-id: ID/, additional_fields)
         end
 
         context 'request to /healthz endpoint' do
@@ -41,7 +45,7 @@ module VCAP::CloudController::Logs
 
           it 'logs the completion of the request' do
             request_logs.complete_request(request_id, status)
-            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/)
+            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/, { cc_status_code: 200 })
           end
         end
 
@@ -53,6 +57,14 @@ module VCAP::CloudController::Logs
         end
       end
 
+      context '#incomplete_request' do
+        it 'logs the incomplete request' do
+          request_logs.start_request(request_id, env)
+          request_logs.log_incomplete_requests
+          expect(logger).to have_received(:error).with(/Incomplete request.+user: user-guid.+with vcap-request-id: ID/, additional_fields)
+        end
+      end
+
       context 'anonymize_ips flag is true' do
         before do
           TestConfig.override(logging: { anonymize_ips: 'true' })
@@ -60,7 +72,7 @@ module VCAP::CloudController::Logs
 
         it 'logs non ip addresses in ip field unaltered' do
           request_logs.start_request(request_id, env)
-          expect(logger).to have_received(:info).with(/ip: ip/)
+          expect(logger).to have_received(:info).with(/ip: ip/, additional_fields)
         end
       end
 
@@ -70,7 +82,7 @@ module VCAP::CloudController::Logs
         context 'anonymize_ips flag is false' do
           it 'logs full ipv4 addresses' do
             request_logs.start_request(request_id, env)
-            expect(logger).to have_received(:info).with(/ip: 192.168.1.80/)
+            expect(logger).to have_received(:info).with(/ip: 192.168.1.80/, additional_fields)
           end
         end
 
@@ -81,7 +93,7 @@ module VCAP::CloudController::Logs
 
           it 'logs anonymized ipv4 addresses' do
             request_logs.start_request(request_id, env)
-            expect(logger).to have_received(:info).with(/ip: 192.168.1.0/)
+            expect(logger).to have_received(:info).with(/ip: 192.168.1.0/, additional_fields)
           end
         end
       end
@@ -92,7 +104,7 @@ module VCAP::CloudController::Logs
         context 'anonymize_ips flag is false' do
           it 'logs canonical and unaltered ipv6 addresses' do
             request_logs.start_request(request_id, env)
-            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:8a2e:0370:7334/)
+            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:8a2e:0370:7334/, additional_fields)
           end
         end
 
@@ -103,7 +115,7 @@ module VCAP::CloudController::Logs
 
           it 'logs canonical and anonymized ipv6 addresses' do
             request_logs.start_request(request_id, env)
-            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/)
+            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/, additional_fields)
           end
         end
       end
@@ -114,7 +126,7 @@ module VCAP::CloudController::Logs
         context 'anonymize_ips flag is false' do
           it 'logs canonical and unaltered ipv6 addresses' do
             request_logs.start_request(request_id, env)
-            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:0000:0370:0000/)
+            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:1234:0000:0000:0370:0000/, additional_fields)
           end
         end
 
@@ -125,7 +137,7 @@ module VCAP::CloudController::Logs
 
           it 'logs canonical and anonymized ipv6 addresses' do
             request_logs.start_request(request_id, env)
-            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/)
+            expect(logger).to have_received(:info).with(/ip: 2001:0db8:85a3:0000:0000:0000:0000:0000/, additional_fields)
           end
         end
       end

--- a/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
@@ -45,7 +45,7 @@ module VCAP::CloudController::Logs
 
           it 'logs the completion of the request' do
             request_logs.complete_request(request_id, status)
-            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/, { cc_status_code: 200 })
+            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/, { status_code: 200 })
           end
         end
 


### PR DESCRIPTION
* A short explanation of the proposed change:

We want to harmonize the cloud controller request logging with the nginx access logs. Some request fields should be logged explicitly with the same names that are used by nginx.

* An explanation of the use cases your change solves

Facilitates searching cloud controller request logs in logging stacks with Kibana.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
