### PR TITLE
Improve draining (for Puma)

### DIFF
--- a/spec/unit/lib/cloud_controller/drain_spec.rb
+++ b/spec/unit/lib/cloud_controller/drain_spec.rb
@@ -20,8 +20,10 @@ module VCAP::CloudController
     before do
       File.write(pid_path, pid)
 
+      allow(Process).to receive(:kill)
+
       # Kernel methods must be stubbed on the object instance that uses them
-      allow(drain).to receive(:sleep)
+      allow(drain).to receive(:sleep).with(1)
     end
 
     after do
@@ -30,79 +32,82 @@ module VCAP::CloudController
     end
 
     describe '#shutdown_nginx' do
-      before do
-        allow(Process).to receive(:kill).with('QUIT', pid)
-      end
-
       it 'sends QUIT to the nginx process specified in the pid file' do
+        expect(Process).to receive(:kill).with('QUIT', pid)
+
         drain.shutdown_nginx(pid_path)
-        expect(Process).to have_received(:kill).with('QUIT', pid)
+
+        log_contents do |log|
+          expect(log).to match(/Sending signal '\w+' to process '\w+' with pid '\d+'/)
+        end
       end
 
       it 'sleeps while it waits for the process to stop' do
-        getpgid_returns = [1, 1, nil, nil]
-        allow(Process).to receive(:getpgid).with(pid) { getpgid_returns.shift || raise(Errno::ESRCH) }
-        expect(drain).to receive(:sleep).twice
-
-        drain.shutdown_nginx(pid_path)
-      end
-
-      it 'logs while it waits for the process to stop' do
-        getpgid_returns = [1, 1, nil, nil]
+        getpgid_returns = [1, 1, nil]
         allow(Process).to receive(:getpgid).with(pid) { getpgid_returns.shift || raise(Errno::ESRCH) }
 
         drain.shutdown_nginx(pid_path)
 
+        expect(drain).to have_received(:sleep).twice
         log_contents do |log|
-          expect(log).to match(/Waiting \d+s for \w+ to shutdown/)
+          expect(log).to match(/Waiting \d+s for process '\w+' with pid '\d+' to shutdown/)
+          expect(log).to match(/Process '\w+' with pid '\d+' is not running/)
         end
       end
 
-      it 'logs that the process has stopped running when its pid file is deleted' do
-        getpgid_returns = [1, nil, nil]
+      it 'times out after 30 * 1s = 30s (default), sends TERM' do
+        getpgid_returns = Array.new(31, 1) + [nil]
         allow(Process).to receive(:getpgid).with(pid) { getpgid_returns.shift || raise(Errno::ESRCH) }
+        expect(Process).to receive(:kill).with('QUIT', pid).ordered
+        expect(Process).to receive(:kill).with('TERM', pid).ordered
 
         drain.shutdown_nginx(pid_path)
 
-        log_contents do |log|
-          expect(log).to match(/\w+ with pid '#{pid}' not running/)
-        end
+        expect(drain).to have_received(:sleep).exactly(30).times
       end
 
-      it 'times out after 30 * 1s = 30s (default)' do
-        allow(Process).to receive(:getpgid).with(pid).and_return(1)
-        expect(drain).to receive(:sleep).with(1).exactly(30).times
-        expect(Process).to receive(:kill).with('TERM', pid)
-
-        drain.shutdown_nginx(pid_path)
-      end
-
-      it 'times out after 60 * 1s = 60s if timeout parameter is set to 60' do
-        allow(Process).to receive(:getpgid).with(pid).and_return(1)
-        expect(drain).to receive(:sleep).with(1).exactly(60).times
-        expect(Process).to receive(:kill).with('TERM', pid)
+      it 'times out after 60 * 1s = 60s if timeout parameter is set to 60, sends TERM' do
+        getpgid_returns = Array.new(61, 1) + [nil]
+        allow(Process).to receive(:getpgid).with(pid) { getpgid_returns.shift || raise(Errno::ESRCH) }
+        expect(Process).to receive(:kill).with('QUIT', pid).ordered
+        expect(Process).to receive(:kill).with('TERM', pid).ordered
 
         drain.shutdown_nginx(pid_path, 60)
+
+        expect(drain).to have_received(:sleep).exactly(60).times
+      end
+
+      it 'waits another 10s after sending TERM' do
+        allow(Process).to receive(:getpgid).with(pid).and_return(1)
+
+        drain.shutdown_nginx(pid_path)
+
+        expect(drain).to have_received(:sleep).exactly(40).times
+        log_contents do |log|
+          expect(log).to match(/Process '\w+' with pid '\d+' is still running - this indicates an error in the shutdown procedure!/)
+        end
       end
     end
 
     describe '#shutdown_cc' do
-      before do
-        allow(Process).to receive(:kill).with('TERM', pid)
-      end
+      it 'sends TERM to the ccng process specified in the pid file' do
+        expect(Process).to receive(:kill).with('TERM', pid)
 
-      it 'sends TERM to the cc process specified in the pid file' do
         drain.shutdown_cc(pid_path)
-        expect(Process).to have_received(:kill).with('TERM', pid)
-      end
-    end
-
-    describe '#log_invocation' do
-      it 'logs that the drain is invoked with the given arguments' do
-        drain.log_invocation([1, 'banana'])
 
         log_contents do |log|
-          expect(log).to match(/Drain invoked with.*1.*banana/)
+          expect(log).to match(/Sending signal '\w+' to process '\w+' with pid '\d+'/)
+        end
+      end
+
+      it 'waits 20s after sending TERM' do
+        allow(Process).to receive(:getpgid).with(pid).and_return(1)
+
+        drain.shutdown_cc(pid_path)
+
+        expect(drain).to have_received(:sleep).exactly(20).times
+        log_contents do |log|
+          expect(log).to match(/Process '\w+' with pid '\d+' is still running - this indicates an error in the shutdown procedure!/)
         end
       end
     end


### PR DESCRIPTION
Introduce a 'final timeout' for nginx and cc: i.e. check every second if the process got terminated; if the 'final timeout' is reached and the process is still there, write an error log.

Without this additional timeout it was (in theory) possible that the termination of cc was triggered although the forceful nginx shutdown has not been finished. And the overall drain procedure could have been completed even though cc was not fully terminated.

For cc the 'final timeout' is 20 seconds. This has been derived from the shutdown timeouts for Puma workers (15s) and threads (10s). This value should be fine for Thin as well.

For nginx the 'final timeout' is 10 seconds.

The explicit log message will make it possible to detect draining issues that might have been unnoticed so far.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
