### PR TITLE
Correctly re-raise exceptions in HTTPClient's create_socket method

### DIFF
--- a/lib/http/httpclient.rb
+++ b/lib/http/httpclient.rb
@@ -27,7 +27,7 @@ module HTTPClientMonkeyPatch
       end
       socket
     rescue SystemCallError, SocketError => e
-      raise e.new(e.message + " (#{host}:#{port})")
+      raise e.exception(e.message + " (#{host}:#{port})")
     end
   end
 end

--- a/spec/unit/lib/http/httpclient_spec.rb
+++ b/spec/unit/lib/http/httpclient_spec.rb
@@ -1,9 +1,20 @@
-require 'httpclient'
+require 'http/httpclient'
 
 RSpec.describe HTTPClient do
   describe 'version' do
     it 'should not be updated' do
       expect(HTTPClient::VERSION).to eq('2.8.3'), 'revisit monkey patch in lib/http/httpclient.rb'
+    end
+  end
+
+  describe 're-raising errors' do
+    let(:client) { double(socket_connect_timeout: nil) }
+
+    it 'adds host and port to the error message' do
+      allow(TCPSocket).to receive(:new).and_raise(Errno::ECONNREFUSED)
+
+      session = HTTPClient::Session.new(client, nil, nil, nil)
+      expect { session.create_socket('host', 123) }.to raise_error(SystemCallError, /(host:123)/)
     end
   end
 end


### PR DESCRIPTION
The RuboCop auto-corrected code was wrong (`NoMethodError`). Added a test to ensure that the `rescue` block is working as expected.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
