### PR TITLE
Prometheus on Thin

### DIFF
--- a/app/controllers/internal/metrics_controller.rb
+++ b/app/controllers/internal/metrics_controller.rb
@@ -8,6 +8,7 @@ module VCAP::CloudController
       get '/internal/v4/metrics', :index
 
       def index
+        CloudController::DependencyLocator.instance.periodic_updater.update!
         [200, Prometheus::Client::Formats::Text.marshal(Prometheus::Client.registry)]
       end
     end

--- a/app/controllers/internal/metrics_controller.rb
+++ b/app/controllers/internal/metrics_controller.rb
@@ -1,6 +1,5 @@
 require 'prometheus/client'
 require 'prometheus/client/formats/text'
-require 'cloud_controller/metrics/prometheus_updater'
 
 module VCAP::CloudController
   module Internal
@@ -9,16 +8,6 @@ module VCAP::CloudController
       get '/internal/v4/metrics', :index
 
       def index
-        periodic_updater = VCAP::CloudController::Metrics::PeriodicUpdater.new(
-          Time.now.utc,
-          Steno::Sink::Counter.new,
-          Steno.logger('cc.api'),
-          [
-            VCAP::CloudController::Metrics::StatsdUpdater.new,
-            VCAP::CloudController::Metrics::PrometheusUpdater.new
-          ]
-        )
-        periodic_updater.update!
         [200, Prometheus::Client::Formats::Text.marshal(Prometheus::Client.registry)]
       end
     end

--- a/app/controllers/internal/staging_completion_controller.rb
+++ b/app/controllers/internal/staging_completion_controller.rb
@@ -115,7 +115,7 @@ module VCAP::CloudController
     end
 
     def prometheus_updater
-      @prometheus_updater ||= VCAP::CloudController::Metrics::PrometheusUpdater.new # this should be using singleton
+      CloudController::DependencyLocator.instance.prometheus_updater
     end
 
     attr_reader :stagers

--- a/app/jobs/diego/sync.rb
+++ b/app/jobs/diego/sync.rb
@@ -7,9 +7,8 @@ module VCAP::CloudController
   module Jobs
     module Diego
       class Sync < VCAP::CloudController::Jobs::CCJob
-        def initialize(statsd=Statsd.new, prometheus_updater=VCAP::CloudController::Metrics::PrometheusUpdater.new)
+        def initialize(statsd=Statsd.new)
           @statsd = statsd
-          @prometheus_updater = prometheus_updater
         end
 
         def perform
@@ -28,7 +27,6 @@ module VCAP::CloudController
             elapsed_ms = ((finish - start) * 1000).round
 
             @statsd.timing('cc.diego_sync.duration', elapsed_ms)
-            @prometheus_updater.report_diego_cell_sync_duration((finish - start))
           end
         end
 

--- a/app/jobs/diego/sync.rb
+++ b/app/jobs/diego/sync.rb
@@ -28,7 +28,7 @@ module VCAP::CloudController
             elapsed_ms = ((finish - start) * 1000).round
 
             @statsd.timing('cc.diego_sync.duration', elapsed_ms)
-            @prometheus_updater.report_diego_cell_sync_duration(elapsed_ms)
+            @prometheus_updater.report_diego_cell_sync_duration((finish - start))
           end
         end
 

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -68,8 +68,7 @@ module CloudController
                    Steno.logger('cc.api'),
                    VCAP::CloudController::Metrics::StatsdUpdater.new(statsd_client),
                    prometheus_updater
-                 )
-        )
+                 ))
     end
 
     def prometheus_updater

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -59,6 +59,19 @@ module CloudController
       @dependencies[:runners] || register(:runners, VCAP::CloudController::Runners.new(config))
     end
 
+    def periodic_updater
+      @dependencies[:periodic_updater] ||
+        register(:periodic_updater,
+                 VCAP::CloudController::Metrics::PeriodicUpdater.new(
+                   Time.now.utc,
+                   Steno::Sink::Counter.new,
+                   Steno.logger('cc.api'),
+                   VCAP::CloudController::Metrics::StatsdUpdater.new(statsd_client),
+                   prometheus_updater
+                 )
+        )
+    end
+
     def prometheus_updater
       register(:prometheus_updater, VCAP::CloudController::Metrics::PrometheusUpdater.new) unless @dependencies[:prometheus_updater]
       @dependencies[:prometheus_updater]

--- a/lib/cloud_controller/deployment_updater/scheduler.rb
+++ b/lib/cloud_controller/deployment_updater/scheduler.rb
@@ -10,13 +10,11 @@ module VCAP::CloudController
           with_error_logging('cc.deployment_updater') do
             config = CloudController::DependencyLocator.instance.config
             statsd_client = CloudController::DependencyLocator.instance.statsd_client
-            prometheus_updater = CloudController::DependencyLocator.instance.prometheus_updater
 
             update_step = proc {
               update(
                 update_frequency: config.get(:deployment_updater, :update_frequency_in_seconds),
-                statsd_client: statsd_client,
-                prometheus_updater: prometheus_updater
+                statsd_client: statsd_client
               )
             }
 
@@ -42,7 +40,7 @@ module VCAP::CloudController
 
         private
 
-        def update(update_frequency:, statsd_client:, prometheus_updater:)
+        def update(update_frequency:, statsd_client:)
           logger = Steno.logger('cc.deployment_updater.scheduler')
 
           update_start_time = Time.now
@@ -54,7 +52,6 @@ module VCAP::CloudController
           ##       so feed in the entire value!
           update_duration_ms = update_duration * 1000
           statsd_client.timing('cc.deployments.update.duration', update_duration_ms)
-          prometheus_updater.report_deployment_duration(update_duration)
 
           logger.info("Update loop took #{update_duration}s")
 

--- a/lib/cloud_controller/deployment_updater/scheduler.rb
+++ b/lib/cloud_controller/deployment_updater/scheduler.rb
@@ -54,7 +54,7 @@ module VCAP::CloudController
           ##       so feed in the entire value!
           update_duration_ms = update_duration * 1000
           statsd_client.timing('cc.deployments.update.duration', update_duration_ms)
-          prometheus_updater.report_deployment_duration(update_duration_ms)
+          prometheus_updater.report_deployment_duration(update_duration)
 
           logger.info("Update loop took #{update_duration}s")
 

--- a/lib/cloud_controller/diego/messenger.rb
+++ b/lib/cloud_controller/diego/messenger.rb
@@ -4,8 +4,9 @@ require 'cloud_controller/diego/desire_app_handler'
 module VCAP::CloudController
   module Diego
     class Messenger
-      def initialize(statsd_updater=VCAP::CloudController::Metrics::StatsdUpdater.new)
+      def initialize(statsd_updater=VCAP::CloudController::Metrics::StatsdUpdater.new, prometheus_updater=CloudController::DependencyLocator.instance.prometheus_updater)
         @statsd_updater = statsd_updater
+        @prometheus_updater = prometheus_updater
       end
 
       def send_stage_request(_config, staging_details)
@@ -15,6 +16,7 @@ module VCAP::CloudController
 
         bbs_stager_client.stage(staging_guid, staging_details)
         @statsd_updater.start_staging_request_received
+        @prometheus_updater.start_staging_request_received
       end
 
       def send_stop_staging_request(staging_guid)

--- a/lib/cloud_controller/metrics/periodic_updater.rb
+++ b/lib/cloud_controller/metrics/periodic_updater.rb
@@ -3,9 +3,10 @@ require 'vcap/stats'
 
 module VCAP::CloudController::Metrics
   class PeriodicUpdater
-    def initialize(start_time, log_counter, logger=Steno.logger, updaters=[StatsdUpdater.new, PrometheusUpdater.new])
+    def initialize(start_time, log_counter, logger, statsd_updater=StatsdUpdater.new, prometheus_updater=PrometheusUpdater.new)
       @start_time = start_time
-      @updaters = updaters
+      @statsd_updater = statsd_updater
+      @prometheus_updater = prometheus_updater
       @log_counter = log_counter
       @logger = logger
       @known_job_queues = {
@@ -47,7 +48,7 @@ module VCAP::CloudController::Metrics
       running_task_count = running_tasks.count
       running_task_memory = running_tasks.sum(:memory_in_mb)
       running_task_memory = 0 if running_task_memory.nil?
-      @updaters.each { |u| u.update_task_stats(running_task_count, running_task_memory) }
+      [@statsd_updater, @prometheus_updater].each { |u| u.update_task_stats(running_task_count, running_task_memory) }
     end
 
     def update_log_counts
@@ -58,19 +59,19 @@ module VCAP::CloudController::Metrics
         hash[level_name] = counts.fetch(level_name.to_s, 0)
       end
 
-      @updaters.each { |u| u.update_log_counts(hash) }
+      @statsd_updater.update_log_counts(hash)
     end
 
     def update_deploying_count
       deploying_count = VCAP::CloudController::DeploymentModel.deploying_count
 
-      @updaters.each { |u| u.update_deploying_count(deploying_count) }
+      [@statsd_updater, @prometheus_updater].each { |u| u.update_deploying_count(deploying_count) }
     end
 
     def update_user_count
       user_count = VCAP::CloudController::User.count
 
-      @updaters.each { |u| u.update_user_count(user_count) }
+      [@statsd_updater, @prometheus_updater].each { |u| u.update_user_count(user_count) }
     end
 
     def update_job_queue_length
@@ -84,13 +85,13 @@ module VCAP::CloudController::Metrics
       end
 
       pending_job_count_by_queue.reverse_merge!(@known_job_queues)
-      @updaters.each { |u| u.update_job_queue_length(pending_job_count_by_queue, total) }
+      [@statsd_updater, @prometheus_updater].each { |u| u.update_job_queue_length(pending_job_count_by_queue, total) }
     end
 
     def update_thread_info
       local_thread_info = thread_info
 
-      @updaters.each { |u| u.update_thread_info(local_thread_info) }
+      [@statsd_updater, @prometheus_updater].each { |u| u.update_thread_info(local_thread_info) }
     end
 
     def update_failed_job_count
@@ -104,7 +105,7 @@ module VCAP::CloudController::Metrics
       end
 
       failed_jobs_by_queue.reverse_merge!(@known_job_queues)
-      @updaters.each { |u| u.update_failed_job_count(failed_jobs_by_queue, total) }
+      [@statsd_updater, @prometheus_updater].each { |u| u.update_failed_job_count(failed_jobs_by_queue, total) }
     end
 
     def update_vitals
@@ -120,7 +121,7 @@ module VCAP::CloudController::Metrics
         num_cores: VCAP::HostSystem.new.num_cores
       }
 
-      @updaters.each { |u| u.update_vitals(vitals) }
+      [@statsd_updater, @prometheus_updater].each { |u| u.update_vitals(vitals) }
     end
 
     def thread_info

--- a/lib/cloud_controller/metrics/periodic_updater.rb
+++ b/lib/cloud_controller/metrics/periodic_updater.rb
@@ -127,6 +127,7 @@ module VCAP::CloudController::Metrics
 
       prom_vitals = vitals.clone
       prom_vitals.delete(:uptime)
+      prom_vitals.delete(:cpu)
       prom_vitals[:started_at] = @start_time.to_i
       @prometheus_updater.update_vitals(prom_vitals)
     end

--- a/lib/cloud_controller/metrics/periodic_updater.rb
+++ b/lib/cloud_controller/metrics/periodic_updater.rb
@@ -48,7 +48,7 @@ module VCAP::CloudController::Metrics
       running_task_count = running_tasks.count
       running_task_memory = running_tasks.sum(:memory_in_mb) || 0
       @statsd_updater.update_task_stats(running_task_count, running_task_memory)
