### PR TITLE
Improve deletion of apps

### DIFF
--- a/app/actions/app_delete.rb
+++ b/app/actions/app_delete.rb
@@ -69,12 +69,12 @@ module VCAP::CloudController
 
     def delete_subresources(app)
       PackageDelete.new(@user_audit_info).delete(app.packages)
-      TaskDelete.new(@user_audit_info).delete(app.tasks)
-      BuildDelete.new(StagingCancel.new(stagers)).delete(app.builds)
+      TaskDelete.new(@user_audit_info).delete_for_app(app.guid)
+      BuildDelete.new(StagingCancel.new(stagers)).delete_for_app(app.guid)
       DropletDelete.new(@user_audit_info).delete(app.droplets)
-      DeploymentDelete.delete(app.deployments)
-      RevisionDelete.delete(app.revisions)
-      SidecarDelete.delete(app.sidecars)
+      DeploymentDelete.delete_for_app(app.guid)
+      RevisionDelete.delete_for_app(app.guid)
+      SidecarDelete.delete_for_app(app.guid)
       RouteMappingDelete.new(@user_audit_info).delete(route_mappings_to_delete(app))
       ProcessDelete.new(@user_audit_info).delete(app.processes)
 

--- a/app/actions/build_delete.rb
+++ b/app/actions/build_delete.rb
@@ -4,12 +4,11 @@ module VCAP::CloudController
       @cancel_action = cancel_action
     end
 
-    def delete(builds)
-      builds = Array(builds)
+    def delete_for_app(guid)
+      builds_in_staging_state = BuildModel.where(app_guid: guid, state: BuildModel::STAGING_STATE).all
+      @cancel_action.cancel(builds_in_staging_state)
 
-      @cancel_action.cancel(builds)
-
-      builds.each(&:destroy)
+      BuildModel.where(app_guid: guid).delete
     end
   end
 end

--- a/app/actions/deployment_delete.rb
+++ b/app/actions/deployment_delete.rb
@@ -2,10 +2,11 @@ module VCAP::CloudController
   class DeploymentDelete
     class << self
       def delete(deployments)
-        deployments.each do |deployment|
-          deployment.historical_related_processes.map(&:destroy)
-          deployment.destroy
-        end
+        deployments.delete
+      end
+
+      def delete_for_app(guid)
+        DeploymentModel.where(app_guid: guid).delete
       end
     end
   end

--- a/app/actions/revision_delete.rb
+++ b/app/actions/revision_delete.rb
@@ -2,14 +2,11 @@ module VCAP::CloudController
   class RevisionDelete
     class << self
       def delete(revisions)
-        Array(revisions).each do |revision|
-          delete_process_commands(revision)
-          revision.destroy
-        end
+        revisions.delete
       end
 
-      def delete_process_commands(revision)
-        revision.process_commands.each(&:destroy)
+      def delete_for_app(guid)
+        RevisionModel.where(app_guid: guid).delete
       end
     end
   end

--- a/app/actions/sidecar_delete.rb
+++ b/app/actions/sidecar_delete.rb
@@ -2,13 +2,11 @@ module VCAP::CloudController
   class SidecarDelete
     class << self
       def delete(sidecars)
-        Array(sidecars).each do |sidecar|
-          sidecar.db.transaction do
-            sidecar.lock!
-            sidecar.sidecar_process_types.each(&:destroy)
-            sidecar.destroy
-          end
-        end
+        sidecars.delete
+      end
+
+      def delete_for_app(guid)
+        SidecarModel.where(app_guid: guid).delete
       end
     end
   end

--- a/app/actions/task_delete.rb
+++ b/app/actions/task_delete.rb
@@ -4,11 +4,13 @@ module VCAP::CloudController
       @user_audit_info = user_audit_info
     end
 
-    def delete(tasks)
-      tasks.each do |task|
-        task.destroy
+    def delete_for_app(guid)
+      TaskModel.where(app_guid: guid).exclude(state: TaskModel::TERMINAL_STATES).each do |task|
         cancel_running_task(task)
+        task.destroy # needs to be done individually due to the 'after_destroy' hook
       end
