### PR TITLE
Implement super secure HA blob storage

### DIFF
--- a/app/controllers/v3/blobs_controller.rb
+++ b/app/controllers/v3/blobs_controller.rb
@@ -1,0 +1,24 @@
+class BlobsController < ApplicationController
+
+  def show
+    client = CloudController::DependencyLocator.instance.credhub_client
+
+    response.headers["ETag"] = 'version1'
+    response.headers["Last-Modified"] = 'Sat, 1 Apr 2023 00:00:00 GMT'
+    send_data(decode_file(client.get_chunked_credential_by_name(hashed_params[:key])), filename: 'file')
+  end
+
+  private
+
+  def decode_file(data)
+    Base64.strict_decode64(data).force_encoding('BINARY')
+  end
+
+  def enforce_read_scope?
+    false
+  end
+
+  def enforce_authentication?
+    false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,6 +311,9 @@ Rails.application.routes.draw do
   delete '/buildpacks/:guid', to: 'buildpacks#destroy'
   post '/buildpacks/:guid/upload', to: 'buildpacks#upload'
 
+  # blobs
+  get '/blobs', to: 'blobs#show'
+
   # feature flags
   get '/feature_flags', to: 'feature_flags#index'
   get '/feature_flags/:name', to: 'feature_flags#show'

--- a/lib/cloud_controller/blobstore/credhub_blob.rb
+++ b/lib/cloud_controller/blobstore/credhub_blob.rb
@@ -1,0 +1,26 @@
+require 'uri'
+
+module CloudController
+  module Blobstore
+    class CredhubBlob < Blob
+      attr_reader :key
+      def initialize(key:)
+        @key = key
+      end
+      def internal_download_url
+        "http://cloud-controller-ng.service.cf.internal:9022/v3/blobs?key=#{ERB::Util.url_encode(key)}"
+      end
+
+      def public_download_url
+        internal_download_url
+      end
+
+      def attributes(*keys)
+        {}
+      end
+
+      def local_path; end
+    end
+  end
+end
+

--- a/lib/cloud_controller/blobstore/credhub_client.rb
+++ b/lib/cloud_controller/blobstore/credhub_client.rb
@@ -1,0 +1,74 @@
+require 'cloud_controller/blobstore/base_client'
+require 'cloud_controller/blobstore/credhub_blob'
+
+module CloudController
+  module Blobstore
+    class CredhubClient < BaseClient
+      def initialize(credhub_client:, directory_key:, root_dir:)
+        @credhub_client = credhub_client
+        @directory_key = directory_key
+        @root_dir = root_dir
+        @min_size = 65536
+        @max_size = 536870912
+      end
+
+      def local?
+        false
+      end
+
+      def exists?(key)
+        @credhub_client.credential_exists?(credhub_path(key))
+      end
+
+      def download_from_blobstore(source_key, destination_path, mode: nil)
+        FileUtils.mkdir_p(File.dirname(destination_path))
+
+        File.open(destination_path, 'wb') do |file|
+          file.write decode_file(@credhub_client.get_chunked_credential_by_name(credhub_path(source_key)))
+          file.chmod(mode) if mode
+        end
+      end
+
+      def ensure_bucket_exists
+      end
+
+      def cp_to_blobstore(source_path, destination_key)
+        File.open(source_path) do |file|
+          @credhub_client.save_credential(credhub_path(destination_key), encode_file(file.read))
+        end
+      end
+
+      def delete_all_in_path(path)
+        full_path = credhub_path(path)
+        @credhub_client.find_credentials_in_path(full_path).each do |entry|
+          @credhub_client.delete_credential(entry)
+        end
+      end
+
+      def blob(key)
+        return CredhubBlob.new(key: credhub_path(key))
+      end
+      def delete_blob(blob)
+        @credhub_client.delete_credential(credhub_path(blob.key))
+      end
+
+      private
+
+      def credhub_path(key)
+        "/cloud_controller_blobs/#{@directory_key}/#{key}"
+      end
+
+      def encode_file(data)
+        Base64.strict_encode64(data.force_encoding('BINARY'))
+      end
+
+      def decode_file(data)
+        Base64.strict_decode64(data).force_encoding('BINARY')
+      end
+
+      def within_limits?(size)
+        true
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -117,9 +117,11 @@ module VCAP::CloudController
             optional(:uaa_client_scope) => String,
 
             optional(:cc_service_key_client_name) => String,
+            optional(:cc_service_key_client_secret) => String,
 
             optional(:credhub_api) => {
               internal_url: String,
+              ca_cert_path: String,
             },
 
             credential_references: {


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

My employer, Bad Development Practices Inc, has strict policies about secret storage. All secrets must be stored within the codebase so we never lose them. (Fool me once ransomware hackers, fool me once...)

The problem is, we don't really feel like the blobstores offered in Cloud Foundry are secure enough for our secrets. They just don't SOUND very secure. "webdav", "fog"?

You know what sounds secure? Credhub. That's where secrets belong, and if my blobs have my secrets, that's where my blobs belong too.

* An explanation of the use cases your change solves

Let's just put a pin in that

* [⛔️] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [🚳] I have viewed, signed, and submitted the Contributor License Agreement

* [🤔] I have made this pull request to the `main` branch

* [🚱] I have run all the unit tests using `bundle exec rake`

* [🚷] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)

* A list of items that my help in our rigorous testing...
  - This reuses the existing Credhub credentials that CCNG already has access to, unfortunately those only have read access, so you'll need to bump the permissions up to full admin access to all credhub paths...
  - The worker also needs access to these super credentials, so make sure you modify the worker `cloud_controller_ng.yml.erb` and `spec` to pass them in there too
  - Installing buildpacks during post-start now requires Credhub to be up. Shouldn't be a problem, unless you co-locate Cloud Controller and Credhub because apparently "started" doesn't really mean "started" for Credhub. No worries, adding some sleep to the `post-start` easily solves this
  - There are some "limitations" in Credhub blob storage. It seems to be limited to around 50-60k per credentials, which makes storing ~~large~~ blobs in a single credential quite difficult. Striping the blob across multiple credentials is an easy solution though
  - Unfortunately reconstructing blobs can take some time, and sometimes diego isn't super patient. I'd recommend using the binary buildpack and smallish apps
  - Oh, there's a `/v3/blobs` resource now, and no security, so maybe add some of that when you get a chance
