### PR TITLE
Put binding and job creation in one transaction

### DIFF
--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -990,6 +990,23 @@ RSpec.describe 'v3 service route bindings' do
                                                                }))
         end
       end
+
+      context 'database disconnect error during creation of enqueue bind job' do
+        before do
+          allow_any_instance_of(ServiceRouteBindingsController).to receive(:enqueue_bind_job).and_raise(Sequel::DatabaseDisconnectError)
+        end
+
+        it 'rolls back the transaction' do
+          api_call.call(admin_headers)
+
+          expect(last_response).to have_status_code(503)
+          expect(parsed_response['errors']).to include(include({
+                                                                 'detail' => include('Database connection failure'),
+                                                                 'title' => 'CF-ServiceUnavailable',
+                                                                 'code' => 10_015
+                                                               }))
+        end
+      end
     end
 
     context 'user-provided service instance' do


### PR DESCRIPTION
For service credential bindings and service route bindings, when the DB becomes unavailable after the service/route binding operation was stored in the DB, but before the delayed job was stored, the operation will be stuck in state 'create initial'. The user cannot delete the binding nor retrigger the creation. An admin has to set the operation to state failed manually in the DB.

This fixes it in that way, that both the operation and the delayed job get created in one DB transaction.

With this implemented, the user can retrigger the creation or delete the binding.


* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
