### PR TITLE
Refactor rate limiters

### DIFF
--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -40,9 +40,9 @@ module VCAP::CloudController
           }
         end
         if config.get(:max_concurrent_service_broker_requests) > 0
-          CloudFoundry::Middleware::ServiceBrokerRequestCounter.instance.limit = config.get(:max_concurrent_service_broker_requests)
           use CloudFoundry::Middleware::ServiceBrokerRateLimiter, {
             logger: Steno.logger('cc.service_broker_rate_limiter'),
+            max_concurrent_requests: config.get(:max_concurrent_service_broker_requests),
             broker_timeout_seconds: config.get(:broker_client_timeout_seconds),
           }
         end

--- a/middleware/mixins/user_reset_interval.rb
+++ b/middleware/mixins/user_reset_interval.rb
@@ -1,13 +1,12 @@
 module CloudFoundry
   module Middleware
     module UserResetInterval
-      def next_reset_interval(user_guid, reset_interval_in_minutes)
+      def next_expires_in(user_guid, reset_interval_in_minutes)
         interval = reset_interval_in_minutes.minutes.to_i
         offset = OpenSSL::Digest::MD5.hexdigest(user_guid).hex.remainder(interval)
+        # TODO: replace hash function with faster (e.g. https://github.com/nashby/xxhash) and FIPS compliant algorithm.
 
-        no_of_intervals = ((Time.now.utc - offset).to_f / interval).floor + 1
-
-        Time.at(offset + (no_of_intervals * interval)).utc
+        interval - (Time.now.to_i - offset).remainder(interval)
       end
     end
   end

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -3,14 +3,14 @@ require 'base_rate_limiter'
 module CloudFoundry
   module Middleware
     class RateLimiter < BaseRateLimiter
-      REQUEST_COUNTER = RequestCounter.new
+      EXPIRING_REQUEST_COUNTER = ExpiringRequestCounter.new('rate-limit')
 
       def initialize(app, opts)
         @per_process_general_limit         = opts[:per_process_general_limit]
         @global_general_limit              = opts[:global_general_limit]
         @per_process_unauthenticated_limit = opts[:per_process_unauthenticated_limit]
         @global_unauthenticated_limit      = opts[:global_unauthenticated_limit]
-        super(app, opts[:logger], REQUEST_COUNTER, opts[:interval])
+        super(app, opts[:logger], EXPIRING_REQUEST_COUNTER, opts[:interval])
       end
 
       private

--- a/middleware/rate_limiter_v2_api.rb
+++ b/middleware/rate_limiter_v2_api.rb
@@ -3,14 +3,14 @@ require 'base_rate_limiter'
 module CloudFoundry
   module Middleware
     class RateLimiterV2API < BaseRateLimiter
-      REQUEST_COUNTER = RequestCounter.new
+      EXPIRING_REQUEST_COUNTER = ExpiringRequestCounter.new('v2-rate-limit')
 
       def initialize(app, opts)
         @per_process_general_limit = opts[:per_process_general_limit]
         @global_general_limit      = opts[:global_general_limit]
         @per_process_admin_limit   = opts[:per_process_admin_limit]
         @global_admin_limit        = opts[:global_admin_limit]
-        super(app, opts[:logger], REQUEST_COUNTER, opts[:interval], 'V2-API')
+        super(app, opts[:logger], EXPIRING_REQUEST_COUNTER, opts[:interval], 'V2-API')
       end
 
       private

--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -2,58 +2,61 @@ require 'concurrent-ruby'
 
 module CloudFoundry
   module Middleware
-    class ServiceBrokerRequestCounter
-      include Singleton
-
-      def initialize
+    class ConcurrentRequestCounter
+      def initialize(key_prefix)
+        @key_prefix = key_prefix
+        @mutex = Mutex.new
         @data = {}
       end
 
-      def limit=(limit)
-        @limit = limit
+      def try_increment?(user_guid, max_concurrent_requests, logger)
+        key = "#{@key_prefix}:#{user_guid}"
+        @mutex.synchronize do
+          @data[key] = Concurrent::Semaphore.new(max_concurrent_requests) unless @data.key?(key)
+          @data[key].try_acquire
+        end
       end
 
