### PR TITLE
Write additional logs when parsing service broker responses 

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -62,6 +62,15 @@ broker_client_default_async_poll_interval_seconds: 60
 broker_client_max_async_poll_duration_minutes: 10080
 broker_client_async_poll_exponential_backoff_rate: 1.0
 
+broker_client_response_parser:
+  log_errors: true
+  log_validators: true
+  log_response_fields:
+    fetch_service_instance_last_operation:
+      - state
+    fetch_service_binding_last_operation:
+      - state
+
 shared_isolation_segment_name: 'shared'
 
 info:

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -185,6 +185,11 @@ module VCAP::CloudController
             broker_client_default_async_poll_interval_seconds: Integer,
             broker_client_max_async_poll_duration_minutes: Integer,
             broker_client_async_poll_exponential_backoff_rate: Numeric,
+            optional(:broker_client_response_parser) => {
+              log_errors: bool,
+              log_validators: bool,
+              log_response_fields: Hash
+            },
             optional(:uaa_client_name) => String,
             optional(:uaa_client_secret) => String,
             optional(:uaa_client_scope) => String,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -112,6 +112,11 @@ module VCAP::CloudController
             broker_client_default_async_poll_interval_seconds: Integer,
             broker_client_max_async_poll_duration_minutes: Integer,
             broker_client_async_poll_exponential_backoff_rate: Numeric,
+            optional(:broker_client_response_parser) => {
+              log_errors: bool,
+              log_validators: bool,
+              log_response_fields: Hash
+            },
             optional(:uaa_client_name) => String,
             optional(:uaa_client_secret) => String,
             optional(:uaa_client_scope) => String,

--- a/lib/services/service_brokers/v2/errors/service_broker_bad_response.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_bad_response.rb
@@ -27,15 +27,6 @@ module VCAP::Services
           def response_code
             502
           end
-
-          def to_h
-            hash = super
-            hash['http'] = {
-              'method' => method,
-              'status' => status,
-            }
-            hash
-          end
         end
       end
     end

--- a/lib/services/service_brokers/v2/errors/service_broker_conflict.rb
+++ b/lib/services/service_brokers/v2/errors/service_broker_conflict.rb
@@ -7,7 +7,7 @@ module VCAP::Services
             error_message = nil
             parsed_response = parsed_json(response.body)
             if parsed_response.is_a?(Hash) && parsed_response.key?('description')
-              error_description = parsed_json(response.body)['description']
+              error_description = parsed_response['description']
               error_message = "Service broker error: #{error_description}"
               if error_message.bytesize > 2**14
                 error_message = error_message.truncate_bytes(2**13) + "...This message has been truncated due to size. To read the full message, check the broker's logs"

--- a/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/response_parser_spec.rb
@@ -5,10 +5,59 @@ module VCAP::Services
     module V2
       RSpec.describe 'ResponseParser' do
         describe 'UnvalidatedResponse' do
-          let(:fake_response) { VCAP::Services::ServiceBrokers::V2::HttpResponse.new(code: 200, body: {}) }
+          let(:path) { '/path' }
+          let(:body) { '' }
+          let(:unvalidated_response) do
+            ResponseParser::UnvalidatedResponse.new(
+              'GET',
+              'https://example.com',
+              path,
+              HttpResponse.new(
+                code: '200',
+                body: body
+              )
+            )
+          end
 
-          it 'should raise an error if the uri is invalid' do
-            expect { ResponseParser::UnvalidatedResponse.new(:get, 'http://examp', 'bad path', fake_response) }.to raise_error(URI::InvalidURIError)
+          context 'invalid uri' do
+            let(:path) { 'bad path' }
+
+            it 'should raise an error' do
+              expect { unvalidated_response }.to raise_error(URI::InvalidURIError)
+            end
+          end
+
+          context 'logging selective response fields' do
+            let(:logger) { instance_double(Steno::Logger, info: nil) }
+            let(:body) { { foo: 'bar', nested: { field: 'yeah' }, other: 'stuff' }.to_json }
+
+            context 'selected fields are included' do
+              it 'logs the fields' do
+                unvalidated_response.log_response_fields(logger, %w[foo nested], {})
+                expect_log_with_data(logger, :info, 'unvalidated_response', { selective_fields: { 'foo' => 'bar', 'nested' => { 'field' => 'yeah' } } })
+              end
+
+              it 'logs context information' do
+                unvalidated_response.log_response_fields(logger, ['foo'], { some: 'context' })
+                expect_log_with_data(logger, :info, 'unvalidated_response', { selective_fields: { 'foo' => 'bar' }, some: 'context' })
+              end
+            end
+
+            context 'selected field is not included' do
+              it 'does not log the field' do
+                unvalidated_response.log_response_fields(logger, ['baz'], {})
+                expect_log_with_data(logger, :info, 'unvalidated_response', { selective_fields: {} })
+              end
+            end
+
+            context 'invalid JSON' do
+              let(:body) { 'invalid json' }
+
+              it 'logs an error message' do
+                unvalidated_response.log_response_fields(logger, ['baz'], {})
+                expect_log_with_data(logger, :info, 'unvalidated_response', { selective_fields: 'could not parse response' })
+              end
+            end
           end
         end
 
@@ -22,11 +71,11 @@ module VCAP::Services
           let(:json_validator) { ResponseParser::JsonSchemaValidator.new(logger, schema, inner_validator) }
           let(:logger) { instance_double(Steno::Logger, warn: nil) }
           let(:schema) {
-            {
+            [:some_schema, {
               '$schema' => 'http://json-schema.org/draft-04/schema#',
               'type' => 'object',
               'properties' => {},
-            }
+            }]
           }
           let(:inner_validator) { instance_double(InnerValidator) }
           let(:broker_response) {
@@ -83,14 +132,14 @@ module VCAP::Services
                   # this is tested above
                 end
 
-                expect(logger).to have_received(:warn).with "MultiJson parse error `\"invalid\"'"
+                expect_log(logger, :warn, "MultiJson parse error `\"invalid\"'")
               end
             end
           end
 
           context 'when the schema has required properties' do
             let(:schema) {
-              {
+              [:some_schema, {
                 'id' => 'some-id',
                 '$schema' => 'http://json-schema.org/draft-04/schema#',
                 'type' => 'object',
@@ -103,7 +152,7 @@ module VCAP::Services
                     'type' => 'string',
                   }
                 }
-              }
+              }]
             }
 
             context 'and there is a single validation failure' do
@@ -163,17 +212,17 @@ module VCAP::Services
           when :unbind
             method = :parse_unbind
             path = '/v2/service_instances/GUID/service_bindings/BINDING_GUID'
-          when :fetch_state
-            method = :parse_fetch_state
+          when :fetch_service_instance_last_operation
+            method = :parse_fetch_service_instance_last_operation
             path = '/v2/service_instances/GUID'
-          when :fetch_catalog
+          when :catalog
             method = :parse_catalog
             path = '/v2/catalog'
           when :fetch_service_binding
-            method = :parse_fetch_binding_parameters
+            method = :parse_fetch_service_binding
             path = '/v2/service_instances/GUID/service_bindings/BINDING_GUID'
           when :fetch_service_instance
-            method = :parse_fetch_instance_parameters
+            method = :parse_fetch_service_instance
             path = '/v2/service_instances/GUID'
           when :fetch_service_binding_last_operation
             method = :parse_fetch_service_binding_last_operation
@@ -214,15 +263,16 @@ module VCAP::Services
           result = opts[:result]
           error = opts[:error]
           service_passthrough = opts[:service]
+          validators = opts[:validators]
 
           context "making a #{operation} request that returns code #{code} and body #{body}" do
             let!(:syslog_service) { VCAP::CloudController::Service.make(:v2, requires: ['syslog_drain']) }
             let!(:non_syslog_non_volume_mounts_service) { VCAP::CloudController::Service.make(:v2, requires: []) }
             let!(:volume_mounts_service) { VCAP::CloudController::Service.make(:v2, requires: ['volume_mount']) }
-            let(:response_parser) { ResponseParser.new('service-broker.com') }
+            let(:response_parser) { ResponseParser.new('service-broker.com', log_errors: true, log_validators: true) }
             let(:fake_response) { instance_double(VCAP::Services::ServiceBrokers::V2::HttpResponse) }
             let(:body) { body }
-            let(:logger) { instance_double(Steno::Logger, warn: nil) }
+            let(:logger) { instance_double(Steno::Logger, error: nil, warn: nil, info: nil) }
             let(:call_method) do
               ->(response_parser, method_name, path, fake_response, service_param) do
                 if service_param
@@ -255,14 +305,42 @@ module VCAP::Services
                 expect { call_method.call(response_parser, @method, @path, fake_response, service_passthrough) }.to raise_error(error) do |e|
                   expect(e.to_h['description']).to eq(description) if description
                 end
-                expect(logger).to have_received(:warn) if expect_warning
+
+                # All errors are logged as 'error'.
+                expect_log_with_data(logger, :error, error, description ? { description: description } : {})
+
+                # Some parsing errors are logged as 'warning'.
+                expect_warning ? expect_log(logger, :warn, /MultiJson parse error/) : expect_no_log(logger, :warn)
+
+                # Validators are logged as 'information'.
+                expect_log_with_data(logger, :info, 'validators', validators ? { validators: validators } : {})
               end
             else
               it 'returns the parsed response' do
                 expect(call_method.call(response_parser, @method, @path, fake_response, service_passthrough)).to eq(result)
