### PR TITLE
Improve performance of decorators

### DIFF
--- a/app/decorators/include_binding_app_decorator.rb
+++ b/app/decorators/include_binding_app_decorator.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
       def decorate(hash, bindings)
         hash.deep_merge({
                           included: {
-                            apps: apps(bindings).map { |app| Presenters::V3::AppPresenter.new(app).to_hash }
+                            apps: apps(bindings)&.map { |app| Presenters::V3::AppPresenter.new(app).to_hash } || []
                           }
                         })
       end
@@ -16,7 +16,10 @@ module VCAP::CloudController
       private
 
       def apps(bindings)
-        AppModel.where(guid: bindings.pluck(:app_guid).uniq).order(:created_at).
+        app_guids = bindings.pluck(:app_guid).compact.uniq
+        return if app_guids.empty?
+
+        AppModel.where(guid: app_guids).order(:created_at).
           eager(Presenters::V3::AppPresenter.associated_resources).all
       end
     end

--- a/app/decorators/include_organization_decorator.rb
+++ b/app/decorators/include_organization_decorator.rb
@@ -7,9 +7,9 @@ module VCAP::CloudController
 
       def decorate(hash, resources)
         hash[:included] ||= {}
-        organization_guids = resources.map(&:organization_guid).uniq
-        organizations = Organization.where(guid: organization_guids).
-                        order(:created_at).eager(Presenters::V3::OrganizationPresenter.associated_resources).all
+        organization_ids = resources.map { |r| r.space.organization_id }.uniq
+        organizations = Organization.where(id: organization_ids).order(:created_at).
+                        eager(Presenters::V3::OrganizationPresenter.associated_resources).all
 
         hash[:included][:organizations] = organizations.map { |organization| Presenters::V3::OrganizationPresenter.new(organization).to_hash }
         hash

--- a/app/decorators/include_role_space_decorator.rb
+++ b/app/decorators/include_role_space_decorator.rb
@@ -7,11 +7,13 @@ module VCAP::CloudController
 
       def decorate(hash, roles)
         hash[:included] ||= {}
-        space_guids = roles.map(&:space_guid).uniq
-        spaces = Space.where(guid: space_guids).order(:created_at).
-                 eager(Presenters::V3::SpacePresenter.associated_resources).all
+        space_ids = roles.select(&:for_space?).map(&:space_id).uniq
+        unless space_ids.empty?
+          spaces = Space.where(id: space_ids).order(:created_at).
+                   eager(Presenters::V3::SpacePresenter.associated_resources).all
+        end
 
-        hash[:included][:spaces] = spaces.map { |space| Presenters::V3::SpacePresenter.new(space).to_hash }
+        hash[:included][:spaces] = spaces&.map { |space| Presenters::V3::SpacePresenter.new(space).to_hash } || []
         hash
       end
     end

--- a/app/decorators/include_route_domain_decorator.rb
+++ b/app/decorators/include_route_domain_decorator.rb
@@ -7,8 +7,8 @@ module VCAP::CloudController
 
       def decorate(hash, routes)
         hash[:included] ||= {}
-        domain_guids = routes.map(&:domain_guid).uniq
-        domains = Domain.where(guid: domain_guids).order(:name).
+        domain_ids = routes.map(&:domain_id).uniq
+        domains = Domain.where(id: domain_ids).order(:name).
                   eager(Presenters::V3::DomainPresenter.associated_resources).all
 
         hash[:included][:domains] = domains.map { |domain| Presenters::V3::DomainPresenter.new(domain).to_hash }

--- a/app/decorators/include_service_plan_service_offering_decorator.rb
+++ b/app/decorators/include_service_plan_service_offering_decorator.rb
@@ -7,10 +7,10 @@ module VCAP::CloudController
 
       def decorate(hash, service_plans)
         hash[:included] ||= {}
-        service_offerings = Service.where(id: service_plans.map(&:service_id).uniq).
+        service_offerings = Service.where(id: service_plans.map(&:service_id).uniq).order(:created_at).
                             eager(Presenters::V3::ServiceOfferingPresenter.associated_resources).all
 
