### PR TITLE
Don't double count updated sidecar memory

### DIFF
--- a/app/actions/sidecar_update.rb
+++ b/app/actions/sidecar_update.rb
@@ -49,7 +49,7 @@ module VCAP::CloudController
           app_guid: sidecar.app_guid,
           type: process_types,
         )
-        policy = SidecarMemoryLessThanProcessMemoryPolicy.new(processes, memory)
+        policy = SidecarMemoryLessThanProcessMemoryPolicy.new(processes, memory, sidecar)
 
         raise InvalidSidecar.new(policy.message) if !policy.valid?
       end

--- a/app/models/runtime/constraints/sidecar_memory_less_than_process_memory_policy.rb
+++ b/app/models/runtime/constraints/sidecar_memory_less_than_process_memory_policy.rb
@@ -2,14 +2,17 @@ class SidecarMemoryLessThanProcessMemoryPolicy
   attr_reader :new_memory, :processes, :message
 
   # memory represents the amount of memory to add to the total sidecar amount
-  def initialize(processes, new_memory=0)
+  def initialize(processes, new_memory=0, existing_sidecar=nil)
     @new_memory = new_memory || 0
     @processes = Array(processes)
+    @existing_sidecar = existing_sidecar
   end
 
   def valid?
     processes.each do |process|
-      total_sidecar_memory = process.sidecars.select(&:memory).sum(&:memory) + new_memory
+      sidecars = process.sidecars
+      sidecars = sidecars.reject { |sidecar| sidecar.name == @existing_sidecar.name } if @existing_sidecar
+      total_sidecar_memory = sidecars.select(&:memory).sum(&:memory) + new_memory
 
       if total_sidecar_memory >= process.memory
         @message = "The memory allocation defined is too large to run with the dependent \"#{process.type}\" process"

--- a/spec/unit/actions/sidecar_update_spec.rb
+++ b/spec/unit/actions/sidecar_update_spec.rb
@@ -164,6 +164,31 @@ module VCAP::CloudController
             )
           end
         end
+
+        context 'the memory allocated to the sidecar exceeds half the memory allocated for the newly associated process' do
+          let(:sidecar) do
+            SidecarModel.make(
+              name:          'my_sidecar',
+              command:       'rackup',
+              app:           app,
+              memory:        250,
+            )
+          end
+
+          let(:params) do
+            {
+              memory_in_mb: 251,
+            }
+          end
+
+          let!(:process) { ProcessModel.make(app: app, memory: 500, type: 'other_worker') }
+          let!(:new_process) { ProcessModel.make(app: app, memory: 500, type: 'other_worker') }
+
+          it 'its only counted once for all processes and succeeds' do
+            SidecarUpdate.update(sidecar, message)
+            expect(sidecar.memory).to eq 251
+          end
+        end
       end
     end
   end

--- a/spec/unit/models/runtime/constraints/sidecar_memory_less_than_process_memory_policy_spec.rb
+++ b/spec/unit/models/runtime/constraints/sidecar_memory_less_than_process_memory_policy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'max instance memory policies' do
   let(:policy_target) { double(instance_memory_limit: 150) }
   let(:error_name) { :random_memory_error }
 
-  describe AppMaxInstanceMemoryPolicy do
+  describe SidecarMemoryLessThanProcessMemoryPolicy do
     let(:app_model) { VCAP::CloudController::AppModel.make }
     let(:process) { VCAP::CloudController::ProcessModelFactory.make(memory: 30, type: 'web', app: app_model) }
 
@@ -49,6 +49,15 @@ RSpec.describe 'max instance memory policies' do
       let(:validator) { SidecarMemoryLessThanProcessMemoryPolicy.new(process, nil) }
 
       it 'does not error' do
+        expect(validator.valid?).to eq true
+      end
+    end
+
+    context 'when updating a sidecar' do
+      let(:process) { VCAP::CloudController::ProcessModelFactory.make(memory: 19, type: 'web', app: app_model) }
+      let(:validator) { SidecarMemoryLessThanProcessMemoryPolicy.new(process, 9, sidecar_1) }
+
+      it 'does not count the exisiting sidecar twice' do
         expect(validator.valid?).to eq true
       end
     end


### PR DESCRIPTION
Pushing existing app with sidecars fails when total sidecar memory exceeds half of the process's allocated memory:

```
---
applications:
- name: dora
  processes:
  - type: web
    instances: 1
    memory: 200M
    disk_quota: 256MB
    log-rate-limit-per-second: 0
    health-check-type: port
  sidecars:
  - name: my-sidecar
    process_types: [ 'web' ]
    command: sleep infinity
    memory: 101M
```

This will succeed on the first push, but fail on the second push as it doesn't exclude `my-sidecar`'s current memory usage when calculating the new total usage.

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
