### PR TITLE
Adapt Periodic Puma Metrics

### DIFF
--- a/app/controllers/internal/metrics_controller.rb
+++ b/app/controllers/internal/metrics_controller.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
       get '/internal/v4/metrics', :index
 
       def index
-        CloudController::DependencyLocator.instance.periodic_updater.update!
+        CloudController::DependencyLocator.instance.periodic_updater.update! unless VCAP::CloudController::Config.config.get(:webserver) == 'puma'
         [200, Prometheus::Client::Formats::Text.marshal(Prometheus::Client.registry)]
       end
     end

--- a/app/controllers/internal/staging_completion_controller.rb
+++ b/app/controllers/internal/staging_completion_controller.rb
@@ -111,7 +111,7 @@ module VCAP::CloudController
     end
 
     def statsd_updater
-      @statsd_updater ||= VCAP::CloudController::Metrics::StatsdUpdater.new
+      CloudController::DependencyLocator.instance.statsd_updater
     end
 
     def prometheus_updater

--- a/app/jobs/diego/sync.rb
+++ b/app/jobs/diego/sync.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
   module Jobs
     module Diego
       class Sync < VCAP::CloudController::Jobs::CCJob
-        def initialize(statsd=Statsd.new)
+        def initialize(statsd=CloudController::DependencyLocator.instance.statsd_client)
           @statsd = statsd
         end
 

--- a/lib/cloud_controller/config_schemas/base/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/clock_schema.rb
@@ -175,6 +175,9 @@ module VCAP::CloudController
               optional(:priorities) => Hash
             },
 
+            statsd_host: String,
+            statsd_port: Integer,
+
             max_labels_per_resource: Integer,
             max_annotations_per_resource: Integer,
             custom_metric_tag_prefix_list: Array

--- a/lib/cloud_controller/diego/messenger.rb
+++ b/lib/cloud_controller/diego/messenger.rb
@@ -4,7 +4,7 @@ require 'cloud_controller/diego/desire_app_handler'
 module VCAP::CloudController
   module Diego
     class Messenger
-      def initialize(statsd_updater=VCAP::CloudController::Metrics::StatsdUpdater.new, prometheus_updater=CloudController::DependencyLocator.instance.prometheus_updater)
+      def initialize(statsd_updater=CloudController::DependencyLocator.instance.statsd_updater, prometheus_updater=CloudController::DependencyLocator.instance.prometheus_updater)
         @statsd_updater = statsd_updater
         @prometheus_updater = prometheus_updater
       end

--- a/lib/cloud_controller/diego/processes_sync.rb
+++ b/lib/cloud_controller/diego/processes_sync.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
       class BBSFetchError < Error
       end
 
-      def initialize(config:, statsd_updater: VCAP::CloudController::Metrics::StatsdUpdater.new)
+      def initialize(config:, statsd_updater: CloudController::DependencyLocator.instance.statsd_updater)
         @config   = config
         @workpool = WorkPool.new(50, store_exceptions: true)
         @statsd_updater = statsd_updater

--- a/lib/cloud_controller/metrics/periodic_updater.rb
+++ b/lib/cloud_controller/metrics/periodic_updater.rb
@@ -90,9 +90,10 @@ module VCAP::CloudController::Metrics
     end
 
     def update_thread_info
-      local_thread_info = thread_info
+      return unless VCAP::CloudController::Config.config.get(:webserver) == 'thin'
 
-      [@statsd_updater, @prometheus_updater].each { |u| u.update_thread_info(local_thread_info) }
+      local_thread_info = thread_info_thin
+      [@statsd_updater, @prometheus_updater].each { |u| u.update_thread_info_thin(local_thread_info) }
     end
 
     def update_failed_job_count
@@ -132,7 +133,7 @@ module VCAP::CloudController::Metrics
       @prometheus_updater.update_vitals(prom_vitals)
     end
 
