### PR TITLE
Make MIN/MAX_CPU_PROXY values that are used for capping the cpu weight configurable

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -51,6 +51,8 @@ failed_jobs:
 completed_tasks:
   cutoff_age_in_days: 31
 
+cpu_weight_min_memory: 128 #mb
+cpu_weight_max_memory: 8192 #mb
 default_app_memory: 1024 #mb
 default_app_disk_in_mb: 1024
 default_app_log_rate_limit_in_bytes_per_second: 1_048_576

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -35,6 +35,8 @@ module VCAP::CloudController
             app_domains: Array,
             disable_private_domain_cross_space_context_path_route_sharing: bool,
 
+            cpu_weight_min_memory: Integer,
+            cpu_weight_max_memory: Integer,
             default_app_memory: Integer,
             default_app_disk_in_mb: Integer,
             default_app_log_rate_limit_in_bytes_per_second: Integer,

--- a/lib/cloud_controller/config_schemas/base/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/clock_schema.rb
@@ -144,6 +144,8 @@ module VCAP::CloudController
               interpolate_service_bindings: bool
             },
 
+            cpu_weight_min_memory: Integer,
+            cpu_weight_max_memory: Integer,
             default_app_memory: Integer,
             default_app_disk_in_mb: Integer,
             default_app_log_rate_limit_in_bytes_per_second: Integer,

--- a/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
@@ -52,8 +52,8 @@ module VCAP::CloudController
               optional(:pbkdf2_hmac_iterations) => Integer
             },
 
-            cpu_weight_min_memory: 128, # mb
-            cpu_weight_max_memory: 8192, # mb
+            cpu_weight_min_memory: Integer,
+            cpu_weight_max_memory: Integer,
             default_app_memory: Integer,
             default_app_disk_in_mb: Integer,
             maximum_app_disk_in_mb: Integer,

--- a/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/deployment_updater_schema.rb
@@ -52,6 +52,8 @@ module VCAP::CloudController
               optional(:pbkdf2_hmac_iterations) => Integer
             },
 
+            cpu_weight_min_memory: 128, # mb
+            cpu_weight_max_memory: 8192, # mb
             default_app_memory: Integer,
             default_app_disk_in_mb: Integer,
             maximum_app_disk_in_mb: Integer,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -156,8 +156,8 @@ module VCAP::CloudController
 
             perform_blob_cleanup: bool,
 
-            cpu_weight_min_memory: 128, # mb
-            cpu_weight_max_memory: 8192, # mb
+            cpu_weight_min_memory: Integer,
+            cpu_weight_max_memory: Integer,
             default_app_memory: Integer,
             default_app_disk_in_mb: Integer,
             instance_file_descriptor_limit: Integer,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -156,6 +156,8 @@ module VCAP::CloudController
 
             perform_blob_cleanup: bool,
 
+            cpu_weight_min_memory: 128, # mb
+            cpu_weight_max_memory: 8192, # mb
             default_app_memory: Integer,
             default_app_disk_in_mb: Integer,
             instance_file_descriptor_limit: Integer,

--- a/lib/cloud_controller/diego/task_cpu_weight_calculator.rb
+++ b/lib/cloud_controller/diego/task_cpu_weight_calculator.rb
@@ -1,10 +1,9 @@
 module VCAP
   module CloudController
     module Diego
-
+      # Base 100% weight equals an 8G instance
+      BASE_WEIGHT = 8192
       class TaskCpuWeightCalculator
-        # Base 100% weight equals an 8G instance
-        BASE_WEIGHT = 8192
         def initialize(memory_in_mb:)
           @memory_in_mb = memory_in_mb
           @min_cpu_proxy = VCAP::CloudController::Config.config.get(:cpu_weight_min_memory)

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -41,6 +41,8 @@ failed_jobs:
 completed_tasks:
   cutoff_age_in_days: 31
 
+cpu_weight_min_memory: 128 #mb
+cpu_weight_max_memory: 8192 #mb
 default_app_memory: 1024 #mb
 default_app_disk_in_mb: 1024
 maximum_app_disk_in_mb: 2048

--- a/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
           let(:memory) { min_cpu_proxy - 1 }
 
           it 'returns a percentage of the MIN / MAX' do
-            expected_weight = (100 * min_cpu_proxy) / max_cpu_proxy
+            expected_weight = (100 * min_cpu_proxy) / BASE_WEIGHT
             expect(calculator.calculate).to eq(expected_weight)
           end
         end
@@ -27,11 +27,10 @@ module VCAP::CloudController
         end
 
         context 'when the memory limit is between the minimum value and maximum default values' do
-          # let(:memory) { (min_cpu_proxy + max_cpu_proxy) / 2 }
           let(:memory) { (min_cpu_proxy + max_cpu_proxy) / 2 }
 
           it 'returns a percentage that is different' do
-            expected_weight = (100 * memory) / max_cpu_proxy
+            expected_weight = (100 * memory) / BASE_WEIGHT
             expect(calculator.calculate).to eq(expected_weight)
           end
         end
@@ -49,13 +48,13 @@ module VCAP::CloudController
           let(:memory) { 5000 }
 
           it 'returns a percentage of 100' do
-            expected_weight = (100 * memory) / 8192
+            expected_weight = (100 * memory) / BASE_WEIGHT
             expect(calculator.calculate).to eq(expected_weight)
           end
         end
 
         context 'when memory limit is equal to the default maximum (8G)' do
