### PR TITLE
Throw error for GET /v3/service_route_bindings/:guid/parameters with state create initial or create failed

### DIFF
--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -108,6 +108,8 @@ class ServiceRouteBindingsController < ApplicationController
 
   def parameters
     route_binding_not_found! unless @route_binding && can_read_from_space?(@route_binding.route.space)
+    not_found_with_message!(@route_binding) unless @route_binding.create_succeeded?
+
     unauthorized! unless can_write_to_active_space?(@route_binding.route.space)
     suspended! unless is_space_active?(@route_binding.route.space)
 
@@ -242,6 +244,12 @@ class ServiceRouteBindingsController < ApplicationController
 
   def route_binding_not_found!
     resource_not_found!(:service_route_binding)
+  end
+
+  def not_found_with_message!(service_route_binding)
+    operation = service_route_binding.last_operation.type == 'create' ? 'Creation' : 'Deletion'
+    state = service_route_binding.last_operation.state
+    resource_not_found_with_message!("#{operation} of route binding #{state}")
   end
 
   def service_instance_not_found!(guid)


### PR DESCRIPTION
This is a fix as part of https://github.com/cloudfoundry/cloud_controller_ng/issues/2637. It contains changes in behaviour for:

GET /v3/service_route_bindings/:guid/parameters

For GET /v3/service_route_bindings/:guid/parameters, if the state is not create succeeded, it should not return parameters. It should raise an error when GET /v3/service_route_bindings/:guid/parameters is called instead of showing empty data.

* Links to any other associated PRs
#2636
#2679
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
