### PR TITLE
Fix test exclusion mechanism of backwards compatibillity tests

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -27,18 +27,18 @@ namespace :spec do
   task without_migrate: ['db:pick'] do
     # We exclude specs that test migration behaviour since this breaks/alters the DB in the middle of a test
     if ARGV[1]
-      run_specs(ARGV[1], 'NO_DB_MIGRATION=true', '--exclude-pattern spec/migrations --exclude-pattern unit/lib/vcap/sequel_case_insensitive_string_monkeypatch_spec.rb')
+      run_specs(ARGV[1], 'NO_DB_MIGRATION=true')
     else
-      run_specs_parallel('spec', 'NO_DB_MIGRATION=true', '--exclude-pattern spec/migrations --exclude-pattern unit/lib/vcap/sequel_case_insensitive_string_monkeypatch_spec.rb')
+      run_specs_parallel('spec', 'NO_DB_MIGRATION=true')
     end
   end
 
-  def run_specs(path, env_vars='', rspec_parameters='')
-    sh "#{env_vars} bundle exec rspec #{path} --require rspec/instafail --format RSpec::Instafail --format progress #{rspec_parameters}"
+  def run_specs(path, env_vars='')
+    sh "#{env_vars} bundle exec rspec #{path} --require rspec/instafail --format RSpec::Instafail --format progress"
   end
 
-  def run_specs_parallel(path, env_vars='', rspec_parameters='')
-    sh "#{env_vars} bundle exec parallel_rspec --test-options '--order rand' --single spec/integration/ --single spec/acceptance/ #{rspec_parameters} -- #{path}"
+  def run_specs_parallel(path, env_vars='')
+    sh "#{env_vars} bundle exec parallel_rspec --test-options '--order rand' --single spec/integration/ --single spec/acceptance/ -- #{path}"
   end
 
   def run_failed_specs

--- a/spec/migrations/20190712210940_backfill_status_for_deployments_spec.rb
+++ b/spec/migrations/20190712210940_backfill_status_for_deployments_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'backfill status_value for deployments', isolation: :truncation do
+RSpec.describe 'backfill status_value for deployments', isolation: :truncation, type: :migration do
   let(:tmp_migrations_dir) { Dir.mktmpdir }
 
   before do

--- a/spec/migrations/20191014212939_add_guid_and_timestamps_to_roles_join_tables_spec.rb
+++ b/spec/migrations/20191014212939_add_guid_and_timestamps_to_roles_join_tables_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'add role_guid and timestamps to roles join tables', isolation: :truncation do
+RSpec.describe 'add role_guid and timestamps to roles join tables', isolation: :truncation, type: :migration do
   let(:db) { Sequel::Model.db }
   let(:user) { VCAP::CloudController::User.make }
   let(:space) { VCAP::CloudController::Space.make }

--- a/spec/migrations/20191218001006_fill_guid_and_timestamps_for_spaces_auditors_spec.rb
+++ b/spec/migrations/20191218001006_fill_guid_and_timestamps_for_spaces_auditors_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'fill role_guid and timestamps for spaces_auditors table', isolation: :truncation do
+RSpec.describe 'fill role_guid and timestamps for spaces_auditors table', isolation: :truncation, type: :migration do
   let(:role_table) { :spaces_auditors }
   let(:filename) { '20191218001006_fill_guid_and_timestamps_for_spaces_auditors.rb' }
 

--- a/spec/migrations/20191218001010_fill_guid_and_timestamps_for_spaces_managers_spec.rb
+++ b/spec/migrations/20191218001010_fill_guid_and_timestamps_for_spaces_managers_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'fill role_guid and timestamps for spaces_managers table', isolation: :truncation do
+RSpec.describe 'fill role_guid and timestamps for spaces_managers table', isolation: :truncation, type: :migration do
   let(:role_table) { :spaces_managers }
   let(:filename) { '20191218001010_fill_guid_and_timestamps_for_spaces_managers.rb' }
 

--- a/spec/migrations/20191218001015_fill_guid_and_timestamps_for_spaces_developers_spec.rb
+++ b/spec/migrations/20191218001015_fill_guid_and_timestamps_for_spaces_developers_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'fill role_guid and timestamps for spaces_developers table', isolation: :truncation do
+RSpec.describe 'fill role_guid and timestamps for spaces_developers table', isolation: :truncation, type: :migration do
   let(:role_table) { :spaces_developers }
   let(:filename) { '20191218001015_fill_guid_and_timestamps_for_spaces_developers.rb' }
 

--- a/spec/migrations/20191218001019_fill_guid_and_timestamps_for_organizations_auditors_spec.rb
+++ b/spec/migrations/20191218001019_fill_guid_and_timestamps_for_organizations_auditors_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'fill role_guid and timestamps for organizations_auditors table', isolation: :truncation do
+RSpec.describe 'fill role_guid and timestamps for organizations_auditors table', isolation: :truncation, type: :migration do
   let(:role_table) { :organizations_auditors }
   let(:filename) { '20191218001019_fill_guid_and_timestamps_for_organizations_auditors.rb' }
 

--- a/spec/migrations/20191218001024_fill_guid_and_timestamps_for_organizations_billing_managers_spec.rb
+++ b/spec/migrations/20191218001024_fill_guid_and_timestamps_for_organizations_billing_managers_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'fill role_guid and timestamps for organizations_billing_managers table', isolation: :truncation do
+RSpec.describe 'fill role_guid and timestamps for organizations_billing_managers table', isolation: :truncation, type: :migration do
   let(:role_table) { :organizations_billing_managers }
   let(:filename) { '20191218001024_fill_guid_and_timestamps_for_organizations_billing_managers.rb' }
 

