### PR TITLE
Refactor presenter's handling of metadata prefixes

### DIFF
--- a/app/fetchers/label_selector_query_generator.rb
+++ b/app/fetchers/label_selector_query_generator.rb
@@ -23,13 +23,15 @@ module VCAP::CloudController
       def guids_for_set_inclusion(label_klass, requirement)
         label_klass.
           select(:resource_guid).
-          where(key_prefix: requirement.key_prefix, key_name: requirement.key_name, value: requirement.values)
+          where(key_name: requirement.key_name, value: requirement.values).
+          where(Sequel.or([[:key_prefix, requirement.key_prefix], [:key_prefix, requirement.key_prefix.to_s]]))
       end
 
       def guids_for_existence(label_klass, requirement)
         label_klass.
           select(:resource_guid).
-          where(key_prefix: requirement.key_prefix, key_name: requirement.key_name)
+          where(key_name: requirement.key_name).
+          where(Sequel.or([[:key_prefix, requirement.key_prefix], [:key_prefix, requirement.key_prefix.to_s]]))
       end
     end
   end

--- a/app/models.rb
+++ b/app/models.rb
@@ -1,5 +1,6 @@
-require 'models/runtime/space'
+require 'models/helpers/metadata_model_mixin'
 
+require 'models/runtime/space'
 require 'models/runtime/app_model'
 require 'models/runtime/build_model'
 require 'models/runtime/route_mapping_model'

--- a/app/models/helpers/metadata_model_mixin.rb
+++ b/app/models/helpers/metadata_model_mixin.rb
@@ -1,0 +1,15 @@
+module VCAP::CloudController
+  module MetadataModelMixin
+    def self.included(included_class)
+      included_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        # Transparently convert datatypes of key_prefix so empty strings are persisted in the DB instead of NULL
+        def key_prefix
+          self[:key_prefix].presence
+        end
+        def key_prefix=(value)
+          self[:key_prefix] = value.nil? ? '' : value
+        end
+      RUBY
+    end
+  end
+end

--- a/app/models/runtime/app_annotation_model.rb
+++ b/app/models/runtime/app_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/app_label_model.rb
+++ b/app/models/runtime/app_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
                 primary_key: :guid,
                 key: :resource_guid,
                 without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/build_annotation_model.rb
+++ b/app/models/runtime/build_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/build_label_model.rb
+++ b/app/models/runtime/build_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/buildpack_annotation_model.rb
+++ b/app/models/runtime/buildpack_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/buildpack_label_model.rb
+++ b/app/models/runtime/buildpack_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/deployment_annotation_model.rb
+++ b/app/models/runtime/deployment_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/deployment_label_model.rb
+++ b/app/models/runtime/deployment_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/domain_annotation_model.rb
+++ b/app/models/runtime/domain_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/domain_label_model.rb
+++ b/app/models/runtime/domain_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/droplet_annotation_model.rb
+++ b/app/models/runtime/droplet_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/droplet_label_model.rb
+++ b/app/models/runtime/droplet_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/isolation_segment_annotation_model.rb
+++ b/app/models/runtime/isolation_segment_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/isolation_segment_label_model.rb
+++ b/app/models/runtime/isolation_segment_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/organization_annotation_model.rb
+++ b/app/models/runtime/organization_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/organization_label_model.rb
+++ b/app/models/runtime/organization_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
                 primary_key: :guid,
                 key: :resource_guid,
                 without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/package_annotation_model.rb