+
+      TaskModel.where(app_guid: guid).delete
     end
 
     private

--- a/app/jobs/runtime/prune_completed_deployments.rb
+++ b/app/jobs/runtime/prune_completed_deployments.rb
@@ -28,9 +28,8 @@ module VCAP::CloudController
                                     exclude(state: [DeploymentModel::DEPLOYING_STATE, DeploymentModel::CANCELING_STATE]).
                                     exclude(id: deployments_to_keep)
 
-            DeploymentDelete.delete(deployments_to_delete)
-
-            logger.info("Cleaned up #{deployments_to_delete.count} DeploymentModel rows for app #{app_guid}")
+            delete_count = DeploymentDelete.delete(deployments_to_delete)
+            logger.info("Cleaned up #{delete_count} DeploymentModel rows for app #{app_guid}")
           end
         end
 

--- a/app/jobs/runtime/prune_excess_app_revisions.rb
+++ b/app/jobs/runtime/prune_excess_app_revisions.rb
@@ -19,8 +19,11 @@ module VCAP::CloudController
             revisions_to_keep = revision_dataset.order(Sequel.desc(:created_at)).
                                 limit(max_retained_revisions_per_app).
                                 select(:id)
-            delete_count = RevisionDelete.delete(revision_dataset.exclude(id: revisions_to_keep))
-            logger.info("Cleaned up #{delete_count.length} revision rows for app #{app_guid}")
+
+            revisions_to_delete = revision_dataset.exclude(id: revisions_to_keep)
+
+            delete_count = RevisionDelete.delete(revisions_to_delete)
+            logger.info("Cleaned up #{delete_count} revision rows for app #{app_guid}")
           end
         end
 

--- a/app/models/runtime/deployment_model.rb
+++ b/app/models/runtime/deployment_model.rb
@@ -57,6 +57,7 @@ module VCAP::CloudController
     one_to_many :labels, class: 'VCAP::CloudController::DeploymentLabelModel', key: :resource_guid, primary_key: :guid
     one_to_many :annotations, class: 'VCAP::CloudController::DeploymentAnnotationModel', key: :resource_guid, primary_key: :guid
 
+    add_association_dependencies historical_related_processes: :destroy
     add_association_dependencies labels: :destroy
     add_association_dependencies annotations: :destroy
 

--- a/db/helpers/add_delete_cascade_to_foreign_key.rb
+++ b/db/helpers/add_delete_cascade_to_foreign_key.rb
@@ -1,0 +1,26 @@
+ForeignKey = Struct.new(:table, :name, :column, :referenced_table, :referenced_column, :new_constraint) do
+  def initialize(table, name, column, referenced_table, referenced_column, new_constraint: false)
+    super(table, name, column, referenced_table, referenced_column, new_constraint)
+  end
+end
+
+def foreign_key_exists?(db, table, name)
+  db.foreign_key_list(table).detect { |fk| fk[:name] == name }.present?
+end
+
+def recreate_foreign_key_with_delete_cascade(db, fkey)
+  # Remove orphaned entries.
+  db[fkey.table].exclude(fkey.column => db[fkey.referenced_table].select(fkey.referenced_column)).delete if fkey.new_constraint
+
+  alter_table fkey.table do
+    drop_constraint fkey.name, type: :foreign_key if foreign_key_exists?(db, fkey.table, fkey.name)
+    add_foreign_key [fkey.column], fkey.referenced_table, key: fkey.referenced_column, name: fkey.name, on_delete: :cascade
+  end
+end
+
+def recreate_foreign_key_without_delete_cascade(db, fkey)
+  alter_table fkey.table do
+    drop_constraint fkey.name, type: :foreign_key if foreign_key_exists?(db, fkey.table, fkey.name)
+    add_foreign_key [fkey.column], fkey.referenced_table, key: fkey.referenced_column, name: fkey.name unless fkey.new_constraint
+  end
+end

