### PR TITLE
Run the ensure_migrations_are_current rake task in a spec

### DIFF
--- a/spec/migrations/ensure_migrations_are_current_spec.rb
+++ b/spec/migrations/ensure_migrations_are_current_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'tasks/rake_config'
+
+RSpec.describe 'ensure migrations are current', isolation: :truncation do
+  before do
+    allow(RakeConfig).to receive(:config).and_return(TestConfig.config_instance)
+  end
+
+  it 'runs the rake task successfully' do
+    Application.load_tasks
+    expect { Rake::Task['db:ensure_migrations_are_current'].invoke }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Otherwise it's only executed after a relase has been created (capi and cf-d) and errors cannot be fixed anymore.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
