### PR TITLE
switch to using digest-xxhash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'addressable'
 gem 'allowy', '>= 2.1.0'
 gem 'clockwork', require: false
 gem 'cloudfront-signer'
+gem 'digest-xxhash'
 gem 'em-http-request', '~> 1.1'
 gem 'eventmachine', '~> 1.2.7'
 gem 'fluent-logger'
@@ -47,7 +48,6 @@ gem 'talentbox-delayed_job_sequel', '~> 4.3.0'
 gem 'thin'
 gem 'unf'
 gem 'vmstat', '~> 2.3'
-gem 'xxhash'
 gem 'yajl-ruby'
 
 # Rails Components

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)
     diff-lcs (1.5.0)
+    digest-xxhash (0.2.7)
     docile (1.1.5)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -563,7 +564,6 @@ GEM
     webrick (1.8.1)
     xml-simple (1.1.9)
       rexml
-    xxhash (0.5.0)
     yajl-ruby (1.4.3)
     yard (0.9.34)
     zeitwerk (2.6.12)
@@ -586,6 +586,7 @@ DEPENDENCIES
   cloudfront-signer
   codeclimate-test-reporter (>= 1.0.8)
   debug (~> 1.9)
+  digest-xxhash
   em-http-request (~> 1.1)
   eventmachine (~> 1.2.7)
   fluent-logger
@@ -663,7 +664,6 @@ DEPENDENCIES
   vcap-concurrency!
   vmstat (~> 2.3)
   webmock (> 2.3.1)
-  xxhash
   yajl-ruby
 
 BUNDLED WITH

--- a/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
+++ b/lib/cloud_controller/diego/buildpack/staging_action_builder.rb
@@ -1,6 +1,6 @@
 require 'credhub/config_helpers'
 require 'diego/action_builder'
-require 'xxhash'
+require 'digest/xxhash'
 
 module VCAP::CloudController
   module Diego
@@ -247,7 +247,7 @@ module VCAP::CloudController
           if config.get(:staging, :legacy_md5_buildpack_paths_enabled)
             "/tmp/buildpacks/#{OpenSSL::Digest::MD5.hexdigest(buildpack_key)}"
           else
-            "/tmp/buildpacks/#{XXhash.xxh64(buildpack_key)}"
+            "/tmp/buildpacks/#{Digest::XXH64.hexdigest(buildpack_key)}"
           end
         end
       end

--- a/middleware/mixins/user_reset_interval.rb
+++ b/middleware/mixins/user_reset_interval.rb
@@ -1,11 +1,11 @@
-require 'xxhash'
+require 'digest/xxhash'
 
 module CloudFoundry
   module Middleware
     module UserResetInterval
       def next_expires_in(user_guid, reset_interval_in_minutes)
         interval = reset_interval_in_minutes.minutes.to_i
-        offset = XXhash.xxh64(user_guid).remainder(interval)
+        offset = Digest::XXH64.hexdigest(user_guid).remainder(interval)
 
         interval - (Time.now.to_i - offset).remainder(interval)
       end

--- a/middleware/mixins/user_reset_interval.rb
+++ b/middleware/mixins/user_reset_interval.rb
@@ -5,7 +5,7 @@ module CloudFoundry
     module UserResetInterval
       def next_expires_in(user_guid, reset_interval_in_minutes)
         interval = reset_interval_in_minutes.minutes.to_i
-        offset = Digest::XXH64.hexdigest(user_guid).remainder(interval)
+        offset = Digest::XXH64.idigest(user_guid).remainder(interval)
 
         interval - (Time.now.to_i - offset).remainder(interval)
       end

--- a/spec/unit/lib/cloud_controller/diego/buildpack/staging_action_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/buildpack/staging_action_builder_spec.rb
@@ -328,7 +328,7 @@ module VCAP::CloudController
               buildpack_entry_1 = ::Diego::Bbs::Models::CachedDependency.new(
                 name: 'buildpack-1',
                 from: 'buildpack-1-url',
-                to: "/tmp/buildpacks/#{XXhash.xxh64('buildpack-1-key')}",
+                to: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('buildpack-1-key')}",
                 cache_key: 'buildpack-1-key',
                 checksum_algorithm: 'sha256',
                 checksum_value: 'checksum'
@@ -336,7 +336,7 @@ module VCAP::CloudController
               buildpack_entry_2 = ::Diego::Bbs::Models::CachedDependency.new(
                 name: 'buildpack-2',
                 from: 'buildpack-2-url',
-                to: "/tmp/buildpacks/#{XXhash.xxh64('buildpack-2-key')}",
+                to: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('buildpack-2-key')}",
                 cache_key: 'buildpack-2-key',
                 checksum_algorithm: 'sha256',
                 checksum_value: 'checksum'
