### PR TITLE
Prevent parallel test failures in request_spec

### DIFF
--- a/spec/unit/lib/vcap/request_spec.rb
+++ b/spec/unit/lib/vcap/request_spec.rb
@@ -113,11 +113,22 @@ module VCAP
       end
 
       let(:user_guid) { SecureRandom.uuid }
+      let(:data) { {} }
+
+      before do
+        allow(Steno.config.context).to receive(:data).and_return(data)
+      end
 
       it 'sets the new user_guid on the Steno logger context' do
         Request.user_guid = user_guid
 
-        expect(Steno.config.context.data['user_guid']).to eq user_guid
+        expect(Steno.config.context.data.fetch('user_guid')).to eq user_guid
+      end
+
+      it 'deletes from the Steno logger context when set to nil' do
+        Request.user_guid = nil
+
+        expect(Steno.config.context.data.key?('user_guid')).to be false
       end
     end
   end


### PR DESCRIPTION
I've seen test failures for the `VCAP::Request.user_guid` context that seem to be caused by parallel test execution. Thus the tests have been changed to mimic those in the `VCAP::Request.current_id` context, i.e. the `Steno.config.context` is mocked.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
