### PR TITLE
Use mc to determine minio readyness

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,13 +64,15 @@ services:
     ports:
       - "127.0.0.1:9001:9001"
       - "127.0.0.1:9000:9000"
+    environment:
+      MC_HOST_custom: http://localhost:9001
     healthcheck:
       test:
         [
           "CMD",
-          "curl",
-          "-f",
-          "http://localhost:9001/minio/health/live"
+          "mc",
+          "ready",
+          "custom"
         ]
       interval: 30s
       timeout: 20s


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Currently, minio is configured to use `curl` for its health check within `docker-compose.yml`. Recent versions of the image seem to no longer contain `curl` which leads to failing health checks in a local setup. Following https://github.com/minio/minio/issues/18389, the recommendation is to use the minio client (`mc`) to verfy the readiness of minio.

* An explanation of the use cases your change solves

Health checks for minio no longer fail for local setups.

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