-    def thread_info
+    def thread_info_thin
       threadqueue = EM.instance_variable_get(:@threadqueue) || []
       resultqueue = EM.instance_variable_get(:@resultqueue) || []
       {

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -5,23 +5,23 @@ module VCAP::CloudController::Metrics
     DURATION_BUCKETS = [5, 10, 30, 60, 300, 600, 890].freeze
 
     METRICS = [
-      { type: :gauge, name: :cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue] },
-      { type: :gauge, name: :cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue] },
+      { type: :gauge, name: :cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue], aggregation: :most_recent },
+      { type: :gauge, name: :cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue], aggregation: :most_recent },
       { type: :counter, name: :cc_staging_requests_total, docstring: 'Number of staging requests' },
       { type: :histogram, name: :cc_staging_succeeded_duration_seconds, docstring: 'Durations of successful staging events', buckets: DURATION_BUCKETS },
       { type: :histogram, name: :cc_staging_failed_duration_seconds, docstring: 'Durations of failed staging events', buckets: DURATION_BUCKETS },
-      { type: :gauge, name: :cc_requests_outstanding_total, docstring: 'Requests outstanding' },
+      { type: :gauge, name: :cc_requests_outstanding_total, docstring: 'Requests outstanding', aggregation: :sum },
       { type: :counter, name: :cc_requests_completed_total, docstring: 'Requests completed' },
-      { type: :gauge, name: :cc_vitals_started_at, docstring: 'CloudController Vitals: started_at' },
-      { type: :gauge, name: :cc_vitals_mem_bytes, docstring: 'CloudController Vitals: mem_bytes' },
-      { type: :gauge, name: :cc_vitals_cpu_load_avg, docstring: 'CloudController Vitals: cpu_load_avg' },
-      { type: :gauge, name: :cc_vitals_mem_used_bytes, docstring: 'CloudController Vitals: mem_used_bytes' },
-      { type: :gauge, name: :cc_vitals_mem_free_bytes, docstring: 'CloudController Vitals: mem_free_bytes' },
-      { type: :gauge, name: :cc_vitals_num_cores, docstring: 'CloudController Vitals: num_cores' },
-      { type: :gauge, name: :cc_running_tasks_total, docstring: 'Total running tasks' },
-      { type: :gauge, name: :cc_running_tasks_memory_bytes, docstring: 'Total memory consumed by running tasks' },
-      { type: :gauge, name: :cc_users_total, docstring: 'Number of users' },
-      { type: :gauge, name: :cc_deployments_in_progress_total, docstring: 'Number of in progress deployments' }
+      { type: :gauge, name: :cc_vitals_started_at, docstring: 'CloudController Vitals: started_at', aggregation: :most_recent },
+      { type: :gauge, name: :cc_vitals_mem_bytes, docstring: 'CloudController Vitals: mem_bytes', aggregation: :most_recent },
+      { type: :gauge, name: :cc_vitals_cpu_load_avg, docstring: 'CloudController Vitals: cpu_load_avg', aggregation: :most_recent },
+      { type: :gauge, name: :cc_vitals_mem_used_bytes, docstring: 'CloudController Vitals: mem_used_bytes', aggregation: :most_recent },
+      { type: :gauge, name: :cc_vitals_mem_free_bytes, docstring: 'CloudController Vitals: mem_free_bytes', aggregation: :most_recent },
+      { type: :gauge, name: :cc_vitals_num_cores, docstring: 'CloudController Vitals: num_cores', aggregation: :most_recent },
+      { type: :gauge, name: :cc_running_tasks_total, docstring: 'Total running tasks', aggregation: :most_recent },
+      { type: :gauge, name: :cc_running_tasks_memory_bytes, docstring: 'Total memory consumed by running tasks', aggregation: :most_recent },
+      { type: :gauge, name: :cc_users_total, docstring: 'Number of users', aggregation: :most_recent },
+      { type: :gauge, name: :cc_deployments_in_progress_total, docstring: 'Number of in progress deployments', aggregation: :most_recent }
     ].freeze
 
     THIN_METRICS = [
@@ -121,17 +121,22 @@ module VCAP::CloudController::Metrics
     private
 
     def register(metric)
-      register_metric(metric[:type], metric[:name], metric[:docstring], labels: metric[:labels] || {}, buckets: metric[:buckets] || {}) unless @registry.exist?(metric[:name])
+      return if @registry.exist?(metric[:name])
+
+      register_metric(metric[:type], metric[:name], metric[:docstring], labels: metric[:labels] || [], buckets: metric[:buckets] || [], aggregation: metric[:aggregation])
     end
 
-    def register_metric(type, name, message, labels: {}, buckets: {})
+    def register_metric(type, name, message, labels:, buckets:, aggregation:)
+      store_settings = {}
+      store_settings[:aggregation] = aggregation if aggregation.present? && Prometheus::Client.config.data_store.instance_of?(Prometheus::Client::DataStores::DirectFileStore)
+
       case type
       when :gauge
-        @registry.gauge(name, docstring: message, labels: labels)
+        @registry.gauge(name, docstring: message, labels: labels, store_settings: store_settings)
       when :counter
-        @registry.counter(name, docstring: message, labels: labels)
+        @registry.counter(name, docstring: message, labels: labels, store_settings: store_settings)
       when :histogram
-        @registry.histogram(name, docstring: message, labels: labels, buckets: buckets)
+        @registry.histogram(name, docstring: message, labels: labels, buckets: buckets, store_settings: store_settings)
       else
         throw ArgumentError("Metric type #{type} does not exist.")
       end

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -12,12 +12,6 @@ module VCAP::CloudController::Metrics
       { type: :histogram, name: :cc_staging_failed_duration_seconds, docstring: 'Durations of failed staging events', buckets: DURATION_BUCKETS },
       { type: :gauge, name: :cc_requests_outstanding_total, docstring: 'Requests outstanding' },
       { type: :counter, name: :cc_requests_completed_total, docstring: 'Requests completed' },
-      { type: :gauge, name: :cc_thread_info_thread_count, docstring: 'Thread count' },
-      { type: :gauge, name: :cc_thread_info_event_machine_connection_count, docstring: 'EventMachine connection count' },
-      { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_size, docstring: 'EventMachine thread queue size' },
-      { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_num_waiting, docstring: 'EventMachine num waiting in thread' },
-      { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_size, docstring: 'EventMachine queue size' },
-      { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_num_waiting, docstring: 'EventMachine requests waiting in queue' },
       { type: :gauge, name: :cc_vitals_started_at, docstring: 'CloudController Vitals: started_at' },
       { type: :gauge, name: :cc_vitals_mem_bytes, docstring: 'CloudController Vitals: mem_bytes' },
       { type: :gauge, name: :cc_vitals_cpu_load_avg, docstring: 'CloudController Vitals: cpu_load_avg' },
@@ -30,26 +24,21 @@ module VCAP::CloudController::Metrics
       { type: :gauge, name: :cc_deployments_in_progress_total, docstring: 'Number of in progress deployments' }
     ].freeze
 
