### PR TITLE
Limit max pagination depth

### DIFF
--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -450,6 +450,7 @@ module VCAP::CloudController
           max_results_per_page: config.get(:renderer, :max_results_per_page),
           default_results_per_page: config.get(:renderer, :default_results_per_page),
           max_inline_relations_depth: config.get(:renderer, :max_inline_relations_depth),
+          pagination_limit: config.get(:renderer, :pagination_limit)
         })
     end
 

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -450,7 +450,7 @@ module VCAP::CloudController
           max_results_per_page: config.get(:renderer, :max_results_per_page),
           default_results_per_page: config.get(:renderer, :default_results_per_page),
           max_inline_relations_depth: config.get(:renderer, :max_inline_relations_depth),
-          pagination_depth_limit: config.get(:renderer, :pagination_depth_limit)
+          max_total_results: config.get(:renderer, :max_total_results)
         })
     end
 

--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -450,7 +450,7 @@ module VCAP::CloudController
           max_results_per_page: config.get(:renderer, :max_results_per_page),
           default_results_per_page: config.get(:renderer, :default_results_per_page),
           max_inline_relations_depth: config.get(:renderer, :max_inline_relations_depth),
-          pagination_limit: config.get(:renderer, :pagination_limit)
+          pagination_depth_limit: config.get(:renderer, :pagination_depth_limit)
         })
     end
 

--- a/app/messages/list_message.rb
+++ b/app/messages/list_message.rb
@@ -68,8 +68,9 @@ module VCAP::CloudController
       end
 
       def validate_maximum_result(page, per_page, record)
-        if (page || PaginationOptions::PAGE_DEFAULT).to_i * (per_page || PaginationOptions::PER_PAGE_DEFAULT).to_i > 9223372036854775807
-          record.errors.add(:maximum_result, '(page * per_page) must be less than 9223372036854775807')
+        maximum_result = VCAP::CloudController::Config.config.get(:renderer, :pagination_depth_limit) || 9223372036854775807
+        if (page || PaginationOptions::PAGE_DEFAULT).to_i * (per_page || PaginationOptions::PER_PAGE_DEFAULT).to_i > maximum_result
+          record.errors.add(:maximum_result, "(page * per_page) must be less than #{maximum_result}")
         end
       end
     end

--- a/app/messages/list_message.rb
+++ b/app/messages/list_message.rb
@@ -68,7 +68,7 @@ module VCAP::CloudController
       end
 
       def validate_maximum_result(page, per_page, record)
-        maximum_result = VCAP::CloudController::Config.config.get(:renderer, :pagination_depth_limit) || 9223372036854775807
+        maximum_result = VCAP::CloudController::Config.config.get(:renderer, :max_total_results) || 9223372036854775807
         if (page || PaginationOptions::PAGE_DEFAULT).to_i * (per_page || PaginationOptions::PER_PAGE_DEFAULT).to_i > maximum_result
           record.errors.add(:maximum_result, "(page * per_page) must be less than #{maximum_result}")
         end

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -1329,11 +1329,6 @@
   http_code: 422
   message: "Cannot stop the app while it is deploying, please cancel the deployment before stopping the app."
 
-390025:
-  name: PaginationLimitExceeded
-  http_code: 422
-  message: "You've requested too many pages. You can't ask for resources with an index greater than %s (equal to the number of pages per request times the page number). Please limit your request to return fewer results."
-
 400001:
   name: KubernetesRouteResourceError
   http_code: 422

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -1329,6 +1329,11 @@
   http_code: 422
   message: "Cannot stop the app while it is deploying, please cancel the deployment before stopping the app."
 
+390025:
+  name: PaginationLimitExceeded
+  http_code: 422
+  message: "You've requested too many pages. You can't ask for resources with an index greater than %s (equal to the number of pages per request times the page number). Please limit your request to return fewer results."
+
 400001:
   name: KubernetesRouteResourceError
   http_code: 422

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -211,6 +211,7 @@ module VCAP::CloudController
               max_results_per_page: Integer,
               default_results_per_page: Integer,
               max_inline_relations_depth: Integer,