-        hash[:included][:service_offerings] = service_offerings.sort_by(&:created_at).map do |service_offering|
+        hash[:included][:service_offerings] = service_offerings.map do |service_offering|
           Presenters::V3::ServiceOfferingPresenter.new(service_offering).to_hash
         end
 

--- a/app/decorators/include_service_plan_space_organization_decorator.rb
+++ b/app/decorators/include_service_plan_space_organization_decorator.rb
@@ -7,13 +7,16 @@ module VCAP::CloudController
 
       def decorate(hash, service_plans)
         hash[:included] ||= {}
-        spaces = Space.where(id: service_plans.map { |p| p.service.service_broker.space_id }.compact.uniq).
-                 order(:created_at).eager(Presenters::V3::SpacePresenter.associated_resources).all
-        orgs = Organization.where(id: spaces.map(&:organization_id).uniq).order(:created_at).
-               eager(Presenters::V3::OrganizationPresenter.associated_resources).all
+        space_ids = service_plans.map { |p| p.service.service_broker.space_id }.compact.uniq
+        unless space_ids.empty?
+          spaces = Space.where(id: space_ids).order(:created_at).
+                   eager(Presenters::V3::SpacePresenter.associated_resources).all
+          orgs = Organization.where(id: spaces.map(&:organization_id).uniq).order(:created_at).
+                 eager(Presenters::V3::OrganizationPresenter.associated_resources).all
+        end
 
-        hash[:included][:spaces] = spaces.sort_by(&:created_at).map { |space| Presenters::V3::SpacePresenter.new(space).to_hash }
-        hash[:included][:organizations] = orgs.sort_by(&:created_at).map { |org| Presenters::V3::OrganizationPresenter.new(org).to_hash }
+        hash[:included][:spaces] = spaces&.map { |space| Presenters::V3::SpacePresenter.new(space).to_hash } || []
+        hash[:included][:organizations] = orgs&.map { |org| Presenters::V3::OrganizationPresenter.new(org).to_hash } || []
         hash
       end
     end

--- a/app/decorators/include_space_organization_decorator.rb
+++ b/app/decorators/include_space_organization_decorator.rb
@@ -7,8 +7,8 @@ module VCAP::CloudController
 
       def decorate(hash, spaces)
         hash[:included] ||= {}
-        organization_guids = spaces.map(&:organization_guid).uniq
-        organizations = Organization.where(guid: organization_guids).order(:created_at).
+        organization_ids = spaces.map(&:organization_id).uniq
+        organizations = Organization.where(id: organization_ids).order(:created_at).
                         eager(Presenters::V3::OrganizationPresenter.associated_resources).all
 
         hash[:included][:organizations] = organizations.map { |organization| Presenters::V3::OrganizationPresenter.new(organization).to_hash }

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -1246,6 +1246,22 @@ RSpec.describe 'Apps' do
         expect(parsed_response).not_to have_key('included')
       end
     end
+
+    context 'when including orgs' do
+      before do
+        VCAP::CloudController::AppModel.make
+      end
+
+      it 'eagerly loads spaces to efficiently access space.organization_id' do
+        expect(VCAP::CloudController::IncludeOrganizationDecorator).to receive(:decorate) do |_, resources|
+          expect(resources).not_to be_empty
+          resources.each { |r| expect(r.associations).to include(:space) }
+        end
+
+        get '/v3/apps?include=space.organization', nil, admin_header
+        expect(last_response).to have_status_code(200)
+      end
+    end
   end
 
   describe 'GET /v3/apps/:guid' do

--- a/spec/request/roles_spec.rb
+++ b/spec/request/roles_spec.rb
@@ -1202,6 +1202,16 @@ order_by=-created_at&created_ats[lt]=2028-05-26T18:47:01Z&guids=#{organization_a
         expect(parsed_response['included']['spaces'][0]).to match_json_response(space_response_object)
       end
 
