### PR TITLE
Add deserialization spec for `ActiveSupport::Duration`

### DIFF
--- a/spec/unit/jobs/deserialization_spec.rb
+++ b/spec/unit/jobs/deserialization_spec.rb
@@ -3,6 +3,103 @@ require 'spec_helper'
 module VCAP::CloudController
   module Jobs
     RSpec.describe Jobs do
+      context 'CreateServiceInstanceJob' do
+        let(:user) { User.make(guid: 'user-guid') }
+        let(:audit_info) { UserAuditInfo.new(user_email: 'user@bommel.com', user_guid: user.guid, user_name: 'user-name') }
+
+        let(:org) { VCAP::CloudController::Organization.make }
+        let(:space) { VCAP::CloudController::Space.make(organization: org) }
+
+        let(:service_offering) { VCAP::CloudController::Service.make }
+        let(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service_offering) }
+        let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(service_plan:, space:) }
+
+        let(:audit_hash) do
+          {
+            'name' => 'audit-hash',
+            'relationships' => {
+              'service_plan' => {
+                'data' => {
+                  'guid' => service_plan.guid
+                }
+              },
+              'space' => {
+                'data' => {
+                  'guid' => space.guid
+                }
+              }
+            },
+            'type' => 'managed'
+          }
+        end
+
+        subject(:job) do
+          job = VCAP::CloudController::V3::CreateServiceInstanceJob.new(service_instance.guid, arbitrary_parameters: nil, user_audit_info: audit_info, audit_hash: audit_hash)
+
+          # Override private instance variables which are set after a job failed
+          job.instance_variable_set(:@maximum_duration, 604_800)
+          job.instance_variable_set(:@first_time, false)
+          job.instance_variable_set(:@retry_number, 1)
+          job
+        end
+
+        let(:serialized_job) do
+          <<~EOS
+            --- !ruby/object:VCAP::CloudController::Jobs::LoggingContextJob
+            handler: !ruby/object:VCAP::CloudController::Jobs::TimeoutJob
+              handler: !ruby/object:VCAP::CloudController::Jobs::PollableJobWrapper
+                existing_guid: #{''}
+                handler: !ruby/object:VCAP::CloudController::V3::CreateServiceInstanceJob
+                  start_time: #{job.start_time}
+                  finished: false
+                  retry_number: 1
+                  service_instance_guid: #{service_instance.guid}
+                  arbitrary_parameters:
+                  user_audit_info: !ruby/object:VCAP::CloudController::UserAuditInfo
+                    user_email: #{audit_info.user_email}
+                    user_name: #{audit_info.user_name}
+                    user_guid: #{audit_info.user_guid}
+                  audit_hash:
+                    name: audit-hash
+                    relationships:
+                      service_plan:
+                        data:
+                          guid: #{service_plan.guid}
+                      space:
+                        data:
+                          guid: #{space.guid}
+                    type: managed
+                  warnings: []
+                  first_time: false
+                  maximum_duration: !ruby/object:ActiveSupport::Duration
+                    value: 604800
+                    parts:
+                      :minutes: 10080
+              timeout: 14400
+            request_id: #{''}
+
+          EOS
+        end
+
+        it 'equals dumped job yaml' do
+          VCAP::CloudController::Jobs::Enqueuer.new(job).enqueue_pollable
+          jobs_in_db = Sequel::Model.db.fetch('SELECT handler FROM delayed_jobs').all
+          expect(jobs_in_db.size).to eq(1)
+
+          # We are not interested in minor differences like ordering of nodes. Therefore comparing it as hash.
+          permitted_classes = [ActiveModel::Errors, ActiveSupport::Duration, Time, Symbol, UserAuditInfo, VCAP::CloudController::V3::CreateServiceInstanceJob, TimeoutJob,
+                               LoggingContextJob, PollableJobWrapper]
+          db_job = YAML.safe_load(jobs_in_db[0][:handler], permitted_classes: permitted_classes, aliases: true).as_json
+          dumped_job = YAML.safe_load(serialized_job, permitted_classes: permitted_classes, aliases: true).as_json
+          expect(db_job).to eq(dumped_job)
+        end
+
+        it 'can be deserialized' do
+          object = YAML.load_dj(serialized_job)
+          expect(object).not_to be_nil
+        end
+      end
+
       context 'SpaceApplyManifestActionJob serialization' do
         let(:user) { User.make(guid: 'user-guid') }
         let(:user_audit_info) { UserAuditInfo.new(user_email: 'user@bommel.com', user_guid: user.guid, user_name: 'user-name') }


### PR DESCRIPTION
During the operation of CC's delayed jobs, we mostly deal with `cloud_controller_ng` objects that have been deserialized. Running CATS, however, revealed we also handle two external Rails objects – `ActiveModel::Errors` and `ActiveSupport::Duration`. So, to keep track of any changes, we added a deserialization spec for `SpaceApplyManifestActionJob` under #2782, which also covers `ActiveModel::Errors`.
Now, we're adding another deserialization spec, this time for `CreateServiceInstanceJob`, to cover `ActiveSupport::Duration`.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
