### PR TITLE
replace --auto-correct with --autocorrect

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ task default: default_tasks
 task rubocop_autocorrect: :environment do
   require 'rubocop'
   cli = RuboCop::CLI.new
-  exit_code = cli.run(%w[--auto-correct --fail-level autocorrect])
+  exit_code = cli.run(%w[--autocorrect --fail-level autocorrect])
   exit(exit_code) if exit_code != 0
 end
 

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -13,7 +13,7 @@ begin
       changelist -= `git diff --cached --name-only --diff-filter=D`.chomp.split("\n")
       abort 'No files have changed; consider running rake rubocop:local instead' if changelist.empty?
       cli = RuboCop::CLI.new
-      exit_code = cli.run(changelist.uniq.grep(/.*\.rb$/).unshift('--auto-correct'))
+      exit_code = cli.run(changelist.uniq.grep(/.*\.rb$/).unshift('--autocorrect'))
       exit(exit_code) if exit_code != 0
     end
 
@@ -28,7 +28,7 @@ begin
       changelist -= `git diff --cached --name-only --diff-filter=D`.chomp.split("\n")
       abort 'No local files; consider running rake rubocop:changed instead' if changelist.empty?
       cli = RuboCop::CLI.new
-      exit_code = cli.run(changelist.uniq.grep(/.*\.rb$/).unshift('--auto-correct'))
+      exit_code = cli.run(changelist.uniq.grep(/.*\.rb$/).unshift('--autocorrect'))
       exit(exit_code) if exit_code != 0
     end
   end

--- a/scripts/rubocop-pre-commit
+++ b/scripts/rubocop-pre-commit
@@ -25,7 +25,7 @@ pushd "${REPO_BASE_DIR}"
 
   printf "\n${CLEAR_LINE}${RED}💀 Rubocop found some issues. Let's see if it can autocorrect the files you're trying to commit...${NO_COLOR}\n"
 
-  if ! bundle exec rubocop --auto-correct --cache=true ${SUSPECTS}; then
+  if ! bundle exec rubocop --autocorrect --cache=true ${SUSPECTS}; then
     printf "\n${CLEAR_LINE}${RED}💀 Rubocop couldn't autocorrect everything! 😭 ${NO_COLOR}\n"
     exit 1
   fi


### PR DESCRIPTION
- will remove deprecated warning when running `bundle exec rake`

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
