### PR TITLE
Remove v3/docs from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,18 +6,6 @@ updates:
     interval: daily
     time: '11:00'
   open-pull-requests-limit: 100
-- package-ecosystem: bundler
-  directory: "/docs/v3"
-  schedule:
-    interval: daily
-    time: '11:00'
-  open-pull-requests-limit: 10
-- package-ecosystem: npm
-  directory: "/docs/v3"
-  schedule:
-    interval: daily
-    time: '11:00'
-  open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
These bumps generally just create noise