### PR TITLE
Don't fetch kpack_lifecycle_data

### DIFF
--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -88,7 +88,6 @@ module VCAP::CloudController
 
     def lifecycle_data
       return buildpack_lifecycle_data if buildpack_lifecycle_data
-      return kpack_lifecycle_data if kpack_lifecycle_data
 
       DockerLifecycleDataModel.new
     end

--- a/app/models/runtime/build_model.rb
+++ b/app/models/runtime/build_model.rb
@@ -60,7 +60,6 @@ module VCAP::CloudController
 
     def lifecycle_data
       return buildpack_lifecycle_data if buildpack_lifecycle_data
-      return kpack_lifecycle_data if kpack_lifecycle_data
 
       DockerLifecycleDataModel.new
     end

--- a/app/models/runtime/droplet_model.rb
+++ b/app/models/runtime/droplet_model.rb
@@ -145,7 +145,7 @@ module VCAP::CloudController
     end
 
     def lifecycle_data
-      buildpack_lifecycle_data || kpack_lifecycle_data || DockerLifecycleDataModel.new
+      buildpack_lifecycle_data || DockerLifecycleDataModel.new
     end
 
     def in_final_state?

--- a/app/models/runtime/process_model.rb
+++ b/app/models/runtime/process_model.rb
@@ -104,16 +104,9 @@ module VCAP::CloudController
           select_all(:processes)
       end
 
-      def kpack_type
-        inner_join(KpackLifecycleDataModel.table_name, app_guid: :app_guid).
-          select_all(:processes)
-      end
-
       def non_docker_type
         inner_join(BuildpackLifecycleDataModel.table_name, app_guid: :app_guid).
-          select_all(:processes).
-          union(inner_join(KpackLifecycleDataModel.table_name, app_guid: :app_guid).
-            select_all(:processes))
+          select_all(:processes)
       end
     end
 

--- a/spec/unit/lib/cloud_controller/diego/processes_sync_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/processes_sync_spec.rb
@@ -183,36 +183,6 @@ module VCAP::CloudController
               end
             end
           end
-
-          context 'when the missing process is a kpack-staged app' do
-            let!(:missing_process) { ProcessModel.make(:kpack) }
-
-            context 'with the diego_docker feature flag enabled' do
-              before do
-                VCAP::CloudController::FeatureFlag.make(name: 'diego_docker', enabled: true)
-              end
-
-              it 'creates missing lrps' do
-                allow(bbs_apps_client).to receive(:desire_app).with(missing_process)
-                subject.sync
-                expect(bbs_apps_client).to have_received(:desire_app).with(missing_process)
-                expect(bbs_apps_client).to have_received(:bump_freshness).once
-              end
-            end
-
-            context 'with the diego_docker feature flag disabled' do
-              before do
-                VCAP::CloudController::FeatureFlag.make(name: 'diego_docker', enabled: false)
-              end
-
-              it 'creates missing lrps' do
-                allow(bbs_apps_client).to receive(:desire_app).with(missing_process)
-                subject.sync
-                expect(bbs_apps_client).to have_received(:desire_app).with(missing_process)
-                expect(bbs_apps_client).to have_received(:bump_freshness).once
-              end
-            end
-          end
         end
 
         context 'when diego already contains the LRP' do

--- a/spec/unit/models/runtime/app_model_spec.rb
+++ b/spec/unit/models/runtime/app_model_spec.rb
@@ -302,15 +302,7 @@ module VCAP::CloudController
         end
       end
 
-      context 'kpack_lifecycle_data' do
-        let!(:kpack_lifecycle_data) { KpackLifecycleDataModel.make(app: app_model) }
-
-        it 'returns kpack_lifecycle_data if it is on the model' do
-          expect(app_model.lifecycle_data).to eq(kpack_lifecycle_data)
-        end
-      end
-
-      context 'buildpack_lifecycle_data and kpack_lifecycle_data is nil' do
+      context 'buildpack_lifecycle_data is nil' do
         let(:non_buildpack_app_model) { AppModel.create(name: 'non-buildpack', space: space) }
 
         it 'returns a docker data model' do

