### PR TITLE
Fix performance issues with delayed_jobs by extending index

### DIFF
--- a/db/migrations/20230627110500_add_priority_by_to_delayed_jobs_index.rb
+++ b/db/migrations/20230627110500_add_priority_by_to_delayed_jobs_index.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  up do
+    drop_index :delayed_jobs, nil, name: :delayed_jobs_reserve
+    add_index :delayed_jobs, [:queue, :locked_at, :locked_by, :failed_at, :run_at, :priority], name: :delayed_jobs_reserve
+  end
+
+  down do
+    drop_index :delayed_jobs, nil, name: :delayed_jobs_reserve
+    add_index :delayed_jobs, [:queue, :locked_at, :locked_by, :failed_at, :run_at], name: :delayed_jobs_reserve
+  end
+end


### PR DESCRIPTION
We found out that when having a lot of delayed_jobs rows in the table, postgresql query planner did a sequential scan of the table. This was due to the query of cc_workers to fetch new jobs being:

```
SELECT *
FROM "delayed_jobs"
WHERE (((("run_at" <= '2023-06-27 07:18:28.061781+0000')
AND ("locked_at" IS NULL))
(.....)
ORDER BY "priority" ASC, "run_at" ASC
LIMIT 1 FOR Update;
```

As an order by is used on `priority` the index over the columns `queue, locked_at, locked_by, failed_at, run_at` is not used.

This is more severe as the query above gets more and more expensive by increasing row count and is queried a lot. Every worker every few seconds does this select. This quickly can become a load issue for the database.

This change adds the `priority` column to the already existing index `delayed_jobs_reserve`. Improves query times as well as database load significantly in our tests.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
