### PR TITLE
Enable the Lint/ItWithoutArgumentsInBlock rubocop

### DIFF
--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -178,6 +178,8 @@ Lint/EmptyInPattern:
   Enabled: true
 Lint/IncompatibleIoSelectWithFiberScheduler:
   Enabled: true
+Lint/ItWithoutArgumentsInBlock:
+  Enabled: true
 Lint/LambdaWithoutLiteralBlock:
   Enabled: true
 Lint/LiteralAssignmentInCondition:


### PR DESCRIPTION
- new in rubocop 1.59

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
explicitly enable the new rubocop

* An explanation of the use cases your change solves
makes me happy to not see the message "The following cops were added to RuboCop, but are not configued"

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
