### PR TITLE
Adds microsecond timestamp precision on the asg_latest_update table

### DIFF
--- a/app/controllers/internal/app_security_group_controller.rb
+++ b/app/controllers/internal/app_security_group_controller.rb
@@ -3,7 +3,7 @@ module VCAP::CloudController
     allow_unauthenticated_access
     get '/internal/v4/asg_latest_update', :return_asg_latest_update
     def return_asg_latest_update
-      [HTTP::OK, MultiJson.dump({ last_update: AsgLatestUpdate.last_update.to_datetime.strftime('%Y-%m-%dT%H:%M:%S.%N%Z') }, pretty: true)]
+      [HTTP::OK, MultiJson.dump({ last_update: AsgLatestUpdate.last_update.to_datetime.rfc3339(9) }, pretty: true)]
     end
   end
 end

--- a/app/controllers/internal/app_security_group_controller.rb
+++ b/app/controllers/internal/app_security_group_controller.rb
@@ -3,7 +3,7 @@ module VCAP::CloudController
     allow_unauthenticated_access
     get '/internal/v4/asg_latest_update', :return_asg_latest_update
     def return_asg_latest_update
-      [HTTP::OK, MultiJson.dump({ last_update: AsgLatestUpdate.last_update.to_datetime.strftime("%Y-%m-%dT%H:%M:%S.%N%Z") }, pretty: true)]
+      [HTTP::OK, MultiJson.dump({ last_update: AsgLatestUpdate.last_update.to_datetime.strftime('%Y-%m-%dT%H:%M:%S.%N%Z') }, pretty: true)]
     end
   end
 end

--- a/app/controllers/internal/app_security_group_controller.rb
+++ b/app/controllers/internal/app_security_group_controller.rb
@@ -3,7 +3,7 @@ module VCAP::CloudController
     allow_unauthenticated_access
     get '/internal/v4/asg_latest_update', :return_asg_latest_update
     def return_asg_latest_update
-      [HTTP::OK, MultiJson.dump({ last_update: AsgLatestUpdate.last_update }, pretty: true)]
+      [HTTP::OK, MultiJson.dump({ last_update: AsgLatestUpdate.last_update.to_datetime.strftime("%Y-%m-%dT%H:%M:%S.%N%Z") }, pretty: true)]
     end
   end
 end

--- a/app/models/runtime/asg_latest_update.rb
+++ b/app/models/runtime/asg_latest_update.rb
@@ -1,6 +1,7 @@
 module VCAP::CloudController
   class AsgLatestUpdate
     class AsgTimestamp < Sequel::Model
+      plugin :microsecond_timestamp_precision
     end
     private_constant :AsgTimestamp
 

--- a/app/models/runtime/asg_latest_update.rb
+++ b/app/models/runtime/asg_latest_update.rb
@@ -8,9 +8,9 @@ module VCAP::CloudController
     def self.renew
       old_update = AsgTimestamp.first
       if old_update
-        old_update.update(last_update: DateTime.now)
+        old_update.update(last_update: Sequel::CURRENT_TIMESTAMP)
       else
-        AsgTimestamp.create(last_update: DateTime.now)
+        AsgTimestamp.create(last_update: Sequel::CURRENT_TIMESTAMP)
       end
     end
 

--- a/db/migrations/20231016094900_microsecond_timestamp_msql_asg_update.rb
+++ b/db/migrations/20231016094900_microsecond_timestamp_msql_asg_update.rb
@@ -1,7 +1,7 @@
 Sequel.migration do
   up do
-    MIN_SERVER_VERSION = 50605
-    raise "Unsupported MySQL version #{self.server_version}, required >= #{MIN_SERVER_VERSION}" if self.server_version < MIN_SERVER_VERSION
+    MIN_SERVER_VERSION = 50_605
+    raise "Unsupported MySQL version #{server_version}, required >= #{MIN_SERVER_VERSION}" if server_version < MIN_SERVER_VERSION
 
     if self.class.name.match?(/mysql/i)
       run <<-SQL.squish

--- a/db/migrations/20231016094900_microsecond_timestamp_msql_asg_update.rb
+++ b/db/migrations/20231016094900_microsecond_timestamp_msql_asg_update.rb
@@ -1,6 +1,8 @@
-require 'date'
 Sequel.migration do
   up do
+    MIN_SERVER_VERSION = 50605
+    raise "Unsupported MySQL version #{self.server_version}, required >= #{MIN_SERVER_VERSION}" if self.server_version < MIN_SERVER_VERSION
+
     if self.class.name.match?(/mysql/i)
       run <<-SQL.squish
         ALTER TABLE asg_timestamps MODIFY last_update TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)

