### PR TITLE
Adopt specs to not insert duplicate annotations

### DIFF
--- a/spec/models/services/service_credential_binding_view_spec.rb
+++ b/spec/models/services/service_credential_binding_view_spec.rb
@@ -29,11 +29,11 @@ module VCAP::CloudController
         describe 'labels_sti_eager_load' do
           it 'eager loads successfully' do
             binding = ServiceBinding.make
-            lb1 = ServiceBindingLabelModel.make(service_binding: binding)
-            lb2 = ServiceBindingLabelModel.make(service_binding: binding)
+            lb1 = ServiceBindingLabelModel.make(service_binding: binding, key_name: 'test1', value: 'bommel')
+            lb2 = ServiceBindingLabelModel.make(service_binding: binding, key_name: 'test2', value: 'bommel')
             key = ServiceKey.make
-            lk1 = ServiceKeyLabelModel.make(service_key: key)
-            lk2 = ServiceKeyLabelModel.make(service_key: key)
+            lk1 = ServiceKeyLabelModel.make(service_key: key, key_name: 'test1', value: 'bommel')
+            lk2 = ServiceKeyLabelModel.make(service_key: key, key_name: 'test2', value: 'bommel')
 
             eager_loaded_service_credential_bindings = nil
             expect do
@@ -54,11 +54,11 @@ module VCAP::CloudController
         describe 'annotations_sti_eager_load' do
           it 'eager loads successfully' do
             binding = ServiceBinding.make
-            lb1 = ServiceBindingAnnotationModel.make(service_binding: binding)
-            lb2 = ServiceBindingAnnotationModel.make(service_binding: binding)
+            lb1 = ServiceBindingAnnotationModel.make(service_binding: binding, key_name: 'test1', value: 'bommel')
+            lb2 = ServiceBindingAnnotationModel.make(service_binding: binding, key_name: 'test2', value: 'bommel')
             key = ServiceKey.make
-            lk1 = ServiceKeyAnnotationModel.make(service_key: key)
-            lk2 = ServiceKeyAnnotationModel.make(service_key: key)
+            lk1 = ServiceKeyAnnotationModel.make(service_key: key, key_name: 'test1', value: 'bommel')
+            lk2 = ServiceKeyAnnotationModel.make(service_key: key, key_name: 'test2', value: 'bommel')
 
             eager_loaded_service_credential_bindings = nil
             expect do

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1659,17 +1659,14 @@ RSpec.describe 'V3 service instances' do
       describe 'updates that do not require broker communication' do
         let!(:service_instance) do
           si = VCAP::CloudController::ManagedServiceInstance.make(
+            guid: 'bommel',
             tags: %w[foo bar],
             space: space
           )
-          si.annotation_ids = [
-            VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value').id,
-            VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy').id
-          ]
-          si.label_ids = [
-            VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value'),
-            VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
-          ]
+          VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+          VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy')
+          VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+          VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
           si
         end
 
@@ -1757,19 +1754,16 @@ RSpec.describe 'V3 service instances' do
         let(:original_maintenance_info) { { version: '1.1.0' } }
         let!(:service_instance) do
           si = VCAP::CloudController::ManagedServiceInstance.make(
+            guid: 'bommel',
             tags: %w[foo bar],
             space: space,
             service_plan: original_service_plan,
             maintenance_info: original_maintenance_info
           )
-          si.annotation_ids = [
-            VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value').id,
-            VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy').id
-          ]
-          si.label_ids = [
-            VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value'),
-            VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
-          ]
+          VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+          VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy')
+          VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+          VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
           si
         end
         let(:guid) { service_instance.guid }
