### PR TITLE
no longer collide syslog drains with different certificate authorities

### DIFF
--- a/app/controllers/internal/syslog_drain_urls_controller.rb
+++ b/app/controllers/internal/syslog_drain_urls_controller.rb
@@ -81,7 +81,7 @@ module VCAP::CloudController
                      url: syslog_drain_url,
                      binding_data_map: {}
                    }
-                   cert_item = injected_item[:binding_data_map][cert] ||= {
+                   cert_item = injected_item[:binding_data_map][[key, cert, ca]] ||= {
                      cert: cert,
                      key: key,
                      ca: ca,

--- a/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
+++ b/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
@@ -300,6 +300,10 @@ module VCAP::CloudController
       let(:instance9) { UserProvidedServiceInstance.make(space: app_obj3.space) }
       let(:instance10) { UserProvidedServiceInstance.make(space: app_obj4.space) }
       let(:instance11) { UserProvidedServiceInstance.make(space: app_obj.space) }
+      let(:instance12) { UserProvidedServiceInstance.make(space: app_obj.space) }
+      let(:instance13) { UserProvidedServiceInstance.make(space: app_obj.space) }
+      let(:instance14) { UserProvidedServiceInstance.make(space: app_obj.space) }
+      let(:instance15) { UserProvidedServiceInstance.make(space: app_obj.space) }
       let!(:binding_with_drain3) { ServiceBinding.make(syslog_drain_url: 'foobar', app: app_obj2, service_instance: instance3) }
       let!(:binding_with_drain4) { ServiceBinding.make(
         syslog_drain_url: 'barfoo',
@@ -349,6 +353,30 @@ module VCAP::CloudController
         service_instance: instance11,
         credentials: { 'foo' => '', 'cert' => '', 'ca' => '' })
       }
+      let!(:binding_with_drain12) { ServiceBinding.make(
+        syslog_drain_url: 'collision_test',
+        app: app_obj,
+        service_instance: instance12,
+        credentials: { 'cert' => '', 'key' => '', 'ca' => '' })
+      }
+      let!(:binding_with_drain13) { ServiceBinding.make(
+        syslog_drain_url: 'collision_test',
+        app: app_obj,
+        service_instance: instance13,
+        credentials: { 'cert' => 'has-cert', 'key' => '', 'ca' => '' })
+      }
+      let!(:binding_with_drain14) { ServiceBinding.make(
+        syslog_drain_url: 'collision_test',
+        app: app_obj,
+        service_instance: instance14,
+        credentials: { 'cert' => '', 'key' => 'has-key', 'ca' => '' })
+      }
+      let!(:binding_with_drain15) { ServiceBinding.make(
+        syslog_drain_url: 'collision_test',
+        app: app_obj,
+        service_instance: instance15,
+        credentials: { 'key' => '', 'cert' => '', 'ca' => 'has-ca' })
+      }
 
       it 'returns a list of syslog drain urls and their credentials' do
         get '/internal/v5/syslog_drain_urls', '{}'
@@ -360,7 +388,7 @@ module VCAP::CloudController
           end
         end
 
-        expect(sorted_results.count).to eq(7)
+        expect(sorted_results.count).to eq(8)
 
         expect(sorted_results).to eq(
           [
@@ -384,6 +412,25 @@ module VCAP::CloudController
                    'apps' => [
                      { 'hostname' => 'org-1.space-1.app-3', 'app_id' => app_obj3.guid },
                      { 'hostname' => 'org-1.space-1.app-4', 'app_id' => app_obj4.guid }] }] },
+            { 'url' => 'collision_test',
+              'credentials' => [
+                { 'cert' => '',
+                  'key' => '',
+                  'ca' => '',
+                  'apps' => [{ 'hostname' => 'org-1.space-1.app-1', 'app_id' => app_obj.guid }] },
+                { 'cert' => '',
+                  'key' => 'has-key',
+                  'ca' => '',
+                  'apps' => [{ 'hostname' => 'org-1.space-1.app-1', 'app_id' => app_obj.guid }] },
+                { 'cert' => '',
+                  'key' => '',
+                  'ca' => 'has-ca',
+                  'apps' => [{ 'hostname' => 'org-1.space-1.app-1', 'app_id' => app_obj.guid }] },
+                { 'cert' => 'has-cert',
+                  'key' => '',
+                  'ca' => '',
+                  'apps' => [{ 'hostname' => 'org-1.space-1.app-1', 'app_id' => app_obj.guid }] },
+              ] },
             { 'url' => 'fish%2cfinger',
               'credentials' => [
                 { 'cert' => '',


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

no longer collide syslog drains with different certificate authorities

* An explanation of the use cases your change solves

if a drain shares a user cert it will no longer share the same ca if they are different. For example, drains without ca's cannot be "coerced" into trusting a cert by another drain on the platform. 

* Links to any other associated PRs
https://github.com/cloudfoundry/loggregator-agent-release/issues/286

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
