### PR TITLE
Upgrade to Rails 7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,10 +51,10 @@ gem 'xxhash'
 gem 'yajl-ruby'
 
 # Rails Components
-gem 'actionpack', '~> 6.1.7'
-gem 'actionview', '~> 6.1.7', '>= 6.1.7.5'
-gem 'activemodel', '~> 6.1.7'
-gem 'railties', '~> 6.1.7', '>= 6.1.7.5'
+gem 'actionpack', '~> 7.0.8'
+gem 'actionview', '~> 7.0.8'
+gem 'activemodel', '~> 7.0.8'
+gem 'railties', '~> 7.0.8'
 
 gem 'azure-storage-blob', git: 'https://github.com/sethboyles/azure-storage-ruby.git', branch: 'x-ms-blob-content-type-fix-1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,27 +49,26 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (6.1.7.6)
-      actionview (= 6.1.7.6)
-      activesupport (= 6.1.7.6)
-      rack (~> 2.0, >= 2.0.9)
+    actionpack (7.0.8)
+      actionview (= 7.0.8)
+      activesupport (= 7.0.8)
+      rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (6.1.7.6)
-      activesupport (= 6.1.7.6)
+    actionview (7.0.8)
+      activesupport (= 7.0.8)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activemodel (6.1.7.6)
-      activesupport (= 6.1.7.6)
-    activesupport (6.1.7.6)
+    activemodel (7.0.8)
+      activesupport (= 7.0.8)
+    activesupport (7.0.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     aliyun-sdk (0.8.0)
@@ -129,8 +128,8 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     declarative (0.0.20)
-    delayed_job (4.1.9)
-      activesupport (>= 3.0, < 6.2)
+    delayed_job (4.1.11)
+      activesupport (>= 3.0, < 8.0)
     diff-lcs (1.5.0)
     docile (1.1.5)
     domain_name (0.5.20190701)
@@ -377,12 +376,13 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (6.1.7.6)
-      actionpack (= 6.1.7.6)
-      activesupport (= 6.1.7.6)
+    railties (7.0.8)
+      actionpack (= 7.0.8)
+      activesupport (= 7.0.8)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
+      zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.1.0)
     rb-fsevent (0.11.2)
@@ -575,9 +575,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionpack (~> 6.1.7)
-  actionview (~> 6.1.7, >= 6.1.7.5)
-  activemodel (~> 6.1.7)
+  actionpack (~> 7.0.8)
+  actionview (~> 7.0.8)
+  activemodel (~> 7.0.8)
   addressable
   allowy (>= 2.1.0)
   azure-storage-blob!
@@ -628,7 +628,7 @@ DEPENDENCIES
   public_suffix
   puma
   rack-test
-  railties (~> 6.1.7, >= 6.1.7.5)
+  railties (~> 7.0.8)
   rake
   redis
   retryable

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,6 @@ class Application < Rails::Application
   config.middleware.delete Rack::ETag
   config.middleware.delete Rack::MethodOverride
 
-  config.autoloader = :zeitwerk
   Rails.autoloaders.main.ignore(Rails.root.join('app/**/*'))
 
   config.generators do |g|

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,9 @@ class Application < Rails::Application
   config.middleware.delete Rack::ETag
   config.middleware.delete Rack::MethodOverride
 
+  config.autoloader = :zeitwerk
+  Rails.autoloaders.main.ignore(Rails.root.join('app/**/*'))
+
   config.generators do |g|
     g.orm             false
     g.stylesheets     false

--- a/spec/unit/lib/delayed_job/delayed_job_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_job_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'delayed_job' do
   describe 'version' do
     it 'is not updated' do
-      expect(Gem.loaded_specs['delayed_job'].version).to eq('4.1.9'), 'revisit monkey patch in lib/delayed_job/quit_trap.rb'
+      expect(Gem.loaded_specs['delayed_job'].version).to eq('4.1.11'), 'revisit monkey patch in lib/delayed_job/quit_trap.rb'
     end
   end
 end


### PR DESCRIPTION
Upgrade to Rails 7.0

- Upgrade guide: ~https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-7-0-to-rails-7-1~ https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-6-1-to-rails-7-0
- Branched off of #3576
- Related: https://github.com/cloudfoundry/cloud_controller_ng/issues/3438
- I don't know the best procedure to validate the Delayed Job exit behavior, so I blindly bumped the version. It might be helpful to have a more explicit test procedure for validating the desired behavior.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)