-      @prometheus_updater.update_task_stats(running_task_count, running_task_memory * 1000 * 1000)
+      @prometheus_updater.update_task_stats(running_task_count, running_task_memory * 1024 * 1024)
     end
 
     def update_log_counts

--- a/lib/cloud_controller/metrics/periodic_updater.rb
+++ b/lib/cloud_controller/metrics/periodic_updater.rb
@@ -3,7 +3,7 @@ require 'vcap/stats'
 
 module VCAP::CloudController::Metrics
   class PeriodicUpdater
-    def initialize(start_time, log_counter, logger, statsd_updater=StatsdUpdater.new, prometheus_updater=PrometheusUpdater.new)
+    def initialize(start_time, log_counter, logger, statsd_updater, prometheus_updater)
       @start_time = start_time
       @statsd_updater = statsd_updater
       @prometheus_updater = prometheus_updater

--- a/lib/cloud_controller/metrics/periodic_updater.rb
+++ b/lib/cloud_controller/metrics/periodic_updater.rb
@@ -46,7 +46,7 @@ module VCAP::CloudController::Metrics
     def update_task_stats
       running_tasks = VCAP::CloudController::TaskModel.where(state: VCAP::CloudController::TaskModel::RUNNING_STATE)
       running_task_count = running_tasks.count
-      running_task_memory = running_task_memory.nil? ? 0 : running_tasks.sum(:memory_in_mb)
+      running_task_memory = running_tasks.sum(:memory_in_mb) || 0
       @statsd_updater.update_task_stats(running_task_count, running_task_memory)
       @prometheus_updater.update_task_stats(running_task_count, running_task_memory * 1000 * 1000)
     end

--- a/lib/cloud_controller/metrics/periodic_updater.rb
+++ b/lib/cloud_controller/metrics/periodic_updater.rb
@@ -123,7 +123,12 @@ module VCAP::CloudController::Metrics
         num_cores: VCAP::HostSystem.new.num_cores
       }
 
-      [@statsd_updater, @prometheus_updater].each { |u| u.update_vitals(vitals) }
+      @statsd_updater.update_vitals(vitals)
+
+      prom_vitals = vitals.clone
+      prom_vitals.delete(:uptime)
+      prom_vitals[:started_at] = @start_time.to_i
+      @prometheus_updater.update_vitals(prom_vitals)
     end
 
     def thread_info

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -9,21 +9,12 @@ module VCAP::CloudController::Metrics
       @registry.gauge(:cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue]) unless @registry.exist?(:cc_job_queues_length_total)
       @registry.gauge(:cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue]) unless @registry.exist?(:cc_failed_jobs_total)
       @registry.counter(:cc_staging_requested, docstring: 'Number of staging requests') unless @registry.exist?(:cc_staging_requested)
-      @registry.gauge(:cc_diego_sync_invalid_desired_lrps, docstring: 'Invalid Desired LRPs') unless @registry.exist?(:cc_diego_sync_invalid_desired_lrps)
       unless @registry.exist?(:cc_staging_succeeded_duration_seconds)
         @registry.histogram(:cc_staging_succeeded_duration_seconds,
                             docstring: 'Durations of successful staging events',
                             buckets: duration_buckets)
       end
       @registry.histogram(:cc_staging_failed_duration_seconds, docstring: 'Durations of failed staging events', buckets: duration_buckets) unless @registry.exist?(:cc_staging_failed_duration_seconds)
-
-      @registry.summary(:cc_diego_sync_duration_summary, docstring: 'Diego cell sync duration summary') unless @registry.exist?(:cc_diego_sync_duration_summary)
-      @registry.histogram(:cc_diego_sync_duration_hist, docstring: 'Diego cell sync duration histogram') unless @registry.exist?(:cc_diego_sync_duration_hist)
-      @registry.gauge(:cc_diego_sync_duration_gauge, docstring: 'Diego cell sync duration gauge') unless @registry.exist?(:cc_diego_sync_duration_gauge)
-
-      @registry.summary(:cc_deployments_update_duration_summary, docstring: 'Deployment duration summary') unless @registry.exist?(:cc_deployments_update_duration_summary)
-      @registry.histogram(:cc_deployments_update_duration_hist, docstring: 'Deployment duration histogram') unless @registry.exist?(:cc_deployments_update_duration_hist)
-      @registry.gauge(:cc_deployments_update_duration_gauge, docstring: 'Deployment duration gauge') unless @registry.exist?(:cc_deployments_update_duration_gauge)
 
       @registry.gauge(:cc_requests_outstanding_gauge, docstring: 'Requests Outstanding Gauge') unless @registry.exist?(:cc_requests_outstanding_gauge)
       @registry.counter(:cc_requests_completed, docstring: 'Requests Completed') unless @registry.exist?(:cc_requests_completed)
@@ -102,10 +93,6 @@ module VCAP::CloudController::Metrics
       update_gauge_metric(:cc_tasks_running_memory_in_mb, total_memory_in_bytes, 'Total memory consumed by running tasks')
     end
 
-    def update_synced_invalid_lrps(lrp_count)
-      update_gauge_metric(:cc_diego_sync_invalid_desired_lrps, lrp_count, 'Invalid Desired LRPs')
-    end
-
     def start_staging_request_received
       increment_counter_metric(:cc_staging_requested, 'Number of staging requests')
     end
@@ -116,18 +103,6 @@ module VCAP::CloudController::Metrics
 
     def report_staging_failure_metrics(duration_ns)
       update_histogram_metric(:cc_staging_failed_duration_seconds, nanoseconds_to_seconds(duration_ns), 'Durations of failed staging events')
-    end
-
-    def report_diego_cell_sync_duration(duration_seconds)
-      update_summary_metric(:cc_diego_sync_duration_summary, duration_seconds, 'Diego cell sync duration summary')
-      update_histogram_metric(:cc_diego_sync_duration_hist, duration_seconds, 'Diego cell sync duration histogram')
-      update_gauge_metric(:cc_diego_sync_duration_gauge, duration_seconds, 'Diego cell sync duration (gauge metric)')
-    end
-
-    def report_deployment_duration(duration_seconds)
-      update_summary_metric(:cc_deployments_update_duration_summary, duration_seconds, 'Deployment duration summary')
-      update_histogram_metric(:cc_deployments_update_duration_hist, duration_seconds, 'Deployment duration histogram')
-      update_gauge_metric(:cc_deployments_update_duration_gauge, duration_seconds, 'Deployment duration (gauge metric)')
     end
 
     private

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController::Metrics
       { type: :gauge, name: :cc_requests_outstanding_total, docstring: 'Requests outstanding' },
       { type: :counter, name: :cc_requests_completed_total, docstring: 'Requests completed' },
       { type: :gauge, name: :cc_thread_info_thread_count, docstring: 'Thread count' },
-      { type: :gauge, name: :cc_thread_info_event_machine_connection_count, docstring: 'Event Machine connection count' },
+      { type: :gauge, name: :cc_thread_info_event_machine_connection_count, docstring: 'EventMachine connection count' },
       { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_size, docstring: 'EventMachine thread queue size' },
       { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_num_waiting, docstring: 'EventMachine num waiting in thread' },
       { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_size, docstring: 'EventMachine queue size' },

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -2,11 +2,39 @@ require 'prometheus/client'
 
 module VCAP::CloudController::Metrics
   class PrometheusUpdater
+    DURATION_BUCKETS = [5, 10, 30, 60, 300, 600, 890].freeze
+
+    METRICS = [
+      { type: :gauge, name: :cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue] },
+      { type: :gauge, name: :cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue] },
+      { type: :counter, name: :cc_staging_requested_total, docstring: 'Number of staging requests' },
+      { type: :histogram, name: :cc_staging_succeeded_duration_seconds, docstring: 'Durations of successful staging events', buckets: DURATION_BUCKETS },
+      { type: :histogram, name: :cc_staging_failed_duration_seconds, docstring: 'Durations of failed staging events', buckets: DURATION_BUCKETS },
+      { type: :gauge, name: :cc_requests_outstanding_total, docstring: 'Requests outstanding' },
+      { type: :counter, name: :cc_requests_completed_total, docstring: 'Requests completed' },
+      { type: :gauge, name: :cc_thread_info_thread_count, docstring: 'Thread count' },
+      { type: :gauge, name: :cc_thread_info_event_machine_connection_count, docstring: 'Event Machine connection count' },
+      { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_size, docstring: 'EventMachine thread queue size' },
+      { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_num_waiting, docstring: 'EventMachine num waiting in thread' },
+      { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_size, docstring: 'EventMachine queue size' },
+      { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_num_waiting, docstring: 'EventMachine requests waiting in queue' },
+      { type: :gauge, name: :cc_vitals_started_at, docstring: 'CloudController Vitals: started_at' },
+      { type: :gauge, name: :cc_vitals_mem_bytes, docstring: 'CloudController Vitals: mem_bytes' },
+      { type: :gauge, name: :cc_vitals_cpu_load_avg, docstring: 'CloudController Vitals: cpu_load_avg' },
+      { type: :gauge, name: :cc_vitals_mem_used_bytes, docstring: 'CloudController Vitals: mem_used_bytes' },
+      { type: :gauge, name: :cc_vitals_mem_free_bytes, docstring: 'CloudController Vitals: mem_free_bytes' },
+      { type: :gauge, name: :cc_vitals_num_cores, docstring: 'CloudController Vitals: num_cores' },
+      { type: :gauge, name: :cc_running_tasks_total, docstring: 'Total running tasks' },
+      { type: :gauge, name: :cc_running_tasks_memory_bytes, docstring: 'Total memory consumed by running tasks' },
+      { type: :gauge, name: :cc_users_total, docstring: 'Number of users' },
+      { type: :gauge, name: :cc_deployments_in_progress_total, docstring: 'Number of in progress deployments' }
+    ].freeze
+
     def initialize(registry=Prometheus::Client.registry)
       @registry = registry
 
       # Register all metrics, to initialize them for discoverability
-      metrics.map do |metric|
+      METRICS.map do |metric|
         register_metric(metric[:type], metric[:name], metric[:docstring], labels: metric[:labels] || {}, buckets: metric[:buckets] || {}) unless @registry.exist?(metric[:name])
       end
     end
@@ -102,38 +130,6 @@ module VCAP::CloudController::Metrics
     end
 
     private
