### PR TITLE
Allow use of different rootfs images for building and running

### DIFF
--- a/app/models/runtime/stack.rb
+++ b/app/models/runtime/stack.rb
@@ -25,8 +25,8 @@ module VCAP::CloudController
 
     plugin :serialization
 
-    export_attributes :name, :description
-    import_attributes :name, :description
+    export_attributes :name, :description, :build_rootfs_image, :run_rootfs_image
+    import_attributes :name, :description, :build_rootfs_image, :run_rootfs_image
 
     strip_attributes :name
 
@@ -45,6 +45,14 @@ module VCAP::CloudController
       self == Stack.default
     rescue MissingDefaultStackError
       false
+    end
+
+    def build_rootfs_image
+      super || self.name
+    end
+
+    def run_rootfs_image
+      super || self.name
     end
 
     def self.configure(file_path)
@@ -83,7 +91,7 @@ module VCAP::CloudController
           Steno.logger('cc.stack').warn('stack.populate.collision', hash)
         end
       else
-        create(hash.slice('name', 'description'))
+        create(hash.slice('name', 'description', 'build_rootfs_image', 'run_rootfs_image'))
       end
     end
 
@@ -108,6 +116,8 @@ module VCAP::CloudController
           'stacks'  => [{
             'name'        => String,
             'description' => String,
+            optional('build_rootfs_image') => String,
+            optional('run_rootfs_image') => String,
           }]
         }
       end

--- a/db/migrations/20230622194039_add_build_and_run_rootfs_images_to_stack.rb
+++ b/db/migrations/20230622194039_add_build_and_run_rootfs_images_to_stack.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  up do
+    alter_table :stacks do
+      add_column :build_rootfs_image, String, size: 255
+      add_column :run_rootfs_image, String, size: 255
+    end
+  end
+
+  down do
+    alter_table :stacks do
+      drop_column :build_rootfs_image
+      drop_column :run_rootfs_image
+    end
+  end
+end

--- a/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/desired_lrp_builder.rb
@@ -38,7 +38,10 @@ module VCAP::CloudController
         end
 
         def root_fs
-          "preloaded:#{@stack}"
+          @stack_obj ||= Stack.find(name: @stack)
+          raise CloudController::Errors::ApiError.new_from_details('StackNotFound', @stack) unless @stack_obj
+
+          "preloaded:#{@stack_obj.run_rootfs_image}"
         end
 
         def setup

--- a/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
@@ -122,7 +122,10 @@ module VCAP::CloudController
         end
 
         def stack
-          "preloaded:#{lifecycle_data[:stack]}"
+          @stack ||= Stack.find(name: lifecycle_stack)
+          raise CloudController::Errors::ApiError.new_from_details('StackNotFound', lifecycle_stack) unless @stack
+
+          "preloaded:#{@stack.build_rootfs_image}"
         end
 
         def lifecycle_stack

--- a/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
@@ -122,7 +122,7 @@ module VCAP::CloudController
         end
 
         def stack
-          lifecycle_data[:stack]
+          "preloaded:#{lifecycle_data[:stack]}"
         end
 
         def lifecycle_stack

