### PR TITLE
Allow dynamic app renaming to be disabled

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -404,3 +404,4 @@ default_app_lifecycle: buildpack
 custom_metric_tag_prefix_list: ["metric.tag.cloudfoundry.org"]
 
 max_manifest_service_binding_poll_duration_in_seconds: 60
+update_metric_tags_on_rename: true

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -364,6 +364,8 @@ module VCAP::CloudController
               write_key: String,
               dataset: String,
             },
+
+            update_metric_tags_on_rename: bool
           }
         end
         # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Operators may choose to disable support for sending Desired LRP Updates when an application is renamed.

* An explanation of the use cases your change solves
Operators may wish to disable this feature.

* Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/pull/298: PR to capi-release to make this new config property configurable.
https://github.com/cloudfoundry/cloud_controller_ng/pull/3107: Earlier dynamic app renaming PR.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
