### PR TITLE
bump rails components to 6.1.7.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,10 +49,10 @@ gem 'vmstat', '~> 2.3'
 gem 'yajl-ruby'
 
 # Rails Components
-gem 'actionpack', '~> 6.1.7', '>= 6.1.7.2'
-gem 'actionview', '~> 6.1.7', '>= 6.1.7.2'
+gem 'actionpack', '~> 6.1.7', '>= 6.1.7.3'
+gem 'actionview', '~> 6.1.7', '>= 6.1.7.3'
 gem 'activemodel', '~> 6.1.7'
-gem 'railties', '~> 6.1.7', '>= 6.1.7.2'
+gem 'railties', '~> 6.1.7', '>= 6.1.7.3'
 
 gem 'azure-storage-blob', git: 'https://github.com/sethboyles/azure-storage-ruby.git', branch: 'x-ms-blob-content-type-fix-1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,22 +49,22 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (6.1.7.2)
-      actionview (= 6.1.7.2)
-      activesupport (= 6.1.7.2)
+    actionpack (6.1.7.3)
+      actionview (= 6.1.7.3)
+      activesupport (= 6.1.7.3)
       rack (~> 2.0, >= 2.0.9)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (6.1.7.2)
-      activesupport (= 6.1.7.2)
+    actionview (6.1.7.3)
+      activesupport (= 6.1.7.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activemodel (6.1.7.2)
-      activesupport (= 6.1.7.2)
-    activesupport (6.1.7.2)
+    activemodel (6.1.7.3)
+      activesupport (= 6.1.7.3)
+    activesupport (6.1.7.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -294,7 +294,7 @@ GEM
       rake (~> 13.0)
     loggregator_emitter (5.2.0)
       beefcake (~> 1.0.0)
-    loofah (2.19.1)
+    loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     machinist (1.0.6)
@@ -369,9 +369,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
-    railties (6.1.7.2)
-      actionpack (= 6.1.7.2)
-      activesupport (= 6.1.7.2)
+    railties (6.1.7.3)
+      actionpack (= 6.1.7.3)
+      activesupport (= 6.1.7.3)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -540,8 +540,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionpack (~> 6.1.7, >= 6.1.7.2)
-  actionview (~> 6.1.7, >= 6.1.7.2)
+  actionpack (~> 6.1.7, >= 6.1.7.3)
+  actionview (~> 6.1.7, >= 6.1.7.3)
   activemodel (~> 6.1.7)
   addressable
   allowy (>= 2.1.0)
@@ -594,7 +594,7 @@ DEPENDENCIES
   public_suffix
   puma
   rack-test
-  railties (~> 6.1.7, >= 6.1.7.2)
+  railties (~> 6.1.7, >= 6.1.7.3)
   rake
   retryable
   rfc822


### PR DESCRIPTION
- dependabot is trying to bump the major.  we could configure dependabot to only look at 6.x line, but 🤷‍♀️

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