--- a/db/migrations/20240115163000_add_delete_cascade_to_foreign_keys.rb
+++ b/db/migrations/20240115163000_add_delete_cascade_to_foreign_keys.rb
@@ -1,0 +1,40 @@
+require File.expand_path('../helpers/add_delete_cascade_to_foreign_key', __dir__)
+
+Sequel.migration do
+  foreign_keys = [
+    ForeignKey.new(:deployment_processes, :fk_deployment_processes_deployment_guid, :deployment_guid, :deployments, :guid),
+    ForeignKey.new(:deployment_labels, :fk_deployment_labels_resource_guid, :resource_guid, :deployments, :guid),
+    ForeignKey.new(:deployment_annotations, :fk_deployment_annotations_resource_guid, :resource_guid, :deployments, :guid),
+    ForeignKey.new(:build_labels, :fk_build_labels_resource_guid, :resource_guid, :builds, :guid),
+    ForeignKey.new(:build_annotations, :fk_build_annotations_resource_guid, :resource_guid, :builds, :guid),
+    ForeignKey.new(:kpack_lifecycle_data, :fk_kpack_lifecycle_build_guid, :build_guid, :builds, :guid),
+    ForeignKey.new(:buildpack_lifecycle_data, :fk_buildpack_lifecycle_build_guid, :build_guid, :builds, :guid, new_constraint: true),
+    ForeignKey.new(:buildpack_lifecycle_buildpacks, :fk_blbuildpack_bldata_guid, :buildpack_lifecycle_data_guid, :buildpack_lifecycle_data, :guid),
+    ForeignKey.new(:task_labels, :fk_task_labels_resource_guid, :resource_guid, :tasks, :guid),
+    ForeignKey.new(:task_annotations, :fk_task_annotations_resource_guid, :resource_guid, :tasks, :guid),
+    ForeignKey.new(:revision_labels, :fk_revision_labels_resource_guid, :resource_guid, :revisions, :guid),
+    ForeignKey.new(:revision_annotations, :fk_revision_annotations_resource_guid, :resource_guid, :revisions, :guid),
+    ForeignKey.new(:revision_process_commands, :rev_commands_revision_guid_fkey, :revision_guid, :revisions, :guid),
+    ForeignKey.new(:revision_sidecars, :fk_sidecar_revision_guid, :revision_guid, :revisions, :guid),
+    ForeignKey.new(:revision_sidecar_process_types, :fk_revision_sidecar_proc_type_sidecar_guid, :revision_sidecar_guid, :revision_sidecars, :guid),
+    ForeignKey.new(:sidecar_process_types, :fk_sidecar_proc_type_sidecar_guid, :sidecar_guid, :sidecars, :guid)
+  ]
+
+  no_transaction
+
+  up do
+    db = self
+
+    foreign_keys.each do |fk|
+      transaction { recreate_foreign_key_with_delete_cascade(db, fk) }
+    end
+  end
+
+  down do
+    db = self
+
+    foreign_keys.each do |fk|
+      transaction { recreate_foreign_key_without_delete_cascade(db, fk) }
+    end
+  end
+end

--- a/lib/cloud_controller/deployments/deployment_target_state.rb
+++ b/lib/cloud_controller/deployments/deployment_target_state.rb
@@ -48,7 +48,7 @@ module VCAP::CloudController
     private
 
     def apply_sidecars(app, revision_sidecars)
-      SidecarDelete.delete(app.sidecars)
+      SidecarDelete.delete_for_app(app.guid)
       revision_sidecars.each { |rs| rehydrate(rs) }
     end
 

