### PR TITLE
Remove awesome_print as it is causing cve scanners to react

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ group :db do
 end
 
 group :operations do
-  gem 'awesome_print'
   gem 'pry-byebug'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,6 @@ GEM
       activesupport (>= 3.2)
       i18n
     ast (2.4.2)
-    awesome_print (1.9.2)
     azure-core (0.1.15)
       faraday (~> 0.9)
       faraday_middleware (~> 0.10)
@@ -549,7 +548,6 @@ DEPENDENCIES
   activemodel (~> 6.1.7)
   addressable
   allowy (>= 2.1.0)
-  awesome_print
   azure-storage-blob!
   byebug
   cf-copilot (= 0.0.14)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,6 @@ init_block = proc do
   require 'machinist/object'
   require 'rack/test'
   require 'timecop'
-  require 'awesome_print'
 
   require 'steno'
   require 'webmock/rspec'


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
awesome_print shows up in cve scanner results.  maybe we don't need pretty things?

* An explanation of the use cases your change solves
cve scanners stop complaining to me

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
