### PR TITLE
Reduce risk of failing tests due to unrelated processes

### DIFF
--- a/spec/unit/lib/background_job_environment_spec.rb
+++ b/spec/unit/lib/background_job_environment_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe BackgroundJobEnvironment do
     end
 
     def open_port_count
-      `lsof -i -P -n | grep LISTEN | wc -l`.to_i
+      `lsof -i -P -n | grep LISTEN | grep #{Process.pid} | wc -l`.to_i
     end
 
     it 'doesnt attempt to open a readiness port' do


### PR DESCRIPTION
Limit the `lsof` result by greping for the process id.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
