### PR TITLE
Fix: Polling stopped after failed service instance update last operation fetch

### DIFF
--- a/app/actions/v3/service_instance_delete.rb
+++ b/app/actions/v3/service_instance_delete.rb
@@ -82,7 +82,7 @@ module VCAP::CloudController
         raise CloudController::Errors::ApiError.new_from_details('UnableToPerform', 'delete', e.message)
       rescue StandardError => e
         update_last_operation_with_failure(e.message)
-        ContinuePolling.call(nil)
+        raise e
       end
 
       def update_last_operation_with_failure(message)

--- a/spec/support/shared_examples/v3_service_binding_create.rb
+++ b/spec/support/shared_examples/v3_service_binding_create.rb
@@ -215,7 +215,7 @@ RSpec.shared_examples 'polling service binding creation' do
       end
     end
 
-    context 'fetching last operations fails' do
+    context 'fetching last operations fails with RuntimeError' do
       before do
         allow(broker_client).to receive(:fetch_and_handle_service_binding_last_operation).and_raise(RuntimeError.new('some error'))
       end
@@ -227,6 +227,38 @@ RSpec.shared_examples 'polling service binding creation' do
         expect(binding.last_operation.type).to eq('create')
         expect(binding.last_operation.state).to eq('failed')
         expect(binding.last_operation.description).to eq('some error')
+      end
+    end
+
+    context 'fetching last operations fails with ServiceBrokerBadResponse' do
+      let(:broker_response) do
+        VCAP::Services::ServiceBrokers::V2::HttpResponse.new(
+          code: '502',
+          body: {}.to_json
+        )
+      end
+
+      let(:bad_response_exception) { VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerBadResponse.new(nil, nil, broker_response) }
+
+      before do
+        allow(broker_client).to receive(:fetch_service_binding_last_operation).and_raise(bad_response_exception)
+      end
+
+      it 'leaves the last operation in its previous state' do
+        action.poll(binding)
+
+        binding.reload
+        expect(binding.last_operation.type).to eq('create')
+        expect(binding.last_operation.state).to eq('in progress')
+        expect(binding.last_operation.broker_provided_operation).to eq(broker_provided_operation)
+        expect(binding.last_operation.description).to eq(description)
+      end
+
+      it 'continues polling' do
+        result = action.poll(binding)
+
+        expect(result[:finished]).to be_falsey
+        expect(result[:retry_after]).to be_nil
       end
     end
 

--- a/spec/unit/actions/v3/service_instance_create_managed_spec.rb
+++ b/spec/unit/actions/v3/service_instance_create_managed_spec.rb
@@ -687,6 +687,37 @@ module VCAP::CloudController
             expect(ServiceInstance.first.last_operation.description).to eq('boom')
           end
         end
+
+        context 'when fetching the last operation from the broker fails' do
+          let(:broker_response) do
+            VCAP::Services::ServiceBrokers::V2::HttpResponse.new(
+              code: '502',
+              body: {}.to_json
+            )
+          end
+
+          let(:bad_response_exception) { VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerBadResponse.new(nil, nil, broker_response) }
+
+          before do
+            allow(client).to receive(:fetch_service_instance_last_operation).and_raise(bad_response_exception)
+          end
+
+          it 'leaves the last operation in its previous state' do
+            action.poll service_instance
+
+            expect(ServiceInstance.first.last_operation.type).to eq('create')
+            expect(ServiceInstance.first.last_operation.state).to eq('in progress')
+            expect(ServiceInstance.first.last_operation.broker_provided_operation).to eq(operation_id)
+            expect(ServiceInstance.first.last_operation.description).to be_nil
+          end
+
+          it 'continues polling' do
+            result = action.poll service_instance
+
+            expect(result[:finished]).to be_falsey
+            expect(result[:retry_after]).to be_nil
+          end
+        end
       end
     end
   end

--- a/spec/unit/actions/v3/service_instance_delete_spec.rb
+++ b/spec/unit/actions/v3/service_instance_delete_spec.rb
@@ -702,9 +702,13 @@ module VCAP::CloudController
             allow(client).to receive(:fetch_service_instance_last_operation).and_raise(StandardError, 'boom')
           end
 