-
-    def metrics
-      [
-        { type: :gauge, name: :cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue] },
-        { type: :gauge, name: :cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue] },
-        { type: :counter, name: :cc_staging_requested_total, docstring: 'Number of staging requests' },
-        { type: :histogram, name: :cc_staging_succeeded_duration_seconds, docstring: 'Durations of successful staging events', buckets: duration_buckets },
-        { type: :histogram, name: :cc_staging_failed_duration_seconds, docstring: 'Durations of failed staging events', buckets: duration_buckets },
-        { type: :gauge, name: :cc_requests_outstanding_total, docstring: 'Requests outstanding' },
-        { type: :counter, name: :cc_requests_completed_total, docstring: 'Requests completed' },
-        { type: :gauge, name: :cc_thread_info_thread_count, docstring: 'Thread count' },
-        { type: :gauge, name: :cc_thread_info_event_machine_connection_count, docstring: 'Event Machine connection count' },
-        { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_size, docstring: 'EventMachine thread queue size' },
-        { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_num_waiting, docstring: 'EventMachine num waiting in thread' },
-        { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_size, docstring: 'EventMachine queue size' },
-        { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_num_waiting, docstring: 'EventMachine requests waiting in queue' },
-        { type: :gauge, name: :cc_vitals_started_at, docstring: 'CloudController Vitals: started_at' },
-        { type: :gauge, name: :cc_vitals_mem_bytes, docstring: 'CloudController Vitals: mem_bytes' },
-        { type: :gauge, name: :cc_vitals_cpu_load_avg, docstring: 'CloudController Vitals: cpu_load_avg' },
-        { type: :gauge, name: :cc_vitals_mem_used_bytes, docstring: 'CloudController Vitals: mem_used_bytes' },
-        { type: :gauge, name: :cc_vitals_mem_free_bytes, docstring: 'CloudController Vitals: mem_free_bytes' },
-        { type: :gauge, name: :cc_vitals_num_cores, docstring: 'CloudController Vitals: num_cores' },
-        { type: :gauge, name: :cc_running_tasks_total, docstring: 'Total running tasks' },
-        { type: :gauge, name: :cc_running_tasks_memory_bytes, docstring: 'Total memory consumed by running tasks' },
-        { type: :gauge, name: :cc_users_total, docstring: 'Number of users' },
-        { type: :gauge, name: :cc_deployments_in_progress_total, docstring: 'Number of in progress deployments' }
-      ]
-    end
-
-    def duration_buckets
-      [5, 10, 30, 60, 300, 600, 890]
-    end
 
     def nanoseconds_to_seconds(time_ns)
       (time_ns / 1e9).to_f

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -4,11 +4,34 @@ module VCAP::CloudController::Metrics
   class PrometheusUpdater
     def initialize(registry=Prometheus::Client.registry)
       @registry = registry
+
+      # Register all metrics, to initialize them for discoverability
+      @registry.gauge(:cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue]) unless @registry.exist?(:cc_job_queues_length_total)
+      @registry.gauge(:cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue]) unless @registry.exist?(:cc_failed_jobs_total)
+      @registry.counter(:cc_staging_requested, docstring: 'Number of staging requests') unless @registry.exist?(:cc_staging_requested)
+      @registry.gauge(:cc_diego_sync_invalid_desired_lrps, docstring: 'Invalid Desired LRPs') unless @registry.exist?(:cc_diego_sync_invalid_desired_lrps)
+      unless @registry.exist?(:cc_staging_succeeded_duration_seconds)
+        @registry.histogram(:cc_staging_succeeded_duration_seconds,
+                            docstring: 'Durations of successful staging events',
+                            buckets: duration_buckets)
+      end
+      @registry.histogram(:cc_staging_failed_duration_seconds, docstring: 'Durations of failed staging events', buckets: duration_buckets) unless @registry.exist?(:cc_staging_failed_duration_seconds)
+
+      @registry.summary(:cc_diego_sync_duration_summary, docstring: 'Diego cell sync duration summary') unless @registry.exist?(:cc_diego_sync_duration_summary)
+      @registry.histogram(:cc_diego_sync_duration_hist, docstring: 'Diego cell sync duration histogram') unless @registry.exist?(:cc_diego_sync_duration_hist)
+      @registry.gauge(:cc_diego_sync_duration_gauge, docstring: 'Diego cell sync duration gauge') unless @registry.exist?(:cc_diego_sync_duration_gauge)
+
+      @registry.summary(:cc_deployments_update_duration_summary, docstring: 'Deployment duration summary') unless @registry.exist?(:cc_deployments_update_duration_summary)
+      @registry.histogram(:cc_deployments_update_duration_hist, docstring: 'Deployment duration histogram') unless @registry.exist?(:cc_deployments_update_duration_hist)
+      @registry.gauge(:cc_deployments_update_duration_gauge, docstring: 'Deployment duration gauge') unless @registry.exist?(:cc_deployments_update_duration_gauge)
+
+      @registry.gauge(:cc_requests_outstanding_gauge, docstring: 'Requests Outstanding Gauge') unless @registry.exist?(:cc_requests_outstanding_gauge)
+      @registry.counter(:cc_requests_completed, docstring: 'Requests Completed') unless @registry.exist?(:cc_requests_completed)
     end
 
-    def update_gauge_metric(metric, value, message)
+    def update_gauge_metric(metric, value, message, labels: {})
       @registry.gauge(metric, docstring: message) unless @registry.exist?(metric)
-      @registry.get(metric).set(value)
+      @registry.get(metric).set(value, labels:)
     end
 
     def increment_gauge_metric(metric, message)
@@ -26,7 +49,7 @@ module VCAP::CloudController::Metrics
       @registry.get(metric).increment
     end
 
-    def update_histogram_metric(metric, value, message, buckets)
+    def update_histogram_metric(metric, value, message, buckets: nil)
       @registry.histogram(metric, buckets: buckets, docstring: message) unless @registry.exist?(metric)
       @registry.get(metric).observe(value)
     end
@@ -44,13 +67,10 @@ module VCAP::CloudController::Metrics
       update_gauge_metric(:cc_total_users, user_count, 'Number of users')
     end
 
-    def update_job_queue_length(pending_job_count_by_queue, total)
+    def update_job_queue_length(pending_job_count_by_queue)
       pending_job_count_by_queue.each do |key, value|
-        metric_key = :"cc_job_queue_length_#{key.to_s.underscore}"
-        update_gauge_metric(metric_key, value, docstring: "Job queue length for worker #{key}")
+        update_gauge_metric(:cc_job_queues_length_total, value, "Job queue length for worker #{key}", labels: { queue: key.to_s.underscore })
       end
-
-      update_gauge_metric(:cc_job_queue_length_total, total, 'Total job queue length')
     end
 
     def update_thread_info(thread_info)
@@ -62,13 +82,10 @@ module VCAP::CloudController::Metrics
       update_gauge_metric(:cc_thread_info_event_machine_resultqueue_num_waiting, thread_info[:event_machine][:resultqueue][:num_waiting], 'EventMachine requests waiting in queue')
     end
 
-    def update_failed_job_count(failed_jobs_by_queue, total)
+    def update_failed_job_count(failed_jobs_by_queue)
       failed_jobs_by_queue.each do |key, value|
-        metric_key = :"cc_failed_job_count_#{key.to_s.underscore}"
-        update_gauge_metric(metric_key, value, "Failed jobs for worker #{key}")
+        update_gauge_metric(:cc_failed_jobs_total, value, "Failed jobs for worker #{key}", labels: { queue: key.to_s.underscore })
       end
-
-      update_gauge_metric(:cc_failed_job_count_total, total, 'Total failed jobs')
     end
 
     def update_vitals(vitals)
@@ -80,9 +97,9 @@ module VCAP::CloudController::Metrics
       end
     end
 
-    def update_task_stats(total_running_tasks, total_memory_in_mb)
+    def update_task_stats(total_running_tasks, total_memory_in_bytes)
       update_gauge_metric(:cc_tasks_running_count, total_running_tasks, 'Total running tasks')
-      update_gauge_metric(:cc_tasks_running_memory_in_mb, total_memory_in_mb, 'Total memory consumed by running tasks')
+      update_gauge_metric(:cc_tasks_running_memory_in_mb, total_memory_in_bytes, 'Total memory consumed by running tasks')
     end
 
     def update_synced_invalid_lrps(lrp_count)
@@ -94,33 +111,33 @@ module VCAP::CloudController::Metrics
     end
 
     def report_staging_success_metrics(duration_ns)
-      increment_counter_metric(:cc_staging_succeeded, 'Number of successful staging events')
-      update_histogram_metric(:cc_staging_succeeded_duration, nanoseconds_to_milliseconds(duration_ns), 'Durations of successful staging events', duration_buckets)
+      update_histogram_metric(:cc_staging_succeeded_duration_seconds, nanoseconds_to_seconds(duration_ns), 'Durations of successful staging events')
     end
 
     def report_staging_failure_metrics(duration_ns)
-      increment_counter_metric(:cc_staging_failed, 'Number of failed staging events')
-      update_histogram_metric(:cc_staging_failed_duration, nanoseconds_to_milliseconds(duration_ns), 'Durations of failed staging events', duration_buckets)
+      update_histogram_metric(:cc_staging_failed_duration_seconds, nanoseconds_to_seconds(duration_ns), 'Durations of failed staging events')
     end
 
-    def report_diego_cell_sync_duration(duration_ms)
-      update_summary_metric(:cc_diego_sync_duration, duration_ms, 'Diego cell sync duration')
-      update_gauge_metric(:cc_diego_sync_duration_gauge, duration_ms, 'Diego cell sync duration (gauge metric)')
+    def report_diego_cell_sync_duration(duration_seconds)
+      update_summary_metric(:cc_diego_sync_duration_summary, duration_seconds, 'Diego cell sync duration summary')
+      update_histogram_metric(:cc_diego_sync_duration_hist, duration_seconds, 'Diego cell sync duration histogram')
+      update_gauge_metric(:cc_diego_sync_duration_gauge, duration_seconds, 'Diego cell sync duration (gauge metric)')
     end
 
-    def report_deployment_duration(duration_ms)
-      update_summary_metric(:cc_deployments_update_duration, duration_ms, 'Deployment duration')
-      update_gauge_metric(:cc_deployments_update_duration_gauge, duration_ms, 'Deployment duration (gauge metric)')
+    def report_deployment_duration(duration_seconds)
+      update_summary_metric(:cc_deployments_update_duration_summary, duration_seconds, 'Deployment duration summary')
+      update_histogram_metric(:cc_deployments_update_duration_hist, duration_seconds, 'Deployment duration histogram')
+      update_gauge_metric(:cc_deployments_update_duration_gauge, duration_seconds, 'Deployment duration (gauge metric)')
     end
 
     private
 
     def duration_buckets
-      Prometheus::Client::Histogram.linear_buckets(start: 10_000, width: 5000, count: 5)
+      [5, 10, 30, 60, 300, 600, 890]
     end
 
-    def nanoseconds_to_milliseconds(time_ns)
-      (time_ns / 1e6).to_i
+    def nanoseconds_to_seconds(time_ns)
+      (time_ns / 1e9).to_f
     end
   end
 end

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -86,8 +86,6 @@ module VCAP::CloudController::Metrics
 
     def update_vitals(vitals)
       vitals.each do |key, value|
-        next if key.to_s.underscore == 'cpu'
-
         metric_key = :"cc_vitals_#{key.to_s.underscore}"
         update_gauge_metric(metric_key, value, "CloudController Vitals: #{key}")
       end

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController::Metrics
       # Register all metrics, to initialize them for discoverability
       @registry.gauge(:cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue]) unless @registry.exist?(:cc_job_queues_length_total)
       @registry.gauge(:cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue]) unless @registry.exist?(:cc_failed_jobs_total)
-      @registry.counter(:cc_staging_requested, docstring: 'Number of staging requests') unless @registry.exist?(:cc_staging_requested)
+      @registry.counter(:cc_staging_requested_total, docstring: 'Number of staging requests') unless @registry.exist?(:cc_staging_requested_total)
 
       unless @registry.exist?(:cc_staging_succeeded_duration_seconds)
         @registry.histogram(:cc_staging_succeeded_duration_seconds,
@@ -21,8 +21,8 @@ module VCAP::CloudController::Metrics
                             buckets: duration_buckets)
       end
 
-      @registry.gauge(:cc_requests_outstanding_gauge, docstring: 'Requests Outstanding Gauge') unless @registry.exist?(:cc_requests_outstanding_gauge)
-      @registry.counter(:cc_requests_completed, docstring: 'Requests Completed') unless @registry.exist?(:cc_requests_completed)
+      @registry.gauge(:cc_requests_outstanding_total, docstring: 'Requests Outstanding') unless @registry.exist?(:cc_requests_outstanding_total)
+      @registry.counter(:cc_requests_completed_total, docstring: 'Requests Completed') unless @registry.exist?(:cc_requests_completed_total)
     end
 
     def update_gauge_metric(metric, value, message, labels: {})

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -80,13 +80,6 @@ module VCAP::CloudController::Metrics
       end
     end
 
