### PR TITLE
Introduce single source of truth for audit events

### DIFF
--- a/app/actions/role_create.rb
+++ b/app/actions/role_create.rb
@@ -19,13 +19,13 @@ module VCAP::CloudController
 
       case type
       when RoleTypes::SPACE_AUDITOR
-        create_space_auditor(user, space)
+        create_space_auditor(user, space, type)
       when RoleTypes::SPACE_DEVELOPER
-        create_space_developer(user, space)
+        create_space_developer(user, space, type)
       when RoleTypes::SPACE_MANAGER
-        create_space_manager(user, space)
+        create_space_manager(user, space, type)
       when RoleTypes::SPACE_SUPPORTER
-        create_space_supporter(user, space)
+        create_space_supporter(user, space, type)
       else
         error!("Role type '#{type}' is invalid.")
       end
@@ -39,13 +39,13 @@ module VCAP::CloudController
 
       case type
       when RoleTypes::ORGANIZATION_USER
-        create_organization_user(user, organization)
+        create_organization_user(user, organization, type)
       when RoleTypes::ORGANIZATION_AUDITOR
-        create_organization_auditor(user, organization)
+        create_organization_auditor(user, organization, type)
       when RoleTypes::ORGANIZATION_MANAGER
-        create_organization_manager(user, organization)
+        create_organization_manager(user, organization, type)
       when RoleTypes::ORGANIZATION_BILLING_MANAGER
-        create_organization_billing_manager(user, organization)
+        create_organization_billing_manager(user, organization, type)
       else
         error!("Role type '#{type}' is invalid.")
       end
@@ -59,52 +59,44 @@ module VCAP::CloudController
       @event_repo ||= Repositories::UserEventRepository.new
     end
 
-    def create_space_auditor(user, space)
-      record_space_event(space, user, 'auditor')
+    def create_space_auditor(user, space, role_type)
+      event_repo.record_space_role_add(space, user, role_type, @user_audit_info, @message.audit_hash)
       SpaceAuditor.create(user_id: user.id, space_id: space.id)
     end
 
-    def create_space_developer(user, space)
-      record_space_event(space, user, 'developer')
+    def create_space_developer(user, space, role_type)
+      event_repo.record_space_role_add(space, user, role_type, @user_audit_info, @message.audit_hash)
       SpaceDeveloper.create(user_id: user.id, space_id: space.id)
     end
 
-    def create_space_manager(user, space)
-      record_space_event(space, user, 'manager')
+    def create_space_manager(user, space, role_type)
+      event_repo.record_space_role_add(space, user, role_type, @user_audit_info, @message.audit_hash)
       SpaceManager.create(user_id: user.id, space_id: space.id)
     end
 
-    def create_space_supporter(user, space)
-      record_space_event(space, user, 'supporter')
+    def create_space_supporter(user, space, role_type)
+      event_repo.record_space_role_add(space, user, role_type, @user_audit_info, @message.audit_hash)
       SpaceSupporter.create(user_id: user.id, space_id: space.id)
     end
 
-    def create_organization_user(user, organization)
-      record_organization_event(organization, user, 'user')
+    def create_organization_user(user, organization, role_type)
+      event_repo.record_organization_role_add(organization, user, role_type, @user_audit_info, @message.audit_hash)
       OrganizationUser.create(user_id: user.id, organization_id: organization.id)
     end
 
-    def create_organization_auditor(user, organization)
-      record_organization_event(organization, user, 'auditor')
+    def create_organization_auditor(user, organization, role_type)
+      event_repo.record_organization_role_add(organization, user, role_type, @user_audit_info, @message.audit_hash)
       OrganizationAuditor.create(user_id: user.id, organization_id: organization.id)
     end
 
-    def create_organization_manager(user, organization)
-      record_organization_event(organization, user, 'manager')
+    def create_organization_manager(user, organization, role_type)
+      event_repo.record_organization_role_add(organization, user, role_type, @user_audit_info, @message.audit_hash)
       OrganizationManager.create(user_id: user.id, organization_id: organization.id)
     end
 
-    def create_organization_billing_manager(user, organization)
-      record_organization_event(organization, user, 'billing_manager')
+    def create_organization_billing_manager(user, organization, role_type)
+      event_repo.record_organization_role_add(organization, user, role_type, @user_audit_info, @message.audit_hash)
       OrganizationBillingManager.create(user_id: user.id, organization_id: organization.id)
-    end
-
-    def record_space_event(space, user, short_event_type)
-      event_repo.record_space_role_add(space, user, short_event_type, @user_audit_info, @message.audit_hash)
-    end
-
-    def record_organization_event(org, user, short_event_type)
-      event_repo.record_organization_role_add(org, user, short_event_type, @user_audit_info, @message.audit_hash)
     end
 
     def space_validation_error!(type, error, user, space)

--- a/app/actions/role_delete.rb
+++ b/app/actions/role_delete.rb
@@ -28,36 +28,13 @@ module VCAP::CloudController
     end
 
     def record_event(role)
-      case role.type
-      when VCAP::CloudController::RoleTypes::SPACE_MANAGER
-        record_space_event(role, 'manager')
-      when VCAP::CloudController::RoleTypes::SPACE_AUDITOR
-        record_space_event(role, 'auditor')
-      when VCAP::CloudController::RoleTypes::SPACE_DEVELOPER
-        record_space_event(role, 'developer')
-      when VCAP::CloudController::RoleTypes::SPACE_SUPPORTER
-        record_space_event(role, 'supporter')
-      when VCAP::CloudController::RoleTypes::ORGANIZATION_USER
-        record_organization_event(role, 'user')
-      when VCAP::CloudController::RoleTypes::ORGANIZATION_AUDITOR
-        record_organization_event(role, 'auditor')
-      when VCAP::CloudController::RoleTypes::ORGANIZATION_BILLING_MANAGER
-        record_organization_event(role, 'billing_manager')
-      when VCAP::CloudController::RoleTypes::ORGANIZATION_MANAGER
-        record_organization_event(role, 'manager')
+      if role.type.in?(RoleTypes::SPACE_ROLES)
+        event_repo.record_space_role_remove(Space.first(id: role.space_id), @role_owner, role.type, @user_audit_info)
+      elsif role.type.in?(RoleTypes::ORGANIZATION_ROLES)
+        event_repo.record_organization_role_remove(Organization.first(id: role.organization_id), @role_owner, role.type, @user_audit_info)
       else
         raise RoleDeleteError.new("Invalid role type: #{role.type}")
       end
-    end
-
-    def record_space_event(role, short_event_type)
-      space = Space.first(id: role.space_id)
-      event_repo.record_space_role_remove(space, @role_owner, short_event_type, @user_audit_info)
-    end
-
-    def record_organization_event(role, short_event_type)
-      organization = Organization.first(id: role.organization_id)
-      event_repo.record_organization_role_remove(organization, @role_owner, short_event_type, @user_audit_info)
     end
   end
 end

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -248,7 +248,7 @@ module VCAP::CloudController
         @user_event_repository.record_organization_role_remove(
           org,
           user,
-          role,
+          "organization_#{role}",
           UserAuditInfo.from_context(SecurityContext),
           request_attrs
         )
@@ -334,7 +334,7 @@ module VCAP::CloudController
       org = find_guid_and_validate_access(:update, guid)
       org.send("add_#{role}", user)
 
-      @user_event_repository.record_organization_role_add(org, user, role, UserAuditInfo.from_context(SecurityContext), request_attrs)
+      @user_event_repository.record_organization_role_add(org, user, "organization_#{role}", UserAuditInfo.from_context(SecurityContext), request_attrs)
 
       [HTTP::CREATED, object_renderer.render_json(self.class, org, @opts)]
     end
@@ -348,7 +348,7 @@ module VCAP::CloudController
       @user_event_repository.record_organization_role_remove(
         Organization.first(guid:),
         user,
-        role.to_s,
+        "organization_#{role}",
         UserAuditInfo.from_context(SecurityContext),
         {}
       )
@@ -370,19 +370,19 @@ module VCAP::CloudController
       end
 
       organization.users.each do |user|
-        @user_event_repository.record_organization_role_add(organization, user, 'user', user_audit_info, request_attrs)
+        @user_event_repository.record_organization_role_add(organization, user, RoleTypes::ORGANIZATION_USER, user_audit_info, request_attrs)
       end
 
       organization.auditors.each do |auditor|
-        @user_event_repository.record_organization_role_add(organization, auditor, 'auditor', user_audit_info, request_attrs)
+        @user_event_repository.record_organization_role_add(organization, auditor, RoleTypes::ORGANIZATION_AUDITOR, user_audit_info, request_attrs)
       end
 
       organization.billing_managers.each do |billing_manager|
