### PR TITLE
Expose process CPU Entitlement in stats

### DIFF
--- a/app/presenters/v3/process_stats_presenter.rb
+++ b/app/presenters/v3/process_stats_presenter.rb
@@ -76,6 +76,7 @@ module VCAP::CloudController
                                       {
                                         time: stats[:stats][:usage][:time],
                                         cpu: stats[:stats][:usage][:cpu],
+                                        cpu_entitlement: stats[:stats][:usage][:cpu_entitlement],
                                         mem: stats[:stats][:usage][:mem],
                                         disk: stats[:stats][:usage][:disk],
                                         log_rate: stats[:stats][:usage][:log_rate]

--- a/docs/v3/source/includes/api_resources/_processes.erb
+++ b/docs/v3/source/includes/api_resources/_processes.erb
@@ -208,8 +208,10 @@
       "usage": {
         "time": "2016-03-23T23:17:30.476314154Z",
         "cpu": 0.00038711029163348665,
+        "cpu_entitlement": 0.01117396940977856,
         "mem": 19177472,
-        "disk": 69705728
+        "disk": 69705728,
+        "log_rate": 0
       },
       "host": "10.244.16.10",
       "instance_internal_ip": "10.255.93.167",
@@ -235,6 +237,7 @@
       "state": "STARTING",
       "usage": {
         "cpu": 0,
+        "cpu_entitlement": null,
         "disk": 0,
         "log_rate": 0,
         "mem": 0,
@@ -282,8 +285,10 @@
   "usage": {
     "time": "2016-03-23T23:17:30.476314154Z",
     "cpu": 0.00038711029163348665,
+    "cpu_entitlement": 0.01117396940977856,
     "mem": 19177472,
-    "disk": 69705728
+    "disk": 69705728,
+    "log_rate": 0
   },
   "host": "10.244.16.10",
   "instance_ports": [

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -88,6 +88,7 @@ module VCAP::CloudController
         {
           time: formatted_current_time,
           cpu: 0,
+          cpu_entitlement: nil,
           mem: 0,
           disk: 0,
           log_rate: 0
@@ -133,6 +134,7 @@ module VCAP::CloudController
 
       def converted_container_metrics(container_metrics, formatted_current_time)
         cpu = container_metrics.cpu_percentage
+        cpu_entitlement = container_metrics.cpu_entitlement_percentage.nil? ? nil : container_metrics.cpu_entitlement_percentage / 100
         mem = container_metrics.memory_bytes
         disk = container_metrics.disk_bytes
         log_rate = container_metrics.log_rate
@@ -143,6 +145,7 @@ module VCAP::CloudController
           {
             time: formatted_current_time,
             cpu: cpu / 100,
+            cpu_entitlement: cpu_entitlement,
             mem: mem,
             disk: disk,
             log_rate: log_rate

--- a/lib/logcache/container_metric_batch.rb
+++ b/lib/logcache/container_metric_batch.rb
@@ -1,6 +1,6 @@
 module Logcache
   class ContainerMetricBatch
-    attr_accessor :cpu_percentage, :memory_bytes, :disk_bytes, :log_rate,
+    attr_accessor :cpu_percentage, :cpu_entitlement_percentage, :memory_bytes, :disk_bytes, :log_rate,
                   :disk_bytes_quota, :memory_bytes_quota, :log_rate_limit,
                   :instance_index
   end

--- a/lib/logcache/container_metric_batcher.rb
+++ b/lib/logcache/container_metric_batcher.rb
@@ -64,6 +64,7 @@ module Logcache
       # on envelope.gauge.metrics - but it does not
       # rubocop:disable Style/PreferredHashMethods
       envelope.gauge.metrics.has_key?('cpu') ||
+        envelope.gauge.metrics.has_key?('cpu_entitlement') ||
         envelope.gauge.metrics.has_key?('memory') ||
         envelope.gauge.metrics.has_key?('memory_quota') ||
         envelope.gauge.metrics.has_key?('disk') ||
@@ -82,6 +83,7 @@ module Logcache
         # on envelope.gauge.metrics - but it does not
         # rubocop:disable Style/PreferredHashMethods
         metric_batch.cpu_percentage = e.gauge.metrics['cpu'].value if e.gauge.metrics.has_key?('cpu')
+        metric_batch.cpu_entitlement_percentage = e.gauge.metrics['cpu_entitlement'].value if e.gauge.metrics.has_key?('cpu_entitlement')
         metric_batch.memory_bytes = e.gauge.metrics['memory'].value.to_i if e.gauge.metrics.has_key?('memory')
         metric_batch.disk_bytes = e.gauge.metrics['disk'].value.to_i if e.gauge.metrics.has_key?('disk')
         metric_batch.log_rate = e.gauge.metrics['log_rate'].value.to_i if e.gauge.metrics.has_key?('log_rate')

--- a/spec/logcache/container_metric_batcher_spec.rb
+++ b/spec/logcache/container_metric_batcher_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe Logcache::ContainerMetricBatcher do
           timestamp: last_timestamp,
           source_id: process_guid,
           gauge: Loggregator::V2::Gauge.new(metrics: {
-                                              'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: cpu_percentage),
+                                              'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: cpu_percentage),
                                               'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: (100 * i) + 2),
                                               'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: (100 * i) + 3),
-                                              'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: (100 * i) + 4)
+                                              'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: (100 * i) + 4)
                                             }),
           instance_id: (offset + i).to_s
         ),
@@ -64,30 +64,33 @@ RSpec.describe Logcache::ContainerMetricBatcher do
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 10),
                                                   'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 11),
                                                   'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13)
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 13),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 14)
                                                 }),
               instance_id: '1'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13),
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 13),
                                                   'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
                                                   'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10)
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 10),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 10)
                                                 }),
               instance_id: '2'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 10),
                                                   'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 9),
                                                   'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 8),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 7)
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 7),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 6)
                                                 }),
               instance_id: '1'
             )
