### PR TITLE
Align Annotations Key Column with Labels

### DIFF
--- a/app/models/runtime/app_annotation_model.rb
+++ b/app/models/runtime/app_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class AppAnnotationModel < Sequel::Model(:app_annotations_migration_view)
+  class AppAnnotationModel < Sequel::Model(:app_annotations)
     set_primary_key :id
     many_to_one :app,
                 class: 'VCAP::CloudController::AppModel',

--- a/app/models/runtime/build_annotation_model.rb
+++ b/app/models/runtime/build_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class BuildAnnotationModel < Sequel::Model(:build_annotations_migration_view)
+  class BuildAnnotationModel < Sequel::Model(:build_annotations)
     set_primary_key :id
     many_to_one :build,
                 class: 'VCAP::CloudController::BuildModel',

--- a/app/models/runtime/buildpack_annotation_model.rb
+++ b/app/models/runtime/buildpack_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class BuildpackAnnotationModel < Sequel::Model(:buildpack_annotations_migration_view)
+  class BuildpackAnnotationModel < Sequel::Model(:buildpack_annotations)
     set_primary_key :id
     many_to_one :buildpack,
                 class: 'VCAP::CloudController::BuildpackModel',

--- a/app/models/runtime/deployment_annotation_model.rb
+++ b/app/models/runtime/deployment_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class DeploymentAnnotationModel < Sequel::Model(:deployment_annotations_migration_view)
+  class DeploymentAnnotationModel < Sequel::Model(:deployment_annotations)
     set_primary_key :id
     many_to_one :deployment,
                 class: 'VCAP::CloudController::DeploymentModel',

--- a/app/models/runtime/domain_annotation_model.rb
+++ b/app/models/runtime/domain_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class DomainAnnotationModel < Sequel::Model(:domain_annotations_migration_view)
+  class DomainAnnotationModel < Sequel::Model(:domain_annotations)
     set_primary_key :id
     many_to_one :domain,
                 class: 'VCAP::CloudController::DomainModel',

--- a/app/models/runtime/droplet_annotation_model.rb
+++ b/app/models/runtime/droplet_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class DropletAnnotationModel < Sequel::Model(:droplet_annotations_migration_view)
+  class DropletAnnotationModel < Sequel::Model(:droplet_annotations)
     set_primary_key :id
     many_to_one :droplet,
                 class: 'VCAP::CloudController::DropletModel',

--- a/app/models/runtime/isolation_segment_annotation_model.rb
+++ b/app/models/runtime/isolation_segment_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class IsolationSegmentAnnotationModel < Sequel::Model(:isolation_segment_annotations_migration_view)
+  class IsolationSegmentAnnotationModel < Sequel::Model(:isolation_segment_annotations)
     set_primary_key :id
     many_to_one :isolation_segment,
                 class: 'VCAP::CloudController::IsolationSegment',

--- a/app/models/runtime/organization_annotation_model.rb
+++ b/app/models/runtime/organization_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class OrganizationAnnotationModel < Sequel::Model(:organization_annotations_migration_view)
+  class OrganizationAnnotationModel < Sequel::Model(:organization_annotations)
     set_primary_key :id
     many_to_one :organization,
                 class: 'VCAP::CloudController::Organization',

--- a/app/models/runtime/package_annotation_model.rb
+++ b/app/models/runtime/package_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class PackageAnnotationModel < Sequel::Model(:package_annotations_migration_view)
+  class PackageAnnotationModel < Sequel::Model(:package_annotations)
     set_primary_key :id
     many_to_one :package,
                 class: 'VCAP::CloudController::PackageModel',

--- a/app/models/runtime/process_annotation_model.rb
+++ b/app/models/runtime/process_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class ProcessAnnotationModel < Sequel::Model(:process_annotations_migration_view)
+  class ProcessAnnotationModel < Sequel::Model(:process_annotations)
     set_primary_key :id
     many_to_one :process,
                 class: 'VCAP::CloudController::ProcessModel',

--- a/app/models/runtime/revision_annotation_model.rb
+++ b/app/models/runtime/revision_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class RevisionAnnotationModel < Sequel::Model(:revision_annotations_migration_view)
+  class RevisionAnnotationModel < Sequel::Model(:revision_annotations)
     set_primary_key :id
     many_to_one :revision,
                 class: 'VCAP::CloudController::RevisionModel',

--- a/app/models/runtime/route_annotation_model.rb
+++ b/app/models/runtime/route_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class RouteAnnotationModel < Sequel::Model(:route_annotations_migration_view)
+  class RouteAnnotationModel < Sequel::Model(:route_annotations)
     set_primary_key :id
     many_to_one :route,
                 primary_key: :guid,

