### PR TITLE
Use xxHash in Rate Limiter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'talentbox-delayed_job_sequel', '~> 4.3.0'
 gem 'thin'
 gem 'unf'
 gem 'vmstat', '~> 2.3'
+gem 'xxhash'
 gem 'yajl-ruby'
 
 # Rails Components

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -562,6 +562,7 @@ GEM
     webrick (1.8.1)
     xml-simple (1.1.9)
       rexml
+    xxhash (0.5.0)
     yajl-ruby (1.4.3)
     yard (0.9.34)
     zeitwerk (2.6.12)
@@ -660,6 +661,7 @@ DEPENDENCIES
   vcap-concurrency!
   vmstat (~> 2.3)
   webmock (> 2.3.1)
+  xxhash
   yajl-ruby
 
 BUNDLED WITH

--- a/middleware/mixins/user_reset_interval.rb
+++ b/middleware/mixins/user_reset_interval.rb
@@ -1,10 +1,11 @@
+require 'xxhash'
+
 module CloudFoundry
   module Middleware
     module UserResetInterval
       def next_expires_in(user_guid, reset_interval_in_minutes)
         interval = reset_interval_in_minutes.minutes.to_i
-        offset = OpenSSL::Digest::MD5.hexdigest(user_guid).hex.remainder(interval)
-        # TODO: replace hash function with faster (e.g. https://github.com/nashby/xxhash) and FIPS compliant algorithm.
+        offset = XXhash.xxh64(user_guid).remainder(interval)
 
         interval - (Time.now.to_i - offset).remainder(interval)
       end

--- a/spec/unit/middleware/mixins/user_reset_interval_spec.rb
+++ b/spec/unit/middleware/mixins/user_reset_interval_spec.rb
@@ -8,7 +8,7 @@ module CloudFoundry
       end
       let(:user_guid) { 'user_guid' }
       let(:reset_interval_in_minutes) { 60 }
-      let(:user_guid_offset) { 1170.seconds }
+      let(:user_guid_offset) { 592.seconds }
 
       context "time is set to beginning of hour + the user's offset" do
         before { Timecop.freeze Time.now.beginning_of_hour + user_guid_offset }


### PR DESCRIPTION
- There is no need for a "cryptographic" hash algorithm.
- `XXhash.xxh64(guid)` is 10 times faster than `OpenSSL::Digest:: SHA1.hexdigest(guid).hex`.

Addresses one of the issues identified in: #3544

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
