### PR TITLE
Set log level for specs to fatal to reduce log size

### DIFF
--- a/spec/performance/packages_controller_index_spec.rb
+++ b/spec/performance/packages_controller_index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PackagesController, type: :controller do # , isolation: :truncati
     before do
       TestConfig.override(
         db: {
-          log_level: 'debug',
+          log_level: 'fatal',
       }
         # logging.level: 'debug2'
       )

--- a/spec/support/bootstrap/spec_bootstrap.rb
+++ b/spec/support/bootstrap/spec_bootstrap.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
       logger = ActiveSupport::Logger.new(File.join(Paths::ARTIFACTS, 'telemetry_spec.log'))
       TelemetryLogger.init(logger)
 
-      StenoConfigurer.new(level: 'debug2').configure do |steno_config_hash|
+      StenoConfigurer.new(level: 'fatal').configure do |steno_config_hash|
         steno_config_hash[:sinks] = [Steno::Sink::IO.for_file(log_filename)]
       end
 

--- a/spec/unit/lib/background_job_environment_spec.rb
+++ b/spec/unit/lib/background_job_environment_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BackgroundJobEnvironment do
     allow(Steno).to receive(:init)
 
     TestConfig.override(
-      logging: { level: 'debug2' },
+      logging: { level: 'fatal' },
     )
   end
   let(:config) { VCAP::CloudController::Config.config }

--- a/spec/unit/lib/bosh_errand_environment_spec.rb
+++ b/spec/unit/lib/bosh_errand_environment_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BoshErrandEnvironment do
   let(:config) { VCAP::CloudController::Config.new(
     {
       db: DbConfig.new.config,
-      logging: { level: 'debug2', stdout_sink_enabled: stdout_sink_enabled }
+      logging: { level: 'fatal', stdout_sink_enabled: stdout_sink_enabled }
     },
     context: :rotate_database_key)
   }

--- a/spec/unit/lib/cloud_controller/steno_configurer_spec.rb
+++ b/spec/unit/lib/cloud_controller/steno_configurer_spec.rb
@@ -4,7 +4,7 @@ require 'steno/codec_rfc3339'
 module VCAP::CloudController
   RSpec.describe StenoConfigurer do
     let(:config_hash) do
-      { level: 'debug2' }
+      { level: 'fatal' }
     end
     subject(:configurer) { StenoConfigurer.new(config_hash) }
 
@@ -42,7 +42,7 @@ module VCAP::CloudController
         configurer.configure do |steno_config_hash|
           block_called = true
           expect(steno_config_hash.fetch(:context)).to be_a Steno::Context::ThreadLocal
-          expect(steno_config_hash.fetch(:default_log_level)).to eq :debug2
+          expect(steno_config_hash.fetch(:default_log_level)).to eq :fatal
           expect(steno_config_hash.fetch(:codec)).to be_a Steno::Codec::JsonRFC3339
         end
 


### PR DESCRIPTION
Set log level for specs to `fatal` to reduce log size. This relevant e.g. for github actions

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