+      it 'eagerly loads users to efficiently access user_guid' do
+        expect(VCAP::CloudController::IncludeRoleUserDecorator).to receive(:decorate) do |_, roles|
+          expect(roles).not_to be_empty
+          roles.each { |r| expect(r.associations).to include(:user) }
+        end
+
+        get('/v3/roles?include=user', nil, admin_header)
+        expect(last_response).to have_status_code(200)
+      end
+
       context 'when there are multiple users with multiple roles' do
         let(:another_user) { VCAP::CloudController::User.make(guid: 'another-user-guid') }
         let(:another_org) { VCAP::CloudController::Organization.make }

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -356,6 +356,30 @@ RSpec.describe 'Routes Request' do
                                            })
         end
       end
+
+      context 'when including spaces' do
+        it 'eagerly loads spaces to efficiently access space_guid' do
+          expect(VCAP::CloudController::IncludeSpaceDecorator).to receive(:decorate) do |_, resources|
+            expect(resources).not_to be_empty
+            resources.each { |r| expect(r.associations).to include(:space) }
+          end
+
+          get '/v3/routes?include=space', nil, admin_header
+          expect(last_response).to have_status_code(200)
+        end
+      end
+
+      context 'when including orgs' do
+        it 'eagerly loads spaces to efficiently access space.organization_id' do
+          expect(VCAP::CloudController::IncludeOrganizationDecorator).to receive(:decorate) do |_, resources|
+            expect(resources).not_to be_empty
+            resources.each { |r| expect(r.associations).to include(:space) }
+          end
+
+          get '/v3/routes?include=space.organization', nil, admin_header
+          expect(last_response).to have_status_code(200)
+        end
+      end
     end
 
     describe 'filters' do

--- a/spec/request/service_route_bindings_spec.rb
+++ b/spec/request/service_route_bindings_spec.rb
@@ -214,19 +214,33 @@ RSpec.describe 'v3 service route bindings' do
     end
 
     describe 'include' do
-      it 'can include `service_instance`' do
-        instance = VCAP::CloudController::UserProvidedServiceInstance.make(:routing)
-        other_instance = VCAP::CloudController::UserProvidedServiceInstance.make(:routing)
+      context 'when including `service_instance`' do
+        let(:instance) { VCAP::CloudController::UserProvidedServiceInstance.make(:routing) }
+        let(:other_instance) { VCAP::CloudController::UserProvidedServiceInstance.make(:routing) }
 
-        VCAP::CloudController::RouteBinding.make(service_instance: instance)
-        2.times { VCAP::CloudController::RouteBinding.make(service_instance: other_instance) }
+        before do
+          VCAP::CloudController::RouteBinding.make(service_instance: instance)
+          2.times { VCAP::CloudController::RouteBinding.make(service_instance: other_instance) }
+        end
 
-        get '/v3/service_route_bindings?include=service_instance', nil, admin_headers
-        expect(last_response).to have_status_code(200)
+        it 'includes service instances`' do
+          get '/v3/service_route_bindings?include=service_instance', nil, admin_headers
+          expect(last_response).to have_status_code(200)
 
-        expect(parsed_response['included']['service_instances']).to have(2).items
-        guids = parsed_response['included']['service_instances'].pluck('guid')
-        expect(guids).to contain_exactly(instance.guid, other_instance.guid)
+          expect(parsed_response['included']['service_instances']).to have(2).items
+          guids = parsed_response['included']['service_instances'].pluck('guid')
+          expect(guids).to contain_exactly(instance.guid, other_instance.guid)
+        end
+
+        it 'eagerly loads service_instances to efficiently access service_instance_guid' do
+          expect(VCAP::CloudController::IncludeBindingServiceInstanceDecorator).to receive(:decorate) do |_, bindings|
+            expect(bindings).not_to be_empty
+            bindings.each { |b| expect(b.associations).to include(:service_instance) }
+          end
+
+          get '/v3/service_route_bindings?include=service_instance', nil, admin_headers
+          expect(last_response).to have_status_code(200)
+        end
       end
 
       it 'can include `route`' do

