### PR TITLE
Introduce config option to disable statsd metrics

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -354,7 +354,7 @@ staging:
 
 statsd_host: "127.0.0.1"
 statsd_port: 8125
-disable_statsd_metrics: false
+enable_statsd_metrics: true
 
 perform_blob_cleanup: false
 

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -354,6 +354,7 @@ staging:
 
 statsd_host: "127.0.0.1"
 statsd_port: 8125
+disable_statsd_metrics: false
 
 perform_blob_cleanup: false
 

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -322,7 +322,7 @@ module VCAP::CloudController
 
             statsd_host: String,
             statsd_port: Integer,
-            optional(:disable_statsd_metrics) => bool,
+            optional(:enable_statsd_metrics) => bool,
             system_hostnames: [String],
             default_app_ssh_access: bool,
 

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -322,6 +322,7 @@ module VCAP::CloudController
 
             statsd_host: String,
             statsd_port: Integer,
+            optional(:disable_statsd_metrics) => bool,
             system_hostnames: [String],
             default_app_ssh_access: bool,
 

--- a/lib/cloud_controller/config_schemas/base/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/clock_schema.rb
@@ -177,7 +177,7 @@ module VCAP::CloudController
 
             statsd_host: String,
             statsd_port: Integer,
-            optional(:disable_statsd_metrics) => bool,
+            optional(:enable_statsd_metrics) => bool,
 
             max_labels_per_resource: Integer,
             max_annotations_per_resource: Integer,

--- a/lib/cloud_controller/config_schemas/base/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/clock_schema.rb
@@ -177,6 +177,7 @@ module VCAP::CloudController
 
             statsd_host: String,
             statsd_port: Integer,
+            optional(:disable_statsd_metrics) => bool,
 
             max_labels_per_resource: Integer,
             max_annotations_per_resource: Integer,

--- a/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
@@ -130,6 +130,7 @@ module VCAP::CloudController
 
             statsd_host: String,
             statsd_port: Integer,
+            optional(:disable_statsd_metrics) => bool,
 
             max_labels_per_resource: Integer,
             max_annotations_per_resource: Integer,

--- a/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
@@ -130,7 +130,7 @@ module VCAP::CloudController
 
             statsd_host: String,
             statsd_port: Integer,
-            optional(:disable_statsd_metrics) => bool,
+            optional(:enable_statsd_metrics) => bool,
 
             max_labels_per_resource: Integer,
             max_annotations_per_resource: Integer,

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -349,14 +349,11 @@ module CloudController
     def statsd_client
       if @dependencies[:statsd_client]
         @dependencies[:statsd_client]
+      elsif config.get(:enable_statsd_metrics) == true || config.get(:enable_statsd_metrics).nil?
+        Statsd.logger = Steno.logger('statsd.client')
+        register(:statsd_client, Statsd.new(config.get(:statsd_host), config.get(:statsd_port)))
       else
-        config = CloudController::DependencyLocator.instance.config
-        if config.get(:enable_statsd_metrics) == true
-          Statsd.logger = Steno.logger('statsd.client')
-          register(:statsd_client, Statsd.new(config.get(:statsd_host), config.get(:statsd_port)))
-        else
-          register(:statsd_client, NullStatsdClient.new)
-        end
+        register(:statsd_client, NullStatsdClient.new)
       end
     end
 

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -351,7 +351,7 @@ module CloudController
         @dependencies[:statsd_client]
       else
         config = CloudController::DependencyLocator.instance.config
-        if config.get(:disable_statsd_metrics) == false
+        if config.get(:enable_statsd_metrics) == true
           Statsd.logger = Steno.logger('statsd.client')
           register(:statsd_client, Statsd.new(config.get(:statsd_host), config.get(:statsd_port)))
         else

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -350,8 +350,13 @@ module CloudController
       if @dependencies[:statsd_client]
         @dependencies[:statsd_client]
       else
