### PR TITLE
Cancel CI Runs if PRs get new changes

### DIFF
--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -1,5 +1,7 @@
 name: Docs Tests
-
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.workflow }}'
+  cancel-in-progress: true
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,5 +1,7 @@
 name: Unit Tests
-
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.workflow }}'
+  cancel-in-progress: true
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
In case a PR gets a new commit or something is force pushed, we want the currently running actions to abort as they are meaningless anyway and just eat up capacity.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
