### PR TITLE
Remove unreachable rescue

### DIFF
--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -167,8 +167,6 @@ class ServiceCredentialBindingsController < ApplicationController
     raise CloudController::Errors::ApiError.
       new_from_details('ServiceFetchBindingParametersNotSupported').
       with_response_code(502)
-  rescue LockCheck::ServiceBindingLockedError => e
-    raise CloudController::Errors::ApiError.new_from_details('AsyncServiceBindingOperationInProgress', e.service_binding.app.name, e.service_binding.service_instance.name)
   end
 
   private

--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -120,8 +120,6 @@ class ServiceRouteBindingsController < ApplicationController
   rescue ServiceBindingRead::NotSupportedError
     bad_request!('user provided service instances do not support fetching route bindings parameters.') if @route_binding.service_instance.user_provided_instance?
     bad_request!('this service does not support fetching route bindings parameters.')
-  rescue LockCheck::ServiceBindingLockedError
-    unprocessable!('There is an operation in progress for the service route binding.')
   end
 
   private


### PR DESCRIPTION
The binding's state is already checked before and if it is not in state **create succeeded**, a `ResourceNotFound` error is raised. Thus the `LockCheck` error can never be raised.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
