### PR TITLE
Ensure that unencrypted fields during a encryption key rotation are not modified

### DIFF
--- a/app/actions/droplet_copy.rb
+++ b/app/actions/droplet_copy.rb
@@ -4,7 +4,6 @@ module VCAP::CloudController
 
     CLONED_ATTRIBUTES = [
       :buildpack_receipt_buildpack_guid,
-      :salt,
       :process_types,
       :buildpack_receipt_buildpack,
       :execution_metadata,

--- a/db/migrations/20230306111500_drop_encrypted_environment_variables.rb
+++ b/db/migrations/20230306111500_drop_encrypted_environment_variables.rb
@@ -1,0 +1,6 @@
+Sequel.migration do
+  change do
+    drop_column :droplets, :encrypted_environment_variables
+    drop_column :droplets, :salt
+  end
+end

--- a/lib/cloud_controller/encryptor.rb
+++ b/lib/cloud_controller/encryptor.rb
@@ -161,7 +161,9 @@ module VCAP::CloudController
           raise 'Field "encryption_key_label" does not exist' unless columns.include?(:encryption_key_label)
           raise 'Field "encryption_iterations" does not exist' unless columns.include?(:encryption_iterations)
 
-          encrypted_fields << { field_name: field_name, salt_name: salt_name }
+          fields = { field_name: field_name, salt_name: salt_name }
+          fields.merge!({ storage_column: storage_column }) if storage_column
+          encrypted_fields << fields
 
           Encryptor.encrypted_classes << self.name
 

--- a/lib/cloud_controller/errands/rotate_database_key.rb
+++ b/lib/cloud_controller/errands/rotate_database_key.rb
@@ -53,7 +53,7 @@ module VCAP::CloudController
             row.lock!
             encrypt_row(encrypted_fields, row)
             row.modified!(:updated_at)
-            row.save(validate: false)
+            row.save(validate: false, changed: true)
           rescue Sequel::NoExistingObject
             raise Sequel::Rollback
           rescue StandardError => e

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -50,6 +50,11 @@ module VCAP::CloudController
     buildpack_lifecycle_data { BuildpackLifecycleDataModel.make(app: object.save) }
   end
 
+  AppModel.blueprint(:all_fields) do
+    droplet_guid { Sham.guid }
+    buildpack_cache_sha256_checksum { Sham.guid }
+  end
+
   AppModel.blueprint(:kpack) do
     name { Sham.name }
     space { Space.make }
@@ -118,6 +123,22 @@ module VCAP::CloudController
     buildpack_lifecycle_data { BuildpackLifecycleDataModel.make(droplet: object.save) }
   end
 
+  DropletModel.blueprint(:all_fields) do
+    execution_metadata { 'some-metadata' }
+    error_id { 'error-id' }
+    error_description { 'a-error' }
+    staging_memory_in_mb { 256 }
+    staging_disk_in_mb { 256 }
+    buildpack_receipt_buildpack { 'a-buildpack' }
+    buildpack_receipt_buildpack_guid { Sham.guid }
+    buildpack_receipt_detect_output { 'buildpack-output' }
+    docker_receipt_image { 'docker-iamge' }
+    package_guid { Sham.guid }
+    build_guid { Sham.guid }
+    docker_receipt_username { 'a-user' }
+    sidecars { 'a-sidecar' }
+  end
+
   DropletModel.blueprint(:docker) do
     guid { Sham.guid }
     droplet_hash { nil }
@@ -163,7 +184,9 @@ module VCAP::CloudController
     command { 'bundle exec rake' }
     state { VCAP::CloudController::TaskModel::RUNNING_STATE }
     memory_in_mb { 256 }
+    disk_in_mb {}
     sequence_id { Sham.sequence_id }
+    failure_reason {}
   end
 
   TaskModel.blueprint(:running) do
@@ -252,23 +275,13 @@ module VCAP::CloudController
 
   Route.blueprint do
     space { Space.make }
-
-    domain do
-      PrivateDomain.make(
-        owning_organization: space.organization,
-      )
-    end
-
+    domain { PrivateDomain.make(owning_organization: space.organization) }
     host { Sham.host }
   end
 
   Route.blueprint(:tcp) do
     port { Sham.port }
-    domain do
-      SharedDomain.make(
-        :tcp,
-      )
-    end
+    domain { SharedDomain.make(:tcp) }
   end
 
   Space.blueprint do
@@ -359,6 +372,15 @@ module VCAP::CloudController
     service_plan               { ServicePlan.make }
     gateway_name               { Sham.guid }
     maintenance_info           {}
+  end
+
+  ManagedServiceInstance.blueprint(:all_fields) do
+    gateway_data               { 'some data' }
+    dashboard_url              { Sham.url }
+    syslog_drain_url           { Sham.url }
+    tags                       { ['a-tag', 'another-tag'] }
+    route_service_url          { Sham.url }
+    maintenance_info           { 'maintenance info' }
   end
 
   ManagedServiceInstance.blueprint(:routing) do
@@ -508,6 +530,18 @@ module VCAP::CloudController
     auth_password     { Sham.auth_password }
   end
 
+  ServiceBroker.blueprint(:space_scoped) do
+    space_id          { Space.make.id }
+  end
+
+  ServiceBrokerUpdateRequest.blueprint do
+    name { Sham.name }
+    broker_url { Sham.url }
+    authentication { '{"credentials":{"username":"new-admin","password":"welcome"}}' }
+    service_broker_id {}
+    fk_service_brokers_id {}
+  end
+
   ServiceDashboardClient.blueprint do
     uaa_id          { Sham.name }
     service_broker  { ServiceBroker.make }
@@ -587,6 +621,15 @@ module VCAP::CloudController
     stack { Stack.make.name }
   end
 
+  BuildpackLifecycleDataModel.blueprint(:all_fields) do
+    buildpacks { ['http://example.com/repo.git'] }
+    stack { Stack.make.name }
+    app_guid { Sham.guid }
+    droplet_guid { Sham.guid }
+    admin_buildpack_name { 'admin-bp' }
+    build_guid { Sham.guid }
+  end
+
   KpackLifecycleDataModel.blueprint do
     build { BuildModel.make }
     buildpacks { [] }
@@ -595,6 +638,12 @@ module VCAP::CloudController
   BuildpackLifecycleBuildpackModel.blueprint do
     admin_buildpack_name { Buildpack.make(name: 'ruby').name }
     buildpack_url { nil }
+  end
+
+  BuildpackLifecycleBuildpackModel.blueprint(:all_fields) do
+    buildpack_lifecycle_data_guid { BuildpackLifecycleDataModel.make.guid }
+    version { Sham.version }
+    buildpack_name { Sham.name }
   end
 
   BuildpackLifecycleBuildpackModel.blueprint(:custom_buildpack) do

--- a/spec/unit/lib/cloud_controller/errands/rotate_database_key_spec.rb
+++ b/spec/unit/lib/cloud_controller/errands/rotate_database_key_spec.rb
@@ -147,6 +147,15 @@ module VCAP::CloudController
           expect(service_instance.credentials).to eq(instance_credentials)
         end
 
+        it 'does not change the updated_at field' do
+          updated_at = app.reload.values[:updated_at]
+
+          sleep(1.5) # ensure that timestamp in `updated_at` would change
+          RotateDatabaseKey.perform(batch_size: 1)
+
+          expect(app.reload.values[:updated_at]).to eq(updated_at)
+        end
+
         it 'does not re-encrypt values that are already encrypted with the new label' do
           expect(Encryptor).not_to receive(:encrypt).
             with(JSON.dump(env_vars_2), app_new_key_label.salt)


### PR DESCRIPTION
During a ccdb encryption key rotation unencrypted fields incl. field `updated_at` should not be modified. 
We've seen cases where `updated_at` & `syslog_drain_url` have been modified during rotation. See #3196
These changes ensure that only modified fields are updated during a rotation.

While writing the tests we noticed that the droplet table contains the columns `encrypted_environment_variables` and `salt` which are no longer referenced in the droplet model. Thus, it should be save to remove those columns.
References:
- https://github.com/cloudfoundry/cloud_controller_ng/commit/d8cc2d935912db912f4d7e1918cb8a09a88cffb4
- https://github.com/cloudfoundry/cloud_controller_ng/commit/d591e30eae040f4c8d60dae94f505c5033b23402
 
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
