### PR TITLE
bump bundler to 2.4.10 in docs/v3/gemfile.lock

### DIFF
--- a/docs/v3/Gemfile.lock
+++ b/docs/v3/Gemfile.lock
@@ -166,4 +166,4 @@ DEPENDENCIES
   sass
 
 BUNDLED WITH
-   2.3.18
+   2.4.10


### PR DESCRIPTION
- we bumped to bundler 2.4.10 when we bumped to ruby 3.2.2 but missed this spot then

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
