### PR TITLE
Remove unused statsd clients

### DIFF
--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -128,10 +128,6 @@ class ApplicationController < ActionController::Base
     @logger ||= Steno.logger('cc.api')
   end
 
-  def statsd_client
-    @statsd_client ||= CloudController::DependencyLocator.instance.statsd_client
-  end
-
   def permission_queryer
     @permission_queryer ||= VCAP::CloudController::Permissions.new(VCAP::CloudController::SecurityContext.current_user)
   end

--- a/lib/cloud_controller/controller_factory.rb
+++ b/lib/cloud_controller/controller_factory.rb
@@ -24,7 +24,6 @@ module CloudController
 
     def default_dependencies
       {
-        statsd_client: dependency_locator.statsd_client,
         object_renderer: dependency_locator.object_renderer,
         collection_renderer: dependency_locator.paginated_collection_renderer
       }


### PR DESCRIPTION
While trying to understand where statsd is referenced, two usages were found that seem to be obsolete.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
