### PR TITLE
Set `work_mem`for annotation/label migration

### DIFF
--- a/db/migrations/20240102150000_add_annotation_label_uniqueness.rb
+++ b/db/migrations/20240102150000_add_annotation_label_uniqueness.rb
@@ -53,6 +53,8 @@ Sequel.migration do
   up do
     (annotation_tables + label_tables).each do |table|
       transaction do
+        run 'SET work_mem = 65536;' if database_type == :postgres
+
         # Create Temporary table for use later on
         create_table! :"#{table}_temp", temp: true do
           primary_key :id, name: :id


### PR DESCRIPTION
Migration `20240102150000_add_annotation_label_uniqueness.rb` contains the delete statements, similar to:
```
DELETE FROM "service_instance_annotations" WHERE ("id" NOT IN (SELECT "min_id" FROM "service_instance_annotations_temp"));
```

Depending on the `work_mem` setting in postgres this statement can become very expensive (e.g. cost of 1608032037) due to a materialized subplan. Increasing the `work_mem` to 64MB allows postgres to use a sequential scan.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
