### PR TITLE
Add tags to task logs

### DIFF
--- a/lib/diego/bbs/models/actual_lrp_pb.rb
+++ b/lib/diego/bbs/models/actual_lrp_pb.rb
@@ -51,6 +51,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :presence, :enum, 10, "diego.bbs.models.ActualLRP.Presence"
     repeated :actual_lrp_internal_routes, :message, 11, "diego.bbs.models.ActualLRPInternalRoute"
     map :metric_tags, :string, :string, 12
+    optional :availability_zone, :string, 14
     oneof :optional_routable do
       optional :routable, :bool, 13
     end

--- a/lib/diego/bbs/models/actual_lrp_requests_pb.rb
+++ b/lib/diego/bbs/models/actual_lrp_requests_pb.rb
@@ -39,6 +39,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :actual_lrp_net_info, :message, 3, "diego.bbs.models.ActualLRPNetInfo"
     repeated :actual_lrp_internal_routes, :message, 4, "diego.bbs.models.ActualLRPInternalRoute"
     map :metric_tags, :string, :string, 5
+    optional :availability_zone, :string, 7
     oneof :optional_routable do
       optional :Routable, :bool, 6
     end

--- a/lib/diego/bbs/models/evacuation_pb.rb
+++ b/lib/diego/bbs/models/evacuation_pb.rb
@@ -20,6 +20,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :actual_lrp_net_info, :message, 3, "diego.bbs.models.ActualLRPNetInfo"
     repeated :actual_lrp_internal_routes, :message, 5, "diego.bbs.models.ActualLRPInternalRoute"
     map :metric_tags, :string, :string, 6
+    optional :availability_zone, :string, 8
     oneof :optional_routable do
       optional :Routable, :bool, 7
     end

--- a/lib/diego/bbs/models/events_pb.rb
+++ b/lib/diego/bbs/models/events_pb.rb
@@ -31,6 +31,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :since, :int64, 8
     optional :modification_tag, :message, 9, "diego.bbs.models.ModificationTag"
     optional :presence, :enum, 10, "diego.bbs.models.ActualLRP.Presence"
+    optional :availability_zone, :string, 12
     oneof :optional_routable do
       optional :Routable, :bool, 11
     end

--- a/lib/diego/bbs/models/task_pb.rb
+++ b/lib/diego/bbs/models/task_pb.rb
@@ -12,6 +12,7 @@ require 'network_pb'
 require 'certificate_properties_pb'
 require 'image_layer_pb'
 require 'log_rate_limit_pb'
+require 'metric_tags_pb'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "diego.bbs.models.TaskDefinition" do
     optional :root_fs, :string, 1
@@ -40,6 +41,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :image_password, :string, 24
     repeated :image_layers, :message, 25, "diego.bbs.models.ImageLayer"
     optional :log_rate_limit, :message, 26, "diego.bbs.models.LogRateLimit"
+    map :metric_tags, :string, :message, 27, "diego.bbs.models.MetricTagValue"
   end
   add_message "diego.bbs.models.Task" do
     optional :task_definition, :message, 1, "diego.bbs.models.TaskDefinition"

--- a/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_recipe_builder_spec.rb
@@ -4,9 +4,11 @@ module VCAP::CloudController
   module Diego
     RSpec.describe TaskRecipeBuilder do
       subject(:task_recipe_builder) { TaskRecipeBuilder.new }
+      let(:org) { Organization.make(name: 'MyOrg', guid: 'org-guid') }
+      let(:space) { Space.make(name: 'MySpace', guid: 'space-guid', organization: org) }
+      let(:app) { AppModel.make(name: 'MyApp', guid: 'banana-guid', space: space) }
 
       describe '#build_staging_task' do
-        let(:app) { AppModel.make(guid: 'banana-guid') }
         let(:staging_details) do
           Diego::StagingDetails.new.tap do |details|
             details.staging_guid = droplet.guid
@@ -150,6 +152,15 @@ module VCAP::CloudController
             expect(result.image_layers).to eq(lifecycle_image_layers)
             expect(result.cpu_weight).to eq(50)
 