+    THIN_METRICS = [
+      { type: :gauge, name: :cc_thread_info_thread_count, docstring: 'Thread count' },
+      { type: :gauge, name: :cc_thread_info_event_machine_connection_count, docstring: 'EventMachine connection count' },
+      { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_size, docstring: 'EventMachine thread queue size' },
+      { type: :gauge, name: :cc_thread_info_event_machine_threadqueue_num_waiting, docstring: 'EventMachine num waiting in thread' },
+      { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_size, docstring: 'EventMachine queue size' },
+      { type: :gauge, name: :cc_thread_info_event_machine_resultqueue_num_waiting, docstring: 'EventMachine requests waiting in queue' }
+    ].freeze
+
     def initialize(registry=Prometheus::Client.registry)
       @registry = registry
 
       # Register all metrics, to initialize them for discoverability
-      METRICS.map do |metric|
-        register_metric(metric[:type], metric[:name], metric[:docstring], labels: metric[:labels] || {}, buckets: metric[:buckets] || {}) unless @registry.exist?(metric[:name])
-      end
-    end
-
-    def register_metric(type, name, message, labels: {}, buckets: {})
-      case type
-      when :gauge
-        @registry.gauge(name, docstring: message, labels: labels)
-      when :counter
-        @registry.counter(name, docstring: message, labels: labels)
-      when :histogram
-        @registry.histogram(name, docstring: message, labels: labels, buckets: buckets)
-      else
-        throw ArgumentError("Metric type #{type} does not exist.")
-      end
+      METRICS.each { |metric| register(metric) }
+      THIN_METRICS.each { |metric| register(metric) } if VCAP::CloudController::Config.config.get(:webserver) == 'thin'
     end
 
     def update_gauge_metric(metric, value, labels: {})
@@ -90,7 +79,7 @@ module VCAP::CloudController::Metrics
       end
     end
 