-        @user_event_repository.record_organization_role_add(organization, billing_manager, 'billing_manager', user_audit_info, request_attrs)
+        @user_event_repository.record_organization_role_add(organization, billing_manager, RoleTypes::ORGANIZATION_BILLING_MANAGER, user_audit_info, request_attrs)
       end
 
       organization.managers.each do |manager|
-        @user_event_repository.record_organization_role_add(organization, manager, 'manager', user_audit_info, request_attrs)
+        @user_event_repository.record_organization_role_add(organization, manager, RoleTypes::ORGANIZATION_MANAGER, user_audit_info, request_attrs)
       end
     end
 
@@ -432,7 +432,7 @@ module VCAP::CloudController
           @user_event_repository.record_organization_role_add(
             organization,
             user,
-            role,
+            "organization_#{role}",
             user_audit_info,
             request_attrs
           )
@@ -445,7 +445,7 @@ module VCAP::CloudController
           @user_event_repository.record_organization_role_remove(
             organization,
             user,
-            role,
+            "organization_#{role}",
             user_audit_info,
             request_attrs
           )

--- a/app/controllers/runtime/spaces_controller.rb
+++ b/app/controllers/runtime/spaces_controller.rb
@@ -323,7 +323,7 @@ module VCAP::CloudController
 
       space.send("add_#{role}", user)
 
-      @user_event_repository.record_space_role_add(space, user, role, UserAuditInfo.from_context(SecurityContext), request_attrs)
+      @user_event_repository.record_space_role_add(space, user, "space_#{role}", UserAuditInfo.from_context(SecurityContext), request_attrs)
 
       [HTTP::CREATED, object_renderer.render_json(self.class, space, @opts)]
     end
@@ -336,7 +336,7 @@ module VCAP::CloudController
 
       space.send("remove_#{role}", user)
 
-      @user_event_repository.record_space_role_remove(space, user, role, UserAuditInfo.from_context(SecurityContext), request_attrs)
+      @user_event_repository.record_space_role_remove(space, user, "space_#{role}", UserAuditInfo.from_context(SecurityContext), request_attrs)
     end
 
     def after_create(space)
@@ -345,15 +345,15 @@ module VCAP::CloudController
       @space_event_repository.record_space_create(space, user_audit_info, request_attrs)
 
       space.managers.each do |mgr|
-        @user_event_repository.record_space_role_add(space, mgr, 'manager', user_audit_info, request_attrs)
+        @user_event_repository.record_space_role_add(space, mgr, RoleTypes::SPACE_MANAGER, user_audit_info, request_attrs)
       end
 
       space.auditors.each do |auditor|
-        @user_event_repository.record_space_role_add(space, auditor, 'auditor', user_audit_info, request_attrs)
+        @user_event_repository.record_space_role_add(space, auditor, RoleTypes::SPACE_AUDITOR, user_audit_info, request_attrs)
       end
 
       space.developers.each do |developer|
-        @user_event_repository.record_space_role_add(space, developer, 'developer', user_audit_info, request_attrs)
+        @user_event_repository.record_space_role_add(space, developer, RoleTypes::SPACE_DEVELOPER, user_audit_info, request_attrs)
       end
     end
 
@@ -415,7 +415,7 @@ module VCAP::CloudController
           @user_event_repository.record_space_role_add(
             space,
             user,
-            role,
+            "space_#{role}",
             user_audit_info,
             request_attrs
           )
@@ -428,7 +428,7 @@ module VCAP::CloudController
           @user_event_repository.record_space_role_remove(
             space,
             user,
-            role,
+            "space_#{role}",
             user_audit_info,
             request_attrs
           )

