### PR TITLE
Readiness health checks story 3 add to lrps

### DIFF
--- a/lib/cloud_controller/diego/app_recipe_builder.rb
+++ b/lib/cloud_controller/diego/app_recipe_builder.rb
@@ -196,15 +196,10 @@ module VCAP::CloudController
         checks = generate_liveness_and_startup_health_check_defintion(lrp_builder)
         readiness_checks = generate_readiness_health_check_definition(lrp_builder)
 
-        if checks.empty? && readiness_checks.empty?
-          return
-        elsif checks.empty?
-          return  ::Diego::Bbs::Models::CheckDefinition.new(readiness_checks: readiness_checks)
-        elsif readiness_checks.empty?
-          return  ::Diego::Bbs::Models::CheckDefinition.new(checks: checks)
-        else
-          return  ::Diego::Bbs::Models::CheckDefinition.new(checks: checks, readiness_checks: readiness_checks)
-        end
+        params = {}
+        params[:checks] = checks unless checks.empty?
+        params[:readiness_checks] = readiness_checks unless readiness_checks.empty?
+        ::Diego::Bbs::Models::CheckDefinition.new(**params) unless params.empty?
       end
 
       def generate_readiness_health_check_definition(lrp_builder)

--- a/lib/cloud_controller/diego/app_recipe_builder.rb
+++ b/lib/cloud_controller/diego/app_recipe_builder.rb
@@ -17,6 +17,7 @@ module VCAP::CloudController
       METRIC_TAG_VALUE = ::Diego::Bbs::Models::MetricTagValue
 
       MONITORED_HEALTH_CHECK_TYPES = [HealthCheckTypes::PORT, HealthCheckTypes::HTTP, ''].map(&:freeze).freeze
+      MONITORED_READINESS_HEALTH_CHECK_TYPES = [HealthCheckTypes::PORT, HealthCheckTypes::HTTP].map(&:freeze).freeze
 
       def initialize(config:, process:, ssh_key: SSHKey.new)
         @config  = config
@@ -192,7 +193,33 @@ module VCAP::CloudController
       end
 
       def generate_healthcheck_definition(lrp_builder)
-        return unless MONITORED_HEALTH_CHECK_TYPES.include?(process.health_check_type)
+        checks = generate_liveness_and_startup_health_check_defintion(lrp_builder)
+        readiness_checks = generate_readiness_health_check_definition(lrp_builder)
+
+        if checks.empty? && readiness_checks.empty?
+          return
+        elsif checks.empty?
+          return  ::Diego::Bbs::Models::CheckDefinition.new(readiness_checks: readiness_checks)
+        elsif readiness_checks.empty?
+          return  ::Diego::Bbs::Models::CheckDefinition.new(checks: checks)
+        else
+          return  ::Diego::Bbs::Models::CheckDefinition.new(checks: checks, readiness_checks: readiness_checks)
+        end
+      end
+
+      def generate_readiness_health_check_definition(lrp_builder)
+        return [] unless MONITORED_READINESS_HEALTH_CHECK_TYPES.include?(process.readiness_health_check_type)
+
+        ports = lrp_builder.ports
+        readiness_checks = []
+        ports.each_with_index do |port, index|
+          readiness_checks << build_readiness_check(port, index)
+        end
+        readiness_checks
+      end
+
+      def generate_liveness_and_startup_health_check_defintion(lrp_builder)
+        return [] unless MONITORED_HEALTH_CHECK_TYPES.include?(process.health_check_type)
 
         desired_ports = lrp_builder.ports
         checks        = []
@@ -200,7 +227,28 @@ module VCAP::CloudController
           checks << build_check(port, index)
         end
 