--- a/spec/unit/decorators/include_binding_app_decorator_spec.rb
+++ b/spec/unit/decorators/include_binding_app_decorator_spec.rb
@@ -4,24 +4,38 @@ require 'decorators/include_binding_app_decorator'
 module VCAP::CloudController
   RSpec.describe IncludeBindingAppDecorator do
     subject(:decorator) { IncludeBindingAppDecorator }
-    let(:bindings) { [ServiceBinding.make, ServiceBinding.make, ServiceBinding.make] }
-    let(:apps) do
-      bindings.map { |b| Presenters::V3::AppPresenter.new(b.app).to_hash }
+    let(:service_credential_bindings) { ServiceCredentialBinding::View.dataset.all }
+
+    context 'service bindings' do
+      let!(:bindings) { [ServiceBinding.make, ServiceBinding.make, ServiceBinding.make] }
+      let(:apps) do
+        bindings.map { |b| Presenters::V3::AppPresenter.new(b.app).to_hash }
+      end
+
+      it 'decorates the given hash with apps from bindings' do
+        dict = { foo: 'bar' }
+        hash = subject.decorate(dict, service_credential_bindings)
+        expect(hash[:foo]).to eq('bar')
+        expect(hash[:included][:apps]).to match_array(apps)
+      end
+
+      it 'does not overwrite other included fields' do
+        dict = { foo: 'bar', included: { fruits: %w[tomato banana] } }
+        hash = subject.decorate(dict, service_credential_bindings)
+        expect(hash[:foo]).to eq('bar')
+        expect(hash[:included][:apps]).to match_array(apps)
+        expect(hash[:included][:fruits]).to match_array(%w[tomato banana])
+      end
     end
 
-    it 'decorates the given hash with apps from bindings' do
-      dict = { foo: 'bar' }
-      hash = subject.decorate(dict, bindings)
-      expect(hash[:foo]).to eq('bar')
-      expect(hash[:included][:apps]).to match_array(apps)
-    end
+    context 'service keys' do
+      let!(:keys) { [ServiceKey.make] }
 
-    it 'does not overwrite other included fields' do
-      dict = { foo: 'bar', included: { fruits: %w[tomato banana] } }
-      hash = subject.decorate(dict, bindings)
-      expect(hash[:foo]).to eq('bar')
-      expect(hash[:included][:apps]).to match_array(apps)
-      expect(hash[:included][:fruits]).to match_array(%w[tomato banana])
+      it 'does not query the database' do
+        expect do
+          subject.decorate({}, service_credential_bindings)
+        end.to have_queried_db_times(/select \* from .apps. where/i, 0)
+      end
     end
 
     describe '.match?' do

--- a/spec/unit/decorators/include_role_organization_decorator_spec.rb
+++ b/spec/unit/decorators/include_role_organization_decorator_spec.rb
@@ -7,14 +7,11 @@ module VCAP::CloudController
 
     let(:organization1) { Organization.make(name: 'first-organization') }
     let(:organization2) { Organization.make(name: 'second-organization') }
-    let(:orguser) { OrganizationUser.make(organization: organization1) }
-    let(:orgauditor) { OrganizationAuditor.make(organization: organization2) }
-    let(:roles) do
-      [
-        Role.where(user_id: orguser.user_id, organization_id: organization1.id).first,
-        Role.where(user_id: orgauditor.user_id, organization_id: organization2.id).first
-      ]
-    end
+    let(:org_user) { OrganizationUser.make(organization: organization1) }
+    let(:org_auditor) { OrganizationAuditor.make(organization: organization2) }
+    let(:space_manager) { SpaceManager.make }
+    # roles is an array of VCAP::CloudController::Role objects
+    let(:roles) { Role.where(guid: [org_user, org_auditor, space_manager].map(&:guid)).all }
 
     it 'decorates the given hash with organizations from roles' do
       wreathless_hash = { foo: 'bar' }
@@ -31,6 +28,16 @@ module VCAP::CloudController
       expect(hash[:included][:organizations]).to contain_exactly(Presenters::V3::OrganizationPresenter.new(organization1).to_hash,
                                                                  Presenters::V3::OrganizationPresenter.new(organization2).to_hash)
       expect(hash[:included][:monkeys]).to match_array(%w[zach greg])
