### PR TITLE
Put service key binding/instance creation and job creation in one transaction

### DIFF
--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -181,7 +181,7 @@ class ServiceCredentialBindingsController < ApplicationController
 
   def create_key_binding(message, service_instance)
     action = V3::ServiceCredentialBindingKeyCreate.new(user_audit_info, message.audit_hash)
-    VCAP::CloudController::ServiceBinding.db.transaction do
+    VCAP::CloudController::ServiceKey.db.transaction do
       binding = action.precursor(service_instance, message:)
 
       pollable_job_guid = enqueue_bind_job(:key, binding.guid, message)

--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -66,7 +66,6 @@ class ServiceCredentialBindingsController < ApplicationController
     when 'key'
       unauthorized! unless can_write_to_active_space?(service_instance.space)
       suspended! unless is_space_active?(service_instance.space)
-
       create_key_binding(message, service_instance)
     end
   rescue V3::ServiceCredentialBindingAppCreate::UnprocessableCreate,
@@ -182,10 +181,12 @@ class ServiceCredentialBindingsController < ApplicationController
 
   def create_key_binding(message, service_instance)
     action = V3::ServiceCredentialBindingKeyCreate.new(user_audit_info, message.audit_hash)
-    binding = action.precursor(service_instance, message:)
+    VCAP::CloudController::ServiceBinding.db.transaction do
+      binding = action.precursor(service_instance, message:)
 
-    pollable_job_guid = enqueue_bind_job(:key, binding.guid, message)
-    head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job_guid}")
+      pollable_job_guid = enqueue_bind_job(:key, binding.guid, message)
+      head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job_guid}")
+    end
   end
 
   def build_create_message(params)

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -257,7 +257,7 @@ class ServiceInstancesV3Controller < ApplicationController
     unprocessable_service_plan! unless service_plan_valid?(service_plan, space)
 
     action = V3::ServiceInstanceCreateManaged.new(user_audit_info, message.audit_hash)
-    VCAP::CloudController::ServiceInstance.db.transaction do
+    VCAP::CloudController::ManagedServiceInstance.db.transaction do
       instance = action.precursor(message:, service_plan:)
 
       provision_job = VCAP::CloudController::V3::CreateServiceInstanceJob.new(

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -257,17 +257,20 @@ class ServiceInstancesV3Controller < ApplicationController
     unprocessable_service_plan! unless service_plan_valid?(service_plan, space)
 
     action = V3::ServiceInstanceCreateManaged.new(user_audit_info, message.audit_hash)
-    instance = action.precursor(message:, service_plan:)
+    VCAP::CloudController::ServiceInstance.db.transaction do
+      instance = action.precursor(message:, service_plan:)
 
-    provision_job = VCAP::CloudController::V3::CreateServiceInstanceJob.new(
-      instance.guid,
-      arbitrary_parameters: message.parameters,
-      user_audit_info: user_audit_info,
-      audit_hash: message.audit_hash
-    )
-    pollable_job = Jobs::Enqueuer.new(provision_job, queue: Jobs::Queues.generic).enqueue_pollable
+      provision_job = VCAP::CloudController::V3::CreateServiceInstanceJob.new(
+        instance.guid,
+        arbitrary_parameters: message.parameters,
+        user_audit_info: user_audit_info,
+        audit_hash: message.audit_hash
+      )
 
-    head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
+      pollable_job = Jobs::Enqueuer.new(provision_job, queue: Jobs::Queues.generic).enqueue_pollable
+
+      head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
+    end
   rescue VCAP::CloudController::ServiceInstanceCreateMixin::UnprocessableOperation,
          V3::ServiceInstanceCreateManaged::InvalidManagedServiceInstance => e
     unprocessable!(e.message)

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1605,7 +1605,7 @@ RSpec.describe 'v3 service credential bindings' do
           it 'rolls back the transaction' do
             api_call.call(admin_headers)
 
-            expect(service_instance.service_keys.count).to eq(0)
+            expect(service_instance.service_bindings.count).to eq(0)
           end
         end
       end

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1586,12 +1586,12 @@ RSpec.describe 'v3 service credential bindings' do
           end
         end
 
-        context 'database disconnect error during creation of enqueue bind job' do
+        context 'when db is unavailable' do
           before do
             allow_any_instance_of(ServiceCredentialBindingsController).to receive(:enqueue_bind_job).and_raise(Sequel::DatabaseDisconnectError)
           end
 
-          it 'rolls back the transaction' do
+          it 'raises the appropriate error' do
             api_call.call(admin_headers)
 
             expect(last_response).to have_status_code(503)
@@ -1600,6 +1600,12 @@ RSpec.describe 'v3 service credential bindings' do
                                                                    'title' => 'CF-ServiceUnavailable',
                                                                    'code' => 10_015
                                                                  }))
