### PR TITLE
Fix migration deadlock on busy systems

### DIFF
--- a/db/migrations/20230725110800_restructure_index_for_improved_pagination_order.rb
+++ b/db/migrations/20230725110800_restructure_index_for_improved_pagination_order.rb
@@ -547,6 +547,7 @@ Sequel.migration do
     },
   ]
 
+  no_transaction
   up do
     index_migration_data.each do |index_migration|
       transaction do


### PR DESCRIPTION
In #3417 there was a change to fix deadlocks created by table joins. However, on our busy system at gov.uk a deadlock still occurred and our deployment attempts in production failed repeatedly.

We fixed this and successfully deployed by forcing a `no_transaction` outside the `up` and `down` but not inside the index migration. I'm not entirely sure why this worked, but our assumption was that the `up` created a transaction and then we end up with sub-transactions for each migration.

Either way, this is the only way we could deploy on a busy system.

I'm open to a discussion on why if anyone can explain, and maybe tell me why this was the wrong solution.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
