### PR TITLE
Fix flaky syslog_drain_urls_controller_spec

### DIFF
--- a/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
+++ b/spec/unit/controllers/internal/syslog_drain_urls_controller_spec.rb
@@ -383,7 +383,7 @@ module VCAP::CloudController
         expect(last_response).to be_successful
 
         sorted_results = decoded_results.sort { |a, b| a['url'] <=> b['url'] }.each do |binding|
-          binding['credentials'].sort! { |a, b| a['cert'] <=> b['cert'] }.each do |credential|
+          binding['credentials'].sort! { |a, b| [a['key'], a['cert'], a['ca']] <=> [b['key'], b['cert'], b['ca']] }.each do |credential|
             credential['apps'].sort! { |a, b| a['hostname'] <=> b['hostname'] }
           end
         end
@@ -419,15 +419,15 @@ module VCAP::CloudController
                   'ca' => '',
                   'apps' => [{ 'hostname' => 'org-1.space-1.app-1', 'app_id' => app_obj.guid }] },
                 { 'cert' => '',
-                  'key' => 'has-key',
-                  'ca' => '',
-                  'apps' => [{ 'hostname' => 'org-1.space-1.app-1', 'app_id' => app_obj.guid }] },
-                { 'cert' => '',
                   'key' => '',
                   'ca' => 'has-ca',
                   'apps' => [{ 'hostname' => 'org-1.space-1.app-1', 'app_id' => app_obj.guid }] },
                 { 'cert' => 'has-cert',
                   'key' => '',
+                  'ca' => '',
+                  'apps' => [{ 'hostname' => 'org-1.space-1.app-1', 'app_id' => app_obj.guid }] },
+                { 'cert' => '',
+                  'key' => 'has-key',
                   'ca' => '',
                   'apps' => [{ 'hostname' => 'org-1.space-1.app-1', 'app_id' => app_obj.guid }] },
               ] },


### PR DESCRIPTION
Adapt sorting to use all keys.

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