@@ -102,6 +105,7 @@ RSpec.describe Logcache::ContainerMetricBatcher do
         expect(subject).to have(1).items
         expect(subject.first.instance_index).to eq(1)
         expect(subject.first.cpu_percentage).to eq(10)
+        expect(subject.first.cpu_entitlement_percentage).to eq(14)
         expect(subject.first.memory_bytes).to eq(11)
         expect(subject.first.disk_bytes).to eq(12)
         expect(subject.first.log_rate).to eq(13)
@@ -125,17 +129,18 @@ RSpec.describe Logcache::ContainerMetricBatcher do
               gauge: Loggregator::V2::Gauge.new(metrics: {
                                                   'absolute_usage' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 300),
                                                   'absolute_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 400),
-                                                  'container_age' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 500)
+                                                  'container_age' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 500),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 600)
                                                 }),
               instance_id: '1'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 10),
                                                   'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 11),
                                                   'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13)
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 13)
                                                 }),
               instance_id: '1'
             ),
@@ -144,17 +149,25 @@ RSpec.describe Logcache::ContainerMetricBatcher do
               gauge: Loggregator::V2::Gauge.new(metrics: {
                                                   'absolute_usage' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 600),
                                                   'absolute_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 700),
-                                                  'container_age' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 800)
+                                                  'container_age' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 800),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 900)
                                                 }),
               instance_id: '2'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 20),
+                                                  'some_other_gauge' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 20_000)
+                                                }),
+              instance_id: '2'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: {
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 20),
                                                   'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 21),
                                                   'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 22),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 23)
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 23)
                                                 }),
               instance_id: '2'
             ),
@@ -163,19 +176,27 @@ RSpec.describe Logcache::ContainerMetricBatcher do
               gauge: Loggregator::V2::Gauge.new(metrics: {
                                                   'absolute_usage' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 900),
                                                   'absolute_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 1000),
-                                                  'container_age' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 1100)
+                                                  'container_age' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 1100),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 1200)
                                                 }),
               instance_id: '3'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 30),
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 30),
                                                   'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 31),
                                                   'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 33)
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 33)
                                                 }),
               instance_id: '3'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: {
+                                                  'some_other_gauge' => Loggregator::V2::GaugeValue.new(unit: 'nanoseconds', value: 10_000)
+                                                }),
+              instance_id: '4'
             )
           ]
         )