--- a/app/models/runtime/service_instance_annotation_model.rb
+++ b/app/models/runtime/service_instance_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class ServiceInstanceAnnotationModel < Sequel::Model(:service_instance_annotations_migration_view)
+  class ServiceInstanceAnnotationModel < Sequel::Model(:service_instance_annotations)
     set_primary_key :id
     many_to_one :service_instance,
                 class: 'VCAP::CloudController::ServiceInstance',

--- a/app/models/runtime/space_annotation_model.rb
+++ b/app/models/runtime/space_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class SpaceAnnotationModel < Sequel::Model(:space_annotations_migration_view)
+  class SpaceAnnotationModel < Sequel::Model(:space_annotations)
     set_primary_key :id
     many_to_one :space,
                 class: 'VCAP::CloudController::Space',

--- a/app/models/runtime/stack_annotation_model.rb
+++ b/app/models/runtime/stack_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class StackAnnotationModel < Sequel::Model(:stack_annotations_migration_view)
+  class StackAnnotationModel < Sequel::Model(:stack_annotations)
     set_primary_key :id
     many_to_one :stack,
                 class: 'VCAP::CloudController::Stack',

--- a/app/models/runtime/task_annotation_model.rb
+++ b/app/models/runtime/task_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class TaskAnnotationModel < Sequel::Model(:task_annotations_migration_view)
+  class TaskAnnotationModel < Sequel::Model(:task_annotations)
     set_primary_key :id
     many_to_one :task,
                 class: 'VCAP::CloudController::TaskModel',

--- a/app/models/runtime/user_annotation_model.rb
+++ b/app/models/runtime/user_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class UserAnnotationModel < Sequel::Model(:user_annotations_migration_view)
+  class UserAnnotationModel < Sequel::Model(:user_annotations)
     set_primary_key :id
     many_to_one :user,
                 class: 'VCAP::CloudController::UserModel',

--- a/app/models/services/route_binding_annotation_model.rb
+++ b/app/models/services/route_binding_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class RouteBindingAnnotationModel < Sequel::Model(:route_binding_annotations_migration_view)
+  class RouteBindingAnnotationModel < Sequel::Model(:route_binding_annotations)
     set_primary_key :id
     many_to_one :route_binding,
                 primary_key: :guid,

--- a/app/models/services/service_binding_annotation_model.rb
+++ b/app/models/services/service_binding_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class ServiceBindingAnnotationModel < Sequel::Model(:service_binding_annotations_migration_view)
+  class ServiceBindingAnnotationModel < Sequel::Model(:service_binding_annotations)
     set_primary_key :id
     many_to_one :service_binding,
                 primary_key: :guid,

--- a/app/models/services/service_broker_annotation_model.rb
+++ b/app/models/services/service_broker_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class ServiceBrokerAnnotationModel < Sequel::Model(:service_broker_annotations_migration_view)
+  class ServiceBrokerAnnotationModel < Sequel::Model(:service_broker_annotations)
     set_primary_key :id
     many_to_one :service_broker,
                 primary_key: :guid,

--- a/app/models/services/service_broker_update_request_annotation_model.rb
+++ b/app/models/services/service_broker_update_request_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class ServiceBrokerUpdateRequestAnnotationModel < Sequel::Model(:service_broker_update_request_annotations_migration_view)
+  class ServiceBrokerUpdateRequestAnnotationModel < Sequel::Model(:service_broker_update_request_annotations)
     set_primary_key :id
     many_to_one :service_broker_update_request,
                 primary_key: :guid,

--- a/app/models/services/service_key_annotation_model.rb
+++ b/app/models/services/service_key_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class ServiceKeyAnnotationModel < Sequel::Model(:service_key_annotations_migration_view)
+  class ServiceKeyAnnotationModel < Sequel::Model(:service_key_annotations)
     set_primary_key :id
     many_to_one :service_key,
                 primary_key: :guid,

--- a/app/models/services/service_offering_annotation_model.rb
+++ b/app/models/services/service_offering_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class ServiceOfferingAnnotationModel < Sequel::Model(:service_offering_annotations_migration_view)
+  class ServiceOfferingAnnotationModel < Sequel::Model(:service_offering_annotations)
     set_primary_key :id
     many_to_one :service,
                 class: 'VCAP::CloudController::Service',

--- a/app/models/services/service_plan_annotation_model.rb
+++ b/app/models/services/service_plan_annotation_model.rb
@@ -1,5 +1,5 @@
 module VCAP::CloudController
-  class ServicePlanAnnotationModel < Sequel::Model(:service_plan_annotations_migration_view)
+  class ServicePlanAnnotationModel < Sequel::Model(:service_plan_annotations)
     set_primary_key :id
     many_to_one :service_plan,
                 class: 'VCAP::CloudController::ServicePlan',