-      def try_acquire?(user_guid)
-        @data[user_guid] = Concurrent::Semaphore.new(@limit) unless @data.key?(user_guid)
-        @data[user_guid].try_acquire
-      end
-
-      def release(user_guid)
-        @data[user_guid].release if @data.key?(user_guid)
+      def decrement(user_guid, logger)
+        key = "#{@key_prefix}:#{user_guid}"
+        @mutex.synchronize do
+          @data[key].release if @data.key?(key)
+        end
       end
     end
 
     class ServiceBrokerRateLimiter
+      CONCURRENT_REQUEST_COUNTER = ConcurrentRequestCounter.new('service-broker-rate-limit')
+
       def initialize(app, opts)
-        @app                               = app
-        @logger                            = opts[:logger]
-        @broker_timeout_seconds            = opts[:broker_timeout_seconds]
-        @request_counter = ServiceBrokerRequestCounter.instance
+        @app = app
+        @logger = opts[:logger]
+        @max_concurrent_requests = opts[:max_concurrent_requests]
+        @broker_timeout_seconds = opts[:broker_timeout_seconds]
+        @concurrent_request_counter = CONCURRENT_REQUEST_COUNTER
       end
 
       def call(env)
-        request = ActionDispatch::Request.new(env)
+        decrement_after_call = false
         user_guid = env['cf.user_guid']
-
-        unless skip_rate_limiting?(env, request)
-          return too_many_requests!(env, user_guid) unless @request_counter.try_acquire?(user_guid)
-
-          begin
-            return @app.call(env)
-          rescue => e
-            raise e
-          ensure
-            @request_counter.release(user_guid)
+        if apply_rate_limiting?(env)
+          if @concurrent_request_counter.try_increment?(user_guid, @max_concurrent_requests, @logger)
+            decrement_after_call = true
+          else
+            return too_many_requests!(env, user_guid)
           end
         end
 
         @app.call(env)
+      ensure
+        @concurrent_request_counter.decrement(user_guid, @logger) if decrement_after_call
       end
 
       private
 
-      def skip_rate_limiting?(env, request)
-        return admin? || !is_service_request?(request) || !rate_limit_method?(request)
+      def apply_rate_limiting?(env)
+        request = ActionDispatch::Request.new(env)
+        !admin? && is_service_request?(request) && rate_limit_method?(request)
       end
 
       def admin?
@@ -68,39 +71,36 @@ module CloudFoundry
           %r{\A/v3/service_instances},
           %r{\A/v3/service_credential_bindings},
           %r{\A/v3/service_route_bindings},
-        ].any? { |re| request.fullpath.match re }
+        ].any? { |re| request.fullpath.match(re) }
       end
 
       def rate_limit_method?(request)
-        %w(PATCH PUT POST DELETE).include? request.method
+        %w(PATCH PUT POST DELETE).include?(request.method)
       end
 
-      def user_token?(env)
-        !!env['cf.user_guid']
-      end
-
-      def suggested_retry_time
+      def suggested_retry_after
         delay_range = (@broker_timeout_seconds * 0.5).floor..(@broker_timeout_seconds * 1.5).ceil
-        Time.now.utc + rand(delay_range).to_i.second
-      end
-
-      def too_many_requests!(env, user_guid)
-        rate_limit_headers = {}
-        rate_limit_headers['Retry-After'] = suggested_retry_time
-        @logger.info("Service broker concurrent rate limit exceeded for user '#{user_guid}'")
-        message = rate_limit_error(env).to_json
-        [429, rate_limit_headers, [message]]
+        rand(delay_range).to_i
       end
 
       def rate_limit_error(env)
-        error_name = 'ServiceBrokerRateLimitExceeded'
-        api_error = CloudController::Errors::ApiError.new_from_details(error_name)
+        api_error = CloudController::Errors::ApiError.new_from_details('ServiceBrokerRateLimitExceeded')
         version   = env['PATH_INFO'][0..2]
         if version == '/v2'
           ErrorPresenter.new(api_error, Rails.env.test?, V2ErrorHasher.new(api_error)).to_hash
         elsif version == '/v3'
           ErrorPresenter.new(api_error, Rails.env.test?, V3ErrorHasher.new(api_error)).to_hash
         end