--- a/db/migrations/20231016094900_microsecond_timestamp_msql_asg_update.rb
+++ b/db/migrations/20231016094900_microsecond_timestamp_msql_asg_update.rb
@@ -1,0 +1,18 @@
+require 'date'
+Sequel.migration do
+  up do
+    if self.class.name.match?(/mysql/i)
+      run <<-SQL.squish
+        ALTER TABLE asg_timestamps MODIFY last_update TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
+      SQL
+    end
+  end
+
+  down do
+    if self.class.name.match?(/mysql/i)
+      run <<-SQL.squish
+        ALTER TABLE asg_timestamps MODIFY last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      SQL
+    end
+  end
+end

--- a/lib/sequel/plugins/microsecond_timestamp_precision.rb
+++ b/lib/sequel/plugins/microsecond_timestamp_precision.rb
@@ -1,0 +1,11 @@
+module Sequel
+  module Plugins
+    module MicrosecondTimestampPrecision
+      module DatasetMethods
+        def supports_timestamp_usecs?
+          true
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20231016094900_microsecond_timestamp_msql_asg_update_spec.rb
+++ b/spec/migrations/20231016094900_microsecond_timestamp_msql_asg_update_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to enable microsecond precision on asg last updated table', isolation: :truncation do
+  include_context 'migration' do
+    let(:migration_filename) { '20231016094900_microsecond_timestamp_msql_asg_update.rb' }
+    let(:ds) { db[:asg_timestamps].with_extend do
+        def supports_timestamp_usecs?
+          true
+        end
+        def timestamp_precision
+          6
+        end
+    end
+
+    }
+  end
+
+  describe 'asg_timestamps table' do
+    it 'the last_update column handles sub-second time' do
+      initial_time = DateTime.new(2010)
+
+      ds.insert(id: 1, last_update: initial_time)
+      t1 = ds.first(id: 1)
+      expect(t1[:last_update].to_datetime.rfc3339(6)).to eq(initial_time.rfc3339(6))
+
+      # Change TIMESTAMP to TIMESTAMP(6)
+      expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true) }.not_to raise_error
+
+      # the migration shouldn't add accuracy to previously inserted values
+      t1_post_migration = ds.first(id: 1)
+      expect(t1_post_migration[:last_update].to_datetime.rfc3339(6)).to eq(initial_time.rfc3339(6))
+
+      # but new data should retain microsecond accuracy
+      post_migration_time = DateTime.now
+      ds.insert(id: 2, last_update: post_migration_time)
+      t2 = ds.first(id: 2)
+      expect(t2[:last_update].to_datetime.rfc3339(6)).to eq(post_migration_time.rfc3339(6))
+    end
+  end
+end

--- a/spec/migrations/20231016094900_microsecond_timestamp_msql_asg_update_spec.rb
+++ b/spec/migrations/20231016094900_microsecond_timestamp_msql_asg_update_spec.rb
@@ -4,16 +4,17 @@ require 'migrations/helpers/migration_shared_context'
 RSpec.describe 'migration to enable microsecond precision on asg last updated table', isolation: :truncation do
   include_context 'migration' do
     let(:migration_filename) { '20231016094900_microsecond_timestamp_msql_asg_update.rb' }
-    let(:ds) { db[:asg_timestamps].with_extend do
+    let(:ds) do
+      db[:asg_timestamps].with_extend do
         def supports_timestamp_usecs?
           true
         end
+
         def timestamp_precision
           6
         end
+      end
     end
-
-    }
   end
 
   describe 'asg_timestamps table' do

--- a/spec/migrations/20231016094900_microsecond_timestamp_msql_asg_update_spec.rb
+++ b/spec/migrations/20231016094900_microsecond_timestamp_msql_asg_update_spec.rb
@@ -9,34 +9,39 @@ RSpec.describe 'migration to enable microsecond precision on asg last updated ta
         def supports_timestamp_usecs?
           true
         end
-
-        def timestamp_precision
-          6
-        end
       end
     end
   end
 
   describe 'asg_timestamps table' do
     it 'the last_update column handles sub-second time' do
-      initial_time = DateTime.new(2010)
+      dt_without_fractional_seconds = DateTime.new(2001, 2, 3, 4, 5, 6)
+      dt_with_fractional_seconds = dt_without_fractional_seconds.advance(seconds: 0.123456)
 
-      ds.insert(id: 1, last_update: initial_time)
+      ds.insert(id: 1, last_update: dt_with_fractional_seconds)
       t1 = ds.first(id: 1)