--- a/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
@@ -37,7 +37,7 @@ module VCAP::CloudController
 
           layers = [
             ::Diego::Bbs::Models::ImageLayer.new(
-              name:              "buildpack-#{stack}-lifecycle",
+              name:              "buildpack-#{lifecycle_stack}-lifecycle",
               url:               LifecycleBundleUriGenerator.uri(config.get(:diego, :lifecycle_bundles)[lifecycle_bundle_key]),
               destination_path:  '/tmp/lifecycle',
               layer_type:        ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
@@ -97,7 +97,7 @@ module VCAP::CloudController
             ::Diego::Bbs::Models::CachedDependency.new(
               from:      LifecycleBundleUriGenerator.uri(config.get(:diego, :lifecycle_bundles)[lifecycle_bundle_key]),
               to:        '/tmp/lifecycle',
-              cache_key: "buildpack-#{stack}-lifecycle",
+              cache_key: "buildpack-#{lifecycle_stack}-lifecycle",
             )
           ]
 
@@ -122,6 +122,10 @@ module VCAP::CloudController
         end
 
         def stack
+          lifecycle_data[:stack]
+        end
+
+        def lifecycle_stack
           lifecycle_data[:stack]
         end
 

--- a/lib/cloud_controller/diego/buildpack/task_action_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/task_action_builder.rb
@@ -87,7 +87,10 @@ module VCAP::CloudController
         end
 
         def stack
-          "preloaded:#{lifecycle_stack}"
+          @stack ||= Stack.find(name: lifecycle_stack)
+          raise CloudController::Errors::ApiError.new_from_details('StackNotFound', lifecycle_stack) unless @stack
+
+          "preloaded:#{@stack.run_rootfs_image}"
         end
 
         def cached_dependencies

--- a/lib/cloud_controller/diego/buildpack/task_action_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/task_action_builder.rb
@@ -13,7 +13,6 @@ module VCAP::CloudController
           @config = config
           @task = task
           @lifecycle_data = lifecycle_data
-          @stack = lifecycle_data[:stack]
         end
 
         def action
@@ -55,8 +54,8 @@ module VCAP::CloudController
         def image_layers
           return [] unless @config.get(:diego, :enable_declarative_asset_downloads)
 
-          destination = @config.get(:diego, :droplet_destinations)[@stack.to_sym]
-          raise InvalidStack.new("no droplet destination defined for requested stack '#{@stack}'") unless destination
+          destination = @config.get(:diego, :droplet_destinations)[lifecycle_stack.to_sym]
+          raise InvalidStack.new("no droplet destination defined for requested stack '#{lifecycle_stack}'") unless destination
 
           layers = [
             ::Diego::Bbs::Models::ImageLayer.new(

--- a/lib/cloud_controller/diego/docker/staging_action_builder.rb
+++ b/lib/cloud_controller/diego/docker/staging_action_builder.rb
@@ -68,7 +68,7 @@ module VCAP::CloudController
         end
 
         def stack
-          config.get(:diego, :docker_staging_stack)
+          "preloaded:#{config.get(:diego, :docker_staging_stack)}"
         end
 
         def task_environment_variables; end

--- a/lib/cloud_controller/diego/task_recipe_builder.rb
+++ b/lib/cloud_controller/diego/task_recipe_builder.rb
@@ -70,7 +70,7 @@ module VCAP::CloudController
           privileged:                       config.get(:diego, :use_privileged_containers_for_staging),
           result_file:                      STAGING_RESULT_FILE,
           trusted_system_certificates_path: STAGING_TRUSTED_SYSTEM_CERT_PATH,
-          root_fs:                          "preloaded:#{action_builder.stack}",
+          root_fs:                          action_builder.stack,
           action:                           timeout(action_builder.action, timeout_ms: config.get(:staging, :timeout_in_seconds).to_i * 1000),
           environment_variables:            action_builder.task_environment_variables,
           legacy_download_user:             LEGACY_DOWNLOAD_USER,

--- a/spec/fixtures/config/stacks_include_build_run.yml
+++ b/spec/fixtures/config/stacks_include_build_run.yml
@@ -1,0 +1,16 @@
+default: "default-stack-name"
+
+stacks:
+  - name: "cflinuxfs4"
+    description: "cflinuxfs4"
+  - name: "default-stack-name"
+    description: "default-stack-description"
+  - name: "cider"
+    description: "cider-description"
+    build_rootfs_image: "cider-build"
+    run_rootfs_image: "cider-run"
+  - name: "separate-build-run-images"
+    description: "A stack that has different rootfs images for building and running apps"
+    build_rootfs_image: "build"
+    run_rootfs_image: "run"
+

--- a/spec/request/v2/apps_spec.rb
+++ b/spec/request/v2/apps_spec.rb
@@ -290,7 +290,9 @@ RSpec.describe 'Apps' do
                   },
                   'entity' => {
                     'name'        => process.stack.name,
-                    'description' => process.stack.description
+                    'description' => process.stack.description,
+                    'build_rootfs_image' => process.stack.name,
+                    'run_rootfs_image' => process.stack.name,
                   }
                 },
                 'routes_url'                 => "/v2/apps/#{process.guid}/routes",

--- a/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/desired_lrp_builder_spec.rb
@@ -216,7 +216,7 @@ module VCAP::CloudController
                 )
               end
 
-              context 'when searching for a lifecycle associated with a nonexistant stack' do
+              context "when searching for a lifecycle associated with a stack that is not configured in the Cloud Controller's lifecycle_bundles config" do
                 let(:lifecycle_bundles) do
                   { "hot-potato": '/path/to/lifecycle.tgz' }
                 end
@@ -227,7 +227,7 @@ module VCAP::CloudController
                 end
               end
 
-              context 'when searching for a droplet destination associated with a nonexistant stack' do
+              context "when searching for a droplet destination associated with a stack that is not configured in the Cloud Controller's droplet_destinations config" do
                 let(:droplet_destinations) do
                   { "hot-potato": '/value/from/config/based/on/stack' }
                 end

--- a/spec/unit/lib/cloud_controller/diego/buildpack/staging_action_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/staging_action_builder_spec.rb
@@ -577,7 +577,7 @@ module VCAP::CloudController
 
         describe '#stack' do
           it 'returns the stack' do
-            expect(builder.stack).to eq('buildpack-stack')
+            expect(builder.stack).to eq('preloaded:buildpack-stack')
           end
         end
 

--- a/spec/unit/lib/cloud_controller/diego/buildpack/staging_action_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/staging_action_builder_spec.rb
@@ -32,6 +32,7 @@ module VCAP::CloudController
           end
         end
         let(:env) { double(:env) }
+        let(:stack) { 'buildpack-stack' }
         let(:lifecycle_data) do
           {
             app_bits_download_uri:              'http://app_bits_download_uri.example.com/path/to/bits',
@@ -39,7 +40,7 @@ module VCAP::CloudController
             build_artifacts_cache_upload_uri:   'http://build_artifacts_cache_upload_uri.example.com/path/to/bits',
             buildpacks:                         buildpacks,
             droplet_upload_uri:                 'http://droplet_upload_uri.example.com/path/to/bits',
-            stack:                              'buildpack-stack',
+            stack:                              stack,
             buildpack_cache_checksum:           'bp-cache-checksum',
             app_bits_checksum:                  { type: 'sha256', value: 'package-checksum' },
           }
