### PR TITLE
Clarify that process stats returns one stats object per instance

### DIFF
--- a/docs/v3/source/includes/api_resources/_processes.erb
+++ b/docs/v3/source/includes/api_resources/_processes.erb
@@ -198,8 +198,30 @@
       "disk_quota": 1073741824,
       "fds_quota": 16384,
       "isolation_segment": "example_iso_segment",
+      "log_rate_limit": null,
       "details": null
-    }
+    },
+    {
+      "type": "web",
+      "index": 1,
+      "state": "STARTING",
+      "usage": {
+        "cpu": 0,
+        "disk": 0,
+        "log_rate": 0,
+        "mem": 0,
+        "time": "2016-03-23T21:34:04+00:00"
+      },
+      "disk_quota": null,
+      "fds_quota": 16384,
+      "host": "",
+      "instance_ports": null,
+      "isolation_segment": null,
+      "log_rate_limit": null,
+      "mem_quota": null,
+      "uptime": 0,
+      "details": null
+      }
   ]
 }
 <% end %>

--- a/docs/v3/source/includes/resources/processes/_stats.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats.md.erb
@@ -1,5 +1,7 @@
 ### Get stats for a process
 
+Process stats are objects that represent the individual instances of a process.
+
 ```
 Example Request
 ```

--- a/docs/v3/source/includes/resources/processes/_stats_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats_object.md.erb
@@ -1,5 +1,7 @@
 ### The process stats object
 
+The process stats object provides information about the status of an individual instance of a process.
+
 ```
 Example process stats object
 ```


### PR DESCRIPTION
I thought it could be clarified that process stats returns one stats object per instance (as opposed to some form of aggregate)