-    def update_log_counts(counts)
-      counts.each do |key, value|
-        metric_key = :"cc_log_count_#{key.to_s.underscore}"
-        update_gauge_metric(metric_key, value, "Log count for log level '#{key}'")
-      end
-    end
-
     def update_task_stats(total_running_tasks, total_memory_in_mb)
       update_gauge_metric(:cc_tasks_running_count, total_running_tasks, 'Total running tasks')
       update_gauge_metric(:cc_tasks_running_memory_in_mb, total_memory_in_mb, 'Total memory consumed by running tasks')

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -9,12 +9,17 @@ module VCAP::CloudController::Metrics
       @registry.gauge(:cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue]) unless @registry.exist?(:cc_job_queues_length_total)
       @registry.gauge(:cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue]) unless @registry.exist?(:cc_failed_jobs_total)
       @registry.counter(:cc_staging_requested, docstring: 'Number of staging requests') unless @registry.exist?(:cc_staging_requested)
+
       unless @registry.exist?(:cc_staging_succeeded_duration_seconds)
         @registry.histogram(:cc_staging_succeeded_duration_seconds,
                             docstring: 'Durations of successful staging events',
                             buckets: duration_buckets)
       end
-      @registry.histogram(:cc_staging_failed_duration_seconds, docstring: 'Durations of failed staging events', buckets: duration_buckets) unless @registry.exist?(:cc_staging_failed_duration_seconds)
+      unless @registry.exist?(:cc_staging_failed_duration_seconds)
+        @registry.histogram(:cc_staging_failed_duration_seconds,
+                            docstring: 'Durations of failed staging events',
+                            buckets: duration_buckets)
+      end
 
       @registry.gauge(:cc_requests_outstanding_gauge, docstring: 'Requests Outstanding Gauge') unless @registry.exist?(:cc_requests_outstanding_gauge)
       @registry.counter(:cc_requests_completed, docstring: 'Requests Completed') unless @registry.exist?(:cc_requests_completed)

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -73,6 +73,8 @@ module VCAP::CloudController::Metrics
 
     def update_vitals(vitals)
       vitals.each do |key, value|
+        next if key.to_s.underscore == 'cpu'
+
         metric_key = :"cc_vitals_#{key.to_s.underscore}"
         update_gauge_metric(metric_key, value, "CloudController Vitals: #{key}")
       end

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -56,11 +56,11 @@ module VCAP::CloudController::Metrics
     end
 
     def update_deploying_count(deploying_count)
-      update_gauge_metric(:cc_deployments_deploying, deploying_count, 'Number of in progress deployments')
+      update_gauge_metric(:cc_deployments_in_progress_total, deploying_count, 'Number of in progress deployments')
     end
 
     def update_user_count(user_count)
-      update_gauge_metric(:cc_total_users, user_count, 'Number of users')
+      update_gauge_metric(:cc_users_total, user_count, 'Number of users')
     end
 
     def update_job_queue_length(pending_job_count_by_queue)
@@ -94,12 +94,12 @@ module VCAP::CloudController::Metrics
     end
 
     def update_task_stats(total_running_tasks, total_memory_in_bytes)
-      update_gauge_metric(:cc_tasks_running_count, total_running_tasks, 'Total running tasks')
-      update_gauge_metric(:cc_tasks_running_memory_in_mb, total_memory_in_bytes, 'Total memory consumed by running tasks')
+      update_gauge_metric(:cc_running_tasks_total, total_running_tasks, 'Total running tasks')
+      update_gauge_metric(:cc_running_tasks_memory_bytes, total_memory_in_bytes, 'Total memory consumed by running tasks')
     end
 
     def start_staging_request_received
-      increment_counter_metric(:cc_staging_requested, 'Number of staging requests')
+      increment_counter_metric(:cc_staging_requested_total, 'Number of staging requests')
     end
 
     def report_staging_success_metrics(duration_ns)

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -6,109 +6,130 @@ module VCAP::CloudController::Metrics
       @registry = registry
 
       # Register all metrics, to initialize them for discoverability
-      @registry.gauge(:cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue]) unless @registry.exist?(:cc_job_queues_length_total)
-      @registry.gauge(:cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue]) unless @registry.exist?(:cc_failed_jobs_total)
-      @registry.counter(:cc_staging_requested_total, docstring: 'Number of staging requests') unless @registry.exist?(:cc_staging_requested_total)
-
-      unless @registry.exist?(:cc_staging_succeeded_duration_seconds)
-        @registry.histogram(:cc_staging_succeeded_duration_seconds,
-                            docstring: 'Durations of successful staging events',
-                            buckets: duration_buckets)
+      metrics.map do |metric|
+        register_metric(metric[:type], metric[:name], metric[:docstring], labels: metric[:labels] || {}, buckets: metric[:buckets] || {}) unless @registry.exist?(metric[:name])
       end
-      unless @registry.exist?(:cc_staging_failed_duration_seconds)
-        @registry.histogram(:cc_staging_failed_duration_seconds,
-                            docstring: 'Durations of failed staging events',
-                            buckets: duration_buckets)
-      end
-
-      @registry.gauge(:cc_requests_outstanding_total, docstring: 'Requests Outstanding') unless @registry.exist?(:cc_requests_outstanding_total)
-      @registry.counter(:cc_requests_completed_total, docstring: 'Requests Completed') unless @registry.exist?(:cc_requests_completed_total)
     end
 
-    def update_gauge_metric(metric, value, message, labels: {})
-      @registry.gauge(metric, docstring: message) unless @registry.exist?(metric)
+    def register_metric(type, name, message, labels: {}, buckets: {})
+      case type
+      when :gauge
+        @registry.gauge(name, docstring: message, labels: labels)
+      when :counter
+        @registry.counter(name, docstring: message, labels: labels)
+      when :histogram
+        @registry.histogram(name, docstring: message, labels: labels, buckets: buckets)
+      else
+        throw ArgumentError("Metric type #{type} does not exist.")
+      end
+    end
+
+    def update_gauge_metric(metric, value, labels: {})
       @registry.get(metric).set(value, labels:)
     end
 
-    def increment_gauge_metric(metric, message)
-      @registry.gauge(metric, docstring: message) unless @registry.exist?(metric)
+    def increment_gauge_metric(metric)
       @registry.get(metric).increment
     end
 
-    def decrement_gauge_metric(metric, message)
-      @registry.gauge(metric, docstring: message) unless @registry.exist?(metric)
+    def decrement_gauge_metric(metric)
       @registry.get(metric).decrement
     end
 
-    def increment_counter_metric(metric, message)
-      @registry.counter(metric, docstring: message) unless @registry.exist?(metric)
+    def increment_counter_metric(metric)
       @registry.get(metric).increment
     end
 
-    def update_histogram_metric(metric, value, message, buckets: nil)
-      @registry.histogram(metric, buckets: buckets, docstring: message) unless @registry.exist?(metric)
+    def update_histogram_metric(metric, value)
       @registry.get(metric).observe(value)
     end
 
-    def update_summary_metric(metric, value, message)
-      @registry.summary(metric, docstring: message) unless @registry.exist?(metric)
+    def update_summary_metric(metric, value)
       @registry.get(metric).observe(value)
     end
 
     def update_deploying_count(deploying_count)
-      update_gauge_metric(:cc_deployments_in_progress_total, deploying_count, 'Number of in progress deployments')
+      update_gauge_metric(:cc_deployments_in_progress_total, deploying_count)
     end
 
     def update_user_count(user_count)
-      update_gauge_metric(:cc_users_total, user_count, 'Number of users')
+      update_gauge_metric(:cc_users_total, user_count)
     end
 
     def update_job_queue_length(pending_job_count_by_queue)
       pending_job_count_by_queue.each do |key, value|
-        update_gauge_metric(:cc_job_queues_length_total, value, "Job queue length for worker #{key}", labels: { queue: key.to_s.underscore })
+        update_gauge_metric(:cc_job_queues_length_total, value, labels: { queue: key.to_s.underscore })
       end
     end
 
     def update_thread_info(thread_info)
-      update_gauge_metric(:cc_thread_info_thread_count, thread_info[:thread_count], 'Thread count')
-      update_gauge_metric(:cc_thread_info_event_machine_connection_count, thread_info[:event_machine][:connection_count], 'Event Machine connection count')
-      update_gauge_metric(:cc_thread_info_event_machine_threadqueue_size, thread_info[:event_machine][:threadqueue][:size], 'EventMachine thread queue size')
-      update_gauge_metric(:cc_thread_info_event_machine_threadqueue_num_waiting, thread_info[:event_machine][:threadqueue][:num_waiting], 'EventMachine num waiting in thread')
-      update_gauge_metric(:cc_thread_info_event_machine_resultqueue_size, thread_info[:event_machine][:resultqueue][:size], 'EventMachine queue size')
-      update_gauge_metric(:cc_thread_info_event_machine_resultqueue_num_waiting, thread_info[:event_machine][:resultqueue][:num_waiting], 'EventMachine requests waiting in queue')
+      update_gauge_metric(:cc_thread_info_thread_count, thread_info[:thread_count])
+      update_gauge_metric(:cc_thread_info_event_machine_connection_count, thread_info[:event_machine][:connection_count])
+      update_gauge_metric(:cc_thread_info_event_machine_threadqueue_size, thread_info[:event_machine][:threadqueue][:size])
+      update_gauge_metric(:cc_thread_info_event_machine_threadqueue_num_waiting, thread_info[:event_machine][:threadqueue][:num_waiting])
+      update_gauge_metric(:cc_thread_info_event_machine_resultqueue_size, thread_info[:event_machine][:resultqueue][:size])
+      update_gauge_metric(:cc_thread_info_event_machine_resultqueue_num_waiting, thread_info[:event_machine][:resultqueue][:num_waiting])
     end
 
     def update_failed_job_count(failed_jobs_by_queue)
       failed_jobs_by_queue.each do |key, value|
-        update_gauge_metric(:cc_failed_jobs_total, value, "Failed jobs for worker #{key}", labels: { queue: key.to_s.underscore })
+        update_gauge_metric(:cc_failed_jobs_total, value, labels: { queue: key.to_s.underscore })
       end
     end
 
     def update_vitals(vitals)
       vitals.each do |key, value|
         metric_key = :"cc_vitals_#{key.to_s.underscore}"
-        update_gauge_metric(metric_key, value, "CloudController Vitals: #{key}")
+        update_gauge_metric(metric_key, value)
       end
     end
 
     def update_task_stats(total_running_tasks, total_memory_in_bytes)
-      update_gauge_metric(:cc_running_tasks_total, total_running_tasks, 'Total running tasks')
-      update_gauge_metric(:cc_running_tasks_memory_bytes, total_memory_in_bytes, 'Total memory consumed by running tasks')
+      update_gauge_metric(:cc_running_tasks_total, total_running_tasks)
+      update_gauge_metric(:cc_running_tasks_memory_bytes, total_memory_in_bytes)
     end
 
     def start_staging_request_received
-      increment_counter_metric(:cc_staging_requested_total, 'Number of staging requests')
+      increment_counter_metric(:cc_staging_requested_total)
     end
 
     def report_staging_success_metrics(duration_ns)
-      update_histogram_metric(:cc_staging_succeeded_duration_seconds, nanoseconds_to_seconds(duration_ns), 'Durations of successful staging events')
+      update_histogram_metric(:cc_staging_succeeded_duration_seconds, nanoseconds_to_seconds(duration_ns))
     end
 
     def report_staging_failure_metrics(duration_ns)