+              optional(:pagination_limit) => Integer,
             },
 
             logcache: {

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -211,7 +211,7 @@ module VCAP::CloudController
               max_results_per_page: Integer,
               default_results_per_page: Integer,
               max_inline_relations_depth: Integer,
-              optional(:pagination_depth_limit) => Integer,
+              optional(:max_total_results) => Integer,
             },
 
             logcache: {

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -211,7 +211,7 @@ module VCAP::CloudController
               max_results_per_page: Integer,
               default_results_per_page: Integer,
               max_inline_relations_depth: Integer,
-              optional(:pagination_limit) => Integer,
+              optional(:pagination_depth_limit) => Integer,
             },
 
             logcache: {

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -506,7 +506,7 @@ module CloudController
       eager_loader = opts[:eager_loader] || VCAP::CloudController::RestController::SecureEagerLoader.new
       serializer = opts[:serializer] || VCAP::CloudController::RestController::PreloadedObjectSerializer.new
       max_results_per_page = opts[:max_results_per_page] || config.get(:renderer, :max_results_per_page)
-      pagination_depth_limit = opts[:pagination_depth_limit] || config.get(:renderer, :pagination_depth_limit)
+      max_total_results = opts[:max_total_results] || config.get(:renderer, :max_total_results)
       default_results_per_page = opts[:default_results_per_page] || config.get(:renderer, :default_results_per_page)
       max_inline_relations_depth = opts[:max_inline_relations_depth] || config.get(:renderer, :max_inline_relations_depth)
       collection_transformer = opts[:collection_transformer]
@@ -516,7 +516,7 @@ module CloudController
         default_results_per_page: default_results_per_page,
         max_inline_relations_depth: max_inline_relations_depth,
         collection_transformer: collection_transformer,
-        pagination_depth_limit: pagination_depth_limit
+        max_total_results: max_total_results
       })
     end
   end

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -506,7 +506,7 @@ module CloudController
       eager_loader = opts[:eager_loader] || VCAP::CloudController::RestController::SecureEagerLoader.new
       serializer = opts[:serializer] || VCAP::CloudController::RestController::PreloadedObjectSerializer.new
       max_results_per_page = opts[:max_results_per_page] || config.get(:renderer, :max_results_per_page)
-      pagination_limit = opts[:pagination_limit] || config.get(:renderer, :pagination_limit)
+      pagination_depth_limit = opts[:pagination_depth_limit] || config.get(:renderer, :pagination_depth_limit)
       default_results_per_page = opts[:default_results_per_page] || config.get(:renderer, :default_results_per_page)
       max_inline_relations_depth = opts[:max_inline_relations_depth] || config.get(:renderer, :max_inline_relations_depth)
       collection_transformer = opts[:collection_transformer]
@@ -516,7 +516,7 @@ module CloudController
         default_results_per_page: default_results_per_page,
         max_inline_relations_depth: max_inline_relations_depth,
         collection_transformer: collection_transformer,
-        pagination_limit: pagination_limit
+        pagination_depth_limit: pagination_depth_limit
       })
     end
   end

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -506,6 +506,7 @@ module CloudController
       eager_loader = opts[:eager_loader] || VCAP::CloudController::RestController::SecureEagerLoader.new
       serializer = opts[:serializer] || VCAP::CloudController::RestController::PreloadedObjectSerializer.new
       max_results_per_page = opts[:max_results_per_page] || config.get(:renderer, :max_results_per_page)
+      pagination_limit = opts[:pagination_limit] || config.get(:renderer, :pagination_limit)
       default_results_per_page = opts[:default_results_per_page] || config.get(:renderer, :default_results_per_page)
       max_inline_relations_depth = opts[:max_inline_relations_depth] || config.get(:renderer, :max_inline_relations_depth)
       collection_transformer = opts[:collection_transformer]
@@ -514,7 +515,8 @@ module CloudController
         max_results_per_page: max_results_per_page,
         default_results_per_page: default_results_per_page,
         max_inline_relations_depth: max_inline_relations_depth,
-        collection_transformer: collection_transformer
+        collection_transformer: collection_transformer,
+        pagination_limit: pagination_limit
       })
     end
   end

--- a/lib/cloud_controller/rest_controller/paginated_collection_renderer.rb
+++ b/lib/cloud_controller/rest_controller/paginated_collection_renderer.rb
@@ -15,7 +15,7 @@ module VCAP::CloudController::RestController
       @max_inline_relations_depth = opts.fetch(:max_inline_relations_depth)
       @default_inline_relations_depth = 0
 