-          it 'updates the last operation description and continues to poll' do
-            result = action.poll
-            expect(result[:finished]).to be_falsey
+          it 'sets the last operation to failed and raises the error' do
+            expect do
+              action.poll
+            end.to raise_error(
+              StandardError,
+              'boom'
+            )
 
             expect(ServiceInstance.first.last_operation.type).to eq('delete')
             expect(ServiceInstance.first.last_operation.state).to eq('failed')

--- a/spec/unit/actions/v3/service_instance_delete_spec.rb
+++ b/spec/unit/actions/v3/service_instance_delete_spec.rb
@@ -1,4 +1,4 @@
-require 'db_spec_helper'
+require 'spec_helper'
 require 'actions/v3/service_instance_delete'
 require 'cloud_controller/user_audit_info'
 
@@ -710,6 +710,37 @@ module VCAP::CloudController
             expect(ServiceInstance.first.last_operation.state).to eq('failed')
             expect(ServiceInstance.first.last_operation.broker_provided_operation).to be_nil
             expect(ServiceInstance.first.last_operation.description).to eq('boom')
+          end
+        end
+
+        context 'when fetching the last operation from the broker fails' do
+          let(:broker_response) do
+            VCAP::Services::ServiceBrokers::V2::HttpResponse.new(
+              code: '502',
+              body: {}.to_json
+            )
+          end
+
+          let(:bad_response_exception) { VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerBadResponse.new(nil, nil, broker_response) }
+
+          before do
+            allow(client).to receive(:fetch_service_instance_last_operation).and_raise(bad_response_exception)
+          end
+
+          it 'leaves the last operation in its previous state' do
+            action.poll
+
+            expect(ServiceInstance.first.last_operation.type).to eq('delete')
+            expect(ServiceInstance.first.last_operation.state).to eq('in progress')
+            expect(ServiceInstance.first.last_operation.broker_provided_operation).to eq(operation_id)
+            expect(ServiceInstance.first.last_operation.description).to be_nil
+          end
+
+          it 'continues polling' do
+            result = action.poll
+
+            expect(result[:finished]).to be_falsey
+            expect(result[:retry_after]).to be_nil
           end
         end
       end

--- a/spec/unit/actions/v3/service_instance_update_managed_spec.rb
+++ b/spec/unit/actions/v3/service_instance_update_managed_spec.rb
@@ -1527,6 +1527,37 @@ module VCAP::CloudController
             expect(ServiceInstance.first.last_operation.description).to eq('boom')
           end
         end
+
+        context 'when fetching the last operation from the broker fails' do
+          let(:broker_response) do
+            VCAP::Services::ServiceBrokers::V2::HttpResponse.new(
+              code: '502',
+              body: {}.to_json
+            )
+          end
+
+          let(:bad_response_exception) { VCAP::Services::ServiceBrokers::V2::Errors::ServiceBrokerBadResponse.new(nil, nil, broker_response) }
+
+          before do
+            allow(client).to receive(:fetch_service_instance_last_operation).and_raise(bad_response_exception)
+          end
+
+          it 'leaves the last operation in its previous state' do
+            action.poll
+
+            expect(ServiceInstance.first.last_operation.type).to eq('update')
+            expect(ServiceInstance.first.last_operation.state).to eq('in progress')
+            expect(ServiceInstance.first.last_operation.broker_provided_operation).to eq(operation_id)
+            expect(ServiceInstance.first.last_operation.description).to be_nil
+          end
+
+          it 'continues polling' do
+            result = action.poll
+
+            expect(result[:finished]).to be_falsey
+            expect(result[:retry_after]).to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

The Cloud Controller stopped polling the last operation state of a service instance update request when the Service Broker was unavailable and a proxy returned a 502 for example. According to the OSBAPI "Responses with any other status code SHOULD be interpreted as an error or invalid response. The Platform SHOULD continue polling until the Service Broker returns a valid response or the maximum polling duration is reached."

Additionally the error handling for the polling for service instance deletion was adjusted to make it consistent with the behaviour of all other service related polling mechanisms. Now the last operation state will keep in progress when HTTPResponseErrors and the like are being raised and polling continues like before. For StandardErrors though, the last operation is set to failed and the polling stops. 

Added tests to all polling operations to make sure the behaviour is consistent.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