@@ -51,6 +52,8 @@ module VCAP::CloudController
           allow(LifecycleBundleUriGenerator).to receive(:uri).with('the-buildpack-bundle').and_return('generated-uri')
           allow(BbsEnvironmentBuilder).to receive(:build).with(env).and_return(generated_environment)
           TestConfig.override(credhub_api: nil)
+
+          Stack.create(name: 'buildpack-stack')
         end
 
         describe '#action' do
@@ -576,8 +579,30 @@ module VCAP::CloudController
         end
 
         describe '#stack' do
+          before do
+            Stack.create(name: 'separate-build-and-run', run_rootfs_image: 'run-image', build_rootfs_image: 'build-image')
+          end
+
           it 'returns the stack' do
             expect(builder.stack).to eq('preloaded:buildpack-stack')
+          end
+
+          context 'when the stack does not exist' do
+            let(:stack) { 'does-not-exist' }
+
+            it 'raises an error' do
+              expect {
+                builder.stack
+              }.to raise_error CloudController::Errors::ApiError, /The stack could not be found/
+            end
+          end
+
+          context 'when the stack has separate build and run rootfs images' do
+            let(:stack) { 'separate-build-and-run' }
+
+            it 'returns the build rootfs image' do
+              expect(builder.stack).to eq('preloaded:build-image')
+            end
           end
         end
 

--- a/spec/unit/lib/cloud_controller/diego/buildpack/task_action_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/task_action_builder_spec.rb
@@ -235,8 +235,30 @@ module VCAP::CloudController
         end
 
         describe '#stack' do
+          before do
+            Stack.create(name: 'potato-stack')
+            Stack.create(name: 'separate-build-and-run', run_rootfs_image: 'run-image', build_rootfs_image: 'build-image')
+          end
+
           it 'returns the stack' do
             expect(builder.stack).to eq('preloaded:potato-stack')
+          end
+
+          context 'when the stack does not exist in the database' do
+            let(:stack) { 'does-not-exist' }
+            it 'raises an error' do
+              expect {
+                builder.stack
+              }.to raise_error CloudController::Errors::ApiError, /The stack could not be found/
+            end
+          end
+
+          context 'when the stack has separate build and run rootfs images' do
+            let(:stack) { 'separate-build-and-run' }
+
+            it 'returns the run image name' do
+              expect(builder.stack).to eq('preloaded:run-image')
+            end
           end
         end
 

--- a/spec/unit/lib/cloud_controller/diego/docker/staging_action_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/staging_action_builder_spec.rb
@@ -133,7 +133,7 @@ module VCAP::CloudController
 
         describe '#stack' do
           it 'returns the configured docker_staging_stack' do
-            expect(builder.stack).to eq('docker-staging-stack')
+            expect(builder.stack).to eq('preloaded:docker-staging-stack')
           end
         end
 

--- a/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
@@ -124,7 +124,7 @@ module VCAP::CloudController
           let(:lifecycle_action_builder) do
             instance_double(
               Buildpack::StagingActionBuilder,
-              stack: 'potato-stack',
+              stack: 'preloaded:potato-stack',
               action: buildpack_staging_action,
               task_environment_variables: lifecycle_environment_variables,
               cached_dependencies: lifecycle_cached_dependencies,
@@ -211,7 +211,7 @@ module VCAP::CloudController
           let(:lifecycle_action_builder) do
             instance_double(
               Docker::StagingActionBuilder,
-              stack: 'docker-stack',
+              stack: 'preloaded:docker-stack',
               action: docker_staging_action,
               task_environment_variables: lifecycle_environment_variables,
               cached_dependencies: lifecycle_cached_dependencies,


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* **A short explanation of the proposed change**:
  This change allows operators to configure CAPI with stacks that have different rootfs images for building and running applications.

cc @geofffranks 

  Implementation details:
  - Adds `build_rootfs_image` and `run_rootfs_image` fields to the `stacks` table. These fields are allowed to be null.
  - Uses `build_rootfs_image` for staging requests to Diego. If null, CAPI falls back to the stack name to maintain backwards compatibility.
  - Uses `run_rootfs_image` for task and desired LRP requests to Diego. If null, CAPI falls back to the stack name to maintain backwards compatibility.
  - Includes some refactors for clarity and consistency across these three workflows (staging, tasks, and desired LRPs).

* **An explanation of the use cases your change solves**:
  The primary use case for the changes is to start incorporating CNB-style stacks, many (perhaps all?) of which include [separate images for building and running](https://github.com/paketo-buildpacks/jammy-base-stack/tree/main/stack) applications. One considerable upside is that many build-time dependencies, such as `gcc`, can be removed from the runtime stack as they are needed only to build (and not run) the application. This also improves the security posture of applications because the run-time stack has fewer dependencies.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
