### PR TITLE
Write Puma logs to Steno

### DIFF
--- a/lib/cloud_controller/logs/steno_io.rb
+++ b/lib/cloud_controller/logs/steno_io.rb
@@ -1,0 +1,14 @@
+class StenoIO
+  def initialize(logger, level)
+    @logger = logger
+    @level = level
+  end
+
+  def write(str)
+    @logger.log(@level, str)
+  end
+
+  def sync
+    true
+  end
+end

--- a/lib/cloud_controller/runners/puma_runner.rb
+++ b/lib/cloud_controller/runners/puma_runner.rb
@@ -1,6 +1,7 @@
 require 'puma'
 require 'puma/configuration'
 require 'puma/events'
+require 'cloud_controller/logs/steno_io'
 
 module VCAP::CloudController
   class PumaRunner
@@ -35,7 +36,10 @@ module VCAP::CloudController
         end
       end
 
-      log_writer = Puma::LogWriter.stdio
+      log_writer = Puma::LogWriter.new(StenoIO.new(logger, :info), StenoIO.new(logger, :error))
+
+      # replace PidFormatter as we already have the pid in the Steno log record
+      puma_config.options[:log_formatter] = Puma::LogWriter::DefaultFormatter.new
 
       events = Puma::Events.new
       events.on_booted do

--- a/spec/unit/lib/cloud_controller/logs/steno_io_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/steno_io_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+module VCAP::CloudController::Logs
+  RSpec.describe StenoIO do
+    let(:logger) { double(:logger) }
+    let(:level) { :info }
+
+    subject { StenoIO.new(logger, level) }
+
+    describe '#write' do
+      it 'writes to the logger' do
+        expect(logger).to receive(:log).with(level, 'message')
+
+        subject.write('message')
+      end
+    end
+
+    describe '#sync' do
+      it 'returns true' do
+        expect(subject.sync).to be(true)
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
+++ b/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
@@ -135,5 +135,19 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe 'Logging' do
+      it 'LogWriter.log uses Steno logger with :info level' do
+        expect(logger).to receive(:log).with(:info, /log message/)
+
+        puma_launcher.log_writer.log('log message')
+      end
+
+      it 'LogWriter.error uses Steno logger with :error level' do
+        expect(logger).to receive(:log).with(:error, /ERROR: error message/)
+
+        expect { puma_launcher.log_writer.error('error message') }.to raise_error(SystemExit)
+      end
+    end
   end
 end


### PR DESCRIPTION
Instead of sending Puma logs to STDOUT and STDERR, re-use the `cc.runner` Steno logger by passing two Steno wrappers to `Puma::LogWriter` - one writing messages at `:info` level and another one writing at `:error` level.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
