### PR TITLE
fix app revision pruning log to only include count of rows deleted

### DIFF
--- a/app/jobs/runtime/prune_excess_app_revisions.rb
+++ b/app/jobs/runtime/prune_excess_app_revisions.rb
@@ -20,7 +20,7 @@ module VCAP::CloudController
                                 limit(max_retained_revisions_per_app).
                                 select(:id)
             delete_count = RevisionDelete.delete(revision_dataset.exclude(id: revisions_to_keep))
-            logger.info("Cleaned up #{delete_count} revision rows for app #{app_guid}")
+            logger.info("Cleaned up #{delete_count.length} revision rows for app #{app_guid}")
           end
         end
 


### PR DESCRIPTION
- ends up becoming excessively long and original code looks like it intended to be number of rows, not exact rows

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
fix app rivision pruning log to only include count of rows deleted

* An explanation of the use cases your change solves
- ends up becoming excessively long and original code looks like it intended to be number of rows, not exact rows, this should reduce overly verbose logs. 

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
