### PR TITLE
Remove PSQL 10 from unittests, add PSQL 16 and MYSQL 8.2

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["postgres:11", "postgres:16"]
+        image: ["postgres:10", "postgres:11", "postgres:16"]
     services:
       postgres:
         image: ${{ matrix.image }}
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["mysql:5.7", "mysql:8.0"]
+        image: ["mysql:5.7", "mysql:8.0", "mysql:8.2"]
     services:
       mysql:
         image: ${{ matrix.image }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["postgres:10", "postgres:14"]
+        image: ["postgres:11", "postgres:16"]
     services:
       postgres:
         image: ${{ matrix.image }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   # MySQL
   mysql:
     container_name: mysql
-    image: mysql:8
+    image: mysql:8.2
     environment:
       MYSQL_ROOT_PASSWORD: supersecret
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,13 @@ services:
   # Postgres
   postgres:
     container_name: postgres
-    image: postgres:14
+    image: postgres:16-alpine
     environment:
       POSTGRES_PASSWORD: supersecret
+    command: # logs every statement sent to the server. Slow, but helpful. Fills up disk Quickly !
+      - "postgres"
+      - "-c"
+      - "log_statement=all"
     ports:
       - "127.0.0.1:5432:5432"
     networks:


### PR DESCRIPTION
PSQL 10 is out of support, 16 is the newest release so we should add this.
Similar to the new psql version we should also at least test against the
newest mysql release.