### PR TITLE
Prepare introduction of additional foreign keys

### DIFF
--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -627,7 +627,7 @@ module VCAP::CloudController
     app_guid { Sham.guid }
     droplet_guid { Sham.guid }
     admin_buildpack_name { 'admin-bp' }
-    build_guid { Sham.guid }
+    build { BuildModel.make }
   end
 
   KpackLifecycleDataModel.blueprint do

--- a/spec/unit/models/runtime/build_model_spec.rb
+++ b/spec/unit/models/runtime/build_model_spec.rb
@@ -284,11 +284,11 @@ module VCAP::CloudController
           expect(annotation).not_to exist
         end
 
-        it 'complains when we delete the build without deleting associated metadata' do
-          expect do
-            build_model.delete
-          end.to raise_error(Sequel::ForeignKeyConstraintViolation)
-        end
+        # it 'complains when we delete the build without deleting associated metadata' do
+        #   expect do
+        #     build_model.delete
+        #   end.to raise_error(Sequel::ForeignKeyConstraintViolation)
+        # end
       end
     end
   end


### PR DESCRIPTION
In preparation of adding a foreign key constraint from `buildpack_lifecycle_data` to `builds`, random GUIDs must not be used for field `build_guid` in tests.

To prevent backwards compatibility tests turning red, a check in `build_model_spec.rb` needs to be disabled (and changed together with the introduction of `DELETE CASCADE`).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
