### PR TITLE
Truncate job errors 3

### DIFF
--- a/db/migrations/20230118223008_convert_cf_api_error_to_text.rb
+++ b/db/migrations/20230118223008_convert_cf_api_error_to_text.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :jobs do
+      set_column_type(:cf_api_error, 'text')
+    end
+  end
+end

--- a/spec/unit/jobs/pollable_job_wrapper_spec.rb
+++ b/spec/unit/jobs/pollable_job_wrapper_spec.rb
@@ -181,26 +181,7 @@ module VCAP::CloudController::Jobs
           expect(errors.size).to eq(1)
           error = errors[0]['test_mode_info']
           expect(error['detail']).to eq('VCAP::CloudController::Jobs::BigException')
-          expect(error['backtrace'].size).to be == 8
-        end
-      end
-
-      context 'with a big message' do
-        # postgres complains with 15,826
-        # mysql complains with 15,828, so test for failure at that point
-
-        it 'squeezes just right one in' do
-          expect {
-            pollable_job.error(job, BigException.new(message: 'x' * 15_825))
-          }.to_not raise_error
-        end
-
-        it 'gives up' do
-          pg_error = /value too long for type character varying/
-          mysql_error = /Data too long for column 'cf_api_error'/
-          expect {
-            pollable_job.error(job, BigException.new(message: 'x' * 15_828))
-          }.to raise_error(::Sequel::DatabaseError, /#{pg_error}|#{mysql_error}/)
+          expect(error['backtrace'].size).to be == 32
         end
       end
     end


### PR DESCRIPTION
Remake of https://github.com/cloudfoundry/cloud_controller_ng/pull/3145, done via cherry-picking instead of rebasing.  This was broken out so we could consider/talk about changing the type of the column without rejecting the other validations added in https://github.com/cloudfoundry/cloud_controller_ng/pull/3154

copied from the other PR:

> An operator was noticing that cloud controller worker was consistently restarting every few minutes because it aggressively kept retrying a failing create-service job. It was consistently retrying this job because it could never save the failed attempt due to the error message being too big for the delayed_jobs last_api_error field. This truncates the error message when cloud controller gets the initial response from the service broker.

> We left our previous commits to try and show how we concluded on doing it here rather than close to where the database save calls are made. We also tried to truncate to fit the text column size, but another table, jobs also saves the error, but in a smaller column of type varchar(16000). This led to the user of the command cf create-service to not get any error message back as the column would have no data as it was too big for that as well. That is how we settled on anything bigger than 2^14 bytes being truncated.