@@ -185,12 +206,14 @@ RSpec.describe Logcache::ContainerMetricBatcher do
       it 'returns an array of batched metrics' do
         expect(subject.first.instance_index).to eq(1)
         expect(subject.first.cpu_percentage).to eq(10)
+        expect(subject.first.cpu_entitlement_percentage).to eq(600)
         expect(subject.first.memory_bytes).to eq(11)
         expect(subject.first.disk_bytes).to eq(12)
         expect(subject.first.log_rate).to eq(13)
 
         expect(subject.second.instance_index).to eq(2)
         expect(subject.second.cpu_percentage).to eq(20)
+        expect(subject.second.cpu_entitlement_percentage).to eq(900)
         expect(subject.second.memory_bytes).to eq(21)
         expect(subject.second.disk_bytes).to eq(22)
         expect(subject.second.log_rate).to eq(23)
@@ -198,9 +221,23 @@ RSpec.describe Logcache::ContainerMetricBatcher do
         cm = subject[2]
         expect(cm.instance_index).to eq(3)
         expect(cm.cpu_percentage).to eq(30)
+        expect(cm.cpu_entitlement_percentage).to eq(1200)
         expect(cm.memory_bytes).to eq(31)
         expect(cm.disk_bytes).to eq(32)
         expect(cm.log_rate).to eq(33)
+      end
+
+      it 'does not return a metrics batch without container metrics' do
+        expect(subject).to all(satisfy do |cm|
+          !(cm.cpu_percentage.nil? &&
+          cm.cpu_entitlement_percentage.nil? &&
+          cm.memory_bytes.nil? &&
+          cm.disk_bytes.nil? &&
+          cm.log_rate.nil? &&
+          cm.disk_bytes_quota.nil? &&
+          cm.memory_bytes_quota.nil? &&
+          cm.log_rate_limit.nil?)
+        end)
       end
     end
 
@@ -210,13 +247,14 @@ RSpec.describe Logcache::ContainerMetricBatcher do
           batch: [Loggregator::V2::Envelope.new(
             source_id: process_guid,
             gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 0.10),
-                                                'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 11.0),
-                                                'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12.0),
-                                                'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13.0),
+                                                'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 0.10),
+                                                'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 0.11),
+                                                'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12.0),
+                                                'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13.0),
+                                                'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 14.0),
                                                 'disk_quota' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 24.0),
                                                 'memory_quota' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 25.0),
-                                                'log_rate_limit' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 26.0)
+                                                'log_rate_limit' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 26.0)
                                               }),
             instance_id: '1'
           )]
@@ -226,9 +264,10 @@ RSpec.describe Logcache::ContainerMetricBatcher do
       it 'returns an array of one batched envelope' do
         expect(subject.first.instance_index).to be(1)
         expect(subject.first.cpu_percentage).to be(0.10)
-        expect(subject.first.memory_bytes).to be(11)
-        expect(subject.first.disk_bytes).to be(12)
-        expect(subject.first.log_rate).to be(13)
+        expect(subject.first.cpu_entitlement_percentage).to be(0.11)
+        expect(subject.first.memory_bytes).to be(12)
+        expect(subject.first.disk_bytes).to be(13)
+        expect(subject.first.log_rate).to be(14)
         expect(subject.first.disk_bytes_quota).to be(24)
         expect(subject.first.memory_bytes_quota).to be(25)
         expect(subject.first.log_rate_limit).to be(26)
@@ -242,39 +281,42 @@ RSpec.describe Logcache::ContainerMetricBatcher do
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
-                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 11),
-                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13),
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 10),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 11),
+                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12),
+                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13),
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 14),
                                                   'disk_quota' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 24),
                                                   'memory_quota' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 25),
-                                                  'log_rate_limit' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 26)
+                                                  'log_rate_limit' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 26)
                                                 }),
               instance_id: '1'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 20),
