### PR TITLE
Filter out spaces that the user does not have access to

### DIFF
--- a/app/decorators/include_space_decorator.rb
+++ b/app/decorators/include_space_decorator.rb
@@ -8,11 +8,23 @@ module VCAP::CloudController
       def decorate(hash, resources)
         hash[:included] ||= {}
         space_guids = resources.map(&:space_guid).uniq
-        spaces = Space.where(guid: space_guids).order(:created_at).
-                 eager(Presenters::V3::SpacePresenter.associated_resources).all
+        spaces_query = Space.where(guid: space_guids).order(:created_at).
+                       eager(Presenters::V3::SpacePresenter.associated_resources)
+        spaces_query = with_readable_space_guids(spaces_query)
 
-        hash[:included][:spaces] = spaces.map { |space| Presenters::V3::SpacePresenter.new(space).to_hash }
+        hash[:included][:spaces] = spaces_query.all.map { |space| Presenters::V3::SpacePresenter.new(space).to_hash }
         hash
+      end
+
+      private
+
+      # This method is used to filter out spaces that the user does not have read access to.
+      # An org_auditor can read routes in a space, but not the space itself.
+      def with_readable_space_guids(spaces_query)
+        permission_queryer = Permissions.new(SecurityContext.current_user)
+        return spaces_query if permission_queryer.can_read_globally?
+
+        spaces_query.where(guid: permission_queryer.readable_space_guids_query)
       end
     end
   end

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -1092,6 +1092,21 @@ RSpec.describe 'Routes Request' do
             ]
           )
         end
+
+        context 'user is org_auditor' do
+          let(:user_header) { set_user_with_header_as_role(user: user, role: 'org_auditor', org: org) }
+
+          it 'includes the unique organizations for the routes, but no spaces' do
+            get "/v3/routes/#{route.guid}?include=space,space.organization", nil, user_header
+            expect(last_response).to have_status_code(200)
+            expect(parsed_response['included']).to match_json_response(
+              'spaces' => [],
+              'organizations' => [
+                org_json_generator.call(org)
+              ]
+            )
+          end
+        end
       end
     end
   end

--- a/spec/unit/decorators/include_space_decorator_spec.rb
+++ b/spec/unit/decorators/include_space_decorator_spec.rb
@@ -7,6 +7,10 @@ module VCAP::CloudController
     let(:space2) { Space.make(name: 'second-space') }
     let(:apps) { [AppModel.make(space: space1), AppModel.make(space: space2), AppModel.make(space: space1)] }
 
+    before do
+      allow(Permissions).to receive(:new).and_return(double(can_read_globally?: true))
+    end
+
     it 'decorates the given hash with spaces from apps' do
       undecorated_hash = { foo: 'bar' }
       hash = subject.decorate(undecorated_hash, apps)


### PR DESCRIPTION
An `org_auditor` can read routes in a space, but not the space itself.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
