### PR TITLE
Display instance internal IP address on Process Stats endpoint

### DIFF
--- a/app/presenters/v3/process_stats_presenter.rb
+++ b/app/presenters/v3/process_stats_presenter.rb
@@ -32,12 +32,13 @@ module VCAP::CloudController
 
         def found_instance_stats_hash(index, stats)
           {
-            type:       @type,
-            index:      index,
-            state:      stats[:state],
-            host:       stats[:stats][:host],
-            uptime:     stats[:stats][:uptime],
-            mem_quota:  stats[:stats][:mem_quota],
+            type: @type,
+            index: index,
+            state: stats[:state],
+            host: stats[:stats][:host],
+            instance_internal_ip: stats[:stats][:net_info][:instance_address],
+            uptime: stats[:stats][:uptime],
+            mem_quota: stats[:stats][:mem_quota],
             disk_quota: stats[:stats][:disk_quota],
             log_rate_limit:  stats[:stats][:log_rate_limit],
             fds_quota:  stats[:stats][:fds_quota],

--- a/docs/v3/source/includes/api_resources/_processes.erb
+++ b/docs/v3/source/includes/api_resources/_processes.erb
@@ -188,6 +188,7 @@
         "disk": 69705728
       },
       "host": "10.244.16.10",
+      "instance_internal_ip": "10.255.93.167",
       "instance_ports": [
         {
           "external": 64546,
@@ -218,6 +219,7 @@
       "disk_quota": null,
       "fds_quota": 16384,
       "host": "",
+      "instance_internal_ip": "",
       "instance_ports": null,
       "isolation_segment": null,
       "log_rate_limit": null,

--- a/docs/v3/source/includes/resources/processes/_stats_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats_object.md.erb
@@ -21,6 +21,7 @@ Name | Type | Description
 **usage.disk** | _integer_ | The current disk usage of the instance
 **usage.log_rate** | _integer_ | The current logging usage of the instance
 **host** | _string_ | The host the instance is running on
+**instance_internal_ip** | _string_ | The internal IP address of the instance
 **instance_ports** | _object_ | JSON array of port mappings between the network-exposed port used to communicate with the app (`external`) and port opened to the running process that it can listen on (`internal`)
 **uptime** | _integer_ | The uptime in seconds for the instance
 **mem_quota** | _integer_ | The current maximum memory allocated for the instance; the value is `null` when memory quota data is unavailable

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -475,6 +475,7 @@ RSpec.describe 'Processes' do
     let(:net_info_1) {
       {
         address: '1.2.3.4',
+        instance_address: '5.6.7.8',
         ports: [
           {
             host_port: 8080,
@@ -538,7 +539,8 @@ RSpec.describe 'Processes' do
             'disk' => 1024,
             'log_rate' => 1024,
           },
-          'host'           => 'toast',
+          'host' => 'toast',
+          'instance_internal_ip' => '5.6.7.8',
           'instance_ports' => [
             {
               'external' => 8080,

--- a/spec/unit/presenters/v3/process_stats_presenter_spec.rb
+++ b/spec/unit/presenters/v3/process_stats_presenter_spec.rb
@@ -12,6 +12,7 @@ module VCAP::CloudController::Presenters::V3
       let(:net_info_1) {
         {
           address: '1.2.3.4',
+          instance_address: '5.6.7.8',
           ports: [
             {
               host_port: 8080,
@@ -31,6 +32,7 @@ module VCAP::CloudController::Presenters::V3
       let(:net_info_2) {
         {
           address: '',
+          instance_address: '',
           ports: nil
         }
       }
@@ -116,6 +118,7 @@ module VCAP::CloudController::Presenters::V3
         expect(result[0][:details]).to eq(nil)
         expect(result[0][:isolation_segment]).to eq('hecka-compliant')
         expect(result[0][:host]).to eq('myhost')
+        expect(result[0][:instance_internal_ip]).to eq('5.6.7.8')
         expect(result[0][:instance_ports]).to eq(instance_ports_1)
         expect(result[0][:uptime]).to eq(12345)
         expect(result[0][:mem_quota]).to eq(process[:memory] * 1024 * 1024)
@@ -156,6 +159,7 @@ module VCAP::CloudController::Presenters::V3
         let(:net_info_1) {
           {
             address: '1.2.3.4',
+            instance_address: '5.6.7.8',
             ports: [
               {
                 host_port: 8080,
@@ -193,6 +197,7 @@ module VCAP::CloudController::Presenters::V3
           expect(result[0][:details]).to eq(nil)
           expect(result[0][:isolation_segment]).to eq('hecka-compliant')
           expect(result[0][:host]).to eq('myhost')
+          expect(result[0][:instance_internal_ip]).to eq('5.6.7.8')
           expect(result[0][:instance_ports]).to eq(instance_ports_1)
           expect(result[0][:uptime]).to eq(12345)
           expect(result[0][:mem_quota]).to eq(process[:memory] * 1024 * 1024)
@@ -235,6 +240,7 @@ module VCAP::CloudController::Presenters::V3
           expect(result[0][:details]).to eq(nil)
           expect(result[0][:isolation_segment]).to eq('hecka-compliant')
           expect(result[0][:host]).to eq('myhost')
+          expect(result[0][:instance_internal_ip]).to eq('5.6.7.8')
           expect(result[0][:instance_ports]).to eq(instance_ports_1)
           expect(result[0][:uptime]).to eq(12345)
           expect(result[0][:mem_quota]).to be_nil


### PR DESCRIPTION
Experimenting with adding the internal IP address (as the `instance_internal_ip` field) to the process stats endpoint for https://github.com/cloudfoundry/cloud_controller_ng/issues/1378. This matches the `CF_INSTANCE_INTERNAL_IP=10.255.93.167` env var and I'm open to other names for sure. Maybe just `internal_ip`?

Example:

```json
{
  "resources": [
    {
      "type": "web",
      "index": 0,
      "state": "RUNNING",
      "host": "10.244.0.139",
      "instance_internal_ip": "10.255.93.167",
      "uptime": 1524,
      "mem_quota": 268435456,
      "disk_quota": 1073741824,
      "log_rate_limit": -1,
      "fds_quota": 16384,
      "isolation_segment": null,
      "details": null,
      "instance_ports": [
        {
          "external": 61000,
          "internal": 8080,
          "external_tls_proxy_port": 61002,
          "internal_tls_proxy_port": 61001
        },
        {
          "external": 61000,
          "internal": 8080,
          "external_tls_proxy_port": null,
          "internal_tls_proxy_port": 61443
        },
        {
          "external": 61001,
          "internal": 2222,
          "external_tls_proxy_port": 61003,
          "internal_tls_proxy_port": 61002
        }
      ],
      "usage": {
        "time": "2023-08-07T22:39:50+00:00",
        "cpu": 0.003555510033188645,
        "mem": 59051576,
        "disk": 175616000,
        "log_rate": 0
      }
    }
  ]
}
```

I think there are probably some request specs that I didn't account for, but if this is a change we actually want I'm happy to fix those up as well.
