### PR TITLE
Enhance local dev setup having a valid 'bits_path'

### DIFF
--- a/.devcontainer/images/nginx/conf/nginx.conf
+++ b/.devcontainer/images/nginx/conf/nginx.conf
@@ -42,6 +42,11 @@ http {
                 server host.docker.internal:3000;
         }
 
+        map $upload_tmp_path $upload_tmp_path_modified {
+          default                    "n/a";
+          "~^/tmp/(?<path>.*)$"  $path;
+        }
+
         include nginx_external_endpoints.conf;
 
 }

--- a/.devcontainer/images/nginx/conf/public_upload.conf
+++ b/.devcontainer/images/nginx/conf/public_upload.conf
@@ -12,7 +12,7 @@ upload_max_output_body_len 0;
 
 # Set specified fields in request body
 upload_set_form_field "${upload_field_name}_name" $upload_file_name;
-upload_set_form_field "${upload_field_name}_path" $upload_tmp_path;
+upload_set_form_field "${upload_field_name}_path" $upload_tmp_path_modified;
 upload_set_form_field "upload_start_time" $msec;
 
 #forward the following fields from existing body

--- a/.devcontainer/scripts/setupDevelopmentEnvironment.sh
+++ b/.devcontainer/scripts/setupDevelopmentEnvironment.sh
@@ -57,7 +57,7 @@ yq -i e '.nginx.instance_socket=""' tmp/cloud_controller.yml
 
 yq -i e '.logging.file="tmp/cloud_controller.log"' tmp/cloud_controller.yml
 yq -i e '.telemetry_log_path="tmp/cloud_controller_telemetry.log"' tmp/cloud_controller.yml
-yq -i e '.directories.tmpdir="tmp"' tmp/cloud_controller.yml
+TMPDIR=$(pwd)/tmp yq -i e '.directories.tmpdir=env(TMPDIR)' tmp/cloud_controller.yml;
 yq -i e '.directories.diagnostics="tmp"' tmp/cloud_controller.yml
 yq -i e '.security_event_logging.enabled=true' tmp/cloud_controller.yml
 yq -i e '.security_event_logging.file="tmp/cef.log"' tmp/cloud_controller.yml


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

For the local dev setup, the `nginx` provided an invalid `bits_path` when uploading a package. This was rejected by `cc` because of the config setting `directories.tmpdir` has to be a prefix of the `bits_path`.

Note: No productive code was touched.

* An explanation of the use cases your change solves

It improves the capabilities of local testing. But `cf create-package` will not work entirely since the package will stay in the state "PROCESSING_UPLOAD".

* Links to any other associated PRs
N/A

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
