### PR TITLE
Add Ports section to V3 upgrade guide conceptual changes

### DIFF
--- a/docs/v3/source/includes/upgrade_guide/changed_resources/_header.md
+++ b/docs/v3/source/includes/upgrade_guide/changed_resources/_header.md
@@ -15,7 +15,7 @@ This table shows how V2 resources map to their respective V3 counterparts. Note 
 |Organizations|Organizations|
 |Quota Definitions|Organization Quotas|[Organization Quotas in V3](#organization-quotas-in-v3)
 |Resource Matches|Resource Matches|
-|Routes, Route Mappings|Routes|[Routes in V3](#routes-in-v3)|
+|Routes, Route Mappings|Routes, Destinations|[Routes in V3](#routes-in-v3)|
 |Security Groups|Security Groups|[Security Groups in V3](#security-groups-in-v3)|
 |Services|Service Offerings|[Service Offerings in V3](#service-offerings-in-v3)
 |Service Bindings, Service Keys|Service Keys|

--- a/docs/v3/source/includes/upgrade_guide/changed_resources/_routes_in_v3.md
+++ b/docs/v3/source/includes/upgrade_guide/changed_resources/_routes_in_v3.md
@@ -4,4 +4,4 @@ In V2, the route resource represented a URL that could be mapped to an app, and 
 
 In V3, these concepts have been collapsed into a single route resource. Now, a route can have one or more "destinations" listed on it. These represent a mapping from the route to a resource that can serve traffic (e.g. a process of an app).
 
-Read more about [routes and destinations](#routes).
+Read more about [routes, destinations, and ports](#routes).

--- a/docs/v3/source/includes/upgrade_guide/conceptual_changes/_ports.md
+++ b/docs/v3/source/includes/upgrade_guide/conceptual_changes/_ports.md
@@ -1,0 +1,7 @@
+### Ports
+
+In V2, users exposed ports on an app by modifying the app's `ports` field.
+
+In V3, users expose ports on a process by creating destinations that map a route to a given app and process. For an app listening on multiple ports, users must create one destination per port. 
+
+Read more about [routes, destinations, and ports](#routes).


### PR DESCRIPTION


* A short explanation of the proposed change:

Ports works differently enough in V3 compared to V2 that it probably warrants its own section in the docs, as some have found the migration confusing.  Hoping this clears it up.