--- a/spec/migrations/20240115163000_add_delete_cascade_to_foreign_keys_spec.rb
+++ b/spec/migrations/20240115163000_add_delete_cascade_to_foreign_keys_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to add delete cascade to foreign keys', isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20240115163000_add_delete_cascade_to_foreign_keys.rb' }
+  end
+
+  describe 'buildpack_lifecycle_data table' do
+    after do
+      db[:buildpack_lifecycle_data].delete
+      db[:builds].delete
+    end
+
+    context 'before adding the foreign key' do
+      it 'allows inserts with a build_guid that does not exist' do
+        expect { db[:buildpack_lifecycle_data].insert(guid: 'bld_guid', build_guid: 'not_exists') }.not_to raise_error
+      end
+    end
+
+    context 'after adding the foreign key' do
+      it 'prevents inserts with a build_guid that does not exist' do
+        Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true)
+
+        expect { db[:buildpack_lifecycle_data].insert(guid: 'bld_guid', build_guid: 'not_exists') }.to raise_error(Sequel::ForeignKeyConstraintViolation)
+      end
+
+      it 'deleted orphaned buildpack_lifecycle_data entries but kept valid ones' do
+        db[:builds].insert(guid: 'build_guid')
+        db[:buildpack_lifecycle_data].insert(guid: 'bld_guid', build_guid: 'build_guid')
+        db[:buildpack_lifecycle_data].insert(guid: 'another_bld_guid', build_guid: 'not_exists')
+
+        Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true)
+
+        expect(db[:buildpack_lifecycle_data].where(guid: 'bld_guid').count).to eq(1)
+        expect(db[:buildpack_lifecycle_data].where(guid: 'another_bld_guid').count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/migrations/Readme.md
+++ b/spec/migrations/Readme.md
@@ -44,7 +44,7 @@ To create resilient and reliable migrations, follow these guidelines:
        ...
      ].freeze
 
-     no_transactions # IMPORTANT: DISABLE AUTOMATIC TRANSACTION MANAGEMENT BY UP/DOWN/CHANGE BLOCKS.
+     no_transaction # IMPORTANT: DISABLE AUTOMATIC TRANSACTION MANAGEMENT BY UP/DOWN/CHANGE BLOCKS.
 
      up do
        annotation_tables.each do |table|

--- a/spec/migrations/helpers/migration_shared_context.rb
+++ b/spec/migrations/helpers/migration_shared_context.rb
@@ -1,31 +1,39 @@
+def mktmpsubdir(tmpdir, name)
+  dir = File.join(tmpdir, name)
+  Dir.mkdir(dir)
+  dir
+end
+
 RSpec.shared_context 'migration' do
-  let(:all_migrations) { Dir.mktmpdir }
-  let(:down_migrations) { Dir.mktmpdir }
-  let(:migration_to_test) { Dir.mktmpdir }
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:down_migrations) { mktmpsubdir(tmpdir, 'down_migrations') }
+  let(:migration_to_test) { mktmpsubdir(tmpdir, 'migration_to_test') }
   let(:db) { Sequel::Model.db }
 
   before do
     Sequel.extension :migration
+
     # Find all migrations
-    migration_files = Dir.glob(sprintf('%s/*.rb', DBMigrator::SEQUEL_MIGRATIONS))
+    all_migration_files = Dir.glob(sprintf('%s/*.rb', DBMigrator::SEQUEL_MIGRATIONS))
     # Calculate the index of our migration file we`d like to test
-    migration_index = migration_files.find_index { |file| file.end_with?(migration_filename) }
+    migration_index = all_migration_files.find_index { |file| file.end_with?(migration_filename) }
     # Make a file list of the migration file we like to test plus all migrations after the one we want to test
-    migration_files_after_test = migration_files[migration_index...]
+    migration_files_after_test = all_migration_files[migration_index...]
+
     # Copy them to a temp directory
-    FileUtils.cp(migration_files, all_migrations)
     FileUtils.cp(migration_files_after_test, down_migrations)
     FileUtils.cp(File.join(DBMigrator::SEQUEL_MIGRATIONS, migration_filename), migration_to_test)
+
+    # Copy migration helper files to temp directory
+    FileUtils.cp_r(File.join(DBMigrator::MIGRATIONS_DIR, 'helpers'), tmpdir)
+
     # Revert the given migration and everything newer so we are at the database version exactly before our migration we want to test.
     Sequel::Migrator.run(db, down_migrations, target: 0, allow_missing_migration_files: true)
   end
 
   after do
-    FileUtils.rm_rf(migration_to_test)
-    FileUtils.rm_rf(down_migrations)
-
     # Complete the migration to not leave the test database half migrated and following tests fail due to this
-    Sequel::Migrator.run(db, all_migrations, allow_missing_migration_files: true)
-    FileUtils.rm_rf(all_migrations)
+    Sequel::Migrator.run(db, down_migrations, allow_missing_migration_files: true)
+    FileUtils.rm_rf(tmpdir)
   end
 end

