### PR TITLE
v3 should allow to update docker registry credentials

### DIFF
--- a/app/actions/package_update.rb
+++ b/app/actions/package_update.rb
@@ -9,9 +9,14 @@ module VCAP::CloudController
 
     def update(package, message)
       package.db.transaction do
+        if package.type == PackageModel::DOCKER_TYPE && (message.username || message.password)
+          package.docker_username = message.username unless message.username.nil?
+          package.docker_password = message.password unless message.password.nil?
+          package.save
+        end
         MetadataUpdate.update(package, message)
       end
-      @logger.info("Finished updating metadata on package #{package.guid}")
+      @logger.info("Finished updating package #{package.guid}")
       package
     rescue Sequel::ValidationFailed => e
       raise InvalidPackage.new(e.message)

--- a/app/controllers/v3/packages_controller.rb
+++ b/app/controllers/v3/packages_controller.rb
@@ -125,6 +125,7 @@ class PackagesController < ApplicationController
 
     package, space = PackageFetcher.new.fetch(hashed_params[:guid])
     package_not_found! unless package && permission_queryer.can_read_from_space?(space.id, space.organization_id)
+    unprocessable_non_docker_package_update! if package.type != PackageModel::DOCKER_TYPE && (message.username || message.password)
     unauthorized! unless permission_queryer.can_write_to_active_space?(space.id)
     suspended! unless permission_queryer.is_space_active?(space.id)
 
@@ -210,6 +211,10 @@ class PackagesController < ApplicationController
 
   def unprocessable_non_docker_package!
     unprocessable!('Cannot create bits package for a Docker app.')
+  end
+
+  def unprocessable_non_docker_package_update!
+    unprocessable!('Cannot update Docker credentials for a buildpack app.')
   end
 
   def unprocessable_app!

--- a/app/messages/package_update_message.rb
+++ b/app/messages/package_update_message.rb
@@ -2,7 +2,7 @@ require 'messages/metadata_base_message'
 
 module VCAP::CloudController
   class PackageUpdateMessage < MetadataBaseMessage
-    register_allowed_keys []
+    register_allowed_keys %i[username password]
 
     validates_with NoAdditionalKeysValidator
   end

--- a/docs/v3/source/includes/resources/packages/_update.md.erb
+++ b/docs/v3/source/includes/resources/packages/_update.md.erb
@@ -29,10 +29,12 @@ Content-Type: application/json
 
 #### Optional parameters
 
-Name | Type | Description
----- | ---- | -----------
-**metadata.labels** | [_label object_](#labels) | Labels applied to the package
+Name | Type                                | Description
+---- |-------------------------------------| -----------
+**metadata.labels** | [_label object_](#labels)           | Labels applied to the package
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the package
+**username**  | string  | The username for the image’s registry. Only possible for Docker package.
+**password**  | string  | The password for the image’s registry. Only possible for Docker package.
 
 #### Permitted roles
  |

--- a/spec/unit/actions/package_update_spec.rb
+++ b/spec/unit/actions/package_update_spec.rb
@@ -30,5 +30,63 @@ module VCAP::CloudController
         expect(package).to have_annotations({ key_name: 'tokyo', value: 'grapes' })
       end
     end
+
+    describe 'update docker credentials' do
+      let(:body) do
+        {
+          username: 'Udo',
+          password: 'It is a secret'
+        }
+      end
+      let(:package) { PackageModel.make(type: 'docker', docker_image: 'image-magick.com') }
+      let(:message) { PackageUpdateMessage.new(body) }
+
+      it "updates the package's docker credentials"  do
+        expect(message).to be_valid
+        package_update.update(package, message)
+
+        package.reload
+        expect(package.docker_username).to eq('Udo')
+        expect(package.docker_password).to eq('It is a secret')
+      end
+    end
+
+    describe 'update docker username' do
+      let(:body) do
+        {
+          username: 'Walz'
+        }
+      end
+      let(:package) { PackageModel.make(type: 'docker', docker_image: 'image-magick.com') }
+      let(:message) { PackageUpdateMessage.new(body) }
+
+      it "updates the package's docker username" do
+        expect(message).to be_valid
+        package_update.update(package, message)
+
+        package.reload
+        expect(package.docker_username).to eq('Walz')
+        expect(package.docker_password).to be_nil
+      end
+    end
+
+    describe 'update docker password' do
+      let(:body) do
+        {
+          password: 'Absolutely secret'
+        }
+      end
+      let(:package) { PackageModel.make(type: 'docker', docker_image: 'image-magick.com') }
+      let(:message) { PackageUpdateMessage.new(body) }
+
+      it "updates the package's docker password" do
+        expect(message).to be_valid
+        package_update.update(package, message)
+
+        package.reload
+        expect(package.docker_username).to be_nil
+        expect(package.docker_password).to eq('Absolutely secret')
+      end
+    end
   end
 end


### PR DESCRIPTION
CAPI issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/3304 Missing v3 feature parity.

PATCH /v3/packages/:guid should allow to update docker registry credentials.

This change adds the possibility to update the docker credentials via PATCH /v3/packages/:guid. After the PATCH the user has to restage the app in order to compile a new droplet with the new credentials.


* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/issues/3304
https://github.com/cloudfoundry/docs-dev-guide/pull/494
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
