### PR TITLE
Fix ambiguous column in AppListFetcher

### DIFF
--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -505,6 +505,8 @@ RSpec.describe 'Apps' do
             updated_ats: { gt: Time.now.utc.iso8601 }
           }
         end
+
+        let!(:app_model) { VCAP::CloudController::AppModel.make }
       end
     end
 


### PR DESCRIPTION
The ambiguous column names were solved by moving code parts requiring qualified names to the end. So if executed, Sequel automatically qualifies all the names previously used.

Fixes #3460

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
