### PR TITLE
Run loops in migrations in own transactions

### DIFF
--- a/db/migrations/20230822153000_streamline_annotation_key_prefix.rb
+++ b/db/migrations/20230822153000_streamline_annotation_key_prefix.rb
@@ -30,18 +30,20 @@ Sequel.migration do
   up do
     annotation_tables.each do |table|
       # Output all annotations with a forward Slash
-      annotations = self[table.to_sym].where(Sequel.like(:key, '%/%'))
-      annotations.each do |annotation|
-        prefix, key_name = VCAP::CloudController::MetadataHelpers.extract_prefix(annotation[:key].to_s)
-        if prefix.present?
-          self[table.to_sym].where(guid: annotation[:guid]).delete
-          self[table.to_sym].insert(guid: annotation[:guid],
-                                    created_at: annotation[:created_at],
-                                    updated_at: Sequel::CURRENT_TIMESTAMP,
-                                    resource_guid: annotation[:resource_guid],
-                                    key_prefix: prefix,
-                                    key: key_name,
-                                    value: annotation[:value])
+      transaction do
+        annotations = self[table.to_sym].where(Sequel.like(:key, '%/%'))
+        annotations.each do |annotation|
+          prefix, key_name = VCAP::CloudController::MetadataHelpers.extract_prefix(annotation[:key].to_s)
+          if prefix.present?
+            self[table.to_sym].where(guid: annotation[:guid]).delete
+            self[table.to_sym].insert(guid: annotation[:guid],
+                                      created_at: annotation[:created_at],
+                                      updated_at: Sequel::CURRENT_TIMESTAMP,
+                                      resource_guid: annotation[:resource_guid],
+                                      key_prefix: prefix,
+                                      key: key_name,
+                                      value: annotation[:value])
+          end
         end
       end
     end

--- a/db/migrations/20230822173000_add_migration_views_for_annotations.rb
+++ b/db/migrations/20230822173000_add_migration_views_for_annotations.rb
@@ -29,12 +29,16 @@ Sequel.migration do
 
   up do
     annotation_tables.each do |table|
-      create_view("#{table}_migration_view".to_sym, self[table.to_sym].select { [id, guid, created_at, updated_at, resource_guid, key_prefix, key.as(key_name), value] })
+      transaction do
+        create_view("#{table}_migration_view".to_sym, self[table.to_sym].select { [id, guid, created_at, updated_at, resource_guid, key_prefix, key.as(key_name), value] })
+      end
     end
   end
   down do
     annotation_tables.each do |table|
-      drop_view("#{table}_migration_view".to_sym, if_exists: true)
+      transaction do
+        drop_view("#{table}_migration_view".to_sym, if_exists: true)
+      end
     end
   end
 end


### PR DESCRIPTION
Similar to #3417 we`d like to put also other operations that run in loops inside cc migrations into own transactions to prevent possibility of a deadlock by having locks on many tables concurrently when it is not at all needed.

* Links to any other associated PRs

#3417

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