-        ::Diego::Bbs::Models::CheckDefinition.new(checks: checks)
+        checks
+      end
+
+      def build_readiness_check(port, index)
+        timeout_ms = (process.readiness_health_check_invocation_timeout || 0) * 1000
+
+        if process.readiness_health_check_type == HealthCheckTypes::HTTP && index == 0
+          ::Diego::Bbs::Models::ReadinessCheck.new(http_check:
+            ::Diego::Bbs::Models::HTTPCheck.new(
+              path: process.readiness_health_check_http_endpoint,
+              port: port,
+              request_timeout_ms: timeout_ms
+            )
+          )
+        else
+          ::Diego::Bbs::Models::ReadinessCheck.new(tcp_check:
+            ::Diego::Bbs::Models::TCPCheck.new(
+              port: port,
+              connect_timeout_ms: timeout_ms
+            )
+          )
+        end
       end
 
       def build_check(port, index)

--- a/lib/diego/bbs/models/check_definition_pb.rb
+++ b/lib/diego/bbs/models/check_definition_pb.rb
@@ -7,8 +7,13 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "diego.bbs.models.CheckDefinition" do
     repeated :checks, :message, 1, "diego.bbs.models.Check"
     optional :log_source, :string, 2
+    repeated :readiness_checks, :message, 3, "diego.bbs.models.ReadinessCheck"
   end
   add_message "diego.bbs.models.Check" do
+    optional :tcp_check, :message, 1, "diego.bbs.models.TCPCheck"
+    optional :http_check, :message, 2, "diego.bbs.models.HTTPCheck"
+  end
+  add_message "diego.bbs.models.ReadinessCheck" do
     optional :tcp_check, :message, 1, "diego.bbs.models.TCPCheck"
     optional :http_check, :message, 2, "diego.bbs.models.HTTPCheck"
   end
@@ -28,6 +33,7 @@ module Diego
     module Models
       CheckDefinition = Google::Protobuf::DescriptorPool.generated_pool.lookup("diego.bbs.models.CheckDefinition").msgclass
       Check = Google::Protobuf::DescriptorPool.generated_pool.lookup("diego.bbs.models.Check").msgclass
+      ReadinessCheck = Google::Protobuf::DescriptorPool.generated_pool.lookup("diego.bbs.models.ReadinessCheck").msgclass
       TCPCheck = Google::Protobuf::DescriptorPool.generated_pool.lookup("diego.bbs.models.TCPCheck").msgclass
       HTTPCheck = Google::Protobuf::DescriptorPool.generated_pool.lookup("diego.bbs.models.HTTPCheck").msgclass
     end

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -571,9 +571,9 @@ module VCAP::CloudController
           end
 
           context 'readiness health check' do
-            context 'when the readiness health check type is not set' do
+            context 'when the readiness health check type defaults to process' do
               before do
-                process.readiness_health_check_type = ''
+                process.readiness_health_check_type = 'process'
               end
 
               it 'does not add any readiness health checks for backwards compatibility' do

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -570,6 +570,94 @@ module VCAP::CloudController
             end
           end
 