+      end
+
+      def too_many_requests!(env, user_guid)
+        @logger.info("Service broker concurrent rate limit exceeded for user '#{user_guid}'")
+        headers = {}
+        headers['Retry-After'] = suggested_retry_after.to_s
+        headers['Content-Type'] = 'text/plain; charset=utf-8'
+        message = rate_limit_error(env).to_json
+        headers['Content-Length'] = message.length.to_s
+        [429, headers, [message]]
       end
     end
   end

--- a/spec/support/shared_examples/middleware/rate_limiting.rb
+++ b/spec/support/shared_examples/middleware/rate_limiting.rb
@@ -1,9 +1,8 @@
-RSpec.shared_examples_for 'endpoint exempts from rate limiting' do |header_suffix=''|
+RSpec.shared_examples_for 'exempted from rate limiting' do |header_suffix=''|
   it 'exempts them from rate limiting' do
-    allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+    allow(ActionDispatch::Request).to receive(:new).and_return(fake_request) if defined?(fake_request)
     _, response_headers, _ = middleware.call(env)
-    expect(request_counter).not_to have_received(:get)
-    expect(request_counter).not_to have_received(:increment)
+    expect(expiring_request_counter).not_to have_received(:increment)
     expect(response_headers["X-RateLimit-Limit#{header_suffix}"]).to be_nil
     expect(response_headers["X-RateLimit-Remaining#{header_suffix}"]).to be_nil
     expect(response_headers["X-RateLimit-Reset#{header_suffix}"]).to be_nil

--- a/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
@@ -105,6 +105,7 @@ module VCAP::CloudController
             expect(CloudFoundry::Middleware::ServiceBrokerRateLimiter).to have_received(:new).with(
               anything,
               logger: instance_of(Steno::Logger),
+              max_concurrent_requests: TestConfig.config_instance.get(:max_concurrent_service_broker_requests),
               broker_timeout_seconds: TestConfig.config_instance.get(:broker_client_timeout_seconds)
             )
           end

--- a/spec/unit/middleware/rate_limiter_v2_api_spec.rb
+++ b/spec/unit/middleware/rate_limiter_v2_api_spec.rb
@@ -16,12 +16,7 @@ module CloudFoundry
           }
         )
       end
-      let(:request_counter) { double }
-      before(:each) {
-        middleware.instance_variable_set('@request_counter', request_counter)
-        allow(request_counter).to receive(:get).and_return([0, Time.now.utc])
-        allow(request_counter).to receive(:increment)
-      }
+      let(:expiring_request_counter) { double }
 
       let(:app) { double(:app, call: [200, {}, 'a body']) }
       let(:per_process_general_limit) { 20 }
@@ -30,14 +25,25 @@ module CloudFoundry
       let(:global_admin_limit) { 1000 }
       let(:interval) { 60 }
       let(:logger) { double('logger', info: nil) }
+      let(:expires_in) { 10.minutes.to_i }
 
       let(:path_info) { '/v2/service_instances' }
-      let(:default_env) { { some: 'env' } }
-      let(:basic_auth_env) { { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('user', 'pass') } }
+      let(:unauthenticated_env) { { some: 'env' } }
       let(:user_1_guid) { 'user-id-1' }
-      let(:user_2_guid) { 'user-id-2' }
       let(:user_1_env) { { 'cf.user_guid' => user_1_guid, 'PATH_INFO' => path_info } }
-      let(:user_2_env) { { 'cf.user_guid' => user_2_guid, 'PATH_INFO' => path_info } }
+
+      let(:frozen_time) { Time.utc(2015, 10, 21, 7, 28) + Time.zone_offset('PDT') }
+      let(:frozen_epoch) { frozen_time.to_i }
+
+      before(:each) do
+        middleware.instance_variable_set('@expiring_request_counter', expiring_request_counter)
+        allow(expiring_request_counter).to receive(:increment).and_return([1, expires_in])
+        Timecop.freeze frozen_time
+      end
+
+      after(:each) do
+        Timecop.return
+      end
 
       describe 'headers as regular user' do
         describe 'X-RateLimit-Limit-V2-API' do