-    def update_thread_info(thread_info)
+    def update_thread_info_thin(thread_info)
       update_gauge_metric(:cc_thread_info_thread_count, thread_info[:thread_count])
       update_gauge_metric(:cc_thread_info_event_machine_connection_count, thread_info[:event_machine][:connection_count])
       update_gauge_metric(:cc_thread_info_event_machine_threadqueue_size, thread_info[:event_machine][:threadqueue][:size])
@@ -130,6 +119,23 @@ module VCAP::CloudController::Metrics
     end
 
     private
+
+    def register(metric)
+      register_metric(metric[:type], metric[:name], metric[:docstring], labels: metric[:labels] || {}, buckets: metric[:buckets] || {}) unless @registry.exist?(metric[:name])
+    end
+
+    def register_metric(type, name, message, labels: {}, buckets: {})
+      case type
+      when :gauge
+        @registry.gauge(name, docstring: message, labels: labels)
+      when :counter
+        @registry.counter(name, docstring: message, labels: labels)
+      when :histogram
+        @registry.histogram(name, docstring: message, labels: labels, buckets: buckets)
+      else
+        throw ArgumentError("Metric type #{type} does not exist.")
+      end
+    end
 
     def nanoseconds_to_seconds(time_ns)
       (time_ns / 1e9).to_f

--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -3,7 +3,7 @@ require 'statsd'
 module VCAP::CloudController
   module Metrics
     class RequestMetrics
-      def initialize(statsd=Statsd.new, prometheus_updater=CloudController::DependencyLocator.instance.prometheus_updater)
+      def initialize(statsd=CloudController::DependencyLocator.instance.statsd_client, prometheus_updater=CloudController::DependencyLocator.instance.prometheus_updater)
         @counter = 0
         @statsd = statsd
         @prometheus_updater = prometheus_updater

--- a/lib/cloud_controller/metrics/statsd_updater.rb
+++ b/lib/cloud_controller/metrics/statsd_updater.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController::Metrics
       end
     end
 
-    def update_thread_info(thread_info)
+    def update_thread_info_thin(thread_info)
       @statsd.batch do |batch|
         batch.gauge('cc.thread_info.thread_count', thread_info[:thread_count])
         batch.gauge('cc.thread_info.event_machine.connection_count', thread_info[:event_machine][:connection_count])

--- a/lib/cloud_controller/metrics/statsd_updater.rb
+++ b/lib/cloud_controller/metrics/statsd_updater.rb
@@ -2,7 +2,7 @@ require 'statsd'
 
 module VCAP::CloudController::Metrics
   class StatsdUpdater
-    def initialize(statsd=Statsd.new)
+    def initialize(statsd=CloudController::DependencyLocator.instance.statsd_client)
       @statsd = statsd
     end
 

--- a/spec/unit/jobs/diego/sync_spec.rb
+++ b/spec/unit/jobs/diego/sync_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module VCAP::CloudController
   module Jobs::Diego
     RSpec.describe Sync, job_context: :clock do
+      let(:statsd_client) { instance_double(Statsd) }
       let(:processes_sync) { instance_double(Diego::ProcessesSync) }
       let(:tasks_sync) { instance_double(Diego::ProcessesSync) }
 
@@ -10,9 +11,11 @@ module VCAP::CloudController
 
       describe '#perform' do
         before do
+          allow_any_instance_of(CloudController::DependencyLocator).to receive(:statsd_client).and_return(statsd_client)
           allow(Diego::ProcessesSync).to receive(:new).and_return(processes_sync)
           allow(Diego::TasksSync).to receive(:new).and_return(tasks_sync)
 
+          allow(statsd_client).to receive(:timing)
           allow(processes_sync).to receive(:sync)
           allow(tasks_sync).to receive(:sync)
         end
@@ -35,7 +38,7 @@ module VCAP::CloudController
           expect(processes_sync).to receive(:sync)
           expect(tasks_sync).to receive(:sync)
           expect(Time).to receive(:now).twice # Ensure that we get two time measurements. _Hopefully_ they get turned into an elapsed time and passed in where they need to be!
-          expect_any_instance_of(Statsd).to receive(:timing).with('cc.diego_sync.duration', kind_of(Numeric))
+          expect(statsd_client).to receive(:timing).with('cc.diego_sync.duration', kind_of(Numeric))
 
           job.perform
         end