--- a/app/repositories/build_event_repository.rb
+++ b/app/repositories/build_event_repository.rb
@@ -1,3 +1,5 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class BuildEventRepository
@@ -10,7 +12,7 @@ module VCAP::CloudController
         }
 
         Event.create(
-          type: 'audit.app.build.create',
+          type: EventTypes::APP_BUILD_CREATE,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,

--- a/app/repositories/deployment_event_repository.rb
+++ b/app/repositories/deployment_event_repository.rb
@@ -1,3 +1,5 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class DeploymentEventRepository
@@ -13,7 +15,7 @@ module VCAP::CloudController
         }
 
         Event.create(
-          type: 'audit.app.deployment.create',
+          type: EventTypes::APP_DEPLOYMENT_CREATE,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,
@@ -37,7 +39,7 @@ module VCAP::CloudController
         }
 
         Event.create(
-          type: 'audit.app.deployment.cancel',
+          type: EventTypes::APP_DEPLOYMENT_CANCEL,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,

--- a/app/repositories/droplet_event_repository.rb
+++ b/app/repositories/droplet_event_repository.rb
@@ -1,3 +1,5 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class DropletEventRepository
@@ -10,7 +12,7 @@ module VCAP::CloudController
         }
 
         Event.create(
-          type: 'audit.app.droplet.create',
+          type: EventTypes::APP_DROPLET_CREATE,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,
@@ -33,7 +35,7 @@ module VCAP::CloudController
         }
 
         Event.create(
-          type: 'audit.app.droplet.create',
+          type: EventTypes::APP_DROPLET_CREATE,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,
@@ -59,7 +61,7 @@ module VCAP::CloudController
         }
 
         Event.create(
-          type: 'audit.app.droplet.create',
+          type: EventTypes::APP_DROPLET_CREATE,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,
@@ -80,7 +82,7 @@ module VCAP::CloudController
         metadata = { droplet_guid: droplet.guid }
 
         Event.create(
-          type: 'audit.app.droplet.delete',
+          type: EventTypes::APP_DROPLET_DELETE,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,
@@ -102,7 +104,7 @@ module VCAP::CloudController
         metadata = { droplet_guid: droplet.guid }
 
         Event.create(
-          type: 'audit.app.droplet.download',
+          type: EventTypes::APP_DROPLET_DOWNLOAD,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,
@@ -123,7 +125,7 @@ module VCAP::CloudController
         metadata = { droplet_guid: droplet.guid }
 
         Event.create(
-          type: 'audit.app.droplet.upload',
+          type: EventTypes::APP_DROPLET_UPLOAD,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,

--- a/app/repositories/event_types.rb
+++ b/app/repositories/event_types.rb
@@ -1,0 +1,185 @@
+module VCAP::CloudController
+  module Repositories
+    class EventTypes
+      class EventTypesError < StandardError
+      end
+
+      AUDIT_EVENTS = [
+        APP_CREATE = 'audit.app.create'.freeze,
+        APP_UPDATE = 'audit.app.update'.freeze,
+        APP_DELETE_REQUEST = 'audit.app.delete-request'.freeze,
+        APP_START = 'audit.app.start'.freeze,
+        APP_RESTART = 'audit.app.restart'.freeze,
+        APP_RESTAGE = 'audit.app.restage'.freeze,
+        APP_STOP = 'audit.app.stop'.freeze,
+
+        APP_PACKAGE_CREATE = 'audit.app.package.create'.freeze,
+        APP_PACKAGE_UPLOAD = 'audit.app.package.upload'.freeze,
+        APP_PACKAGE_DOWNLOAD = 'audit.app.package.download'.freeze,
+        APP_PACKAGE_DELETE = 'audit.app.package.delete'.freeze,
+
+        APP_PROCESS_CREATE = 'audit.app.process.create'.freeze,
+        APP_PROCESS_UPDATE = 'audit.app.process.update'.freeze,
+        APP_PROCESS_DELETE = 'audit.app.process.delete'.freeze,
+        APP_PROCESS_RESCHEDULING = 'audit.app.process.rescheduling'.freeze,
+        APP_PROCESS_CRASH = 'audit.app.process.crash'.freeze,
+        APP_PROCESS_TERMINATE_INSTANCE = 'audit.app.process.terminate_instance'.freeze,
+        APP_PROCESS_SCALE = 'audit.app.process.scale'.freeze,
+
+        APP_DROPLET_CREATE = 'audit.app.droplet.create'.freeze,
+        APP_DROPLET_UPLOAD = 'audit.app.droplet.upload'.freeze,
+        APP_DROPLET_DOWNLOAD = 'audit.app.droplet.download'.freeze,
+        APP_DROPLET_DELETE = 'audit.app.droplet.delete'.freeze,
+        APP_DROPLET_MAPPED = 'audit.app.droplet.mapped'.freeze,
+
+        APP_TASK_CREATE = 'audit.app.task.create'.freeze,
+        APP_TASK_CANCEL = 'audit.app.task.cancel'.freeze,
+
+        APP_MAP_ROUTE = 'audit.app.map-route'.freeze,
+        APP_UNMAP_ROUTE = 'audit.app.unmap-route'.freeze,
+
+        APP_BUILD_CREATE = 'audit.app.build.create'.freeze,
+        APP_ENVIRONMENT_SHOW = 'audit.app.environment.show'.freeze,
+        APP_ENVIRONMENT_VARIABLE_SHOW = 'audit.app.environment_variables.show'.freeze,
+        APP_REVISION_CREATE = 'audit.app.revision.create'.freeze,
+        APP_REVISION_ENV_VARS_SHOW = 'audit.app.revision.environment_variables.show'.freeze,
+        APP_DEPLOYMENT_CANCEL = 'audit.app.deployment.cancel'.freeze,
+        APP_DEPLOYMENT_CREATE = 'audit.app.deployment.create'.freeze,
+        APP_COPY_BITS = 'audit.app.copy-bits'.freeze,
+        APP_UPLOAD_BITS = 'audit.app.upload-bits'.freeze,
+        APP_APPLY_MANIFEST = 'audit.app.apply_manifest'.freeze,
+        APP_SSH_AUTHORIZED = 'audit.app.ssh-authorized'.freeze,
+        APP_SSH_UNAUTHORIZED = 'audit.app.ssh-unauthorized'.freeze,
+
+        SERVICE_CREATE = 'audit.service.create'.freeze,
+        SERVICE_UPDATE = 'audit.service.update'.freeze,
+        SERVICE_DELETE = 'audit.service.delete'.freeze,
+
+        SERVICE_BROKER_CREATE = 'audit.service_broker.create'.freeze,
+        SERVICE_BROKER_UPDATE = 'audit.service_broker.update'.freeze,
+        SERVICE_BROKER_DELETE = 'audit.service_broker.delete'.freeze,
+
+        SERVICE_PLAN_CREATE = 'audit.service_plan.create'.freeze,
+        SERVICE_PLAN_UPDATE = 'audit.service_plan.update'.freeze,
+        SERVICE_PLAN_DELETE = 'audit.service_plan.delete'.freeze,
+
+        SERVICE_INSTANCE_CREATE = 'audit.service_instance.create'.freeze,
+        SERVICE_INSTANCE_UPDATE = 'audit.service_instance.update'.freeze,
+        SERVICE_INSTANCE_DELETE = 'audit.service_instance.delete'.freeze,
+        SERVICE_INSTANCE_START_CREATE = 'audit.service_instance.start_create'.freeze,
+        SERVICE_INSTANCE_START_UPDATE = 'audit.service_instance.start_update'.freeze,
+        SERVICE_INSTANCE_START_DELETE = 'audit.service_instance.start_delete'.freeze,
+        SERVICE_INSTANCE_BIND_ROUTE = 'audit.service_instance.bind_route'.freeze,
+        SERVICE_INSTANCE_UNBIND_ROUTE = 'audit.service_instance.unbind_route'.freeze,
+        SERVICE_INSTANCE_SHARE = 'audit.service_instance.share'.freeze,
+        SERVICE_INSTANCE_UNSHARE = 'audit.service_instance.unshare'.freeze,
+        SERVICE_INSTANCE_PURGE = 'audit.service_instance.purge'.freeze,
+        SERVICE_INSTANCE_SHOW = 'audit.service_instance.show'.freeze,
+
+        SERVICE_BINDING_CREATE = 'audit.service_binding.create'.freeze,
+        SERVICE_BINDING_UPDATE = 'audit.service_binding.update'.freeze,
+        SERVICE_BINDING_DELETE = 'audit.service_binding.delete'.freeze,
+        SERVICE_BINDING_START_CREATE = 'audit.service_binding.start_create'.freeze,
+        SERVICE_BINDING_START_DELETE = 'audit.service_binding.start_delete'.freeze,
+        SERVICE_BINDING_SHOW = 'audit.service_binding.show'.freeze,
+
+        SERVICE_KEY_CREATE = 'audit.service_key.create'.freeze,
+        SERVICE_KEY_UPDATE = 'audit.service_key.update'.freeze,
+        SERVICE_KEY_DELETE = 'audit.service_key.delete'.freeze,
+        SERVICE_KEY_START_CREATE = 'audit.service_key.start_create'.freeze,
+        SERVICE_KEY_START_DELETE = 'audit.service_key.start_delete'.freeze,
+        SERVICE_KEY_SHOW = 'audit.service_key.show'.freeze,
+
+        SERVICE_PLAN_VISIBILITY_CREATE = 'audit.service_plan_visibility.create'.freeze,
+        SERVICE_PLAN_VISIBILITY_UPDATE = 'audit.service_plan_visibility.update'.freeze,
+        SERVICE_PLAN_VISIBILITY_DELETE = 'audit.service_plan_visibility.delete'.freeze,
+
+        SERVICE_ROUTE_BINDING_CREATE = 'audit.service_route_binding.create'.freeze,
+        SERVICE_ROUTE_BINDING_UPDATE = 'audit.service_route_binding.update'.freeze,
+        SERVICE_ROUTE_BINDING_DELETE = 'audit.service_route_binding.delete'.freeze,
+        SERVICE_ROUTE_BINDING_START_CREATE =  'audit.service_route_binding.start_create'.freeze,
+        SERVICE_ROUTE_BINDING_START_DELETE =  'audit.service_route_binding.start_delete'.freeze,
+
+        USER_PROVIDED_SERVICE_INSTANCE_CREATE = 'audit.user_provided_service_instance.create'.freeze,
+        USER_PROVIDED_SERVICE_INSTANCE_UPDATE = 'audit.user_provided_service_instance.update'.freeze,
+        USER_PROVIDED_SERVICE_INSTANCE_DELETE = 'audit.user_provided_service_instance.delete'.freeze,
+        USER_PROVIDED_SERVICE_INSTANCE_SHOW = 'audit.user_provided_service_instance.show'.freeze,
+
+        ROUTE_CREATE = 'audit.route.create'.freeze,
+        ROUTE_UPDATE = 'audit.route.update'.freeze,
+        ROUTE_DELETE_REQUEST = 'audit.route.delete-request'.freeze,
+        ROUTE_SHARE = 'audit.route.share'.freeze,
+        ROUTE_UNSHARE = 'audit.route.unshare'.freeze,
+        ROUTE_TRANSFER_OWNER = 'audit.route.transfer-owner'.freeze,
+
+        ORGANIZATION_CREATE = 'audit.organization.create'.freeze,
+        ORGANIZATION_UPDATE = 'audit.organization.update'.freeze,
+        ORGANIZATION_DELETE_REQUEST = 'audit.organization.delete-request'.freeze,
+
+        SPACE_CREATE = 'audit.space.create'.freeze,
+        SPACE_UPDATE = 'audit.space.update'.freeze,
+        SPACE_DELETE_REQUEST = 'audit.space.delete-request'.freeze,
+
+        USER_SPACE_AUDITOR_ADD = 'audit.user.space_auditor_add'.freeze,
+        USER_SPACE_AUDITOR_REMOVE = 'audit.user.space_auditor_remove'.freeze,
+        USER_SPACE_SUPPORTER_ADD = 'audit.user.space_supporter_add'.freeze,
+        USER_SPACE_SUPPORTER_REMOVE = 'audit.user.space_supporter_remove'.freeze,
+        USER_SPACE_DEVELOPER_ADD = 'audit.user.space_developer_add'.freeze,
+        USER_SPACE_DEVELOPER_REMOVE = 'audit.user.space_developer_remove'.freeze,
+        USER_SPACE_MANAGER_ADD = 'audit.user.space_manager_add'.freeze,
+        USER_SPACE_MANAGER_REMOVE = 'audit.user.space_manager_remove'.freeze,
+
+        SERVICE_DASHBOARD_CLIENT_CREATE = 'audit.service_dashboard_client.create'.freeze,
+        SERVICE_DASHBOARD_CLIENT_DELETE = 'audit.service_dashboard_client.delete'.freeze,
+
+        USER_ORGANIZATION_USER_ADD = 'audit.user.organization_user_add'.freeze,
+        USER_ORGANIZATION_USER_REMOVE = 'audit.user.organization_user_remove'.freeze,
+        USER_ORGANIZATION_AUDITOR_ADD = 'audit.user.organization_auditor_add'.freeze,
+        USER_ORGANIZATION_AUDITOR_REMOVE = 'audit.user.organization_auditor_remove'.freeze,
+        USER_ORGANIZATION_BILLING_MANAGER_ADD = 'audit.user.organization_billing_manager_add'.freeze,
+        USER_ORGANIZATION_BILLING_MANAGER_REMOVE = 'audit.user.organization_billing_manager_remove'.freeze,
+        USER_ORGANIZATION_MANAGER_ADD = 'audit.user.organization_manager_add'.freeze,
+        USER_ORGANIZATION_MANAGER_REMOVE = 'audit.user.organization_manager_remove'.freeze
+      ].freeze
+
+      SPECIAL_EVENTS = [
+        APP_CRASH = 'app.crash'.freeze,
+        BLOB_REMOVE_ORPHAN = 'blob.remove_orphan'.freeze
+      ].freeze
+
+      ALL_EVENT_TYPES = [
+        AUDIT_EVENTS,
+        SPECIAL_EVENTS
+      ].freeze
+
+      USER_SPACE_EVENTS = [
+        USER_SPACE_AUDITOR_ADD,
+        USER_SPACE_AUDITOR_REMOVE,
+        USER_SPACE_SUPPORTER_ADD,
+        USER_SPACE_SUPPORTER_REMOVE,
+        USER_SPACE_DEVELOPER_ADD,
+        USER_SPACE_DEVELOPER_REMOVE,
+        USER_SPACE_MANAGER_ADD,
+        USER_SPACE_MANAGER_REMOVE
+      ].freeze
+
+      USER_ORGANIZATION_EVENTS = [
+        USER_ORGANIZATION_USER_ADD,
+        USER_ORGANIZATION_USER_REMOVE,
+        USER_ORGANIZATION_AUDITOR_ADD,
+        USER_ORGANIZATION_AUDITOR_REMOVE,
+        USER_ORGANIZATION_BILLING_MANAGER_ADD,
+        USER_ORGANIZATION_BILLING_MANAGER_REMOVE,
+        USER_ORGANIZATION_MANAGER_ADD,
+        USER_ORGANIZATION_MANAGER_REMOVE
+      ].freeze
+
+      def self.get(event_type_str)
+        event_type_str = event_type_str.upcase
+        raise EventTypesError.new("Audit event type '#{event_type_str}' is invalid.") unless EventTypes.const_defined?(event_type_str)
+
+        EventTypes.const_get(event_type_str)
+      end
+    end
+  end
+end

--- a/app/repositories/organization_event_repository.rb
+++ b/app/repositories/organization_event_repository.rb
@@ -1,9 +1,11 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class OrganizationEventRepository
       def record_organization_create(organization, user_audit_info, request_attrs)
         Event.create(
-          type: 'audit.organization.create',
+          type: EventTypes::ORGANIZATION_CREATE,
           actee: organization.guid,
           organization_guid: organization.guid,
           actee_type: 'organization',
@@ -21,7 +23,7 @@ module VCAP::CloudController
 
       def record_organization_update(organization, user_audit_info, request_attrs)
         Event.create(
-          type: 'audit.organization.update',
+          type: EventTypes::ORGANIZATION_UPDATE,
           actee: organization.guid,
           organization_guid: organization.guid,
           actee_type: 'organization',
@@ -39,7 +41,7 @@ module VCAP::CloudController
 
       def record_organization_delete_request(organization, user_audit_info, request_attrs)
         Event.create(
-          type: 'audit.organization.delete-request',
+          type: EventTypes::ORGANIZATION_DELETE_REQUEST,
           actee: organization.guid,
           organization_guid: organization.guid,
           actee_type: 'organization',

--- a/app/repositories/orphaned_blob_event_repository.rb
+++ b/app/repositories/orphaned_blob_event_repository.rb
@@ -1,9 +1,11 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class OrphanedBlobEventRepository
       def self.record_delete(directory_key, blob_key)
         Event.create(
-          type: 'blob.remove_orphan',
+          type: EventTypes::BLOB_REMOVE_ORPHAN,
           actor: 'system',
           actor_type: 'system',
           actor_name: 'system',

--- a/app/repositories/package_event_repository.rb
+++ b/app/repositories/package_event_repository.rb
@@ -1,3 +1,5 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class PackageEventRepository
@@ -9,9 +11,8 @@ module VCAP::CloudController
           package_guid: package.guid,
           request: request_attrs
         }
-        type = 'audit.app.package.create'
 
-        create_event(package, type, user_audit_info, metadata)
+        create_event(package, EventTypes::APP_PACKAGE_CREATE, user_audit_info, metadata)
       end
 
       def self.record_app_package_copy(package, user_audit_info, source_package_guid)
@@ -23,7 +24,7 @@ module VCAP::CloudController
             source_package_guid:
           }
         }
-        type = 'audit.app.package.create'
+        type = EventTypes::APP_PACKAGE_CREATE
 
         create_event(package, type, user_audit_info, metadata)
       end
@@ -31,33 +32,29 @@ module VCAP::CloudController
       def self.record_app_package_upload(package, user_audit_info)
         VCAP::AppLogEmitter.emit(package.app_guid, "Uploading app package for app with guid #{package.app_guid}")
         metadata = { package_guid: package.guid }
-        type     = 'audit.app.package.upload'
 
-        create_event(package, type, user_audit_info, metadata)
+        create_event(package, EventTypes::APP_PACKAGE_UPLOAD, user_audit_info, metadata)
       end
 
       def self.record_app_upload_bits(package, user_audit_info)
         VCAP::AppLogEmitter.emit(package.app_guid, "Uploading bits for app with guid #{package.app_guid}")
         metadata = { package_guid: package.guid }
-        type     = 'audit.app.upload-bits'
 
-        create_event(package, type, user_audit_info, metadata)
+        create_event(package, EventTypes::APP_UPLOAD_BITS, user_audit_info, metadata)
       end
 
       def self.record_app_package_delete(package, user_audit_info)
         VCAP::AppLogEmitter.emit(package.app_guid, "Deleting app package for app with guid #{package.app_guid}")
         metadata = { package_guid: package.guid }
-        type     = 'audit.app.package.delete'
 
-        create_event(package, type, user_audit_info, metadata)
+        create_event(package, EventTypes::APP_PACKAGE_DELETE, user_audit_info, metadata)
       end
 
       def self.record_app_package_download(package, user_audit_info)
         VCAP::AppLogEmitter.emit(package.app_guid, "Downloading app package for app with guid #{package.app_guid}")
         metadata = { package_guid: package.guid }
-        type     = 'audit.app.package.download'
 
-        create_event(package, type, user_audit_info, metadata)
+        create_event(package, EventTypes::APP_PACKAGE_DOWNLOAD, user_audit_info, metadata)
       end
 
       def self.create_event(package, type, user_audit_info, metadata)

--- a/app/repositories/process_event_repository.rb
+++ b/app/repositories/process_event_repository.rb
@@ -1,5 +1,6 @@
 require 'repositories/mixins/app_manifest_event_mixins'
 require 'repositories/mixins/truncation_mixin'
+require 'repositories/event_types'
 
 module VCAP::CloudController
   module Repositories
@@ -17,7 +18,7 @@ module VCAP::CloudController
 
         create_event(
           process: process,
-          type: 'audit.app.process.create',
+          type: EventTypes::APP_PROCESS_CREATE,
           actor_guid: user_audit_info.user_guid,
           actor_name: user_audit_info.user_email,
           actor_username: user_audit_info.user_name,
@@ -30,7 +31,7 @@ module VCAP::CloudController
 
         create_event(
           process: process,
-          type: 'audit.app.process.delete',
+          type: EventTypes::APP_PROCESS_DELETE,
           actor_guid: user_audit_info.user_guid,
           actor_name: user_audit_info.user_email,
           actor_username: user_audit_info.user_name,
@@ -54,7 +55,7 @@ module VCAP::CloudController
 
         create_event(
           process: process,
-          type: 'audit.app.process.update',
+          type: EventTypes::APP_PROCESS_UPDATE,
           actor_guid: user_audit_info.user_guid,
           actor_name: user_audit_info.user_email,
           actor_username: user_audit_info.user_name,
@@ -73,7 +74,7 @@ module VCAP::CloudController
 
         create_event(
           process: process,
-          type: 'audit.app.process.scale',
+          type: EventTypes::APP_PROCESS_SCALE,
           actor_guid: user_audit_info.user_guid,
           actor_name: user_audit_info.user_email,
           actor_username: user_audit_info.user_name,
@@ -86,7 +87,7 @@ module VCAP::CloudController
 
         create_event(
           process: process,
-          type: 'audit.app.process.terminate_instance',
+          type: EventTypes::APP_PROCESS_TERMINATE_INSTANCE,
           actor_guid: user_audit_info.user_guid,
           actor_name: user_audit_info.user_email,
           actor_username: user_audit_info.user_name,
@@ -104,7 +105,7 @@ module VCAP::CloudController
 
         create_event(
           process: process,
-          type: 'audit.app.process.crash',
+          type: EventTypes::APP_PROCESS_CRASH,
           actor_guid: process.guid,
           actor_name: process.type,
           actor_type: 'process',
@@ -117,7 +118,7 @@ module VCAP::CloudController
 
         create_event(
           process: process,
-          type: 'audit.app.process.rescheduling',
+          type: EventTypes::APP_PROCESS_RESCHEDULING,
           actor_guid: process.guid,
           actor_name: process.type,
           actor_type: 'process',

--- a/app/repositories/revision_event_repository.rb
+++ b/app/repositories/revision_event_repository.rb
@@ -1,13 +1,15 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class RevisionEventRepository
       def self.record_create(revision, app, user_audit_info)
         VCAP::AppLogEmitter.emit(revision.app_guid, "Creating revision for app with guid #{app.guid}")
-        create_revision_event('audit.app.revision.create', app, revision, user_audit_info)
+        create_revision_event(EventTypes::APP_REVISION_CREATE, app, revision, user_audit_info)
       end
 
       def self.record_show_environment_variables(revision, app, user_audit_info)
-        create_revision_event('audit.app.revision.environment_variables.show', app, revision, user_audit_info)
+        create_revision_event(EventTypes::APP_REVISION_ENV_VARS_SHOW, app, revision, user_audit_info)
       end
 
       def self.create_revision_event(type, app, revision, user_audit_info)

--- a/app/repositories/route_event_repository.rb
+++ b/app/repositories/route_event_repository.rb
@@ -1,4 +1,5 @@
 require 'repositories/mixins/app_manifest_event_mixins'
+require 'repositories/event_types'
 
 module VCAP::CloudController
   module Repositories
@@ -8,7 +9,7 @@ module VCAP::CloudController
       def record_route_create(route, actor_audit_info, request_attrs, manifest_triggered: false)
         Event.create(
           space: route.space,
-          type: 'audit.route.create',
+          type: EventTypes::ROUTE_CREATE,
           actee: route.guid,
           actee_type: 'route',
           actee_name: route.host,
@@ -26,7 +27,7 @@ module VCAP::CloudController
       def record_route_update(route, actor_audit_info, request_attrs)
         Event.create(
           space: route.space,
-          type: 'audit.route.update',
+          type: EventTypes::ROUTE_UPDATE,
           actee: route.guid,
           actee_type: 'route',
           actee_name: route.host,
@@ -44,7 +45,7 @@ module VCAP::CloudController
       def record_route_share(route, actor_audit_info, target_space_guids)
         Event.create(
           space: route.space,
-          type: 'audit.route.share',
+          type: EventTypes::ROUTE_SHARE,
           actee: route.guid,
           actee_type: 'route',
           actee_name: route.host,
@@ -62,7 +63,7 @@ module VCAP::CloudController
       def record_route_unshare(route, actor_audit_info, target_space_guid)
         Event.create(
           space: route.space,
-          type: 'audit.route.unshare',
+          type: EventTypes::ROUTE_UNSHARE,
           actee: route.guid,
           actee_type: 'route',
           actee_name: route.host,
@@ -80,7 +81,7 @@ module VCAP::CloudController
       def record_route_transfer_owner(route, actor_audit_info, original_space, target_space_guid)
         Event.create(
           space: original_space,
-          type: 'audit.route.transfer-owner',
+          type: EventTypes::ROUTE_TRANSFER_OWNER,
           actee: route.guid,
           actee_type: 'route',
           actee_name: route.host,
@@ -97,7 +98,7 @@ module VCAP::CloudController
 
       def record_route_delete_request(route, actor_audit_info, recursive)
         Event.create(
-          type: 'audit.route.delete-request',
+          type: EventTypes::ROUTE_DELETE_REQUEST,
           actee: route.guid,
           actee_type: 'route',
           actee_name: route.host,
@@ -116,7 +117,7 @@ module VCAP::CloudController
 
       def record_route_map(route_mapping, actor_audit_info)
         Event.create(
-          type: 'audit.app.map-route',
+          type: EventTypes::APP_MAP_ROUTE,
           actee: route_mapping.app_guid,
           actee_type: 'app',
           actee_name: route_mapping.app.name,
@@ -139,7 +140,7 @@ module VCAP::CloudController
 
       def record_route_unmap(route_mapping, actor_audit_info)
         Event.create(
-          type: 'audit.app.unmap-route',
+          type: EventTypes::APP_UNMAP_ROUTE,
           actee: route_mapping.app_guid,
           actee_type: 'app',
           actee_name: route_mapping.app.name,

--- a/app/repositories/service_binding_event_repository.rb
+++ b/app/repositories/service_binding_event_repository.rb
@@ -1,4 +1,5 @@
 require 'repositories/mixins/app_manifest_event_mixins'
+require 'repositories/event_types'
 
 module VCAP::CloudController
   module Repositories
@@ -10,7 +11,7 @@ module VCAP::CloudController
           attrs = censor_request_attributes(request)
 
           record_event(
-            type: 'audit.service_binding.start_create',
+            type: EventTypes::SERVICE_BINDING_START_CREATE,
             service_binding: service_binding,
             user_audit_info: user_audit_info,
             metadata: add_manifest_triggered(manifest_triggered, { request: attrs })
@@ -21,7 +22,7 @@ module VCAP::CloudController
           attrs = censor_request_attributes(request)
 
           record_event(
-            type: 'audit.service_binding.create',
+            type: EventTypes::SERVICE_BINDING_CREATE,
             service_binding: service_binding,
             user_audit_info: user_audit_info,
             metadata: add_manifest_triggered(manifest_triggered, { request: attrs })
@@ -30,7 +31,7 @@ module VCAP::CloudController
 
         def record_start_delete(service_binding, user_audit_info)
           record_event(
-            type: 'audit.service_binding.start_delete',
+            type: EventTypes::SERVICE_BINDING_START_DELETE,
             service_binding: service_binding,
             user_audit_info: user_audit_info,
             metadata: {
@@ -44,7 +45,7 @@ module VCAP::CloudController
 
         def record_delete(service_binding, user_audit_info)
           record_event(
-            type: 'audit.service_binding.delete',
+            type: EventTypes::SERVICE_BINDING_DELETE,
             service_binding: service_binding,
             user_audit_info: user_audit_info,
             metadata: {

--- a/app/repositories/service_event_repository.rb
+++ b/app/repositories/service_event_repository.rb
@@ -1,4 +1,5 @@
 require 'presenters/helpers/censorship'
+require 'repositories/event_types'
 
 module VCAP::CloudController
   module Repositories
@@ -106,7 +107,8 @@ module VCAP::CloudController
             actee_type: 'service_broker',
             actee_name: broker.name
           }
-          create_event("audit.service_broker.#{type}", user_actor, actee, metadata)
+
+          create_event(EventTypes.get("SERVICE_BROKER_#{type}"), user_actor, actee, metadata)
         end
 
         def record_broker_event_with_request(type, broker, request)
@@ -116,7 +118,7 @@ module VCAP::CloudController
             actee_type: 'service_broker',
             actee_name: broker.name
           }
-          create_event("audit.service_broker.#{type}", user_actor, actee, metadata)
+          create_event(EventTypes.get("SERVICE_BROKER_#{type}"), user_actor, actee, metadata)
         end
 
         def record_service_instance_event(event, service_instance, params=nil)
@@ -155,7 +157,7 @@ module VCAP::CloudController
             actee_name: service_key.name
           }
           space_data = { space: service_key.space }
-          create_event("audit.service_key.#{type}", user_actor, actee, metadata, space_data)
+          create_event(EventTypes.get("SERVICE_KEY_#{type}"), user_actor, actee, metadata, space_data)
         end
 
         def record_service_purge_event(service)
@@ -169,7 +171,7 @@ module VCAP::CloudController
             actee_type: 'service',
             actee_name: service.label
           }
-          create_event('audit.service.delete', user_actor, actee, metadata)
+          create_event(EventTypes::SERVICE_DELETE, user_actor, actee, metadata)
         end
 
         def record_service_delete_event(service)
@@ -179,7 +181,7 @@ module VCAP::CloudController
             actee_type: 'service',
             actee_name: service.label
           }
-          create_event('audit.service.delete', user_actor, actee, metadata)
+          create_event(EventTypes::SERVICE_DELETE, user_actor, actee, metadata)
         end
 
         def record_service_plan_delete_event(plan)
@@ -189,7 +191,7 @@ module VCAP::CloudController
             actee_type: 'service_plan',
             actee_name: plan.name
           }
-          create_event('audit.service_plan.delete', user_actor, actee, metadata)
+          create_event(EventTypes::SERVICE_PLAN_DELETE, user_actor, actee, metadata)
         end
 
         private
@@ -205,7 +207,7 @@ module VCAP::CloudController
 
           metadata = { request: params }
 
-          create_event("audit.service_plan_visibility.#{type}", user_actor, actee, metadata, space_data)
+          create_event(EventTypes.get("SERVICE_PLAN_VISIBILITY_#{type}"), user_actor, actee, metadata, space_data)
         end
 
         def with_parameters_redacted(request_data)
@@ -250,7 +252,7 @@ module VCAP::CloudController
 
           space_data = { space: service_instance.space }
 
-          create_event("audit.#{type}.#{event}", user_actor, actee, metadata, space_data)
+          create_event(EventTypes.get("#{type}_#{event}"), user_actor, actee, metadata, space_data)
         end
 
         def user_actor
@@ -273,7 +275,7 @@ module VCAP::CloudController
             actee_type: 'service',
             actee_name: service.label
           }
-          create_event("audit.service.#{type}", broker_actor(broker), actee, {})
+          create_event(EventTypes.get("SERVICE_#{type}"), broker_actor(broker), actee, {})
         end
 
         def record_service_plan_event(type, plan)
@@ -284,7 +286,7 @@ module VCAP::CloudController
             actee_type: 'service_plan',
             actee_name: plan.name
           }
-          create_event("audit.service_plan.#{type}", broker_actor(broker), actee, {})
+          create_event(EventTypes.get("SERVICE_PLAN_#{type}"), broker_actor(broker), actee, {})
         end
 
         def record_service_dashboard_client_event(type, client_attrs, broker)
@@ -302,7 +304,7 @@ module VCAP::CloudController
             actee_name: client_attrs['id']
           }
 
-          create_event("audit.service_dashboard_client.#{type}", broker_actor(broker), actee, metadata)
+          create_event(EventTypes.get("SERVICE_DASHBOARD_CLIENT_#{type}"), broker_actor(broker), actee, metadata)
         end
 
         def with_service_event(service, &)
@@ -340,7 +342,7 @@ module VCAP::CloudController
           result   = yield
 
           actee[:actee] = object.guid
-          create_event(type, actor, actee, metadata)
+          create_event(EventTypes.get(type), actor, actee, metadata)
           result
         end
 
@@ -354,9 +356,9 @@ module VCAP::CloudController
 
         def event_type(object, object_type)
           if object.new?
-            "audit.#{object_type}.create"
+            "#{object_type}_CREATE"
           else
-            "audit.#{object_type}.update"
+            "#{object_type}_UPDATE"
           end
         end
       end

--- a/app/repositories/service_generic_binding_event_repository.rb
+++ b/app/repositories/service_generic_binding_event_repository.rb
@@ -1,4 +1,5 @@
 require 'repositories/mixins/app_manifest_event_mixins'
+require 'repositories/event_types'
 
 module VCAP::CloudController
   module Repositories
@@ -17,7 +18,7 @@ module VCAP::CloudController
         attrs = censor_request_attributes(request)
 
         record_event(
-          type: "audit.#{@actee_name}.start_create",
+          type: EventTypes.get("#{@actee_name}_start_create".upcase),
           service_binding: service_binding,
           user_audit_info: user_audit_info,
           metadata: add_manifest_triggered(manifest_triggered, { request: attrs })
@@ -28,7 +29,7 @@ module VCAP::CloudController
         attrs = censor_request_attributes(request)
 
         record_event(
-          type: "audit.#{@actee_name}.create",
+          type: EventTypes.get("#{@actee_name}_create".upcase),
           service_binding: service_binding,
           user_audit_info: user_audit_info,
           metadata: add_manifest_triggered(manifest_triggered, { request: attrs })
@@ -39,7 +40,7 @@ module VCAP::CloudController
         attrs = censor_request_attributes(request)
 
         record_event(
-          type: "audit.#{@actee_name}.update",
+          type: EventTypes.get("#{@actee_name}_update".upcase),
           service_binding: service_binding,
           user_audit_info: user_audit_info,
           metadata: add_manifest_triggered(manifest_triggered, { request: attrs })
@@ -48,7 +49,7 @@ module VCAP::CloudController
 
       def record_start_delete(service_binding, user_audit_info)
         record_event(
-          type: "audit.#{@actee_name}.start_delete",
+          type: EventTypes.get("#{@actee_name}_start_delete".upcase),
           service_binding: service_binding,
           user_audit_info: user_audit_info,
           metadata: {
@@ -63,7 +64,7 @@ module VCAP::CloudController
 
       def record_delete(service_binding, user_audit_info)
         record_event(
-          type: "audit.#{@actee_name}.delete",
+          type: EventTypes.get("#{@actee_name}_delete".upcase),
           service_binding: service_binding,
           user_audit_info: user_audit_info,
           metadata: {
@@ -86,7 +87,7 @@ module VCAP::CloudController
         metadata[:request].merge!({ app_guid: service_binding.app_guid }) if service_binding.try(:app_guid)
 
         record_event(
-          type: "audit.#{@actee_name}.show",
+          type: EventTypes.get("#{@actee_name}_show".upcase),
           service_binding: service_binding,
           user_audit_info: user_audit_info,
           metadata: metadata

--- a/app/repositories/service_instance_share_event_repository.rb
+++ b/app/repositories/service_instance_share_event_repository.rb
@@ -1,10 +1,12 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class ServiceInstanceShareEventRepository
       class << self
         def record_share_event(service_instance, target_space_guids, user_audit_info)
           Event.create(
-            type: 'audit.service_instance.share',
+            type: EventTypes::SERVICE_INSTANCE_SHARE,
             actor: user_audit_info.user_guid,
             actor_type: 'user',
             actor_name: user_audit_info.user_email,
@@ -23,7 +25,7 @@ module VCAP::CloudController
 
         def record_unshare_event(service_instance, target_space_guid, user_audit_info)
           Event.create(
-            type: 'audit.service_instance.unshare',
+            type: EventTypes::SERVICE_INSTANCE_UNSHARE,
             actor: user_audit_info.user_guid,
             actor_type: 'user',
             actor_name: user_audit_info.user_email,

--- a/app/repositories/service_usage_event_repository.rb
+++ b/app/repositories/service_usage_event_repository.rb
@@ -1,4 +1,5 @@
 require 'database/old_record_cleanup'
+require 'repositories/event_types'
 
 module VCAP::CloudController
   module Repositories

--- a/app/repositories/space_event_repository.rb
+++ b/app/repositories/space_event_repository.rb
@@ -1,10 +1,12 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class SpaceEventRepository
       def record_space_create(space, user_audit_info, request_attrs)
         Event.create(
           space: space,
-          type: 'audit.space.create',
+          type: EventTypes::SPACE_CREATE,
           actee: space.guid,
           actee_type: 'space',
           actee_name: space.name,
@@ -22,7 +24,7 @@ module VCAP::CloudController
       def record_space_update(space, user_audit_info, request_attrs)
         Event.create(
           space: space,
-          type: 'audit.space.update',
+          type: EventTypes::SPACE_UPDATE,
           actee: space.guid,
           actee_type: 'space',
           actee_name: space.name,
@@ -39,7 +41,7 @@ module VCAP::CloudController
 
       def record_space_delete_request(space, user_audit_info, recursive)
         Event.create(
-          type: 'audit.space.delete-request',
+          type: EventTypes::SPACE_DELETE_REQUEST,
           actee: space.guid,
           actee_type: 'space',
           actee_name: space.name,

--- a/app/repositories/task_event_repository.rb
+++ b/app/repositories/task_event_repository.rb
@@ -1,13 +1,15 @@
+require 'repositories/event_types'
+
 module VCAP
   module CloudController
     module Repositories
       class TaskEventRepository
         def record_task_create(task, user_audit_info)
-          record_event(task, user_audit_info, 'audit.app.task.create')
+          record_event(task, user_audit_info, EventTypes::APP_TASK_CREATE)
         end
 
         def record_task_cancel(task, user_audit_info)
-          record_event(task, user_audit_info, 'audit.app.task.cancel')
+          record_event(task, user_audit_info, EventTypes::APP_TASK_CANCEL)
         end
 
         private

--- a/app/repositories/user_event_repository.rb
+++ b/app/repositories/user_event_repository.rb
@@ -1,20 +1,22 @@
+require 'repositories/event_types'
+
 module VCAP::CloudController
   module Repositories
     class UserEventRepository
-      def record_space_role_add(space, assignee, role, actor_audit_info, request_attrs={})
-        record_space_role_event("audit.user.space_#{role}_add", space, assignee, actor_audit_info, request_attrs)
+      def record_space_role_add(space, assignee, role_type, actor_audit_info, request_attrs={})
+        record_space_role_event(EventTypes.get("USER_#{role_type}_ADD"), space, assignee, actor_audit_info, request_attrs)
       end
 
-      def record_space_role_remove(space, assignee, role, actor_audit_info, request_attrs={})
-        record_space_role_event("audit.user.space_#{role}_remove", space, assignee, actor_audit_info, request_attrs)
+      def record_space_role_remove(space, assignee, role_type, actor_audit_info, request_attrs={})
+        record_space_role_event(EventTypes.get("USER_#{role_type}_REMOVE"), space, assignee, actor_audit_info, request_attrs)
       end
 
-      def record_organization_role_add(organization, assignee, role, actor_audit_info, request_attrs={})
-        record_organization_role_event("audit.user.organization_#{role}_add", organization, assignee, actor_audit_info, request_attrs)
+      def record_organization_role_add(organization, assignee, role_type, actor_audit_info, request_attrs={})
+        record_organization_role_event(EventTypes.get("USER_#{role_type}_ADD"), organization, assignee, actor_audit_info, request_attrs)
       end
 
-      def record_organization_role_remove(organization, assignee, role, actor_audit_info, request_attrs={})
-        record_organization_role_event("audit.user.organization_#{role}_remove", organization, assignee, actor_audit_info, request_attrs)
+      def record_organization_role_remove(organization, assignee, role_type, actor_audit_info, request_attrs={})
+        record_organization_role_event(EventTypes.get("USER_#{role_type}_REMOVE"), organization, assignee, actor_audit_info, request_attrs)
       end
 
       private

--- a/docs/v3/source/includes/resources/audit_events/_header.md
+++ b/docs/v3/source/includes/resources/audit_events/_header.md
@@ -1,5 +1,0 @@
-## Audit Events
-
-Audit events help Cloud Foundry operators monitor actions taken against resources (such as apps) via user or system actions.
-
-For more information and a list of all possible event types, see the [Cloud Foundry docs](https://docs.cloudfoundry.org/running/managing-cf/audit-events.html).

--- a/docs/v3/source/includes/resources/audit_events/_header.md.erb
+++ b/docs/v3/source/includes/resources/audit_events/_header.md.erb
@@ -1,0 +1,155 @@
+## Audit Events
+
+Audit events help Cloud Foundry operators monitor actions taken against resources (such as apps) via user or system actions.
+
+For more information, see the [Cloud Foundry docs](https://docs.cloudfoundry.org/running/managing-cf/audit-events.html).
+
+#### Audit Event Types
+
+##### App lifecycle
+- `audit.app.apply_manifest`
+- `audit.app.build.create`
+- `audit.app.copy-bits`
+- `audit.app.create`
+- `audit.app.delete-request`
+- `audit.app.deployment.cancel`
+- `audit.app.deployment.create`
+- `audit.app.droplet.create`
+- `audit.app.droplet.delete`
+- `audit.app.droplet.download`
+- `audit.app.droplet.mapped`
+- `audit.app.droplet.upload`
+- `audit.app.environment.show`
+- `audit.app.environment_variables.show`
+- `audit.app.map-route`
+- `audit.app.package.create`
+- `audit.app.package.delete`
+- `audit.app.package.download`
+- `audit.app.package.upload`
+- `audit.app.process.crash`
+- `audit.app.process.create`
+- `audit.app.process.delete`
+- `audit.app.process.rescheduling`
+- `audit.app.process.scale`
+- `audit.app.process.terminate_instance`
+- `audit.app.process.update`
+- `audit.app.restage`
+- `audit.app.restart`
+- `audit.app.revision.create`
+- `audit.app.revision.environment_variables.show`
+- `audit.app.ssh-authorized`
+- `audit.app.ssh-unauthorized`
+- `audit.app.start`
+- `audit.app.stop`
+- `audit.app.task.cancel`
+- `audit.app.task.create`
+- `audit.app.unmap-route`
+- `audit.app.update`
+- `audit.app.upload-bits`
+
+##### Organization lifecycle
+- `audit.organization.create`
+- `audit.organization.delete-request`
+- `audit.organization.update`
+
+##### Route lifecycle
+- `audit.route.create`
+- `audit.route.delete-request`
+- `audit.route.share`
+- `audit.route.transfer-owner`
+- `audit.route.unshare`
+- `audit.route.update`
+
+##### Service lifecycle
+- `audit.service.create`
+- `audit.service.delete`
+- `audit.service.update`
+
+##### Service_binding lifecycle
+- `audit.service_binding.create`
+- `audit.service_binding.delete`
+- `audit.service_binding.show`
+- `audit.service_binding.start_create`
+- `audit.service_binding.start_delete`
+- `audit.service_binding.update`
+
+##### Service_broker lifecycle
+- `audit.service_broker.create`
+- `audit.service_broker.delete`
+- `audit.service_broker.update`
+
+##### Service_dashboard_client lifecycle
+- `audit.service_dashboard_client.create`
+- `audit.service_dashboard_client.delete`
+
+##### Service_instance lifecycle
+- `audit.service_instance.bind_route`
+- `audit.service_instance.create`
+- `audit.service_instance.delete`
+- `audit.service_instance.purge`
+- `audit.service_instance.share`
+- `audit.service_instance.show`
+- `audit.service_instance.start_create`
+- `audit.service_instance.start_delete`
+- `audit.service_instance.start_update`
+- `audit.service_instance.unbind_route`
+- `audit.service_instance.unshare`
+- `audit.service_instance.update`
+
+##### Service_key lifecycle
+- `audit.service_key.create`
+- `audit.service_key.delete`
+- `audit.service_key.show`
+- `audit.service_key.start_create`
+- `audit.service_key.start_delete`
+- `audit.service_key.update`
+
+##### Service_plan lifecycle
+- `audit.service_plan.create`
+- `audit.service_plan.delete`
+- `audit.service_plan.update`
+
+##### Service_plan_visibility lifecycle
+- `audit.service_plan_visibility.create`
+- `audit.service_plan_visibility.delete`
+- `audit.service_plan_visibility.update`
+
+##### Service_route_binding lifecycle
+- `audit.service_route_binding.create`
+- `audit.service_route_binding.delete`
+- `audit.service_route_binding.start_create`
+- `audit.service_route_binding.start_delete`
+- `audit.service_route_binding.update`
+
+##### Space lifecycle
+- `audit.space.create`
+- `audit.space.delete-request`
+- `audit.space.update`
+
+##### User lifecycle
+- `audit.user.organization_auditor_add`
+- `audit.user.organization_auditor_remove`
+- `audit.user.organization_billing_manager_add`
+- `audit.user.organization_billing_manager_remove`
+- `audit.user.organization_manager_add`
+- `audit.user.organization_manager_remove`
+- `audit.user.organization_user_add`
+- `audit.user.organization_user_remove`
+- `audit.user.space_auditor_add`
+- `audit.user.space_auditor_remove`
+- `audit.user.space_developer_add`
+- `audit.user.space_developer_remove`
+- `audit.user.space_manager_add`
+- `audit.user.space_manager_remove`
+- `audit.user.space_supporter_add`
+- `audit.user.space_supporter_remove`
+
+##### User_provided_service_instance lifecycle
+- `audit.user_provided_service_instance.create`
+- `audit.user_provided_service_instance.delete`
+- `audit.user_provided_service_instance.show`
+- `audit.user_provided_service_instance.update`
+
+##### Special events
+- `app.crash`
+- `blob.remove_orphan`

--- a/docs/v3/source/includes/resources/audit_events/_list.md.erb
+++ b/docs/v3/source/includes/resources/audit_events/_list.md.erb
@@ -5,7 +5,7 @@ Example Request
 ```
 
 ```shell
-curl "https://api.example.org/v3/audit_events" \
+curl "https://api.example.org/v3/audit_events"     \
   -X GET \
   -H "Authorization: bearer [token]"
 ```

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -1,0 +1,20 @@
+namespace :docs do
+  def print_events(events, title=nil)
+    puts("\n##### #{title.capitalize}\n") unless title.nil?
+    group = ''
+    events.sort.each do |event|
+      event_group = event.split('.')[1]
+      if group != event_group && title.nil?
+        group = event_group
+        puts("\n##### #{group.capitalize} lifecycle")
+      end
+      puts("- `#{event}`")
+    end
+  end
+
+  desc 'Generate list of all audit events'
+  task audit_events_list: :environment do
+    print_events(VCAP::CloudController::Repositories::EventTypes::AUDIT_EVENTS)
+    print_events(VCAP::CloudController::Repositories::EventTypes::SPECIAL_EVENTS, 'Special events')
+  end
+end

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -470,7 +470,7 @@ RSpec.resource 'Events', type: %i[api legacy_api] do
     end
 
     example 'List Associate Role Space Events' do
-      user_event_repository.record_space_role_add(test_space, test_assignee, 'auditor', user_audit_info)
+      user_event_repository.record_space_role_add(test_space, test_assignee, 'space_auditor', user_audit_info)
 
       client.get '/v2/events?q=type:audit.user.space_auditor_add', {}, headers
       expect(status).to eq(200)
@@ -487,7 +487,7 @@ RSpec.resource 'Events', type: %i[api legacy_api] do
     end
 
     example 'List Remove Role Space Events' do
-      user_event_repository.record_space_role_remove(test_space, test_assignee, 'auditor', user_audit_info)
+      user_event_repository.record_space_role_remove(test_space, test_assignee, 'space_auditor', user_audit_info)
 
       client.get '/v2/events?q=type:audit.user.space_auditor_remove', {}, headers
       expect(status).to eq(200)

--- a/spec/unit/repositories/event_types_spec.rb
+++ b/spec/unit/repositories/event_types_spec.rb
@@ -1,0 +1,155 @@
+require 'spec_helper'
+require 'repositories/event_types'
+
+module VCAP::CloudController
+  module Repositories
+    RSpec.describe EventTypes do
+      describe '#get' do
+        it 'returns a valid audit event' do
+          event = EventTypes.get('APP_CREATE')
+          expect(event).to eq('audit.app.create')
+        end
+
+        it 'converts lower case input values' do
+          event = EventTypes.get('ApP_creaTE')
+          expect(event).to eq('audit.app.create')
+        end
+
+        it 'raises an error for unknown events' do
+          expect { EventTypes.get('unknown_event') }.to raise_error(EventTypes::EventTypesError)
+        end
+      end
+
+      describe 'all event types' do
+        let(:expected_event_types) do
+          ['audit.app.create',
+           'audit.app.update',
+           'audit.app.delete-request',
+           'audit.app.start',
+           'audit.app.restart',
+           'audit.app.restage',
+           'audit.app.stop',
+           'audit.app.package.create',
+           'audit.app.package.upload',
+           'audit.app.package.download',
+           'audit.app.package.delete',
+           'audit.app.process.create',
+           'audit.app.process.update',
+           'audit.app.process.delete',
+           'audit.app.process.rescheduling',
+           'audit.app.process.crash',
+           'audit.app.process.terminate_instance',
+           'audit.app.process.scale',
+           'audit.app.droplet.create',
+           'audit.app.droplet.upload',
+           'audit.app.droplet.download',
+           'audit.app.droplet.delete',
+           'audit.app.droplet.mapped',
+           'audit.app.task.create',
+           'audit.app.task.cancel',
+           'audit.app.map-route',
+           'audit.app.unmap-route',
+           'audit.app.build.create',
+           'audit.app.environment.show',
+           'audit.app.environment_variables.show',
+           'audit.app.revision.create',
+           'audit.app.revision.environment_variables.show',
+           'audit.app.deployment.cancel',
+           'audit.app.deployment.create',
+           'audit.app.copy-bits',
+           'audit.app.upload-bits',
+           'audit.app.apply_manifest',
+           'audit.app.ssh-authorized',
+           'audit.app.ssh-unauthorized',
+           'audit.service.create',
+           'audit.service.update',
+           'audit.service.delete',
+           'audit.service_broker.create',
+           'audit.service_broker.update',
+           'audit.service_broker.delete',
+           'audit.service_plan.create',
+           'audit.service_plan.update',
+           'audit.service_plan.delete',
+           'audit.service_instance.create',
+           'audit.service_instance.update',
+           'audit.service_instance.delete',
+           'audit.service_instance.start_create',
+           'audit.service_instance.start_update',
+           'audit.service_instance.start_delete',
+           'audit.service_instance.bind_route',
+           'audit.service_instance.unbind_route',
+           'audit.service_instance.share',
+           'audit.service_instance.unshare',
+           'audit.service_instance.purge',
+           'audit.service_instance.show',
+           'audit.service_binding.create',
+           'audit.service_binding.update',
+           'audit.service_binding.delete',
+           'audit.service_binding.start_create',
+           'audit.service_binding.start_delete',
+           'audit.service_binding.show',
+           'audit.service_key.create',
+           'audit.service_key.update',
+           'audit.service_key.delete',
+           'audit.service_key.start_create',
+           'audit.service_key.start_delete',
+           'audit.service_key.show',
+           'audit.service_plan_visibility.create',
+           'audit.service_plan_visibility.update',
+           'audit.service_plan_visibility.delete',
+           'audit.service_route_binding.create',
+           'audit.service_route_binding.update',
+           'audit.service_route_binding.delete',
+           'audit.service_route_binding.start_create',
+           'audit.service_route_binding.start_delete',
+           'audit.user_provided_service_instance.create',
+           'audit.user_provided_service_instance.update',
+           'audit.user_provided_service_instance.delete',
+           'audit.user_provided_service_instance.show',
+           'audit.route.create',
+           'audit.route.update',
+           'audit.route.delete-request',
+           'audit.route.share',
+           'audit.route.unshare',
+           'audit.route.transfer-owner',
+           'audit.organization.create',
+           'audit.organization.update',
+           'audit.organization.delete-request',
+           'audit.space.create',
+           'audit.space.update',
+           'audit.space.delete-request',
+           'audit.user.space_auditor_add',
+           'audit.user.space_auditor_remove',
+           'audit.user.space_supporter_add',
+           'audit.user.space_supporter_remove',
+           'audit.user.space_developer_add',
+           'audit.user.space_developer_remove',
+           'audit.user.space_manager_add',
+           'audit.user.space_manager_remove',
+           'audit.service_dashboard_client.create',
+           'audit.service_dashboard_client.delete',
+           'audit.user.organization_user_add',
+           'audit.user.organization_user_remove',
+           'audit.user.organization_auditor_add',
+           'audit.user.organization_auditor_remove',
+           'audit.user.organization_billing_manager_add',
+           'audit.user.organization_billing_manager_remove',
+           'audit.user.organization_manager_add',
+           'audit.user.organization_manager_remove',
+           'app.crash',
+           'blob.remove_orphan']
+        end
+
+        it 'expects that audit events did not change' do
+          # All audit events should be correctly documented in:
+          # - API docs (docs/v3/source/includes/resources/audit_events/_header.md.erb)
+          # - cf docs (https://docs.cloudfoundry.org/running/managing-cf/audit-events.html)
+          #
+          # List of all events can be obtained with `rake docs:audit_events_list`
+
+          expect(EventTypes::ALL_EVENT_TYPES.flatten).to match_array(expected_event_types), 'Audit events changed, adjust documentation and test'
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/repositories/user_event_repository_spec.rb
+++ b/spec/unit/repositories/user_event_repository_spec.rb
@@ -14,12 +14,10 @@ module VCAP::CloudController
       let(:assigner_audit_info) { UserAuditInfo.new(user_email: assigner_email, user_name: assigner_username, user_guid: assigner.guid) }
 
       describe 'space role events' do
-        let(:roles) { %i[manager developer auditor] }
-
-        describe '#record_space_role_add' do
-          it 'records the event correctly' do
-            roles.each do |role|
-              event = subject.record_space_role_add(space, assignee, role, assigner_audit_info, request_attrs)
+        Roles::SPACE_ROLE_NAMES.each do |role|
+          describe "#record_space_#{role}_add" do
+            it 'records the event correctly' do
+              event = subject.record_space_role_add(space, assignee, "space_#{role}", assigner_audit_info, request_attrs)
               event.reload
               expect(event.space).to eq(space)
               expect(event.type).to eq("audit.user.space_#{role}_add")
@@ -33,12 +31,10 @@ module VCAP::CloudController
               expect(event.metadata).to eq({ 'request' => request_attrs })
             end
           end
-        end
 
-        describe '#record_space_role_remove' do
-          it 'records the event correctly' do
-            roles.each do |role|
-              event = subject.record_space_role_remove(space, assignee, role, assigner_audit_info, request_attrs)
+          describe "#record_space_#{role}_remove" do
+            it 'records the event correctly' do
+              event = subject.record_space_role_remove(space, assignee, "space_#{role}", assigner_audit_info, request_attrs)
               event.reload
               expect(event.space).to eq(space)
               expect(event.type).to eq("audit.user.space_#{role}_remove")
@@ -56,12 +52,10 @@ module VCAP::CloudController
       end
 
       describe 'organization role events' do
-        let(:roles) { %i[user manager billing_manager auditor] }
-
-        describe '#record_organization_role_add' do
-          it 'records the event correctly' do
-            roles.each do |role|
-              event = subject.record_organization_role_add(org, assignee, role, assigner_audit_info, request_attrs)
+        Roles::ORG_ROLE_NAMES.each do |role|
+          describe "#record_organization_#{role}_add" do
+            it 'records the event correctly' do
+              event = subject.record_organization_role_add(org, assignee, "organization_#{role}", assigner_audit_info, request_attrs)
               event.reload
               expect(event.organization_guid).to eq(org.guid)
               expect(event.type).to eq("audit.user.organization_#{role}_add")
@@ -74,12 +68,10 @@ module VCAP::CloudController
               expect(event.metadata).to eq({ 'request' => request_attrs })
             end
           end
-        end
 
-        describe '#record_organization_role_remove' do
-          it 'records the event correctly' do
-            roles.each do |role|
-              event = subject.record_organization_role_remove(org, assignee, role, assigner_audit_info, request_attrs)
+          describe "#record_organization_#{role}_remove" do
+            it 'records the event correctly' do
+              event = subject.record_organization_role_remove(org, assignee, "organization_#{role}", assigner_audit_info, request_attrs)
               event.reload
               expect(event.organization_guid).to eq(org.guid)
               expect(event.type).to eq("audit.user.organization_#{role}_remove")


### PR DESCRIPTION
Audit events are generated in multiple modules and classes within ccng. This makes it difficult to get an overview of the available audit events.
This refactoring introduces a new event_types class which contains all audit events. This can be used e.g. to update the docs.

Related docs PR: https://github.com/cloudfoundry/docs-running-cf/pull/115


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