@@ -48,19 +54,21 @@ module CloudFoundry
         end
 
         describe 'X-RateLimit-Remaining-V2-API' do
+          let(:user_2_guid) { 'user-id-2' }
+          let(:user_2_env) { { 'cf.user_guid' => user_2_guid, 'PATH_INFO' => path_info } }
+
           it 'shows the user the number of remaining requests rounded down to nearest 10%' do
-            allow(request_counter).to receive(:get).and_return([0, Time.now.utc])
             _, response_headers, _ = middleware.call(user_1_env)
             expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('180')
 
-            allow(request_counter).to receive(:get).and_return([10, Time.now.utc])
+            allow(expiring_request_counter).to receive(:increment).and_return([11, expires_in])
             _, response_headers, _ = middleware.call(user_1_env)
             expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('80')
           end
 
           it "tracks user's remaining requests independently" do
-            expect(request_counter).to receive(:get).with(user_1_guid, interval, logger).and_return([0, Time.now.utc])
-            expect(request_counter).to receive(:get).with(user_2_guid, interval, logger).and_return([10, Time.now.utc])
+            expect(expiring_request_counter).to receive(:increment).with(user_1_guid, interval, logger).and_return([1, expires_in])
+            expect(expiring_request_counter).to receive(:increment).with(user_2_guid, interval, logger).and_return([11, expires_in])
 
             _, response_headers, _ = middleware.call(user_1_env)
             expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('180')
@@ -72,157 +80,32 @@ module CloudFoundry
 
         describe 'X-RateLimit-Reset-V2-API' do
           it 'shows the user when the interval will expire' do
-            valid_until = Time.now.utc.beginning_of_hour + interval.minutes
-            allow(request_counter).to receive(:get).and_return([0, valid_until])
             _, response_headers, _ = middleware.call(user_1_env)
-            expect(response_headers['X-RateLimit-Reset-V2-API'].to_i).to eq(valid_until.utc.to_i)
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq((frozen_epoch + expires_in).to_s)
           end
-        end
-      end
-
-      describe 'headers as admin user' do
-        before do
-          allow(VCAP::CloudController::SecurityContext).to receive(:admin_read_only?).and_return(true)
-        end
-        describe 'X-RateLimit-Limit-V2-API' do
-          it 'shows the user the total request limit' do
-            _, response_headers, _ = middleware.call(user_1_env)
-            expect(response_headers['X-RateLimit-Limit-V2-API']).to eq(global_admin_limit.to_s)
-          end
-        end
-
-        describe 'X-RateLimit-Remaining-V2-API' do
-          it 'shows the user the number of remaining requests rounded down to nearest 10%' do
-            allow(request_counter).to receive(:get).and_return([0, Time.now.utc])
-            _, response_headers, _ = middleware.call(user_1_env)
-            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('900')
-
-            allow(request_counter).to receive(:get).and_return([10, Time.now.utc])
-            _, response_headers, _ = middleware.call(user_1_env)
-            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('800')
-          end
-        end
-
-        describe 'X-RateLimit-Reset-V2-API' do
-          it 'shows the user when the interval will expire' do
-            valid_until = Time.now.utc.beginning_of_hour + interval.minutes
-            allow(request_counter).to receive(:get).and_return([0, valid_until])
-            _, response_headers, _ = middleware.call(user_1_env)
-            expect(response_headers['X-RateLimit-Reset-V2-API'].to_i).to eq(valid_until.utc.to_i)
-          end
-        end
-      end
-
-      describe "when the user has the 'cloud_controller.v2_api_rate_limit_exempt' scope" do
-        before do
-          allow(VCAP::CloudController::SecurityContext).to receive(:v2_rate_limit_exempted?).and_return(true)
-        end
-
-        it 'exempts them from rate limiting' do
-          _, response_headers, _ = middleware.call(user_1_env)
-
-          expect(request_counter).not_to have_received(:get)
-          expect(request_counter).not_to have_received(:increment)
-          expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
-          expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
-          expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
         end
       end
 
       it 'increments the counter and allows the request to continue' do
         _, _, _ = middleware.call(user_1_env)