-                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 21),
-                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 22),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 23),
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 20),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 21),
+                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 22),
+                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 23),
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 24),
                                                   'disk_quota' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 34),
                                                   'memory_quota' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 35),
-                                                  'log_rate_limit' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 36)
+                                                  'log_rate_limit' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 36)
                                                 }),
               instance_id: '2'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 30),
-                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 31),
-                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 33),
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 30),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 31),
+                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
+                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 33),
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 34),
                                                   'disk_quota' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 44),
                                                   'memory_quota' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 45),
-                                                  'log_rate_limit' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 46)
+                                                  'log_rate_limit' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 46)
                                                 }),
               instance_id: '3'
             )
@@ -286,18 +328,20 @@ RSpec.describe Logcache::ContainerMetricBatcher do
       it 'returns an array of batched metrics' do
         expect(subject.first.instance_index).to eq(1)
         expect(subject.first.cpu_percentage).to eq(10)
-        expect(subject.first.memory_bytes).to eq(11)
-        expect(subject.first.disk_bytes).to eq(12)
-        expect(subject.first.log_rate).to eq(13)
+        expect(subject.first.cpu_entitlement_percentage).to eq(11)
+        expect(subject.first.memory_bytes).to eq(12)
+        expect(subject.first.disk_bytes).to eq(13)
+        expect(subject.first.log_rate).to eq(14)
         expect(subject.first.disk_bytes_quota).to eq(24)
         expect(subject.first.memory_bytes_quota).to eq(25)
         expect(subject.first.log_rate_limit).to eq(26)
 
         expect(subject.second.instance_index).to eq(2)
         expect(subject.second.cpu_percentage).to eq(20)
-        expect(subject.second.memory_bytes).to eq(21)
-        expect(subject.second.disk_bytes).to eq(22)
-        expect(subject.second.log_rate).to eq(23)
+        expect(subject.second.cpu_entitlement_percentage).to eq(21)
+        expect(subject.second.memory_bytes).to eq(22)
+        expect(subject.second.disk_bytes).to eq(23)
+        expect(subject.second.log_rate).to eq(24)
         expect(subject.second.disk_bytes_quota).to eq(34)
         expect(subject.second.memory_bytes_quota).to eq(35)
         expect(subject.second.log_rate_limit).to eq(36)
@@ -305,9 +349,10 @@ RSpec.describe Logcache::ContainerMetricBatcher do
         cm = subject[2]
         expect(cm.instance_index).to eq(3)
         expect(cm.cpu_percentage).to eq(30)
-        expect(cm.memory_bytes).to eq(31)
-        expect(cm.disk_bytes).to eq(32)
-        expect(cm.log_rate).to eq(33)
+        expect(cm.cpu_entitlement_percentage).to eq(31)
+        expect(cm.memory_bytes).to eq(32)
+        expect(cm.disk_bytes).to eq(33)
+        expect(cm.log_rate).to eq(34)
         expect(cm.disk_bytes_quota).to eq(44)
         expect(cm.memory_bytes_quota).to eq(45)
         expect(cm.log_rate_limit).to eq(46)
@@ -320,32 +365,17 @@ RSpec.describe Logcache::ContainerMetricBatcher do
           batch: [
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
-              gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10),
-                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 11),
-                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13)
-                                                }),
+              gauge: Loggregator::V2::Gauge.new(metrics: { 'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 10) }),
               instance_id: '1'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
-              gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 20),
-                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 21),
-                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 22),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 23)
-                                                }),
+              gauge: Loggregator::V2::Gauge.new(metrics: { 'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 20) }),
               instance_id: '2'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
-              gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 30),
-                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 31),
-                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 32),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 33)
-                                                }),
+              gauge: Loggregator::V2::Gauge.new(metrics: { 'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 30) }),
               instance_id: '1'
             )
           ]
