### PR TITLE
Fix/Improve PumaRunner Setup and Configuration

### DIFF
--- a/lib/cloud_controller/runners/puma_runner.rb
+++ b/lib/cloud_controller/runners/puma_runner.rb
@@ -6,19 +6,7 @@ module VCAP::CloudController
   class PumaRunner
     def initialize(config, app, logger, periodic_updater, request_logs)
       @logger = logger
-      @periodic_updater = periodic_updater
-      @request_logs = request_logs
       puma_config = Puma::Configuration.new do |conf|
-        # this is actually called everytime a worker is started
-        # https://github.com/puma/puma/blob/5f3f489ee867317c47724d0fc5b1d906f1b23de6/lib/puma/dsl.rb#L607
-        # we probably want to come up with a different way to do this.  Perhaps a singleton?
-        conf.after_worker_fork do
-          Thread.new do
-            EM.run do
-              @periodic_updater.setup_updates
-            end
-          end
-        end
         if config.get(:nginx, :use_nginx)
           conf.bind "unix://#{config.get(:nginx, :instance_socket)}"
         else
@@ -30,11 +18,19 @@ module VCAP::CloudController
         conf.before_fork do
           Sequel::Model.db.disconnect
         end
+        conf.on_worker_shutdown do
+          request_logs.log_incomplete_requests if request_logs
+        end
       end
       log_writer = Puma::LogWriter.stdio
       events = Puma::Events.new
+      events.on_booted do
+        Thread.new do
+          EM.run { periodic_updater.setup_updates }
+        end
+      end
       events.on_stopped do
-        stop!
+        EM.stop
       end
 
       @puma_launcher = Puma::Launcher.new(puma_config, log_writer:, events:)
@@ -45,12 +41,6 @@ module VCAP::CloudController
     rescue StandardError => e
       @logger.error "Encountered error: #{e}\n#{e.backtrace.join("\n")}"
       raise e
-    end
-
-    def stop!
-      @logger.info('Stopping EventMachine')
-      EM.stop
-      @request_logs.log_incomplete_requests if @request_logs
     end
   end
 end

--- a/lib/cloud_controller/runners/puma_runner.rb
+++ b/lib/cloud_controller/runners/puma_runner.rb
@@ -6,14 +6,26 @@ module VCAP::CloudController
   class PumaRunner
     def initialize(config, app, logger, periodic_updater, request_logs)
       @logger = logger
+
       puma_config = Puma::Configuration.new do |conf|
         if config.get(:nginx, :use_nginx)
           conf.bind "unix://#{config.get(:nginx, :instance_socket)}"
         else
           conf.bind "tcp://0.0.0.0:#{config.get(:external_port)}"
         end
-        conf.threads(0, config.get(:puma, :max_threads)) if config.get(:puma, :max_threads)
-        conf.workers config.get(:puma, :workers) if config.get(:puma, :workers)
+
+        conf.workers(config.get(:puma, :workers) || 1)
+        conf.threads(0, config.get(:puma, :max_threads) || 1)
+
+        # In theory there shouldn't be any open connections when shutting down Puma as they have either been gracefully
+        # drained or forcefully terminated (after cc.nginx_drain_timeout) by Nginx. Puma has some built-in (i.e. not
+        # changeable) timeouts as well as some configurable timeouts.
+
+        # Reduce the worker shutdown timeout to 15 seconds (default is 30).
+        conf.worker_shutdown_timeout(15)
+        # Reduce the thread shutdown timeout to 10 seconds (4 [force_shutdown_after] + 5 [SHUTDOWN_GRACE_TIME] + 1)
+        conf.force_shutdown_after(4)
+
         conf.app app
         conf.before_fork do
           Sequel::Model.db.disconnect
@@ -22,7 +34,9 @@ module VCAP::CloudController
           request_logs.log_incomplete_requests if request_logs
         end
       end
+
       log_writer = Puma::LogWriter.stdio
+
       events = Puma::Events.new
       events.on_booted do
         Thread.new do
