### PR TITLE
Add dedicated config file for cc local workers

### DIFF
--- a/config/cloud_controller_local_worker_override.yml
+++ b/config/cloud_controller_local_worker_override.yml
@@ -1,3 +1,3 @@
-# Configurations specific to cc local workers are overridden using this file in capi-release.
-# It will be merged with the cc_ng configuration file, and then cc local workers will be started with the resulting configuration file.
+# This file is intended for development purposes only! Configurations specific to cc local workers can be overridden using the same file in capi-release.
+# It will merge with the cc_ng configuration file, and start cc local workers.
 ---

--- a/config/cloud_controller_local_worker_override.yml
+++ b/config/cloud_controller_local_worker_override.yml
@@ -1,0 +1,3 @@
+# Configurations specific to cc local workers are overridden using this file in capi-release.
+# It will be merged with the cc_ng configuration file, and then cc local workers will be started with the resulting configuration file.
+---

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController
 
     class << self
       def load_from_file(file_name, context: :api, secrets_hash: {})
-        config = VCAP::CloudController::YAMLConfig.safe_load_file(file_name)
+        config = read_file(file_name)
         load_from_hash(config, context:, secrets_hash:)
       end
 

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -20,7 +20,7 @@ namespace :jobs do
     RakeConfig.context = :api
 
     CloudController::DelayedWorker.new(queues: [queue],
-                                       name: args.name).start_working(is_cc_local_worker: true)
+                                       name: args.name).start_working
   end
 
   desc 'Start a delayed_job worker.'
@@ -63,8 +63,8 @@ namespace :jobs do
       }
     end
 
-    def start_working(is_cc_local_worker: false)
-      config = RakeConfig.config(is_cc_local_worker:)
+    def start_working
+      config = RakeConfig.config
       BackgroundJobEnvironment.new(config).setup_environment(readiness_port)
 
       logger = Steno.logger('cc-worker')

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -20,7 +20,7 @@ namespace :jobs do
     RakeConfig.context = :api
 
     CloudController::DelayedWorker.new(queues: [queue],
-                                       name: args.name).start_working
+                                       name: args.name).start_working(is_cc_local_worker: true)
   end
 
   desc 'Start a delayed_job worker.'
@@ -63,8 +63,8 @@ namespace :jobs do
       }
     end
 
-    def start_working
-      config = RakeConfig.config
+    def start_working(is_cc_local_worker: false)
+      config = RakeConfig.config(is_cc_local_worker:)
       BackgroundJobEnvironment.new(config).setup_environment(readiness_port)
 
       logger = Steno.logger('cc-worker')

--- a/lib/tasks/rake_config.rb
+++ b/lib/tasks/rake_config.rb
@@ -6,19 +6,19 @@ class RakeConfig
 
     attr_writer :context
 
-    def config(is_cc_local_worker: false)
+    def config
       secrets_hash = {}
       # TODO: require secrets fetcher?
       secrets_hash = VCAP::CloudController::SecretsFetcher.fetch_secrets_from_file(secrets_file) unless secrets_file.nil?
 
-      api_config = VCAP::CloudController::Config.load_from_file(config_file, context:, secrets_hash:)
+      api_config_hash = VCAP::CloudController::Config.read_file(config_file)
 
-      if is_cc_local_worker
+      if context == :api
         local_worker_config_hash = VCAP::CloudController::Config.read_file(cc_local_worker_config_file)
-        return VCAP::CloudController::Config.load_from_hash(api_config.config_hash.deep_merge(local_worker_config_hash))
+        api_config_hash = api_config_hash.deep_merge(local_worker_config_hash)
       end
 
-      api_config
+      VCAP::CloudController::Config.load_from_hash(api_config_hash, context:, secrets_hash:)
     end
 
     private

--- a/lib/tasks/rake_config.rb
+++ b/lib/tasks/rake_config.rb
@@ -6,15 +6,29 @@ class RakeConfig
 
     attr_writer :context
 
-    def config
+    def config(is_cc_local_worker: false)
       secrets_hash = {}
       # TODO: require secrets fetcher?
       secrets_hash = VCAP::CloudController::SecretsFetcher.fetch_secrets_from_file(secrets_file) unless secrets_file.nil?
 
-      VCAP::CloudController::Config.load_from_file(config_file, context:, secrets_hash:)
+      api_config = VCAP::CloudController::Config.load_from_file(config_file, context:, secrets_hash:)
+
+      if is_cc_local_worker
+        local_worker_config_hash = VCAP::CloudController::Config.read_file(cc_local_worker_config_file)
+        return VCAP::CloudController::Config.load_from_hash(api_config.config_hash.deep_merge(local_worker_config_hash))
+      end
+
+      api_config
     end
 
     private
+
+    def cc_local_worker_config_file
+      return ENV['CLOUD_CONTROLLER_LOCAL_WORKER_OVERRIDE_CONFIG'] if ENV['CLOUD_CONTROLLER_LOCAL_WORKER_OVERRIDE_CONFIG']
+
+      [File.expand_path('../../config/cloud_controller_local_worker_override.yml', __dir__),
+       '/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_local_worker_override.yml'].find { |candidate| candidate && File.exist?(candidate) }
+    end
 
     def config_file
       return ENV['CLOUD_CONTROLLER_NG_CONFIG'] if ENV['CLOUD_CONTROLLER_NG_CONFIG']


### PR DESCRIPTION
Before this PR, same config file was used for both ccng and the (two) cc local workers. This dedicated file aims to decouple this bond and provide a way to override the configurations for cc local workers.

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
