### PR TITLE
More aggressive cleanup of failed delayed jobs

### DIFF
--- a/app/jobs/runtime/failed_jobs_cleanup.rb
+++ b/app/jobs/runtime/failed_jobs_cleanup.rb
@@ -2,10 +2,11 @@ module VCAP::CloudController
   module Jobs
     module Runtime
       class FailedJobsCleanup < VCAP::CloudController::Jobs::CCJob
-        attr_accessor :cutoff_age_in_days
+        attr_accessor :cutoff_age_in_days, :max_number_of_failed_delayed_jobs
 
-        def initialize(cutoff_age_in_days)
+        def initialize(cutoff_age_in_days:, max_number_of_failed_delayed_jobs: nil)
           @cutoff_age_in_days = cutoff_age_in_days
+          @max_number_of_failed_delayed_jobs = max_number_of_failed_delayed_jobs
         end
 
         def perform
@@ -15,9 +16,25 @@ module VCAP::CloudController
                              where(Sequel.lit("run_at < CURRENT_TIMESTAMP - INTERVAL '?' DAY", cutoff_age_in_days.to_i))
 
           logger = Steno.logger('cc.background')
-          logger.info("Cleaning up #{old_delayed_jobs.count} Failed Delayed Jobs")
+          logger.info("Cleaning up #{old_delayed_jobs.count} old Failed Delayed Jobs")
 
           old_delayed_jobs.delete
+
+          unless max_number_of_failed_delayed_jobs.nil?
+            ids_from_failed_jobs_that_are_too_much = Delayed::Job.
+                                                     where(Sequel.lit('failed_at is not null')).
+                                                     order(Sequel.desc(:id)).
+                                                     offset(max_number_of_failed_delayed_jobs.to_i).
+                                                     # Mysql handles offset differently, therefore using a large
+                                                     # number to mimic unlimited offset
+                                                     limit(1844674407370955161).
+                                                     select(:id)
+
+            logger.info("Cleaning up #{ids_from_failed_jobs_that_are_too_much.count} Failed Delayed Jobs because they exceed max_number_of_failed_delayed_jobs")
+
+            Delayed::Job.where(id: ids_from_failed_jobs_that_are_too_much).delete
+          end
+          logger.info('Cleaning up ')
         end
 
         def job_name_in_configuration

--- a/app/jobs/runtime/pending_build_cleanup.rb
+++ b/app/jobs/runtime/pending_build_cleanup.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
         attr_reader :expiration_in_seconds
 
-        def initialize(expiration_in_seconds)
+        def initialize(expiration_in_seconds:)
           @expiration_in_seconds = expiration_in_seconds
         end
 

--- a/app/jobs/runtime/pending_droplet_cleanup.rb
+++ b/app/jobs/runtime/pending_droplet_cleanup.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
         attr_reader :expiration_in_seconds
 
-        def initialize(expiration_in_seconds)
+        def initialize(expiration_in_seconds:)
           @expiration_in_seconds = expiration_in_seconds
         end
 

--- a/config/bosh-lite.yml
+++ b/config/bosh-lite.yml
@@ -30,6 +30,7 @@ audit_events:
 
 failed_jobs:
   cutoff_age_in_days: 31
+  frequency_in_seconds: 144000 #4h
 
 completed_tasks:
   cutoff_age_in_days: 31

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -46,7 +46,6 @@ audit_events:
 
 failed_jobs:
   cutoff_age_in_days: 31
-  max_number_of_failed_delayed_jobs: 100000
   frequency_in_seconds: 144000 #4h
 
 completed_tasks:

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -46,6 +46,8 @@ audit_events:
 
 failed_jobs:
   cutoff_age_in_days: 31
+  max_number_of_failed_delayed_jobs: 100000
+  frequency_in_seconds: 144000 #4h
 
 completed_tasks:
   cutoff_age_in_days: 31