```
❯ cats
The following feature-flags are disabled!:
diego_docker
hide_marketplace_from_unauthenticated_users
route_sharing
service_instance_sharing
user_org_creation

Would you like them all enabled? (y/N):
Use CONFIG of /Users/gcobb/workspace/capi-env-pool/flower-kangaroo/integration_config.json
Printing sanitized $CONFIG
{
  "api": "api.flower-kangaroo.capi.land",
  "apps_domain": "flower-kangaroo.capi.land",
  "admin_user": "admin",
  "skip_ssl_validation": true,
  "use_http": true,
  "include_apps": true,
  "include_capi_experimental": true,
  "include_detect": true,
  "include_security_groups": true,
  "include_services": true,
  "include_v3": true,
  "include_tasks": true,
  "include_backend_compatibility": false,
  "include_capi_no_bridge": false,
  "include_container_networking": false,
  "include_credhub" : false,
  "include_docker": false,
  "include_internet_dependent": false,
  "include_isolation_segments": false,
  "include_persistent_app": false,
  "include_private_docker_registry": false,
  "include_privileged_container_support": false,
  "include_route_services": false,
  "include_routing": false,
  "include_routing_isolation_segments": false,
  "include_service_discovery": false,
  "include_service_instance_sharing": false,
  "include_ssh": false,
  "include_sso": false,
  "include_zipkin": false
}
Using Ginkgo Version 2.13.2
Running Suite: CATS - /Users/gcobb/go/src/github.com/cloudfoundry/cf-acceptance-tests
=====================================================================================
Random Seed: 1704217744 - will randomize all specs

Will run 235 of 237 specs
Running in parallel across 4 processes
Running CATs with CF CLI version  cf version 8.5.0+73aa161.2022-09-12

------------------------------
[SynchronizedBeforeSuite] PASSED [24.404 seconds]
[SynchronizedBeforeSuite]
/Users/gcobb/go/src/github.com/cloudfoundry/cf-acceptance-tests/cats_suite_test.go:69

  Captured StdOut/StdErr Output >>
  Running CATs with CF CLI version  cf version 8.5.0+73aa161.2022-09-12

  << Captured StdOut/StdErr Output
------------------------------
SSSS•••••S
------------------------------
P [PENDING]
[windows] Getting instance information scaling memory fails when scaled beyond available resources
/Users/gcobb/go/src/github.com/cloudfoundry/cf-acceptance-tests/windows/instance_reporting.go:51
------------------------------
••S•SS•SSS••S•••S•••S•••S•••SSSS•S•••••SSSSS••S•S•SS•SS••S•SS•S•S••S••••S••SSS•••S•S•SSSSSS••S•••••••SSS•S•SSSS••••
------------------------------
P [PENDING]
Context Paths when another app has a route with a context path routes to app with context path
/Users/gcobb/go/src/github.com/cloudfoundry/cf-acceptance-tests/windows/context_paths.go:87
------------------------------
•SS••••S•SS•SS•SSS•SS••S••SSS••S•SSS•S••••S••••SS•••S••SS
------------------------------
• [37.085 seconds]
[apps] Application Lifecycle pushing makes system environment variables available and validates
/Users/gcobb/go/src/github.com/cloudfoundry/cf-acceptance-tests/apps/lifecycle.go:276

  Captured StdOut/StdErr Output >>
  envValues: {0 10.244.0.139 10.255.158.60 61016 10.244.0.139:61016 [{"external":61016,"internal":8080,"external_tls_proxy":61018,"internal_tls_proxy":61001},{"external":61016,"internal":8080,"internal_tls_proxy":61443},{"external":61017,"internal":2222,"external_tls_proxy":61019,"internal_tls_proxy":61002}]}
  << Captured StdOut/StdErr Output
------------------------------
••S•SS•S••S•••SS•••S•S••SSS••SSS•SS••••SS•S••••SS•••

Ran 128 of 237 Specs in 3590.859 seconds
SUCCESS! -- 128 Passed | 0 Failed | 2 Pending | 107 Skipped


Ginkgo ran 1 suite in 59m58.115305708s
Test Suite Passed
```
