### PR TITLE
Task labels were not getting deleted causing issues with foreign key violations.

### DIFF
--- a/app/jobs/runtime/prune_completed_tasks.rb
+++ b/app/jobs/runtime/prune_completed_tasks.rb
@@ -13,10 +13,12 @@ module VCAP::CloudController
         def perform
           logger = Steno.logger('cc.background')
           logger.info('Cleaning up old TaskModel rows')
-
           tasks_to_delete = TaskModel.where(state: prunable_states).where(Sequel.lit('updated_at < ?', cutoff_age))
-          deleted_count   = Database::BatchDelete.new(tasks_to_delete).delete
+          task_labels_to_delete = TaskLabelModel.where(task: tasks_to_delete)
+          deleted_label_count = Database::BatchDelete.new(task_labels_to_delete).delete
+          deleted_count = Database::BatchDelete.new(tasks_to_delete).delete
 
+          logger.info("Cleaned up #{deleted_label_count} TaskLabelModel rows")
           logger.info("Cleaned up #{deleted_count} TaskModel rows")
         end
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

**A short explanation of the proposed change:**
When applying labels to tasks, it generate a foreign key constraint between tasks and task labels. When deleting the task, the underlying label does not cascade it's delete. This fix deletes the label of the tasks that are being marked for deletion.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