+            expect(result.metric_tags.keys.size).to eq(7)
+            expect(result.metric_tags['source_id'].static).to eq('banana-guid')
+            expect(result.metric_tags['organization_id'].static).to eq('org-guid')
+            expect(result.metric_tags['space_id'].static).to eq('space-guid')
+            expect(result.metric_tags['app_id'].static).to eq('banana-guid')
+            expect(result.metric_tags['organization_name'].static).to eq('MyOrg')
+            expect(result.metric_tags['space_name'].static).to eq('MySpace')
+            expect(result.metric_tags['app_name'].static).to eq('MyApp')
+
             expect(result.completion_callback_url).to eq("https://#{internal_service_hostname}:#{tls_port}" \
                                                          "/internal/v3/staging/#{droplet.guid}/build_completed?start=#{staging_details.start_after_staging}")
 
@@ -225,6 +236,18 @@ module VCAP::CloudController
           it 'sets the log source' do
             result = task_recipe_builder.build_staging_task(config, staging_details)
             expect(result.log_source).to eq('STG')
+          end
+
+          it 'sets the metric tags' do
+            result = task_recipe_builder.build_staging_task(config, staging_details)
+            expect(result.metric_tags.keys.size).to eq(7)
+            expect(result.metric_tags['source_id'].static).to eq('banana-guid')
+            expect(result.metric_tags['organization_id'].static).to eq('org-guid')
+            expect(result.metric_tags['space_id'].static).to eq('space-guid')
+            expect(result.metric_tags['app_id'].static).to eq('banana-guid')
+            expect(result.metric_tags['organization_name'].static).to eq('MyOrg')
+            expect(result.metric_tags['space_name'].static).to eq('MySpace')
+            expect(result.metric_tags['app_name'].static).to eq('MyApp')
           end
 
           it 'does not set the image layers' do
@@ -320,7 +343,6 @@ module VCAP::CloudController
       end
 
       describe '#build_app_task' do
-        let(:app) { AppModel.make(guid: 'banana-guid') }
         let(:task) do
           TaskModel.create(
             name: 'potato-task',
@@ -474,6 +496,15 @@ module VCAP::CloudController
             expect(result.placement_tags).to eq([isolation_segment])
             expect(result.max_pids).to eq(100)
             expect(result.certificate_properties).to eq(certificate_properties)
+
+            expect(result.metric_tags.keys.size).to eq(7)
+            expect(result.metric_tags['source_id'].static).to eq('banana-guid')
+            expect(result.metric_tags['organization_id'].static).to eq('org-guid')
+            expect(result.metric_tags['space_id'].static).to eq('space-guid')
+            expect(result.metric_tags['app_id'].static).to eq('banana-guid')
+            expect(result.metric_tags['organization_name'].static).to eq('MyOrg')
+            expect(result.metric_tags['space_name'].static).to eq('MySpace')
+            expect(result.metric_tags['app_name'].static).to eq('MyApp')
           end
 
           context 'when a volume mount is provided' do
@@ -615,6 +646,15 @@ module VCAP::CloudController
             expect(result.placement_tags).to eq([isolation_segment])
             expect(result.max_pids).to eq(100)
             expect(result.certificate_properties).to eq(certificate_properties)
+
+            expect(result.metric_tags.keys.size).to eq(7)
+            expect(result.metric_tags['source_id'].static).to eq('banana-guid')
+            expect(result.metric_tags['organization_id'].static).to eq('org-guid')
+            expect(result.metric_tags['space_id'].static).to eq('space-guid')
+            expect(result.metric_tags['app_id'].static).to eq('banana-guid')
+            expect(result.metric_tags['organization_name'].static).to eq('MyOrg')
+            expect(result.metric_tags['space_name'].static).to eq('MySpace')
+            expect(result.metric_tags['app_name'].static).to eq('MyApp')
 
             expect(result.image_username).to eq('dockerusername')
             expect(result.image_password).to eq('dockerpassword')


### PR DESCRIPTION
Add tags to task logs to provide app, space, and organization information and match the logs of LRPs.

Related PRs:
* https://github.com/cloudfoundry/bbs/pull/77
* https://github.com/cloudfoundry/rep/pull/50

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