+++ b/app/models/runtime/package_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/package_label_model.rb
+++ b/app/models/runtime/package_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/process_annotation_model.rb
+++ b/app/models/runtime/process_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/process_label_model.rb
+++ b/app/models/runtime/process_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/revision_annotation_model.rb
+++ b/app/models/runtime/revision_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/revision_label_model.rb
+++ b/app/models/runtime/revision_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/route_annotation_model.rb
+++ b/app/models/runtime/route_annotation_model.rb
@@ -6,5 +6,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/route_label_model.rb
+++ b/app/models/runtime/route_label_model.rb
@@ -4,5 +4,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/service_instance_annotation_model.rb
+++ b/app/models/runtime/service_instance_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/service_instance_label_model.rb
+++ b/app/models/runtime/service_instance_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/space_annotation_model.rb
+++ b/app/models/runtime/space_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/space_label_model.rb
+++ b/app/models/runtime/space_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/stack_annotation_model.rb
+++ b/app/models/runtime/stack_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/stack_label_model.rb
+++ b/app/models/runtime/stack_label_model.rb
@@ -5,5 +5,7 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/task_annotation_model.rb
+++ b/app/models/runtime/task_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/task_label_model.rb
+++ b/app/models/runtime/task_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/user_annotation_model.rb
+++ b/app/models/runtime/user_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/runtime/user_label_model.rb
+++ b/app/models/runtime/user_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/route_binding_annotation_model.rb
+++ b/app/models/services/route_binding_annotation_model.rb
@@ -6,5 +6,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/route_binding_label_model.rb
+++ b/app/models/services/route_binding_label_model.rb
@@ -4,5 +4,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_binding_annotation_model.rb
+++ b/app/models/services/service_binding_annotation_model.rb
@@ -6,5 +6,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_binding_label_model.rb
+++ b/app/models/services/service_binding_label_model.rb
@@ -4,5 +4,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_broker_annotation_model.rb
+++ b/app/models/services/service_broker_annotation_model.rb
@@ -6,5 +6,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_broker_label_model.rb
+++ b/app/models/services/service_broker_label_model.rb
@@ -4,5 +4,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_broker_update_request_annotation_model.rb
+++ b/app/models/services/service_broker_update_request_annotation_model.rb
@@ -6,5 +6,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_broker_update_request_label_model.rb
+++ b/app/models/services/service_broker_update_request_label_model.rb
@@ -4,5 +4,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_key_annotation_model.rb
+++ b/app/models/services/service_key_annotation_model.rb
@@ -6,5 +6,6 @@ module VCAP::CloudController
       without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_key_label_model.rb
+++ b/app/models/services/service_key_label_model.rb
@@ -4,5 +4,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_offering_annotation_model.rb
+++ b/app/models/services/service_offering_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_offering_label_model.rb
+++ b/app/models/services/service_offering_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_plan_annotation_model.rb
+++ b/app/models/services/service_plan_annotation_model.rb
@@ -7,5 +7,6 @@ module VCAP::CloudController
                 without_guid_generation: true
 
     def_column_alias(:key_name, :key)
+    include MetadataModelMixin
   end
 end

--- a/app/models/services/service_plan_label_model.rb
+++ b/app/models/services/service_plan_label_model.rb
@@ -5,5 +5,6 @@ module VCAP::CloudController
       primary_key: :guid,
       key: :resource_guid,
       without_guid_generation: true
+    include MetadataModelMixin
   end
 end

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -2812,7 +2812,7 @@ RSpec.describe 'V3 service instances' do
 
       before do
         VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'banana', service_instance: instance)
-        VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'fruit', value: 'avocado', service_instance: instance)
+        VCAP::CloudController::ServiceInstanceLabelModel.make(key_name: 'spice', value: 'cinnamon', service_instance: instance)
         VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_name: 'contact', value: 'marie', service_instance: instance)
         VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_name: 'email', value: 'some@example.com', service_instance: instance)
       end

--- a/spec/unit/fetchers/task_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/task_list_fetcher_spec.rb
@@ -11,7 +11,7 @@ module VCAP::CloudController
     let!(:task_for_app2) { TaskModel.make(app_guid: app2_in_space1.guid) }
 
     let!(:label_for_task_in_space1) { TaskLabelModel.make(resource_guid: task_in_space1.guid, key_name: 'key', value: 'value') }
-    let!(:label_for_task_in_space1_jr) { TaskLabelModel.make(resource_guid: task_in_space1.guid, key_name: 'key', value: 'slimjim') }
+    let!(:label_for_task_in_space1_jr) { TaskLabelModel.make(resource_guid: task_in_space1.guid, key_name: 'key2', value: 'slimjim') }
 
     let(:space2) { Space.make }
     let(:app_in_space2) { AppModel.make(space_guid: space2.guid) }
@@ -285,7 +285,7 @@ module VCAP::CloudController
           end
 
           context 'in space 2' do
-            let(:filters) { { 'label_selector' => 'key=slimjim', 'app_guid' => app_in_space2.guid } }
+            let(:filters) { { 'label_selector' => 'key2=slimjim', 'app_guid' => app_in_space2.guid } }
             it 'returns the correct set of tasks' do
               expect(results.count).to eq(0)
             end


### PR DESCRIPTION
* A short explanation of the proposed change:

This commit updates how the presenter handles metadata (labels and annotations), treating nil and an empty string as an empty prefix. Earlier behavior would render an empty string as "/key=value" due to the prefix's non-nil status. The correct format in the absence of a prefix should be "key=value"; this commit rectifies this. This adjustment was made anticipating a subsequent change that will alter the default datatype of the prefix column in the database from NULL to an empty string. This step is essential to ensure the proper functioning of a unique key constraint, as multiple NULL values are considered distinct, hence, the UNIQUE constraints in the DB fail to work with NULL values in the columns.

* Links to any other associated PRs

Preparation for https://github.com/cloudfoundry/cloud_controller_ng/pull/3394

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
