### PR TITLE
Use DISTINCT only when required (service plan|offering list fetcher)

### DIFF
--- a/app/fetchers/base_service_list_fetcher.rb
+++ b/app/fetchers/base_service_list_fetcher.rb
@@ -63,7 +63,7 @@ module VCAP::CloudController
                     end.from_self(alias: klass.table_name)
                   end
 
-        dataset.distinct.eager(eager_loaded_associations)
+        dataset.eager(eager_loaded_associations)
       end
 
       def readable_by_plan_org(dataset, readable_orgs_query)
@@ -156,7 +156,8 @@ module VCAP::CloudController
 
       def join_plan_org_visibilities(dataset)
         dataset = join_service_plans(dataset)
-        join(dataset, :inner, :service_plan_visibilities, service_plan_id: Sequel[:service_plans][:id])
+        dataset = join(dataset, :inner, :service_plan_visibilities, service_plan_id: Sequel[:service_plans][:id])
+        dataset.distinct # service plans can have multiple visibilities
       end
 
       def join_service_brokers(dataset)
@@ -181,12 +182,14 @@ module VCAP::CloudController
 
       def join_plan_spaces(dataset)
         dataset = join_plan_orgs(dataset)
-        join(dataset, :inner, Sequel[:spaces].as(:plan_spaces), organization_id: Sequel[:plan_orgs][:id])
+        dataset = join(dataset, :inner, Sequel[:spaces].as(:plan_spaces), organization_id: Sequel[:plan_orgs][:id])
+        dataset.distinct # organizations can have multiple spaces
       end
 
       def join_service_instances(dataset)
         dataset = join_service_plans(dataset)
-        join(dataset, :inner, :service_instances, service_plan_id: Sequel[:service_plans][:id])
+        dataset = join(dataset, :inner, :service_instances, service_plan_id: Sequel[:service_plans][:id])
+        dataset.distinct # service plans can have multiple instances
       end
 
       def join(dataset, type, table, on)

--- a/app/fetchers/service_offering_list_fetcher.rb
+++ b/app/fetchers/service_offering_list_fetcher.rb
@@ -32,7 +32,8 @@ module VCAP::CloudController
       end
 
       def join_service_plans(dataset)
-        join(dataset, :inner, :service_plans, service_id: Sequel[:services][:id])
+        dataset = join(dataset, :inner, :service_plans, service_id: Sequel[:services][:id])
+        dataset.distinct # services can have multiple plans
       end
     end
   end


### PR DESCRIPTION
As part of PR #3620 it has been validated that there is no overlap between the different sources (`UNION`ed datasets). But as these single datasets are created by `JOIN`ing several tables, there might be duplicates depending on the cardinality of those relations. Thus the overall `DISTINCT` is replaced by `DISTINCT`s added when `JOIN`ing a table with a one-to-many relation. Calling `.distinct` multiple times does not have any negative effect as this simply sets a flag on the Sequel dataset.

This change should improve performance of requests to the following endpoints whenever those `JOIN`s are not needed (e.g. depending on request parameters):
- /v3/service_offerings
- /v3/service_plans

Tests now ensure that there are:
- multiple plans per offering
- multiple service instances per plan
- multiple visibilities per plan
- multiple spaces per organization

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
