### PR TITLE
Make user lookup resilient and consistent

### DIFF
--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -28,6 +28,8 @@ class RolesController < ApplicationController
       message: message,
       decorators: decorators
     )
+  rescue UaaUnavailable
+    raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
   end
 
   def show
@@ -43,6 +45,8 @@ class RolesController < ApplicationController
     resource_not_found!(:role) unless role
 
     render status: :ok, json: Presenters::V3::RolePresenter.new(role, decorators:)
+  rescue UaaUnavailable
+    raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
   end
 
   def create

--- a/app/controllers/v3/users_controller.rb
+++ b/app/controllers/v3/users_controller.rb
@@ -33,6 +33,8 @@ class UsersController < ApplicationController
     user_not_found! unless user
 
     render status: :ok, json: Presenters::V3::UserPresenter.new(user, uaa_users: User.uaa_users_info([user.guid]))
+  rescue VCAP::CloudController::UaaUnavailable
+    raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
   end
 
   def create


### PR DESCRIPTION
User lookup for /v3/users can fail when UAA is down (UAA is expected to be available (HA)). Currently, CC simply sets the username field to null when UAA is unavailable. This is unexpected for clients. This PR aims to implement the retries (with backoff) and eventually fail with 503 when UAA is not available.

Fixes: #3357

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
