### PR TITLE
Use direct file store in prometheus tests

### DIFF
--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -4,7 +4,11 @@ require 'cloud_controller/metrics/prometheus_updater'
 module VCAP::CloudController::Metrics
   RSpec.describe PrometheusUpdater do
     let(:updater) { PrometheusUpdater.new(prom_client) }
-    let(:prom_client) { Prometheus::Client::Registry.new }
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:prom_client) do
+      Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: tmpdir)
+      Prometheus::Client::Registry.new
+    end
 
     describe 'Prometheus creation guards work correctly' do
       # This might look to be a duplicate of 'records the current number of deployments that are DEPLOYING'


### PR DESCRIPTION
As the `DirectFileStore` is used in production, tests should make use of this 'metrics store' as well.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
