### PR TITLE
Fix flappy space_delete_spec

### DIFF
--- a/spec/unit/actions/space_delete_spec.rb
+++ b/spec/unit/actions/space_delete_spec.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
         space_delete.delete([space])
         expect(VCAP::CloudController::Event.count).to eq(2)
 
-        events = VCAP::CloudController::Event.all
+        events = VCAP::CloudController::Event.order(:id).all
         event = events.last
         expect(event.values).to include(
           type: 'audit.space.delete-request',
@@ -48,7 +48,7 @@ module VCAP::CloudController
         expect(event.metadata).to eq({ 'request' => { 'recursive' => true } })
         expect(event.timestamp).to be
 
-        event = VCAP::CloudController::Event.first
+        event = events.first
         expect(event.values).to include(
           type: 'audit.app.delete-request'
         )


### PR DESCRIPTION
Without an `ORDER BY` clause it's not guaranteed that `events.last` and `events.first` are as expected as Postgres does not specify the ordering of a result set.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
