### PR TITLE
Add linter for syntax errors in the v3 docs examples

### DIFF
--- a/docs/v3/gulpfile.js
+++ b/docs/v3/gulpfile.js
@@ -62,6 +62,21 @@ function checkInternalLinksAndExit(htmlPath) {
   }
 }
 
+function checkSyntaxErrorsAndExit(htmlPath) {
+  const $ = cheerio.load(fs.readFileSync(htmlPath, 'utf8'));
+  const syntaxErrors = $('code .err');
+  if (syntaxErrors.length) {
+    syntaxErrors.each((_index, errorElement) => {
+      console.error('⚠️ v3 docs error: Found syntax error');
+      console.error('👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇')
+      console.error($(errorElement.parentNode).text());
+      console.error('👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆\n')
+    });
+
+    process.exit(1)
+  }
+}
+
 function checkPathAndExit(path, options, done) {
   const app = express();
   app.use(express.static(path));
@@ -102,6 +117,7 @@ gulp.task('default', gulp.series('webserver'));
 
 gulp.task('checkV3docs', gulp.series('build', done => {
   checkInternalLinksAndExit('build/index.html');
+  checkSyntaxErrorsAndExit('build/index.html');
 
   checkPathAndExit('build', {
     checkLinks: true,

--- a/docs/v3/source/includes/concepts/_includes.md.erb
+++ b/docs/v3/source/includes/concepts/_includes.md.erb
@@ -109,7 +109,7 @@ Example response
 {
    "guid": "b90f287b-fcdd-4cbb-9523-1a8dbd2a9837",
    "name": "staticfile",
-   "...": "..."
+   "...": "...",
    "included": {
       "spaces": [
          {

--- a/docs/v3/source/includes/resources/routes/_update_destination.md.erb
+++ b/docs/v3/source/includes/resources/routes/_update_destination.md.erb
@@ -29,8 +29,7 @@ Content-Type: application/json
   },
   "weight": 61,
   "port": 8080,
-  "protocol": "http2"
-    },
+  "protocol": "http2",
   "links": {
     "self": {
       "href": "https://api.example.org/v3/routes/cbad697f-cac1-48f4-9017-ac08f39dfb31/destinations"


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

> The v3 docs highlight syntax errors in examples (e.g. [here](https://v3-apidocs.cloudfoundry.org/version/3.140.0/#update-a-destination-protocol-for-a-route)). This PR adds an additional check to the existing docs linters to detect these errors before they are released.

* An explanation of the use cases your change solves

> This will help prevent basic syntax errors in the docs.

* Links to any other associated PRs

N/A

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
