### PR TITLE
Switch to "using" Zeitwerk Rails autoloader

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,9 @@ class Application < Rails::Application
   config.middleware.delete Rack::ETag
   config.middleware.delete Rack::MethodOverride
 
+  config.autoloader = :zeitwerk
+  Rails.autoloaders.main.ignore(Rails.root.join('app/**/*'))
+
   config.generators do |g|
     g.orm             false
     g.stylesheets     false


### PR DESCRIPTION
This is a prerequisite for upgrading the Rails 7. We don't appear to use the Rails autoloader, so none of the module/class names/file paths are conventional, which breaks Zeitwerk. I didn't find an obvious way to turn off the Rails autoloader, so I instead ignored the entire app directory, which appears to work. There may be a better way.

Related: #3438

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)


