### PR TITLE
Add new metric job_queue_load for cc-worker

### DIFF
--- a/lib/cloud_controller/metrics/periodic_updater.rb
+++ b/lib/cloud_controller/metrics/periodic_updater.rb
@@ -94,7 +94,9 @@ module VCAP::CloudController::Metrics
     end
 
     def update_job_queue_load
-      jobs_by_queue_with_run_now = Delayed::Job.where(Sequel.lit('attempts = ? AND run_at <= ?', 0, Time.now)).group_and_count(:queue)
+      jobs_by_queue_with_run_now = Delayed::Job.
+                                   where(Sequel.lit('run_at <= ?', Time.now)).
+                                   where(Sequel.lit('failed_at IS NULL')).group_and_count(:queue)
 
       total = 0
       pending_job_load_by_queue = jobs_by_queue_with_run_now.each_with_object({}) do |row, hash|

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -19,6 +19,7 @@ module VCAP::CloudController::Metrics
 
     METRICS = [
       { type: :gauge, name: :cc_job_queues_length_total, docstring: 'Job queues length of worker processes', labels: [:queue], aggregation: :most_recent },
+      { type: :gauge, name: :cc_job_queues_load_total, docstring: 'Number of background jobs ready to run now ', labels: [:queue], aggregation: :most_recent },
       { type: :gauge, name: :cc_failed_jobs_total, docstring: 'Number of failed jobs of worker processes', labels: [:queue], aggregation: :most_recent },
       { type: :counter, name: :cc_staging_requests_total, docstring: 'Number of staging requests' },
       { type: :histogram, name: :cc_staging_succeeded_duration_seconds, docstring: 'Durations of successful staging events', buckets: DURATION_BUCKETS },
@@ -99,6 +100,12 @@ module VCAP::CloudController::Metrics
     def update_job_queue_length(pending_job_count_by_queue)
       pending_job_count_by_queue.each do |key, value|
         update_gauge_metric(:cc_job_queues_length_total, value, labels: { queue: key.to_s.underscore })
+      end
+    end
+
+    def update_job_queue_load(update_job_queue_load)
+      update_job_queue_load.each do |key, value|
+        update_gauge_metric(:cc_job_queues_load_total, value, labels: { queue: key.to_s.underscore })
       end
     end
 

--- a/lib/cloud_controller/metrics/statsd_updater.rb
+++ b/lib/cloud_controller/metrics/statsd_updater.rb
@@ -23,6 +23,15 @@ module VCAP::CloudController::Metrics
       end
     end
 
+    def update_job_queue_load(pending_job_load_by_queue, total)
+      @statsd.batch do |batch|
+        pending_job_load_by_queue.each do |key, value|
+          batch.gauge("cc.job_queue_load.#{key}", value)
+        end
+        batch.gauge('cc.job_queue_load.total', total)
+      end
+    end
+
     def update_thread_info_thin(thread_info)
       @statsd.batch do |batch|
         batch.gauge('cc.thread_info.thread_count', thread_info[:thread_count])

--- a/spec/request/internal/metrics_spec.rb
+++ b/spec/request/internal/metrics_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe 'Metrics' do
     it 'includes job queue load metric labelled for each queue' do
       get '/internal/v4/metrics', nil
 
-      expect(last_response.body).not_to match(/cc_job_queues_load_total{queue="cc_api_0"} 1\.0/)
-      expect(last_response.body).not_to match(/cc_job_queues_load_total{queue="cc_generic"} 1\.0/)
+      expect(last_response.body).to match(/cc_job_queues_load_total{queue="cc_api_0"} 0\.0/)
+      expect(last_response.body).to match(/cc_job_queues_load_total{queue="cc_generic"} 0\.0/)
     end
   end
 

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -78,6 +78,24 @@ module VCAP::CloudController::Metrics
       end
     end
 
+    describe '#update_job_queue_load' do
+      it 'records the load of the delayed job queues and total' do
+        expected_local_load   = 5
+        expected_generic_load = 6
+
+        pending_job_load_by_queue = {
+          cc_local: expected_local_load,
+          cc_generic: expected_generic_load
+        }
+
+        updater.update_job_queue_load(pending_job_load_by_queue)
+
+        metric = prom_client.get :cc_job_queues_load_total
+        expect(metric.get(labels: { queue: 'cc_local' })).to eq 5
+        expect(metric.get(labels: { queue: 'cc_generic' })).to eq 6
+      end
+    end
+
     describe '#update_failed_job_count' do
       it 'records the number of failed jobs in the delayed job queue and the total to statsd' do
         expected_local_length   = 5


### PR DESCRIPTION
Relying only on the length of the cc-worker job queue to decide when to scale out resources isn't always accurate. This is because the queue might contain jobs that aren't ready to run and aren't using any resources.

We propose to add a new metric to measure the system load. The new metric will show the number of jobs that are ready to start, not just all the jobs in the queue. 

Related PR for cf doc: [cloudfoundry/docs-running-cf/120](https://github.com/cloudfoundry/docs-running-cf/pull/120)

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