--- a/spec/unit/models/runtime/build_model_spec.rb
+++ b/spec/unit/models/runtime/build_model_spec.rb
@@ -53,24 +53,6 @@ module VCAP::CloudController
         expect(build_model.lifecycle_data).to eq(lifecycle_data)
       end
 
-      context 'kpack' do
-        let(:kpack_lifecycle_data) do
-          KpackLifecycleDataModel.make(
-            build: build_model
-          )
-        end
-
-        before do
-          build_model.buildpack_lifecycle_data = nil
-          build_model.kpack_lifecycle_data = kpack_lifecycle_data
-          build_model.save
-        end
-
-        it 'returns kpack_lifecycle_data if it is on the model' do
-          expect(build_model.lifecycle_data).to eq(kpack_lifecycle_data)
-        end
-      end
-
       it 'is a persistable hash' do
         expect(build_model.reload.lifecycle_data.buildpacks).to eq(lifecycle_data.buildpacks)
         expect(build_model.reload.lifecycle_data.stack).to eq(lifecycle_data.stack)

--- a/spec/unit/models/runtime/droplet_model_spec.rb
+++ b/spec/unit/models/runtime/droplet_model_spec.rb
@@ -83,7 +83,6 @@ module VCAP::CloudController
 
         before do
           droplet_model.buildpack_lifecycle_data = nil
-          droplet_model.kpack_lifecycle_data = nil
           droplet_model.save
         end
 
@@ -136,15 +135,6 @@ module VCAP::CloudController
           droplet_model.save
         end
 
-        it 'returns kpack_lifecycle_data if it is on the model' do
-          expect(droplet_model.lifecycle_data).to eq(lifecycle_data)
-        end
-
-        it 'is a persistable hash' do
-          expect(droplet_model.reload.lifecycle_data.buildpacks).to eq(lifecycle_data.buildpacks)
-          expect(droplet_model.reload.lifecycle_data.stack).to eq(lifecycle_data.stack)
-        end
-
         it 'deletes the dependent kpack_lifecycle_data_models when a droplet is deleted' do
           expect do
             droplet_model.destroy
@@ -156,7 +146,6 @@ module VCAP::CloudController
         let(:droplet_model) { DropletModel.make(:docker) }
 
         before do
-          droplet_model.kpack_lifecycle_data = nil
           droplet_model.buildpack_lifecycle_data = nil
           droplet_model.save
         end

--- a/spec/unit/models/runtime/process_model_spec.rb
+++ b/spec/unit/models/runtime/process_model_spec.rb
@@ -32,7 +32,6 @@ module VCAP::CloudController
 
     describe 'dataset module' do
       let!(:buildpack_process) { ProcessModel.make }
-      let!(:kpack_process) { ProcessModel.make(:kpack) }
       let!(:docker_process) { ProcessModel.make(:docker) }
 
       describe '#buildpack_type' do
@@ -41,15 +40,9 @@ module VCAP::CloudController
         end
       end
 
-      describe '#kpack_type' do
-        it 'only returns processes associated with a kpack app' do
-          expect(ProcessModel.kpack_type.map(&:name)).to contain_exactly(kpack_process.name)
-        end
-      end
-
       describe '#non_docker_type' do
         it 'only returns processes not associated with a docker app' do
-          expect(ProcessModel.non_docker_type.map(&:name)).to contain_exactly(buildpack_process.name, kpack_process.name)
+          expect(ProcessModel.non_docker_type.map(&:name)).to contain_exactly(buildpack_process.name)
         end
       end
     end


### PR DESCRIPTION
As the `kpack` lifecycle type has been removed, it does not make sense anymore to fetch `kpack_lifecycle_data` as this results in unnecessary database queries.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
