### PR TITLE
Add stack name to unknown buildpack error message

### DIFF
--- a/lib/cloud_controller/diego/lifecycles/buildpack_lifecycle_data_validator.rb
+++ b/lib/cloud_controller/diego/lifecycles/buildpack_lifecycle_data_validator.rb
@@ -15,7 +15,11 @@ module VCAP::CloudController
         next if buildpack_info.buildpack.nil?
         next if buildpack_info.buildpack_url
 
-        errors.add(:buildpack, %("#{buildpack_info.buildpack}" must be an existing admin buildpack or a valid git URI))
+        if stack
+          errors.add(:buildpack, %("#{buildpack_info.buildpack}" for stack "#{stack.name}" must be an existing admin buildpack or a valid git URI))
+        else
+          errors.add(:buildpack, %("#{buildpack_info.buildpack}" must be an existing admin buildpack or a valid git URI))
+        end
       end
     end
 

--- a/spec/unit/lib/cloud_controller/diego/lifecycles/buildpack_lifecycle_data_validator_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/lifecycles/buildpack_lifecycle_data_validator_spec.rb
@@ -19,6 +19,18 @@ module VCAP::CloudController
       end
     end
 
+    context 'when stack is nil and buildpack is nonexistant' do
+      let(:stack) { nil }
+      let(:buildpack_name_or_url) { 'nonexistant_buildpack' }
+      let(:buildpack) { nil }
+
+      it 'is not valid' do
+        expect(validator).not_to be_valid
+        expect(validator.errors_on(:stack)).to include('must be an existing stack')
+        expect(validator.errors_on(:buildpack)).to include('"nonexistant_buildpack" must be an existing admin buildpack or a valid git URI')
+      end
+    end
+
     context 'when given a buildpack url' do
       let(:buildpack_name_or_url) { 'http://yeah.com' }
       let(:buildpack) { nil }
@@ -63,10 +75,11 @@ module VCAP::CloudController
 
       context 'when given an invalid BuildpackInfo' do
         let(:buildpack_infos) { [buildpack_info, BuildpackInfo.new('invalid-bp', nil)] }
+        let(:stack) { Stack.make(name: 'existing_stack') }
 
         it 'includes an error for the invalid buildpack' do
           expect(validator).not_to be_valid
-          expect(validator.errors[:buildpack]).to include('"invalid-bp" must be an existing admin buildpack or a valid git URI')
+          expect(validator.errors[:buildpack]).to include('"invalid-bp" for stack "existing_stack" must be an existing admin buildpack or a valid git URI')
         end
       end
     end


### PR DESCRIPTION
Helps in cases where the buildpack exists for one stack but not another


* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