-      expect(t1[:last_update].to_datetime.rfc3339(6)).to eq(initial_time.rfc3339(6))
+
+      if db.database_type == :mysql
+        expect(t1[:last_update].to_datetime.subsec).to eq(0)
+        expect(t1[:last_update].to_datetime.rfc3339(6)).to eq(dt_without_fractional_seconds.rfc3339(6))
+      else
+        expect(t1[:last_update].to_datetime.subsec).not_to eq(0)
+        expect(t1[:last_update].to_datetime.rfc3339(6)).to eq(dt_with_fractional_seconds.rfc3339(6))
+      end
 
       # Change TIMESTAMP to TIMESTAMP(6)
       expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true) }.not_to raise_error
 
       # the migration shouldn't add accuracy to previously inserted values
       t1_post_migration = ds.first(id: 1)
-      expect(t1_post_migration[:last_update].to_datetime.rfc3339(6)).to eq(initial_time.rfc3339(6))
+      expect(t1_post_migration[:last_update].to_datetime.rfc3339(6)).to eq(t1[:last_update].to_datetime.rfc3339(6))
 
       # but new data should retain microsecond accuracy
-      post_migration_time = DateTime.now
-      ds.insert(id: 2, last_update: post_migration_time)
+      ds.insert(id: 2, last_update: dt_with_fractional_seconds)
       t2 = ds.first(id: 2)
-      expect(t2[:last_update].to_datetime.rfc3339(6)).to eq(post_migration_time.rfc3339(6))
+
+      expect(t2[:last_update].to_datetime.subsec).not_to eq(0)
+      expect(t2[:last_update].to_datetime.rfc3339(6)).to eq(dt_with_fractional_seconds.rfc3339(6))
     end
   end
 end

--- a/spec/request/internal/asg_update_timestamp_spec.rb
+++ b/spec/request/internal/asg_update_timestamp_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'App Security Group Update Timestamp' do
 
       expect(last_response).to have_status_code(200)
       parsed_response = MultiJson.load(last_response.body)
-      expect(parsed_response['last_update']).to eq('1970-01-01T00:00:00Z')
+      expect(parsed_response['last_update']).to eq('1970-01-01T00:00:00.000000000+00:00')
     end
   end
 end

--- a/spec/unit/models/runtime/asg_latest_update_spec.rb
+++ b/spec/unit/models/runtime/asg_latest_update_spec.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
       context 'when there is no previous update' do
         it 'creates an asgLatestUpdate' do
           AsgLatestUpdate.renew
-          expect(AsgLatestUpdate.last_update.rfc3339(6)).to be > 1.minute.ago
+          expect(AsgLatestUpdate.last_update).to be > 1.second.ago
         end
       end
     end

--- a/spec/unit/models/runtime/asg_latest_update_spec.rb
+++ b/spec/unit/models/runtime/asg_latest_update_spec.rb
@@ -12,15 +12,16 @@ module VCAP::CloudController
       context 'when there is no previous update' do
         it 'creates an asgLatestUpdate' do
           AsgLatestUpdate.renew
-          expect(AsgLatestUpdate.last_update).to be > 1.minute.ago
+          expect(AsgLatestUpdate.last_update.rfc3339(6)).to be > 1.minute.ago
         end
       end
     end
 
     describe 'last_update' do
       it 'returns the last update timestamp' do
-        AsgLatestUpdate.const_get(:AsgTimestamp).create last_update: Time.new(2019)
-        expect(AsgLatestUpdate.last_update).to eq Time.new(2019)
+        AsgLatestUpdate.const_get(:AsgTimestamp).create last_update: Time.parse("2019-01-01T01:01:01.1234+00:00")
+        expect(AsgLatestUpdate.last_update.to_datetime.rfc3339(6)).to eq "2019-01-01T01:01:01.123400+00:00"
+
       end
 
       context 'when there is no previous update' do

--- a/spec/unit/models/runtime/asg_latest_update_spec.rb
+++ b/spec/unit/models/runtime/asg_latest_update_spec.rb
@@ -19,9 +19,8 @@ module VCAP::CloudController
 
     describe 'last_update' do
       it 'returns the last update timestamp' do
-        AsgLatestUpdate.const_get(:AsgTimestamp).create last_update: Time.parse("2019-01-01T01:01:01.1234+00:00")
-        expect(AsgLatestUpdate.last_update.to_datetime.rfc3339(6)).to eq "2019-01-01T01:01:01.123400+00:00"
-
+        AsgLatestUpdate.const_get(:AsgTimestamp).create last_update: Time.parse('2019-01-01T01:01:01.1234+00:00')
+        expect(AsgLatestUpdate.last_update.to_datetime.rfc3339(6)).to eq '2019-01-01T01:01:01.123400+00:00'
       end
 
       context 'when there is no previous update' do


### PR DESCRIPTION
This works around race conditions seen when policy-server-asg-syncer polls cloud_controller in between two ASG updates of the same second.

Fixes #3479
- https://github.com/cloudfoundry/cloud_controller_ng/issues/3479

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