-        Statsd.logger = Steno.logger('statsd.client')
-        register(:statsd_client, Statsd.new(config.get(:statsd_host), config.get(:statsd_port)))
+        config = CloudController::DependencyLocator.instance.config
+        if config.get(:disable_statsd_metrics) == false
+          Statsd.logger = Steno.logger('statsd.client')
+          register(:statsd_client, Statsd.new(config.get(:statsd_host), config.get(:statsd_port)))
+        else
+          register(:statsd_client, NullStatsdClient.new)
+        end
       end
     end
 
@@ -439,6 +444,24 @@ module CloudController
                                                                                collection_transformer:,
                                                                                max_total_results:
                                                                              })
+    end
+  end
+
+  class NullStatsdClient
+    def timing(_key, _value)
+      # Null implementation
+    end
+
+    def increment(_key)
+      # Null implementation
+    end
+
+    def gauge(_stat, _value, _sample_rate=1)
+      # Null implementation
+    end
+
+    def batch
+      # Null implementation
     end
   end
 end

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -206,7 +206,7 @@ droplets:
 
 statsd_host: "127.0.0.1"
 statsd_port: 8125
-disable_statsd_metrics: false
+enable_statsd_metrics: true
 
 perform_blob_cleanup: false
 

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -206,6 +206,7 @@ droplets:
 
 statsd_host: "127.0.0.1"
 statsd_port: 8125
+disable_statsd_metrics: false
 
 perform_blob_cleanup: false
 

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -502,6 +502,23 @@ RSpec.describe CloudController::DependencyLocator do
 
       expect(locator.statsd_client).to eq(expected_client)
     end
+
+    it 'returns the statsd client for other than api vms' do
+      host = 'test-host'
+      port = 1234
+      TestConfig.context = :deployment_updater
+      TestConfig.override(
+        statsd_host: host,
+        statsd_port: port
+      )
+
+      expected_client = double(Statsd)
+
+      allow(Statsd).to receive(:new).with(host, port).
+        and_return(expected_client)
+
+      expect(locator.statsd_client).to eq(expected_client)
+    end
   end
 
   describe '#bbs_stager_client' do

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe CloudController::DependencyLocator do
       TestConfig.override(
         statsd_host: host,
         statsd_port: port,
-        disable_statsd_metrics: true
+        enable_statsd_metrics: false
       )
 
       expected_client = double(CloudController::NullStatsdClient)

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -484,6 +484,24 @@ RSpec.describe CloudController::DependencyLocator do
 
       expect(locator.statsd_client).to eq(expected_client)
     end
+
+    it 'returns the null statsd client' do
+      host = 'test-host'
+      port = 1234
+
+      TestConfig.override(
+        statsd_host: host,
+        statsd_port: port,
+        disable_statsd_metrics: true
+      )
+
+      expected_client = double(CloudController::NullStatsdClient)
+
+      allow(CloudController::NullStatsdClient).to receive(:new).
+        and_return(expected_client)
+
+      expect(locator.statsd_client).to eq(expected_client)
+    end
   end
 
   describe '#bbs_stager_client' do

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -485,13 +485,8 @@ RSpec.describe CloudController::DependencyLocator do
       expect(locator.statsd_client).to eq(expected_client)
     end
 
-    it 'returns the null statsd client' do
-      host = 'test-host'
-      port = 1234
-
+    it 'returns the null statsd client if enable_statsd_metrics is set to false' do
       TestConfig.override(
-        statsd_host: host,
-        statsd_port: port,
         enable_statsd_metrics: false
       )
 
@@ -509,7 +504,8 @@ RSpec.describe CloudController::DependencyLocator do
       TestConfig.context = :deployment_updater
       TestConfig.override(
         statsd_host: host,
-        statsd_port: port
+        statsd_port: port,
+        enable_statsd_metrics: nil
       )
 
       expected_client = double(Statsd)


### PR DESCRIPTION
This config option allows to send metrics only via prometheus on api vms. The default is true (i.e. enabled). In the default case, metrics are sent via statsd and prometheus.

* Links to any other associated PRs
#3526, #3528, #3521

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