-      @pagination_depth_limit = opts.fetch(:pagination_depth_limit)
+      @max_total_results = opts.fetch(:max_total_results)
 
       @collection_transformer = opts[:collection_transformer]
     end
@@ -87,8 +87,8 @@ module VCAP::CloudController::RestController
         raise CloudController::Errors::ApiError.new_from_details('BadQueryParameter', "results_per_page must be <= #{@max_results_per_page}")
       end
 
-      if !@pagination_depth_limit.nil? && page * page_size > @pagination_depth_limit
-        raise CloudController::Errors::ApiError.new_from_details('BadQueryParameter', "(page * per_page) must be less than #{@pagination_depth_limit}")
+      if !@max_total_results.nil? && page * page_size > @max_total_results
+        raise CloudController::Errors::ApiError.new_from_details('BadQueryParameter', "(page * per_page) must be less than #{@max_total_results}")
       end
 
       if inline_relations_depth > @max_inline_relations_depth

--- a/lib/cloud_controller/rest_controller/paginated_collection_renderer.rb
+++ b/lib/cloud_controller/rest_controller/paginated_collection_renderer.rb
@@ -15,7 +15,7 @@ module VCAP::CloudController::RestController
       @max_inline_relations_depth = opts.fetch(:max_inline_relations_depth)
       @default_inline_relations_depth = 0
 
-      @pagination_limit = opts.fetch(:pagination_limit)
+      @pagination_depth_limit = opts.fetch(:pagination_depth_limit)
 
       @collection_transformer = opts[:collection_transformer]
     end
@@ -87,8 +87,8 @@ module VCAP::CloudController::RestController
         raise CloudController::Errors::ApiError.new_from_details('BadQueryParameter', "results_per_page must be <= #{@max_results_per_page}")
       end
 
-      if !@pagination_limit.nil? && page * page_size > @pagination_limit
-        raise CloudController::Errors::ApiError.new_from_details('PaginationLimitExceeded', @pagination_limit.to_s)
+      if !@pagination_depth_limit.nil? && page * page_size > @pagination_depth_limit
+        raise CloudController::Errors::ApiError.new_from_details('BadQueryParameter', "(page * per_page) must be less than #{@pagination_depth_limit}")
       end
 
       if inline_relations_depth > @max_inline_relations_depth

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -213,6 +213,7 @@ RSpec.describe CloudController::DependencyLocator do
         max_results_per_page: 100_000,
         default_results_per_page: 100_001,
         max_inline_relations_depth: 100_002,
+        pagination_limit: 100_003,
         collection_transformer: nil
       }
 
@@ -244,7 +245,7 @@ RSpec.describe CloudController::DependencyLocator do
       renderer = double('renderer')
       expect(VCAP::CloudController::RestController::PaginatedCollectionRenderer).
         to receive(:new).
-        with(eager_loader, serializer, opts.merge(max_results_per_page: 10_000)).
+        with(eager_loader, serializer, opts.merge(max_results_per_page: 10_000, pagination_limit: nil)).
         and_return(renderer)
 
       expect(locator.large_paginated_collection_renderer).to eq(renderer)

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe CloudController::DependencyLocator do
         max_results_per_page: 100_000,
         default_results_per_page: 100_001,
         max_inline_relations_depth: 100_002,
-        pagination_depth_limit: 100_003,
+        max_total_results: 100_003,
         collection_transformer: nil
       }
 
@@ -245,7 +245,7 @@ RSpec.describe CloudController::DependencyLocator do
       renderer = double('renderer')
       expect(VCAP::CloudController::RestController::PaginatedCollectionRenderer).
         to receive(:new).
-        with(eager_loader, serializer, opts.merge(max_results_per_page: 10_000, pagination_depth_limit: nil)).
+        with(eager_loader, serializer, opts.merge(max_results_per_page: 10_000, max_total_results: nil)).
         and_return(renderer)
 
       expect(locator.large_paginated_collection_renderer).to eq(renderer)

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe CloudController::DependencyLocator do
         max_results_per_page: 100_000,
         default_results_per_page: 100_001,
         max_inline_relations_depth: 100_002,
-        pagination_limit: 100_003,
+        pagination_depth_limit: 100_003,
         collection_transformer: nil
       }
 
