### PR TITLE
Introduce new config attribute for Puma

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -265,7 +265,7 @@ module VCAP::CloudController
             optional(:puma) => {
               workers: Integer,
               max_threads: Integer,
-              optional(:max_connections) => Integer
+              optional(:max_db_connections_per_process) => Integer
             },
 
             install_buildpacks: [

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -264,7 +264,8 @@ module VCAP::CloudController
             webserver: String, # thin or puma
             optional(:puma) => {
               workers: Integer,
-              max_threads: Integer
+              max_threads: Integer,
+              optional(:max_connections) => Integer
             },
 
             install_buildpacks: [

--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -39,6 +39,9 @@ module VCAP::CloudController
       app     = builder.build(@config, request_metrics, request_logs)
 
       @server = if @config.get(:webserver) == 'puma'
+                  max_connections_per_process = @config.get(:puma, :max_connections)
+                  @config.set(:db, @config.get(:db).merge(max_connections: max_connections_per_process)) unless max_connections_per_process.nil?
+
                   VCAP::CloudController::PumaRunner.new(@config, app, logger, periodic_updater, request_logs)
                 else
                   VCAP::CloudController::ThinRunner.new(@config, app, logger, periodic_updater, request_logs)

--- a/spec/support/bootstrap/db_config.rb
+++ b/spec/support/bootstrap/db_config.rb
@@ -20,7 +20,8 @@ class DbConfig
       database: VCAP::CloudController::DatabasePartsParser.database_parts_from_connection(connection_string),
       pool_timeout: 10,
       read_timeout: 3600,
-      connection_validation_timeout: 3600
+      connection_validation_timeout: 3600,
+      max_connections: 42
     }
   end
 

--- a/spec/unit/lib/cloud_controller/runner_spec.rb
+++ b/spec/unit/lib/cloud_controller/runner_spec.rb
@@ -66,30 +66,30 @@ module VCAP::CloudController
         end
       end
 
-      describe 'setting max connections per process for puma' do
-        context 'when max connections per process value is specified' do
+      describe 'setting max db connections per process for puma' do
+        context 'when max db connections per process value is specified' do
           before do
-            TestConfig.override(webserver: 'puma', puma: { max_connections: 10 })
+            TestConfig.override(webserver: 'puma', puma: { max_db_connections_per_process: 10 })
             allow(Config).to receive(:load_from_file).and_return(TestConfig.config_instance)
           end
 
           it 'overrides the db max_connections' do
-            expect(subject.instance_variable_get(:@server)).to be_an_instance_of(PumaRunner)
-            expect(subject.config.get(:puma, :max_connections)).to eq(10)
-            expect(subject.config.get(:db, :max_connections)).to eq(10)
+            expect(DB).to receive(:load_models).with(hash_including(max_connections: 10), an_instance_of(Steno::Logger))
+
+            subject
           end
         end
 
-        context 'when max connections per process is not specified' do
+        context 'when max db connections per process value is not specified' do
           before do
             TestConfig.override(webserver: 'puma')
             allow(Config).to receive(:load_from_file).and_return(TestConfig.config_instance)
           end
 
           it 'renders the default value from cc_ng' do
-            expect(subject.instance_variable_get(:@server)).to be_an_instance_of(PumaRunner)
-            expect(subject.config.get(:puma, :max_connections)).to be_nil
-            expect(subject.config.get(:db, :max_connections)).to eq(42)
+            expect(DB).to receive(:load_models).with(hash_including(max_connections: 42), an_instance_of(Steno::Logger))
+
+            subject
           end
         end
       end


### PR DESCRIPTION
Currently, with Puma, all processes (i.e. main + Puma workers) is configured with the same db max_connections. This PR aims to introduce new config attribute (max connections per process / optional). If not specified, the default db max_connections from cc_ng will be used.

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
