### PR TITLE
Change delayed_jobs_reserve index

### DIFF
--- a/db/migrations/20240222131500_change_delayed_jobs_reserve_index.rb
+++ b/db/migrations/20240222131500_change_delayed_jobs_reserve_index.rb
@@ -1,0 +1,17 @@
+Sequel.migration do
+  up do
+    if database_type == :postgres
+      drop_index :delayed_jobs, nil, name: :delayed_jobs_reserve, options: %i[if_exists concurrently]
+      add_index :delayed_jobs, %i[queue locked_at locked_by failed_at run_at priority],
+                where: { failed_at: nil }, name: :delayed_jobs_reserve, options: %i[if_not_exists concurrently]
+    end
+  end
+
+  down do
+    if database_type == :postgres
+      drop_index :delayed_jobs, nil, name: :delayed_jobs_reserve, options: %i[if_exists concurrently]
+      add_index :delayed_jobs, %i[queue locked_at locked_by failed_at run_at priority],
+                name: :delayed_jobs_reserve, options: %i[if_not_exists concurrently]
+    end
+  end
+end


### PR DESCRIPTION
Add `WHERE` condition. Jobs that failed are only kept for debugging purposes, they are not taken into account when reserving a job. The corresponding `SELECT` statement [1] includes `WHERE failed_at IS NULL`, so the corresponding index can omit failed jobs.

Partial indexes are not supported for **MySQL**, thus this change is only for **PostgreSQL**.

[1] https://github.com/TalentBox/delayed_job_sequel/blob/938ff68e98b44bbc391805c672a74c5ee3aef08b/lib/delayed/backend/sequel.rb#L26

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