-        expect(request_counter).to have_received(:increment).with(user_1_guid)
+        expect(expiring_request_counter).to have_received(:increment).with(user_1_guid, interval, logger)
         expect(app).to have_received(:call)
       end
 
       it 'does not drop headers created in next middleware' do
         allow(app).to receive(:call).and_return([200, { 'from' => 'wrapped-app' }, 'a body'])
-        _, headers, _ = middleware.call({})
+        _, headers, _ = middleware.call(user_1_env)
         expect(headers).to match(hash_including('from' => 'wrapped-app'))
       end
 
-      describe 'exempting non v2/* endpoints' do
-        describe 'exempting internal endpoints' do
-          context 'when the user is hitting a path starting with "/internal"' do
-            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/internal/pants/1234') }
-
-            it 'exempts them from rate limiting' do
-              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-              _, response_headers, _ = middleware.call(default_env)
-              expect(request_counter).not_to have_received(:get)
-              expect(request_counter).not_to have_received(:increment)
-              expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
-              expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
-              expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
-            end
-          end
-
-          context 'when the user is hitting containing, but NOT starting with "/internal"' do
-            let(:headers) { ActionDispatch::Http::Headers.from_hash({ 'HTTP_X_FORWARDED_FOR' => 'forwarded_ip' }) }
-            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v2/pants/internal/1234', headers: headers) }
-
-            it 'rate limits them' do
-              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-              expect(request_counter).to receive(:get).with('forwarded_ip', interval, logger).and_return([0, Time.now.utc])
-              expect(request_counter).to receive(:increment).with('forwarded_ip')
-              _, response_headers, _ = middleware.call(default_env)
-              expect(response_headers['X-RateLimit-Limit-V2-API']).to_not be_nil
-              expect(response_headers['X-RateLimit-Remaining-V2-API']).to_not be_nil
-              expect(response_headers['X-RateLimit-Reset-V2-API']).to_not be_nil
-            end
-          end
-        end
-
-        context 'when the user is hitting a root path /' do
-          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/') }
-
-          it_behaves_like 'endpoint exempts from rate limiting', '-V2-API' do
-            let(:env) { default_env }
-          end
-        end
-
-        context 'when the user is hitting a root path /v2/info' do
-          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v2/info') }
-
-          it_behaves_like 'endpoint exempts from rate limiting', '-V2-API' do
-            let(:env) { default_env }
-          end
-        end
-
-        context 'when the user is hitting a root path /v3' do
-          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3') }
-
-          it_behaves_like 'endpoint exempts from rate limiting', '-V2-API' do
-            let(:env) { default_env }
-          end
-        end
-
-        context 'when the user is hitting a root path /v3/services' do
-          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/services') }
-
-          it_behaves_like 'endpoint exempts from rate limiting', '-V2-API' do
-            let(:env) { default_env }
-          end
-        end
-
-        context 'when the user is hitting a root path /healthz' do
-          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/healthz') }
-
-          it_behaves_like 'endpoint exempts from rate limiting', '-V2-API' do
-            let(:env) { default_env }
-          end
-        end
-      end
-
       describe 'when the user is not logged in' do
+        let(:expires_in_2) { expires_in + 5.minutes.to_i }
+
         describe 'when the user has basic auth credentials' do
-          it 'exempts them from rate limiting' do
-            _, response_headers, _ = middleware.call(basic_auth_env)
-            expect(request_counter).not_to have_received(:get)
-            expect(request_counter).not_to have_received(:increment)
-            expect(response_headers['X-RateLimit-Limit-V2-API']).to be_nil
-            expect(response_headers['X-RateLimit-Remaining-V2-API']).to be_nil
-            expect(response_headers['X-RateLimit-Reset-V2-API']).to be_nil
+          let(:basic_auth_env) { { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('user', 'pass') } }
+
+          it_behaves_like 'exempted from rate limiting', '-V2-API' do
+            let(:env) { basic_auth_env }
           end
         end
 
