### PR TITLE
Add routes_space_id index

### DIFF
--- a/db/migrations/20240219113000_add_routes_space_id_index.rb
+++ b/db/migrations/20240219113000_add_routes_space_id_index.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    add_index :routes, :space_id, name: :routes_space_id_index, options: %i[if_not_exists concurrently] if database_type == :postgres
+  end
+
+  down do
+    drop_index :routes, :space_id, name: :routes_space_id_index, options: %i[if_exists concurrently] if database_type == :postgres
+  end
+end


### PR DESCRIPTION
For MySQL there already is a foreign key index, thus it only needs to be added for PostgreSQL.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