--- a/spec/unit/actions/build_delete_spec.rb
+++ b/spec/unit/actions/build_delete_spec.rb
@@ -7,14 +7,68 @@ module VCAP::CloudController
     subject(:build_delete) { BuildDelete.new(cancel_action) }
     let(:cancel_action) { instance_double(StagingCancel, cancel: nil) }
 
-    describe '#delete' do
-      let!(:build) { BuildModel.make }
+    describe '#delete_for_app' do
+      let!(:app) { AppModel.make }
+      let!(:build1) { BuildModel.make(app: app, state: BuildModel::STAGED_STATE) }
+      let!(:build2) { BuildModel.make(app: app, state: BuildModel::STAGING_STATE) }
 
-      it 'deletes and cancels the build record' do
-        build_delete.delete([build])
+      it 'deletes the builds' do
+        expect do
+          build_delete.delete_for_app(app.guid)
+        end.to change(BuildModel, :count).by(-2)
+        [build1, build2].each { |b| expect(b).not_to exist }
+      end
 
-        expect(build.exists?).to be(false), 'Expected build to not exist, but it does'
-        expect(cancel_action).to have_received(:cancel).with([build])
+      it 'cancels builds in STAGING_STATE' do
+        build_delete.delete_for_app(app.guid)
+
+        expect(cancel_action).to have_received(:cancel).with([build2])
+      end
+
+      it 'deletes associated labels' do
+        label1 = BuildLabelModel.make(build: build1, key_name: 'test', value: 'bommel')
+        label2 = BuildLabelModel.make(build: build2, key_name: 'test', value: 'bommel')
+
+        expect do
+          build_delete.delete_for_app(app.guid)
+        end.to change(BuildLabelModel, :count).by(-2)
+        [label1, label2].each { |l| expect(l).not_to exist }
+      end
+
+      it 'deletes associated annotations' do
+        annotation1 = BuildAnnotationModel.make(build: build1, key_name: 'test', value: 'bommel')
+        annotation2 = BuildAnnotationModel.make(build: build2, key_name: 'test', value: 'bommel')
+
+        expect do
+          build_delete.delete_for_app(app.guid)
+        end.to change(BuildAnnotationModel, :count).by(-2)
+        [annotation1, annotation2].each { |a| expect(a).not_to exist }
+      end
+
+      it 'deletes associated buildpack lifecycle data/buildpack' do
+        lifecycle_data1 = BuildpackLifecycleDataModel.make(build: build1)
+        lifecycle_data2 = BuildpackLifecycleDataModel.make(build: build2)
+        lifecycle_buildpack1 = BuildpackLifecycleBuildpackModel.make(
+          buildpack_lifecycle_data: lifecycle_data1, admin_buildpack_name: nil, buildpack_url: 'http://example.com/buildpack1'
+        )
+        lifecycle_buildpack2 = BuildpackLifecycleBuildpackModel.make(
+          buildpack_lifecycle_data: lifecycle_data2, admin_buildpack_name: nil, buildpack_url: 'http://example.com/buildpack2'
+        )
+
+        expect do
+          build_delete.delete_for_app(app.guid)
+        end.to change(BuildpackLifecycleDataModel, :count).by(-2).and change(BuildpackLifecycleBuildpackModel, :count).by(-2)
+        [lifecycle_data1, lifecycle_data2, lifecycle_buildpack1, lifecycle_buildpack2].each { |l| expect(l).not_to exist }
+      end
+
+      it 'deletes associated kpack lifecycle data' do
+        lifecycle1 = KpackLifecycleDataModel.make(build: build1)
+        lifecycle2 = KpackLifecycleDataModel.make(build: build2)
+
+        expect do
+          build_delete.delete_for_app(app.guid)
+        end.to change(KpackLifecycleDataModel, :count).by(-2)
+        [lifecycle1, lifecycle2].each { |l| expect(l).not_to exist }
       end
     end
   end