--- a/lib/cloud_controller/config_schemas/base/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/clock_schema.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
             },
             failed_jobs: {
               cutoff_age_in_days: Integer,
-              max_number_of_failed_delayed_jobs: Integer,
+              optional(:max_number_of_failed_delayed_jobs) => Integer,
               frequency_in_seconds: Integer,
             },
             completed_tasks: {

--- a/lib/cloud_controller/config_schemas/base/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/clock_schema.rb
@@ -22,7 +22,9 @@ module VCAP::CloudController
               cutoff_age_in_days: Integer
             },
             failed_jobs: {
-              cutoff_age_in_days: Integer
+              cutoff_age_in_days: Integer,
+              max_number_of_failed_delayed_jobs: Integer,
+              frequency_in_seconds: Integer,
             },
             completed_tasks: {
               cutoff_age_in_days: Integer

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -36,7 +36,6 @@ audit_events:
 
 failed_jobs:
   cutoff_age_in_days: 31
-  max_number_of_failed_delayed_jobs: 100000
   frequency_in_seconds: 144000 #4h
 
 completed_tasks:

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -36,6 +36,8 @@ audit_events:
 
 failed_jobs:
   cutoff_age_in_days: 31
+  max_number_of_failed_delayed_jobs: 100000
+  frequency_in_seconds: 144000 #4h
 
 completed_tasks:
   cutoff_age_in_days: 31

--- a/spec/unit/jobs/runtime/failed_jobs_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/failed_jobs_cleanup_spec.rb
@@ -23,10 +23,9 @@ module VCAP::CloudController
     end
 
     RSpec.describe FailedJobsCleanup, job_context: :worker do
-      let(:cutoff_age_in_days) { 2 }
       let(:worker) { Delayed::Worker.new }
 
-      subject(:cleanup_job) { FailedJobsCleanup.new(cutoff_age_in_days) }
+      subject(:cleanup_job) { FailedJobsCleanup.new(cutoff_age_in_days: 2, max_number_of_failed_delayed_jobs: 2) }
 
       it { is_expected.to be_a_valid_job }
 
@@ -73,6 +72,29 @@ module VCAP::CloudController
               }.to change {
                 Delayed::Job.find(id: @delayed_job.id)
               }.from(@delayed_job).to(nil)
+            end
+          end
+          context 'when the number of delayed jobs exceeds max_number_of_failed_delayed_jobs' do
+            let(:run_at) { Time.now.utc }
+            let(:the_job) { FailingJob.new }
+            let(:the_job2) { SuccessJob.new }
+
+            it 'removes the exceeding jobs' do
+              Delayed::Worker.destroy_failed_jobs = false
+              @delayed_job2 = Delayed::Job.enqueue(the_job, run_at: run_at, queue: worker.name, created_at: (Time.now.utc - 1.day))
+              @delayed_job3 = Delayed::Job.enqueue(the_job, run_at: run_at, queue: worker.name, created_at: (Time.now.utc - 1.day))
+              @delayed_job4 = Delayed::Job.enqueue(the_job, run_at: run_at, queue: worker.name, created_at: (Time.now.utc - 1.day))
+              @delayed_job5 = Delayed::Job.enqueue(the_job2, run_at: run_at, queue: worker.name, created_at: (Time.now.utc - 1.day))
+              @delayed_job6 = Delayed::Job.enqueue(the_job2, run_at: run_at, queue: worker.name, created_at: (Time.now.utc - 1.day))
+              worker.work_off 5
+
+              expect {
+                cleanup_job.perform
+              }.to change {
+                Delayed::Job.count
+              }.by(-2)
+              expect(Delayed::Job.find(id: @delayed_job.id)).to be_nil
+              expect(Delayed::Job.find(id: @delayed_job2.id)).to be_nil
             end
           end
         end

--- a/spec/unit/jobs/runtime/pending_build_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/pending_build_cleanup_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module VCAP::CloudController
   module Jobs::Runtime
     RSpec.describe PendingBuildCleanup, job_context: :worker do
-      subject(:cleanup_job) { PendingBuildCleanup.new(staging_timeout) }
+      subject(:cleanup_job) { PendingBuildCleanup.new(expiration_in_seconds: 15.minutes.to_i) }
       let(:staging_timeout) { 15.minutes.to_i }
 
       it { is_expected.to be_a_valid_job }

--- a/spec/unit/jobs/runtime/pending_droplet_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/pending_droplet_cleanup_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module VCAP::CloudController
   module Jobs::Runtime
     RSpec.describe PendingDropletCleanup, job_context: :worker do
