### PR TITLE
Add validation for resource match mode

### DIFF
--- a/app/messages/resource_match_create_message.rb
+++ b/app/messages/resource_match_create_message.rb
@@ -22,53 +22,71 @@ module VCAP::CloudController
 
     private
 
+    PERMISSIONS_REGEX = /^[0-7]{3,4}$/
+
     def each_resource
       if resources.is_a?(Array)
         resources.each do |r|
           checksum_validator(r[:checksum])
           size_validator(r[:size_in_bytes])
+          mode_validator(r[:mode])
         end
       end
     end
 
-    RESOURCE_ERROR_PREAMBLE = 'array contains at least one resource with a'.freeze
+    RESOURCE_ERROR_PREAMBLE = 'array contains at least one resource with'.freeze
 
     def checksum_validator(checksum)
       unless checksum.is_a?(Hash)
-        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} non-object checksum") unless errors.added?(
-          :resources, "#{RESOURCE_ERROR_PREAMBLE} non-object checksum"
+        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} a non-object checksum") unless errors.added?(
+          :resources, "#{RESOURCE_ERROR_PREAMBLE} a non-object checksum"
         )
         return
       end
 
       unless checksum[:value].is_a?(String)
-        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} non-string checksum value") unless errors.added?(
-          :resources, "#{RESOURCE_ERROR_PREAMBLE} non-string checksum value"
+        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} a non-string checksum value") unless errors.added?(
+          :resources, "#{RESOURCE_ERROR_PREAMBLE} a non-string checksum value"
         )
         return
       end
 
       unless valid_sha1?(checksum[:value])
-        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} non-SHA1 checksum value") unless errors.added?(
-          :resources, "#{RESOURCE_ERROR_PREAMBLE} non-SHA1 checksum value"
+        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} a non-SHA1 checksum value") unless errors.added?(
+          :resources, "#{RESOURCE_ERROR_PREAMBLE} a non-SHA1 checksum value"
         )
-        return
       end
     end
 
     def size_validator(size)
       unless size.is_a?(Integer)
-        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} non-integer size_in_bytes") unless errors.added?(
-          :resources, "#{RESOURCE_ERROR_PREAMBLE} non-integer size_in_bytes"
+        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} a non-integer size_in_bytes") unless errors.added?(
+          :resources, "#{RESOURCE_ERROR_PREAMBLE} a non-integer size_in_bytes"
         )
         return
       end
 
       unless size >= 0
-        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} negative size_in_bytes") unless errors.added?(
-          :resources, "#{RESOURCE_ERROR_PREAMBLE} negative size_in_bytes"
+        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} a negative size_in_bytes") unless errors.added?(
+          :resources, "#{RESOURCE_ERROR_PREAMBLE} a negative size_in_bytes"
+        )
+      end
+    end
+
+    def mode_validator(mode)
+      return if mode.nil?
+
+      unless mode.is_a?(String)
+        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} a non-string mode") unless errors.added?(
+          :resources, "#{RESOURCE_ERROR_PREAMBLE} a non-string mode"
         )
         return
+      end
+
+      unless PERMISSIONS_REGEX.match?(mode)
+        errors.add(:resources, "#{RESOURCE_ERROR_PREAMBLE} an incorrect mode") unless errors.added?(
+          :resources, "#{RESOURCE_ERROR_PREAMBLE} an incorrect mode"
+        )
       end
     end
 

--- a/spec/unit/messages/resource_match_create_message_spec.rb
+++ b/spec/unit/messages/resource_match_create_message_spec.rb
@@ -166,6 +166,44 @@ RSpec.describe VCAP::CloudController::ResourceMatchCreateMessage do
         end
       end
 
+      context 'when the v3 mode is not a string' do
+        let(:params) do
+          {
+            resources: [
+              {
+                checksum: { value: '002d760bea1be268e27077412e11a320d0f164d3' },
+                size_in_bytes: 36,
+                mode: 123
+              }
+            ]
+          }
+        end
+
+        it 'has the correct error message' do
+          expect(subject).to be_invalid
+          expect(subject.errors[:resources]).to include('array contains at least one resource with a non-string mode')
+        end
+      end
+
+      context 'when the v3 mode is not a POSIX file permissions string' do
+        let(:params) do
+          {
+            resources: [
+              {
+                checksum: { value: '002d760bea1be268e27077412e11a320d0f164d3' },
+                size_in_bytes: 36,
+                mode: '9876'
+              }
+            ]
+          }
+        end
+
+        it 'has the correct error message' do
+          expect(subject).to be_invalid
+          expect(subject.errors[:resources]).to include('array contains at least one resource with an incorrect mode')
+        end
+      end
+
       context 'when there are multiple validation violations' do
         let(:params) do
           {


### PR DESCRIPTION
If provided, the `mode` field (resource match object) must be a string. Without this fix a request to `/v3/resource_matches` with
```
  { .. "mode": 644 .. }
```
resulted in an `UnknownError`. Now the error message
```
  "array contains at least one resource with a non-string mode"
```
is returned instead.

Furthermore the format is checked and if the provided value is not a _POSIX file permissions_ string, the following error message is returned:
```
  "array contains at least one resource with an incorrect mode"
```

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
