### PR TITLE
Exclude the newly added Readme.md file when checking applied migrations

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -129,7 +129,7 @@ namespace :db do
     db = VCAP::CloudController::DB.connect(RakeConfig.config.get(:db), db_logger)
 
     latest_migration_in_db = db[:schema_migrations].order(Sequel.desc(:filename)).first[:filename]
-    latest_migration_in_dir = File.basename(Dir['db/migrations/*'].max)
+    latest_migration_in_dir = File.basename(Dir['db/migrations/*.rb'].max)
 
     unless latest_migration_in_db == latest_migration_in_dir
       puts "Expected latest migration #{latest_migration_in_db} to equal #{latest_migration_in_dir}"


### PR DESCRIPTION
**kiki-back-compat-migrations** complains with this message [1]:
```
Expected latest migration 20230822173000_add_migration_views_for_annotations.rb to equal Readme.md
```

[1] https://ci.capi.land/teams/main/pipelines/capi/jobs/kiki-back-compat-migrations/builds/1279

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