--- a/spec/unit/actions/deployment_delete_spec.rb
+++ b/spec/unit/actions/deployment_delete_spec.rb
@@ -3,44 +3,58 @@ require 'actions/deployment_delete'
 
 module VCAP::CloudController
   RSpec.describe DeploymentDelete do
-    subject(:deployment_delete) { DeploymentDelete }
-
-    describe '#delete' do
-      let!(:deployment) { DeploymentModel.make }
-      let!(:deployment2) { DeploymentModel.make }
-
-      it 'deletes and cancels the deployment record' do
-        deployment_delete.delete([deployment, deployment2])
-
-        expect(deployment.exists?).to be(false), 'Expected deployment to not exist, but it does'
-        expect(deployment2.exists?).to be(false), 'Expected deployment2 to not exist, but it does'
+    RSpec.shared_examples 'DeploymentDelete action' do
+      it 'deletes the deployments' do
+        expect do
+          deployment_delete
+        end.to change(DeploymentModel, :count).by(-2)
+        [deployment1, deployment2].each { |d| expect(d).not_to exist }
       end
 
       it 'deletes associated labels' do
-        label = DeploymentLabelModel.make(resource_guid: deployment.guid, key_name: 'test1', value: 'bommel')
+        label1 = DeploymentLabelModel.make(deployment: deployment1, key_name: 'test', value: 'bommel')
+        label2 = DeploymentLabelModel.make(deployment: deployment2, key_name: 'test', value: 'bommel')
+
         expect do
-          deployment_delete.delete([deployment])
-        end.to change(DeploymentLabelModel, :count).by(-1)
-        expect(label).not_to exist
-        expect(deployment).not_to exist
+          deployment_delete
+        end.to change(DeploymentLabelModel, :count).by(-2)
+        [label1, label2].each { |l| expect(l).not_to exist }
       end
 
       it 'deletes associated annotations' do
-        annotation = DeploymentAnnotationModel.make(resource_guid: deployment.guid, key_name: 'test1', value: 'bommel')
+        annotation1 = DeploymentAnnotationModel.make(deployment: deployment1, key_name: 'test', value: 'bommel')
+        annotation2 = DeploymentAnnotationModel.make(deployment: deployment2, key_name: 'test', value: 'bommel')
+
         expect do
-          deployment_delete.delete([deployment])
-        end.to change(DeploymentAnnotationModel, :count).by(-1)
-        expect(annotation).not_to exist
-        expect(deployment).not_to exist
+          deployment_delete
+        end.to change(DeploymentAnnotationModel, :count).by(-2)
+        [annotation1, annotation2].each { |a| expect(a).not_to exist }
       end
 
       it 'deletes associated historical processes' do
-        process = DeploymentProcessModel.make(deployment:)
+        process1 = DeploymentProcessModel.make(deployment: deployment1)
+        process2 = DeploymentProcessModel.make(deployment: deployment2)
+
         expect do
-          deployment_delete.delete([deployment])
-        end.to change(DeploymentProcessModel, :count).by(-1)
-        expect(process).not_to exist
-        expect(deployment).not_to exist
+          deployment_delete
+        end.to change(DeploymentProcessModel, :count).by(-2)
+        [process1, process2].each { |p| expect(p).not_to exist }
+      end
+    end
+
+    let!(:app) { AppModel.make }
+    let!(:deployment1) { DeploymentModel.make(app:) }
+    let!(:deployment2) { DeploymentModel.make(app:) }
+
+    describe '#delete' do
+      it_behaves_like 'DeploymentDelete action' do
+        subject(:deployment_delete) { DeploymentDelete.delete(DeploymentModel.where(id: [deployment1.id, deployment2.id])) }
+      end
+    end
+
+    describe '#delete_for_app' do
+      it_behaves_like 'DeploymentDelete action' do
+        subject(:deployment_delete) { DeploymentDelete.delete_for_app(app.guid) }
       end
     end
   end

--- a/spec/unit/actions/revision_delete_spec.rb
+++ b/spec/unit/actions/revision_delete_spec.rb
@@ -3,57 +3,70 @@ require 'actions/revision_delete'
 
 module VCAP::CloudController
   RSpec.describe RevisionDelete do
