### PR TITLE
Use consistent hash structure for process stats

### DIFF
--- a/app/presenters/v3/process_stats_presenter.rb
+++ b/app/presenters/v3/process_stats_presenter.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
 
         def instance_stats_hash(index, stats)
           case stats[:state]
-          when 'DOWN'
+          when VCAP::CloudController::Diego::LRP_DOWN
             down_instance_stats_hash(index, stats)
           else
             found_instance_stats_hash(index, stats)
@@ -55,7 +55,7 @@ module VCAP::CloudController
             type: @type,
             index: index,
             state: stats[:state],
-            uptime: stats[:uptime],
+            uptime: stats.dig(:stats, :uptime),
             isolation_segment: stats[:isolation_segment],
             details: stats[:details]
           }

--- a/lib/cloud_controller/diego/reporters/instances_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_reporter.rb
@@ -37,7 +37,7 @@ module VCAP::CloudController
           instances[actual_lrp.actual_lrp_key.index] = result
         end
 
-        fill_unreported_instances_with_down_instances(instances, process)
+        fill_unreported_instances_with_down_instances(instances, process, flat: true)
       rescue StandardError => e
         raise e if e.is_a? CloudController::Errors::InstancesUnavailable
 

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -44,13 +44,13 @@ module VCAP::CloudController
           result[actual_lrp.actual_lrp_key.index] = info
         end
 
-        fill_unreported_instances_with_down_instances(result, process)
+        fill_unreported_instances_with_down_instances(result, process, flat: false)
 
         warnings = [log_cache_errors].compact
         [result, warnings]
       rescue CloudController::Errors::NoRunningInstances => e
         logger.info('stats_for_app.error', error: e.to_s)
-        [fill_unreported_instances_with_down_instances({}, process), []]
+        [fill_unreported_instances_with_down_instances({}, process, flat: false), []]
       rescue StandardError => e
         logger.error('stats_for_app.error', error: e.to_s)
         raise e if e.is_a?(CloudController::Errors::ApiError) && e.name == 'ServiceUnavailable'

--- a/lib/cloud_controller/diego/reporters/reporter_mixins.rb
+++ b/lib/cloud_controller/diego/reporters/reporter_mixins.rb
@@ -7,14 +7,14 @@ module VCAP::CloudController
         (time / 1e9).to_i
       end
 
-      def fill_unreported_instances_with_down_instances(reported_instances, process)
+      def fill_unreported_instances_with_down_instances(reported_instances, process, flat:)
         process.instances.times do |i|
           next if reported_instances[i]
 
-          reported_instances[i] = {
-            state: 'DOWN',
-            uptime: 0
-          }
+          down_instance = { state: VCAP::CloudController::Diego::LRP_DOWN }
+          down_instance.merge!(flat ? { uptime: 0 } : { stats: { uptime: 0 } })
+
+          reported_instances[i] = down_instance
         end
 
         reported_instances

--- a/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
@@ -234,7 +234,9 @@ module VCAP::CloudController
             {
               0 => {
                 state: 'DOWN',
-                uptime: 0
+                stats: {
+                  uptime: 0
+                }
               }
             }
           end
@@ -292,7 +294,9 @@ module VCAP::CloudController
               {
                 0 => {
                   state: 'DOWN',
-                  uptime: 0
+                  stats: {
+                    uptime: 0
+                  }
                 }
               }
             end

--- a/spec/unit/presenters/v3/process_stats_presenter_spec.rb
+++ b/spec/unit/presenters/v3/process_stats_presenter_spec.rb
@@ -103,8 +103,10 @@ module VCAP::CloudController::Presenters::V3
           },
           2 => {
             state: 'DOWN',
-            uptime: 0,
-            details: 'you must construct additional pylons'
+            details: 'you must construct additional pylons',
+            stats: {
+              uptime: 0
+            }
           }
         }
       end


### PR DESCRIPTION
The `ProcessStatsPresenter` distinguishes between **down** and **found** instances. For **down** instances it expects the `uptime` key in the given hash itself, for **found** instances, it is part of the `stats` hash. Although the `ReporterMixin` constructed **down** instances as expected, there were cases (e.g. placement errors) where a different hash was created. This resulted in a JSON response containing `"uptime":null`.

With this change a consistent hash structure is used for all cases, i.e. `uptime` is a key in `stats`.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
