### PR TITLE
Disable automatic transactions, follow up of #3424

### DIFF
--- a/db/migrations/20230725110800_restructure_index_for_improved_pagination_order.rb
+++ b/db/migrations/20230725110800_restructure_index_for_improved_pagination_order.rb
@@ -547,7 +547,8 @@ Sequel.migration do
     },
   ]
 
-  no_transaction
+  no_transaction # Disable automatic transactions
+
   up do
     index_migration_data.each do |index_migration|
       transaction do

--- a/db/migrations/20230822153000_streamline_annotation_key_prefix.rb
+++ b/db/migrations/20230822153000_streamline_annotation_key_prefix.rb
@@ -27,6 +27,8 @@ Sequel.migration do
   ].freeze
   annotation_tables = table_base_names.map { |tbn| "#{tbn}_annotations" }.freeze
 
+  no_transaction # Disable automatic transactions
+
   up do
     annotation_tables.each do |table|
       # Output all annotations with a forward Slash

--- a/db/migrations/20230822173000_add_migration_views_for_annotations.rb
+++ b/db/migrations/20230822173000_add_migration_views_for_annotations.rb
@@ -27,6 +27,8 @@ Sequel.migration do
   ].freeze
   annotation_tables = table_base_names.map { |tbn| "#{tbn}_annotations" }.freeze
 
+  no_transaction # Disable automatic transactions
+
   up do
     annotation_tables.each do |table|
       transaction do


### PR DESCRIPTION
As found out while testing the behaviour of Sequel in #3424 we must call no_transaction for migration that define own tranaction blocks.

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