-      subject(:cleanup_job) { PendingDropletCleanup.new(staging_timeout) }
+      subject(:cleanup_job) { PendingDropletCleanup.new(expiration_in_seconds: 15.minutes.to_i) }
       let(:staging_timeout) { 15.minutes.to_i }
 
       it { is_expected.to be_a_valid_job }

--- a/spec/unit/lib/cloud_controller/clock/scheduler_spec.rb
+++ b/spec/unit/lib/cloud_controller/clock/scheduler_spec.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
           },
           app_usage_events: { cutoff_age_in_days: 1, },
           audit_events: { cutoff_age_in_days: 3, },
-          failed_jobs: { cutoff_age_in_days: 4, },
+          failed_jobs: { frequency_in_seconds: 400, cutoff_age_in_days: 4, max_number_of_failed_delayed_jobs: 10 },
           service_usage_events: { cutoff_age_in_days: 5, },
           completed_tasks: { cutoff_age_in_days: 6, },
           pending_droplets: { frequency_in_seconds: 300, expiration_in_seconds: 600 },
@@ -67,12 +67,6 @@ module VCAP::CloudController
           expect(args).to eql(name: 'audit_events', at: '20:00', priority: 0)
           expect(Jobs::Runtime::EventsCleanup).to receive(:new).with(3).and_call_original
           expect(block.call).to be_instance_of(Jobs::Runtime::EventsCleanup)
-        end
-
-        expect(clock).to receive(:schedule_daily_job) do |args, &block|
-          expect(args).to eql(name: 'failed_jobs', at: '21:00', priority: 0)
-          expect(Jobs::Runtime::FailedJobsCleanup).to receive(:new).with(4).and_call_original
-          expect(block.call).to be_instance_of(Jobs::Runtime::FailedJobsCleanup)
         end
 
         expect(clock).to receive(:schedule_daily_job) do |args, &block|
@@ -143,14 +137,20 @@ module VCAP::CloudController
         allow(clock).to receive(:schedule_frequent_inline_job)
         expect(clock).to receive(:schedule_frequent_worker_job) do |args, &block|
           expect(args).to eql(name: 'pending_droplets', interval: 300)
-          expect(Jobs::Runtime::PendingDropletCleanup).to receive(:new).with(600).and_call_original
+          expect(Jobs::Runtime::PendingDropletCleanup).to receive(:new).with(expiration_in_seconds: 600).and_call_original
           expect(block.call).to be_instance_of(Jobs::Runtime::PendingDropletCleanup)
         end
 
         expect(clock).to receive(:schedule_frequent_worker_job) do |args, &block|
           expect(args).to eql(name: 'pending_builds', interval: 400)
-          expect(Jobs::Runtime::PendingBuildCleanup).to receive(:new).with(700).and_call_original
+          expect(Jobs::Runtime::PendingBuildCleanup).to receive(:new).with(expiration_in_seconds: 700).and_call_original
           expect(block.call).to be_instance_of(Jobs::Runtime::PendingBuildCleanup)
+        end
+
+        expect(clock).to receive(:schedule_frequent_worker_job) do |args, &block|
+          expect(args).to eql(name: 'failed_jobs', interval: 400)
+          expect(Jobs::Runtime::FailedJobsCleanup).to receive(:new).with(cutoff_age_in_days: 4, max_number_of_failed_delayed_jobs: 10).and_call_original
+          expect(block.call).to be_instance_of(Jobs::Runtime::FailedJobsCleanup)
         end
 
         schedule.start


### PR DESCRIPTION
The idea was to have an additional absolute limit of failed jobs so that they get deleted even before the 14d failed_jobs.cutoff_age_in_days. The limit should be configurable.

Therefore we implement a new parameter for maximum number of failed delayed_jobs that should be in the delayed_jobs table. If the number gets exceeded, entries will be deleted keeping the ones with the higher ids. The failed_jobs cleanup job will now run more often than once per day.

Currently, failed delayed_jobs are deleted after 14d (configurable) to keep some info about failed jobs that helps debugging: https://github.com/cloudfoundry/cloud_controller_ng/blob/main/app/jobs/runtime/failed_jobs_cleanup.rb. 
This can still lead to very large number of delayed_jobs records that slow down DB queries working on delayed_jobs (also addressed by an index, ccng #3324).

Related to https://github.com/cloudfoundry/capi-release/pull/328

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