@@ -245,7 +245,7 @@ RSpec.describe CloudController::DependencyLocator do
       renderer = double('renderer')
       expect(VCAP::CloudController::RestController::PaginatedCollectionRenderer).
         to receive(:new).
-        with(eager_loader, serializer, opts.merge(max_results_per_page: 10_000, pagination_limit: nil)).
+        with(eager_loader, serializer, opts.merge(max_results_per_page: 10_000, pagination_depth_limit: nil)).
         and_return(renderer)
 
       expect(locator.large_paginated_collection_renderer).to eq(renderer)

--- a/spec/unit/lib/rest_controller/paginated_collection_renderer_spec.rb
+++ b/spec/unit/lib/rest_controller/paginated_collection_renderer_spec.rb
@@ -15,14 +15,14 @@ module VCAP::CloudController::RestController
         max_results_per_page: max_results_per_page,
         max_inline_relations_depth: max_inline_relations_depth,
         collection_transformer: collection_transformer,
-        pagination_limit: pagination_limit
+        pagination_depth_limit: pagination_depth_limit
       }
     end
     let(:default_results_per_page) { 100_000 }
     let(:max_results_per_page) { 100_000 }
     let(:max_inline_relations_depth) { 100_000 }
     let(:collection_transformer) { nil }
-    let(:pagination_limit) { nil }
+    let(:pagination_depth_limit) { nil }
 
     describe '#render_json' do
       let(:opts) do
@@ -33,13 +33,13 @@ module VCAP::CloudController::RestController
             orphan_relations: orphan_relations,
             exclude_relations: exclude_relations,
             include_relations: include_relations,
-            pagination_limit: pagination_limit
+            pagination_depth_limit: pagination_depth_limit
         }
       end
       let(:page) { nil }
       let(:inline_relations_depth) { nil }
       let(:results_per_page) { nil }
-      let(:pagination_limit) { nil }
+      let(:pagination_depth_limit) { nil }
       let(:orphan_relations) { nil }
       let(:exclude_relations) { nil }
       let(:include_relations) { nil }
@@ -113,9 +113,9 @@ module VCAP::CloudController::RestController
         end
       end
 
-      context 'when pagination_limit' do
+      context 'when pagination_depth_limit' do
         context 'is more than the requested resources index(page*max_results_per_page)' do
