### PR TITLE
Remove some outdated stuff from the v3 docs

### DIFF
--- a/docs/v3/source/includes/concepts/_lifecycles.md.erb
+++ b/docs/v3/source/includes/concepts/_lifecycles.md.erb
@@ -7,7 +7,7 @@ pull a Docker image from a registry to run an app.
 
 Name | Type | Description
 ---- | ---- | -----------
-**type** | _string_ | Type of the lifecycle; valid values are `buildpack`, `docker`, `kpack`
+**type** | _string_ | Type of the lifecycle; valid values are `buildpack`, `docker`
 **data** | _object_ | Data that is used during staging and running for a lifecycle
 
 ### Buildpack lifecycle

--- a/docs/v3/source/includes/resources/roles/_get.md.erb
+++ b/docs/v3/source/includes/resources/roles/_get.md.erb
@@ -46,4 +46,4 @@ Org Billing Manager | Can only see organization roles in billing-managed organiz
 Space Auditor | Can see roles in audited spaces or parent organizations
 Space Developer | Can see roles in developed spaces or parent organizations
 Space Manager | Can see roles in managed spaces or parent organizations
-[Space Supporter](#valid-role-types) (*under development*) | Can see roles in supported spaces or parent organizations
+Space Supporter | Can see roles in supported spaces or parent organizations


### PR DESCRIPTION
- The space supporter role is not under development anymore.
- The `kpack` lifecycle type has been removed.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
