### PR TITLE
Explicit (empty) result for internal POST endpoints

### DIFF
--- a/app/controllers/internal/app_crashed_controller.rb
+++ b/app/controllers/internal/app_crashed_controller.rb
@@ -19,6 +19,8 @@ module VCAP::CloudController
 
       Repositories::ProcessEventRepository.record_crash(process, crash_payload)
       Repositories::AppEventRepository.new.create_app_crash_event(process, crash_payload)
+
+      [200, '{}']
     end
 
     private

--- a/app/controllers/internal/app_readiness_changed_controller.rb
+++ b/app/controllers/internal/app_readiness_changed_controller.rb
@@ -18,6 +18,8 @@ module VCAP::CloudController
       payload['version'] = Diego::ProcessGuid.cc_process_version(process_guid)
 
       Repositories::ProcessEventRepository.record_readiness_changed(process, payload)
+
+      [200, '{}']
     end
 
     private

--- a/app/controllers/internal/app_rescheduling_controller.rb
+++ b/app/controllers/internal/app_rescheduling_controller.rb
@@ -18,6 +18,8 @@ module VCAP::CloudController
       rescheduling_payload['version'] = Diego::ProcessGuid.cc_process_version(process_guid)
 
       Repositories::ProcessEventRepository.record_rescheduling(process, rescheduling_payload)
+
+      [200, '{}']
     end
 
     private

--- a/spec/unit/controllers/internal/app_crashed_controller_spec.rb
+++ b/spec/unit/controllers/internal/app_crashed_controller_spec.rb
@@ -33,6 +33,7 @@ module VCAP::CloudController
       it 'audits the app crashed event' do
         post url, MultiJson.dump(crashed_request)
         expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq '{}'
 
         app_event = Event.find(actee: diego_process.guid, actor_type: 'app')
 
@@ -51,6 +52,7 @@ module VCAP::CloudController
       it 'audits the process crashed event' do
         post url, MultiJson.dump(crashed_request)
         expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq '{}'
 
         app_event = Event.find(actee: diego_process.guid, actor_type: 'process')
 
@@ -75,6 +77,7 @@ module VCAP::CloudController
           post url, MultiJson.dump(crashed_request)
 
           expect(last_response.status).to eq(404)
+          expect(last_response.body).to match(/ProcessNotFound/)
         end
       end
     end

--- a/spec/unit/controllers/internal/app_readiness_changed_controller_spec.rb
+++ b/spec/unit/controllers/internal/app_readiness_changed_controller_spec.rb
@@ -33,6 +33,7 @@ module VCAP::CloudController
         it 'audits the app readiness changed event' do
           post url, MultiJson.dump(readiness_changed_request)
           expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq '{}'
 
           app_event = Event.find(actee: diego_process.guid, actor_type: 'process')
 
@@ -52,6 +53,7 @@ module VCAP::CloudController
         it 'audits the app readiness changed event' do
           post url, MultiJson.dump(readiness_changed_request)
           expect(last_response.status).to eq(200)
+          expect(last_response.body).to eq '{}'
 
           app_event = Event.find(actee: diego_process.guid, actor_type: 'process')
 

--- a/spec/unit/controllers/internal/app_rescheduling_controller_spec.rb
+++ b/spec/unit/controllers/internal/app_rescheduling_controller_spec.rb
@@ -32,6 +32,7 @@ module VCAP::CloudController
       it 'audits the process rescheduling event' do
         post url, MultiJson.dump(rescheduling_request)
         expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq '{}'
 
         app_event = Event.find(actee: diego_process.guid, actor_type: 'process')
 
@@ -55,6 +56,7 @@ module VCAP::CloudController
           post url, MultiJson.dump(rescheduling_request)
 
           expect(last_response.status).to eq(404)
+          expect(last_response.body).to match(/ProcessNotFound/)
         end
       end
     end


### PR DESCRIPTION
Add explicit result (HTTP status code 200 + empty JSON response) for internal POST endpoints. Otherwise the method's return value is added to the response, e.g. an event object. This causes serialization issues when using Puma as webserver, such as:
```
NoMethodError: undefined method `bytesize' for [:id, 123]:Array
```

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
