### PR TITLE
Update diego sync to not fetch every bit of every object, only completely fetch objects that need syncing

### DIFF
--- a/lib/cloud_controller/diego/processes_sync.rb
+++ b/lib/cloud_controller/diego/processes_sync.rb
@@ -21,35 +21,26 @@ module VCAP::CloudController
         @bump_freshness = true
         diego_lrps = bbs_apps_client.fetch_scheduling_infos.index_by { |d| d.desired_lrp_key.process_guid }
         logger.info('fetched-scheduling-infos')
-
-        batched_processes do |processes|
+        to_update = []
+        to_create = []
+        to_update_lrp = {}
+        batched_processes_for_update do |processes|
           processes.each do |process|
             process_guid = ProcessGuid.from_process(process)
             diego_lrp    = diego_lrps.delete(process_guid)
 
             if diego_lrp.nil?
-              workpool.submit(process) do |p|
-                logger.info('desiring-lrp', process_guid: p.guid, app_guid: p.app_guid)
-                bbs_apps_client.desire_app(p)
-                logger.info('desire-lrp', process_guid: p.guid)
-              end
+              to_create.append(process.guid)
             elsif process.updated_at.to_f.to_s != diego_lrp.annotation
-              workpool.submit(process, diego_lrp) do |p, l|
-                logger.info('updating-lrp', process_guid: p.guid, app_guid: p.app_guid)
-                bbs_apps_client.update_app(p, l)
-                logger.info('update-lrp', process_guid: p.guid)
-              end
+              to_update_lrp[process.guid] = diego_lrp
+              to_update.append(process.guid)
             end
           end
         end
 
-        diego_lrps.each_key do |process_guid_to_delete|
-          workpool.submit(process_guid_to_delete) do |guid|
-            logger.info('deleting-lrp', process_guid: guid)
-            bbs_apps_client.stop_app(guid)
-            logger.info('delete-lrp', process_guid: guid)
-          end
-        end
+        update_processes(to_update, to_update_lrp)
+        create_processes(to_create)
+        delete_processes(diego_lrps)
 
         workpool.drain
 
@@ -95,15 +86,49 @@ module VCAP::CloudController
         @statsd_updater.update_synced_invalid_lrps(invalid_lrps)
       end
 
+      def update_processes(to_update, to_update_lrp)
+        batched_processes(to_update) do |processes|
+          processes.each do |process|
+            workpool.submit(process, to_update_lrp[process.guid]) do |p, l|
+              logger.info('updating-lrp', process_guid: p.guid, app_guid: p.app_guid)
+              bbs_apps_client.update_app(p, l)
+              logger.info('update-lrp', process_guid: p.guid)
+            end
+          end
+        end
+      end
+
+      def create_processes(to_create)
+        batched_processes(to_create) do |processes|
+          processes.each do |process|
+            workpool.submit(process) do |p|
+              logger.info('desiring-lrp', process_guid: p.guid, app_guid: p.app_guid)
+              bbs_apps_client.desire_app(p)
+              logger.info('desire-lrp', process_guid: p.guid)
+            end
+          end
+        end
+      end
+
+      def delete_processes(to_delete)
+        to_delete.each_key do |process_guid_to_delete|
+          workpool.submit(process_guid_to_delete) do |guid|
+            logger.info('deleting-lrp', process_guid: guid)
+            bbs_apps_client.stop_app(guid)
+            logger.info('delete-lrp', process_guid: guid)
+          end
+        end
+      end
+
       def formatted_backtrace_from_error(error)
         error.backtrace.present? ? error.backtrace.join("\n") + "\n..." : ''
       end
 
-      def batched_processes
+      def batched_processes_for_update
         last_id = 0
 
         loop do
-          processes = processes(last_id).all
+          processes = processes_for_sync(last_id).all
           yield processes
           return if processes.count < BATCH_SIZE
 
@@ -111,21 +136,37 @@ module VCAP::CloudController
         end
       end
 
-      def processes(last_id)
+      def batched_processes(ids)
+        ids.each_slice(BATCH_SIZE) do |id_chunk|
+          processes = processes(id_chunk).all
+          yield processes
+        end
+      end
+
+      def processes(ids)
         processes = ProcessModel.
                     diego.
                     runnable.
-                    where(Sequel.lit("#{ProcessModel.table_name}.id > ?", last_id)).
+                    where(Sequel.lit("#{ProcessModel.table_name}.guid IN ?", ids)).
                     order("#{ProcessModel.table_name}__id".to_sym).
-                    eager(:desired_droplet, :space, :service_bindings, { routes: :domain }, { app: :buildpack_lifecycle_data }).
-                    limit(BATCH_SIZE)
-
+                    eager(:desired_droplet, :space, :service_bindings, { routes: :domain }, { app: :buildpack_lifecycle_data })
         if FeatureFlag.enabled?(:diego_docker)
           processes.select_all(ProcessModel.table_name)
         else
           # `select_all` is called by `non_docker_type`
           processes.non_docker_type
         end
+      end
+
+      def processes_for_sync(last_id)
+        processes = ProcessModel.
+                    diego.
+                    runnable.
+                    where(Sequel.lit("#{ProcessModel.table_name}.id > ?", last_id)).
+                    order("#{ProcessModel.table_name}__id".to_sym).
+                    limit(BATCH_SIZE)
+
+        processes.select("#{ProcessModel.table_name}__guid".to_sym, "#{ProcessModel.table_name}__version".to_sym, "#{ProcessModel.table_name}__updated_at".to_sym)
       end
 
       def bbs_apps_client


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Possible way to decrease cost of diego syncing?

* An explanation of the use cases your change solves

Large envirnments may fetch all the process details of all the processes of the system rather then the information needed to preform a sync

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
