### PR TITLE
Add generic Korifi error

### DIFF
--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -1348,3 +1348,8 @@
   name: EiriniLRPError
   http_code: 422
   message: "Failed to %s LRP resource: '%s'"
+
+420000:
+  name: KorifiError
+  http_code: 500
+  message: "%s"


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add an error for use in Korifi.

* An explanation of the use cases your change solves
This will prevent confusion if other parties attempt to use the 420000 error code.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