@@ -2566,6 +2560,7 @@ RSpec.describe 'V3 service instances' do
     context 'user-provided service instance' do
       let!(:service_instance) do
         si = VCAP::CloudController::UserProvidedServiceInstance.make(
+          guid: 'bommel',
           space: space,
           name: 'foo',
           credentials: {
@@ -2576,14 +2571,10 @@ RSpec.describe 'V3 service instances' do
           route_service_url: 'https://bar.com',
           tags: %w[accounting mongodb]
         )
-        si.annotation_ids = [
-          VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value').id,
-          VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy').id
-        ]
-        si.label_ids = [
-          VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value'),
-          VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
-        ]
+        VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+        VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy')
+        VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+        VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
         si
       end
 

--- a/spec/unit/actions/annotation_delete_spec.rb
+++ b/spec/unit/actions/annotation_delete_spec.rb
@@ -6,8 +6,9 @@ module VCAP::CloudController
     subject(:annotation_delete) { AnnotationDelete }
 
     describe '#delete' do
-      let!(:annotation) { AppAnnotationModel.make }
-      let!(:annotation2) { AppAnnotationModel.make }
+      let!(:isolation_segment) { IsolationSegmentModel.make }
+      let!(:annotation) { IsolationSegmentAnnotationModel.make(resource_guid: isolation_segment.guid, key_name: 'test1', value: 'bommel') }
+      let!(:annotation2) { IsolationSegmentAnnotationModel.make(resource_guid: isolation_segment.guid, key_name: 'test2', value: 'bommel') }
 
       it 'deletes and cancels the annotation' do
         annotation_delete.delete([annotation, annotation2])

--- a/spec/unit/actions/annotations_update_spec.rb
+++ b/spec/unit/actions/annotations_update_spec.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
 
       context 'when lazily migrating old annotations' do
         let!(:annotation_model) do
-          AppAnnotationModel.create(resource_guid: app.guid, key_name: 'clodefloundry.org/release', value: 'stable2')
+          AppAnnotationModel.make(resource_guid: app.guid, key_name: 'clodefloundry.org/release', value: 'stable2')
         end
       end
 
@@ -47,15 +47,15 @@ module VCAP::CloudController
         end
 
         let!(:old_annotation) do
-          AppAnnotationModel.create(resource_guid: app.guid, key_name: 'release', value: 'unstable')
+          AppAnnotationModel.make(resource_guid: app.guid, key_name: 'release', value: 'unstable')
         end
 
         let!(:annotation_to_be_deleted) do
-          AppAnnotationModel.create(resource_guid: app.guid, key_name: 'please', value: 'delete me')
+          AppAnnotationModel.make(resource_guid: app.guid, key_name: 'please', value: 'delete me')
         end
 
         let!(:prefixed_annotation_to_be_deleted) do
-          AppAnnotationModel.create(resource_guid: app.guid, key_prefix: 'pre.fix', key_name: 'release', value: 'delete me')
+          AppAnnotationModel.make(resource_guid: app.guid, key_prefix: 'pre.fix', key_name: 'release', value: 'delete me')
         end
 
         it 'updates the old annotation' do
@@ -102,8 +102,8 @@ module VCAP::CloudController
         context 'app already has max annotations' do
           context 'annotations added exceeds max annotations' do
             let!(:app_with_annotations) do
-              AppAnnotationModel.create(resource_guid: app.guid, key_name: 'release1', value: 'veryunstable')
-              AppAnnotationModel.create(resource_guid: app.guid, key_name: 'release2', value: 'stillunstable')
+              AppAnnotationModel.make(resource_guid: app.guid, key_name: 'release1', value: 'veryunstable')
+              AppAnnotationModel.make(resource_guid: app.guid, key_name: 'release2', value: 'stillunstable')
             end
 
             let(:annotations) do
@@ -126,10 +126,10 @@ module VCAP::CloudController
 
         context 'annotations exceed max annotations' do
           let!(:app_with_annotations) do
-            AppAnnotationModel.create(resource_guid: app.guid, key_name: 'release', value: 'unstable')
-            AppAnnotationModel.create(resource_guid: app.guid, key_name: 'release1', value: 'veryunstable')
-            AppAnnotationModel.create(resource_guid: app.guid, key_name: 'release2', value: 'stillunstable')
-            AppAnnotationModel.create(resource_guid: app.guid, key_name: 'release3', value: 'help')
+            AppAnnotationModel.make(resource_guid: app.guid, key_name: 'release', value: 'unstable')
+            AppAnnotationModel.make(resource_guid: app.guid, key_name: 'release1', value: 'veryunstable')
+            AppAnnotationModel.make(resource_guid: app.guid, key_name: 'release2', value: 'stillunstable')
+            AppAnnotationModel.make(resource_guid: app.guid, key_name: 'release3', value: 'help')
           end
 
           context 'deleting old annotation' do

--- a/spec/unit/actions/app_delete_spec.rb
+++ b/spec/unit/actions/app_delete_spec.rb
@@ -135,7 +135,7 @@ module VCAP::CloudController
         end
 
         it 'deletes associated labels' do
-          label = AppLabelModel.make(app:)
+          label = AppLabelModel.make(app: app, key_name: 'test', value: 'bommel')
 
           expect do
             app_delete.delete(app_dataset)
@@ -145,7 +145,7 @@ module VCAP::CloudController
         end
 
         it 'deletes associated annotations' do
-          annotation = AppAnnotationModel.make(app:)
+          annotation = AppAnnotationModel.make(app: app, key_name: 'test', value: 'bommel')
 
           expect do
             app_delete.delete(app_dataset)

--- a/spec/unit/actions/buildpack_delete_spec.rb
+++ b/spec/unit/actions/buildpack_delete_spec.rb
@@ -45,8 +45,8 @@ module VCAP::CloudController
       end
 
       context 'when the buildpack has associated metadata' do
-        let!(:label) { BuildpackLabelModel.make(resource_guid: buildpack.guid) }
-        let!(:annotation) { BuildpackAnnotationModel.make(resource_guid: buildpack.guid) }
+        let!(:label) { BuildpackLabelModel.make(resource_guid: buildpack.guid, key_name: 'test', value: 'bommel') }
+        let!(:annotation) { BuildpackAnnotationModel.make(resource_guid: buildpack.guid, key_name: 'test', value: 'bommel') }
 
         it 'deletes associated labels' do
           expect do

--- a/spec/unit/actions/deployment_delete_spec.rb
+++ b/spec/unit/actions/deployment_delete_spec.rb
@@ -17,7 +17,7 @@ module VCAP::CloudController
       end
 
       it 'deletes associated labels' do
-        label = DeploymentLabelModel.make(resource_guid: deployment.guid)
+        label = DeploymentLabelModel.make(resource_guid: deployment.guid, key_name: 'test1', value: 'bommel')
         expect do
           deployment_delete.delete([deployment])
         end.to change(DeploymentLabelModel, :count).by(-1)
@@ -26,7 +26,7 @@ module VCAP::CloudController
       end
 
       it 'deletes associated annotations' do
-        annotation = DeploymentAnnotationModel.make(resource_guid: deployment.guid)
+        annotation = DeploymentAnnotationModel.make(resource_guid: deployment.guid, key_name: 'test1', value: 'bommel')
         expect do
           deployment_delete.delete([deployment])
         end.to change(DeploymentAnnotationModel, :count).by(-1)

--- a/spec/unit/actions/label_delete_spec.rb
+++ b/spec/unit/actions/label_delete_spec.rb
@@ -6,8 +6,9 @@ module VCAP::CloudController
     subject(:label_delete) { LabelDelete }
 
     describe '#delete' do
-      let!(:label) { AppLabelModel.make }
-      let!(:label2) { AppLabelModel.make }
+      let!(:app) { AppModel.make }
+      let!(:label) { AppLabelModel.make(resource_guid: app.guid, key_name: 'test1', value: 'bommel') }
+      let!(:label2) { AppLabelModel.make(resource_guid: app.guid, key_name: 'test2', value: 'bommel') }
 
       it 'deletes and cancels the label' do
         label_delete.delete([label, label2])

--- a/spec/unit/actions/labels_update_spec.rb
+++ b/spec/unit/actions/labels_update_spec.rb
@@ -49,8 +49,8 @@ module VCAP::CloudController
         context 'app already has max labels' do
           context 'labels added exceeds max labels' do
             let!(:app_with_labels) do
-              AppLabelModel.create(resource_guid: app.guid, key_name: 'release1', value: 'veryunstable')
-              AppLabelModel.create(resource_guid: app.guid, key_name: 'release2', value: 'stillunstable')
+              AppLabelModel.make(resource_guid: app.guid, key_name: 'release1', value: 'veryunstable')
+              AppLabelModel.make(resource_guid: app.guid, key_name: 'release2', value: 'stillunstable')
             end
 
             let(:labels) do
@@ -73,10 +73,10 @@ module VCAP::CloudController
 
         context 'labels exceed max labels' do
           let!(:app_with_labels) do
-            AppLabelModel.create(resource_guid: app.guid, key_name: 'release', value: 'unstable')
-            AppLabelModel.create(resource_guid: app.guid, key_name: 'release1', value: 'veryunstable')
-            AppLabelModel.create(resource_guid: app.guid, key_name: 'release2', value: 'stillunstable')
-            AppLabelModel.create(resource_guid: app.guid, key_name: 'release3', value: 'help')
+            AppLabelModel.make(resource_guid: app.guid, key_name: 'release', value: 'unstable')
+            AppLabelModel.make(resource_guid: app.guid, key_name: 'release1', value: 'veryunstable')
+            AppLabelModel.make(resource_guid: app.guid, key_name: 'release2', value: 'stillunstable')
+            AppLabelModel.make(resource_guid: app.guid, key_name: 'release3', value: 'help')
           end
 
           context 'deleting old label' do
@@ -130,10 +130,10 @@ module VCAP::CloudController
         end
 
         let!(:old_label) do
-          AppLabelModel.create(resource_guid: app.guid, key_name: 'release', value: 'unstable')
+          AppLabelModel.make(resource_guid: app.guid, key_name: 'release', value: 'unstable')
         end
         let!(:old_label_with_prefix) do
-          AppLabelModel.create(resource_guid: app.guid, key_prefix: 'joyofcooking.com', key_name: 'potato', value: 'fried')
+          AppLabelModel.make(resource_guid: app.guid, key_prefix: 'joyofcooking.com', key_name: 'potato', value: 'fried')
         end
 
         it 'updates the old label' do
@@ -154,13 +154,13 @@ module VCAP::CloudController
         end
 
         let!(:delete_me_label) do
-          AppLabelModel.create(resource_guid: app.guid, key_name: 'release', value: 'unstable')
+          AppLabelModel.make(resource_guid: app.guid, key_name: 'release', value: 'unstable')
         end
         let!(:prefixed_delete_me_label) do
-          AppLabelModel.create(resource_guid: app.guid, key_prefix: 'pre.fix', key_name: 'release', value: 'unstable')
+          AppLabelModel.make(resource_guid: app.guid, key_prefix: 'pre.fix', key_name: 'release', value: 'unstable')
         end
         let!(:keep_me_label) do
-          AppLabelModel.create(resource_guid: app.guid, key_name: 'potato', value: 'mashed')
+          AppLabelModel.make(resource_guid: app.guid, key_name: 'potato', value: 'mashed')
         end
 
         it 'deletes labels that are nil' do
@@ -217,10 +217,10 @@ module VCAP::CloudController
         end
 
         let!(:old_label) do
-          OrganizationLabelModel.create(resource_guid: org.guid, key_name: 'release', value: 'unstable')
+          OrganizationLabelModel.make(resource_guid: org.guid, key_name: 'release', value: 'unstable')
         end
         let!(:old_label_with_prefix) do
-          OrganizationLabelModel.create(resource_guid: org.guid, key_prefix: 'joyofcooking.com', key_name: 'potato', value: 'fried')
+          OrganizationLabelModel.make(resource_guid: org.guid, key_prefix: 'joyofcooking.com', key_name: 'potato', value: 'fried')
         end
 
         it 'updates the old label' do
@@ -240,10 +240,10 @@ module VCAP::CloudController
         end
 
         let!(:delete_me_label) do
-          OrganizationLabelModel.create(resource_guid: org.guid, key_name: 'release', value: 'unstable')
+          OrganizationLabelModel.make(resource_guid: org.guid, key_name: 'release', value: 'unstable')
         end
         let!(:keep_me_label) do
-          OrganizationLabelModel.create(resource_guid: org.guid, key_name: 'potato', value: 'mashed')
+          OrganizationLabelModel.make(resource_guid: org.guid, key_name: 'potato', value: 'mashed')
         end
 
         it 'deletes labels that are nil' do

--- a/spec/unit/actions/package_delete_spec.rb
+++ b/spec/unit/actions/package_delete_spec.rb
@@ -64,7 +64,7 @@ module VCAP::CloudController
         end
 
         it 'deletes associated labels' do
-          label = PackageLabelModel.make(resource_guid: package.guid)
+          label = PackageLabelModel.make(resource_guid: package.guid, key_name: 'test', value: 'bommel')
           expect do
             package_delete.delete([package])
           end.to change(PackageLabelModel, :count).by(-1)
@@ -73,7 +73,7 @@ module VCAP::CloudController
         end
 
         it 'deletes associated annotations' do
-          annotation = PackageAnnotationModel.make(resource_guid: package.guid)
+          annotation = PackageAnnotationModel.make(resource_guid: package.guid, key_name: 'test', value: 'bommel')
           expect do
             package_delete.delete([package])
           end.to change(PackageAnnotationModel, :count).by(-1)

--- a/spec/unit/actions/process_delete_spec.rb
+++ b/spec/unit/actions/process_delete_spec.rb
@@ -28,7 +28,7 @@ module VCAP::CloudController
         end
 
         it 'deletes associated labels' do
-          label = ProcessLabelModel.make(resource_guid: process.guid)
+          label = ProcessLabelModel.make(resource_guid: process.guid, key_name: 'test1', value: 'bommel')
           expect do
             process_delete.delete([process])
           end.to change(ProcessLabelModel, :count).by(-1)
@@ -37,7 +37,7 @@ module VCAP::CloudController
         end
 
         it 'deletes associated annotations' do
-          annotation = ProcessAnnotationModel.make(resource_guid: process.guid)
+          annotation = ProcessAnnotationModel.make(resource_guid: process.guid, key_name: 'test1', value: 'bommel')
           expect do
             process_delete.delete([process])
           end.to change(ProcessAnnotationModel, :count).by(-1)

--- a/spec/unit/actions/revision_delete_spec.rb
+++ b/spec/unit/actions/revision_delete_spec.rb
@@ -17,7 +17,7 @@ module VCAP::CloudController
       end
 
       it 'deletes associated labels' do
-        label = RevisionLabelModel.make(resource_guid: revision.guid)
+        label = RevisionLabelModel.make(resource_guid: revision.guid, key_name: 'test', value: 'bommel')
         expect do
           revision_delete.delete(revision)
         end.to change(RevisionLabelModel, :count).by(-1)
@@ -26,7 +26,7 @@ module VCAP::CloudController
       end
 
       it 'deletes associated annotations' do
-        annotation = RevisionAnnotationModel.make(resource_guid: revision.guid)
+        annotation = RevisionAnnotationModel.make(resource_guid: revision.guid, key_name: 'test', value: 'bommel')
         expect do
           revision_delete.delete(revision)
         end.to change(RevisionAnnotationModel, :count).by(-1)

--- a/spec/unit/actions/service_instance_update_user_provided_spec.rb
+++ b/spec/unit/actions/service_instance_update_user_provided_spec.rb
@@ -35,6 +35,7 @@ module VCAP::CloudController
       let(:original_name) { 'foo' }
       let!(:service_instance) do
         si = VCAP::CloudController::UserProvidedServiceInstance.make(
+          guid: 'bommel',
           name: original_name,
           credentials: {
             foo: 'bar',
@@ -44,14 +45,10 @@ module VCAP::CloudController
           route_service_url: 'https://bar.com',
           tags: %w[accounting mongodb]
         )
-        si.label_ids = [
-          VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value'),
-          VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
-        ]
-        si.annotation_ids = [
-          VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value').id,
-          VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy').id
-        ]
+        VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+        VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
+        VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+        VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy')
         si.service_instance_operation = VCAP::CloudController::ServiceInstanceOperation.make(type: 'create', state: 'succeeded')
         si
       end

--- a/spec/unit/actions/services/service_instance_delete_spec.rb
+++ b/spec/unit/actions/services/service_instance_delete_spec.rb
@@ -61,7 +61,7 @@ module VCAP::CloudController
       end
 
       it 'deletes associated labels' do
-        labels = service_instance_dataset.map { |si| ServiceInstanceLabelModel.make(resource_guid: si.guid) }
+        labels = service_instance_dataset.map { |si| ServiceInstanceLabelModel.make(resource_guid: si.guid, key_name: 'test', value: 'bommel') }
 
         expect do
           service_instance_delete.delete(service_instance_dataset)
@@ -70,7 +70,7 @@ module VCAP::CloudController
       end
 
       it 'deletes associated annotations' do
-        annotations = service_instance_dataset.map { |si| ServiceInstanceAnnotationModel.make(resource_guid: si.guid) }
+        annotations = service_instance_dataset.map { |si| ServiceInstanceAnnotationModel.make(resource_guid: si.guid, key_name: 'test', value: 'bommel') }
 
         expect do
           service_instance_delete.delete(service_instance_dataset)

--- a/spec/unit/actions/stack_delete_spec.rb
+++ b/spec/unit/actions/stack_delete_spec.rb
@@ -17,7 +17,7 @@ module VCAP::CloudController
         end
 
         it 'deletes associated labels' do
-          label = StackLabelModel.make(resource_guid: stack.guid)
+          label = StackLabelModel.make(resource_guid: stack.guid, key_name: 'test1', value: 'bommel')
           expect do
             stack_delete.delete(stack)
           end.to change(StackLabelModel, :count).by(-1)
@@ -26,7 +26,7 @@ module VCAP::CloudController
         end
 
         it 'deletes associated annotations' do
-          annotation = StackAnnotationModel.make(resource_guid: stack.guid)
+          annotation = StackAnnotationModel.make(resource_guid: stack.guid, key_name: 'test1', value: 'bommel')
           expect do
             stack_delete.delete(stack)
           end.to change(StackAnnotationModel, :count).by(-1)

--- a/spec/unit/actions/task_delete_spec.rb
+++ b/spec/unit/actions/task_delete_spec.rb
@@ -88,8 +88,8 @@ module VCAP::CloudController
       end
 
       it 'deletes associated labels' do
-        label1 = TaskLabelModel.make(task: task1)
-        label2 = TaskLabelModel.make(task: task2)
+        label1 = TaskLabelModel.make(task: task1, key_name: 'test', value: 'bommel')
+        label2 = TaskLabelModel.make(task: task2, key_name: 'test', value: 'bommel')
 
         expect do
           task_delete.delete(task_dataset)
@@ -101,8 +101,8 @@ module VCAP::CloudController
       end
 
       it 'deletes associated annotations' do
-        annotation1 = TaskAnnotationModel.make(task: task1)
-        annotation2 = TaskAnnotationModel.make(task: task2)
+        annotation1 = TaskAnnotationModel.make(task: task1, key_name: 'test', value: 'bommel')
+        annotation2 = TaskAnnotationModel.make(task: task2, key_name: 'test', value: 'bommel')
 
         expect do
           task_delete.delete(task_dataset)

--- a/spec/unit/actions/v3/service_instance_delete_spec.rb
+++ b/spec/unit/actions/v3/service_instance_delete_spec.rb
@@ -82,6 +82,7 @@ module VCAP::CloudController
         context 'user-provided service instances' do
           let!(:service_instance) do
             si = VCAP::CloudController::UserProvidedServiceInstance.make(
+              guid: 'bommel',
               name: 'foo',
               credentials: {
                 foo: 'bar',
@@ -91,14 +92,11 @@ module VCAP::CloudController
               route_service_url: 'https://bar.com',
               tags: %w[accounting mongodb]
             )
-            si.label_ids = [
-              VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value'),
-              VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
-            ]
-            si.annotation_ids = [
-              VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value').id,
-              VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy').id
-            ]
+            VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+            VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
+            VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+            VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy')
+
             si.service_instance_operation = VCAP::CloudController::ServiceInstanceOperation.make(type: 'update', state: 'succeeded')
             si
           end

--- a/spec/unit/actions/v3/service_instance_update_managed_spec.rb
+++ b/spec/unit/actions/v3/service_instance_update_managed_spec.rb
@@ -50,6 +50,7 @@ module VCAP::CloudController
       let(:original_dashboard_url) { 'http://your-og-instance.com' }
       let!(:original_instance) do
         si = VCAP::CloudController::ManagedServiceInstance.make(
+          guid: 'bommel',
           service_plan: original_service_plan,
           name: original_name,
           tags: %w[accounting mongodb],
@@ -57,14 +58,13 @@ module VCAP::CloudController
           maintenance_info: original_maintenance_info,
           dashboard_url: original_dashboard_url
         )
-        si.label_ids = [
-          VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value'),
-          VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
-        ]
-        si.annotation_ids = [
-          VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value').id,
-          VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy').id
-        ]
+
+        VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+        VCAP::CloudController::ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
+
+        VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+        VCAP::CloudController::ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy')
+
         si
       end
       let(:new_arbitrary_parameters) { { foo: 'bar' } }
@@ -1249,14 +1249,6 @@ module VCAP::CloudController
             maintenance_info: original_maintenance_info,
             dashboard_url: original_dashboard_url
           )
-          si.label_ids = [
-            VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value'),
-            VCAP::CloudController::ServiceInstanceLabelModel.make(key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
-          ]
-          si.annotation_ids = [
-            VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value').id,
-            VCAP::CloudController::ServiceInstanceAnnotationModel.make(key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy').id
-          ]
           si.save_with_new_operation(
             {},
             {
@@ -1265,6 +1257,10 @@ module VCAP::CloudController
               broker_provided_operation: operation_id
             }
           )
+          ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+          ServiceInstanceLabelModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'tail', value: 'fluffy')
+          ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'to_delete', value: 'value')
+          ServiceInstanceAnnotationModel.make(service_instance: si, key_prefix: 'pre.fix', key_name: 'fox', value: 'bushy')
           si
         end
 

--- a/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
@@ -176,8 +176,8 @@ module VCAP::CloudController
         let(:filters) { { 'label_selector' => 'dog in (chihuahua,scooby-doo)' } }
 
         before do
-          ServiceBrokerLabelModel.create(service_broker: broker, key_name: 'dog', value: 'scooby-doo')
-          ServiceBrokerLabelModel.create(service_broker: space_scoped_broker_1, key_name: 'dog', value: 'poodle')
+          ServiceBrokerLabelModel.make(service_broker: broker, key_name: 'dog', value: 'scooby-doo')
+          ServiceBrokerLabelModel.make(service_broker: space_scoped_broker_1, key_name: 'dog', value: 'poodle')
         end
 
         it 'includes the relevant brokers' do

--- a/spec/unit/jobs/v3/services/update_broker_job_spec.rb
+++ b/spec/unit/jobs/v3/services/update_broker_job_spec.rb
@@ -19,7 +19,7 @@ module VCAP
           end
 
           let!(:label) do
-            ServiceBrokerLabelModel.create(
+            ServiceBrokerLabelModel.make(
               service_broker: broker,
               key_name: 'potato',
               value: 'yam'
@@ -27,7 +27,7 @@ module VCAP
           end
 
           let!(:annotation) do
-            ServiceBrokerAnnotationModel.create(
+            ServiceBrokerAnnotationModel.make(
               service_broker: broker,
               key_name: 'style',
               value: 'mashed'

--- a/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
@@ -243,7 +243,7 @@ module VCAP::CloudController
           RouteMappingModel.make(app: oldest_web_process_with_instances.app, process_type: oldest_web_process_with_instances.type)
         end
 
-        let!(:oldest_label) { ProcessLabelModel.make(resource_guid: oldest_web_process_with_instances.guid) }
+        let!(:oldest_label) { ProcessLabelModel.make(resource_guid: oldest_web_process_with_instances.guid, key_name: 'test', value: 'bommel') }
 
         it 'destroys the oldest web process and ignores the original web process' do
           expect do

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -1005,14 +1005,14 @@ module VCAP::CloudController
             let(:metric_tag_key_prefix) { 'metric.tag.cloudfoundry.org' }
 
             before do
-              AppLabelModel.create(
+              AppLabelModel.make(
                 app: app_model,
                 key_prefix: metric_tag_key_prefix,
                 key_name: 'DatadogValue',
                 value: 'woof'
               )
 
-              AppLabelModel.create(
+              AppLabelModel.make(
                 app: app_model,
                 key_prefix: 'nonmetric.tag.cloudfoundry.org',
                 key_name: 'SomeotherValue',
@@ -1032,7 +1032,7 @@ module VCAP::CloudController
 
               context 'when app labels tags match existing custom metrics tags' do
                 before do
-                  AppLabelModel.create(
+                  AppLabelModel.make(
                     app: app_model,
                     key_prefix: metric_tag_key_prefix,
                     key_name: 'organization_name',
@@ -1047,28 +1047,28 @@ module VCAP::CloudController
 
               context 'when app labels contain forbidden key_names' do
                 before do
-                  AppLabelModel.create(
+                  AppLabelModel.make(
                     app: app_model,
                     key_prefix: metric_tag_key_prefix,
                     key_name: 'deployment',
                     value: 'kafka'
                   )
 
-                  AppLabelModel.create(
+                  AppLabelModel.make(
                     app: app_model,
                     key_prefix: metric_tag_key_prefix,
                     key_name: 'index',
                     value: '999'
                   )
 
-                  AppLabelModel.create(
+                  AppLabelModel.make(
                     app: app_model,
                     key_prefix: metric_tag_key_prefix,
                     key_name: 'ip',
                     value: '127.0.0.1'
                   )
 
-                  AppLabelModel.create(
+                  AppLabelModel.make(
                     app: app_model,
                     key_prefix: metric_tag_key_prefix,
                     key_name: 'job',

--- a/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
+++ b/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
@@ -204,16 +204,6 @@ module VCAP::CloudController
           expect(paginated_result.total).to be > 1
         end
       end
-
-      it 'returns correct total results for distinct result' do
-        options = { page: page, per_page: per_page, order_by: :key_name }
-        pagination_options = PaginationOptions.new(options)
-        2.times { SpaceLabelModel.create(key_name: 'testLabel') }
-        dataset = SpaceLabelModel.dataset.distinct(:key_name)
-        paginated_result = paginator.get_page(dataset, pagination_options)
-
-        expect(paginated_result.total).to eq(1)
-      end
     end
   end
 end

--- a/spec/unit/models/runtime/app_annotation_model_spec.rb
+++ b/spec/unit/models/runtime/app_annotation_model_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     it 'can be created' do
       app = AppModel.make(name: 'dora')
-      AppAnnotationModel.create(resource_guid: app.guid, key_prefix: 'something', key_name: 'release', value: 'stable')
+      AppAnnotationModel.make(resource_guid: app.guid, key_prefix: 'something', key_name: 'release', value: 'stable')
       expect(AppAnnotationModel.find(key_prefix: 'something', key_name: 'release').value).to eq 'stable'
     end
   end

--- a/spec/unit/models/runtime/app_label_model_spec.rb
+++ b/spec/unit/models/runtime/app_label_model_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     it 'can be created' do
       app = AppModel.make(name: 'dora')
-      AppLabelModel.create(resource_guid: app.guid, key_name: 'release', value: 'stable')
+      AppLabelModel.make(resource_guid: app.guid, key_name: 'release', value: 'stable')
       expect(AppLabelModel.find(key_name: 'release').value).to eq 'stable'
     end
   end

--- a/spec/unit/models/runtime/droplet_annotation_model_spec.rb
+++ b/spec/unit/models/runtime/droplet_annotation_model_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     it 'can be created' do
       droplet = DropletModel.make
-      DropletAnnotationModel.create(resource_guid: droplet.guid, key_prefix: 'coolapp', key_name: 'release', value: 'stable')
+      DropletAnnotationModel.make(resource_guid: droplet.guid, key_prefix: 'coolapp', key_name: 'release', value: 'stable')
       expect(DropletAnnotationModel.find(key_prefix: 'coolapp', key_name: 'release').value).to eq 'stable'
     end
   end

--- a/spec/unit/models/runtime/droplet_label_model_spec.rb
+++ b/spec/unit/models/runtime/droplet_label_model_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     it 'can be created' do
       droplet = DropletModel.make
-      DropletLabelModel.create(resource_guid: droplet.guid, key_name: 'release', value: 'stable')
+      DropletLabelModel.make(resource_guid: droplet.guid, key_name: 'release', value: 'stable')
       expect(DropletLabelModel.find(key_name: 'release').value).to eq 'stable'
     end
   end

--- a/spec/unit/models/runtime/organization_annotation_model_spec.rb
+++ b/spec/unit/models/runtime/organization_annotation_model_spec.rb
@@ -6,8 +6,8 @@ module VCAP::CloudController
 
     it 'can be created' do
       org = Organization.make(name: 'zrob-org')
-      OrganizationAnnotationModel.create(resource_guid: org.guid, key_prefix: 'us', key_name: 'state', value: 'Ohio')
-      expect(OrganizationAnnotationModel.find(key_prefix: 'us', key_name: 'state').value).to eq 'Ohio'
+      OrganizationAnnotationModel.make(resource_guid: org.guid, key_prefix: 'us', key_name: 'state', value: 'Ohio')
+      expect(OrganizationAnnotationModel.find(resource_guid: org.guid, key_prefix: 'us', key_name: 'state').value).to eq 'Ohio'
     end
   end
 end

--- a/spec/unit/models/runtime/organization_label_model_spec.rb
+++ b/spec/unit/models/runtime/organization_label_model_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     it 'can be created' do
       org = Organization.make(name: 'dora_org')
-      OrganizationLabelModel.create(resource_guid: org.guid, key_name: 'release', value: 'stable')
+      OrganizationLabelModel.make(resource_guid: org.guid, key_name: 'release', value: 'stable')
       expect(OrganizationLabelModel.find(key_name: 'release').value).to eq 'stable'
     end
   end

--- a/spec/unit/models/runtime/package_model_spec.rb
+++ b/spec/unit/models/runtime/package_model_spec.rb
@@ -117,8 +117,8 @@ module VCAP::CloudController
 
     describe 'metadata' do
       let(:package) { PackageModel.make }
-      let(:annotation) { PackageAnnotationModel.make(package:) }
-      let(:label) { PackageLabelModel.make(package:) }
+      let(:annotation) { PackageAnnotationModel.make(package: package, key_name: 'test1', value: 'bommel') }
+      let(:label) { PackageLabelModel.make(package: package, key_name: 'test1', value: 'bommel') }
 
       it 'can access its metadata' do
         expect(annotation.package.guid).to eq(package.guid)

--- a/spec/unit/models/runtime/space_label_model_spec.rb
+++ b/spec/unit/models/runtime/space_label_model_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     it 'can be created' do
       space = Space.make(name: 'dora_space')
-      SpaceLabelModel.create(resource_guid: space.guid, key_name: 'release', value: 'stable')
+      SpaceLabelModel.make(resource_guid: space.guid, key_name: 'release', value: 'stable')
       expect(SpaceLabelModel.find(key_name: 'release').value).to eq 'stable'
     end
   end

--- a/spec/unit/models/runtime/user_annotation_model_spec.rb
+++ b/spec/unit/models/runtime/user_annotation_model_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     it 'can be created' do
       user = User.make(guid: 'dora')
-      UserAnnotationModel.create(resource_guid: user.guid, key_prefix: 'something', key_name: 'release', value: 'stable')
+      UserAnnotationModel.make(resource_guid: user.guid, key_prefix: 'something', key_name: 'release', value: 'stable')
       expect(UserAnnotationModel.find(key_prefix: 'something', key_name: 'release').value).to eq 'stable'
     end
   end

--- a/spec/unit/models/runtime/user_label_model_spec.rb
+++ b/spec/unit/models/runtime/user_label_model_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
 
     it 'can be created' do
       user = User.make(guid: 'dora')
-      UserLabelModel.create(resource_guid: user.guid, key_name: 'release', value: 'stable')
+      UserLabelModel.make(resource_guid: user.guid, key_name: 'release', value: 'stable')
       expect(UserLabelModel.find(key_name: 'release').value).to eq 'stable'
     end
   end

--- a/spec/unit/models/services/service_instance_spec.rb
+++ b/spec/unit/models/services/service_instance_spec.rb
@@ -543,8 +543,8 @@ module VCAP::CloudController
 
     describe 'metadata' do
       let(:service_instance) { ServiceInstance.make }
-      let(:annotation) { ServiceInstanceAnnotationModel.make(service_instance:) }
-      let(:label) { ServiceInstanceLabelModel.make(service_instance:) }
+      let(:annotation) { ServiceInstanceAnnotationModel.make(service_instance: service_instance, key_name: 'test', value: 'bommel') }
+      let(:label) { ServiceInstanceLabelModel.make(service_instance: service_instance, key_name: 'test', value: 'bommel') }
 
       it 'can access a service_instance from its metadata' do
         expect(annotation.resource_guid).to eq(service_instance.guid)


### PR DESCRIPTION
Preparation for #3394 to remove the use of inserting duplicate annotations into the DB as part of the rspec tets


Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
