### PR TITLE
Remove migration views

### DIFF
--- a/db/migrations/20240229113008_drop_annotations_and_labels_migration_views.rb
+++ b/db/migrations/20240229113008_drop_annotations_and_labels_migration_views.rb
@@ -1,0 +1,48 @@
+Sequel.migration do
+  table_base_names = %w[
+    app
+    build
+    buildpack
+    deployment
+    domain
+    droplet
+    isolation_segment
+    organization
+    package
+    process
+    revision
+    route_binding
+    route
+    service_binding
+    service_broker
+    service_broker_update_request
+    service_instance
+    service_key
+    service_offering
+    service_plan
+    space
+    stack
+    task
+    user
+  ].freeze
+  annotation_tables = table_base_names.map { |tbn| "#{tbn}_annotations" }.freeze
+  label_tables = table_base_names.map { |tbn| "#{tbn}_labels" }.freeze
+
+  no_transaction # Disable automatic transactions
+
+  up do
+    (annotation_tables + label_tables).each do |table|
+      transaction do
+        drop_view(:"#{table}_migration_view", if_exists: true)
+      end
+    end
+  end
+
+  down do
+    (annotation_tables + label_tables).each do |table|
+      transaction do
+        create_view(:"#{table}_migration_view", self[table.to_sym].select { [id, guid, created_at, updated_at, resource_guid, key_prefix, key_name, value] }, if_exists: true)
+      end
+    end
+  end
+end

--- a/db/migrations/20240229113008_drop_annotations_and_labels_migration_views.rb
+++ b/db/migrations/20240229113008_drop_annotations_and_labels_migration_views.rb
@@ -41,7 +41,7 @@ Sequel.migration do
   down do
     (annotation_tables + label_tables).each do |table|
       transaction do
-        create_view(:"#{table}_migration_view", self[table.to_sym].select { [id, guid, created_at, updated_at, resource_guid, key_prefix, key_name, value] }, if_exists: true)
+        create_view(:"#{table}_migration_view", self[table.to_sym].select { [id, guid, created_at, updated_at, resource_guid, key_prefix, key_name, value] })
       end
     end
   end


### PR DESCRIPTION
After merging #3394 and #3393 we can remove the views we introduced for annotations and labels tables.

This is a breaking change, migrating from a CF-Deployment version before PR 3394 to a version that removes the view will cause a downtime on the old CloudControllers since they still use the views.

In this database migration the annotations and labels migrations views will be dropped. They were introduced to in #3394 to help implementing the uniqueness of labels and annotations, they have no other use in the code. Now that #3394 and #3393 are through, the views are not needed anymore and can be deleted.

* Links to any other associated PRs
#3394 and #3393
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