+    end
+
+    context 'only space roles' do
+      let!(:roles) { Role.where(guid: space_manager.guid).all }
+
+      it 'does not query the database' do
+        expect do
+          subject.decorate({}, roles)
+        end.to have_queried_db_times(/select \* from .organizations. where/i, 0)
+      end
     end
 
     describe '.match?' do

--- a/spec/unit/decorators/include_role_space_decorator_spec.rb
+++ b/spec/unit/decorators/include_role_space_decorator_spec.rb
@@ -7,12 +7,11 @@ module VCAP::CloudController
 
     let(:space1) { Space.make(name: 'first-space') }
     let(:space2) { Space.make(name: 'second-space') }
-    let(:roles) do
-      [
-        SpaceManager.make(space: space1),
-        SpaceAuditor.make(space: space2)
-      ]
-    end
+    let(:space_manager) { SpaceManager.make(space: space1) }
+    let(:space_auditor) { SpaceAuditor.make(space: space2) }
+    let(:org_manager) { OrganizationManager.make }
+    # roles is an array of VCAP::CloudController::Role objects
+    let(:roles) { Role.where(guid: [space_manager, space_auditor, org_manager].map(&:guid)).all }
 
     it 'decorates the given hash with spaces from roles' do
       wreathless_hash = { foo: 'bar' }
@@ -27,6 +26,16 @@ module VCAP::CloudController
       expect(hash[:foo]).to eq('bar')
       expect(hash[:included][:spaces]).to contain_exactly(Presenters::V3::SpacePresenter.new(space1).to_hash, Presenters::V3::SpacePresenter.new(space2).to_hash)
       expect(hash[:included][:monkeys]).to match_array(%w[zach greg])
+    end
+
+    context 'only org roles' do
+      let!(:roles) { Role.where(guid: org_manager.guid).all }
+
+      it 'does not query the database' do
+        expect do
+          subject.decorate({}, roles)
+        end.to have_queried_db_times(/select \* from .spaces. where/i, 0)
+      end
     end
 
     describe '.match?' do

--- a/spec/unit/decorators/include_service_plan_space_organization_decorator_spec.rb
+++ b/spec/unit/decorators/include_service_plan_space_organization_decorator_spec.rb
@@ -13,10 +13,20 @@ module VCAP::CloudController
       let!(:space_scoped_plan_1) { generate_space_scoped_plan(space1) }
       let!(:space_scoped_plan_2) { generate_space_scoped_plan(space2) }
 
-      it 'does not add space or orgs for global plan' do
-        hash = described_class.decorate({}, [ServicePlan.make(public: true)])
-        expect(hash[:included][:spaces]).to be_empty
-        expect(hash[:included][:organizations]).to be_empty
+      context 'global plan' do
+        let!(:plans) { [ServicePlan.make(public: true)] }
+
+        it 'does not add space or orgs' do
+          hash = described_class.decorate({}, plans)
+          expect(hash[:included][:spaces]).to be_empty
+          expect(hash[:included][:organizations]).to be_empty
+        end
+
+        it 'does not query the database' do
+          expect do
+            described_class.decorate({}, plans)
+          end.to have_queried_db_times(/select \* from .(spaces|organizations). where/i, 0)
+        end
       end
 
       it 'decorates the given hash with spaces and orgs from service plans' do


### PR DESCRIPTION
- Use direct attributes (e.g. `space.organization_id`) instead of accessor methods that require another object to be loaded from the database (e.g. `space.organization_guid` which is a helper method for `space.organization.guid`).
- When another object is needed to create the list of ids/guids that should be included (e.g. `service_plan.service.service_broker.space_id` requires `service` and `service_broker` objects), a test case has been added that ensures these objects are eager loaded when the decorator is used in a list endpoint.
- Sort by `created_at` as part of the database query, don't sort the result set afterwards.
- Handle `nil` values correctly, i.e. compact arrays and don't issue database queries if nothing would get selected. Add tests that ensure this behavior.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
