### PR TITLE
Eager load domains for routes associated with a process

### DIFF
--- a/app/models/runtime/process_model.rb
+++ b/app/models/runtime/process_model.rb
@@ -129,7 +129,8 @@ module VCAP::CloudController
       left_primary_key: [:app_guid, :type], left_key: [:app_guid, :process_type],
       right_primary_key: :guid, right_key: :route_guid,
       distinct:     true,
-      order:        Sequel.asc(:id)
+      order:        Sequel.asc(:id),
+      eager:        :domain
 
     many_to_many :sidecars,
       class:             'VCAP::CloudController::SidecarModel',

--- a/spec/unit/models/runtime/process_model_spec.rb
+++ b/spec/unit/models/runtime/process_model_spec.rb
@@ -1349,12 +1349,26 @@ module VCAP::CloudController
     end
 
     describe 'uris' do
+      let(:process) { ProcessModelFactory.make(app: parent_app) }
+
       it 'should return the fqdns and paths on the app' do
-        process = ProcessModelFactory.make(app: parent_app)
         domain = PrivateDomain.make(name: 'mydomain.com', owning_organization: org)
         route  = Route.make(host: 'myhost', domain: domain, space: space, path: '/my%20path')
         RouteMappingModel.make(app: process.app, route: route, process_type: process.type)
         expect(process.uris).to eq(['myhost.mydomain.com/my%20path'])
+      end
+
+      it 'should eager load domains' do
+        domains = 2.times.map { |i| PrivateDomain.make(name: "domain#{i}.com", owning_organization: org) }
+        routes = 4.times.map { |i| Route.make(host: "host#{i}", domain: domains[i % 2], space: space) }
+        routes.each { |route| RouteMappingModel.make(app: process.app, route: route, process_type: process.type) }
+
+        uris = nil
+        expect {
+          uris = process.uris
+        }.to have_queried_db_times(/select \* from .domains. where/i, 1)
+
+        expect(uris.length).to eq(4)
       end
     end
 


### PR DESCRIPTION
The `routes` association in the `process` model is used to determine the `uris` belonging to a process. This also requires the `name` from the associated `domain` which leads to 1 + n `SELECT` queries (1 * `SELECT FROM routes` + n * `SELECT FROM domains`), where n is the number of associated routes. When eager loading domains, there are only 2 `SELECT` queries no matter how many routes are associated with a process.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