@@ -392,7 +392,7 @@ module VCAP::CloudController
                 buildpack_entry_1 = ::Diego::Bbs::Models::CachedDependency.new(
                   name: 'buildpack-1',
                   from: 'buildpack-1-url',
-                  to: "/tmp/buildpacks/#{XXhash.xxh64('buildpack-1-key')}",
+                  to: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('buildpack-1-key')}",
                   cache_key: 'buildpack-1-key',
                   checksum_algorithm: 'sha256',
                   checksum_value: 'checksum'
@@ -400,7 +400,7 @@ module VCAP::CloudController
                 buildpack_entry_2 = ::Diego::Bbs::Models::CachedDependency.new(
                   name: 'buildpack-2',
                   from: 'buildpack-2-url',
-                  to: "/tmp/buildpacks/#{XXhash.xxh64('buildpack-2-key')}",
+                  to: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('buildpack-2-key')}",
                   cache_key: 'buildpack-2-key'
                 )
 
@@ -430,7 +430,7 @@ module VCAP::CloudController
               buildpack_entry_1 = ::Diego::Bbs::Models::CachedDependency.new(
                 name: 'buildpack-1',
                 from: 'buildpack-1-url',
-                to: "/tmp/buildpacks/#{XXhash.xxh64('buildpack-1-key')}",
+                to: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('buildpack-1-key')}",
                 cache_key: 'buildpack-1-key',
                 checksum_algorithm: 'sha256',
                 checksum_value: 'checksum'
@@ -438,7 +438,7 @@ module VCAP::CloudController
               buildpack_entry_2 = ::Diego::Bbs::Models::CachedDependency.new(
                 name: 'custom',
                 from: 'custom-url',
-                to: "/tmp/buildpacks/#{XXhash.xxh64('custom-key')}",
+                to: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('custom-key')}",
                 cache_key: 'custom-key'
               )
 
@@ -541,7 +541,7 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::ImageLayer.new(
                     name: 'buildpack-1',
                     url: 'buildpack-1-url',
-                    destination_path: "/tmp/buildpacks/#{XXhash.xxh64('buildpack-1-key')}",
+                    destination_path: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('buildpack-1-key')}",
                     digest_algorithm: ::Diego::Bbs::Models::ImageLayer::DigestAlgorithm::SHA256,
                     digest_value: 'checksum',
                     layer_type: ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
@@ -552,7 +552,7 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::ImageLayer.new(
                     name: 'buildpack-2',
                     url: 'buildpack-2-url',
-                    destination_path: "/tmp/buildpacks/#{XXhash.xxh64('buildpack-2-key')}",
+                    destination_path: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('buildpack-2-key')}",
                     digest_algorithm: ::Diego::Bbs::Models::ImageLayer::DigestAlgorithm::SHA256,
                     digest_value: 'checksum',
                     layer_type: ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
@@ -574,7 +574,7 @@ module VCAP::CloudController
                     ::Diego::Bbs::Models::ImageLayer.new(
                       name: 'buildpack-2',
                       url: 'buildpack-2-url',
-                      destination_path: "/tmp/buildpacks/#{XXhash.xxh64('buildpack-2-key')}",
+                      destination_path: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('buildpack-2-key')}",
                       layer_type: ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
                       media_type: ::Diego::Bbs::Models::ImageLayer::MediaType::ZIP
                     )
@@ -596,7 +596,7 @@ module VCAP::CloudController
                   ::Diego::Bbs::Models::ImageLayer.new(
                     name: 'custom',
                     url: 'custom-url',
-                    destination_path: "/tmp/buildpacks/#{XXhash.xxh64('custom-key')}",
+                    destination_path: "/tmp/buildpacks/#{Digest::XXH64.hexdigest('custom-key')}",
                     layer_type: ::Diego::Bbs::Models::ImageLayer::Type::SHARED,
                     media_type: ::Diego::Bbs::Models::ImageLayer::MediaType::ZIP
                   )


### PR DESCRIPTION
Addresses:
```
Failed to read buildpack directory '/tmp/buildpacks/1b846093a63ea491' for buildpack '/tmp/buildpacks/1b846093a63ea491' 
```

Caused by libxxhash version mismatch between golang and ruby libraries used by diego and capi.
digest-xxhash is listed as one of the ruby wrappers here: https://xxhash.com/

Issue first reported here: https://cloudfoundry.slack.com/archives/C02FM2BPE/p1705917612965329?thread_ts=1705502726.635979&cid=C02FM2BPE