### PR TITLE
add script to start docker container with db for unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ keep it up to date, documenting the purpose of the various types of tests.
 
 By default `rspec` will randomly pick between postgres and mysql.
 
+#### Running the Units Tests in Docker
+
+If you don't want to set up a up a test DB locally, you can run
+`./scripts/start-db-in-docker.sh`. This script will start a docker container
+with a running postgres. Then you can run the tests from the docker container
+by running `rspec`.
+
+#### Running the Test DB Locally
 If postgres is not running on your OSX machine, you can start up a server by doing the following:
 ```
 brew services start postgresql

--- a/scripts/docker-shell-with-started-db
+++ b/scripts/docker-shell-with-started-db
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e -u
+
+ROOT_DIR_PATH="$(cd $(dirname $0)/.. && pwd)"
+cd "${ROOT_DIR_PATH}"
+
+db=postgres
+docker_image=cloudfoundry/tas-runtime-postgres
+
+# This script only works for postgres because the tas-runtime mysql images do
+# not have ruby on them.
+
+docker run \
+   --rm \
+   -it \
+   --privileged \
+   -v "${PWD}:/cloud_controller_ng" \
+   -e "DB=$db" \
+   --cap-add ALL \
+   -w /cloud_controller_ng \
+   $docker_image \
+   /bin/bash /cloud_controller_ng/scripts/start-db-in-docker.sh

--- a/scripts/start-db-in-docker.sh
+++ b/scripts/start-db-in-docker.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e -u
+
+function bootDB {
+  db="$1"
+   
+  launchDB="(/postgres-entrypoint.sh postgres &> /var/log/postgres-boot.log) &"
+  testConnection="psql -h localhost -U postgres -c '\conninfo'"
+  createTestDB="psql -h localhost -U postgres -c 'create database cc_test'"
+
+  echo -n "booting ${db}"
+  eval "$launchDB"
+  for _ in $(seq 1 60); do
+    if eval "${testConnection}" &> /dev/null; then
+      break
+    fi
+    echo -n "."
+    sleep 1
+  done
+
+  if eval "${testConnection}" &> /dev/null; then
+    echo "connection established to ${db}"
+  else 
+    echo "unable to connect to ${db}"
+    exit 1
+  fi
+}
+
+function moreSetup {
+  apt-get update
+  apt-get install -y libpq-dev default-libmysqlclient-dev
+  bundle install
+  rake db:create
+}
+
+cd /cloud_controller_ng
+export GOPATH=$PWD
+
+bootDB "${DB:-"notset"}"
+moreSetup
+set +e
+exec /bin/bash


### PR DESCRIPTION
I don't work on a machine that has a local DB. When I started working on readiness healthcheck stuff I spent 2+ hours just trying to get one setup. In the end, I made this script from a similar one in cf-networking-release. I don't promise that it works for every CAPI use case (it only works with postgres for example), but it works great for when a new person wants to run some tests and iterate quickly.

To use, run: `./scripts/docker-shell-with-started-db`

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