--- a/spec/migrations/20191218001028_fill_guid_and_timestamps_for_organizations_managers_spec.rb
+++ b/spec/migrations/20191218001028_fill_guid_and_timestamps_for_organizations_managers_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'fill role_guid and timestamps for organizations_managers table', isolation: :truncation do
+RSpec.describe 'fill role_guid and timestamps for organizations_managers table', isolation: :truncation, type: :migration do
   let(:role_table) { :organizations_managers }
   let(:filename) { '20191218001028_fill_guid_and_timestamps_for_organizations_managers.rb' }
 

--- a/spec/migrations/20191218001034_fill_guid_and_timestamps_for_organizations_users_spec.rb
+++ b/spec/migrations/20191218001034_fill_guid_and_timestamps_for_organizations_users_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'fill role_guid and timestamps for organizations_users table', isolation: :truncation do
+RSpec.describe 'fill role_guid and timestamps for organizations_users table', isolation: :truncation, type: :migration do
   let(:role_table) { :organizations_users }
   let(:filename) { '20191218001034_fill_guid_and_timestamps_for_organizations_users.rb' }
 

--- a/spec/migrations/20220818142407_add_unique_index_to_service_instance_operations_service_instance_id_spec.rb
+++ b/spec/migrations/20220818142407_add_unique_index_to_service_instance_operations_service_instance_id_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'migration to add unique index on service_instance_id to service_instance_operations', isolation: :truncation do
+RSpec.describe 'migration to add unique index on service_instance_id to service_instance_operations', isolation: :truncation, type: :migration do
   let(:filename) { '20220818142407_add_unique_index_to_service_instance_operations_service_instance_id.rb' }
   let(:tmp_migrations_dir) { Dir.mktmpdir }
   let(:db) { Sequel::Model.db }

--- a/spec/migrations/20230822153000_streamline_annotation_key_prefix_spec.rb
+++ b/spec/migrations/20230822153000_streamline_annotation_key_prefix_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'migrations/helpers/migration_shared_context'
 
-RSpec.describe 'migration to streamline changes to annotation_key_prefix', isolation: :truncation do
+RSpec.describe 'migration to streamline changes to annotation_key_prefix', isolation: :truncation, type: :migration do
   include_context 'migration' do
     let(:migration_filename) { '20230822153000_streamline_annotation_key_prefix.rb' }
   end

--- a/spec/migrations/20231016094900_microsecond_timestamp_msql_asg_update_spec.rb
+++ b/spec/migrations/20231016094900_microsecond_timestamp_msql_asg_update_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'migrations/helpers/migration_shared_context'
 
-RSpec.describe 'migration to enable microsecond precision on asg last updated table', isolation: :truncation do
+RSpec.describe 'migration to enable microsecond precision on asg last updated table', isolation: :truncation, type: :migration do
   include_context 'migration' do
     let(:migration_filename) { '20231016094900_microsecond_timestamp_msql_asg_update.rb' }
     let(:ds) do

--- a/spec/migrations/20231205143526_remove_deployments_with_degenerate_spec.rb
+++ b/spec/migrations/20231205143526_remove_deployments_with_degenerate_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'migrations/helpers/migration_shared_context'
 
-RSpec.describe 'migration to clean up degenerate records from deployments records', isolation: :truncation do
+RSpec.describe 'migration to clean up degenerate records from deployments records', isolation: :truncation, type: :migration do
   include_context 'migration' do
     let(:migration_filename) { '20231205143526_remove_deployments_with_degenerate.rb' }
   end

--- a/spec/migrations/ensure_migrations_are_current_spec.rb
+++ b/spec/migrations/ensure_migrations_are_current_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'tasks/rake_config'
 
-RSpec.describe 'ensure migrations are current', isolation: :truncation do
+RSpec.describe 'ensure migrations are current', isolation: :truncation, type: :migration do
   before do
     allow(RakeConfig).to receive(:config).and_return(TestConfig.config_instance)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -137,6 +137,9 @@ each_run_block = proc do
       @uaa_server = FakeUAAServer.new(6789)
       @uaa_server.start
     end
+    rspec_config.before(:all, type: :migration) do
+      skip 'Skipped due to NO_DB_MIGRATION env variable being set' if ENV['NO_DB_MIGRATION']
+    end
     rspec_config.after(:all, type: :integration) do
       WebMock.disable_net_connect!(allow: %w[codeclimate.com fake.bbs])
       @uaa_server.stop

--- a/spec/unit/lib/vcap/sequel_case_insensitive_string_monkeypatch_spec.rb
+++ b/spec/unit/lib/vcap/sequel_case_insensitive_string_monkeypatch_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'vcap/sequel_case_insensitive_string_monkeypatch'
 
-RSpec.describe 'String :name' do
+RSpec.describe 'String :name', type: :migration do
   let(:table_name) { :unique_str_defaults }
   let(:db_config) { DbConfig.new }
 


### PR DESCRIPTION
This Change fixes the exclusions of certain rspecs that trigger schema migrations for the rake task `spec:without_migrate'.
This task is useful when wanting to run the tests agains a predefined db schema e.g. a newer one, to test backwards compatibility.

With this change rspec and rspec_parallel properly include tagged test suites if the NO_DB_MIGRATION environment variable is set to an arbitrary value.