### PR TITLE
Make restructure_index migration idempotent and small transactions

### DIFF
--- a/db/migrations/20230725110800_restructure_index_for_improved_pagination_order.rb
+++ b/db/migrations/20230725110800_restructure_index_for_improved_pagination_order.rb
@@ -1,479 +1,573 @@
 Sequel.migration do
+  index_migration_data = [
+    # CREATED AT
+    {
+      table: :organizations,
+      old_index: :organizations_created_at_index,
+      old_columns: [:created_at],
+      new_index: :organizations_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :revisions,
+      old_index: :revisions_created_at_index,
+      old_columns: [:created_at],
+      new_index: :revisions_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :services,
+      old_index: :services_created_at_index,
+      old_columns: [:created_at],
+      new_index: :services_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :packages,
+      old_index: :packages_created_at_index,
+      old_columns: [:created_at],
+      new_index: :packages_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :routes,
+      old_index: :routes_created_at_index,
+      old_columns: [:created_at],
+      new_index: :routes_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :service_instances,
+      old_index: :si_created_at_index,
+      old_columns: [:created_at],
+      new_index: :service_instances_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :app_events,
+      old_index: :app_events_created_at_index,
+      old_columns: [:created_at],
+      new_index: :app_events_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :apps,
+      old_index: :apps_v3_created_at_index,
+      old_columns: [:created_at],
+      new_index: :apps_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :service_usage_events,
+      old_index: :created_at_index,
+      old_columns: [:created_at],
+      new_index: :service_usage_events_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :sidecars,
+      old_index: :sidecars_created_at_index,
+      old_columns: [:created_at],
+      new_index: :sidecars_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :deployments,
+      old_index: :deployments_created_at_index,
+      old_columns: [:created_at],
+      new_index: :deployments_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :security_groups,
+      old_index: :sg_created_at_index,
+      old_columns: [:created_at],
+      new_index: :security_groups_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :delayed_jobs,
+      old_index: :dj_created_at_index,
+      old_columns: [:created_at],
+      new_index: :delayed_jobs_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :builds,
+      old_index: :builds_created_at_index,
+      old_columns: [:created_at],
+      new_index: :builds_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :quota_definitions,
+      old_index: :qd_created_at_index,
+      old_columns: [:created_at],
+      new_index: :quota_definitions_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :tasks,
+      old_index: :tasks_created_at_index,
+      old_columns: [:created_at],
+      new_index: :tasks_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :droplets,
+      old_index: :droplets_created_at_index,
+      old_columns: [:created_at],
+      new_index: :droplets_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :users,
+      old_index: :users_created_at_index,
+      old_columns: [:created_at],
+      new_index: :users_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :space_quota_definitions,
+      old_index: :sqd_created_at_index,
+      old_columns: [:created_at],
+      new_index: :space_quota_definitions_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :isolation_segments,
+      old_index: :isolation_segments_created_at_index,
+      old_columns: [:created_at],
+      new_index: :isolation_segments_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :service_brokers,
+      old_index: :sbrokers_created_at_index,
+      old_columns: [:created_at],
+      new_index: :service_brokers_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :processes,
+      old_index: :apps_created_at_index,
+      old_columns: [:created_at],
+      new_index: :processes_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :service_keys,
+      old_index: :sk_created_at_index,
+      old_columns: [:created_at],
+      new_index: :service_keys_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :service_plans,
+      old_index: :service_plans_created_at_index,
+      old_columns: [:created_at],
+      new_index: :service_plans_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :stacks,
+      old_index: :stacks_created_at_index,
+      old_columns: [:created_at],
+      new_index: :stacks_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :route_bindings,
+      old_index: :route_bindings_created_at_index,
+      old_columns: [:created_at],
+      new_index: :route_bindings_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :app_usage_events,
+      old_index: :usage_events_created_at_index,
+      old_columns: [:created_at],
+      new_index: :app_usage_events_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :jobs,
+      old_index: :jobs_created_at_index,
+      old_columns: [:created_at],
+      new_index: :jobs_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :events,
+      old_index: :events_created_at_index,
+      old_columns: [:created_at],
+      new_index: :events_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :service_bindings,
+      old_index: :sb_created_at_index,
+      old_columns: [:created_at],
+      new_index: :service_bindings_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :domains,
+      old_index: :domains_created_at_index,
+      old_columns: [:created_at],
+      new_index: :domains_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :buildpacks,
+      old_index: :buildpacks_created_at_index,
+      old_columns: [:created_at],
+      new_index: :buildpacks_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    {
+      table: :spaces,
+      old_index: :spaces_created_at_index,
+      old_columns: [:created_at],
+      new_index: :spaces_created_at_guid_index,
+      new_columns: [:created_at, :guid]
+    },
+    # UPDATED AT
+    {
+      table: :organizations,
+      old_index: :organizations_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :organizations_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :revisions,
+      old_index: :revisions_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :revisions_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :services,
+      old_index: :services_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :services_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :packages,
+      old_index: :packages_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :packages_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :routes,
+      old_index: :routes_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :routes_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :service_instances,
+      old_index: :si_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :service_instances_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :app_events,
+      old_index: :app_events_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :app_events_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :apps,
+      old_index: :apps_v3_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :apps_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :sidecars,
+      old_index: :sidecars_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :sidecars_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :deployments,
+      old_index: :deployments_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :deployments_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :security_groups,
+      old_index: :sg_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :security_groups_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :delayed_jobs,
+      old_index: :dj_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :delayed_jobs_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :builds,
+      old_index: :builds_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :builds_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :quota_definitions,
+      old_index: :qd_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :quota_definitions_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :tasks,
+      old_index: :tasks_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :tasks_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :droplets,
+      old_index: :droplets_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :droplets_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :users,
+      old_index: :users_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :users_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :space_quota_definitions,
+      old_index: :sqd_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :space_quota_definitions_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :isolation_segments,
+      old_index: :isolation_segments_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :isolation_segments_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :service_brokers,
+      old_index: :sbrokers_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :service_brokers_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :processes,
+      old_index: :apps_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :processes_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :service_keys,
+      old_index: :sk_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :service_keys_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :service_plans,
+      old_index: :service_plans_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :service_plans_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :stacks,
+      old_index: :stacks_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :stacks_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :route_bindings,
+      old_index: :route_bindings_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :route_bindings_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :jobs,
+      old_index: :jobs_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :jobs_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :events,
+      old_index: :events_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :events_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :service_bindings,
+      old_index: :sb_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :service_bindings_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :domains,
+      old_index: :domains_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :domains_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :buildpacks,
+      old_index: :buildpacks_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :buildpacks_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    {
+      table: :spaces,
+      old_index: :spaces_updated_at_index,
+      old_columns: [:updated_at],
+      new_index: :spaces_updated_at_guid_index,
+      new_columns: [:updated_at, :guid]
+    },
+    # LABEL
+    {
+      table: :services,
+      old_index: :services_label_index,
+      old_columns: [:label],
+      new_index: :services_label_guid_index,
+      new_columns: [:label, :guid]
+    },
+    # NAME
+    {
+      table: :organizations,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :organizations_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    {
+      table: :service_instances,
+      old_index: :service_instances_name_index,
+      old_columns: [:name],
+      new_index: :service_instances_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    {
+      table: :apps,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :apps_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    {
+      table: :isolation_segments,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :isolation_segments_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    {
+      table: :service_brokers,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :service_brokers_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    {
+      table: :service_keys,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :service_keys_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    {
+      table: :service_plans,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :service_plans_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    {
+      table: :stacks,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :stacks_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    {
+      table: :service_bindings,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :service_bindings_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    {
+      table: :spaces,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :spaces_name_guid_index,
+      new_columns: [:name, :guid]
+    },
+    # DESIRED_STATE
+    {
+      table: :apps,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :apps_desired_state_guid_index,
+      new_columns: [:desired_state, :guid]
+    },
+    # POSITION
+    {
+      table: :buildpacks,
+      old_index: nil,
+      old_columns: nil,
+      new_index: :buildpacks_position_guid_index,
+      new_columns: [:position, :guid]
+    },
+  ]
+
   up do
-    #####################
-    #### CREATED_AT #####
-    #####################
-    drop_index :organizations, nil, name: :organizations_created_at_index
-    add_index :organizations, [:created_at, :guid], name: :organizations_created_at_guid_index
-
-    drop_index :revisions, nil, name: :revisions_created_at_index
-    add_index :revisions, [:created_at, :guid], name: :revisions_created_at_guid_index
-
-    drop_index :services, nil, name: :services_created_at_index
-    add_index :services, [:created_at, :guid], name: :services_created_at_guid_index
-
-    drop_index :packages, nil, name: :packages_created_at_index
-    add_index :packages, [:created_at, :guid], name: :packages_created_at_guid_index
-
-    drop_index :routes, nil, name: :routes_created_at_index
-    add_index :routes, [:created_at, :guid], name: :routes_created_at_guid_index
-
-    drop_index :service_instances, nil, name: :si_created_at_index
-    add_index :service_instances, [:created_at, :guid], name: :service_instances_created_at_guid_index
-
-    drop_index :app_events, nil, name: :app_events_created_at_index
-    add_index :app_events, [:created_at, :guid], name: :app_events_created_at_guid_index
-
-    drop_index :apps, nil, name: :apps_v3_created_at_index
-    add_index :apps, [:created_at, :guid], name: :apps_created_at_guid_index
-
-    drop_index :service_usage_events, nil, name: :created_at_index
-    add_index :service_usage_events, [:created_at, :guid], name: :service_usage_events_created_at_guid_index
-
-    drop_index :sidecars, nil, name: :sidecars_created_at_index
-    add_index :sidecars, [:created_at, :guid], name: :sidecars_created_at_guid_index
-
-    drop_index :deployments, nil, name: :deployments_created_at_index
-    add_index :deployments, [:created_at, :guid], name: :deployments_created_at_guid_index
-
-    drop_index :security_groups, nil, name: :sg_created_at_index
-    add_index :security_groups, [:created_at, :guid], name: :security_groups_created_at_guid_index
-
-    drop_index :delayed_jobs, nil, name: :dj_created_at_index
-    add_index :delayed_jobs, [:created_at, :guid], name: :delayed_jobs_created_at_guid_index
-
-    drop_index :builds, nil, name: :builds_created_at_index
-    add_index :builds, [:created_at, :guid], name: :builds_created_at_guid_index
-
-    drop_index :quota_definitions, nil, name: :qd_created_at_index
-    add_index :quota_definitions, [:created_at, :guid], name: :quota_definitions_created_at_guid_index
-
-    drop_index :tasks, nil, name: :tasks_created_at_index
-    add_index :tasks, [:created_at, :guid], name: :tasks_created_at_guid_index
-
-    drop_index :droplets, nil, name: :droplets_created_at_index
-    add_index :droplets, [:created_at, :guid], name: :droplets_created_at_guid_index
-
-    drop_index :users, nil, name: :users_created_at_index
-    add_index :users, [:created_at, :guid], name: :users_created_at_guid_index
-
-    drop_index :space_quota_definitions, nil, name: :sqd_created_at_index
-    add_index :space_quota_definitions, [:created_at, :guid], name: :space_quota_definitions_created_at_guid_index
-
-    drop_index :isolation_segments, nil, name: :isolation_segments_created_at_index
-    add_index :isolation_segments, [:created_at, :guid], name: :isolation_segments_created_at_guid_index
-
-    drop_index :service_brokers, nil, name: :sbrokers_created_at_index
-    add_index :service_brokers, [:created_at, :guid], name: :service_brokers_created_at_guid_index
-
-    drop_index :processes, nil, name: :apps_created_at_index
-    add_index :processes, [:created_at, :guid], name: :processes_created_at_guid_index
-
-    drop_index :service_keys, nil, name: :sk_created_at_index
-    add_index :service_keys, [:created_at, :guid], name: :service_keys_created_at_guid_index
-
-    drop_index :service_plans, nil, name: :service_plans_created_at_index
-    add_index :service_plans, [:created_at, :guid], name: :service_plans_created_at_guid_index
-
-    drop_index :stacks, nil, name: :stacks_created_at_index
-    add_index :stacks, [:created_at, :guid], name: :stacks_created_at_guid_index
-
-    drop_index :route_bindings, nil, name: :route_bindings_created_at_index
-    add_index :route_bindings, [:created_at, :guid], name: :route_bindings_created_at_guid_index
-
-    drop_index :app_usage_events, nil, name: :usage_events_created_at_index
-    add_index :app_usage_events, [:created_at, :guid], name: :app_usage_events_created_at_guid_index
-
-    drop_index :jobs, nil, name: :jobs_created_at_index
-    add_index :jobs, [:created_at, :guid], name: :jobs_created_at_guid_index
-
-    drop_index :events, nil, name: :events_created_at_index
-    add_index :events, [:created_at, :guid], name: :events_created_at_guid_index
-
-    drop_index :service_bindings, nil, name: :sb_created_at_index
-    add_index :service_bindings, [:created_at, :guid], name: :service_bindings_created_at_guid_index
-
-    drop_index :domains, nil, name: :domains_created_at_index
-    add_index :domains, [:created_at, :guid], name: :domains_created_at_guid_index
-
-    drop_index :buildpacks, nil, name: :buildpacks_created_at_index
-    add_index :buildpacks, [:created_at, :guid], name: :buildpacks_created_at_guid_index
-
-    drop_index :spaces, nil, name: :spaces_created_at_index
-    add_index :spaces, [:created_at, :guid], name: :spaces_created_at_guid_index
-
-    #####################
-    #### UPDATED_AT #####
-    #####################
-
-    drop_index :organizations, nil, name: :organizations_updated_at_index
-    add_index :organizations, [:updated_at, :guid], name: :organizations_updated_at_guid_index
-
-    drop_index :revisions, nil, name: :revisions_updated_at_index
-    add_index :revisions, [:updated_at, :guid], name: :revisions_updated_at_guid_index
-
-    drop_index :services, nil, name: :services_updated_at_index
-    add_index :services, [:updated_at, :guid], name: :services_updated_at_guid_index
-
-    drop_index :packages, nil, name: :packages_updated_at_index
-    add_index :packages, [:updated_at, :guid], name: :packages_updated_at_guid_index
-
-    drop_index :routes, nil, name: :routes_updated_at_index
-    add_index :routes, [:updated_at, :guid], name: :routes_updated_at_guid_index
-
-    drop_index :service_instances, nil, name: :si_updated_at_index
-    add_index :service_instances, [:updated_at, :guid], name: :service_instances_updated_at_guid_index
-
-    drop_index :app_events, nil, name: :app_events_updated_at_index
-    add_index :app_events, [:updated_at, :guid], name: :app_events_updated_at_guid_index
-
-    drop_index :apps, nil, name: :apps_v3_updated_at_index
-    add_index :apps, [:updated_at, :guid], name: :apps_updated_at_guid_index
-
-    drop_index :sidecars, nil, name: :sidecars_updated_at_index
-    add_index :sidecars, [:updated_at, :guid], name: :sidecars_updated_at_guid_index
-
-    drop_index :deployments, nil, name: :deployments_updated_at_index
-    add_index :deployments, [:updated_at, :guid], name: :deployments_updated_at_guid_index
-
-    drop_index :security_groups, nil, name: :sg_updated_at_index
-    add_index :security_groups, [:updated_at, :guid], name: :security_groups_updated_at_guid_index
-
-    drop_index :delayed_jobs, nil, name: :dj_updated_at_index
-    add_index :delayed_jobs, [:updated_at, :guid], name: :delayed_jobs_updated_at_guid_index
-
-    drop_index :builds, nil, name: :builds_updated_at_index
-    add_index :builds, [:updated_at, :guid], name: :builds_updated_at_guid_index
-
-    drop_index :quota_definitions, nil, name: :qd_updated_at_index
-    add_index :quota_definitions, [:updated_at, :guid], name: :quota_definitions_updated_at_guid_index
-
-    drop_index :tasks, nil, name: :tasks_updated_at_index
-    add_index :tasks, [:updated_at, :guid], name: :tasks_updated_at_guid_index
-
-    drop_index :droplets, nil, name: :droplets_updated_at_index
-    add_index :droplets, [:updated_at, :guid], name: :droplets_updated_at_guid_index
-
-    drop_index :users, nil, name: :users_updated_at_index
-    add_index :users, [:updated_at, :guid], name: :users_updated_at_guid_index
-
-    drop_index :space_quota_definitions, nil, name: :sqd_updated_at_index
-    add_index :space_quota_definitions, [:updated_at, :guid], name: :space_quota_definitions_updated_at_guid_index
-
-    drop_index :isolation_segments, nil, name: :isolation_segments_updated_at_index
-    add_index :isolation_segments, [:updated_at, :guid], name: :isolation_segments_updated_at_guid_index
-
-    drop_index :service_brokers, nil, name: :sbrokers_updated_at_index
-    add_index :service_brokers, [:updated_at, :guid], name: :service_brokers_updated_at_guid_index
-
-    drop_index :processes, nil, name: :apps_updated_at_index
-    add_index :processes, [:updated_at, :guid], name: :processes_updated_at_guid_index
-
-    drop_index :service_keys, nil, name: :sk_updated_at_index
-    add_index :service_keys, [:updated_at, :guid], name: :service_keys_updated_at_guid_index
-
-    drop_index :service_plans, nil, name: :service_plans_updated_at_index
-    add_index :service_plans, [:updated_at, :guid], name: :service_plans_updated_at_guid_index
-
-    drop_index :stacks, nil, name: :stacks_updated_at_index
-    add_index :stacks, [:updated_at, :guid], name: :stacks_updated_at_guid_index
-
-    drop_index :route_bindings, nil, name: :route_bindings_updated_at_index
-    add_index :route_bindings, [:updated_at, :guid], name: :route_bindings_updated_at_guid_index
-
-    drop_index :jobs, nil, name: :jobs_updated_at_index
-    add_index :jobs, [:updated_at, :guid], name: :jobs_updated_at_guid_index
-
-    drop_index :events, nil, name: :events_updated_at_index
-    add_index :events, [:updated_at, :guid], name: :events_updated_at_guid_index
-
-    drop_index :service_bindings, nil, name: :sb_updated_at_index
-    add_index :service_bindings, [:updated_at, :guid], name: :service_bindings_updated_at_guid_index
-
-    drop_index :domains, nil, name: :domains_updated_at_index
-    add_index :domains, [:updated_at, :guid], name: :domains_updated_at_guid_index
-
-    drop_index :buildpacks, nil, name: :buildpacks_updated_at_index
-    add_index :buildpacks, [:updated_at, :guid], name: :buildpacks_updated_at_guid_index
-
-    drop_index :spaces, nil, name: :spaces_updated_at_index
-    add_index :spaces, [:updated_at, :guid], name: :spaces_updated_at_guid_index
-
-    ##############
-    #### NAME ####
-    ##############
-
-    add_index :organizations, [:name, :guid], name: :organizations_name_guid_index
-
-    drop_index :services, nil, name: :services_label_index
-    add_index :services, [:label, :guid], name: :services_label_guid_index
-
-    drop_index :service_instances, nil, name: :service_instances_name_index
-    add_index :service_instances, [:name, :guid], name: :service_instances_name_guid_index
-
-    add_index :apps, [:name, :guid], name: :apps_name_guid_index
-
-    add_index :isolation_segments, [:name, :guid], name: :isolation_segments_name_guid_index
-
-    add_index :service_brokers, [:name, :guid], name: :service_brokers_name_guid_index
-
-    add_index :service_keys, [:name, :guid], name: :service_keys_name_guid_index
-
-    add_index :service_plans, [:name, :guid], name: :service_plans_name_guid_index
-
-    add_index :stacks, [:name, :guid], name: :stacks_name_guid_index
-
-    add_index :service_bindings, [:name, :guid], name: :service_bindings_name_guid_index
-
-    add_index :spaces, [:name, :guid], name: :spaces_name_guid_index
-
-    #######################
-    #### DESIRED_STATE ####
-    #######################
-    add_index :apps, [:desired_state, :guid], name: :apps_desired_state_guid_index
-
-    ##################
-    #### POSITION ####
-    ##################
-    add_index :buildpacks, [:position, :guid], name: :buildpacks_position_guid_index
+    index_migration_data.each do |index_migration|
+      transaction do
+        if index_migration[:old_index].present? && index_migration[:old_columns].present?
+          drop_index index_migration[:table], nil, name: index_migration[:old_index], if_exists: true
+        end
+        if self.indexes(index_migration[:table])[index_migration[:new_index]].nil?
+          add_index index_migration[:table], index_migration[:new_columns], name: index_migration[:new_index]
+        end
+      end
+    end
   end
 
   down do
-    ####################
-    #### CREATED_AT ####
-    ####################
-    drop_index :organizations, nil, name: :organizations_created_at_guid_index
-    add_index :organizations, [:created_at], name: :organizations_created_at_index
-
-    drop_index :revisions, nil, name: :revisions_created_at_guid_index
-    add_index :revisions, [:created_at], name: :revisions_created_at_index
-
-    drop_index :services, nil, name: :services_created_at_guid_index
-    add_index :services, [:created_at], name: :services_created_at_index
-
-    drop_index :packages, nil, name: :packages_created_at_guid_index
-    add_index :packages, [:created_at], name: :packages_created_at_index
-
-    drop_index :routes, nil, name: :routes_created_at_guid_index
-    add_index :routes, [:created_at], name: :routes_created_at_index
-
-    drop_index :service_instances, nil, name: :service_instances_created_at_guid_index
-    add_index :service_instances, [:created_at], name: :si_created_at_index
-
-    drop_index :app_events, nil, name: :app_events_created_at_guid_index
-    add_index :app_events, [:created_at], name: :app_events_created_at_index
-
-    drop_index :apps, nil, name: :apps_created_at_guid_index
-    add_index :apps, [:created_at], name: :apps_v3_created_at_index
-
-    drop_index :service_usage_events, nil, name: :service_usage_events_created_at_guid_index
-    add_index :service_usage_events, [:created_at], name: :created_at_index
-
-    drop_index :sidecars, nil, name: :sidecars_created_at_guid_index
-    add_index :sidecars, [:created_at], name: :sidecars_created_at_index
-
-    drop_index :deployments, nil, name: :deployments_created_at_guid_index
-    add_index :deployments, [:created_at], name: :deployments_created_at_index
-
-    drop_index :security_groups, nil, name: :security_groups_created_at_guid_index
-    add_index :security_groups, [:created_at], name: :sg_created_at_index
-
-    drop_index :delayed_jobs, nil, name: :delayed_jobs_created_at_guid_index
-    add_index :delayed_jobs, [:created_at], name: :dj_created_at_index
-
-    drop_index :builds, nil, name: :builds_created_at_guid_index
-    add_index :builds, [:created_at], name: :builds_created_at_index
-
-    drop_index :quota_definitions, nil, name: :quota_definitions_created_at_guid_index
-    add_index :quota_definitions, [:created_at], name: :qd_created_at_index
-
-    drop_index :tasks, nil, name: :tasks_created_at_guid_index
-    add_index :tasks, [:created_at], name: :tasks_created_at_index
-
-    drop_index :droplets, nil, name: :droplets_created_at_guid_index
-    add_index :droplets, [:created_at], name: :droplets_created_at_index
-
-    drop_index :users, nil, name: :users_created_at_guid_index
-    add_index :users, [:created_at], name: :users_created_at_index
-
-    drop_index :space_quota_definitions, nil, name: :space_quota_definitions_created_at_guid_index
-    add_index :space_quota_definitions, [:created_at], name: :sqd_created_at_index
-
-    drop_index :isolation_segments, nil, name: :isolation_segments_created_at_guid_index
-    add_index :isolation_segments, [:created_at], name: :isolation_segments_created_at_index
-
-    drop_index :service_brokers, nil, name: :service_brokers_created_at_guid_index
-    add_index :service_brokers, [:created_at], name: :sbrokers_created_at_index
-
-    drop_index :processes, nil, name: :processes_created_at_guid_index
-    add_index :processes, [:created_at], name: :apps_created_at_index
-
-    drop_index :service_keys, nil, name: :service_keys_created_at_guid_index
-    add_index :service_keys, [:created_at], name: :sk_created_at_index
-
-    drop_index :service_plans, nil, name: :service_plans_created_at_guid_index
-    add_index :service_plans, [:created_at], name: :service_plans_created_at_index
-
-    drop_index :stacks, nil, name: :stacks_created_at_guid_index
-    add_index :stacks, [:created_at], name: :stacks_created_at_index
-
-    drop_index :route_bindings, nil, name: :route_bindings_created_at_guid_index
-    add_index :route_bindings, [:created_at], name: :route_bindings_created_at_index
-
-    drop_index :app_usage_events, nil, name: :app_usage_events_created_at_guid_index
-    add_index :app_usage_events, [:created_at], name: :usage_events_created_at_index
-
-    drop_index :jobs, nil, name: :jobs_created_at_guid_index
-    add_index :jobs, [:created_at], name: :jobs_created_at_index
-
-    drop_index :events, nil, name: :events_created_at_guid_index
-    add_index :events, [:created_at], name: :events_created_at_index
-
-    drop_index :service_bindings, nil, name: :service_bindings_created_at_guid_index
-    add_index :service_bindings, [:created_at], name: :sb_created_at_index
-
-    drop_index :domains, nil, name: :domains_created_at_guid_index
-    add_index :domains, [:created_at], name: :domains_created_at_index
-
-    drop_index :buildpacks, nil, name: :buildpacks_created_at_guid_index
-    add_index :buildpacks, [:created_at], name: :buildpacks_created_at_index
-
-    drop_index :spaces, nil, name: :spaces_created_at_guid_index
-    add_index :spaces, [:created_at], name: :spaces_created_at_index
-
-    ####################
-    #### UPDATED_AT ####
-    ####################
-
-    drop_index :organizations, nil, name: :organizations_updated_at_guid_index
-    add_index :organizations, [:updated_at], name: :organizations_updated_at_index
-
-    drop_index :revisions, nil, name: :revisions_updated_at_guid_index
-    add_index :revisions, [:updated_at], name: :revisions_updated_at_index
-
-    drop_index :services, nil, name: :services_updated_at_guid_index
-    add_index :services, [:updated_at], name: :services_updated_at_index
-
-    drop_index :packages, nil, name: :packages_updated_at_guid_index
-    add_index :packages, [:updated_at], name: :packages_updated_at_index
-
-    drop_index :routes, nil, name: :routes_updated_at_guid_index
-    add_index :routes, [:updated_at], name: :routes_updated_at_index
-
-    drop_index :service_instances, nil, name: :service_instances_updated_at_guid_index
-    add_index :service_instances, [:updated_at], name: :si_updated_at_index
-
-    drop_index :app_events, nil, name: :app_events_updated_at_guid_index
-    add_index :app_events, [:updated_at], name: :app_events_updated_at_index
-
-    drop_index :apps, nil, name: :apps_updated_at_guid_index
-    add_index :apps, [:updated_at], name: :apps_v3_updated_at_index
-
-    drop_index :sidecars, nil, name: :sidecars_updated_at_guid_index
-    add_index :sidecars, [:updated_at], name: :sidecars_updated_at_index
-
-    drop_index :deployments, nil, name: :deployments_updated_at_guid_index
-    add_index :deployments, [:updated_at], name: :deployments_updated_at_index
-
-    drop_index :security_groups, nil, name: :security_groups_updated_at_guid_index
-    add_index :security_groups, [:updated_at], name: :sg_updated_at_index
-
-    drop_index :delayed_jobs, nil, name: :delayed_jobs_updated_at_guid_index
-    add_index :delayed_jobs, [:updated_at], name: :dj_updated_at_index
-
-    drop_index :builds, nil, name: :builds_updated_at_guid_index
-    add_index :builds, [:updated_at], name: :builds_updated_at_index
-
-    drop_index :quota_definitions, nil, name: :quota_definitions_updated_at_guid_index
-    add_index :quota_definitions, [:updated_at], name: :qd_updated_at_index
-
-    drop_index :tasks, nil, name: :tasks_updated_at_guid_index
-    add_index :tasks, [:updated_at], name: :tasks_updated_at_index
-
-    drop_index :droplets, nil, name: :droplets_updated_at_guid_index
-    add_index :droplets, [:updated_at], name: :droplets_updated_at_index
-
-    drop_index :users, nil, name: :users_updated_at_guid_index
-    add_index :users, [:updated_at], name: :users_updated_at_index
-
-    drop_index :space_quota_definitions, nil, name: :space_quota_definitions_updated_at_guid_index
-    add_index :space_quota_definitions, [:updated_at], name: :sqd_updated_at_index
-
-    drop_index :isolation_segments, nil, name: :isolation_segments_updated_at_guid_index
-    add_index :isolation_segments, [:updated_at], name: :isolation_segments_updated_at_index
-
-    drop_index :service_brokers, nil, name: :service_brokers_updated_at_guid_index
-    add_index :service_brokers, [:updated_at], name: :sbrokers_updated_at_index
-
-    drop_index :processes, nil, name: :processes_updated_at_guid_index
-    add_index :processes, [:updated_at], name: :apps_updated_at_index
-
-    drop_index :service_keys, nil, name: :service_keys_updated_at_guid_index
-    add_index :service_keys, [:updated_at], name: :sk_updated_at_index
-
-    drop_index :service_plans, nil, name: :service_plans_updated_at_guid_index
-    add_index :service_plans, [:updated_at], name: :service_plans_updated_at_index
-
-    drop_index :stacks, nil, name: :stacks_updated_at_guid_index
-    add_index :stacks, [:updated_at], name: :stacks_updated_at_index
-
-    drop_index :route_bindings, nil, name: :route_bindings_updated_at_guid_index
-    add_index :route_bindings, [:updated_at], name: :route_bindings_updated_at_index
-
-    drop_index :jobs, nil, name: :jobs_updated_at_guid_index
-    add_index :jobs, [:updated_at], name: :jobs_updated_at_index
-
-    drop_index :events, nil, name: :events_updated_at_guid_index
-    add_index :events, [:updated_at], name: :events_updated_at_index
-
-    drop_index :service_bindings, nil, name: :service_bindings_updated_at_guid_index
-    add_index :service_bindings, [:updated_at], name: :sb_updated_at_index
-
-    drop_index :domains, nil, name: :domains_updated_at_guid_index
-    add_index :domains, [:updated_at], name: :domains_updated_at_index
-
-    drop_index :buildpacks, nil, name: :buildpacks_updated_at_guid_index
-    add_index :buildpacks, [:updated_at], name: :buildpacks_updated_at_index
-
-    drop_index :spaces, nil, name: :spaces_updated_at_guid_index
-    add_index :spaces, [:updated_at], name: :spaces_updated_at_index
-
-    #####################
-    #### Name #####
-    #####################
-
-    drop_index :organizations, nil, name: :organizations_name_guid_index
-
-    drop_index :services, nil, name: :services_label_guid_index
-    add_index :services, [:label], name: :services_label_index
-
-    drop_index :service_instances, nil, name: :service_instances_name_guid_index
-    add_index :service_instances, [:name], name: :service_instances_name_index
-
-    drop_index :apps, nil, name: :apps_name_guid_index
-
-    drop_index :isolation_segments, nil, name: :isolation_segments_name_guid_index
-
-    drop_index :service_brokers, nil, name: :service_brokers_name_guid_index
-
-    drop_index :service_keys, nil, name: :service_keys_name_guid_index
-
-    drop_index :service_plans, nil, name: :service_plans_name_guid_index
-
-    drop_index :stacks, nil, name: :stacks_name_guid_index
-
-    drop_index :service_bindings, nil, name: :service_bindings_name_guid_index
-
-    drop_index :spaces, nil, name: :spaces_name_guid_index
-
-    #######################
-    #### DESIRED_STATE ####
-    #######################
-    drop_index :apps, nil, name: :apps_desired_state_guid_index
-
-    ##################
-    #### POSITION ####
-    ##################
-    drop_index :buildpacks, nil, name: :buildpacks_position_guid_index
+    index_migration_data.each do |index_migration|
+      transaction do
+        drop_index index_migration[:table], nil, name: index_migration[:new_index], if_exists: true
+        if index_migration[:old_index].present? && index_migration[:old_columns].present? && self.indexes(index_migration[:table])[index_migration[:old_index]].nil?
+          add_index index_migration[:table], index_migration[:old_columns], name: index_migration[:old_index]
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes a deadlock issue when running the migration 20230725110800_restructure_index_for_improved_pagination_order.rb

This migration migrated halve the DBs tables in a single transaction because `up do` implicitly creates a transaction inside its whole block. This has the side effect that queries with joins can lock some tables while the transaction locks tables the select also waits on and vice versa. Creating a deadlock situation. The migration in its previous state needed some luck with lock.

This change fixes the scenario so no deadlock can occur by running the migration for each table in an own transaction. So the whole transaction just requires a lock for a single table which prevents any mutual deadlock situations.

Additionally the migration was made idempotent as when such a deadlock happens on postgres the DLLs also get transactionally reverted so the migration can start over again. However this is not the case for mysql. If the transaction is aborted due to a deadlock half of the tables indices stay migrated the other half is not. The previous implementation then would fail e.g. on a drop index due to the index being already drop creating a situation where manual intervention is needed for mysql. This now cannot happen anymore due to idempotency of the migration.

* Links to any other associated PRs

#3352

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