@@ -39,7 +53,7 @@ module VCAP::CloudController
     def start!
       @puma_launcher.run
     rescue StandardError => e
-      @logger.error "Encountered error: #{e}\n#{e.backtrace.join("\n")}"
+      @logger.error "Encountered error: #{e}\n#{e.backtrace&.join("\n")}"
       raise e
     end
   end

--- a/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
+++ b/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
@@ -2,118 +2,137 @@ require 'spec_helper'
 
 module VCAP::CloudController
   RSpec.describe PumaRunner do
-    let(:valid_config_file_path) { File.join(Paths::CONFIG, 'cloud_controller.yml') }
-    let(:config_file) { File.new(valid_config_file_path) }
-    let(:unix_socket) { '/path/to/socket' }
+    let(:port) { '8181' }
     let(:use_nginx) { true }
-    let(:local_port) { '8181' }
-    let(:app) { double(:app, call: nil) }
-    let(:periodic_updater) { double(:periodic_updater) }
+    let(:socket) { '/path/to/socket' }
+    let(:num_workers) { 3 }
+    let(:max_threads) { 4 }
+    let(:app) { double(:app) }
     let(:logger) { double(:logger) }
+    let(:periodic_updater) { double(:periodic_updater) }
     let(:request_logs) { double(:request_logs) }
-
-    before do
-      allow(logger).to receive :info
-      allow(EM).to receive(:run).and_yield
-      allow_any_instance_of(Puma::Launcher).to receive(:run)
-      allow(periodic_updater).to receive :setup_updates
-    end
+    let(:puma_launcher) { subject.instance_variable_get(:@puma_launcher) }
 
     subject do
       TestConfig.override(
-        external_host: 'some_local_ip',
+        external_port: port,
         nginx: {
           use_nginx: use_nginx,
-          instance_socket: unix_socket
+          instance_socket: socket
         },
         puma: {
-          workers: 3,
-          max_threads: 4
+          workers: num_workers,
+          max_threads: max_threads
         }
       )
       PumaRunner.new(TestConfig.config_instance, app, logger, periodic_updater, request_logs)
     end
 
-    describe 'start!' do
-      it 'starts the puma server' do
-        expect(Puma::Launcher).to receive(:new).with(an_instance_of(Puma::Configuration), log_writer: anything, events: anything).and_call_original
-        expect_any_instance_of(Puma::Launcher).to receive(:run)
-        subject.start!
+    before do
+      allow(logger).to receive(:info)
+    end
+
+    describe 'initialize' do
+      it 'configures the puma launcher' do
+        expect(Puma::Launcher).to receive(:new).with(
+          an_instance_of(Puma::Configuration),
+          log_writer: an_instance_of(Puma::LogWriter),
+          events: an_instance_of(Puma::Events)
+        )
+
+        subject
       end
 
-      it 'configures the app as middleware' do
-        subject.start!
-        puma_launcher = subject.instance_variable_get(:@puma_launcher)
+      it 'binds to the configured socket' do
+        subject
 
-        puma_launcher.config.app.call({})
-        expect(app).to have_received(:call)
+        expect(puma_launcher.config.final_options[:binds].first).to eq("unix://#{socket}")
       end
 
-      it 'binds to the configured unix socket' do
-        subject.start!
-        puma_launcher = subject.instance_variable_get(:@puma_launcher)
+      context 'when not using nginx' do
+        let(:use_nginx) { false }
 
-        expect(puma_launcher.config.final_options[:binds]).to include("unix://#{unix_socket}")
+        it 'binds to the configured port' do
+          subject
+
+          expect(puma_launcher.config.final_options[:binds].first).to eq("tcp://0.0.0.0:#{port}")
+        end
       end
 
       it 'configures workers and threads' do
-        subject.start!
-        puma_launcher = subject.instance_variable_get(:@puma_launcher)
+        subject
 
+        expect(puma_launcher.config.final_options[:workers]).to eq(num_workers)
         expect(puma_launcher.config.final_options[:min_threads]).to eq(0)
