### PR TITLE
update lock information logging to happen on info and to happen only once per state switch

### DIFF
--- a/lib/locket/lock_runner.rb
+++ b/lib/locket/lock_runner.rb
@@ -25,13 +25,20 @@ module Locket
       raise Error.new('Cannot start more than once') if @thread
 
       @thread = Thread.new do
+        failed = false
         loop do
           begin
             service.lock(build_lock_request)
-            logger.debug("Acquired lock '#{key}' for owner '#{owner}'")
+            if !@lock_acquired then
+              logger.info("Acquired lock '#{key}' for owner '#{owner}'")
+            end
             @lock_acquired = true
+            failed = false
           rescue GRPC::BadStatus => e
-            logger.debug("Failed to acquire lock '#{key}' for owner '#{owner}': #{e.message}")
+            if !failed then
+              logger.info("Failed to acquire lock '#{key}' for owner '#{owner}': #{e.message}")
+            end
+            failed = true
             @lock_acquired = false
           end
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
> update lock information logging to happen on info and to happen only once per state switch

* An explanation of the use cases your change solves:
> makes lock information easier to find in logs, but less verbose so to be able to bring it to the info level

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