+
+                expect_no_log(logger, :error)
+
+                # DELETE request + 410 response => logged as 'warning'.
+                expect_warning ? expect_log(logger, :warn, /Already deleted/) : expect_no_log(logger, :warn)
+
+                # Validators are logged as 'information'.
+                expect_log_with_data(logger, :info, 'validators', validators ? { validators: validators } : {})
               end
             end
           end
+        end
+
+        def expect_log_with_data(logger, log_level, log_message, log_data)
+          expect(logger).to have_received(log_level).with(log_message, hash_including(log_data))
+        end
+
+        def expect_log(logger, log_level, log_message)
+          expect(logger).to have_received(log_level).with(log_message)
+        end
+
+        def expect_no_log(logger, log_level)
+          expect(logger).not_to have_received(log_level)
         end
 
         def self.instance_uri
@@ -642,270 +720,269 @@ module VCAP::Services
         end
 
         # rubocop:disable Layout/LineLength
-        test_case(:provision, 200, broker_partial_json,                                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
-        test_case(:provision, 200, broker_malformed_json,                                       error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
-        test_case(:provision, 200, broker_empty_json,                                           result: client_result_with_state('succeeded'))
-        test_case(:provision, 200, with_dashboard_url.to_json,                                  result: client_result_with_state('succeeded').merge(with_dashboard_url))
-        test_pass_through(:provision, 200, with_dashboard_url,                                  expected_state: 'succeeded')
-        test_case(:provision, 200, with_invalid_dashboard_url.to_json,                          error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
-        test_case(:provision, 201, broker_partial_json,                                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
-        test_case(:provision, 201, broker_malformed_json,                                       error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
-        test_case(:provision, 201, broker_empty_json,                                           result: client_result_with_state('succeeded'))
-        test_case(:provision, 201, with_dashboard_url.to_json,                                  result: client_result_with_state('succeeded').merge(with_dashboard_url))
-        test_pass_through(:provision, 201, with_dashboard_url,                                  expected_state: 'succeeded')
-        test_pass_through(:provision, 201, with_null_dashboard_url,                             expected_state: 'succeeded')
-        test_case(:provision, 201, with_invalid_dashboard_url.to_json,                          error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
-        test_case(:provision, 202, broker_partial_json,                                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
-        test_case(:provision, 202, broker_malformed_json,                                       error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
-        test_case(:provision, 202, broker_empty_json,                                           result: client_result_with_state('in progress'))
-        test_case(:provision, 202, broker_non_empty_json,                                       result: client_result_with_state('in progress'))
-        test_case(:provision, 202, with_dashboard_url.to_json,                                  result: client_result_with_state('in progress').merge(with_dashboard_url))
-        test_case(:provision, 202, with_operation.to_json,                                      result: client_result_with_state('in progress').merge(with_operation))
-        test_case(:provision, 202, with_non_string_operation.to_json,                           error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
-        test_case(:provision, 202, with_long_operation.to_json,                                 error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
-        test_pass_through(:provision, 202, with_dashboard_url,                                  expected_state: 'in progress')
-        test_pass_through(:provision, 202, with_null_dashboard_url,                             expected_state: 'in progress')
-        test_case(:provision, 202, with_invalid_dashboard_url.to_json,                          error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
-        test_case(:provision, 204, broker_partial_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 204, broker_malformed_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 204, broker_empty_json,                                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 409, broker_partial_json,                                         error: Errors::ServiceBrokerConflict)
-        test_case(:provision, 409, broker_malformed_json,                                       error: Errors::ServiceBrokerConflict)
-        test_case(:provision, 409, broker_empty_json,                                           error: Errors::ServiceBrokerConflict)
-        test_case(:provision, 410, broker_partial_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 410, broker_malformed_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 410, broker_empty_json,                                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 422, broker_partial_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 422, broker_malformed_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 422, broker_empty_json,                                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 422, { error: 'AsyncRequired' }.to_json,                          error: Errors::AsyncRequired)
-        test_case(:provision, 422, { error: 'RequiresApp' }.to_json,                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:provision, 422, { error: 'ConcurrencyError' }.to_json,                       error: Errors::ConcurrencyError)
-        test_case(:provision, 422, { error: 'MaintenanceInfoConflict' }.to_json,                error: Errors::MaintenanceInfoConflict)
+        test_case(:provision, 200, broker_partial_json,                          error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
+        test_case(:provision, 200, broker_malformed_json,                        error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
+        test_case(:provision, 200, broker_empty_json,                            result: client_result_with_state('succeeded'), validators: %w[CommonErrorValidator JsonSchemaValidator[provision_response_schema] SuccessValidator[succeeded]])
+        test_case(:provision, 200, with_dashboard_url.to_json,                   result: client_result_with_state('succeeded').merge(with_dashboard_url))
+        test_pass_through(:provision, 200, with_dashboard_url,                   expected_state: 'succeeded')
+        test_case(:provision, 200, with_invalid_dashboard_url.to_json,           error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
+        test_case(:provision, 201, broker_partial_json,                          error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
+        test_case(:provision, 201, broker_malformed_json,                        error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
+        test_case(:provision, 201, broker_empty_json,                            result: client_result_with_state('succeeded'), validators: %w[CommonErrorValidator JsonSchemaValidator[provision_response_schema] SuccessValidator[succeeded]])
+        test_case(:provision, 201, with_dashboard_url.to_json,                   result: client_result_with_state('succeeded').merge(with_dashboard_url))
+        test_pass_through(:provision, 201, with_dashboard_url,                   expected_state: 'succeeded')
+        test_pass_through(:provision, 201, with_null_dashboard_url,              expected_state: 'succeeded')
+        test_case(:provision, 201, with_invalid_dashboard_url.to_json,           error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
+        test_case(:provision, 202, broker_partial_json,                          error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
+        test_case(:provision, 202, broker_malformed_json,                        error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
+        test_case(:provision, 202, broker_empty_json,                            result: client_result_with_state('in progress'), validators: ['CommonErrorValidator', 'JsonSchemaValidator[provision_response_schema]', 'SuccessValidator[in progress]'])
+        test_case(:provision, 202, broker_non_empty_json,                        result: client_result_with_state('in progress'))
+        test_case(:provision, 202, with_dashboard_url.to_json,                   result: client_result_with_state('in progress').merge(with_dashboard_url))
+        test_case(:provision, 202, with_operation.to_json,                       result: client_result_with_state('in progress').merge(with_operation))
+        test_case(:provision, 202, with_non_string_operation.to_json,            error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
+        test_case(:provision, 202, with_long_operation.to_json,                  error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
+        test_pass_through(:provision, 202, with_dashboard_url,                   expected_state: 'in progress')
+        test_pass_through(:provision, 202, with_null_dashboard_url,              expected_state: 'in progress')
+        test_case(:provision, 202, with_invalid_dashboard_url.to_json,           error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
+        test_case(:provision, 204, broker_partial_json,                          error: Errors::ServiceBrokerBadResponse)
+        test_case(:provision, 204, broker_malformed_json,                        error: Errors::ServiceBrokerBadResponse)
+        test_case(:provision, 204, broker_empty_json,                            error: Errors::ServiceBrokerBadResponse)
+        test_case(:provision, 409, broker_partial_json,                          error: Errors::ServiceBrokerConflict, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:provision, 409, broker_malformed_json,                        error: Errors::ServiceBrokerConflict)
+        test_case(:provision, 409, broker_empty_json,                            error: Errors::ServiceBrokerConflict)
+        test_case(:provision, 410, broker_partial_json,                          error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:provision, 410, broker_malformed_json,                        error: Errors::ServiceBrokerBadResponse)
+        test_case(:provision, 410, broker_empty_json,                            error: Errors::ServiceBrokerBadResponse)
+        test_case(:provision, 422, broker_partial_json,                          error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailWhenValidator FailingValidator])
+        test_case(:provision, 422, broker_malformed_json,                        error: Errors::ServiceBrokerBadResponse)
+        test_case(:provision, 422, broker_empty_json,                            error: Errors::ServiceBrokerBadResponse)
+        test_case(:provision, 422, { error: 'AsyncRequired' }.to_json,           error: Errors::AsyncRequired)
+        test_case(:provision, 422, { error: 'RequiresApp' }.to_json,             error: Errors::ServiceBrokerBadResponse)
+        test_case(:provision, 422, { error: 'ConcurrencyError' }.to_json,        error: Errors::ConcurrencyError)
+        test_case(:provision, 422, { error: 'MaintenanceInfoConflict' }.to_json, error: Errors::MaintenanceInfoConflict)
         test_common_error_cases(:provision)
 
-        test_case(:bind,      200, broker_partial_json,                                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
-        test_case(:bind,      200, broker_malformed_json,                                       error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
-        test_case(:bind,      200, broker_empty_json,                                           result: client_result_with_state('succeeded'))
-        test_case(:bind,      200, with_credentials.to_json,                                    result: client_result_with_state('succeeded').merge(with_credentials))
-        test_case(:bind,      200, { 'credentials' => 'invalid' }.to_json,                      error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, 'expected credentials to be a valid JSON object'))
-        test_case(:bind,      200, with_syslog_drain_url.to_json, service: :syslog,             result: client_result_with_state('succeeded').merge('syslog_drain_url' => 'syslog.com/drain'))
-        test_case(:bind,      200, with_nil_syslog_drain_url.to_json, service: :no_syslog,      result: client_result_with_state('succeeded').merge('syslog_drain_url' => nil))
-        test_case(:bind,      200, with_syslog_drain_url.to_json, service: :no_syslog,          error: Errors::ServiceBrokerInvalidSyslogDrainUrl)
-        test_case(:bind,      200, with_valid_route_service_url.to_json,                        result: client_result_with_state('succeeded').merge(with_valid_route_service_url))
-        test_case(:bind,      200, with_invalid_route_service_url_with_space.to_json,           error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      200, with_invalid_route_service_url_with_no_host.to_json,         error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      200, with_http_route_service_url.to_json,                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      200, with_invalid_volume_mounts.to_json, service: :volume_mount,  error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_error(with_invalid_volume_mounts.to_json, binding_uri))
-        test_case(:bind,      200, with_valid_volume_mounts.to_json, service: :volume_mount,    result: client_result_with_state('succeeded').merge(with_valid_volume_mounts))
-        test_case(:bind,      200, without_volume_mounts.to_json, service: :no_volume_mount,    result: client_result_with_state('succeeded'))
-        test_case(:bind,      200, with_valid_volume_mounts.to_json, service: :no_volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: volume_mounts_not_required_error(binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_device_type.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_device_type_error(binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_nil_driver.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('driver', binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_empty_driver.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('driver', binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_no_device.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('device', binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_no_device_type.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('device_type', binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_no_mode.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('mode', binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_no_container_dir.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('container_dir', binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_no_driver.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('driver', binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_no_volume_id.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_volume_id_error(binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_bad_volume_id.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_volume_id_error(binding_uri))
-        test_case(:bind,      200, with_invalid_volume_mounts_bad_mount_config.to_json, service: :volume_mount,  error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_bad_mount_config_error(binding_uri))
-        test_case(:bind,      200, with_valid_volume_mounts_nil_mount_config.to_json, service: :volume_mount,    result: client_result_with_state('succeeded').merge(with_valid_volume_mounts_nil_mount_config))
-        test_pass_through(:bind, 200, with_credentials,                                         expected_state: 'succeeded')
-
-        test_case(:bind,      201, broker_partial_json,                                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
-        test_case(:bind,      201, broker_malformed_json,                                       error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
-        test_case(:bind,      201, broker_empty_json,                                           result: client_result_with_state('succeeded'))
-        test_case(:bind,      201, with_credentials.to_json,                                    result: client_result_with_state('succeeded').merge(with_credentials))
-        test_case(:bind,      201, { 'credentials' => 'invalid' }.to_json,                      error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, 'expected credentials to be a valid JSON object'))
-        test_case(:bind,      201, with_syslog_drain_url.to_json, service: :syslog,             result: client_result_with_state('succeeded').merge('syslog_drain_url' => 'syslog.com/drain'))
-        test_case(:bind,      201, with_syslog_drain_url.to_json, service: :no_syslog,          error: Errors::ServiceBrokerInvalidSyslogDrainUrl)
-        test_case(:bind,      201, with_nil_syslog_drain_url.to_json, service: :no_syslog,      result: client_result_with_state('succeeded').merge('syslog_drain_url' => nil))
-        test_case(:bind,      201, with_valid_route_service_url.to_json,                        result: client_result_with_state('succeeded').merge(with_valid_route_service_url))
-        test_case(:bind,      201, with_invalid_route_service_url_with_space.to_json,           error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      201, with_invalid_route_service_url_with_no_host.to_json,         error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      201, with_http_route_service_url.to_json,                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      201, with_invalid_volume_mounts.to_json, service: :volume_mount,  error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_error(with_invalid_volume_mounts.to_json, binding_uri))
-        test_case(:bind,      201, with_valid_volume_mounts.to_json, service: :volume_mount,    result: client_result_with_state('succeeded').merge(with_valid_volume_mounts))
-        test_case(:bind,      201, without_volume_mounts.to_json, service: :no_volume_mount,    result: client_result_with_state('succeeded'))
-        test_case(:bind,      201, with_valid_volume_mounts.to_json, service: :no_volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: volume_mounts_not_required_error(binding_uri))
-        test_pass_through(:bind, 201, with_credentials,                                         expected_state: 'succeeded')
-
-        test_case(:bind,      202, broker_empty_json,                                             result: {})
-        test_case(:bind,      202, with_operation.to_json,                                        result: with_operation)
-        test_case(:bind,      202, broker_malformed_json,                                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_malformed_json, binding_uri))
-        test_case(:bind,      202, broker_partial_json,                                           error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
-        test_case(:bind,      202, with_non_string_operation.to_json,                             error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
-        test_case(:bind,      202, with_long_operation.to_json,                                   error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
-        test_case(:bind,      204, broker_partial_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      204, broker_malformed_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      204, broker_empty_json,                                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      409, broker_partial_json,                                         error: Errors::ServiceBrokerConflict)
-        test_case(:bind,      409, broker_malformed_json,                                       error: Errors::ServiceBrokerConflict)
-        test_case(:bind,      409, broker_empty_json,                                           error: Errors::ServiceBrokerConflict)
-        test_case(:bind,      410, broker_partial_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      410, broker_malformed_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      410, broker_empty_json,                                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      422, broker_partial_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      422, broker_malformed_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      422, broker_empty_json,                                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:bind,      422, { error: 'AsyncRequired' }.to_json,                          error: Errors::AsyncRequired)
-        test_case(:bind,      422, { error: 'RequiresApp' }.to_json,                            error: Errors::AppRequired)
-        test_case(:bind,      422, { error: 'ConcurrencyError' }.to_json,                       error: Errors::ConcurrencyError)
+        test_case(:bind, 200, broker_partial_json,                                                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
+        test_case(:bind, 200, broker_malformed_json,                                                       error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
+        test_case(:bind, 200, broker_empty_json,                                                           result: client_result_with_state('succeeded'), validators: %w[CommonErrorValidator JsonObjectValidator CredentialsValidator SyslogDrainValidator RouteServiceURLValidator VolumeMountsValidator SuccessValidator[succeeded]])
+        test_case(:bind, 200, with_credentials.to_json,                                                    result: client_result_with_state('succeeded').merge(with_credentials))
+        test_case(:bind, 200, { 'credentials' => 'invalid' }.to_json,                                      error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, 'expected credentials to be a valid JSON object'))
+        test_case(:bind, 200, with_syslog_drain_url.to_json, service: :syslog,                             result: client_result_with_state('succeeded').merge('syslog_drain_url' => 'syslog.com/drain'))
+        test_case(:bind, 200, with_nil_syslog_drain_url.to_json, service: :no_syslog,                      result: client_result_with_state('succeeded').merge('syslog_drain_url' => nil))
+        test_case(:bind, 200, with_syslog_drain_url.to_json, service: :no_syslog,                          error: Errors::ServiceBrokerInvalidSyslogDrainUrl)
+        test_case(:bind, 200, with_valid_route_service_url.to_json,                                        result: client_result_with_state('succeeded').merge(with_valid_route_service_url))
+        test_case(:bind, 200, with_invalid_route_service_url_with_space.to_json,                           error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 200, with_invalid_route_service_url_with_no_host.to_json,                         error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 200, with_http_route_service_url.to_json,                                         error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 200, with_invalid_volume_mounts.to_json, service: :volume_mount,                  error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_error(with_invalid_volume_mounts.to_json, binding_uri))
+        test_case(:bind, 200, with_valid_volume_mounts.to_json, service: :volume_mount,                    result: client_result_with_state('succeeded').merge(with_valid_volume_mounts))
+        test_case(:bind, 200, without_volume_mounts.to_json, service: :no_volume_mount,                    result: client_result_with_state('succeeded'))
+        test_case(:bind, 200, with_valid_volume_mounts.to_json, service: :no_volume_mount,                 error: Errors::ServiceBrokerInvalidVolumeMounts, description: volume_mounts_not_required_error(binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_device_type.to_json, service: :volume_mount,      error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_device_type_error(binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_nil_driver.to_json, service: :volume_mount,       error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('driver', binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_empty_driver.to_json, service: :volume_mount,     error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('driver', binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_no_device.to_json, service: :volume_mount,        error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('device', binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_no_device_type.to_json, service: :volume_mount,   error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('device_type', binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_no_mode.to_json, service: :volume_mount,          error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('mode', binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_no_container_dir.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('container_dir', binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_no_driver.to_json, service: :volume_mount,        error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_field_error('driver', binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_no_volume_id.to_json, service: :volume_mount,     error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_volume_id_error(binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_bad_volume_id.to_json, service: :volume_mount,    error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_missing_volume_id_error(binding_uri))
+        test_case(:bind, 200, with_invalid_volume_mounts_bad_mount_config.to_json, service: :volume_mount, error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_bad_mount_config_error(binding_uri))
+        test_case(:bind, 200, with_valid_volume_mounts_nil_mount_config.to_json, service: :volume_mount,   result: client_result_with_state('succeeded').merge(with_valid_volume_mounts_nil_mount_config))
+        test_pass_through(:bind, 200, with_credentials,                                                    expected_state: 'succeeded')
+        test_case(:bind, 201, broker_partial_json,                                                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
+        test_case(:bind, 201, broker_malformed_json,                                                       error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
+        test_case(:bind, 201, broker_empty_json,                                                           result: client_result_with_state('succeeded'), validators: %w[CommonErrorValidator JsonObjectValidator CredentialsValidator SyslogDrainValidator RouteServiceURLValidator VolumeMountsValidator SuccessValidator[succeeded]])
+        test_case(:bind, 201, with_credentials.to_json,                                                    result: client_result_with_state('succeeded').merge(with_credentials))
+        test_case(:bind, 201, { 'credentials' => 'invalid' }.to_json,                                      error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, 'expected credentials to be a valid JSON object'))
+        test_case(:bind, 201, with_syslog_drain_url.to_json, service: :syslog,                             result: client_result_with_state('succeeded').merge('syslog_drain_url' => 'syslog.com/drain'))
+        test_case(:bind, 201, with_syslog_drain_url.to_json, service: :no_syslog,                          error: Errors::ServiceBrokerInvalidSyslogDrainUrl)
+        test_case(:bind, 201, with_nil_syslog_drain_url.to_json, service: :no_syslog,                      result: client_result_with_state('succeeded').merge('syslog_drain_url' => nil))
+        test_case(:bind, 201, with_valid_route_service_url.to_json,                                        result: client_result_with_state('succeeded').merge(with_valid_route_service_url))
+        test_case(:bind, 201, with_invalid_route_service_url_with_space.to_json,                           error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 201, with_invalid_route_service_url_with_no_host.to_json,                         error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 201, with_http_route_service_url.to_json,                                         error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 201, with_invalid_volume_mounts.to_json, service: :volume_mount,                  error: Errors::ServiceBrokerInvalidVolumeMounts, description: invalid_volume_mounts_error(with_invalid_volume_mounts.to_json, binding_uri))
+        test_case(:bind, 201, with_valid_volume_mounts.to_json, service: :volume_mount,                    result: client_result_with_state('succeeded').merge(with_valid_volume_mounts))
+        test_case(:bind, 201, without_volume_mounts.to_json, service: :no_volume_mount,                    result: client_result_with_state('succeeded'))
+        test_case(:bind, 201, with_valid_volume_mounts.to_json, service: :no_volume_mount,                 error: Errors::ServiceBrokerInvalidVolumeMounts, description: volume_mounts_not_required_error(binding_uri))
+        test_pass_through(:bind, 201, with_credentials,                                                    expected_state: 'succeeded')
+        test_case(:bind, 202, broker_empty_json,                                                           result: {}, validators: %w[CommonErrorValidator JsonSchemaValidator[async_binding_response_schema] SuccessValidator])
+        test_case(:bind, 202, with_operation.to_json,                                                      result: with_operation)
+        test_case(:bind, 202, broker_malformed_json,                                                       error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
+        test_case(:bind, 202, broker_partial_json,                                                         error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
+        test_case(:bind, 202, with_non_string_operation.to_json,                                           error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
+        test_case(:bind, 202, with_long_operation.to_json,                                                 error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
+        test_case(:bind, 204, broker_partial_json,                                                         error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 204, broker_malformed_json,                                                       error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 204, broker_empty_json,                                                           error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 409, broker_partial_json,                                                         error: Errors::ServiceBrokerConflict, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:bind, 409, broker_malformed_json,                                                       error: Errors::ServiceBrokerConflict)
+        test_case(:bind, 409, broker_empty_json,                                                           error: Errors::ServiceBrokerConflict)
+        test_case(:bind, 410, broker_partial_json,                                                         error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:bind, 410, broker_malformed_json,                                                       error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 410, broker_empty_json,                                                           error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 422, broker_partial_json,                                                         error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailWhenValidator FailingValidator])
+        test_case(:bind, 422, broker_malformed_json,                                                       error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 422, broker_empty_json,                                                           error: Errors::ServiceBrokerBadResponse)
+        test_case(:bind, 422, { error: 'AsyncRequired' }.to_json,                                          error: Errors::AsyncRequired)
+        test_case(:bind, 422, { error: 'RequiresApp' }.to_json,                                            error: Errors::AppRequired)
+        test_case(:bind, 422, { error: 'ConcurrencyError' }.to_json,                                       error: Errors::ConcurrencyError)
         test_common_error_cases(:bind)
 
-        test_case(:fetch_state, 200, broker_partial_json,                                       error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
-        test_case(:fetch_state, 200, broker_malformed_json,                                     error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_malformed_json, instance_uri), expect_warning: true)
-        test_case(:fetch_state, 200, broker_empty_json,                                         error: Errors::ServiceBrokerResponseMalformed, description: response_not_understood('succeeded', '', instance_uri))
-        test_case(:fetch_state, 200, broker_body_with_state('unrecognized').to_json,            error: Errors::ServiceBrokerResponseMalformed, description: response_not_understood('succeeded', 'unrecognized', instance_uri))
-        test_case(:fetch_state, 200, broker_body_with_state('succeeded').to_json,               result: client_result_with_state('succeeded'))
-        test_case(:fetch_state, 200, broker_body_with_state('succeeded').merge('description' => 'a description').to_json, result: client_result_with_state('succeeded', description: 'a description'))
-        test_pass_through(:fetch_state, 200, broker_body_with_state('succeeded'),               expected_state: 'succeeded')
-        test_case(:fetch_state, 201, broker_partial_json,                                       error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_state, 201, broker_malformed_json,                                     error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_state, 201, broker_body_with_state('succeeded').to_json,               error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 202, broker_partial_json,                                       error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_state, 202, broker_malformed_json,                                     error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_state, 202, broker_body_with_state('succeeded').to_json,               error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 204, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 204, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 204, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 409, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 409, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 409, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 400, broker_empty_json,                                         result: client_result_with_state('failed', description: 'Bad request', status_code: 400))
-        test_case(:fetch_state, 400, broker_partial_json,                                       result: client_result_with_state('failed', description: 'Bad request', status_code: 400))
-        test_case(:fetch_state, 400, broker_malformed_json,                                     result: client_result_with_state('failed', description: 'Bad request', status_code: 400))
-        test_case(:fetch_state, 400, broker_error_json,                                         result: client_result_with_state('failed', description: 'Bad request', status_code: 400))
-        test_case(:fetch_state, 400, broker_error_json(description: 'Some description'),        result: client_result_with_state('failed', description: 'Some description', status_code: 400))
-        test_case(:fetch_state, 410, broker_empty_json,                                         result: {})
-        test_case(:fetch_state, 410, broker_partial_json,                                       result: {})
-        test_case(:fetch_state, 410, broker_malformed_json,                                     result: {})
-        test_case(:fetch_state, 422, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 422, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_state, 422, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_common_error_cases(:fetch_state)
+        test_case(:fetch_service_instance_last_operation, 200, broker_partial_json,                                                    error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
+        test_case(:fetch_service_instance_last_operation, 200, broker_malformed_json,                                                  error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_malformed_json, instance_uri), expect_warning: true)
+        test_case(:fetch_service_instance_last_operation, 200, broker_empty_json,                                                      error: Errors::ServiceBrokerResponseMalformed, description: response_not_understood('succeeded', '', instance_uri))
+        test_case(:fetch_service_instance_last_operation, 200, broker_body_with_state('unrecognized').to_json,                         error: Errors::ServiceBrokerResponseMalformed, description: response_not_understood('succeeded', 'unrecognized', instance_uri))
+        test_case(:fetch_service_instance_last_operation, 200, broker_body_with_state('succeeded').to_json,                            result: client_result_with_state('succeeded'), validators: ['JsonObjectValidator', 'StateValidator[succeeded,failed,in progress]', 'SuccessValidator'])
+        test_case(:fetch_service_instance_last_operation, 200, broker_body_with_state('succeeded').merge(description: 'desc').to_json, result: client_result_with_state('succeeded', description: 'desc'))
+        test_pass_through(:fetch_service_instance_last_operation, 200, broker_body_with_state('succeeded'),                            expected_state: 'succeeded')
+        test_case(:fetch_service_instance_last_operation, 201, broker_partial_json,                                                    error: Errors::ServiceBrokerResponseMalformed, validators: %w[JsonObjectValidator FailingValidator])
+        test_case(:fetch_service_instance_last_operation, 201, broker_malformed_json,                                                  error: Errors::ServiceBrokerResponseMalformed, expect_warning: true)
+        test_case(:fetch_service_instance_last_operation, 201, broker_body_with_state('succeeded').to_json,                            error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance_last_operation, 202, broker_partial_json,                                                    error: Errors::ServiceBrokerResponseMalformed, validators: %w[JsonObjectValidator FailingValidator])
+        test_case(:fetch_service_instance_last_operation, 202, broker_malformed_json,                                                  error: Errors::ServiceBrokerResponseMalformed, expect_warning: true)
+        test_case(:fetch_service_instance_last_operation, 202, broker_body_with_state('succeeded').to_json,                            error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance_last_operation, 204, broker_partial_json,                                                    error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance_last_operation, 204, broker_malformed_json,                                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance_last_operation, 204, broker_empty_json,                                                      error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance_last_operation, 409, broker_partial_json,                                                    error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance_last_operation, 409, broker_malformed_json,                                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance_last_operation, 409, broker_empty_json,                                                      error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance_last_operation, 400, broker_empty_json,                                                      result: client_result_with_state('failed', description: 'Bad request', status_code: 400), validators: %w[BadRequestValidator])
+        test_case(:fetch_service_instance_last_operation, 400, broker_partial_json,                                                    result: client_result_with_state('failed', description: 'Bad request', status_code: 400))
+        test_case(:fetch_service_instance_last_operation, 400, broker_malformed_json,                                                  result: client_result_with_state('failed', description: 'Bad request', status_code: 400))
+        test_case(:fetch_service_instance_last_operation, 400, broker_error_json,                                                      result: client_result_with_state('failed', description: 'Bad request', status_code: 400))
+        test_case(:fetch_service_instance_last_operation, 400, broker_error_json(description: 'Some description'),                     result: client_result_with_state('failed', description: 'Some description', status_code: 400))
+        test_case(:fetch_service_instance_last_operation, 410, broker_empty_json,                                                      result: {}, validators: %w[SuccessValidator])
+        test_case(:fetch_service_instance_last_operation, 410, broker_partial_json,                                                    result: {})
+        test_case(:fetch_service_instance_last_operation, 410, broker_malformed_json,                                                  result: {})
+        test_case(:fetch_service_instance_last_operation, 422, broker_partial_json,                                                    error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:fetch_service_instance_last_operation, 422, broker_malformed_json,                                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance_last_operation, 422, broker_empty_json,                                                      error: Errors::ServiceBrokerBadResponse)
+        test_common_error_cases(:fetch_service_instance_last_operation)
 
-        test_case(:fetch_catalog, 200, broker_partial_json,                                     error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_catalog, 200, broker_malformed_json,                                   error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_catalog, 200, broker_empty_json,                                       result: {})
-        test_case(:fetch_catalog, 200, valid_catalog.to_json,                                   result: valid_catalog)
-        test_case(:fetch_catalog, 201, broker_partial_json,                                     error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_catalog, 201, broker_malformed_json,                                   error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_catalog, 201, broker_empty_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 201, valid_catalog.to_json,                                   error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 204, broker_partial_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 204, broker_malformed_json,                                   error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 204, broker_empty_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 204, valid_catalog.to_json,                                   error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 409, broker_partial_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 409, broker_malformed_json,                                   error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 409, broker_empty_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 410, broker_partial_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 410, broker_malformed_json,                                   error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 410, broker_empty_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 422, broker_partial_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 422, broker_malformed_json,                                   error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_catalog, 422, broker_empty_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_common_error_cases(:fetch_catalog)
+        test_case(:catalog, 200, broker_partial_json,   error: Errors::ServiceBrokerResponseMalformed)
+        test_case(:catalog, 200, broker_malformed_json, error: Errors::ServiceBrokerResponseMalformed, expect_warning: true)
+        test_case(:catalog, 200, broker_empty_json,     result: {}, validators: %w[CommonErrorValidator JsonObjectValidator SuccessValidator])
+        test_case(:catalog, 200, valid_catalog.to_json, result: valid_catalog)
+        test_case(:catalog, 201, broker_partial_json,   error: Errors::ServiceBrokerResponseMalformed, validators: %w[CommonErrorValidator JsonObjectValidator FailingValidator])
+        test_case(:catalog, 201, broker_malformed_json, error: Errors::ServiceBrokerResponseMalformed, expect_warning: true)
+        test_case(:catalog, 201, broker_empty_json,     error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 201, valid_catalog.to_json, error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 204, broker_partial_json,   error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 204, broker_malformed_json, error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 204, broker_empty_json,     error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 204, valid_catalog.to_json, error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 409, broker_partial_json,   error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 409, broker_malformed_json, error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 409, broker_empty_json,     error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 410, broker_partial_json,   error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 410, broker_malformed_json, error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 410, broker_empty_json,     error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 422, broker_partial_json,   error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:catalog, 422, broker_malformed_json, error: Errors::ServiceBrokerBadResponse)
+        test_case(:catalog, 422, broker_empty_json,     error: Errors::ServiceBrokerBadResponse)
+        test_common_error_cases(:catalog)
 
-        test_case(:deprovision, 200, broker_partial_json,                                       error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
-        test_case(:deprovision, 200, broker_malformed_json,                                     error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
-        test_case(:deprovision, 200, broker_empty_json,                                         result: client_result_with_state('succeeded'))
-        test_pass_through(:deprovision, 200,                                                    expected_state: 'succeeded')
-        test_case(:deprovision, 201, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_partial_json, instance_uri))
-        test_case(:deprovision, 201, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_malformed_json, instance_uri))
-        test_case(:deprovision, 201, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_empty_json, instance_uri))
-        test_case(:deprovision, 201, { description: 'error' }.to_json,                          error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, { description: 'error' }.to_json, instance_uri))
-        test_case(:deprovision, 202, broker_partial_json,                                       error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
-        test_case(:deprovision, 202, broker_malformed_json,                                     error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
-        test_case(:deprovision, 202, broker_empty_json,                                         result: client_result_with_state('in progress'))
-        test_case(:deprovision, 202, broker_non_empty_json,                                     result: client_result_with_state('in progress'))
-        test_case(:deprovision, 202, with_operation.to_json,                                    result: client_result_with_state('in progress').merge(with_operation))
-        test_case(:deprovision, 202, with_non_string_operation.to_json,                         error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
-        test_case(:deprovision, 202, with_long_operation.to_json,                               error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
-        test_pass_through(:deprovision, 202,                                                    expected_state: 'in progress')
-        test_case(:deprovision, 204, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:deprovision, 204, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:deprovision, 204, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:deprovision, 409, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:deprovision, 409, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:deprovision, 410, broker_empty_json,                                         result: {})
-        test_case(:deprovision, 410, broker_partial_json,                                       result: {})
-        test_case(:deprovision, 410, broker_malformed_json,                                     result: {})
-        test_case(:deprovision, 422, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:deprovision, 422, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:deprovision, 422, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:deprovision, 422, { error: 'AsyncRequired' }.to_json,                        error: Errors::AsyncRequired)
-        test_case(:deprovision, 422, { error: 'ConcurrencyError' }.to_json,                     error: Errors::ConcurrencyError)
+        test_case(:deprovision, 200, broker_partial_json,                   error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
+        test_case(:deprovision, 200, broker_malformed_json,                 error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
+        test_case(:deprovision, 200, broker_empty_json,                     result: client_result_with_state('succeeded'), validators: %w[CommonErrorValidator JsonObjectValidator SuccessValidator[succeeded]])
+        test_pass_through(:deprovision, 200,                                expected_state: 'succeeded')
+        test_case(:deprovision, 201, broker_partial_json,                   error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_partial_json, instance_uri), validators: %w[CommonErrorValidator IgnoreDescriptionKeyFailingValidator])
+        test_case(:deprovision, 201, broker_malformed_json,                 error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_malformed_json, instance_uri))
+        test_case(:deprovision, 201, broker_empty_json,                     error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_empty_json, instance_uri))
+        test_case(:deprovision, 201, { description: 'error' }.to_json,      error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, { description: 'error' }.to_json, instance_uri))
+        test_case(:deprovision, 202, broker_partial_json,                   error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
+        test_case(:deprovision, 202, broker_malformed_json,                 error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
+        test_case(:deprovision, 202, broker_empty_json,                     result: client_result_with_state('in progress'), validators: ['CommonErrorValidator', 'JsonSchemaValidator[deprovision_response_schema]', 'SuccessValidator[in progress]'])
+        test_case(:deprovision, 202, broker_non_empty_json,                 result: client_result_with_state('in progress'))
+        test_case(:deprovision, 202, with_operation.to_json,                result: client_result_with_state('in progress').merge(with_operation))
+        test_case(:deprovision, 202, with_non_string_operation.to_json,     error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
+        test_case(:deprovision, 202, with_long_operation.to_json,           error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
+        test_pass_through(:deprovision, 202,                                expected_state: 'in progress')
+        test_case(:deprovision, 204, broker_partial_json,                   error: Errors::ServiceBrokerBadResponse)
+        test_case(:deprovision, 204, broker_malformed_json,                 error: Errors::ServiceBrokerBadResponse)
+        test_case(:deprovision, 204, broker_empty_json,                     error: Errors::ServiceBrokerBadResponse)
+        test_case(:deprovision, 409, broker_partial_json,                   error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:deprovision, 409, broker_malformed_json,                 error: Errors::ServiceBrokerBadResponse)
+        test_case(:deprovision, 410, broker_empty_json,                     result: {}, expect_warning: true, validators: %w[CommonErrorValidator SuccessValidator])
+        test_case(:deprovision, 410, broker_partial_json,                   result: {}, expect_warning: true)
+        test_case(:deprovision, 410, broker_malformed_json,                 result: {}, expect_warning: true)
+        test_case(:deprovision, 422, broker_empty_json,                     error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailWhenValidator FailingValidator])
+        test_case(:deprovision, 422, broker_partial_json,                   error: Errors::ServiceBrokerBadResponse)
+        test_case(:deprovision, 422, broker_malformed_json,                 error: Errors::ServiceBrokerBadResponse)
+        test_case(:deprovision, 422, { error: 'AsyncRequired' }.to_json,    error: Errors::AsyncRequired)
+        test_case(:deprovision, 422, { error: 'ConcurrencyError' }.to_json, error: Errors::ConcurrencyError)
         test_common_error_cases(:deprovision)
 
-        test_case(:unbind, 200, broker_partial_json,                                            error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
-        test_case(:unbind, 200, broker_malformed_json,                                          error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
-        test_case(:unbind, 200, broker_empty_json,                                              result: client_result_with_state('succeeded'))
-        test_pass_through(:unbind, 200,                                                         expected_state: 'succeeded')
-        test_case(:unbind, 201, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_partial_json, binding_uri))
-        test_case(:unbind, 201, broker_malformed_json,                                          error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_malformed_json, binding_uri))
-        test_case(:unbind, 201, broker_empty_json,                                              error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_empty_json, binding_uri))
-        test_case(:unbind, 201, { description: 'error' }.to_json,                               error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, { description: 'error' }.to_json, binding_uri))
-        test_case(:unbind, 202, broker_empty_json,                                              result: {})
-        test_case(:unbind, 202, broker_malformed_json,                                          error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
-        test_case(:unbind, 202, broker_partial_json,                                            error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
-        test_case(:unbind, 202, with_operation.to_json,                                         result: with_operation)
-        test_case(:unbind, 202, with_non_string_operation.to_json,                              error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
-        test_case(:unbind, 202, with_long_operation.to_json,                                    error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
-        test_case(:unbind, 204, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:unbind, 204, broker_malformed_json,                                          error: Errors::ServiceBrokerBadResponse)
-        test_case(:unbind, 204, broker_empty_json,                                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:unbind, 409, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:unbind, 409, broker_malformed_json,                                          error: Errors::ServiceBrokerBadResponse)
-        test_case(:unbind, 410, broker_empty_json,                                              result: {})
-        test_case(:unbind, 410, broker_partial_json,                                            result: {})
-        test_case(:unbind, 410, broker_malformed_json,                                          result: {})
-        test_case(:unbind, 422, broker_empty_json,                                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:unbind, 422, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:unbind, 422, broker_malformed_json,                                          error: Errors::ServiceBrokerBadResponse)
-        test_case(:unbind, 422, { error: 'AsyncRequired' }.to_json,                             error: Errors::AsyncRequired)
-        test_case(:unbind, 422, { error: 'ConcurrencyError' }.to_json,                          error: Errors::ConcurrencyError)
+        test_case(:unbind, 200, broker_partial_json,                   error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
+        test_case(:unbind, 200, broker_malformed_json,                 error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
+        test_case(:unbind, 200, broker_empty_json,                     result: client_result_with_state('succeeded'), validators: %w[CommonErrorValidator JsonObjectValidator SuccessValidator[succeeded]])
+        test_pass_through(:unbind, 200,                                expected_state: 'succeeded')
+        test_case(:unbind, 201, broker_partial_json,                   error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_partial_json, binding_uri), validators: %w[CommonErrorValidator IgnoreDescriptionKeyFailingValidator])
+        test_case(:unbind, 201, broker_malformed_json,                 error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_malformed_json, binding_uri))
+        test_case(:unbind, 201, broker_empty_json,                     error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_empty_json, binding_uri))
+        test_case(:unbind, 201, { description: 'error' }.to_json,      error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, { description: 'error' }.to_json, binding_uri))
+        test_case(:unbind, 202, broker_empty_json,                     result: {}, validators: %w[CommonErrorValidator JsonSchemaValidator[async_binding_response_schema] SuccessValidator])
+        test_case(:unbind, 202, broker_malformed_json,                 error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
+        test_case(:unbind, 202, broker_partial_json,                   error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
+        test_case(:unbind, 202, with_operation.to_json,                result: with_operation)
+        test_case(:unbind, 202, with_non_string_operation.to_json,     error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
+        test_case(:unbind, 202, with_long_operation.to_json,           error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
+        test_case(:unbind, 204, broker_partial_json,                   error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:unbind, 204, broker_malformed_json,                 error: Errors::ServiceBrokerBadResponse)
+        test_case(:unbind, 204, broker_empty_json,                     error: Errors::ServiceBrokerBadResponse)
+        test_case(:unbind, 409, broker_partial_json,                   error: Errors::ServiceBrokerBadResponse)
+        test_case(:unbind, 409, broker_malformed_json,                 error: Errors::ServiceBrokerBadResponse)
+        test_case(:unbind, 410, broker_empty_json,                     result: {}, expect_warning: true, validators: %w[CommonErrorValidator SuccessValidator])
+        test_case(:unbind, 410, broker_partial_json,                   result: {}, expect_warning: true)
+        test_case(:unbind, 410, broker_malformed_json,                 result: {}, expect_warning: true)
+        test_case(:unbind, 422, broker_empty_json,                     error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailWhenValidator FailingValidator])
+        test_case(:unbind, 422, broker_partial_json,                   error: Errors::ServiceBrokerBadResponse)
+        test_case(:unbind, 422, broker_malformed_json,                 error: Errors::ServiceBrokerBadResponse)
+        test_case(:unbind, 422, { error: 'AsyncRequired' }.to_json,    error: Errors::AsyncRequired)
+        test_case(:unbind, 422, { error: 'ConcurrencyError' }.to_json, error: Errors::ConcurrencyError)
         test_common_error_cases(:unbind)
-        test_case(:update, 200, broker_partial_json,                                            error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
-        test_case(:update, 200, broker_malformed_json,                                          error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
-        test_case(:update, 200, with_invalid_dashboard_url.to_json,                             error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
-        test_case(:update, 200, broker_empty_json,                                              result: client_result_with_state('succeeded'))
-        test_case(:update, 200, with_dashboard_url.to_json,                                     result: client_result_with_state('succeeded').merge(with_dashboard_url))
-        test_pass_through(:update, 200, with_null_dashboard_url,                                expected_state: 'succeeded')
-        test_pass_through(:update, 200,                                                         expected_state: 'succeeded')
-        test_case(:update, 201, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_partial_json, instance_uri))
-        test_case(:update, 201, broker_malformed_json,                                          error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_malformed_json, instance_uri))
-        test_case(:update, 201, broker_empty_json,                                              error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_empty_json, instance_uri))
-        test_case(:update, 201, { 'foo' => 'bar' }.to_json,                                     error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, { 'foo' => 'bar' }.to_json, instance_uri))
-        test_case(:update, 202, broker_partial_json,                                            error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
-        test_case(:update, 202, broker_malformed_json,                                          error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
-        test_case(:update, 202, broker_empty_json,                                              result: client_result_with_state('in progress'))
-        test_case(:update, 202, broker_non_empty_json,                                          result: client_result_with_state('in progress'))
-        test_case(:update, 202, with_operation.to_json,                                         result: client_result_with_state('in progress').merge(with_operation))
-        test_case(:update, 202, with_dashboard_url.to_json,                                     result: client_result_with_state('in progress').merge(with_dashboard_url))
-        test_pass_through(:update, 202, with_null_dashboard_url,                                expected_state: 'in progress')
-        test_case(:update, 202, with_invalid_dashboard_url.to_json,                             error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
-        test_case(:update, 202, with_non_string_operation.to_json,                              error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
-        test_case(:update, 202, with_long_operation.to_json,                                    error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
-        test_pass_through(:update, 202,                                                         expected_state: 'in progress')
-        test_case(:update, 204, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:update, 204, broker_malformed_json,                                          error: Errors::ServiceBrokerBadResponse)
-        test_case(:update, 204, broker_empty_json,                                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:update, 409, broker_empty_json,                                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:update, 409, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:update, 410, broker_empty_json,                                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:update, 410, broker_partial_json,                                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:update, 422, broker_empty_json,                                              error: Errors::ServiceBrokerRequestRejected)
-        test_case(:update, 422, broker_partial_json,                                            error: Errors::ServiceBrokerRequestRejected)
-        test_case(:update, 422, { error: 'AsyncRequired' }.to_json,                             error: Errors::AsyncRequired)
-        test_case(:update, 422, { error: 'MaintenanceInfoConflict' }.to_json,                   error: Errors::MaintenanceInfoConflict)
+
+        test_case(:update, 200, broker_partial_json,                          error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
+        test_case(:update, 200, broker_malformed_json,                        error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
+        test_case(:update, 200, with_invalid_dashboard_url.to_json,           error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
+        test_case(:update, 200, broker_empty_json,                            result: client_result_with_state('succeeded'), validators: %w[CommonErrorValidator JsonSchemaValidator[update_response_schema] SuccessValidator[succeeded]])
+        test_case(:update, 200, with_dashboard_url.to_json,                   result: client_result_with_state('succeeded').merge(with_dashboard_url))
+        test_pass_through(:update, 200, with_null_dashboard_url,              expected_state: 'succeeded')
+        test_pass_through(:update, 200,                                       expected_state: 'succeeded')
+        test_case(:update, 201, broker_partial_json,                          error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_partial_json, instance_uri), validators: %w[CommonErrorValidator IgnoreDescriptionKeyFailingValidator])
+        test_case(:update, 201, broker_malformed_json,                        error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_malformed_json, instance_uri))
+        test_case(:update, 201, broker_empty_json,                            error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, broker_empty_json, instance_uri))
+        test_case(:update, 201, { 'foo' => 'bar' }.to_json,                   error: Errors::ServiceBrokerBadResponse, description: broker_returned_an_error(201, { 'foo' => 'bar' }.to_json, instance_uri))
+        test_case(:update, 202, broker_partial_json,                          error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
+        test_case(:update, 202, broker_malformed_json,                        error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
+        test_case(:update, 202, broker_empty_json,                            result: client_result_with_state('in progress'), validators: ['CommonErrorValidator', 'JsonSchemaValidator[update_response_schema]', 'SuccessValidator[in progress]'])
+        test_case(:update, 202, broker_non_empty_json,                        result: client_result_with_state('in progress'))
+        test_case(:update, 202, with_operation.to_json,                       result: client_result_with_state('in progress').merge(with_operation))
+        test_case(:update, 202, with_dashboard_url.to_json,                   result: client_result_with_state('in progress').merge(with_dashboard_url))
+        test_pass_through(:update, 202, with_null_dashboard_url,              expected_state: 'in progress')
+        test_case(:update, 202, with_invalid_dashboard_url.to_json,           error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type object did not match one or more of the following types: string, null"))
+        test_case(:update, 202, with_non_string_operation.to_json,            error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' of type object did not match the following type: string"))
+        test_case(:update, 202, with_long_operation.to_json,                  error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/operation' was not of a maximum string length of 10000"))
+        test_pass_through(:update, 202,                                       expected_state: 'in progress')
+        test_case(:update, 204, broker_partial_json,                          error: Errors::ServiceBrokerBadResponse)
+        test_case(:update, 204, broker_malformed_json,                        error: Errors::ServiceBrokerBadResponse)
+        test_case(:update, 204, broker_empty_json,                            error: Errors::ServiceBrokerBadResponse)
+        test_case(:update, 409, broker_empty_json,                            error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:update, 409, broker_partial_json,                          error: Errors::ServiceBrokerBadResponse)
+        test_case(:update, 410, broker_empty_json,                            error: Errors::ServiceBrokerBadResponse)
+        test_case(:update, 410, broker_partial_json,                          error: Errors::ServiceBrokerBadResponse)
+        test_case(:update, 422, broker_empty_json,                            error: Errors::ServiceBrokerRequestRejected, validators: %w[CommonErrorValidator FailWhenValidator FailingValidator])
+        test_case(:update, 422, broker_partial_json,                          error: Errors::ServiceBrokerRequestRejected)
+        test_case(:update, 422, { error: 'AsyncRequired' }.to_json,           error: Errors::AsyncRequired)
+        test_case(:update, 422, { error: 'MaintenanceInfoConflict' }.to_json, error: Errors::MaintenanceInfoConflict)
         test_common_error_cases(:update)
 
-        test_case(:fetch_service_binding, 200, { foo: 'bar' }.to_json,                               result: { 'foo' => 'bar' })
-        test_case(:fetch_service_binding, 200, broker_malformed_json,                                error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_malformed_json, binding_uri))
+        test_case(:fetch_service_binding, 200, { foo: 'bar' }.to_json,                               result: { 'foo' => 'bar' }, validators: %w[CommonErrorValidator JsonSchemaValidator[fetch_service_binding_response_schema] SuccessValidator])
+        test_case(:fetch_service_binding, 200, broker_malformed_json,                                error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, binding_uri))
         test_case(:fetch_service_binding, 200, broker_partial_json,                                  error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_uri))
         test_case(:fetch_service_binding, 200, broker_empty_json,                                    result: {})
         test_case(:fetch_service_binding, 200, { parameters: {} }.to_json,                           result: { 'parameters' => {} })
@@ -935,86 +1012,86 @@ module VCAP::Services
         test_case(:fetch_service_binding, 200, with_invalid_volume_mounts_bad_mode_value.to_json,    error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/volume_mounts/0/mode' value \"read\" did not match one of the following values: r, rw"))
         test_case(:fetch_service_binding, 200, with_invalid_volume_mounts_no_container_dir.to_json,  error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/volume_mounts/0' did not contain a required property of 'container_dir'"))
         test_case(:fetch_service_binding, 200, with_invalid_volume_mounts_bad_container_dir.to_json, error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(binding_uri, "\nThe property '#/volume_mounts/0/container_dir' of type boolean did not match the following type: string"))
-        test_case(:fetch_service_binding, 201, broker_partial_json,                             error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 201, broker_malformed_json,                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 201, broker_empty_json,                               error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 201, {}.to_json,                                      error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 204, broker_partial_json,                             error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 204, broker_malformed_json,                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 204, broker_empty_json,                               error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 204, {}.to_json,                                      error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 408, {}.to_json,                                      error: Errors::ServiceBrokerApiTimeout, description: broker_timeout_error(binding_uri))
-        test_case(:fetch_service_binding, 409, broker_partial_json,                             error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 409, broker_malformed_json,                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 409, broker_empty_json,                               error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 410, broker_partial_json,                             error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 410, broker_malformed_json,                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 410, broker_empty_json,                               error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 422, broker_partial_json,                             error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 422, broker_malformed_json,                           error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 422, broker_empty_json,                               error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding, 504, {}.to_json,                                      error: Errors::ServiceBrokerBadResponse, description: broker_bad_response_error(binding_uri, 'Status Code: 504 message, Body: {}'))
+        test_case(:fetch_service_binding, 201, broker_partial_json,                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 201, broker_malformed_json,                                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 201, broker_empty_json,                                    error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 201, {}.to_json,                                           error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 204, broker_partial_json,                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 204, broker_malformed_json,                                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 204, broker_empty_json,                                    error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 204, {}.to_json,                                           error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 408, {}.to_json,                                           error: Errors::ServiceBrokerApiTimeout, description: broker_timeout_error(binding_uri))
+        test_case(:fetch_service_binding, 409, broker_partial_json,                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 409, broker_malformed_json,                                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 409, broker_empty_json,                                    error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 410, broker_partial_json,                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 410, broker_malformed_json,                                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 410, broker_empty_json,                                    error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 422, broker_partial_json,                                  error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:fetch_service_binding, 422, broker_malformed_json,                                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 422, broker_empty_json,                                    error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding, 504, {}.to_json,                                           error: Errors::ServiceBrokerBadResponse, description: broker_bad_response_error(binding_uri, 'Status Code: 504 message, Body: {}'))
         test_common_error_cases(:fetch_service_binding)
 
-        test_case(:fetch_service_instance, 200, { foo: 'bar' }.to_json,                         result: { 'foo' => 'bar' })
-        test_case(:fetch_service_instance, 200, broker_empty_json,                              result: {})
-        test_case(:fetch_service_instance, 200, broker_malformed_json,                          error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_malformed_json, instance_uri))
-        test_case(:fetch_service_instance, 200, broker_partial_json,                            error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
-        test_case(:fetch_service_instance, 200, { service_id: '123' }.to_json,                  result: { 'service_id' => '123' })
-        test_case(:fetch_service_instance, 200, { plan_id: '123' }.to_json,                     result: { 'plan_id' => '123' })
-        test_case(:fetch_service_instance, 200, { parameters: {} }.to_json,                     result: { 'parameters' => {} })
-        test_case(:fetch_service_instance, 200, { dashboard_url: '123' }.to_json,               result: { 'dashboard_url' => '123' })
-        test_case(:fetch_service_instance, 200, { service_id: true }.to_json,                   error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/service_id' of type boolean did not match the following type: string"))
-        test_case(:fetch_service_instance, 200, { plan_id: true }.to_json,                      error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/plan_id' of type boolean did not match the following type: string"))
-        test_case(:fetch_service_instance, 200, { parameters: true }.to_json,                   error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/parameters' of type boolean did not match the following type: object"))
-        test_case(:fetch_service_instance, 200, { dashboard_url: true }.to_json,                error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type boolean did not match the following type: string"))
-        test_case(:fetch_service_instance, 201, broker_partial_json,                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 201, broker_malformed_json,                          error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 201, broker_empty_json,                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 201, {}.to_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 204, broker_partial_json,                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 204, broker_malformed_json,                          error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 204, broker_empty_json,                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 204, {}.to_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 408, {}.to_json,                                     error: Errors::ServiceBrokerApiTimeout, description: broker_timeout_error(instance_uri))
-        test_case(:fetch_service_instance, 409, broker_partial_json,                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 409, broker_malformed_json,                          error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 409, broker_empty_json,                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 410, broker_partial_json,                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 410, broker_malformed_json,                          error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 410, broker_empty_json,                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 422, broker_partial_json,                            error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 422, broker_malformed_json,                          error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 422, broker_empty_json,                              error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_instance, 504, {}.to_json,                                     error: Errors::ServiceBrokerBadResponse, description: broker_bad_response_error(instance_uri, 'Status Code: 504 message, Body: {}'))
+        test_case(:fetch_service_instance, 200, { foo: 'bar' }.to_json,           result: { 'foo' => 'bar' }, validators: %w[CommonErrorValidator JsonSchemaValidator[fetch_service_instance_response_schema] SuccessValidator])
+        test_case(:fetch_service_instance, 200, broker_empty_json,                result: {})
+        test_case(:fetch_service_instance, 200, broker_malformed_json,            error: Errors::ServiceBrokerResponseMalformed, expect_warning: true, description: invalid_json_error(broker_malformed_json, instance_uri))
+        test_case(:fetch_service_instance, 200, broker_partial_json,              error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, instance_uri))
+        test_case(:fetch_service_instance, 200, { service_id: '123' }.to_json,    result: { 'service_id' => '123' })
+        test_case(:fetch_service_instance, 200, { plan_id: '123' }.to_json,       result: { 'plan_id' => '123' })
+        test_case(:fetch_service_instance, 200, { parameters: {} }.to_json,       result: { 'parameters' => {} })
+        test_case(:fetch_service_instance, 200, { dashboard_url: '123' }.to_json, result: { 'dashboard_url' => '123' })
+        test_case(:fetch_service_instance, 200, { service_id: true }.to_json,     error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/service_id' of type boolean did not match the following type: string"))
+        test_case(:fetch_service_instance, 200, { plan_id: true }.to_json,        error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/plan_id' of type boolean did not match the following type: string"))
+        test_case(:fetch_service_instance, 200, { parameters: true }.to_json,     error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/parameters' of type boolean did not match the following type: object"))
+        test_case(:fetch_service_instance, 200, { dashboard_url: true }.to_json,  error: Errors::ServiceBrokerResponseMalformed, description: malformed_response_error(instance_uri, "\nThe property '#/dashboard_url' of type boolean did not match the following type: string"))
+        test_case(:fetch_service_instance, 201, broker_partial_json,              error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 201, broker_malformed_json,            error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 201, broker_empty_json,                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 201, {}.to_json,                       error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 204, broker_partial_json,              error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 204, broker_malformed_json,            error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 204, broker_empty_json,                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 204, {}.to_json,                       error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 408, {}.to_json,                       error: Errors::ServiceBrokerApiTimeout, description: broker_timeout_error(instance_uri))
+        test_case(:fetch_service_instance, 409, broker_partial_json,              error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 409, broker_malformed_json,            error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 409, broker_empty_json,                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 410, broker_partial_json,              error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 410, broker_malformed_json,            error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 410, broker_empty_json,                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 422, broker_partial_json,              error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:fetch_service_instance, 422, broker_malformed_json,            error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 422, broker_empty_json,                error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_instance, 504, {}.to_json,                       error: Errors::ServiceBrokerBadResponse, description: broker_bad_response_error(instance_uri, 'Status Code: 504 message, Body: {}'))
         test_common_error_cases(:fetch_service_instance)
 
-        test_pass_through(:fetch_service_binding_last_operation, 200, broker_body_with_state('succeeded'), expected_state: 'succeeded')
-        test_case(:fetch_service_binding_last_operation, 200, { state: 'in progress' }.to_json, result: { 'last_operation' => { 'state' => 'in progress' } })
-        test_case(:fetch_service_binding_last_operation, 200, broker_partial_json,                                       error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_last_operation_uri))
-        test_case(:fetch_service_binding_last_operation, 200, broker_malformed_json,                                     error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_malformed_json, binding_last_operation_uri), expect_warning: true)
-        test_case(:fetch_service_binding_last_operation, 200, broker_empty_json,                                         error: Errors::ServiceBrokerResponseMalformed, description: response_not_understood('succeeded', '', binding_last_operation_uri))
-        test_case(:fetch_service_binding_last_operation, 200, broker_body_with_state('unrecognized').to_json,            error: Errors::ServiceBrokerResponseMalformed, description: response_not_understood('succeeded', 'unrecognized', binding_last_operation_uri))
-        test_case(:fetch_service_binding_last_operation, 200, broker_body_with_state('succeeded').to_json,               result: client_result_with_state('succeeded'))
-        test_case(:fetch_service_binding_last_operation, 200, broker_body_with_state('succeeded').merge('description' => 'a description').to_json, result: client_result_with_state('succeeded', description: 'a description'))
-        test_case(:fetch_service_binding_last_operation, 201, broker_partial_json,                                       error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_service_binding_last_operation, 201, broker_malformed_json,                                     error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_service_binding_last_operation, 201, broker_body_with_state('succeeded').to_json,               error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 202, broker_partial_json,                                       error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_service_binding_last_operation, 202, broker_malformed_json,                                     error: Errors::ServiceBrokerResponseMalformed)
-        test_case(:fetch_service_binding_last_operation, 202, broker_body_with_state('succeeded').to_json,               error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 204, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 204, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 204, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 409, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 409, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 409, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 410, broker_empty_json,                                         result: {})
-        test_case(:fetch_service_binding_last_operation, 410, broker_partial_json,                                       result: {})
-        test_case(:fetch_service_binding_last_operation, 410, broker_malformed_json,                                     result: {})
-        test_case(:fetch_service_binding_last_operation, 422, broker_partial_json,                                       error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 422, broker_malformed_json,                                     error: Errors::ServiceBrokerBadResponse)
-        test_case(:fetch_service_binding_last_operation, 422, broker_empty_json,                                         error: Errors::ServiceBrokerBadResponse)
+        test_pass_through(:fetch_service_binding_last_operation, 200, broker_body_with_state('succeeded'),                            expected_state: 'succeeded')
+        test_case(:fetch_service_binding_last_operation, 200, { state: 'in progress' }.to_json,                                       result: { 'last_operation' => { 'state' => 'in progress' } }, validators: ['JsonObjectValidator', 'StateValidator[succeeded,failed,in progress]', 'SuccessValidator'])
+        test_case(:fetch_service_binding_last_operation, 200, broker_partial_json,                                                    error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_partial_json, binding_last_operation_uri))
+        test_case(:fetch_service_binding_last_operation, 200, broker_malformed_json,                                                  error: Errors::ServiceBrokerResponseMalformed, description: invalid_json_error(broker_malformed_json, binding_last_operation_uri), expect_warning: true)
+        test_case(:fetch_service_binding_last_operation, 200, broker_empty_json,                                                      error: Errors::ServiceBrokerResponseMalformed, description: response_not_understood('succeeded', '', binding_last_operation_uri))
+        test_case(:fetch_service_binding_last_operation, 200, broker_body_with_state('unrecognized').to_json,                         error: Errors::ServiceBrokerResponseMalformed, description: response_not_understood('succeeded', 'unrecognized', binding_last_operation_uri))
+        test_case(:fetch_service_binding_last_operation, 200, broker_body_with_state('succeeded').to_json,                            result: client_result_with_state('succeeded'))
+        test_case(:fetch_service_binding_last_operation, 200, broker_body_with_state('succeeded').merge(description: 'desc').to_json, result: client_result_with_state('succeeded', description: 'desc'))
+        test_case(:fetch_service_binding_last_operation, 201, broker_partial_json,                                                    error: Errors::ServiceBrokerResponseMalformed, validators: %w[JsonObjectValidator FailingValidator])
+        test_case(:fetch_service_binding_last_operation, 201, broker_malformed_json,                                                  error: Errors::ServiceBrokerResponseMalformed, expect_warning: true)
+        test_case(:fetch_service_binding_last_operation, 201, broker_body_with_state('succeeded').to_json,                            error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding_last_operation, 202, broker_partial_json,                                                    error: Errors::ServiceBrokerResponseMalformed, validators: %w[JsonObjectValidator FailingValidator])
+        test_case(:fetch_service_binding_last_operation, 202, broker_malformed_json,                                                  error: Errors::ServiceBrokerResponseMalformed, expect_warning: true)
+        test_case(:fetch_service_binding_last_operation, 202, broker_body_with_state('succeeded').to_json,                            error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding_last_operation, 204, broker_partial_json,                                                    error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding_last_operation, 204, broker_malformed_json,                                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding_last_operation, 204, broker_empty_json,                                                      error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding_last_operation, 409, broker_partial_json,                                                    error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding_last_operation, 409, broker_malformed_json,                                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding_last_operation, 409, broker_empty_json,                                                      error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding_last_operation, 410, broker_empty_json,                                                      result: {}, validators: %w[SuccessValidator])
+        test_case(:fetch_service_binding_last_operation, 410, broker_partial_json,                                                    result: {})
+        test_case(:fetch_service_binding_last_operation, 410, broker_malformed_json,                                                  result: {})
+        test_case(:fetch_service_binding_last_operation, 422, broker_partial_json,                                                    error: Errors::ServiceBrokerBadResponse, validators: %w[CommonErrorValidator FailingValidator])
+        test_case(:fetch_service_binding_last_operation, 422, broker_malformed_json,                                                  error: Errors::ServiceBrokerBadResponse)
+        test_case(:fetch_service_binding_last_operation, 422, broker_empty_json,                                                      error: Errors::ServiceBrokerBadResponse)
         test_common_error_cases(:fetch_service_binding_last_operation)
         # rubocop:enable Layout/LineLength
       end


### PR DESCRIPTION
To help analyzing interactions between Cloud Controller and service brokers, additional logs can be emitted by the `ResponseParser`, that is responsible for transforming unvalidated service broker JSON responses into validated data structures. Three different types of logs have been added:

### 1. Errors
Setting the config parameter `broker_client_response_parser.log_errors` to `true` results in one log per parsing error happening inside the `ResponseParser`. The message contains the actual error class (e.g. `VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerBadResponse`) and is logged at level `error`. The `data.description` field includes the error description and (depending on the error class) might also contain the actual payload returned by the broker.

### 2. Validator stack
To get a log message per broker response that contains the stack of validators used to process the JSON payload, the config parameter `broker_client_response_parser.log_validators` can be set to `true`. The `validators` message is logged at level `info`.

For a 202 response to a `provision` request, the following stack of validators is logged:
```
[
  "CommonErrorValidator",
  "JsonSchemaValidator[provision_response_schema]",
  "SuccessValidator[in progress]"
]
```

For a 200 response to a `fetch_service_instance_last_operation` request, the log message contains:
```
[
  "JsonObjectValidator",
  "StateValidator[succeeded,failed,in progress]",
  "SuccessValidator"
]
```

### 3. Selective fields
The config parameter `broker_client_response_parser.log_response_fields` can be set to a hash where the key indicates the request type and the value is a list of fields in the response JSON that should be logged. The following request types exist:
- catalog
- provision
- update
- deprovision
- bind
- unbind
- fetch_service_instance_last_operation
- fetch_service_binding_last_operation
- fetch_service_instance
- fetch_service_binding

To log the `state` field returned when fetching the last operation for a service instance or binding, the configuration looks like:
```
broker_client_response_parser:
  log_response_fields:
    fetch_service_instance_last_operation:
      - state
    fetch_service_binding_last_operation:
      - state
```

The log message written at `info` level is `unvalidated_response` with `data.selective_fields` containing the fields from the broker response (e.g. `{"state":"in progress"}`).

All newly added logs come from `source` `cc.service_broker.v2.client` and the log `data` always contains:
- `type` indicating the request type (e.g. `provision`),
- `method`, `url` and `path` showing the HTTP request method and endpoint,
- `code` containing the HTTP response code.

### Implementation details
- Some methods have been renamed for consistency.
- A base Validator class has been added to support the creation of the validator stack log message.
- Methods returning a JSON schema now also return their _name_ (i.e. tuple of name + schema) used when logging the validator stack.
- All `parse_` methods use `parse_unvalidated_response_with_validator` that yields the unvalidated JSON response from the broker and expects a validator stack in return. Within this method all new logs are written, i.e. the selective fields from the unvalidated response, the validator stack and errors in case of an exception.

See https://github.com/cloudfoundry/capi-release/pull/293 for adding config options.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