--- a/db/migrations/20231221123000_rename_annotations_key_column.rb
+++ b/db/migrations/20231221123000_rename_annotations_key_column.rb
@@ -1,0 +1,61 @@
+TABLE_BASE_NAMES = %w[
+  app
+  build
+  buildpack
+  deployment
+  domain
+  droplet
+  isolation_segment
+  organization
+  package
+  process
+  revision
+  route_binding
+  route
+  service_binding
+  service_broker
+  service_broker_update_request
+  service_instance
+  service_key
+  service_offering
+  service_plan
+  space
+  stack
+  task
+  user
+].freeze
+annotation_tables = TABLE_BASE_NAMES.map { |tbn| "#{tbn}_annotations" }.freeze
+
+Sequel.migration do
+  no_transaction # Disable automatic transactions
+
+  up do
+    annotation_tables.each do |table|
+      transaction do
+        # PSQL renames columns in views automatically just mysql cannot do it
+        drop_view(:"#{table}_migration_view", if_exists: true) if database_type == :mysql
+        rename_column table.to_sym, :key, :key_name if schema(table.to_sym).map(&:first).include?(:key)
+        if database_type == :mysql
+          create_view(:"#{table}_migration_view", self[table.to_sym].select do
+                                                    [id, guid, created_at, updated_at, resource_guid, key_prefix, key_name, value]
+                                                  end)
+        end
+      end
+    end
+  end
+
+  down do
+    annotation_tables.each do |table|
+      transaction do
+        # PSQL renames columns in views automatically just mysql cannot do it
+        drop_view(:"#{table}_migration_view", if_exists: true) if database_type == :mysql
+        rename_column table.to_sym, :key_name, :key if schema(table.to_sym).map(&:first).include?(:key_name)
+        if database_type == :mysql
+          create_view(:"#{table}_migration_view", self[table.to_sym].select do
+                                                    [id, guid, created_at, updated_at, resource_guid, key_prefix, key, value]
+                                                  end)
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20231221123000_rename_annotations_key_column_spec.rb
+++ b/spec/migrations/20231221123000_rename_annotations_key_column_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+RSpec.describe 'migration to streamline changes to annotation_key_prefix', isolation: :truncation do
+  let(:filename) { '20231221123000_rename_annotations_key_column.rb' }
+  let(:tmp_down_migrations_dir) { Dir.mktmpdir }
+  let(:tmp_up_migrations_dir) { Dir.mktmpdir }
+  let(:db) { Sequel::Model.db }
+  let(:tables) do
+    %w[
+      app
+      build
+      buildpack
+      deployment
+      domain
+      droplet
+      isolation_segment
+      organization
+      package
+      process
+      revision
+      route_binding
+      route
+      service_binding
+      service_broker
+      service_broker_update_request
+      service_instance
+      service_key
+      service_offering
+      service_plan
+      space
+      stack
+      task
+      user
+    ].freeze
+  end
+
+  let(:annotation_tables) { tables.map { |tbn| "#{tbn}_annotations" }.freeze }
+
+  before do
+    Sequel.extension :migration
+    # Find all migrations
+    migration_files = Dir.glob("#{DBMigrator::SEQUEL_MIGRATIONS}/*.rb")
+    # Calculate the index of our migration file we`d  like to test
+    migration_index = migration_files.find_index { |file| file.end_with?(filename) }
+    # Make a file list of the migration file we like to test plus all migrations after the one we want to test
+    migration_files_after_test = migration_files[migration_index...]
+    # Copy them to a temp directory
+    FileUtils.cp(migration_files_after_test, tmp_down_migrations_dir)
+    FileUtils.cp(File.join(DBMigrator::SEQUEL_MIGRATIONS, filename), tmp_up_migrations_dir)
+    # Revert the given migration and everything newer so we are at the database version exactly before our migration we want to test.
+    Sequel::Migrator.run(db, tmp_down_migrations_dir, target: 0, allow_missing_migration_files: true)
+  end
+
+  after do
+    FileUtils.rm_rf(tmp_up_migrations_dir)
+    FileUtils.rm_rf(tmp_down_migrations_dir)
+  end
+
+  describe 'annotation tables' do
+    it 'has renamed the column key to key_name' do
+      annotation_tables.each do |table|
+        expect(db[table.to_sym].columns).to include(:key)
+        expect(db[table.to_sym].columns).not_to include(:key_name)
+      end
+      expect { Sequel::Migrator.run(db, tmp_up_migrations_dir, allow_missing_migration_files: true) }.not_to raise_error
+      annotation_tables.each do |table|
+        expect(db[table.to_sym].columns).not_to include(:key)
+        expect(db[table.to_sym].columns).to include(:key_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Renamed annotations key column to key_name in order to align with labels definitions. This change will provide a more consistent schema across labels and annotations and makes annotation keys behave the same as label keys.

See ADR: decisions/0004-adding-key-prefix-to-annotations.md
Also see this ADR for more information https://github.com/cloudfoundry/cloud_controller_ng/blob/main/decisions/0011-make-labels-and-annotations-unique.md

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