-    subject(:revision_delete) { RevisionDelete }
-
-    describe '#delete' do
-      let!(:revision) { RevisionModel.make }
-      let!(:revision2) { RevisionModel.make }
-
-      it 'deletes the revision' do
-        revision_delete.delete([revision, revision2])
-
-        expect(revision.exists?).to be(false), 'Expected revision to not exist, but it does'
-        expect(revision2.exists?).to be(false), 'Expected revision2 to not exist, but it does'
+    RSpec.shared_examples 'RevisionDelete action' do
+      it 'deletes the revisions' do
+        expect do
+          revision_delete
+        end.to change(RevisionModel, :count).by(-2)
+        [revision1, revision2].each { |r| expect(r).not_to exist }
       end
 
       it 'deletes associated labels' do
-        label = RevisionLabelModel.make(resource_guid: revision.guid, key_name: 'test', value: 'bommel')
+        label1 = RevisionLabelModel.make(revision: revision1, key_name: 'test', value: 'bommel')
+        label2 = RevisionLabelModel.make(revision: revision2, key_name: 'test', value: 'bommel')
+
         expect do
-          revision_delete.delete(revision)
-        end.to change(RevisionLabelModel, :count).by(-1)
-        expect(label).not_to exist
-        expect(revision).not_to exist
+          revision_delete
+        end.to change(RevisionLabelModel, :count).by(-2)
+        [label1, label2].each { |l| expect(l).not_to exist }
       end
 
       it 'deletes associated annotations' do
-        annotation = RevisionAnnotationModel.make(resource_guid: revision.guid, key_name: 'test', value: 'bommel')
+        annotation1 = RevisionAnnotationModel.make(revision: revision1, key_name: 'test', value: 'bommel')
+        annotation2 = RevisionAnnotationModel.make(revision: revision2, key_name: 'test', value: 'bommel')
+
         expect do
-          revision_delete.delete(revision)
-        end.to change(RevisionAnnotationModel, :count).by(-1)
-        expect(annotation).not_to exist
-        expect(revision).not_to exist
+          revision_delete
+        end.to change(RevisionAnnotationModel, :count).by(-2)
+        [annotation1, annotation2].each { |a| expect(a).not_to exist }
       end
 
-      it 'deletes associated revision_process_commands' do
-        process_command = revision.add_command_for_process_type('worker', 'foo rackup')
+      it 'deletes associated process commands' do
+        process_command1 = RevisionProcessCommandModel.make(revision: revision1)
+        process_command2 = RevisionProcessCommandModel.make(revision: revision2)
 
         expect do
-          revision_delete.delete(revision)
+          revision_delete
         end.to change(RevisionProcessCommandModel, :count).by(-2)
-
-        expect(process_command).not_to exist
-        expect(revision).not_to exist
+        [process_command1, process_command2].each { |p| expect(p).not_to exist }
       end
 
-      it 'deletes associated revision_sidecars' do
-        # process_command = revision.add_command_for_process_type('worker', 'foo rackup')
-        #
-        # expect {
-        #   revision_delete.delete(revision)
-        # }.to change { RevisionProcessCommandModel.count }.by(-2)
-        #
-        # expect(process_command.exists?).to be_falsey
-        # expect(revision.exists?).to be_falsey
+      it 'deletes associated sidecars and sidecar process types' do
+        sidecar1 = RevisionSidecarModel.make(revision: revision1, revision_sidecar_process_type_guids: nil)
+        sidecar2 = RevisionSidecarModel.make(revision: revision2, revision_sidecar_process_type_guids: nil)
+        sidecar_process_type1 = RevisionSidecarProcessTypeModel.make(revision_sidecar: sidecar1)
+        sidecar_process_type2 = RevisionSidecarProcessTypeModel.make(revision_sidecar: sidecar2)
+
+        expect do
+          revision_delete
+        end.to change(RevisionSidecarModel, :count).by(-2).and change(RevisionSidecarProcessTypeModel, :count).by(-2)
+        [sidecar1, sidecar2, sidecar_process_type1, sidecar_process_type2].each { |s| expect(s).not_to exist }
+      end
+    end
+
+    let!(:app) { AppModel.make }
+    let!(:revision1) { RevisionModel.make(app: app, process_command_guids: nil) }
+    let!(:revision2) { RevisionModel.make(app: app, process_command_guids: nil) }
+
+    describe '#delete' do
+      it_behaves_like 'RevisionDelete action' do
+        subject(:revision_delete) { RevisionDelete.delete(RevisionModel.where(id: [revision1.id, revision2.id])) }
+      end
+    end
+
+    describe '#delete_for_app' do
+      it_behaves_like 'RevisionDelete action' do
+        subject(:revision_delete) { RevisionDelete.delete_for_app(app.guid) }
       end
     end
   end

