### PR TITLE
Add parameter to enable stdout logging for errands

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -102,6 +102,7 @@ logging:
   anonymize_ips: false
   format:
     timestamp: 'rfc3339'
+  stdout_sink_enabled: true
 
 log_audit_events: false
 

--- a/lib/cloud_controller/bosh_errand_environment.rb
+++ b/lib/cloud_controller/bosh_errand_environment.rb
@@ -3,7 +3,7 @@ class BoshErrandEnvironment
     @config = config
 
     VCAP::CloudController::StenoConfigurer.new(config.get(:logging)).configure do |steno_config_hash|
-      steno_config_hash[:sinks] << Steno::Sink::IO.new($stdout)
+      steno_config_hash[:sinks] << Steno::Sink::IO.new($stdout) if config.get(:logging, :stdout_sink_enabled)
     end
   end
 

--- a/lib/cloud_controller/config_schemas/vms/rotate_database_key_schema.rb
+++ b/lib/cloud_controller/config_schemas/vms/rotate_database_key_schema.rb
@@ -10,6 +10,7 @@ module VCAP::CloudController
               level: String, # debug, info, etc.
               file: String, # Log file to use
               syslog: String, # Name to associate with syslog messages (should start with 'vcap.')
+              stdout_sink_enabled: bool,
             },
 
             pid_filename: String, # Pid filename to use

--- a/spec/unit/lib/bosh_errand_environment_spec.rb
+++ b/spec/unit/lib/bosh_errand_environment_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe BoshErrandEnvironment do
+  let(:stdout_sink_enabled) { true }
+  let(:config) { VCAP::CloudController::Config.new(
+    {
+      db: DbConfig.new.config,
+      logging: { level: 'debug2', stdout_sink_enabled: stdout_sink_enabled }
+    },
+    context: :rotate_database_key)
+  }
+
+  subject(:bosh_errand_environment) { BoshErrandEnvironment.new(config) }
+
+  describe '#initialize' do
+    it 'configures steno logger with stdout sink' do
+      bosh_errand_environment.setup_environment
+      expect(Steno.logger('cc.errand').instance_variable_get(:@sinks).length).to be(2)
+    end
+
+    context 'when `stdout_sink_enabled` is `false`' do
+      let(:stdout_sink_enabled) { false }
+
+      it 'configures steno logger wo stdout sink' do
+        bosh_errand_environment.setup_environment
+        expect(Steno.logger('cc.errand').instance_variable_get(:@sinks).length).to be(1)
+      end
+    end
+  end
+
+  describe '#setup_environment' do
+    before do
+      allow(VCAP::CloudController::DB).to receive(:load_models)
+    end
+
+    it 'loads models' do
+      expect(VCAP::CloudController::DB).to receive(:load_models)
+      bosh_errand_environment.setup_environment
+    end
+
+    it 'configures components' do
+      expect(config).to receive(:configure_components)
+      bosh_errand_environment.setup_environment
+    end
+  end
+end


### PR DESCRIPTION
Add a parameter to enable stdout logging for errands. Default is set to `true` which is the same as the current behavior.
This is only relevant for database encryption key rotation as this is the only job executed as errand.

* Links to any other associated PRs
  Capi-Release: https://github.com/cloudfoundry/capi-release/pull/316

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
