### PR TITLE
Add support for gcp fog storage options

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -176,6 +176,7 @@ resource_pool:
     blobstore_timeout: 5
     provider: "Local"
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 packages:
   app_package_directory_key: "cc-packages"
@@ -185,6 +186,7 @@ packages:
     blobstore_timeout: 5
     provider: "Local"
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 droplets:
   droplet_directory_key: cc-droplets
@@ -193,6 +195,7 @@ droplets:
     blobstore_timeout: 5
     provider: "Local"
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 buildpacks:
   buildpack_directory_key: cc-buildpacks
@@ -200,6 +203,7 @@ buildpacks:
     blobstore_timeout: 5
     provider: "Local"
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 registry_buddy:
   host: "127.0.0.1"

--- a/lib/cloud_controller/blobstore/client_provider.rb
+++ b/lib/cloud_controller/blobstore/client_provider.rb
@@ -31,7 +31,8 @@ module CloudController
             root_dir: root_dir,
             min_size: options[:minimum_size],
             max_size: options[:maximum_size],
-            storage_options: options[:fog_aws_storage_options]
+            aws_storage_options: options[:fog_aws_storage_options],
+            gcp_storage_options: options[:fog_gcp_storage_options]
           )
 
           logger = Steno.logger('cc.blobstore')

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -144,13 +144,15 @@ module VCAP::CloudController
               minimum_size: Integer,
               resource_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             buildpacks: {
               buildpack_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             packages: {
@@ -159,6 +161,7 @@ module VCAP::CloudController
               app_package_directory_key: String,
               fog_connection: Hash,
               fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash,
               optional(:image_registry) => {
                 base_path: String
               }
@@ -168,7 +171,8 @@ module VCAP::CloudController
               droplet_directory_key: String,
               max_staged_droplets_stored: Integer,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             optional(:registry_buddy) => {

--- a/lib/cloud_controller/config_schemas/base/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/clock_schema.rb
@@ -77,13 +77,15 @@ module VCAP::CloudController
               minimum_size: Integer,
               resource_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             buildpacks: {
               buildpack_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             packages: {
@@ -91,6 +93,7 @@ module VCAP::CloudController
               app_package_directory_key: String,
               fog_connection: Hash,
               fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash,
               optional(:image_registry) => {
                 base_path: String
               }
@@ -99,7 +102,8 @@ module VCAP::CloudController
             droplets: {
               droplet_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             db_encryption_key: enum(String, NilClass),

--- a/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
@@ -80,13 +80,15 @@ module VCAP::CloudController
               minimum_size: Integer,
               resource_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             buildpacks: {
               buildpack_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             packages: {
@@ -94,6 +96,7 @@ module VCAP::CloudController
               app_package_directory_key: String,
               fog_connection: Hash,
               fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash,
               optional(:image_registry) => {
                 base_path: String
               }
@@ -102,7 +105,8 @@ module VCAP::CloudController
             droplets: {
               droplet_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             stacks_file: String,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -68,13 +68,15 @@ module VCAP::CloudController
               minimum_size: Integer,
               resource_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             buildpacks: {
               buildpack_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             packages: {
@@ -82,6 +84,7 @@ module VCAP::CloudController
               app_package_directory_key: String,
               fog_connection: Hash,
               fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash,
               optional(:image_registry) => {
                 base_path: String
               }
@@ -90,7 +93,8 @@ module VCAP::CloudController
             droplets: {
               droplet_directory_key: String,
               fog_connection: Hash,
-              fog_aws_storage_options: Hash
+              fog_aws_storage_options: Hash,
+              fog_gcp_storage_options: Hash
             },
 
             optional(:registry_buddy) => {

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -140,18 +140,22 @@ resource_pool:
   maximum_size: 42
   minimum_size: 1
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 buildpacks:
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 packages:
   max_package_size: 42
   max_valid_packages_stored: 42
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 droplets:
   max_staged_droplets_stored: 42
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 request_timeout_in_seconds: 600
 skip_cert_verify: true
@@ -175,11 +179,13 @@ resource_pool:
   minimum_size: 1
   fog_connection: {}
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 buildpacks:
   buildpack_directory_key: ''
   fog_connection: {}
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 packages:
   app_package_directory_key: ''
@@ -187,12 +193,14 @@ packages:
   max_valid_packages_stored: 42
   fog_connection: {}
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 droplets:
   droplet_directory_key: ''
   max_staged_droplets_stored: 42
   fog_connection: {}
   fog_aws_storage_options: {}
+  fog_gcp_storage_options: {}
 
 
 

--- a/spec/unit/lib/cloud_controller/blobstore/client_provider_spec.rb
+++ b/spec/unit/lib/cloud_controller/blobstore/client_provider_spec.rb
@@ -46,7 +46,8 @@ module CloudController
                                                           root_dir: anything,
                                                           min_size: anything,
                                                           max_size: anything,
-                                                          storage_options: { encryption: 'my organic algo' })
+                                                          aws_storage_options: { encryption: 'my organic algo' },
+                                                          gcp_storage_options: anything)
           end
 
           context 'fog methods' do
@@ -59,6 +60,25 @@ module CloudController
                 client.download_from_blobstore('key', 'dest', mode: 775)
               end
             end
+          end
+        end
+
+        context 'when a gcp uniform option is requested' do
+          before do
+            options.merge!(fog_gcp_storage_options: { uniform: false })
+          end
+
+          it 'passes the specified uniform option to the fog client' do
+            allow(FogClient).to receive(:new).and_call_original
+            ClientProvider.provide(options: options, directory_key: 'key')
+            expect(FogClient).to have_received(:new).with(connection_config: anything,
+                                                          directory_key: anything,
+                                                          cdn: anything,
+                                                          root_dir: anything,
+                                                          min_size: anything,
+                                                          max_size: anything,
+                                                          aws_storage_options: anything,
+                                                          gcp_storage_options: { uniform: false })
           end
         end
 
@@ -76,7 +96,8 @@ module CloudController
                                                           root_dir: anything,
                                                           min_size: anything,
                                                           max_size: anything,
-                                                          storage_options: anything)
+                                                          aws_storage_options: anything,
+                                                          gcp_storage_options: anything)
           end
         end
 

--- a/spec/unit/lib/cloud_controller/config_spec.rb
+++ b/spec/unit/lib/cloud_controller/config_spec.rb
@@ -9,6 +9,7 @@ module VCAP::CloudController
           fog_aws_storage_options: {
             encryption: 'AES256'
           },
+          fog_gcp_storage_options: {},
           app_package_directory_key: 'app_key'
         },
         droplets: {
@@ -327,6 +328,7 @@ module VCAP::CloudController
             fog_aws_storage_options: {
               encryption: 'AES256'
             },
+            fog_gcp_storage_options: {},
             app_package_directory_key: 'app_key'
           },
           droplets: {
@@ -489,6 +491,7 @@ module VCAP::CloudController
                                                        fog_aws_storage_options: {
                                                          encryption: 'AES256'
                                                        },
+                                                       fog_gcp_storage_options: {},
                                                        app_package_directory_key: 'app_key'
                                                      })
         expect(config_instance.get(:packages, :fog_aws_storage_options)).to eq(encryption: 'AES256')


### PR DESCRIPTION
Currently we only support the fog storage option 'encryption' for AWS. This PR allows setting generic storage options for GCP.


Based on #3454
Related capi-release PR: https://github.com/cloudfoundry/capi-release/pull/351

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