+          end
+
+          it 'rolls back the transaction' do
+            api_call.call(admin_headers)
+
+            expect(service_instance.has_keys?).to be_falsey
           end
         end
       end
@@ -1812,6 +1818,29 @@ RSpec.describe 'v3 service credential bindings' do
         let(:audit) { VCAP::CloudController::Event.last }
 
         it_behaves_like 'service credential binding create endpoint', VCAP::CloudController::ServiceKey, false, 'service_key', 'service_keys'
+      end
+
+      context 'when db is unavailable' do
+        before do
+          allow_any_instance_of(ServiceCredentialBindingsController).to receive(:enqueue_bind_job).and_raise(Sequel::DatabaseDisconnectError)
+        end
+
+        it 'raises the appropriate error' do
+          api_call.call(admin_headers)
+
+          expect(last_response).to have_status_code(503)
+          expect(parsed_response['errors']).to include(include({
+                                                                 'detail' => include('Database connection failure'),
+                                                                 'title' => 'CF-ServiceUnavailable',
+                                                                 'code' => 10_015
+                                                               }))
+        end
+
+        it 'rolls back the transaction' do
+          api_call.call(admin_headers)
+
+          expect(service_instance.has_keys?).to be_falsey
+        end
       end
     end
   end

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -1605,7 +1605,7 @@ RSpec.describe 'v3 service credential bindings' do
           it 'rolls back the transaction' do
             api_call.call(admin_headers)
 
-            expect(service_instance.has_keys?).to be_falsey
+            expect(service_instance.service_keys.count).to eq(0)
           end
         end
       end
@@ -1839,7 +1839,7 @@ RSpec.describe 'v3 service credential bindings' do
         it 'rolls back the transaction' do
           api_call.call(admin_headers)
 
-          expect(service_instance.has_keys?).to be_falsey
+          expect(service_instance.service_keys.count).to eq(0)
         end
       end
     end

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1179,7 +1179,7 @@ RSpec.describe 'V3 service instances' do
           allow_any_instance_of(VCAP::CloudController::Jobs::Enqueuer).to receive(:enqueue_pollable).and_raise(Sequel::DatabaseDisconnectError)
         end
 
-        it 'rolls back the transaction' do
+        it 'raises the appropriate error' do
           api_call.call(admin_headers)
 
           expect(last_response).to have_status_code(503)
@@ -1188,6 +1188,12 @@ RSpec.describe 'V3 service instances' do
                                                                  'title' => 'CF-ServiceUnavailable',
                                                                  'code' => 10_015
                                                                }))
+        end
+
+        it 'does not create a service instance in the database' do
+          api_call.call(admin_headers)
+
+          expect(instance).to be_nil
         end
       end
 

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -1010,7 +1010,7 @@ RSpec.describe 'v3 service route bindings' do
         it 'rolls back the transaction' do
           api_call.call(admin_headers)
 
-          expect(service_instance.service_keys.count).to eq(0)
+          expect(service_instance.routes.count).to eq(0)
         end
       end
     end

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -991,12 +991,12 @@ RSpec.describe 'v3 service route bindings' do
         end
       end
 
-      context 'database disconnect error during creation of enqueue bind job' do
+      context 'when db is unavailable' do
         before do
           allow_any_instance_of(ServiceRouteBindingsController).to receive(:enqueue_bind_job).and_raise(Sequel::DatabaseDisconnectError)
         end
 
-        it 'rolls back the transaction' do
+        it 'raises the appropriate error' do
           api_call.call(admin_headers)
 
           expect(last_response).to have_status_code(503)
@@ -1005,6 +1005,12 @@ RSpec.describe 'v3 service route bindings' do
                                                                  'title' => 'CF-ServiceUnavailable',
                                                                  'code' => 10_015
                                                                }))
+        end
+
+        it 'rolls back the transaction' do
+          api_call.call(admin_headers)
+
+          expect(service_instance.has_keys?).to be_falsey
         end
       end
     end

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -1010,7 +1010,7 @@ RSpec.describe 'v3 service route bindings' do
         it 'rolls back the transaction' do
           api_call.call(admin_headers)
 
-          expect(service_instance.has_keys?).to be_falsey
+          expect(service_instance.service_keys.count).to eq(0)
         end
       end
     end


### PR DESCRIPTION
Similar as in #3567, now for service key binding and service instance creation to be consistent with #3567.

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* Links to any other associated PRs
#3567
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