--- a/spec/unit/lib/cloud_controller/clock/scheduler_spec.rb
+++ b/spec/unit/lib/cloud_controller/clock/scheduler_spec.rb
@@ -157,6 +157,7 @@ module VCAP::CloudController
       end
 
       it 'schedules the frequent inline jobs' do
+        allow_any_instance_of(CloudController::DependencyLocator).to receive(:statsd_client).and_return(instance_double(Statsd))
         allow(clock).to receive(:schedule_daily_job)
         allow(clock).to receive(:schedule_frequent_worker_job)
         expect(clock).to receive(:schedule_frequent_inline_job) do |args, &block|

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -92,7 +92,7 @@ module VCAP::CloudController::Metrics
       end
     end
 
-    describe '#update_thread_info' do
+    describe '#update_thread_info_thin' do
       it 'contains EventMachine data' do
         thread_info = {
           thread_count: 5,
@@ -109,7 +109,7 @@ module VCAP::CloudController::Metrics
           }
         }
 
-        updater.update_thread_info(thread_info)
+        updater.update_thread_info_thin(thread_info)
 
         metric = prom_client.metrics.find { |m| m.name == :cc_thread_info_thread_count }
         expect(metric.get).to eq 5

--- a/spec/unit/lib/cloud_controller/metrics/statsd_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/statsd_updater_spec.rb
@@ -86,7 +86,7 @@ module VCAP::CloudController::Metrics
       end
     end
 
-    describe '#update_thread_info' do
+    describe '#update_thread_info_thin' do
       let(:batch) { double(:batch) }
 
       before do
@@ -110,7 +110,7 @@ module VCAP::CloudController::Metrics
           }
         }
 
-        updater.update_thread_info(thread_info)
+        updater.update_thread_info_thin(thread_info)
 
         expect(batch).to have_received(:gauge).with('cc.thread_info.thread_count', 5)
         expect(batch).to have_received(:gauge).with('cc.thread_info.event_machine.connection_count', 10)

--- a/spec/unit/lib/vcap/stats_spec.rb
+++ b/spec/unit/lib/vcap/stats_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe VCAP::Stats do
+  describe '#process_memory_bytes_and_cpu' do
+    before do
+      allow(VCAP::Stats).to receive_messages(ps_pid: "123456 7.8\n", ps_ppid: "121212 3.4\n343434 5.6\n")
+    end
+
+    it 'returns the memory bytes and cpu for the process' do
+      rss_bytes, pcpu = VCAP::Stats.process_memory_bytes_and_cpu
+
+      expect(rss_bytes).to eq(126_418_944)
+      expect(pcpu).to eq(8)
+    end
+
+    context 'when Puma is configured as webserver' do
+      before do
+        TestConfig.override(webserver: 'puma')
+      end
+
+      it 'returns the summed up memory bytes and cpu for the process and its subprocesses' do
+        rss_bytes, pcpu = VCAP::Stats.process_memory_bytes_and_cpu
+
+        expect(rss_bytes).to eq(602_216_448)
+        expect(pcpu).to eq(17)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- The current `thread_info` is tightly coupled to Thin/EventMachine; don't emit those metrics when running the Puma webserver; maybe we will come up with other thread-related metrics for Puma at a later point in time.
- Return the summed up memory bytes and cpu for the Puma process and its worker subprocesses.
- When using Puma, the `periodic_updater` shall run in the main process only, thus direct invocations of `update!` from a controller (executed within a worker process) must be removed.
- When running Puma, the `DirectFileStore` data store is used for prometheus metrics.
- Aggregation methods for (gauge) metrics are specified and applied when using the `DirectFileStore`.
  - For `cc_requests_outstanding_total` the values per worker are summed up.
  - For metrics that are collected by the `periodic_updater` running in the main process, the aggregation method MOST_RECENT has been specified to eliminate the unnecessary `pid` label.
- Replace `VCAP::CloudController::Metrics::StatsdUpdater.new` with `CloudController::DependencyLocator.instance.statsd_updater`.
- Replace `Statsd.new` with `CloudController::DependencyLocator.instance.statsd_client`.
- Add `statsd_host` + `statsd_port` to `ClockSchema`; don't rely on default values (see cloudfoundry/capi-release#359)

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