@@ -240,26 +123,21 @@ module CloudFoundry
           end
 
           it 'identifies them by the "HTTP_X_FORWARDED_FOR" header' do
-            valid_until = Time.now.utc
-            valid_until_2 = Time.now.utc
-
             allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-            expect(request_counter).to receive(:get).with(forwarded_ip, interval, logger).and_return([0, valid_until])
-            expect(request_counter).to receive(:increment).with(forwarded_ip)
-            _, response_headers, _ = middleware.call(default_env)
+            expect(expiring_request_counter).to receive(:increment).with(forwarded_ip, interval, logger).and_return([1, expires_in])
+            _, response_headers, _ = middleware.call(unauthenticated_env)
             expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('180')
-            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq(valid_until.to_i.to_s)
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq((frozen_epoch + expires_in).to_s)
 
             allow(ActionDispatch::Request).to receive(:new).and_return(fake_request_2)
-            expect(request_counter).to receive(:get).with(forwarded_ip_2, interval, logger).and_return([2, valid_until_2])
-            expect(request_counter).to receive(:increment).with(forwarded_ip_2)
-            _, response_headers, _ = middleware.call(default_env)
+            expect(expiring_request_counter).to receive(:increment).with(forwarded_ip_2, interval, logger).and_return([3, expires_in_2])
+            _, response_headers, _ = middleware.call(unauthenticated_env)
             expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('160')
-            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq(valid_until_2.to_i.to_s)
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq((frozen_epoch + expires_in_2).to_s)
           end
         end
 
-        describe 'when the there is no "HTTP_X_FORWARDED_FOR" header' do
+        describe 'when there is no "HTTP_X_FORWARDED_FOR" header' do
           let(:headers) { ActionDispatch::Http::Headers.from_hash({ 'X_HEADER' => 'nope' }) }
           let(:ip) { 'some-ip' }
           let(:ip_2) { 'some-ip-2' }
@@ -267,68 +145,164 @@ module CloudFoundry
           let(:fake_request_2) { instance_double(ActionDispatch::Request, headers: headers, ip: ip_2, fullpath: '/v2/some/path') }
 
           it 'identifies them by the request ip' do
-            valid_until = Time.now.utc.beginning_of_hour
-            valid_until_2 = Time.now.utc.beginning_of_hour + 5.minutes
-            allow(request_counter).to receive(:get).with(ip, interval, logger).and_return([0, valid_until])
-            allow(request_counter).to receive(:get).with(ip_2, interval, logger).and_return([2, valid_until_2])
-
             allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
-            _, response_headers, _ = middleware.call(default_env)
-            expect(request_counter).to have_received(:increment).with(ip)
+            expect(expiring_request_counter).to receive(:increment).with(ip, interval, logger).and_return([1, expires_in])
+            _, response_headers, _ = middleware.call(unauthenticated_env)
             expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('180')
-            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq(valid_until.utc.to_i.to_s)
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq((frozen_epoch + expires_in).to_s)
 
             allow(ActionDispatch::Request).to receive(:new).and_return(fake_request_2)
-            _, response_headers, _ = middleware.call(default_env)
-            expect(request_counter).to have_received(:increment).with(ip_2)
+            expect(expiring_request_counter).to receive(:increment).with(ip_2, interval, logger).and_return([3, expires_in_2])
+            _, response_headers, _ = middleware.call(unauthenticated_env)
             expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('160')