-      update_histogram_metric(:cc_staging_failed_duration_seconds, nanoseconds_to_seconds(duration_ns), 'Durations of failed staging events')
+      update_histogram_metric(:cc_staging_failed_duration_seconds, nanoseconds_to_seconds(duration_ns))
     end
 
     private
+
+    def metrics
+      [
+        { type: :gauge, name: :cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue] },
+        { type: :gauge, name: :cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue] },
+        { type: :counter, name: :cc_staging_requested_total, docstring: 'Number of staging requests' },
+        { type: :histogram, name: :cc_staging_succeeded_duration_seconds, docstring: 'Durations of successful staging events', buckets: duration_buckets },
+        { type: :histogram, name: :cc_staging_failed_duration_seconds, docstring: 'Durations of failed staging events', buckets: duration_buckets },
+        { type: :gauge, name: :cc_requests_outstanding_total, docstring: 'Requests outstanding' },
+        { type: :counter, name: :cc_requests_completed_total, docstring: 'Requests completed' },
+        { type: :gauge, name: :cc_thread_info_thread_count, docstring: 'Thread count' },
+        { type: :gauge, name: :cc_thread_info_event_machine_connection_count, docstring: 'Event Machine connection count' },
+        { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_size, docstring: 'EventMachine thread queue size' },
+        { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_num_waiting, docstring: 'EventMachine num waiting in thread' },
+        { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_size, docstring: 'EventMachine queue size' },
+        { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_num_waiting, docstring: 'EventMachine requests waiting in queue' },
+        { type: :gauge, name: :cc_vitals_started_at, docstring: 'CloudController Vitals: started_at' },
+        { type: :gauge, name: :cc_vitals_mem_bytes, docstring: 'CloudController Vitals: mem_bytes' },
+        { type: :gauge, name: :cc_vitals_cpu_load_avg, docstring: 'CloudController Vitals: cpu_load_avg' },
+        { type: :gauge, name: :cc_vitals_mem_used_bytes, docstring: 'CloudController Vitals: mem_used_bytes' },
+        { type: :gauge, name: :cc_vitals_mem_free_bytes, docstring: 'CloudController Vitals: mem_free_bytes' },
+        { type: :gauge, name: :cc_vitals_num_cores, docstring: 'CloudController Vitals: num_cores' },
+        { type: :gauge, name: :cc_running_tasks_total, docstring: 'Total running tasks' },
+        { type: :gauge, name: :cc_running_tasks_memory_bytes, docstring: 'Total memory consumed by running tasks' },
+        { type: :gauge, name: :cc_users_total, docstring: 'Number of users' },
+        { type: :gauge, name: :cc_deployments_in_progress_total, docstring: 'Number of in progress deployments' }
+      ]
+    end
 
     def duration_buckets
       [5, 10, 30, 60, 300, 600, 890]

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -7,7 +7,7 @@ module VCAP::CloudController::Metrics
     METRICS = [
       { type: :gauge, name: :cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue] },
       { type: :gauge, name: :cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue] },
-      { type: :counter, name: :cc_staging_requested_total, docstring: 'Number of staging requests' },
+      { type: :counter, name: :cc_staging_requests_total, docstring: 'Number of staging requests' },
       { type: :histogram, name: :cc_staging_succeeded_duration_seconds, docstring: 'Durations of successful staging events', buckets: DURATION_BUCKETS },
       { type: :histogram, name: :cc_staging_failed_duration_seconds, docstring: 'Durations of failed staging events', buckets: DURATION_BUCKETS },
       { type: :gauge, name: :cc_requests_outstanding_total, docstring: 'Requests outstanding' },
@@ -118,7 +118,7 @@ module VCAP::CloudController::Metrics
     end
 
     def start_staging_request_received
-      increment_counter_metric(:cc_staging_requested_total)
+      increment_counter_metric(:cc_staging_requests_total)
     end
 
     def report_staging_success_metrics(duration_ns)

--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -14,7 +14,7 @@ module VCAP::CloudController
         @statsd.gauge('cc.requests.outstanding.gauge', @counter)
         @statsd.increment 'cc.requests.outstanding'
 
-        @prometheus_updater.update_gauge_metric(:cc_requests_outstanding_gauge, @counter, 'Requests Outstanding Gauge')
+        @prometheus_updater.increment_gauge_metric(:cc_requests_outstanding_gauge, 'Requests Outstanding Gauge')
       end
 
       def complete_request(status)
@@ -28,7 +28,7 @@ module VCAP::CloudController
           batch.increment http_status_metric
         end
 
-        @prometheus_updater.update_gauge_metric(:cc_requests_outstanding_gauge, @counter, 'Requests Outstanding Gauge')
+        @prometheus_updater.decrement_gauge_metric(:cc_requests_outstanding_gauge, 'Requests Outstanding Gauge')
         @prometheus_updater.increment_gauge_metric(:cc_requests_completed, 'Requests Completed')
       end
     end

--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -29,7 +29,7 @@ module VCAP::CloudController
         end
 
         @prometheus_updater.decrement_gauge_metric(:cc_requests_outstanding_gauge, 'Requests Outstanding Gauge')
-        @prometheus_updater.increment_gauge_metric(:cc_requests_completed, 'Requests Completed')
+        @prometheus_updater.increment_counter_metric(:cc_requests_completed, 'Requests Completed')
       end
     end
   end

--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -14,7 +14,7 @@ module VCAP::CloudController
         @statsd.gauge('cc.requests.outstanding.gauge', @counter)
         @statsd.increment 'cc.requests.outstanding'
 
-        @prometheus_updater.increment_gauge_metric(:cc_requests_outstanding_gauge, 'Requests Outstanding Gauge')
+        @prometheus_updater.increment_gauge_metric(:cc_requests_outstanding_total, 'Requests Outstanding')
       end
 
       def complete_request(status)
@@ -28,8 +28,8 @@ module VCAP::CloudController
           batch.increment http_status_metric
         end
 
-        @prometheus_updater.decrement_gauge_metric(:cc_requests_outstanding_gauge, 'Requests Outstanding Gauge')
-        @prometheus_updater.increment_counter_metric(:cc_requests_completed, 'Requests Completed')
+        @prometheus_updater.decrement_gauge_metric(:cc_requests_outstanding_total, 'Requests Outstanding')
+        @prometheus_updater.increment_counter_metric(:cc_requests_completed_total, 'Requests Completed')
       end
     end
   end

--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -15,7 +15,6 @@ module VCAP::CloudController
         @statsd.increment 'cc.requests.outstanding'
 
         @prometheus_updater.update_gauge_metric(:cc_requests_outstanding_gauge, @counter, 'Requests Outstanding Gauge')
-        @prometheus_updater.increment_gauge_metric(:cc_requests_outstanding, 'Requests Outstanding')
       end
 
       def complete_request(status)
@@ -30,9 +29,7 @@ module VCAP::CloudController
         end
 
         @prometheus_updater.update_gauge_metric(:cc_requests_outstanding_gauge, @counter, 'Requests Outstanding Gauge')
-        @prometheus_updater.decrement_gauge_metric(:cc_requests_outstanding, 'Requests Outstanding')
         @prometheus_updater.increment_gauge_metric(:cc_requests_completed, 'Requests Completed')
-        @prometheus_updater.increment_gauge_metric(http_status_metric.gsub('.', '_').to_sym, "Times HTTP status #{http_status_code} have been received")
       end
     end
   end

--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -3,7 +3,7 @@ require 'statsd'
 module VCAP::CloudController
   module Metrics
     class RequestMetrics
-      def initialize(statsd=Statsd.new, prometheus_updater=PrometheusUpdater.new)
+      def initialize(statsd=Statsd.new, prometheus_updater=CloudController::DependencyLocator.instance.prometheus_updater)
         @counter = 0
         @statsd = statsd
         @prometheus_updater = prometheus_updater
@@ -14,7 +14,7 @@ module VCAP::CloudController
         @statsd.gauge('cc.requests.outstanding.gauge', @counter)
         @statsd.increment 'cc.requests.outstanding'
 
-        @prometheus_updater.increment_gauge_metric(:cc_requests_outstanding_total, 'Requests Outstanding')
+        @prometheus_updater.increment_gauge_metric(:cc_requests_outstanding_total)
       end
 
       def complete_request(status)
@@ -28,8 +28,8 @@ module VCAP::CloudController
           batch.increment http_status_metric
         end
 
-        @prometheus_updater.decrement_gauge_metric(:cc_requests_outstanding_total, 'Requests Outstanding')
-        @prometheus_updater.increment_counter_metric(:cc_requests_completed_total, 'Requests Completed')
+        @prometheus_updater.decrement_gauge_metric(:cc_requests_outstanding_total)
+        @prometheus_updater.increment_counter_metric(:cc_requests_completed_total)
       end
     end
   end

--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -170,6 +170,7 @@ module VCAP::CloudController
         VCAP::CloudController::Metrics::StatsdUpdater.new(statsd_client),
         prometheus_updater
         )
+      CloudController::DependencyLocator.instance.register(:periodic_updater, @periodic_updater)
     end
 
     def statsd_client

--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
 
       request_logs = VCAP::CloudController::Logs::RequestLogs.new(Steno.logger('cc.api'))
 
-      request_metrics = VCAP::CloudController::Metrics::RequestMetrics.new(statsd_client)
+      request_metrics = VCAP::CloudController::Metrics::RequestMetrics.new(statsd_client, prometheus_updater)
       builder = RackAppBuilder.new
       app     = builder.build(@config, request_metrics, request_logs)
 
@@ -168,7 +168,7 @@ module VCAP::CloudController
         @log_counter,
         Steno.logger('cc.api'),
         VCAP::CloudController::Metrics::StatsdUpdater.new(statsd_client),
-        VCAP::CloudController::Metrics::PrometheusUpdater.new
+        prometheus_updater
         )
     end
 
@@ -178,6 +178,10 @@ module VCAP::CloudController
       logger.info("configuring statsd server at #{@config.get(:statsd_host)}:#{@config.get(:statsd_port)}")
       Statsd.logger = Steno.logger('statsd.client')
       @statsd_client = Statsd.new(@config.get(:statsd_host), @config.get(:statsd_port))
+    end
+
+    def prometheus_updater
+      CloudController::DependencyLocator.instance.prometheus_updater
     end
   end
 end

--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -167,10 +167,9 @@ module VCAP::CloudController
         Time.now.utc,
         @log_counter,
         Steno.logger('cc.api'),
-        [
-          VCAP::CloudController::Metrics::StatsdUpdater.new(statsd_client)
-        ]
-      )
+        VCAP::CloudController::Metrics::StatsdUpdater.new(statsd_client),
+        VCAP::CloudController::Metrics::PrometheusUpdater.new
+        )
     end
 
     def statsd_client

--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -169,7 +169,7 @@ module VCAP::CloudController
         Steno.logger('cc.api'),
         VCAP::CloudController::Metrics::StatsdUpdater.new(statsd_client),
         prometheus_updater
-        )
+      )
       CloudController::DependencyLocator.instance.register(:periodic_updater, @periodic_updater)
     end
 