-          let(:pagination_limit) { 100 }
+          let(:pagination_depth_limit) { 100 }
           let(:opts) do
             {
               results_per_page: 9,
@@ -128,7 +128,7 @@ module VCAP::CloudController::RestController
         end
 
         context 'equals to the requested resources index(page*max_results_per_page)' do
-          let(:pagination_limit) { 100 }
+          let(:pagination_depth_limit) { 100 }
           let(:opts) do
             {
               results_per_page: 10,
@@ -141,7 +141,7 @@ module VCAP::CloudController::RestController
         end
 
         context 'is less than the requested resources index(page*max_results_per_page)' do
-          let(:pagination_limit) { 100 }
+          let(:pagination_depth_limit) { 100 }
           let(:opts) do
             {
               results_per_page: 11,
@@ -149,7 +149,7 @@ module VCAP::CloudController::RestController
             }
           end
           it 'raises ApiError error' do
-            expect { render_json_call }.to raise_error(CloudController::Errors::ApiError, /You can't ask for resources with an index greater than/)
+            expect { render_json_call }.to raise_error(CloudController::Errors::ApiError, 'The query parameter is invalid: (page * per_page) must be less than 100')
           end
         end
       end

--- a/spec/unit/lib/rest_controller/paginated_collection_renderer_spec.rb
+++ b/spec/unit/lib/rest_controller/paginated_collection_renderer_spec.rb
@@ -14,13 +14,15 @@ module VCAP::CloudController::RestController
         default_results_per_page: default_results_per_page,
         max_results_per_page: max_results_per_page,
         max_inline_relations_depth: max_inline_relations_depth,
-        collection_transformer: collection_transformer
+        collection_transformer: collection_transformer,
+        pagination_limit: pagination_limit
       }
     end
     let(:default_results_per_page) { 100_000 }
     let(:max_results_per_page) { 100_000 }
     let(:max_inline_relations_depth) { 100_000 }
     let(:collection_transformer) { nil }
+    let(:pagination_limit) { nil }
 
     describe '#render_json' do
       let(:opts) do
@@ -30,12 +32,14 @@ module VCAP::CloudController::RestController
             inline_relations_depth: inline_relations_depth,
             orphan_relations: orphan_relations,
             exclude_relations: exclude_relations,
-            include_relations: include_relations
+            include_relations: include_relations,
+            pagination_limit: pagination_limit
         }
       end
       let(:page) { nil }
       let(:inline_relations_depth) { nil }
       let(:results_per_page) { nil }
+      let(:pagination_limit) { nil }
       let(:orphan_relations) { nil }
       let(:exclude_relations) { nil }
       let(:include_relations) { nil }
@@ -105,6 +109,47 @@ module VCAP::CloudController::RestController
 
           it 'renders limits number of results to default_results_per_page' do
             expect(JSON.parse(render_json_call)['resources'].size).to eq(1)
+          end
+        end
+      end
+
+      context 'when pagination_limit' do
+        context 'is more than the requested resources index(page*max_results_per_page)' do
+          let(:pagination_limit) { 100 }
+          let(:opts) do
+            {
+              results_per_page: 9,
+              page: 11
+            }
+          end
+          it 'renders json response' do
+            expect(render_json_call).to be_instance_of(String)
+          end
+        end
+
+        context 'equals to the requested resources index(page*max_results_per_page)' do
+          let(:pagination_limit) { 100 }
+          let(:opts) do
+            {
+              results_per_page: 10,
+              page: 10
+            }
+          end
+          it 'renders json response' do
+            expect(render_json_call).to be_instance_of(String)
+          end
+        end
+
+        context 'is less than the requested resources index(page*max_results_per_page)' do
+          let(:pagination_limit) { 100 }
+          let(:opts) do
+            {
+              results_per_page: 11,
+              page: 10
+            }
+          end
+          it 'raises ApiError error' do
+            expect { render_json_call }.to raise_error(CloudController::Errors::ApiError, /You can't ask for resources with an index greater than/)
           end
         end
       end

--- a/spec/unit/lib/rest_controller/paginated_collection_renderer_spec.rb
+++ b/spec/unit/lib/rest_controller/paginated_collection_renderer_spec.rb
@@ -15,14 +15,14 @@ module VCAP::CloudController::RestController
         max_results_per_page: max_results_per_page,
         max_inline_relations_depth: max_inline_relations_depth,
         collection_transformer: collection_transformer,
-        pagination_depth_limit: pagination_depth_limit
+        max_total_results: max_total_results
       }
     end
     let(:default_results_per_page) { 100_000 }
     let(:max_results_per_page) { 100_000 }
     let(:max_inline_relations_depth) { 100_000 }
     let(:collection_transformer) { nil }
-    let(:pagination_depth_limit) { nil }
+    let(:max_total_results) { nil }
 
     describe '#render_json' do
       let(:opts) do
@@ -33,13 +33,13 @@ module VCAP::CloudController::RestController
             orphan_relations: orphan_relations,
             exclude_relations: exclude_relations,
             include_relations: include_relations,
-            pagination_depth_limit: pagination_depth_limit
+            max_total_results: max_total_results
         }
       end
       let(:page) { nil }
       let(:inline_relations_depth) { nil }
       let(:results_per_page) { nil }
-      let(:pagination_depth_limit) { nil }
+      let(:max_total_results) { nil }
       let(:orphan_relations) { nil }
       let(:exclude_relations) { nil }
       let(:include_relations) { nil }
@@ -113,9 +113,9 @@ module VCAP::CloudController::RestController
         end
       end
 
-      context 'when pagination_depth_limit' do
+      context 'when max_total_results' do
         context 'is more than the requested resources index(page*max_results_per_page)' do