-            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq(valid_until_2.utc.to_i.to_s)
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq((frozen_epoch + expires_in_2).to_s)
+          end
+        end
+      end
+
+      describe 'headers as admin user' do
+        before do
+          allow(VCAP::CloudController::SecurityContext).to receive(:admin_read_only?).and_return(true)
+        end
+
+        describe 'X-RateLimit-Limit-V2-API' do
+          it 'shows the user the total request limit' do
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Limit-V2-API']).to eq(global_admin_limit.to_s)
+          end
+        end
+
+        describe 'X-RateLimit-Remaining-V2-API' do
+          it 'shows the user the number of remaining requests rounded down to nearest 10%' do
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('900')
+
+            allow(expiring_request_counter).to receive(:increment).and_return([11, expires_in])
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('800')
+          end
+        end
+
+        describe 'X-RateLimit-Reset-V2-API' do
+          it 'shows the user when the interval will expire' do
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Reset-V2-API']).to eq((frozen_epoch + expires_in).to_s)
+          end
+        end
+      end
+
+      describe "when the user has the 'cloud_controller.v2_api_rate_limit_exempt' scope" do
+        before do
+          allow(VCAP::CloudController::SecurityContext).to receive(:v2_rate_limit_exempted?).and_return(true)
+        end
+
+        it_behaves_like 'exempted from rate limiting', '-V2-API' do
+          let(:env) { user_1_env }
+        end
+      end
+
+      describe 'exempting non v2/* endpoints' do
+        context 'when the user is hitting the /v3/service_instances path' do
+          let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/service_instances') }
+
+          it_behaves_like 'exempted from rate limiting', '-V2-API' do
+            let(:env) { user_1_env }
+          end
+        end
+
+        describe 'exempting internal endpoints' do
+          context 'when the user is hitting a path starting with "/internal"' do
+            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/internal/pants/1234') }
+
+            it_behaves_like 'exempted from rate limiting', '-V2-API' do
+              let(:env) { user_1_env }
+            end
+          end
+
+          context 'when the user is hitting a path containing, but NOT starting with "/internal"' do
+            let(:headers) { ActionDispatch::Http::Headers.from_hash({ 'HTTP_X_FORWARDED_FOR' => 'forwarded_ip' }) }
+            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v2/pants/internal/1234', headers: headers) }
+
+            it 'rate limits them' do
+              allow(ActionDispatch::Request).to receive(:new).and_return(fake_request)
+              expect(expiring_request_counter).to receive(:increment).with('forwarded_ip', interval, logger).and_return([0, expires_in])
+              _, response_headers, _ = middleware.call(unauthenticated_env)
+              expect(response_headers['X-RateLimit-Limit-V2-API']).to_not be_nil
+              expect(response_headers['X-RateLimit-Remaining-V2-API']).to_not be_nil
+              expect(response_headers['X-RateLimit-Reset-V2-API']).to_not be_nil
+            end
+          end
+        end
+
+        describe 'exempting root endpoints' do
+          context 'when the user is hitting the / path' do
+            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/') }
+
+            it_behaves_like 'exempted from rate limiting', '-V2-API' do
+              let(:env) { user_1_env }
+            end
+          end
+
+          context 'when the user is hitting the /v2/info path' do
+            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v2/info') }
+
+            it_behaves_like 'exempted from rate limiting', '-V2-API' do
+              let(:env) { user_1_env }
+            end
+          end
+
+          context 'when the user is hitting the /v3 path' do
+            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3') }
+
+            it_behaves_like 'exempted from rate limiting', '-V2-API' do
+              let(:env) { user_1_env }
+            end
+          end
+
+          context 'when the user is hitting the /healthz path' do
+            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/healthz') }
+
+            it_behaves_like 'exempted from rate limiting', '-V2-API' do
+              let(:env) { user_1_env }
+            end
           end
         end
       end
 
       context 'when limit has exceeded' do
         let(:path_info) { '/v2/foo' }
-        let(:middleware_env) do
-          { 'cf.user_guid' => 'user-id-1', 'PATH_INFO' => path_info }
+
+        before(:each) do
+          allow(expiring_request_counter).to receive(:increment).and_return([per_process_general_limit + 1, expires_in])
         end
-        before(:each) { allow(request_counter).to receive(:get).and_return([per_process_general_limit + 1, Time.now.utc]) }
 
         it 'returns 429 response' do
-          status, _, _ = middleware.call(middleware_env)
+          status, _, _ = middleware.call(user_1_env)
           expect(status).to eq(429)
         end
 
-        it 'does not increment the request counter' do
-          _, _, _ = middleware.call(middleware_env)
-          expect(request_counter).to_not have_received(:increment)
-        end
-
         it 'prevents "X-RateLimit-Remaining-V2-API" from going lower than zero' do
