### PR TITLE
Fix the annotation migration for mysql

### DIFF
--- a/db/migrations/20240102150000_add_annotation_label_uniqueness.rb
+++ b/db/migrations/20240102150000_add_annotation_label_uniqueness.rb
@@ -65,8 +65,10 @@ Sequel.migration do
           run "LOCK TABLES #{table} WRITE, #{table}_temp WRITE;" if database_type == :mysql && db_supports_table_locks
         rescue Sequel::DatabaseError
           db_supports_table_locks = false
+          # rubocop:disable Layout/LineLength, Rails/Output
           p("Cannot guarantee consistent migration for table #{table} as your used user lacks the \"LOCK TABLE\" Permission or the database does not support locking tables (e.g. percona xtradb cluster).")
           p("Continuing to do the migration for table #{table}, there is a small chance of a migration failure due to lack of above feature but eventually reruns of this migration should succeed.")
+          # rubocop:enable Layout/LineLength, Rails/Output
         end
 
         # Updating the temporary column with truncated keys(should never chop of anything since the api just allows 63 chars)


### PR DESCRIPTION
Slack Conversation: https://cloudfoundry.slack.com/archives/C07C04W4Q/p1704495655161239

Some mysql like DBs apearently do not support locking tables. An example for this is Percona xtraDB Cluster. With this change we optimistically try to run this migration consitently if we can. If not we try it anyway best effort.

The migration removes possible duplcates and then sets a unique constraint to prevent new duplicates. For this whole process to work consistently we need table locks to prevent inserts of new duplicates while the deduplication runs. Otherwise the creation of the unique
  constraint may fail.

In case the table lock feature is not supported or the mysql db user is lacking permissions we deduplicate anyway and in case a error to set the unique constraint occurs we fail and rely on retry mechanism of db migrations to eventually succede the migration when the next run is not triggering the race condition described above that causes the migration to fail.

For Databases that support table locking this race condition cannot happen at all since writes to the table in question are prevented.
