### PR TITLE
Add delayed_jobs_reserve_where index

### DIFF
--- a/db/migrations/20230726132200_add_delayed_jobs_reserve_where_index.rb
+++ b/db/migrations/20230726132200_add_delayed_jobs_reserve_where_index.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    add_index :delayed_jobs, [:queue, :locked_at, :locked_by, :failed_at, :run_at], name: :delayed_jobs_reserve_where
+  end
+
+  down do
+    drop_index :delayed_jobs, nil, name: :delayed_jobs_reserve_where
+  end
+end


### PR DESCRIPTION
With PR #3324 the `delayed_jobs_reserve` index was changed by adding the field `priority` which is used in the `ORDER BY` clause. This change re-adds the previous index, that only contains fields used in the `WHERE` clause of the query. Although PostgreSQL could always use the new index, there seem to be situations where the query planner decides for a sequential table scan (theory: if the number of entries is rather low).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
