### PR TITLE
Readiness health checks story 1: adding properties to app manifest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ group :test do
   gem 'rspec-rails', '~> 6.0.3'
   gem 'rspec-wait'
   gem 'rspec_api_documentation', '>= 6.1.0'
-  gem 'rubocop', '~> 1.54.1'
+  gem 'rubocop', '~> 1.54.2'
   gem 'timecop'
   gem 'webmock', '> 2.3.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,7 +444,7 @@ GEM
       activesupport (>= 3.0.0)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0)
-    rubocop (1.54.1)
+    rubocop (1.54.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -619,7 +619,7 @@ DEPENDENCIES
   rspec-rails (~> 6.0.3)
   rspec-wait
   rspec_api_documentation (>= 6.1.0)
-  rubocop (~> 1.54.1)
+  rubocop (~> 1.54.2)
   rubyzip (>= 1.3.0)
   sequel (~> 5.70)
   sequel_pg

--- a/app/messages/app_manifest_message.rb
+++ b/app/messages/app_manifest_message.rb
@@ -23,6 +23,9 @@ module VCAP::CloudController
       :health_check_invocation_timeout,
       :health_check_timeout,
       :health_check_type,
+      :readiness_health_check_http_endpoint,
+      :readiness_health_check_type,
+      :readiness_health_check_invocation_timeout,
       :instances,
       :metadata,
       :memory,
@@ -208,10 +211,17 @@ module VCAP::CloudController
       mapping[:health_check_http_endpoint] = health_check_http_endpoint if requested?(:health_check_http_endpoint)
       mapping[:timeout] = timeout if requested?(:timeout)
       mapping[:health_check_invocation_timeout] = health_check_invocation_timeout if requested?(:health_check_invocation_timeout)
+      mapping[:readiness_health_check_invocation_timeout] = readiness_health_check_invocation_timeout if requested?(:readiness_health_check_invocation_timeout)
+      mapping[:readiness_health_check_http_endpoint] = readiness_health_check_http_endpoint if requested?(:readiness_health_check_http_endpoint)
 
       if requested?(:health_check_type)
         mapping[:health_check_type] = converted_health_check_type(health_check_type)
       end
+
+      if requested?(:readiness_health_check_type)
+        mapping[:readiness_health_check_type] = converted_health_check_type(readiness_health_check_type)
+      end
+
       mapping
     end
 
@@ -221,12 +231,17 @@ module VCAP::CloudController
       mapping[:health_check_http_endpoint] = params[:health_check_http_endpoint] if params.key?(:health_check_http_endpoint)
       mapping[:health_check_timeout] = params[:health_check_timeout] if params.key?(:health_check_timeout)
       mapping[:health_check_invocation_timeout] = params[:health_check_invocation_timeout] if params.key?(:health_check_invocation_timeout)
+      mapping[:readiness_health_check_invocation_timeout] = params[:readiness_health_check_invocation_timeout] if params.key?(:readiness_health_check_invocation_timeout)
+      mapping[:readiness_health_check_http_endpoint] = params[:readiness_health_check_http_endpoint] if params.key?(:readiness_health_check_http_endpoint)
       mapping[:timeout] = params[:timeout] if params.key?(:timeout)
       mapping[:type] = params[:type]
 
       if params.key?(:health_check_type)
         mapping[:health_check_type] = converted_health_check_type(params[:health_check_type])
         mapping[:health_check_timeout] = params[:health_check_timeout] if params.key?(:health_check_timeout)
+      end
+      if params.key?(:readiness_health_check_type)
+        mapping[:readiness_health_check_type] = converted_health_check_type(params[:readiness_health_check_type])
       end
       mapping
     end

--- a/app/messages/manifest_process_update_message.rb
+++ b/app/messages/manifest_process_update_message.rb
@@ -3,14 +3,29 @@ require 'models/helpers/health_check_types'
 
 module VCAP::CloudController
   class ManifestProcessUpdateMessage < BaseMessage
-    register_allowed_keys [:command, :health_check_type, :health_check_http_endpoint, :health_check_invocation_timeout, :timeout, :type]
+    register_allowed_keys [
+      :command,
+      :health_check_http_endpoint,
+      :health_check_invocation_timeout,
+      :health_check_type,
+      :readiness_health_check_http_endpoint,
+      :readiness_health_check_invocation_timeout,
+      :readiness_health_check_type,
+      :timeout,
+      :type
+    ]
 
     def self.health_check_endpoint_and_type_requested?
       proc { |a| a.requested?(:health_check_type) && a.requested?(:health_check_http_endpoint) }
     end
 
+    def self.readiness_health_check_endpoint_and_type_requested?
+      proc { |a| a.requested?(:readiness_health_check_type) && a.requested?(:readiness_health_check_http_endpoint) }
+    end
+
     validates_with NoAdditionalKeysValidator
     validates_with HealthCheckValidator, if: health_check_endpoint_and_type_requested?
+    validates_with ReadinessHealthCheckValidator, if: readiness_health_check_endpoint_and_type_requested?
 
     validates :command,
       string: true,
@@ -35,6 +50,25 @@ module VCAP::CloudController
       allow_nil: true,
       numericality: { only_integer: true, greater_than_or_equal_to: 1 },
       if: proc { |a| a.requested?(:health_check_invocation_timeout) }
+
+    validates :readiness_health_check_type,
+      inclusion: {
+        in: [HealthCheckTypes::PORT, HealthCheckTypes::PROCESS, HealthCheckTypes::HTTP],
+        message: 'must be "port", "process", or "http"'
+      },
+      if: proc { |a| a.requested?(:readiness_health_check_type) }
+
+    validates :readiness_health_check_invocation_timeout,
+      allow_nil: true,
+      numericality: { only_integer: true, greater_than_or_equal_to: 1 },
+      if: proc { |a| a.requested?(:readiness_health_check_invocation_timeout) }
+
+    # This code implicitly depends on class UriPathValidator
+    # See gem active_model/validations/validates.rb: validates(*attributes) for details
+    validates :readiness_health_check_http_endpoint,
+      allow_nil: true,
+      uri_path: true,
+      if: proc { |a| a.requested?(:readiness_health_check_http_endpoint) }
 
     validates :timeout,
       allow_nil: true,

--- a/app/messages/validators.rb
+++ b/app/messages/validators.rb
@@ -158,6 +158,14 @@ module VCAP::CloudController::Validators
     end
   end
 
+  class ReadinessHealthCheckValidator < ActiveModel::Validator
+    def validate(record)
+      if record.readiness_health_check_type != VCAP::CloudController::HealthCheckTypes::HTTP
+        record.errors.add(:readiness_health_check_type, message: 'must be "http" to set a health check HTTP endpoint')
+      end
+    end
+  end
+
   class OrgVisibilityValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       return if value.nil?

--- a/db/migrations/20130730000217_create_service_brokers_table.rb
+++ b/db/migrations/20130730000217_create_service_brokers_table.rb
@@ -2,9 +2,9 @@ Sequel.migration do
   change do
     create_table :service_brokers do
       VCAP::Migration.common(self, :sbrokers)
-      String :name,        null: false
+      String :name,       null: false
       String :broker_url, null: false
-      String :token,       null: false
+      String :token,      null: false
 
       index :name, unique: true
       index :broker_url, unique: true

--- a/spec/request/spaces_spec.rb
+++ b/spec/request/spaces_spec.rb
@@ -231,9 +231,9 @@ RSpec.describe 'Spaces' do
       let(:expected_codes_and_responses) do
         h = Hash.new(code: 200, response_guid: space.guid)
 
-        h['org_auditor'] =                 { code: 404, response_guid: nil }
-        h['org_billing_manager'] =         { code: 404, response_guid: nil }
-        h['no_role'] =                     { code: 404, response_object: nil }
+        h['org_auditor']         = { code: 404, response_guid: nil }
+        h['org_billing_manager'] = { code: 404, response_guid: nil }
+        h['no_role']             = { code: 404, response_object: nil }
         h
       end
 
@@ -485,12 +485,12 @@ RSpec.describe 'Spaces' do
       let(:expected_codes_and_responses) do
         h = Hash.new(code: 200, response_guids: [space1.guid, space2.guid, space3.guid])
 
-        h['org_auditor'] =                 { code: 200, response_guids: [] }
-        h['org_billing_manager'] =         { code: 200, response_guids: [] }
-        h['space_manager'] =               { code: 200, response_guids: [space1.guid] }
-        h['space_auditor'] =               { code: 200, response_guids: [space1.guid] }
-        h['space_developer'] =             { code: 200, response_guids: [space1.guid] }
-        h['space_supporter'] = { code: 200, response_guids: [space1.guid] }
+        h['org_auditor']         = { code: 200, response_guids: [] }
+        h['org_billing_manager'] = { code: 200, response_guids: [] }
+        h['space_manager']       = { code: 200, response_guids: [space1.guid] }
+        h['space_auditor']       = { code: 200, response_guids: [space1.guid] }
+        h['space_developer']     = { code: 200, response_guids: [space1.guid] }
+        h['space_supporter']     = { code: 200, response_guids: [space1.guid] }
 
         h['no_role'] = { code: 200, response_objects: [] }
         h
@@ -1224,9 +1224,9 @@ RSpec.describe 'Spaces' do
       let(:expected_codes_and_responses) do
         h = Hash.new(code: 200, response_object: expected_response)
 
-        h['org_auditor'] =                 { code: 404, response_guid: nil }
-        h['org_billing_manager'] =         { code: 404, response_guid: nil }
-        h['no_role'] =                     { code: 404, response_object: nil }
+        h['org_auditor']         = { code: 404, response_guid: nil }
+        h['org_billing_manager'] = { code: 404, response_guid: nil }
+        h['no_role']             = { code: 404, response_object: nil }
         h
       end
 
@@ -1256,11 +1256,11 @@ RSpec.describe 'Spaces' do
 
       let(:expected_codes_and_responses) do
         h = Hash.new(code: 403)
-        h['no_role'] =             { code: 404 }
-        h['org_auditor'] =         { code: 404 }
+        h['no_role']             = { code: 404 }
+        h['org_auditor']         = { code: 404 }
         h['org_billing_manager'] = { code: 404 }
-        h['org_manager'] =         { code: 403 }
-        h['admin'] =               { code: 200 }
+        h['org_manager']         = { code: 403 }
+        h['admin']               = { code: 200 }
         h
       end
 

--- a/spec/unit/messages/manifest_process_update_message_spec.rb
+++ b/spec/unit/messages/manifest_process_update_message_spec.rb
@@ -160,6 +160,112 @@ module VCAP::CloudController
         end
       end
 
+      context 'readiness health check properties' do
+        describe 'readiness_health_check_type' do
+          context 'when readiness_health_check type is port' do
+            let(:params) { { readiness_health_check_type: 'port' } }
+
+            it 'is valid' do
+              expect(message).to be_valid
+            end
+          end
+
+          context 'when readiness_health_check type is process' do
+            let(:params) { { readiness_health_check_type: 'process' } }
+
+            it 'is valid' do
+              expect(message).to be_valid
+            end
+          end
+
+          context 'when readiness_health_check type is http' do
+            let(:params) { { readiness_health_check_type: 'http' } }
+
+            it 'is valid' do
+              expect(message).to be_valid
+            end
+          end
+
+          context 'when readiness_health_check type is invalid' do
+            let(:params) { { readiness_health_check_type: 'meow' } }
+
+            it 'is not valid' do
+              expect(message).not_to be_valid
+              expect(message.errors[:readiness_health_check_type]).to include('must be "port", "process", or "http"')
+            end
+          end
+        end
+
+        context 'when readiness health check timeout is a number' do
+          let(:params) { { readiness_health_check_invocation_timeout: 333 } }
+
+          it 'is valid' do
+            expect(message).to be_valid
+          end
+        end
+
+        context 'when readiness health check timeout is not a number' do
+          let(:params) { { readiness_health_check_invocation_timeout: 'velma' } }
+
+          it 'is not valid' do
+            expect(message).not_to be_valid
+            expect(message.errors.count).to eq(1)
+            expect(message.errors[:readiness_health_check_invocation_timeout]).to include('is not a number')
+          end
+        end
+
+        context 'when readiness health check timeout is not a valid number' do
+          context 'when readiness health check timeout is negative' do
+            let(:params) { { readiness_health_check_invocation_timeout: -10_000 } }
+
+            it 'is not valid' do
+              expect(message).not_to be_valid
+              expect(message.errors.count).to eq(1)
+              expect(message.errors[:readiness_health_check_invocation_timeout]).to include('must be greater than or equal to 1')
+            end
+          end
+
+          context 'when readiness health check timeout is 0' do
+            let(:params) { { readiness_health_check_invocation_timeout: 0 } }
+
+            it 'is not valid' do
+              expect(message).not_to be_valid
+              expect(message.errors.count).to eq(1)
+              expect(message.errors[:readiness_health_check_invocation_timeout]).to include('must be greater than or equal to 1')
+            end
+          end
+        end
+
+        describe 'readiness_health_check_http_endpoint' do
+          context 'when readiness_health_check_http_endpoint is a valid URI path and type is http' do
+            let(:params) { { readiness_health_check_type: 'http', readiness_health_check_http_endpoint: '/validendpoint' } }
+
+            it 'is valid' do
+              expect(message).to be_valid
+            end
+          end
+
+          context 'when readiness_health_check_http_endpoint is not a valid URI path' do
+            let(:params) { { readiness_health_check_http_endpoint: 'hello there' } }
+
+            it 'is not valid' do
+              expect(message).not_to be_valid
+              expect(message.errors[:readiness_health_check_http_endpoint]).to include('must be a valid URI path')
+            end
+          end
+
+          context 'when health check type is not http and endpoint is specified' do
+            let(:params) { { readiness_health_check_type: 'port', readiness_health_check_http_endpoint: '/endpoint' } }
+
+            it 'is not valid' do
+              expect(message).not_to be_valid
+              expect(message.errors.count).to eq(1)
+              expect(message.errors[:readiness_health_check_type]).to include('must be "http" to set a health check HTTP endpoint')
+            end
+          end
+        end
+      end
+
       describe 'timeout' do
         context 'when timeout is not an number' do
           let(:params) { { timeout: 'hello there' } }


### PR DESCRIPTION
This PR is part of a larger effort detailed [here in this Cloud Controller PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/3351) and here in [this CFF RFC](https://github.com/cloudfoundry/community/blob/rfc-readiness-healthchecks/toc/rfc/rfc-draft-readiness-healthchecks.md).


In this story users can set 3 new app manifest properties. When they are set to valid properties, nothing happens. When they are set to invalid properties, it responds with an error.

### New App Manifest Properties
```
applications:
- name: test-app
  processes:
  - type: web
    health-check-http-endpoint: /health
    health-check-invocation-timeout: 2
    health-check-type: http
    timeout: 80
    readiness-health-check-http-endpoint: /ready       # 👈 new property
    readiness-health-check-invocation-timeout: 2       # 👈 new property
    readiness-health-check-type: http                  # 👈 new property
```

### Error Cases
* None of these are required.
* readiness-health-check-type needs to be validated as one of: process, http or port [similar to health-check-type](https://github.com/cloudfoundry/cloud_controller_ng/blob/021b1633cd5c65e50d29633905672e3cd68ad446/app/messages/manifest_process_update_message.rb#L20-L25).
* readiness-health-check-invocation-timeout - validated as an integer > 1 [similar to health-check-invocation-timeout](https://github.com/cloudfoundry/cloud_controller_ng/blob/021b1633cd5c65e50d29633905672e3cd68ad446/app/messages/manifest_process_update_message.rb#L34-L37)
* readiness-health-check-endpoint is validated as a URL [similar to health-check-endpoint](https://github.com/cloudfoundry/cloud_controller_ng/blob/021b1633cd5c65e50d29633905672e3cd68ad446/app/messages/manifest_process_update_message.rb#L29C16-L32)
* readiness-health-check-endpoint can only be set when readiness-health-check-type is set to http.