-          let(:memory) { 8192 }
+          let(:memory) { BASE_WEIGHT }
 
           it 'returns 100' do
             expect(calculator.calculate).to eq(100)
@@ -66,13 +65,13 @@ module VCAP::CloudController
           let(:memory) { 15_000 }
 
           it 'returns a percentage above 100' do
-            expected_weight = (100 * memory) / 8192
+            expected_weight = (100 * memory) / BASE_WEIGHT
             expect(calculator.calculate).to eq(expected_weight)
           end
         end
 
         context 'when memory limit is equal to 16G' do
-          let(:memory) { 16_384 }
+          let(:memory) { BASE_WEIGHT * 2 }
 
           it 'returns 200' do
             expect(calculator.calculate).to eq(200)
@@ -80,7 +79,7 @@ module VCAP::CloudController
         end
 
         context 'when memory limit is equal or above 16G' do
-          let(:memory) { 32_768 }
+          let(:memory) { BASE_WEIGHT * 4 }
 
           it 'returns 200' do
             expect(calculator.calculate).to eq(200)

--- a/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
@@ -41,7 +41,6 @@ module VCAP::CloudController
           TestConfig.override(cpu_weight_max_memory: 16_384)
         end
 
-        # let(:calculator) { TaskCpuWeightCalculator.new(memory, TestConfig.config_instance) }
         let(:calculator) { TaskCpuWeightCalculator.new(memory_in_mb: memory) }
 
         context 'when the memory limit is between the minimum value and maximum default values' do

--- a/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_cpu_weight_calculator_spec.rb
@@ -4,10 +4,10 @@ require 'cloud_controller/diego/task_cpu_weight_calculator'
 module VCAP::CloudController
   module Diego
     RSpec.describe TaskCpuWeightCalculator do
-      describe '#calculate' do
+      describe '#calculate with default values' do
         let(:calculator) { TaskCpuWeightCalculator.new(memory_in_mb: memory) }
-        let(:min_cpu_proxy) { VCAP::CloudController::Diego::MIN_CPU_PROXY }
-        let(:max_cpu_proxy) { VCAP::CloudController::Diego::MAX_CPU_PROXY }
+        let(:min_cpu_proxy) { VCAP::CloudController::Config.config.get(:cpu_weight_min_memory) }
+        let(:max_cpu_proxy) { VCAP::CloudController::Config.config.get(:cpu_weight_max_memory) }
 
         context 'when the memory limit is below the minimum value' do
           let(:memory) { min_cpu_proxy - 1 }
@@ -18,7 +18,7 @@ module VCAP::CloudController
           end
         end
 
-        context 'when the memory limit is above the maximum value' do
+        context 'when the memory limit is above the maximum default value' do
           let(:memory) { max_cpu_proxy + 1 }
 
           it 'returns 100' do
@@ -26,12 +26,64 @@ module VCAP::CloudController
           end
         end
 
-        context 'when the memory limit is between the minimum and maximum values' do
+        context 'when the memory limit is between the minimum value and maximum default values' do
+          # let(:memory) { (min_cpu_proxy + max_cpu_proxy) / 2 }
           let(:memory) { (min_cpu_proxy + max_cpu_proxy) / 2 }
 
           it 'returns a percentage that is different' do
             expected_weight = (100 * memory) / max_cpu_proxy
             expect(calculator.calculate).to eq(expected_weight)
+          end
+        end
+      end
+
+      describe '#calculate with cpu_weight_max_memory=16384' do
+        before do
+          TestConfig.override(cpu_weight_max_memory: 16_384)
+        end
+
+        # let(:calculator) { TaskCpuWeightCalculator.new(memory, TestConfig.config_instance) }
+        let(:calculator) { TaskCpuWeightCalculator.new(memory_in_mb: memory) }
+
+        context 'when the memory limit is between the minimum value and maximum default values' do
+          let(:memory) { 5000 }
+
+          it 'returns a percentage of 100' do
+            expected_weight = (100 * memory) / 8192
+            expect(calculator.calculate).to eq(expected_weight)
+          end
+        end
+
+        context 'when memory limit is equal to the default maximum (8G)' do
+          let(:memory) { 8192 }
+
+          it 'returns 100' do
+            expect(calculator.calculate).to eq(100)
+          end
+        end
+
+        context 'when the memory limit is between the default maximum (8G) and 16G of memory' do
+          let(:memory) { 15_000 }
+
+          it 'returns a percentage above 100' do
+            expected_weight = (100 * memory) / 8192
+            expect(calculator.calculate).to eq(expected_weight)
+          end
+        end
+
+        context 'when memory limit is equal to 16G' do
+          let(:memory) { 16_384 }
+
+          it 'returns 200' do
+            expect(calculator.calculate).to eq(200)
+          end
+        end
+
+        context 'when memory limit is equal or above 16G' do
+          let(:memory) { 32_768 }
+
+          it 'returns 200' do
+            expect(calculator.calculate).to eq(200)
           end
         end
       end


### PR DESCRIPTION
Currently CPU assignment to application instances is capped at 8GB instance memory.

This configuration option allows to set maximum memory in MB (cpu_weight_max_memory) that is used for CPU weight calculation. In this case application with more than 8G of memory will get a value above 100% (e.g. 16G apps would get a value of 200%). In this way 16G app will have twice as many cpu shares compared to 8G app.

The default values for cpu_weight_max_memory and cpu_weight_min_memory which ensures the default scenario are respectively 8192 MB and 128 MB.

Link to the open ccng issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/3588

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
