### PR TITLE
Use sub query for user visibility filter

### DIFF
--- a/app/models/services/service.rb
+++ b/app/models/services/service.rb
@@ -36,9 +36,8 @@ module VCAP::CloudController
 
       def user_visibility_filter(current_user, operation=nil)
         visible_plans = ServicePlan.user_visible(current_user, operation)
-        ids_from_plans = visible_plans.map(&:service_id).uniq
 
-        { id: ids_from_plans }
+        { id: visible_plans.select(:service_id).distinct }
       end
 
       def user_visibility_for_read(current_user, _admin_override)


### PR DESCRIPTION
In case there are many service instances related db queries might become very complex:
```
SELECT * FROM \"services\" WHERE ((\"services\".\"id\" IN (7)) AND (\"id\" IN (<super long list of service ids>)))
```

This can lead to high memory consumption on the api VMs and can also cause memory bloats as everything is loaded into memory.

With this change we change the query to use a sub query instead:
```
SELECT * FROM \"services\" WHERE ((\"services\".\"id\" IN (7)) AND (\"id\" IN (SELECT DISTINCT \"service_id\" FROM \"service_plans\")))
```


* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