@@ -396,39 +426,37 @@ RSpec.describe Logcache::ContainerMetricBatcher do
           batch: [
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
-              gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 10)
-                                                }),
+              gauge: Loggregator::V2::Gauge.new(metrics: { 'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 10) }),
+              instance_id: '1'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: { 'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 11) }),
+              instance_id: '1'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: { 'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12) }),
+              instance_id: '1'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: { 'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13) }),
+              instance_id: '1'
+            ),
+            Loggregator::V2::Envelope.new(
+              source_id: process_guid,
+              gauge: Loggregator::V2::Gauge.new(metrics: { 'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 14) }),
               instance_id: '1'
             ),
             Loggregator::V2::Envelope.new(
               source_id: process_guid,
               gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 11)
-                                                }),
-              instance_id: '1'
-            ),
-            Loggregator::V2::Envelope.new(
-              source_id: process_guid,
-              gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 12)
-                                                }),
-              instance_id: '1'
-            ),
-            Loggregator::V2::Envelope.new(
-              source_id: process_guid,
-              gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 13)
-                                                }),
-              instance_id: '1'
-            ),
-            Loggregator::V2::Envelope.new(
-              source_id: process_guid,
-              gauge: Loggregator::V2::Gauge.new(metrics: {
-                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 20),
-                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 21),
-                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 22),
-                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 23)
+                                                  'cpu' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 20),
+                                                  'cpu_entitlement' => Loggregator::V2::GaugeValue.new(unit: 'percentage', value: 21),
+                                                  'memory' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 22),
+                                                  'disk' => Loggregator::V2::GaugeValue.new(unit: 'bytes', value: 23),
+                                                  'log_rate' => Loggregator::V2::GaugeValue.new(unit: 'B/s', value: 24)
                                                 }),
               instance_id: '2'
             )
@@ -437,20 +465,22 @@ RSpec.describe Logcache::ContainerMetricBatcher do
       end
       let(:num_instances) { 2 }
 
-      it 'returns a single envelope per instance' do
+      it 'returns a single container metric batch per instance' do
         expect(subject.count).to eq(2)
 
         expect(subject.first.instance_index).to eq(1)
         expect(subject.first.cpu_percentage).to eq(10)
-        expect(subject.first.memory_bytes).to eq(11)
-        expect(subject.first.disk_bytes).to eq(12)
-        expect(subject.first.log_rate).to eq(13)
+        expect(subject.first.cpu_entitlement_percentage).to eq(11)
+        expect(subject.first.memory_bytes).to eq(12)
+        expect(subject.first.disk_bytes).to eq(13)
+        expect(subject.first.log_rate).to eq(14)
 
         expect(subject.second.instance_index).to eq(2)
         expect(subject.second.cpu_percentage).to eq(20)
-        expect(subject.second.memory_bytes).to eq(21)
-        expect(subject.second.disk_bytes).to eq(22)
-        expect(subject.second.log_rate).to eq(23)
+        expect(subject.second.cpu_entitlement_percentage).to eq(21)
+        expect(subject.second.memory_bytes).to eq(22)
+        expect(subject.second.disk_bytes).to eq(23)
+        expect(subject.second.log_rate).to eq(24)
       end
     end
 

--- a/spec/logcache/container_metric_batcher_spec.rb
+++ b/spec/logcache/container_metric_batcher_spec.rb
@@ -100,8 +100,6 @@ RSpec.describe Logcache::ContainerMetricBatcher do
       let(:filter) { ->(e) { e.gauge.metrics['cpu'].value == 10 } }
 
       it 'filters envelopes' do