--- a/spec/unit/actions/sidecar_delete_spec.rb
+++ b/spec/unit/actions/sidecar_delete_spec.rb
@@ -3,28 +3,38 @@ require 'actions/sidecar_delete'
 
 module VCAP::CloudController
   RSpec.describe SidecarDelete do
-    subject(:sidecar_delete) { SidecarDelete }
-
-    describe '.delete' do
-      let!(:sidecar) { SidecarModel.make }
-      let!(:sidecar2) { SidecarModel.make }
-
+    RSpec.shared_examples 'SidecarDelete action' do
       it 'deletes the sidecars' do
-        sidecar_delete.delete([sidecar, sidecar2])
-
-        expect(sidecar.exists?).to be(false), 'Expected sidecar to not exist, but it does'
-        expect(sidecar2.exists?).to be(false), 'Expected sidecar2 to not exist, but it does'
+        expect do
+          sidecar_delete
+        end.to change(SidecarModel, :count).by(-2)
+        [sidecar1, sidecar2].each { |s| expect(s).not_to exist }
       end
 
-      it 'deletes associated sidecar_process_commands' do
-        process_type = SidecarProcessTypeModel.make(sidecar:)
+      it 'deletes associated sidecar process types' do
+        process_type1 = SidecarProcessTypeModel.make(sidecar: sidecar1)
+        process_type2 = SidecarProcessTypeModel.make(sidecar: sidecar2)
 
         expect do
-          sidecar_delete.delete(sidecar)
-        end.to change(SidecarProcessTypeModel, :count).by(-1)
+          sidecar_delete
+        end.to change(SidecarProcessTypeModel, :count).by(-2)
+        [process_type1, process_type2].each { |p| expect(p).not_to exist }
+      end
+    end
 
-        expect(process_type).not_to exist
-        expect(sidecar).not_to exist
+    let!(:app) { AppModel.make }
+    let!(:sidecar1) { SidecarModel.make(app:) }
+    let!(:sidecar2) { SidecarModel.make(app:) }
+
+    describe '#delete' do
+      it_behaves_like 'SidecarDelete action' do
+        subject(:sidecar_delete) { SidecarDelete.delete(SidecarModel.where(id: [sidecar1.id, sidecar2.id])) }
+      end
+    end
+
+    describe '#delete_for_app' do
+      it_behaves_like 'SidecarDelete action' do
+        subject(:sidecar_delete) { SidecarDelete.delete_for_app(app.guid) }
       end
     end
   end

--- a/spec/unit/models/runtime/build_model_spec.rb
+++ b/spec/unit/models/runtime/build_model_spec.rb
@@ -284,11 +284,11 @@ module VCAP::CloudController
           expect(annotation).not_to exist
         end
 
-        # it 'complains when we delete the build without deleting associated metadata' do
-        #   expect do
-        #     build_model.delete
-        #   end.to raise_error(Sequel::ForeignKeyConstraintViolation)
-        # end
+        it 'deletes metadata on delete due to DELETE CASCADE foreign key' do
+          expect do
+            build_model.delete
+          end.not_to raise_error
+        end
       end
     end
   end


### PR DESCRIPTION
Tasks in a non-terminal state have to be deleted individually due to an `after_destroy` hook that creates an app usage event. The other tasks are bulk-deleted.

Builds in state `STAGING` have to be canceled; then all builds can be bulk-deleted.

All deployments/revisions/sidecars are bulk-deleted.

Closes #3543.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