-        expect(puma_launcher.config.final_options[:max_threads]).to eq(4)
-        expect(puma_launcher.config.final_options[:workers]).to eq(3)
+        expect(puma_launcher.config.final_options[:max_threads]).to eq(max_threads)
       end
 
-      it 'disconnects the database before fork' do
-        expect(Sequel::Model.db).to receive(:disconnect)
-        subject.start!
-        puma_launcher = subject.instance_variable_get(:@puma_launcher)
+      context 'when not specifying the number of workers and threads' do
+        let(:num_workers) { nil }
+        let(:max_threads) { nil }
 
+        it 'configures 1 as default' do
+          subject
+
+          expect(puma_launcher.config.final_options[:workers]).to eq(1)
+          expect(puma_launcher.config.final_options[:max_threads]).to eq(1)
+        end
+      end
+
+      it 'configures the app as middleware' do
+        subject
+
+        expect(app).to receive(:call)
+        puma_launcher.config.app.call({})
+      end
+
+      it 'disconnects the database before forking workers' do
+        subject
+
+        expect(Sequel::Model.db).to receive(:disconnect)
         puma_launcher.config.final_options[:before_fork].first.call
       end
 
       it 'logs incomplete requests on worker shutdown' do
-        expect(request_logs).to receive(:log_incomplete_requests)
-        subject.start!
-        puma_launcher = subject.instance_variable_get(:@puma_launcher)
+        subject
 
+        expect(request_logs).to receive(:log_incomplete_requests)
         puma_launcher.config.final_options[:before_worker_shutdown].first.call
       end
+    end
 
-      it 'sets up metrics updates in the Events:on_booted hook' do
+    describe 'start!' do
+      it 'starts the puma server' do
+        expect(puma_launcher).to receive(:run)
+
         subject.start!
-        puma_launcher = subject.instance_variable_get(:@puma_launcher)
-
-        expect(periodic_updater).to receive(:setup_updates)
-        allow(Thread).to receive(:new).and_yield
-        allow(EM).to receive(:run).and_yield
-        expect(EM).to receive(:run)
-        puma_launcher.events.fire(:on_booted)
       end
 
       it 'logs an error if an exception is raised' do
-        allow_any_instance_of(Puma::Launcher).to receive(:run).and_raise('we have a problem')
+        allow(puma_launcher).to receive(:run).and_raise('we have a problem')
         expect(logger).to receive(:error)
+
         expect { subject.start! }.to raise_exception('we have a problem')
       end
     end
 
-    describe '#start! with local port' do
-      let(:use_nginx) { false }
+    describe 'Events' do
+      describe 'on_booted' do
+        it 'sets up periodic metrics updater with EM' do
+          expect(Thread).to receive(:new).and_yield
+          expect(EM).to receive(:run).and_yield
+          expect(periodic_updater).to receive(:setup_updates)
 
-      it 'binds to the configured local port' do
-        subject.start!
-        puma_launcher = subject.instance_variable_get(:@puma_launcher)
-
-        expect(puma_launcher.config.final_options[:binds]).to include("tcp://0.0.0.0:#{local_port}")
+          puma_launcher.events.fire(:on_booted)
+        end
       end
-    end
 
-    describe 'Events:on_stopped' do
-      it 'stops EM' do
-        expect(EM).to receive(:stop)
-        subject.instance_variable_get(:@puma_launcher).events.fire(:on_stopped)
+      describe 'on_stopped' do
+        it 'stops EM and logs incomplete requests' do
+          expect(EM).to receive(:stop)
+
+          puma_launcher.events.fire(:on_stopped)
+        end
       end
     end
   end


### PR DESCRIPTION
- Use `Events:on_booted` instead of `Configuration:after_worker_fork`; the `periodic_updater` shall run in the main process only.
- Use `Configuration:on_worker_shutdown` instead of `Events:on_stopped` to log incomplete requests; this needs to run inside the worker processes.
- Don't try to write a log message from inside `Events:on_stopped`; this yields a **can't be called from trap context** error.
- Configure thread/worker shutdown timeouts.
- Default `workers` and `max_threads` to 1.
- Refactor tests.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