-          allow(request_counter).to receive(:get).and_return([per_process_general_limit + 100, Time.now.utc])
-          _, response_headers, _ = middleware.call(middleware_env)
+          allow(expiring_request_counter).to receive(:increment).and_return([per_process_general_limit + 100, expires_in])
+          _, response_headers, _ = middleware.call(user_1_env)
           expect(response_headers['X-RateLimit-Remaining-V2-API']).to eq('0')
         end
 
         it 'contains the correct headers' do
-          valid_until = Time.now.utc
-          allow(request_counter).to receive(:get).and_return([per_process_general_limit + 1, valid_until])
           error_presenter = instance_double(ErrorPresenter, to_hash: { foo: 'bar' })
           allow(ErrorPresenter).to receive(:new).and_return(error_presenter)
-
-          _, response_headers, _ = middleware.call(middleware_env)
-          expect(response_headers['Retry-After']).to eq(valid_until.utc.to_i.to_s)
+          _, response_headers, _ = middleware.call(user_1_env)
+          expect(response_headers['Retry-After']).to eq(expires_in.to_s)
           expect(response_headers['Content-Type']).to eq('text/plain; charset=utf-8')
           expect(response_headers['Content-Length']).to eq({ foo: 'bar' }.to_json.length.to_s)
         end
 
         it 'ends the request' do
-          _, _, _ = middleware.call(middleware_env)
+          _, _, _ = middleware.call(user_1_env)
           expect(app).not_to have_received(:call)
         end
 
         it 'formats the response error in v2 format' do
-          _, _, body = middleware.call(middleware_env)
+          _, _, body = middleware.call(user_1_env)
           json_body = JSON.parse(body.first)
           expect(json_body).to include(
             'code' => 10018,
@@ -338,32 +312,29 @@ module CloudFoundry
         end
 
         context 'when the user is admin' do
-          let(:default_env) { { 'some' => 'env', 'PATH_INFO' => path_info } }
-
           before do
             allow(VCAP::CloudController::SecurityContext).to receive(:admin_read_only?).and_return(true)
           end
 
           it 'contains the correct headers' do
-            valid_until = Time.now.utc
-            allow(request_counter).to receive(:get).and_return([per_process_admin_limit + 1, valid_until])
+            allow(expiring_request_counter).to receive(:increment).and_return([per_process_admin_limit + 1, expires_in])
             error_presenter = instance_double(ErrorPresenter, to_hash: { foo: 'bar' })
             allow(ErrorPresenter).to receive(:new).and_return(error_presenter)
 
-            _, response_headers, _ = middleware.call(middleware_env)
-            expect(response_headers['Retry-After']).to eq(valid_until.utc.to_i.to_s)
+            _, response_headers, _ = middleware.call(user_1_env)
+            expect(response_headers['Retry-After']).to eq(expires_in.to_s)
             expect(response_headers['Content-Type']).to eq('text/plain; charset=utf-8')
             expect(response_headers['Content-Length']).to eq({ foo: 'bar' }.to_json.length.to_s)
           end
         end
 
-        context 'when the user is exempt from rate limiting' do
+        context 'when the user is exempted from rate limiting' do
           before do
             allow(VCAP::CloudController::SecurityContext).to receive(:v2_rate_limit_exempted?).and_return(true)
           end
 
           it 'returns 200 response' do
-            status, _, _ = middleware.call(middleware_env)
+            status, _, _ = middleware.call(user_1_env)
             expect(status).to eq(200)
           end
         end


### PR DESCRIPTION
To prepare for the introduction of a Redis-based rate limiting (required for Puma), the current implementation has been refactored.

- `ExpiringRequestCounter`
-- Renamed from `RequestCounter`.
-- Single `increment` method (combines old `get` + `increment` methods).
-- Returns _expires_in_ seconds instead of _valid_until_ timestamp.

- `ConcurrentRequestCounter`
-- Renamed from `ServiceBrokerRequestCounter`.
-- Not a singleton anymore.
-- Renamed methods from `try_acquire?`/`release` to `try_increment?`/`decrement`.

- `UserResetInterval` returns next _expires_in_ seconds instead of _reset_interval_ timestamp.

- `Retry-After` header returns "delay-seconds" instead of epoch seconds (fixes #2544).

- Tests cleanup.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
