### PR TITLE
Replace dataset.map().flatten.map() with optimized SQL query

### DIFF
--- a/app/fetchers/droplet_list_fetcher.rb
+++ b/app/fetchers/droplet_list_fetcher.rb
@@ -44,7 +44,9 @@ module VCAP::CloudController
         droplet_table_name = DropletModel.table_name
 
         if message.requested?(:organization_guids)
-          space_guids_from_orgs = Organization.where(guid: message.organization_guids).map(&:spaces).flatten.map(&:guid)
+          space_guids_from_orgs = Space.join(:organizations, id: :organization_id).
+                                  where(organizations__guid: message.organization_guids).
+                                  select(:spaces__guid)
           dataset = dataset.select_all(droplet_table_name).
                     join_table(:inner, AppModel.table_name, { guid: Sequel[:droplets][:app_guid], space_guid: space_guids_from_orgs }, { table_alias: :apps_orgs })
         end

--- a/app/fetchers/route_fetcher.rb
+++ b/app/fetchers/route_fetcher.rb
@@ -27,8 +27,10 @@ module VCAP::CloudController
         dataset = dataset.where(port: message.ports) if message.requested?(:ports)
 
         if message.requested?(:organization_guids)
-          space_ids = Organization.where(guid: message.organization_guids).map(&:spaces).flatten.map(&:id)
-          dataset = dataset.where(space_id: space_ids)
+          space_ids_from_orgs = Space.join(:organizations, id: :organization_id).
+                                where(organizations__guid: message.organization_guids).
+                                select(:spaces__id)
+          dataset = dataset.where(space_id: space_ids_from_orgs)
         end
 
         dataset = dataset.where(domain_id: Domain.where(guid: message.domain_guids).select(:id)) if message.requested?(:domain_guids)

--- a/app/fetchers/task_list_fetcher.rb
+++ b/app/fetchers/task_list_fetcher.rb
@@ -37,7 +37,10 @@ module VCAP::CloudController
       def filter_app_dataset(message, app_dataset)
         app_dataset = app_dataset.where(space_guid: message.space_guids) if message.requested?(:space_guids)
         if message.requested?(:organization_guids)
-          app_dataset = app_dataset.where(space_guid: Organization.where(guid: message.organization_guids).map(&:spaces).flatten.map(&:guid))
+          space_guids_from_orgs = Space.join(:organizations, id: :organization_id).
+                                  where(organizations__guid: message.organization_guids).
+                                  select(:spaces__guid)
+          app_dataset = app_dataset.where(space_guid: space_guids_from_orgs)
         end
         app_dataset = app_dataset.where(guid: message.app_guids) if message.requested?(:app_guids)
         app_dataset


### PR DESCRIPTION
The following code first fetches all the filtered orgs (1 query) and then all associated spaces (n queries) to only keep their guids:

  Organization.where(guid: ...).map(&:spaces).flatten.map(&:guid))

The same can be achieved with a single SQL query that only returns the needed data:

  Space.join(:organizations, id: :organization_id).
    where(organizations__guid: ...).select(:spaces__guid)

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
