### PR TITLE
Adapt response handling for /v3/service_credential_bindings/:guid/parameters

### DIFF
--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -147,6 +147,7 @@ class ServiceCredentialBindingsController < ApplicationController
 
   def parameters
     ensure_service_credential_binding_is_accessible!
+    not_found_with_message!(service_credential_binding) unless service_credential_binding.create_succeeded?
 
     fetcher = ServiceBindingRead.new
     parameters = fetcher.fetch_parameters(service_credential_binding)

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -927,17 +927,81 @@ RSpec.describe 'v3 service credential bindings' do
       context 'when the service allows bindings to be fetched' do
         before do
           instance.service.update(bindings_retrievable: true)
+          stub_param_broker_request_for_binding(binding, binding_params)
         end
 
-        context 'when an operation is still on going for the binding' do
+        context "last binding operation is in 'create succeeded' state" do
+          before do
+            binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'succeeded' })
+          end
+
+          it 'returns parameters' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(200)
+          end
+        end
+
+        context "last binding operation is in 'create in progress' state" do
           before do
             binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'in progress' })
           end
 
-          it 'fails as not allowed' do
+          it 'returns an error' do
             api_call.call(admin_headers)
+            expect(last_response).to have_status_code(404)
+            expect(parsed_response['errors']).to include(include({
+                                                                   'detail' => 'Creation of service binding in progress',
+                                                                   'title' => 'CF-ResourceNotFound',
+                                                                   'code' => 10_010
+                                                                 }))
+          end
+        end
 
-            expect(last_response).to have_status_code(409)
+        context "last binding operation is in 'create failed' state" do
+          before do
+            binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })
+          end
+
+          it 'returns an error' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(404)
+            expect(parsed_response['errors']).to include(include({
+                                                                   'detail' => 'Creation of service binding failed',
+                                                                   'title' => 'CF-ResourceNotFound',
+                                                                   'code' => 10_010
+                                                                 }))
+          end
+        end
+
+        context "last binding operation is in 'delete in progress' state" do
+          before do
+            binding.save_with_attributes_and_new_operation({}, { type: 'delete', state: 'in progress' })
+          end
+
+          it 'returns an error' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(404)
+            expect(parsed_response['errors']).to include(include({
+                                                                   'detail' => 'Deletion of service binding in progress',
+                                                                   'title' => 'CF-ResourceNotFound',
+                                                                   'code' => 10_010
+                                                                 }))
+          end
+        end
+
+        context "last binding operation is in 'delete failed' state" do
+          before do
+            binding.save_with_attributes_and_new_operation({}, { type: 'delete', state: 'failed' })
+          end
+
+          it 'returns an error' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(404)
+            expect(parsed_response['errors']).to include(include({
+                                                                   'detail' => 'Deletion of service binding failed',
+                                                                   'title' => 'CF-ResourceNotFound',
+                                                                   'code' => 10_010
+                                                                 }))
           end
         end
 
@@ -1008,6 +1072,81 @@ RSpec.describe 'v3 service credential bindings' do
 
           expect(last_response).to have_status_code(200)
           expect(parsed_response).to eq(binding_params)
+        end
+
+        context "last service key operation is in 'create succeeded' state" do
+          before do
+            binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'succeeded' })
+          end
+
+          it 'returns parameters' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(200)
+          end
+        end
+
+        context "last service key operation is in 'create in progress' state" do
+          before do
+            binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'in progress' })
+          end
+
+          it 'returns an error' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(404)
+            expect(parsed_response['errors']).to include(include({
+                                                                   'detail' => 'Creation of service key in progress',
+                                                                   'title' => 'CF-ResourceNotFound',
+                                                                   'code' => 10_010
+                                                                 }))
+          end
+        end
+
+        context "last service key operation is in 'create failed' state" do
+          before do
+            binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })
+          end
+
+          it 'returns an error' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(404)
+            expect(parsed_response['errors']).to include(include({
+                                                                   'detail' => 'Creation of service key failed',
+                                                                   'title' => 'CF-ResourceNotFound',
+                                                                   'code' => 10_010
+                                                                 }))
+          end
+        end
+
+        context "last service key operation is in 'delete in progress' state" do
+          before do
+            binding.save_with_attributes_and_new_operation({}, { type: 'delete', state: 'in progress' })
+          end
+
+          it 'returns an error' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(404)
+            expect(parsed_response['errors']).to include(include({
+                                                                   'detail' => 'Deletion of service key in progress',
+                                                                   'title' => 'CF-ResourceNotFound',
+                                                                   'code' => 10_010
+                                                                 }))
+          end
+        end
+
+        context "last service key operation is in 'delete failed' state" do
+          before do
+            binding.save_with_attributes_and_new_operation({}, { type: 'delete', state: 'failed' })
+          end
+
+          it 'returns an error' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(404)
+            expect(parsed_response['errors']).to include(include({
+                                                                   'detail' => 'Deletion of service key failed',
+                                                                   'title' => 'CF-ResourceNotFound',
+                                                                   'code' => 10_010
+                                                                 }))
+          end
         end
       end
     end


### PR DESCRIPTION
This is a fix as part of https://github.com/cloudfoundry/cloud_controller_ng/issues/2637. It contains changes in behaviour for:

GET /v3/service_credential_bindings/:guid/parameters

For GET /v3/service_credential_bindings/:guid/parameters, if the state is not create succeeded, it should not return parameters and it should raise an appropriate error.

When the state is not create succeeded for service credential key bindings (type=create and state=create in service_key_operations table), GET /v3/service_credential_bindings/:guid/parameters will return an appropriate error with information why parameters are not returned, e.g. {"errors":[{"detail":"Creation of service key initial","title":"CF-ResourceNotFound","code":10010}]}

* Links to any other associated PRs
#3443
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
