### PR TITLE
Fix regression of clean up degenerate deployments

### DIFF
--- a/.github/workflows/unit_tests_backwards_compatibility.yml
+++ b/.github/workflows/unit_tests_backwards_compatibility.yml
@@ -12,6 +12,10 @@ on:
       new_cc_ref:
         description: 'New Version of CC_NG that needs testing for backwards incompatible changes'
         required: true
+      new_cc_repo:
+        description: 'New REPO of CC_NG that needs testing for backwards incompatible changes'
+        required: false
+        default: 'cloudfoundry/cloud_controller_ng'
   pull_request:
     branches: [ main ]
     paths:
@@ -50,7 +54,12 @@ jobs:
           ref: ${{ (
               github.event_name == 'workflow_dispatch'
               && github.event.inputs.new_cc_ref
-              || github.head_ref
+              || github.event.pull_request.head.ref
+            )}}
+          repository: ${{ (
+            github.event_name == 'workflow_dispatch'
+            && github.event.inputs.new_cc_repo
+            || github.event.pull_request.head.repo.full_name
             )}}
       - name: Setup Environment
         uses: ./.github/workflows/composite/setup
@@ -94,7 +103,12 @@ jobs:
           ref: ${{ (
             github.event_name == 'workflow_dispatch'
             && github.event.inputs.new_cc_ref
-            || github.head_ref
+            || github.event.pull_request.head.ref
+            )}}
+          repository: ${{ (
+            github.event_name == 'workflow_dispatch'
+            && github.event.inputs.new_cc_repo
+            || github.event.pull_request.head.repo.full_name
             )}}
       - name: Setup Environment
         uses: ./.github/workflows/composite/setup

--- a/db/migrations/20231205143526_remove_deployments_with_degenerate.rb
+++ b/db/migrations/20231205143526_remove_deployments_with_degenerate.rb
@@ -1,7 +1,14 @@
 Sequel.migration do
   up do
     degenerate_records = self[:deployments].where(status_reason: 'DEGENERATE')
-    degenerate_records.delete
+
+    if degenerate_records.count > 0
+      guids_dataset = degenerate_records.select(:guid)
+      self[:deployment_processes].where(deployment_guid: guids_dataset).delete
+      self[:deployment_labels].where(resource_guid: guids_dataset).delete
+      self[:deployment_annotations].where(resource_guid: guids_dataset).delete
+      degenerate_records.delete
+    end
   end
 
   down do

--- a/spec/migrations/20231205143526_remove_deployments_with_degenerate_spec.rb
+++ b/spec/migrations/20231205143526_remove_deployments_with_degenerate_spec.rb
@@ -8,15 +8,31 @@ RSpec.describe 'migration to clean up degenerate records from deployments record
 
   describe 'deployments table' do
     it 'degenerate record is removed from deployments' do
-      db[:deployments].insert(
-        guid: 'bommel',
-        original_web_process_instance_count: 1,
-        status_reason: 'DEGENERATE'
-      )
+      db[:deployments].insert(guid: 'deployed_guid', original_web_process_instance_count: 1, status_reason: 'DEPLOYED')
+      db[:deployment_processes].insert(guid: 'deployed_process_guid', deployment_guid: 'deployed_guid')
+      db[:deployment_annotations].insert(guid: 'deployed_annotation_guid', resource_guid: 'deployed_guid')
+      db[:deployment_labels].insert(guid: 'deployed_label_guid', resource_guid: 'deployed_guid')
+
+      db[:deployments].insert(guid: 'degenerate_guid', original_web_process_instance_count: 1, status_reason: 'DEGENERATE')
+      db[:deployment_processes].insert(guid: 'degenerate_process_guid', deployment_guid: 'degenerate_guid')
+      db[:deployment_annotations].insert(guid: 'degenerate_annotation_guid', resource_guid: 'degenerate_guid')
+      db[:deployment_labels].insert(guid: 'degenerate_label_guid', resource_guid: 'degenerate_guid')
+
+      expect { db[:deployments].where(guid: 'degenerate_guid').delete }.to raise_error(Sequel::ForeignKeyConstraintViolation)
 
       expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true) }.not_to raise_error
-      deployment = db[:deployments].first(status_reason: 'DEGENERATE')
-      expect(deployment).to be_nil
+
+      expect(db[:deployments].where(status_reason: 'DEGENERATE').count).to eq(0)
+
+      expect(db[:deployments].first(guid: 'degenerate_guid')).to be_nil
+      expect(db[:deployment_processes].first(guid: 'degenerate_process_guid')).to be_nil
+      expect(db[:deployment_annotations].first(guid: 'degenerate_annotation_guid')).to be_nil
+      expect(db[:deployment_labels].first(guid: 'degenerate_label_guid')).to be_nil
+
+      expect(db[:deployments].first(guid: 'deployed_guid')).not_to be_nil
+      expect(db[:deployment_processes].first(guid: 'deployed_process_guid')).not_to be_nil
+      expect(db[:deployment_annotations].first(guid: 'deployed_annotation_guid')).not_to be_nil
+      expect(db[:deployment_labels].first(guid: 'deployed_label_guid')).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
The [Clean up degenerate deployments ](https://github.com/cloudfoundry/cloud_controller_ng/pull/3538) might fail because the foreign key constraint exists. So first the child records should be deleted, then the parent records. With this PR the delete problem can be fixed

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
