### PR TITLE
error log deserialization errors

### DIFF
--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -1357,4 +1357,4 @@
 420001:
   name: DeserializationError
   http_code: 500
-  message: "Failed to deserialize: %s"
+  message: "%s"

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -1353,3 +1353,8 @@
   name: KorifiError
   http_code: 500
   message: "%s"
+
+420001:
+  name: DeserializationError
+  http_code: 500
+  message: "Failed to deserialize: %s"

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController::Serializer
         begin
           MultiJson.load string
         rescue MultiJson::ParseError
-          logger ||= Steno.logger('cc.serializer')
+          logger = Steno.logger('cc.serializer')
           logger.error("Failed to deserialize #{guid}")
           { 'corrupted-env': string }
         end

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController::Serializer
         rescue MultiJson::ParseError
           logger ||= Steno.logger('cc.serializer')
           logger.error("Failed to deserialize #{guid}")
-          nil
+          { 'corrupted-env': string }
         end
       end
       alias_method "#{accessor_method_name}_without_serialization", accessor_method_name

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -10,7 +10,8 @@ module VCAP::CloudController::Serializer
         begin
           MultiJson.load string
         rescue MultiJson::ParseError
-          raise CloudController::Errors::ApiError.new_from_details('DeserializationError', "Failed to deserialize #{guid} for object type #{self.class}. Trying to deserialize #{string}. You may have to delete and recreate the object")
+          error = "Failed to deserialize #{guid} for object type #{self.class}. Trying to deserialize #{string}. You may have to delete and recreate the object"
+          raise CloudController::Errors::ApiError.new_from_details('DeserializationError', error)
         end
       end
       alias_method "#{accessor_method_name}_without_serialization", accessor_method_name

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -10,10 +10,7 @@ module VCAP::CloudController::Serializer
         begin
           MultiJson.load string
         rescue MultiJson::ParseError
-          logger = Steno.logger('cc.serializer')
-          error_log = "Failed to deserialize #{guid} for object type #{self.class}. Trying to deserialize #{string.dump}. You may have to delete and recreate the object"
-          logger.error(error_log)
-          raise CloudController::Errors::ApiError.new_from_details('DeserializationError', error_log)
+          raise CloudController::Errors::ApiError.new_from_details('DeserializationError', "Failed to deserialize #{guid} for object type #{self.class}. Trying to deserialize #{string}. You may have to delete and recreate the object")
         end
       end
       alias_method "#{accessor_method_name}_without_serialization", accessor_method_name

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -9,10 +9,10 @@ module VCAP::CloudController::Serializer
 
         begin
           MultiJson.load string
-        rescue MultiJson::ParseError => e
+        rescue MultiJson::ParseError
           logger = Steno.logger('cc.serializer')
-          logger.error("Failed to deserialize #{guid} for object type #{to_s}. Trying to deserialize #{string.dump}")
-          raise
+          logger.error("Failed to deserialize #{guid} for object type #{self.class}. Trying to deserialize #{string.dump}")
+          raise CloudController::Errors::ApiError.new_from_details('DeserializationError', string)
         end
       end
       alias_method "#{accessor_method_name}_without_serialization", accessor_method_name

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController::Serializer
         rescue MultiJson::ParseError
           logger = Steno.logger('cc.serializer')
           logger.error("Failed to deserialize #{guid}")
-          { 'corrupted-env': string }
+          { 'corrupted-json': string }
         end
       end
       alias_method "#{accessor_method_name}_without_serialization", accessor_method_name

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -9,10 +9,10 @@ module VCAP::CloudController::Serializer
 
         begin
           MultiJson.load string
-        rescue MultiJson::ParseError
+        rescue MultiJson::ParseError => e
           logger = Steno.logger('cc.serializer')
-          logger.error("Failed to deserialize #{guid}")
-          { 'corrupted-json': string }
+          logger.error("Failed to deserialize #{guid} for object type #{to_s}. Trying to deserialize #{string.dump}")
+          raise
         end
       end
       alias_method "#{accessor_method_name}_without_serialization", accessor_method_name

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -7,7 +7,13 @@ module VCAP::CloudController::Serializer
         string = send("#{accessor_method_name}_without_serialization")
         return if string.blank?
 
-        MultiJson.load string
+        begin
+          MultiJson.load string
+        rescue MultiJson::ParseError
+          logger ||= Steno.logger('cc.serializer')
+          logger.error("Failed to deserialize #{guid}")
+          nil
+        end
       end
       alias_method "#{accessor_method_name}_without_serialization", accessor_method_name
       alias_method accessor_method_name, "#{accessor_method_name}_with_serialization"

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -11,8 +11,9 @@ module VCAP::CloudController::Serializer
           MultiJson.load string
         rescue MultiJson::ParseError
           logger = Steno.logger('cc.serializer')
-          logger.error("Failed to deserialize #{guid} for object type #{self.class}. Trying to deserialize #{string.dump}")
-          raise CloudController::Errors::ApiError.new_from_details('DeserializationError', string)
+          errorLog = "Failed to deserialize #{guid} for object type #{self.class}. Trying to deserialize #{string.dump}. You may have to delete and recreate the object"
+          logger.error(errorLog)
+          raise CloudController::Errors::ApiError.new_from_details('DeserializationError', errorLog)
         end
       end
       alias_method "#{accessor_method_name}_without_serialization", accessor_method_name

--- a/lib/cloud_controller/serializer.rb
+++ b/lib/cloud_controller/serializer.rb
@@ -11,9 +11,9 @@ module VCAP::CloudController::Serializer
           MultiJson.load string
         rescue MultiJson::ParseError
           logger = Steno.logger('cc.serializer')
-          errorLog = "Failed to deserialize #{guid} for object type #{self.class}. Trying to deserialize #{string.dump}. You may have to delete and recreate the object"
-          logger.error(errorLog)
-          raise CloudController::Errors::ApiError.new_from_details('DeserializationError', errorLog)
+          error_log = "Failed to deserialize #{guid} for object type #{self.class}. Trying to deserialize #{string.dump}. You may have to delete and recreate the object"
+          logger.error(error_log)
+          raise CloudController::Errors::ApiError.new_from_details('DeserializationError', error_log)
         end
       end
       alias_method "#{accessor_method_name}_without_serialization", accessor_method_name


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This would allow users to retrieve applications without environment variables causing problems. Hypothetically this error should *never* be thrown, but if it is, then it's likely not something we can recover the environment variables that were there before. It's maybe better to treat them like they just got wiped out. This does not preclude work to try and fix how we got it corrupted, but we couldn't reproduce. 

* An explanation of the use cases your change solves
We're trying to look into a interesting problem. What seems to have happened, although we can't identify the cause, is that the environment variables of an application got corrupted. Specifically, it went from json in the db to a null terminated string that isn't json. We never got the specific data.

This causes extreme platform instability from a certain perspective. Specifically, it causes inability to read all the applications from the platform. Anything scanning /v2/apps will be unable to obtain all the applications without randomly getting an error partway through if *any* application's environment variables are corrupted. 

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