-          let(:pagination_depth_limit) { 100 }
+          let(:max_total_results) { 100 }
           let(:opts) do
             {
               results_per_page: 9,
@@ -128,7 +128,7 @@ module VCAP::CloudController::RestController
         end
 
         context 'equals to the requested resources index(page*max_results_per_page)' do
-          let(:pagination_depth_limit) { 100 }
+          let(:max_total_results) { 100 }
           let(:opts) do
             {
               results_per_page: 10,
@@ -141,7 +141,7 @@ module VCAP::CloudController::RestController
         end
 
         context 'is less than the requested resources index(page*max_results_per_page)' do
-          let(:pagination_depth_limit) { 100 }
+          let(:max_total_results) { 100 }
           let(:opts) do
             {
               results_per_page: 11,

--- a/spec/unit/messages/list_message_spec.rb
+++ b/spec/unit/messages/list_message_spec.rb
@@ -65,7 +65,7 @@ module VCAP::CloudController
       end
     end
 
-    describe 'maximum_result with pagination_depth_limit not configured' do
+    describe 'maximum_result with max_total_results not configured' do
       it 'is valid if page and per_page is nil' do
         message = ListMessage.from_params({ page: nil, per_page: nil }, [])
         expect(message).to be_valid
@@ -94,8 +94,8 @@ module VCAP::CloudController
       end
     end
 
-    describe 'maximum_result with pagination_depth_limit set to 10_000' do
-      before { TestConfig.override(renderer: { pagination_depth_limit: 10_000 }) }
+    describe 'maximum_result with max_total_results set to 10_000' do
+      before { TestConfig.override(renderer: { max_total_results: 10_000 }) }
 
       it 'is valid if page and per_page is nil' do
         message = ListMessage.from_params({ page: nil, per_page: nil }, [])

--- a/spec/unit/messages/list_message_spec.rb
+++ b/spec/unit/messages/list_message_spec.rb
@@ -65,7 +65,7 @@ module VCAP::CloudController
       end
     end
 
-    describe 'maximum_result' do
+    describe 'maximum_result with pagination_depth_limit not configured' do
       it 'is valid if page and per_page is nil' do
         message = ListMessage.from_params({ page: nil, per_page: nil }, [])
         expect(message).to be_valid
@@ -91,6 +91,37 @@ module VCAP::CloudController
         message = ListMessage.from_params({ page: 9223372036854775807, per_page: 2 }, [])
         expect(message).to be_invalid
         expect(message.errors[:maximum_result]).to include('(page * per_page) must be less than 9223372036854775807')
+      end
+    end
+
+    describe 'maximum_result with pagination_depth_limit set to 10_000' do
+      before { TestConfig.override(renderer: { pagination_depth_limit: 10_000 }) }
+
+      it 'is valid if page and per_page is nil' do
+        message = ListMessage.from_params({ page: nil, per_page: nil }, [])
+        expect(message).to be_valid
+      end
+
+      it 'is valid when using default page' do
+        message = ListMessage.from_params({ page: nil, per_page: 5000 }, [])
+        expect(message).to be_valid
+      end
+
+      it 'is valid when using default per_page' do
+        message = ListMessage.from_params({ page: 20, per_page: nil }, [])
+        expect(message).to be_valid
+      end
+
+      it 'is invalid when page * default per_page exceeds DB limits' do
+        message = ListMessage.from_params({ page: 10_0001, per_page: nil }, [])
+        expect(message).to be_invalid
+        expect(message.errors[:maximum_result]).to include('(page * per_page) must be less than 10000')
+      end
+
+      it 'is invalid when page * per_page exceeds DB limits' do
+        message = ListMessage.from_params({ page: 5001, per_page: 2 }, [])
+        expect(message).to be_invalid
+        expect(message.errors[:maximum_result]).to include('(page * per_page) must be less than 10000')
       end
     end
 


### PR DESCRIPTION
Requesting a resource with a high index number in your paginated list endpoint results in sql queries having a large offset value. Such queries get gradually slower the higher the offset is in the sql query. As an example we saw queries finish in 7ms with an offset of 0. When the offset was 10 million the same query took nearly a minute to be answered from the database. A user can thus construct quite costly queries on resouces that have large tables.

This change introduces a limit on how far you can go back in your requests pagination. The limit is quite high and disabled by default. It can be enabled via cloud_controller configuration and values below 1 million seem fine. That would mean no page larger than 2000 can be requested in case of default page size. Ultimately the user is asked to narrow its list request (by created_at time for example) to reach elements in later pages.

If the limit is disabled it will still produce a warning message in the cloud controller logs to make operators aware if consumers make queries that produce large offset values in sql queries. This then just gets a real issue when then table really has that many elements.

* An explanation of the use cases your change solves

As a platform operator i`d like to make sure no single resource can be exhausted by individuals thus i`d like to limit expensive operations on pagination related to sql queries offset parameter.

Related capi-release PR for config parameter:
https://github.com/cloudfoundry/capi-release/pull/331

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
