### PR TITLE
Fix missing statsd config error on workers

### DIFF
--- a/lib/cloud_controller/diego/messenger.rb
+++ b/lib/cloud_controller/diego/messenger.rb
@@ -4,19 +4,14 @@ require 'cloud_controller/diego/desire_app_handler'
 module VCAP::CloudController
   module Diego
     class Messenger
-      def initialize(statsd_updater=CloudController::DependencyLocator.instance.statsd_updater, prometheus_updater=CloudController::DependencyLocator.instance.prometheus_updater)
-        @statsd_updater = statsd_updater
-        @prometheus_updater = prometheus_updater
-      end
-
       def send_stage_request(_config, staging_details)
         logger.info('staging.begin', package_guid: staging_details.package.guid)
 
         staging_guid = staging_details.staging_guid
 
         bbs_stager_client.stage(staging_guid, staging_details)
-        @statsd_updater.start_staging_request_received
-        @prometheus_updater.start_staging_request_received
+        statsd_updater.start_staging_request_received
+        prometheus_updater.start_staging_request_received
       end
 
       def send_stop_staging_request(staging_guid)
@@ -60,6 +55,14 @@ module VCAP::CloudController
 
       def bbs_stager_client
         CloudController::DependencyLocator.instance.bbs_stager_client
+      end
+
+      def statsd_updater
+        CloudController::DependencyLocator.instance.statsd_updater
+      end
+
+      def prometheus_updater
+        CloudController::DependencyLocator.instance.prometheus_updater
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/diego/messenger_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/messenger_spec.rb
@@ -4,9 +4,7 @@ require 'cloud_controller/diego/bbs_stager_client'
 module VCAP::CloudController
   module Diego
     RSpec.describe Messenger do
-      subject(:messenger) { Messenger.new(statsd_updater, prometheus_updater) }
-      let(:statsd_updater) { instance_double(VCAP::CloudController::Metrics::StatsdUpdater) }
-      let(:prometheus_updater) { instance_double(VCAP::CloudController::Metrics::PrometheusUpdater) }
+      subject(:messenger) { Messenger.new }
 
       let(:bbs_stager_client) { instance_double(BbsStagerClient) }
       let(:config) { TestConfig.config_instance }
@@ -20,6 +18,8 @@ module VCAP::CloudController
       end
 
       describe '#send_stage_request' do
+        let(:statsd_updater) { instance_double(VCAP::CloudController::Metrics::StatsdUpdater) }
+        let(:prometheus_updater) { instance_double(VCAP::CloudController::Metrics::PrometheusUpdater) }
         let(:package) { PackageModel.make }
         let(:droplet) { DropletModel.make(package:) }
         let(:staging_guid) { droplet.guid }
@@ -31,6 +31,8 @@ module VCAP::CloudController
         end
 
         before do
+          CloudController::DependencyLocator.instance.register(:statsd_updater, statsd_updater)
+          CloudController::DependencyLocator.instance.register(:prometheus_updater, prometheus_updater)
           staging_details.lifecycle = instance_double(BuildpackLifecycle, type: Lifecycles::BUILDPACK)
           allow(bbs_stager_client).to receive(:stage)
           allow(statsd_updater).to receive(:start_staging_request_received)


### PR DESCRIPTION
Workers do not emit metrics (there is no `statsd_injector` process) and thus don't need any statsd config. As only a single method of the `Diego::Messenger` is using `statsd_updater` and `prometheus_updater` and this method is not used by worker processes, these updaters must not be initialized in the constructor.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
