### PR TITLE
Fix migrate failures on vms with missing spec folder

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -244,16 +244,24 @@ namespace :db do
   def migrate
     Steno.init(Steno::Config.new(sinks: [Steno::Sink::IO.new($stdout)]))
     db_logger = Steno.logger('cc.db.migrations')
-    require_relative '../../spec/support/bootstrap/db_config'
-    DbConfig.new
+    begin
+      require_relative '../../spec/support/bootstrap/db_config'
+      DbConfig.new
+    rescue LoadError
+      # Only needed when running tests
+    end
     DBMigrator.from_config(RakeConfig.config, db_logger).apply_migrations
   end
 
   def rollback(number_to_rollback)
     Steno.init(Steno::Config.new(sinks: [Steno::Sink::IO.new($stdout)]))
     db_logger = Steno.logger('cc.db.migrations')
-    require_relative '../../spec/support/bootstrap/db_config'
-    DbConfig.new
+    begin
+      require_relative '../../spec/support/bootstrap/db_config'
+      DbConfig.new
+    rescue LoadError
+      # Only needed when running tests
+    end
     DBMigrator.from_config(RakeConfig.config, db_logger).rollback(number_to_rollback)
   end
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