-        subject
-
         expect(subject).to have(1).items
         expect(subject.first.instance_index).to eq(1)
         expect(subject.first.cpu_percentage).to eq(10)

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -536,7 +536,8 @@ RSpec.describe 'Processes' do
             fds_quota: process.file_descriptors,
             usage: {
               time: usage_time,
-              cpu: 80,
+              cpu: 0.8,
+              cpu_entitlement: 0.1,
               mem: 128,
               disk: 1024,
               log_rate: 1024
@@ -560,7 +561,8 @@ RSpec.describe 'Processes' do
           'details' => 'some-details',
           'usage' => {
             'time' => usage_time,
-            'cpu' => 80,
+            'cpu' => 0.8,
+            'cpu_entitlement' => 0.1,
             'mem' => 128,
             'disk' => 1024,
             'log_rate' => 1024
@@ -604,6 +606,21 @@ RSpec.describe 'Processes' do
 
           expect(last_response.status).to eq(200)
           expect(parsed_response).to be_a_response_like(expected_response)
+        end
+      end
+
+      context 'cpu entitlement usage is not available' do
+        before do
+          stats_for_process[0][:stats][:usage][:cpu_entitlement] = nil
+        end
+
+        it 'returns cpu entitlement as null' do
+          get "/v3/processes/#{process.guid}/stats", nil, developer_headers
+
+          parsed_response = MultiJson.load(last_response.body)
+
+          expect(last_response.status).to eq(200)
+          expect(parsed_response['resources'][0]['usage']['cpu_entitlement']).to be_nil
         end
       end
     end

--- a/spec/unit/presenters/v3/process_stats_presenter_spec.rb
+++ b/spec/unit/presenters/v3/process_stats_presenter_spec.rb
@@ -74,6 +74,7 @@ module VCAP::CloudController::Presenters::V3
               usage: {
                 time: '2015-12-08 16:54:48 -0800',
                 cpu: 80,
+                cpu_entitlement: 85,
                 mem: 128,
                 disk: 1024,
                 log_rate: 2048
@@ -97,6 +98,7 @@ module VCAP::CloudController::Presenters::V3
               usage: {
                 time: '2015-03-13 16:54:48 -0800',
                 cpu: 70,
+                cpu_entitlement: 75,
                 mem: 128,
                 disk: 1024,
                 log_rate: 7168
@@ -133,6 +135,7 @@ module VCAP::CloudController::Presenters::V3
         expect(result[0][:fds_quota]).to eq(process.file_descriptors)
         expect(result[0][:usage]).to eq({ time: '2015-12-08 16:54:48 -0800',
                                           cpu: 80,
+                                          cpu_entitlement: 85,
                                           mem: 128,
                                           disk: 1024,
                                           log_rate: 2048 })
@@ -148,6 +151,7 @@ module VCAP::CloudController::Presenters::V3
         expect(result[1][:uptime]).to eq(42)
         expect(result[1][:usage]).to eq({ time: '2015-03-13 16:54:48 -0800',
                                           cpu: 70,
+                                          cpu_entitlement: 75,
                                           mem: 128,
                                           disk: 1024,
                                           log_rate: 7168 })
@@ -183,6 +187,7 @@ module VCAP::CloudController::Presenters::V3
                 usage: {
                   time: '2015-12-08 16:54:48 -0800',
                   cpu: 80,
+                  cpu_entitlement: 85,
                   mem: 128,
                   disk: 1024,
                   log_rate: 2048
@@ -221,6 +226,7 @@ module VCAP::CloudController::Presenters::V3
                 usage: {
                   time: '2015-12-08 16:54:48 -0800',
                   cpu: 80,
+                  cpu_entitlement: 85,
                   mem: 128,
                   disk: 1024,
                   log_rate: 2048
@@ -289,6 +295,7 @@ module VCAP::CloudController::Presenters::V3
           expect(result[0][:fds_quota]).to eq(process.file_descriptors)
           expect(result[0][:usage]).to eq({ time: '2015-12-08 16:54:48 -0800',
                                             cpu: 80,
+                                            cpu_entitlement: 85,
                                             mem: 128,
                                             disk: 1024,
                                             log_rate: 2048 })


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Extend the existing v3 processes stats endpoint to include the CPU Entitlement for the process.

* An explanation of the use cases your change solves

It can be difficult to reason about process CPU usage using the existing cpu stat. For example the value is impacted by changes to the underlying vCPUs available on the Diego Cell. CPU Entitlement is a more generally useful metric.

https://www.cloudfoundry.org/blog/better-way-split-cake-cpu-entitlements/

* Links to any other associated PRs

https://github.com/cloudfoundry/diego-release/issues/897

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)

@mkocher 