### PR TITLE
Implement additional audit events

### DIFF
--- a/app/controllers/services/service_keys_controller.rb
+++ b/app/controllers/services/service_keys_controller.rb
@@ -73,6 +73,8 @@ module VCAP::CloudController
         e.name == 'NotAuthorized' ? raise(CloudController::Errors::ApiError.new_from_details('ServiceKeyNotFound', guid)) : raise(e)
       end
 
+      @services_event_repository.record_service_key_event(:show, service_key)
+
       [HTTP::OK,
        { 'Location' => "#{self.class.path}/#{service_key.guid}" },
        object_renderer.render_json(self.class, service_key, @opts)]

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -199,6 +199,8 @@ class ServiceInstancesV3Controller < ApplicationController
     service_instance_not_found! unless service_instance && can_read_service_instance?(service_instance)
     unauthorized! unless permission_queryer.can_read_secrets_in_space?(service_instance.space_id, service_instance.space.organization_id)
 
+    service_event_repository.record_user_provided_service_instance_event(:show, service_instance)
+
     render status: :ok, json: (service_instance.credentials || {})
   end
 

--- a/app/repositories/service_generic_binding_event_repository.rb
+++ b/app/repositories/service_generic_binding_event_repository.rb
@@ -76,6 +76,23 @@ module VCAP::CloudController
         )
       end
 
+      def record_show(service_binding, user_audit_info)
+        metadata = {
+          request: {
+            service_instance_guid: service_binding.service_instance_guid
+          }
+        }
+
+        metadata[:request].merge!({ app_guid: service_binding.app_guid }) if service_binding.try(:app_guid)
+
+        record_event(
+          type: "audit.#{@actee_name}.show",
+          service_binding: service_binding,
+          user_audit_info: user_audit_info,
+          metadata: metadata
+        )
+      end
+
       private
 
       def censor_request_attributes(request)

--- a/spec/request/v2/service_bindings_spec.rb
+++ b/spec/request/v2/service_bindings_spec.rb
@@ -311,6 +311,23 @@ RSpec.describe 'ServiceBindings' do
       get "/v2/service_bindings/#{non_displayed_binding.guid}", nil, headers_for(user)
       expect(last_response.status).to eq(404)
     end
+
+    it 'creates an audit event' do
+      get "/v2/service_bindings/#{service_binding1.guid}", nil, headers_for(user)
+
+      event = VCAP::CloudController::Event.last
+      expect(event.type).to eq('audit.service_binding.show')
+      expect(event.actee).to eq(service_binding1.guid)
+      expect(event.actee_type).to eq('service_binding')
+      expect(event.metadata).to match(
+        {
+          'request' => {
+            'app_guid' => service_binding1.app_guid,
+            'service_instance_guid' => service_binding1.service_instance_guid
+          }
+        }
+      )
+    end
   end
 
   describe 'POST /v2/service_bindings' do

--- a/spec/request/v2/service_keys_spec.rb
+++ b/spec/request/v2/service_keys_spec.rb
@@ -89,6 +89,23 @@ RSpec.describe 'ServiceKeys' do
         }
       )
     end
+
+    it 'creates an audit event' do
+      get "/v2/service_keys/#{service_key1.guid}", nil, headers_for(user)
+
+      event = VCAP::CloudController::Event.last
+      expect(event.type).to eq('audit.service_key.show')
+      expect(event.actee).to eq(service_key1.guid)
+      expect(event.actee_type).to eq('service_key')
+      expect(event.metadata).to match(
+        {
+          'request' => {
+            'name' => service_key1.name,
+            'service_instance_guid' => service_key1.service_instance_guid
+          }
+        }
+      )
+    end
   end
 
   describe 'GET /v2/service_keys/:guid/parameters' do


### PR DESCRIPTION
Some API endpoints which return credentials do not write audit events. This change adds the following audit events:
- `audit.service_instance.show` & `audit.user_provided_service_instance.show` 
   Endpoints:
   - GET /v2/service_instances/:guid
   - GET /v3/service_instances/:guid/credentials

- `audit.service_binding.show`
  Endpoints:
  - GET /v3/service_credential_bindings/:guid/details
  - GET /v2/service_bindings/:guid

- `audit.service_key.show`
  Endpoints:
  - GET /v3/service_credential_bindings/:guid/details
  - GET /v2/service_keys/:guid

[Docs](https://docs.cloudfoundry.org/running/managing-cf/audit-events.html#types) will be updated in separate PR once this is merged

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