+          context 'readiness health check' do
+            context 'when the readiness health check type is not set' do
+              before do
+                process.readiness_health_check_type = ''
+              end
+
+              it 'does not add any readiness health checks for backwards compatibility' do
+                lrp = builder.build_app_lrp
+                expect(lrp.check_definition.readiness_checks).to be_empty
+              end
+            end
+
+            context 'when the readiness health check type is set to "port"' do
+              before do
+                process.readiness_health_check_type = 'port'
+              end
+
+              it 'adds a TCP readiness health check definition' do
+                lrp       = builder.build_app_lrp
+                tcp_check = lrp.check_definition.readiness_checks.first.tcp_check
+                expect(tcp_check.port).to eq(4444)
+                expect(tcp_check.connect_timeout_ms).to eq(0)
+              end
+
+              it 'does not set connection timeouts' do
+                lrp       = builder.build_app_lrp
+                tcp_check = lrp.check_definition.readiness_checks.first.tcp_check
+                expect(tcp_check.connect_timeout_ms).to eq(0)
+              end
+
+              context 'when there is an invocation_timeout' do
+                before do
+                  process.readiness_health_check_invocation_timeout = 10
+                end
+
+                it 'sets the connect_timeout_ms' do
+                  lrp = builder.build_app_lrp
+                  tcp_check = lrp.check_definition.readiness_checks.first.tcp_check
+                  expect(tcp_check.port).to eq(4444)
+                  expect(tcp_check.connect_timeout_ms).to eq(10_000)
+                end
+              end
+            end
+
+            context 'when the health check type is set to "http"' do
+              before do
+                process.readiness_health_check_type          = 'http'
+                process.readiness_health_check_http_endpoint = '/http-endpoint'
+                process.readiness_health_check_invocation_timeout = 10
+              end
+
+              it 'adds an HTTP readiness health check definition using the first port' do
+                lrp        = builder.build_app_lrp
+                http_check = lrp.check_definition.readiness_checks.first.http_check
+                expect(http_check.port).to eq(4444)
+                expect(http_check.path).to eq('/http-endpoint')
+                expect(http_check.request_timeout_ms).to eq(10000)
+              end
+
+              it 'defaults the HTTP invocation timeout to zero' do
+                process.readiness_health_check_invocation_timeout = nil
+                lrp = builder.build_app_lrp
+                http_check = lrp.check_definition.readiness_checks.first.http_check
+                expect(http_check.port).to eq(4444)
+                expect(http_check.path).to eq('/http-endpoint')
+                expect(http_check.request_timeout_ms).to eq(0)
+              end
+
+              it 'keeps a TCP readiness health check definition for other ports' do
+                lrp       = builder.build_app_lrp
+                tcp_check = lrp.check_definition.readiness_checks[1].tcp_check
+                expect(tcp_check.port).to eq(5555)
+              end
+            end
+
+            context 'when the readiness health check type is not recognized' do
+              before do
+                process.readiness_health_check_type = 'meow'
+              end
+
+              it 'does not add readiness healthcheck definitions' do
+                lrp              = builder.build_app_lrp
+                check_definition = lrp.check_definition
+                expect(check_definition.readiness_checks).to be_empty
+              end
+            end
+          end
+
           describe 'routes' do
             before do
               routing_info = {


### PR DESCRIPTION
This PR is part of a larger effort detailed [here in this Cloud Controller PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/3351) and here in [this CFF RFC](https://github.com/cloudfoundry/community/blob/rfc-readiness-healthchecks/toc/rfc/rfc-draft-readiness-healthchecks.md).

In this story, the 3 new app manifest properties ([created in this PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/3354)), are set in the db.

### New App Manifest Properties
```
applications:
- name: test-app
  processes:
  - type: web
    health-check-http-endpoint: /health
    health-check-invocation-timeout: 2
    health-check-type: http
    timeout: 80
    readiness-health-check-http-endpoint: /ready       # 👈 new property
    readiness-health-check-invocation-timeout: 2       # 👈 new property
    readiness-health-check-type: http                  # 👈 new property
```

### Acceptance Setup
1. Deploy with diego-release develop. 
2. Get on the VM with the bbs and run `cfdot desired-lrps | jq .check_definition`

 ### Acceptance Steps
1. When I do not set any readiness health check properties, then NO readiness checks are set on the LRP.
1. When I provide valid properties for http readiness health checks they are set on the LRP.
  ```
    readiness-health-check-http-endpoint: /ready
    readiness-health-check-invocation-timeout: 2
    readiness-health-check-type: http
  ```

1. When I provide valid properties for port readiness health checks they are set on the LRP.
  ```
    readiness-health-check-type: port
  ```
  
1. When I provide valid properties for process readiness health checks they are NOT set on the LRP.
  ```
    readiness-health-check-type: process
  ```

### Previous PRs
* https://github.com/cloudfoundry/cloud_controller_ng/pull/3354
* https://github.com/cloudfoundry/cloud_controller_ng/pull/3361