### PR TITLE
Enable CF API to present `routable` field for app processes

### DIFF
--- a/app/presenters/v3/process_stats_presenter.rb
+++ b/app/presenters/v3/process_stats_presenter.rb
@@ -35,6 +35,7 @@ module VCAP::CloudController
             type: @type,
             index: index,
             state: stats[:state],
+            routable: stats[:routable],
             host: stats[:stats][:host],
             instance_internal_ip: stats[:stats][:net_info][:instance_address],
             uptime: stats[:stats][:uptime],
@@ -55,6 +56,7 @@ module VCAP::CloudController
             type: @type,
             index: index,
             state: stats[:state],
+            routable: stats[:routable],
             uptime: stats.dig(:stats, :uptime),
             isolation_segment: stats[:isolation_segment],
             details: stats[:details]

--- a/docs/v3/source/includes/resources/processes/_stats_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats_object.md.erb
@@ -14,7 +14,7 @@ Name | Type | Description
 **type** | _string_ | Process type; a unique identifier for processes belonging to an app
 **index** | _integer_ | The zero-based index of running instances
 **state** | _string_ | The state of the instance; valid values are `RUNNING`, `CRASHED`, `STARTING`, `DOWN`
-**routable** | _boolean_ | Whether or not the instance is routable (determined by the readiness check of the app)
+**routable** | _boolean_ | Whether or not the instance is routable (determined by the readiness check of the app). If app readiness checks and routability are unsupported by Diego, this will return as `null`.
 **usage** | _object_ | Object containing actual usage data for the instance; the value is `{}` when usage data is unavailable
 **usage.time** | _[timestamp](#timestamps)_ | The time when the usage was requested
 **usage.cpu** | _number_ | The current cpu usage of the instance

--- a/docs/v3/source/includes/resources/processes/_stats_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats_object.md.erb
@@ -14,6 +14,7 @@ Name | Type | Description
 **type** | _string_ | Process type; a unique identifier for processes belonging to an app
 **index** | _integer_ | The zero-based index of running instances
 **state** | _string_ | The state of the instance; valid values are `RUNNING`, `CRASHED`, `STARTING`, `DOWN`
+**routable** | _boolean_ | Whether or not the instance is routable (determined by the readiness check of the app)
 **usage** | _object_ | Object containing actual usage data for the instance; the value is `{}` when usage data is unavailable
 **usage.time** | _[timestamp](#timestamps)_ | The time when the usage was requested
 **usage.cpu** | _number_ | The current cpu usage of the instance

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -29,7 +29,6 @@ module VCAP::CloudController
 
           info = {
             state: LrpStateTranslator.translate_lrp_state(actual_lrp),
-            routable: actual_lrp.routable,
             isolation_segment: desired_lrp.PlacementTags.first,
             stats: {
               name: process.name,
@@ -41,7 +40,9 @@ module VCAP::CloudController
               fds_quota: process.file_descriptors
             }.merge(metrics_data_for_instance(stats, quota_stats, log_cache_errors, formatted_current_time, index))
           }
-          info[:details]                          = actual_lrp.placement_error if actual_lrp.placement_error.present?
+          info[:details] = actual_lrp.placement_error if actual_lrp.placement_error.present?
+
+          info[:routable] = (actual_lrp.routable if actual_lrp.optional_routable)
           result[actual_lrp.actual_lrp_key.index] = info
         end
 

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -29,6 +29,7 @@ module VCAP::CloudController
 
           info = {
             state: LrpStateTranslator.translate_lrp_state(actual_lrp),
+            routable: actual_lrp.routable,
             isolation_segment: desired_lrp.PlacementTags.first,
             stats: {
               name: process.name,

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -521,6 +521,7 @@ RSpec.describe 'Processes' do
       {
         0 => {
           state: 'RUNNING',
+          routable: true,
           details: 'some-details',
           isolation_segment: 'very-isolated',
           stats: {
@@ -554,6 +555,7 @@ RSpec.describe 'Processes' do
           'type' => 'worker',
           'index' => 0,
           'state' => 'RUNNING',
+          'routable' => true,
           'isolation_segment' => 'very-isolated',
           'details' => 'some-details',
           'usage' => {

--- a/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
@@ -16,14 +16,15 @@ module VCAP::CloudController
       let(:is_routable) { true }
 
       def make_actual_lrp(instance_guid:, index:, state:, error:, since:)
-        ::Diego::Bbs::Models::ActualLRP.new(
+        lrp = ::Diego::Bbs::Models::ActualLRP.new(
           actual_lrp_key: ::Diego::Bbs::Models::ActualLRPKey.new(index:),
           actual_lrp_instance_key: ::Diego::Bbs::Models::ActualLRPInstanceKey.new(instance_guid:),
           state: state,
-          routable: is_routable,
           placement_error: error,
           since: since
         )
+        lrp.routable = is_routable unless is_routable.nil?
+        lrp
       end
 
       before { Timecop.freeze(Time.at(1.day.ago.to_i)) }
@@ -124,6 +125,16 @@ module VCAP::CloudController
           it 'sets the routable property to false' do
             response, = instances_reporter.stats_for_app(process)
             expect(response[0][:routable]).to be(false)
+          end
+        end
+
+        context 'when diego does not send the routable property' do
+          let(:is_routable) { nil }
+
+          it 'does not include the routable property in stats' do
+            response, = instances_reporter.stats_for_app(process)
+            expect(response[0]).to have_key(:routable)
+            expect(response[0][:routable]).to be_nil
           end
         end
 

--- a/spec/unit/presenters/v3/process_stats_presenter_spec.rb
+++ b/spec/unit/presenters/v3/process_stats_presenter_spec.rb
@@ -163,6 +163,44 @@ module VCAP::CloudController::Presenters::V3
         )
       end
 
+      context 'diego does not provide the "routable" field' do
+        let(:stats_for_process) do
+          {
+            0 => {
+              state: 'RUNNING',
+              routable: nil,
+              isolation_segment: 'hecka-compliant',
+              stats: {
+                name: process.name,
+                uris: process.uris,
+                host: 'myhost',
+                net_info: net_info_1,
+                uptime: 12_345,
+                mem_quota: process[:memory] * 1024 * 1024,
+                disk_quota: process[:disk_quota] * 1024 * 1024,
+                log_rate_limit: process[:log_rate_limit],
+                fds_quota: process.file_descriptors,
+                usage: {
+                  time: '2015-12-08 16:54:48 -0800',
+                  cpu: 80,
+                  mem: 128,
+                  disk: 1024,
+                  log_rate: 2048
+                }
+              }
+            }
+          }
+        end
+
+        it 'does not set routable, with state of RUNNING' do
+          result = presenter.present_stats_hash
+
+          expect(result[0][:state]).to eq('RUNNING')
+          expect(result[0]).to have_key(:routable)
+          expect(result[0][:routable]).to be_nil
+        end
+      end
+
       context 'the process is running, but not routable due to failed readiness check in diego' do
         let(:stats_for_process) do
           {

--- a/spec/unit/presenters/v3/process_stats_presenter_spec.rb
+++ b/spec/unit/presenters/v3/process_stats_presenter_spec.rb
@@ -59,6 +59,7 @@ module VCAP::CloudController::Presenters::V3
         {
           0 => {
             state: 'RUNNING',
+            routable: true,
             isolation_segment: 'hecka-compliant',
             stats: {
               name: process.name,
@@ -82,6 +83,7 @@ module VCAP::CloudController::Presenters::V3
           1 => {
             state: 'CRASHED',
             details: 'some-details',
+            routable: false,
             stats: {
               name: process.name,
               uris: process.uris,
@@ -103,6 +105,7 @@ module VCAP::CloudController::Presenters::V3
           },
           2 => {
             state: 'DOWN',
+            routable: false,
             details: 'you must construct additional pylons',
             stats: {
               uptime: 0
@@ -117,6 +120,7 @@ module VCAP::CloudController::Presenters::V3
         expect(result[0][:type]).to eq(process.type)
         expect(result[0][:index]).to eq(0)
         expect(result[0][:state]).to eq('RUNNING')
+        expect(result[0][:routable]).to be(true)
         expect(result[0][:details]).to be_nil
         expect(result[0][:isolation_segment]).to eq('hecka-compliant')
         expect(result[0][:host]).to eq('myhost')
@@ -136,6 +140,7 @@ module VCAP::CloudController::Presenters::V3
         expect(result[1][:type]).to eq(process.type)
         expect(result[1][:index]).to eq(1)
         expect(result[1][:state]).to eq('CRASHED')
+        expect(result[1][:routable]).to be(false)
         expect(result[1][:details]).to eq('some-details')
         expect(result[1][:isolation_segment]).to be_nil
         expect(result[1][:host]).to eq('toast')
@@ -151,10 +156,48 @@ module VCAP::CloudController::Presenters::V3
           type: process.type,
           index: 2,
           state: 'DOWN',
+          routable: false,
           uptime: 0,
           isolation_segment: nil,
           details: 'you must construct additional pylons'
         )
+      end
+
+      context 'the process is running, but not routable due to failed readiness check in diego' do
+        let(:stats_for_process) do
+          {
+            0 => {
+              state: 'RUNNING',
+              routable: false,
+              isolation_segment: 'hecka-compliant',
+              stats: {
+                name: process.name,
+                uris: process.uris,
+                host: 'myhost',
+                net_info: net_info_1,
+                uptime: 12_345,
+                mem_quota: process[:memory] * 1024 * 1024,
+                disk_quota: process[:disk_quota] * 1024 * 1024,
+                log_rate_limit: process[:log_rate_limit],
+                fds_quota: process.file_descriptors,
+                usage: {
+                  time: '2015-12-08 16:54:48 -0800',
+                  cpu: 80,
+                  mem: 128,
+                  disk: 1024,
+                  log_rate: 2048
+                }
+              }
+            }
+          }
+        end
+
+        it 'sets routable to false, with state of RUNNING' do
+          result = presenter.present_stats_hash
+
+          expect(result[0][:state]).to eq('RUNNING')
+          expect(result[0][:routable]).to be(false)
+        end
       end
 
       context 'the process is running on opi and not diego, so *_tls_proxy_ports are not included in the port struct' do


### PR DESCRIPTION
This enables CF API clients to provide feedback to developers on whether apps are currently passing readiness checks and are routable.

https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0020-readiness-healthchecks.md#cli-changes