### PR TITLE
Expose process version on the v3 API

### DIFF
--- a/app/presenters/v3/process_presenter.rb
+++ b/app/presenters/v3/process_presenter.rb
@@ -22,6 +22,7 @@ module VCAP::CloudController
             guid:             process.guid,
             created_at:       process.created_at,
             updated_at:       process.updated_at,
+            version:          process.version,
             type:             process.type,
             command:          redact(process.specified_or_detected_command),
             instances:        process.instances,

--- a/docs/v3/source/includes/api_resources/_processes.erb
+++ b/docs/v3/source/includes/api_resources/_processes.erb
@@ -31,6 +31,7 @@
   },
   "created_at": "2016-03-23T18:48:22Z",
   "updated_at": "2016-03-23T18:48:42Z",
+  "version": "e9df685c-0464-4aa7-b5f0-8ed843077c13",
   "links": {
     "self": {
       "href": "https://api.example.org/v3/processes/6a901b7c-9417-4dc1-8189-d3234aa0ab82"
@@ -101,6 +102,7 @@
       },
       "created_at": "2016-03-23T18:48:22Z",
       "updated_at": "2016-03-23T18:48:42Z",
+      "version": "e9df685c-0464-4aa7-b5f0-8ed843077c13",
       "links": {
         "self": {
           "href": "https://api.example.org/v3/processes/6a901b7c-9417-4dc1-8189-d3234aa0ab82"
@@ -148,6 +150,7 @@
       },
       "created_at": "2016-03-23T18:48:22Z",
       "updated_at": "2016-03-23T18:48:42Z",
+      "version": "74e513bb-7b9e-445c-84d5-7fea1394e611",
       "links": {
         "self": {
           "href": "https://api.example.org/v3/processes/3fccacd9-4b02-4b96-8d02-8e865865e9eb"

--- a/docs/v3/source/includes/resources/processes/_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_object.md.erb
@@ -12,6 +12,7 @@ Name | Type | Description
 **guid** | _uuid_ | Unique identifier for the process
 **created_at** | _[timestamp](#timestamps)_ | The time with zone when the object was created
 **updated_at** | _[timestamp](#timestamps)_ | The time with zone when the object was last updated
+**version** | _uuid_ | Random identifier that changes every time the process will be recreated in the runtime.
 **type** | _string_ | Process type; a unique identifier for processes belonging to an app
 **command** | _string_ or _null_ | The command used to start the process; use _null_ to revert to the buildpack-detected or procfile-provided start command
 **instances** | _integer_ | The number of instances to run

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe 'Processes' do
             'metadata' => { 'annotations' => {}, 'labels' => {} },
             'created_at'   => iso8601,
             'updated_at'   => iso8601,
+            'version'      => web_process.version,
             'links'        => {
               'self'  => { 'href' => "#{link_prefix}/v3/processes/#{web_process.guid}" },
               'scale' => { 'href' => "#{link_prefix}/v3/processes/#{web_process.guid}/actions/scale", 'method' => 'POST' },
@@ -159,6 +160,7 @@ RSpec.describe 'Processes' do
             'metadata' => { 'annotations' => {}, 'labels' => {} },
             'created_at'   => iso8601,
             'updated_at'   => iso8601,
+            'version'      => worker_process.version,
             'links'        => {
               'self'  => { 'href' => "#{link_prefix}/v3/processes/#{worker_process.guid}" },
               'scale' => { 'href' => "#{link_prefix}/v3/processes/#{worker_process.guid}/actions/scale", 'method' => 'POST' },
@@ -417,6 +419,7 @@ RSpec.describe 'Processes' do
         'metadata' => { 'annotations' => {}, 'labels' => {} },
         'created_at'   => iso8601,
         'updated_at'   => iso8601,
+        'version'      => process.version,
         'links'        => {
           'self'  => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}" },
           'scale' => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}/actions/scale", 'method' => 'POST' },
@@ -658,6 +661,7 @@ RSpec.describe 'Processes' do
         },
         'created_at'   => iso8601,
         'updated_at'   => iso8601,
+        'version'      => process.version,
         'links'        => {
           'self'  => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}" },
           'scale' => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}/actions/scale", 'method' => 'POST' },
@@ -801,6 +805,7 @@ RSpec.describe 'Processes' do
         'metadata' => { 'annotations' => {}, 'labels' => {} },
         'created_at'   => iso8601,
         'updated_at'   => iso8601,
+        'version'      => process.version,
         'links'        => {
           'self'  => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}" },
           'scale' => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}/actions/scale", 'method' => 'POST' },
@@ -1155,6 +1160,7 @@ RSpec.describe 'Processes' do
             'metadata' => { 'annotations' => {}, 'labels' => {} },
             'created_at'   => iso8601,
             'updated_at'   => iso8601,
+            'version'      => process1.version,
             'links'        => {
               'self'  => { 'href' => "#{link_prefix}/v3/processes/#{process1.guid}" },
               'scale' => { 'href' => "#{link_prefix}/v3/processes/#{process1.guid}/actions/scale", 'method' => 'POST' },
@@ -1189,6 +1195,7 @@ RSpec.describe 'Processes' do
             'metadata' => { 'annotations' => {}, 'labels' => {} },
             'created_at'   => iso8601,
             'updated_at'   => iso8601,
+            'version'      => process2.version,
             'links'        => {
               'self'  => { 'href' => "#{link_prefix}/v3/processes/#{process2.guid}" },
               'scale' => { 'href' => "#{link_prefix}/v3/processes/#{process2.guid}/actions/scale", 'method' => 'POST' },
@@ -1308,6 +1315,7 @@ RSpec.describe 'Processes' do
         'metadata' => { 'annotations' => {}, 'labels' => {} },
         'created_at'   => iso8601,
         'updated_at'   => iso8601,
+        'version'      => process.version,
         'links'        => {
           'self'  => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}" },
           'scale' => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}/actions/scale", 'method' => 'POST' },
@@ -1410,6 +1418,7 @@ RSpec.describe 'Processes' do
         },
         'created_at'   => iso8601,
         'updated_at'   => iso8601,
+        'version'      => process.version,
         'links'        => {
           'self'  => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}" },
           'scale' => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}/actions/scale", 'method' => 'POST' },
@@ -1520,6 +1529,7 @@ RSpec.describe 'Processes' do
         'metadata' => { 'annotations' => {}, 'labels' => {} },
         'created_at'   => iso8601,
         'updated_at'   => iso8601,
+        'version'      => process.version,
         'links'        => {
           'self'  => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}" },
           'scale' => { 'href' => "#{link_prefix}/v3/processes/#{process.guid}/actions/scale", 'method' => 'POST' },

--- a/spec/unit/presenters/v3/process_presenter_spec.rb
+++ b/spec/unit/presenters/v3/process_presenter_spec.rb
@@ -86,6 +86,8 @@ module VCAP::CloudController::Presenters::V3
       context('when health_check_type is http') do
         it 'presents the process as a hash' do
           expect(result[:guid]).to eq(process.guid)
+          expect(result[:version]).to be_a_guid
+          expect(result[:version]).to eq(process.version)
           expect(result[:instances]).to eq(3)
           expect(result[:memory_in_mb]).to eq(42)
           expect(result[:disk_in_mb]).to eq(37)
@@ -106,6 +108,8 @@ module VCAP::CloudController::Presenters::V3
         let(:health_check_type) { 'port' }
         it 'presents the process as a hash without a health_check/data/endpoint' do
           expect(result[:guid]).to eq(process.guid)
+          expect(result[:version]).to be_a_guid
+          expect(result[:version]).to eq(process.version)
           expect(result[:instances]).to eq(3)
           expect(result[:memory_in_mb]).to eq(42)
           expect(result[:disk_in_mb]).to eq(37)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

> Expose process versions on the v3 API.

* An explanation of the use cases your change solves

> Process versions were already exposed on the v2 API in various places (e.g. [`GET /v2/apps`](https://apidocs.cloudfoundry.org/16.22.0/apps/retrieve_a_particular_app.html). We did not bring this field over to v3. 
> 
> I've historically been opposed to exposing process versions in v3, because they feel like an internal implementation detail of how CC and Diego stay in sync with eachother. That said, process versions are occasionally useful when locating LRPs in diego or debugging issues with the CAPI sync job. I've found myself using the v2 API to get process versions, which has demonstrated the value of bringing this forward to the v3 API.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