--- a/spec/request/internal/metrics_spec.rb
+++ b/spec/request/internal/metrics_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe 'Metrics' do
 
       expect(last_response.body).to match(/cc_vitals_num_cores [1-9][0-9]*\.\d+/)
       expect(last_response.body).to match(/cc_vitals_uptime [0-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_vitals_cpu [1-9][0-9]*\.\d+/)
       expect(last_response.body).to match(/cc_vitals_mem_bytes [1-9][0-9]*\.\d+/)
       expect(last_response.body).to match(/cc_vitals_cpu_load_avg [0-9][0-9]*\.\d+/)
       expect(last_response.body).to match(/cc_vitals_mem_used_bytes [1-9][0-9]*\.\d+/)
@@ -103,21 +102,6 @@ RSpec.describe 'Metrics' do
 
       expect(last_response.body).to match(/cc_failed_job_count_cc_api_0 [0-9][0-9]*\.\d+/)
       expect(last_response.body).to match(/cc_failed_job_count_total [0-9][0-9]*\.\d+/)
-    end
-  end
-
-  context 'cc_log_count' do
-    it 'reports log counts' do
-      get '/internal/v4/metrics', nil
-
-      expect(last_response.body).to match(/cc_log_count_off [0-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_log_count_fatal [0-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_log_count_error [0-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_log_count_warn [0-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_log_count_info [0-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_log_count_debug1 [0-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_log_count_debug2 [0-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_log_count_all [0-9][0-9]*\.\d+/)
     end
   end
 

--- a/spec/request/internal/metrics_spec.rb
+++ b/spec/request/internal/metrics_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Metrics' do
       get '/internal/v4/metrics', nil
 
       expect(last_response.body).to match(/cc_vitals_num_cores [1-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_vitals_uptime [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_vitals_started_at [0-9][0-9]*\.\d+/)
       expect(last_response.body).to match(/cc_vitals_mem_bytes [1-9][0-9]*\.\d+/)
       expect(last_response.body).to match(/cc_vitals_cpu_load_avg [0-9][0-9]*\.\d+/)
       expect(last_response.body).to match(/cc_vitals_mem_used_bytes [1-9][0-9]*\.\d+/)

--- a/spec/request/internal/metrics_spec.rb
+++ b/spec/request/internal/metrics_spec.rb
@@ -133,11 +133,11 @@ RSpec.describe 'Metrics' do
     end
   end
 
-  context 'cc_staging_requested' do
-    it 'reports cc_staging_requested' do
+  context 'cc_staging_requested_total' do
+    it 'reports cc_staging_requested_total' do
       get '/internal/v4/metrics', nil
 
-      expect(last_response.body).to match(/cc_staging_requested [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_requested_total [0-9][0-9]*\.\d+/)
     end
   end
 
@@ -179,19 +179,19 @@ RSpec.describe 'Metrics' do
     end
   end
 
-  context 'cc_requests_completed' do
-    it 'reports cc_requests_completed' do
+  context 'cc_requests_completed_total' do
+    it 'reports cc_requests_completed_total' do
       get '/internal/v4/metrics', nil
 
-      expect(last_response.body).to match(/cc_requests_completed [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_requests_completed_total [0-9][0-9]*\.\d+/)
     end
   end
 
-  context 'cc_requests_outstanding_gauge' do
-    it 'reports cc_requests_outstanding_gauge' do
+  context 'cc_requests_outstanding_total' do
+    it 'reports cc_requests_outstanding_total' do
       get '/internal/v4/metrics', nil
 
-      expect(last_response.body).to match(/cc_requests_outstanding_gauge [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_requests_outstanding_total [0-9][0-9]*\.\d+/)
     end
   end
 end

--- a/spec/request/internal/metrics_spec.rb
+++ b/spec/request/internal/metrics_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe 'Metrics' do
 
   context 'cc_job_queue_length' do
     before do
-      Delayed::Job.enqueue(VCAP::CloudController::Jobs::Runtime::EventsCleanup.new(1), {queue: 'cc_api_0', run_at: Time.now + 1.day})
-      Delayed::Job.enqueue(VCAP::CloudController::Jobs::Runtime::EventsCleanup.new(1), {queue: 'cc_generic', run_at: Time.now + 1.day})
+      Delayed::Job.enqueue(VCAP::CloudController::Jobs::Runtime::EventsCleanup.new(1), { queue: 'cc_api_0', run_at: Time.now + 1.day })
+      Delayed::Job.enqueue(VCAP::CloudController::Jobs::Runtime::EventsCleanup.new(1), { queue: 'cc_generic', run_at: Time.now + 1.day })
     end
 
     after do

--- a/spec/request/internal/metrics_spec.rb
+++ b/spec/request/internal/metrics_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Metrics' do
 
       expect(last_response.status).to eq 200
 
-      expect(last_response.body).to include('cc_total_users 10.0')
+      expect(last_response.body).to include('cc_users_total 10.0')
     end
   end
 
@@ -120,8 +120,8 @@ RSpec.describe 'Metrics' do
     it 'reports task stats' do
       get '/internal/v4/metrics', nil
 
-      expect(last_response.body).to match(/cc_tasks_running_count [0-9][0-9]*\.\d+/)
-      expect(last_response.body).to match(/cc_tasks_running_memory_in_mb [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_running_tasks_total [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_running_tasks_memory_bytes [0-9][0-9]*\.\d+/)
     end
   end
 
@@ -129,7 +129,69 @@ RSpec.describe 'Metrics' do
     it 'reports deploying_count' do
       get '/internal/v4/metrics', nil
 
-      expect(last_response.body).to match(/cc_deployments_deploying [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_deployments_in_progress_total [0-9][0-9]*\.\d+/)
+    end
+  end
+
+  context 'cc_staging_requested' do
+    it 'reports cc_staging_requested' do
+      get '/internal/v4/metrics', nil
+
+      expect(last_response.body).to match(/cc_staging_requested [0-9][0-9]*\.\d+/)
+    end
+  end
+
+  context 'cc_staging_succeeded_duration_seconds' do
+    it 'reports cc_staging_succeeded_duration_seconds' do
+      get '/internal/v4/metrics', nil
+
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_bucket{le="5"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_bucket{le="5"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_bucket{le="10"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_bucket{le="30"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_bucket{le="60"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_bucket{le="300"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_bucket{le="600"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_bucket{le="890"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_bucket{le="\+Inf"} [0-9][0-9]*\.\d+/)
+
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_sum [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_succeeded_duration_seconds_count [0-9][0-9]*\.\d+/)
+    end
+  end
+
+  context 'cc_staging_failed_duration_seconds' do
+    it 'reports cc_staging_failed_duration_seconds' do
+      get '/internal/v4/metrics', nil
+
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_bucket{le="5"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_bucket{le="5"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_bucket{le="10"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_bucket{le="30"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_bucket{le="60"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_bucket{le="300"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_bucket{le="600"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_bucket{le="890"} [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_bucket{le="\+Inf"} [0-9][0-9]*\.\d+/)
+
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_sum [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_failed_duration_seconds_count [0-9][0-9]*\.\d+/)
+    end
+  end
+
+  context 'cc_requests_completed' do
+    it 'reports cc_requests_completed' do
+      get '/internal/v4/metrics', nil
+
+      expect(last_response.body).to match(/cc_requests_completed [0-9][0-9]*\.\d+/)
+    end
+  end
+
+  context 'cc_requests_outstanding_gauge' do
+    it 'reports cc_requests_outstanding_gauge' do
+      get '/internal/v4/metrics', nil
+
+      expect(last_response.body).to match(/cc_requests_outstanding_gauge [0-9][0-9]*\.\d+/)
     end
   end
 end

--- a/spec/request/internal/metrics_spec.rb
+++ b/spec/request/internal/metrics_spec.rb
@@ -133,11 +133,11 @@ RSpec.describe 'Metrics' do
     end
   end
 
-  context 'cc_staging_requested_total' do
-    it 'reports cc_staging_requested_total' do
+  context 'cc_staging_requests_total' do
+    it 'reports cc_staging_requests_total' do
       get '/internal/v4/metrics', nil
 
-      expect(last_response.body).to match(/cc_staging_requested_total [0-9][0-9]*\.\d+/)
+      expect(last_response.body).to match(/cc_staging_requests_total [0-9][0-9]*\.\d+/)
     end
   end
 

--- a/spec/unit/controllers/internal/metric_controller_spec.rb
+++ b/spec/unit/controllers/internal/metric_controller_spec.rb
@@ -19,14 +19,6 @@ module VCAP::CloudController
             raise "Unexpected call: #{instance_var}"
           end
         end
-
-        VCAP::CloudController::Metrics::PeriodicUpdater.new(
-          Time.now.utc,
-          Steno::Sink::Counter.new,
-          Steno.logger('cc.api'),
-          VCAP::CloudController::Metrics::StatsdUpdater.new,
-          VCAP::CloudController::Metrics::PrometheusUpdater.new
-        ).update!
       end
 
       describe '#index' do

--- a/spec/unit/controllers/internal/metric_controller_spec.rb
+++ b/spec/unit/controllers/internal/metric_controller_spec.rb
@@ -19,6 +19,14 @@ module VCAP::CloudController
             raise "Unexpected call: #{instance_var}"
           end
         end
+
+        VCAP::CloudController::Metrics::PeriodicUpdater.new(
+          Time.now.utc,
+          Steno::Sink::Counter.new,
+          Steno.logger('cc.api'),
+          VCAP::CloudController::Metrics::StatsdUpdater.new,
+          VCAP::CloudController::Metrics::PrometheusUpdater.new
+        ).update!
       end
 
       describe '#index' do

--- a/spec/unit/jobs/diego/sync_spec.rb
+++ b/spec/unit/jobs/diego/sync_spec.rb
@@ -36,7 +36,6 @@ module VCAP::CloudController
           expect(tasks_sync).to receive(:sync)
           expect(Time).to receive(:now).twice # Ensure that we get two time measurements. _Hopefully_ they get turned into an elapsed time and passed in where they need to be!
           expect_any_instance_of(Statsd).to receive(:timing).with('cc.diego_sync.duration', kind_of(Numeric))
-          expect_any_instance_of(VCAP::CloudController::Metrics::PrometheusUpdater).to receive(:report_diego_cell_sync_duration).with(kind_of(Numeric))
 
           job.perform
         end

--- a/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
@@ -565,7 +565,6 @@ module VCAP::CloudController::Metrics
 
       before do
         allow(statsd_updater).to receive(:update_log_counts)
-        allow(prometheus_updater).to receive(:update_log_counts)
 
         allow(log_counter).to receive(:counts).and_return(count)
       end
@@ -587,26 +586,6 @@ module VCAP::CloudController::Metrics
     end
 
     describe '#update!' do
-      before do
-        allow(statsd_updater).to receive(:update_user_count)
-        allow(statsd_updater).to receive(:update_job_queue_length)
-        allow(statsd_updater).to receive(:update_thread_info)
-        allow(statsd_updater).to receive(:update_failed_job_count)
-        allow(statsd_updater).to receive(:update_vitals)
-        allow(statsd_updater).to receive(:update_log_counts)
-        allow(statsd_updater).to receive(:update_task_stats)
-        allow(statsd_updater).to receive(:update_deploying_count)
-
-        allow(prometheus_updater).to receive(:update_user_count)
-        allow(prometheus_updater).to receive(:update_job_queue_length)
-        allow(prometheus_updater).to receive(:update_thread_info)
-        allow(prometheus_updater).to receive(:update_failed_job_count)
-        allow(prometheus_updater).to receive(:update_vitals)
-        allow(prometheus_updater).to receive(:update_log_counts)
-        allow(prometheus_updater).to receive(:update_task_stats)
-        allow(prometheus_updater).to receive(:update_deploying_count)
-      end
-
       it 'calls all update methods' do
         expect(periodic_updater).to receive(:update_user_count).once
         expect(periodic_updater).to receive(:update_job_queue_length).once
@@ -616,6 +595,7 @@ module VCAP::CloudController::Metrics
         expect(periodic_updater).to receive(:update_log_counts).once
         expect(periodic_updater).to receive(:update_task_stats).once
         expect(periodic_updater).to receive(:update_deploying_count).once
+
         periodic_updater.update!
       end
     end

--- a/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
@@ -528,7 +528,6 @@ module VCAP::CloudController::Metrics
           expect(expected_vitals[:mem_used_bytes]).to eq(542)
           expect(expected_vitals[:mem_free_bytes]).to eq(927)
           expect(expected_vitals[:mem_bytes]).to eq(1.1.to_i)
-          expect(expected_vitals[:cpu]).to eq(2.to_f)
           expect(expected_vitals[:num_cores]).to eq(4)
         end
       end

--- a/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
@@ -56,7 +56,7 @@ module VCAP::CloudController::Metrics
         periodic_updater.update_task_stats
 
         expect(statsd_updater).to have_received(:update_task_stats).with(anything, 513)
-        expect(prometheus_updater).to have_received(:update_task_stats).with(anything, 513_000_000)
+        expect(prometheus_updater).to have_received(:update_task_stats).with(anything, 537_919_488)
       end
 
       context 'when there are no running tasks' do

--- a/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
@@ -523,7 +523,7 @@ module VCAP::CloudController::Metrics
         end
 
         expect(prometheus_updater).to have_received(:update_vitals) do |expected_vitals|
-          expect(expected_vitals[:uptime]).to be_within(1).of(Time.now.to_i - start_time.to_i)
+          expect(expected_vitals[:started_at]).to eq(start_time.to_i)
           expect(expected_vitals[:cpu_load_avg]).to eq(0.5)
           expect(expected_vitals[:mem_used_bytes]).to eq(542)
           expect(expected_vitals[:mem_free_bytes]).to eq(927)

--- a/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/periodic_updater_spec.rb
@@ -56,7 +56,7 @@ module VCAP::CloudController::Metrics
         periodic_updater.update_task_stats
 
         expect(statsd_updater).to have_received(:update_task_stats).with(anything, 513)
-        expect(prometheus_updater).to have_received(:update_task_stats).with(anything, 513)
+        expect(prometheus_updater).to have_received(:update_task_stats).with(anything, 513_000_000)
       end
 
       context 'when there are no running tasks' do
@@ -256,7 +256,7 @@ module VCAP::CloudController::Metrics
           expected_total = 1
 
           expect(statsd_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
-          expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
+          expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue)
         end
       end
 
@@ -270,7 +270,7 @@ module VCAP::CloudController::Metrics
           expected_total = 0
 
           expect(statsd_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
-          expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
+          expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue)
         end
       end
 
@@ -289,7 +289,7 @@ module VCAP::CloudController::Metrics
         expected_total = 3
 
         expect(statsd_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
-        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
+        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue)
       end
 
       it 'finds jobs which have not been attempted yet' do
@@ -306,7 +306,7 @@ module VCAP::CloudController::Metrics
         expected_total = 2
 
         expect(statsd_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
-        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
+        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue)
       end
 
       it 'ignores jobs that have already been attempted' do
@@ -321,7 +321,7 @@ module VCAP::CloudController::Metrics
         expected_total = 0
 
         expect(statsd_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
-        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
+        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue)
       end
 
       it '"resets" pending job count to 0 after they have been emitted' do
@@ -337,7 +337,7 @@ module VCAP::CloudController::Metrics
         expected_total = 2
 
         expect(statsd_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
-        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
+        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue)
 
         Delayed::Job.dataset.delete
         periodic_updater.update_job_queue_length
@@ -349,7 +349,7 @@ module VCAP::CloudController::Metrics
         expected_total = 0
 
         expect(statsd_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
-        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue, expected_total)
+        expect(prometheus_updater).to have_received(:update_job_queue_length).with(expected_pending_job_count_by_queue)
       end
     end
 
@@ -374,7 +374,7 @@ module VCAP::CloudController::Metrics
           expected_total = 1
 
           expect(statsd_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
-          expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
+          expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue)
         end
       end
 
@@ -392,7 +392,7 @@ module VCAP::CloudController::Metrics
           expected_total = 0
 
           expect(statsd_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
-          expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
+          expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue)
         end
       end
 
@@ -414,7 +414,7 @@ module VCAP::CloudController::Metrics
         expected_total = 3
 
         expect(statsd_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
-        expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
+        expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue)
       end
 
       it '"resets" failed job count to 0 after they have been emitted' do
@@ -431,7 +431,7 @@ module VCAP::CloudController::Metrics
         expected_total = 2
 
         expect(statsd_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
-        expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
+        expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue)
 
         Delayed::Job.dataset.delete
         periodic_updater.update_failed_job_count
@@ -443,7 +443,7 @@ module VCAP::CloudController::Metrics
         expected_total = 0
 
         expect(statsd_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
-        expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue, expected_total)
+        expect(prometheus_updater).to have_received(:update_failed_job_count).with(expected_failed_jobs_by_queue)
       end
     end
 

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -182,7 +182,7 @@ module VCAP::CloudController::Metrics
     end
 
     describe '#start_staging_request_received' do
-      it 'increments "cc_staging_requested"' do
+      it 'increments "cc_staging_requested_total"' do
         updater.start_staging_request_received
 
         metric = prom_client.metrics.find { |m| m.name == :cc_staging_requested_total }

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -199,21 +199,19 @@ module VCAP::CloudController::Metrics
         updater.report_staging_success_metrics(duration_ns)
 
         metric = prom_client.get :cc_staging_succeeded_duration_seconds
-        # expected buckets for duration, in millis : 10000, 15000, 20000, 25000, 30000
-        expect(metric.get).to eq({ '+Inf' => 1.0, '10' => 0.0, '30' => 1.0, '300' => 1.0, '5' => 0.0, '60' => 1.0, '600' => 1.0, '890' => 1.0, 'sum' => 20.0 })
+        expect(metric.get).to eq({ '5' => 0.0, '10' => 0.0, '30' => 1.0, '60' => 1.0, '300' => 1.0, '600' => 1.0, '890' => 1.0, 'sum' => 20.0, '+Inf' => 1.0 })
       end
     end
 
     describe '#report_staging_failure_metrics' do
       it 'emits staging failure metrics' do
-        # 20 seconds
+        # 900 seconds
         duration_ns = 900 * 1e9
 
         updater.report_staging_failure_metrics(duration_ns)
 
         metric = prom_client.get :cc_staging_failed_duration_seconds
-        # expected buckets for duration, in millis : 10000, 15000, 20000, 25000, 30000
-        expect(metric.get).to eq({ '+Inf' => 1.0, '10' => 0.0, '30' => 0.0, '300' => 0.0, '5' => 0.0, '60' => 0.0, '600' => 0.0, '890' => 0.0, 'sum' => 900.0 })
+        expect(metric.get).to eq({ '5' => 0.0, '10' => 0.0, '30' => 0.0, '60' => 0.0, '300' => 0.0, '600' => 0.0, '890' => 0.0, 'sum' => 900.0, '+Inf' => 1.0 })
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -22,12 +22,12 @@ module VCAP::CloudController::Metrics
         expected_deploying_count = 7
 
         updater.update_deploying_count(expected_deploying_count)
-        metric = prom_client.metrics.find { |m| m.name == :cc_deployments_deploying }
+        metric = prom_client.metrics.find { |m| m.name == :cc_deployments_in_progress_total }
         expect(metric).to be_present
         expect(metric.get).to eq 7
 
         updater.update_deploying_count(expected_deploying_count)
-        metric = prom_client.metrics.find { |m| m.name == :cc_deployments_deploying }
+        metric = prom_client.metrics.find { |m| m.name == :cc_deployments_in_progress_total }
         expect(metric).to be_present
         expect(metric.get).to eq 7
       end
@@ -38,7 +38,7 @@ module VCAP::CloudController::Metrics
         expected_deploying_count = 7
 
         updater.update_deploying_count(expected_deploying_count)
-        metric = prom_client.metrics.find { |m| m.name == :cc_deployments_deploying }
+        metric = prom_client.metrics.find { |m| m.name == :cc_deployments_in_progress_total }
         expect(metric).to be_present
         expect(metric.get).to eq 7
       end
@@ -50,7 +50,7 @@ module VCAP::CloudController::Metrics
 
         updater.update_user_count(expected_user_count)
 
-        metric = prom_client.metrics.find { |m| m.name == :cc_total_users }
+        metric = prom_client.metrics.find { |m| m.name == :cc_users_total }
         expect(metric).to be_present
         expect(metric.get).to eq 5
       end
@@ -173,10 +173,10 @@ module VCAP::CloudController::Metrics
       it 'records the number of running tasks and task memory' do
         updater.update_task_stats(5, 512)
 
-        metric = prom_client.metrics.find { |m| m.name == :cc_tasks_running_count }
+        metric = prom_client.metrics.find { |m| m.name == :cc_running_tasks_total }
         expect(metric.get).to eq 5
 
-        metric = prom_client.metrics.find { |m| m.name == :cc_tasks_running_memory_in_mb }
+        metric = prom_client.metrics.find { |m| m.name == :cc_running_tasks_memory_bytes }
         expect(metric.get).to eq 512
       end
     end
@@ -185,12 +185,12 @@ module VCAP::CloudController::Metrics
       it 'increments "cc_staging_requested"' do
         updater.start_staging_request_received
 
-        metric = prom_client.metrics.find { |m| m.name == :cc_staging_requested }
+        metric = prom_client.metrics.find { |m| m.name == :cc_staging_requested_total }
         expect(metric.get).to eq 1
 
         updater.start_staging_request_received
 
-        metric = prom_client.metrics.find { |m| m.name == :cc_staging_requested }
+        metric = prom_client.metrics.find { |m| m.name == :cc_staging_requested_total }
         expect(metric.get).to eq 2
       end
     end

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -134,19 +134,18 @@ module VCAP::CloudController::Metrics
     describe '#update_vitals' do
       it 'updates vitals' do
         vitals = {
-          uptime: 33,
+          started_at: 1_699_522_477.0,
           cpu_load_avg: 0.5,
           mem_used_bytes: 542,
           mem_free_bytes: 927,
           mem_bytes: 1,
-          cpu: 2.0,
           num_cores: 4
         }
 
         updater.update_vitals(vitals)
 
-        metric = prom_client.metrics.find { |m| m.name == :cc_vitals_uptime }
-        expect(metric.get).to eq 33
+        metric = prom_client.metrics.find { |m| m.name == :cc_vitals_started_at }
+        expect(metric.get).to eq 1_699_522_477.0
 
         metric = prom_client.metrics.find { |m| m.name == :cc_vitals_cpu_load_avg }
         expect(metric.get).to eq 0.5

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -207,7 +207,7 @@ module VCAP::CloudController::Metrics
         expect(metric.get).to eq 1
 
         metric = prom_client.metrics.find { |m| m.name == :cc_vitals_cpu }
-        expect(metric.get).to eq 2.0
+        expect(metric).to eq nil
 
         metric = prom_client.metrics.find { |m| m.name == :cc_vitals_num_cores }
         expect(metric.get).to eq 4

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -177,15 +177,15 @@ module VCAP::CloudController::Metrics
     end
 
     describe '#start_staging_request_received' do
-      it 'increments "cc_staging_requested_total"' do
+      it 'increments "cc_staging_requests_total"' do
         updater.start_staging_request_received
 
-        metric = prom_client.metrics.find { |m| m.name == :cc_staging_requested_total }
+        metric = prom_client.metrics.find { |m| m.name == :cc_staging_requests_total }
         expect(metric.get).to eq 1
 
         updater.start_staging_request_received
 
-        metric = prom_client.metrics.find { |m| m.name == :cc_staging_requested_total }
+        metric = prom_client.metrics.find { |m| m.name == :cc_staging_requests_total }
         expect(metric.get).to eq 2
       end
     end

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -160,10 +160,6 @@ module VCAP::CloudController::Metrics
         metric = prom_client.metrics.find { |m| m.name == :cc_vitals_mem_bytes }
         expect(metric.get).to eq 1
 
-        # test that metric is not being emitted via prometheus
-        metric = prom_client.metrics.find { |m| m.name == :cc_vitals_cpu }
-        expect(metric).to be_nil
-
         metric = prom_client.metrics.find { |m| m.name == :cc_vitals_num_cores }
         expect(metric.get).to eq 4
       end

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -174,13 +174,13 @@ module VCAP::CloudController::Metrics
 
         # test that metric is not being emitted via prometheus
         metric = prom_client.metrics.find { |m| m.name == :cc_vitals_cpu }
-        expect(metric).to eq nil
+        expect(metric).to be_nil
 
         metric = prom_client.metrics.find { |m| m.name == :cc_vitals_num_cores }
         expect(metric.get).to eq 4
       end
     end
-    
+
     describe '#update_task_stats' do
       it 'records the number of running tasks and task memory' do
         updater.update_task_stats(5, 512)

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -193,14 +193,6 @@ module VCAP::CloudController::Metrics
       end
     end
 
-    describe '#update_synced_invalid_lrps' do
-      it 'records number of running tasks and task memory to statsd' do
-        updater.update_synced_invalid_lrps(5)
-        metric = prom_client.metrics.find { |m| m.name == :cc_diego_sync_invalid_desired_lrps }
-        expect(metric.get).to eq 5
-      end
-    end
-
     describe '#start_staging_request_received' do
       it 'increments "cc_staging_requested"' do
         updater.start_staging_request_received
@@ -240,32 +232,6 @@ module VCAP::CloudController::Metrics
         metric = prom_client.metrics.find { |m| m.name == :cc_staging_failed_duration }
         # expected buckets for duration, in millis : 10000, 15000, 20000, 25000, 30000
         expect(metric.get).to eq({ '10000.0' => 0, '15000.0' => 0, '20000.0' => 1, '25000.0' => 1, '30000.0' => 1, 'sum' => 20_000, '+Inf' => 1 })
-      end
-    end
-
-    describe '#report_diego_cell_sync_duration' do
-      it 'reports diego cell sync duration' do
-        duration_ns = 20 * 1e9
-
-        updater.report_diego_cell_sync_duration(duration_ns)
-        metric = prom_client.metrics.find { |m| m.name == :cc_diego_sync_duration }
-        expect(metric.get).to eq({ 'count' => 1.0, 'sum' => 20_000_000_000.0 })
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_diego_sync_duration_gauge }
-        expect(metric.get).to eq duration_ns
-      end
-    end
-
-    describe '#report_deployment_duration' do
-      it 'reports deployments update duration' do
-        duration_ns = 20 * 1e9
-
-        updater.report_deployment_duration(duration_ns)
-        metric = prom_client.metrics.find { |m| m.name == :cc_deployments_update_duration }
-        expect(metric.get).to eq({ 'count' => 1.0, 'sum' => 20_000_000_000.0 })
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_deployments_update_duration_gauge }
-        expect(metric.get).to eq duration_ns
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -172,6 +172,7 @@ module VCAP::CloudController::Metrics
         metric = prom_client.metrics.find { |m| m.name == :cc_vitals_mem_bytes }
         expect(metric.get).to eq 1
 
+        # test that metric is not being emitted via prometheus
         metric = prom_client.metrics.find { |m| m.name == :cc_vitals_cpu }
         expect(metric).to eq nil
 
@@ -179,52 +180,7 @@ module VCAP::CloudController::Metrics
         expect(metric.get).to eq 4
       end
     end
-
-    describe '#update_log_counts' do
-      it 'updates log counts' do
-        counts = {
-          off: 1,
-          fatal: 2,
-          error: 3,
-          warn: 4,
-          info: 5,
-          debug: 6,
-          debug1: 7,
-          debug2: 8,
-          all: 9
-        }
-
-        updater.update_log_counts(counts)
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_log_count_off }
-        expect(metric.get).to eq 1
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_log_count_fatal }
-        expect(metric.get).to eq 2
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_log_count_error }
-        expect(metric.get).to eq 3
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_log_count_warn }
-        expect(metric.get).to eq 4
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_log_count_info }
-        expect(metric.get).to eq 5
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_log_count_debug }
-        expect(metric.get).to eq 6
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_log_count_debug1 }
-        expect(metric.get).to eq 7
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_log_count_debug2 }
-        expect(metric.get).to eq 8
-
-        metric = prom_client.metrics.find { |m| m.name == :cc_log_count_all }
-        expect(metric.get).to eq 9
-      end
-    end
-
+    
     describe '#update_task_stats' do
       it 'records the number of running tasks and task memory' do
         updater.update_task_stats(5, 512)

--- a/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
@@ -24,7 +24,12 @@ module VCAP::CloudController::Metrics
 
         expect(statsd_client).to have_received(:gauge).with('cc.requests.outstanding.gauge', 1)
         expect(statsd_client).to have_received(:increment).with('cc.requests.outstanding')
-        expect(prometheus_client).to have_received(:update_gauge_metric).with(:cc_requests_outstanding_gauge, 1, kind_of(String))
+      end
+
+      it 'increments outstanding requests for prometheus' do
+        request_metrics.start_request
+
+        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_requests_outstanding_gauge, kind_of(String))
       end
     end
 
@@ -46,8 +51,12 @@ module VCAP::CloudController::Metrics
         expect(batch).to have_received(:decrement).with('cc.requests.outstanding')
         expect(batch).to have_received(:increment).with('cc.requests.completed')
         expect(batch).to have_received(:increment).with('cc.http_status.2XX')
+      end
 
-        expect(prometheus_client).to have_received(:update_gauge_metric).with(:cc_requests_outstanding_gauge, -1, kind_of(String))
+      it 'increments completed and decrements outstanding for prometheus' do
+        request_metrics.complete_request(status)
+
+        expect(prometheus_client).to have_received(:decrement_gauge_metric).with(:cc_requests_outstanding_gauge, kind_of(String))
         expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_requests_completed, kind_of(String))
       end
 

--- a/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
@@ -30,7 +30,7 @@ module VCAP::CloudController::Metrics
       it 'increments outstanding requests for prometheus' do
         request_metrics.start_request
 
-        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_requests_outstanding_gauge, kind_of(String))
+        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_requests_outstanding_total, kind_of(String))
       end
     end
 
@@ -57,8 +57,8 @@ module VCAP::CloudController::Metrics
       it 'increments completed and decrements outstanding for prometheus' do
         request_metrics.complete_request(status)
 
-        expect(prometheus_client).to have_received(:decrement_gauge_metric).with(:cc_requests_outstanding_gauge, kind_of(String))
-        expect(prometheus_client).to have_received(:increment_counter_metric).with(:cc_requests_completed, kind_of(String))
+        expect(prometheus_client).to have_received(:decrement_gauge_metric).with(:cc_requests_outstanding_total, kind_of(String))
+        expect(prometheus_client).to have_received(:increment_counter_metric).with(:cc_requests_completed_total, kind_of(String))
       end
 
       it 'normalizes http status codes in statsd' do

--- a/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
@@ -11,6 +11,7 @@ module VCAP::CloudController::Metrics
       allow(prometheus_client).to receive(:update_gauge_metric)
       allow(prometheus_client).to receive(:decrement_gauge_metric)
       allow(prometheus_client).to receive(:increment_gauge_metric)
+      allow(prometheus_client).to receive(:increment_counter_metric)
     end
 
     describe '#start_request' do
@@ -57,7 +58,7 @@ module VCAP::CloudController::Metrics
         request_metrics.complete_request(status)
 
         expect(prometheus_client).to have_received(:decrement_gauge_metric).with(:cc_requests_outstanding_gauge, kind_of(String))
-        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_requests_completed, kind_of(String))
+        expect(prometheus_client).to have_received(:increment_counter_metric).with(:cc_requests_completed, kind_of(String))
       end
 
       it 'normalizes http status codes in statsd' do

--- a/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
@@ -25,7 +25,6 @@ module VCAP::CloudController::Metrics
         expect(statsd_client).to have_received(:gauge).with('cc.requests.outstanding.gauge', 1)
         expect(statsd_client).to have_received(:increment).with('cc.requests.outstanding')
         expect(prometheus_client).to have_received(:update_gauge_metric).with(:cc_requests_outstanding_gauge, 1, kind_of(String))
-        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_requests_outstanding, kind_of(String))
       end
     end
 
@@ -49,23 +48,18 @@ module VCAP::CloudController::Metrics
         expect(batch).to have_received(:increment).with('cc.http_status.2XX')
 
         expect(prometheus_client).to have_received(:update_gauge_metric).with(:cc_requests_outstanding_gauge, -1, kind_of(String))
-        expect(prometheus_client).to have_received(:decrement_gauge_metric).with(:cc_requests_outstanding, kind_of(String))
         expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_requests_completed, kind_of(String))
-        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_http_status_2XX, kind_of(String))
       end
 
       it 'normalizes http status codes in statsd' do
         request_metrics.complete_request(200)
         expect(batch).to have_received(:increment).with('cc.http_status.2XX')
-        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_http_status_2XX, kind_of(String))
 
         request_metrics.complete_request(300)
         expect(batch).to have_received(:increment).with('cc.http_status.3XX')
-        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_http_status_3XX, kind_of(String))
 
         request_metrics.complete_request(400)
         expect(batch).to have_received(:increment).with('cc.http_status.4XX')
-        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_http_status_4XX, kind_of(String))
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/request_metrics_spec.rb
@@ -30,7 +30,7 @@ module VCAP::CloudController::Metrics
       it 'increments outstanding requests for prometheus' do
         request_metrics.start_request
 
-        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_requests_outstanding_total, kind_of(String))
+        expect(prometheus_client).to have_received(:increment_gauge_metric).with(:cc_requests_outstanding_total)
       end
     end
 
@@ -57,8 +57,8 @@ module VCAP::CloudController::Metrics
       it 'increments completed and decrements outstanding for prometheus' do
         request_metrics.complete_request(status)
 
-        expect(prometheus_client).to have_received(:decrement_gauge_metric).with(:cc_requests_outstanding_total, kind_of(String))
-        expect(prometheus_client).to have_received(:increment_counter_metric).with(:cc_requests_completed_total, kind_of(String))
+        expect(prometheus_client).to have_received(:decrement_gauge_metric).with(:cc_requests_outstanding_total)
+        expect(prometheus_client).to have_received(:increment_counter_metric).with(:cc_requests_completed_total)
       end
 
       it 'normalizes http status codes in statsd' do


### PR DESCRIPTION
A short explanation of the proposed change:

Adjust Prometheus endpoint:
- Remove deprecated metrics and metrics which have been found not useful according to discussions in the community
- Make use of the DependencyLocator for retrieving a singleton of the PrometheusUpdater and PeriodicUpdater
- Change vitals_uptime to vitals_started_at
- Emit cc_staging_requests_total metric
- Apply prometheus best practices like naming, base units, using labels, initialising metrics for discoverability
- Use counter metrics for metrics which do not decrease
- Remove metrics, which are emitted on the scheduler VM. Those metrics currently cannot be collected and will be still emitted via statsd

This implementation is meant for experimental usage. It is difficult to decide on the best metric type or bucket size initially, without having it used in productive environments. The metrics emitted via Prometheus can be collected and displayed in dashboards while still using the statsd metrics for alert/real monitoring. We should communicate that breaking changes are likely, as long as this is treated as a experimental feature.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
