### PR TITLE
ISSUE-3693 Make http code consistent for service related parameter fetch operations

### DIFF
--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -163,9 +163,7 @@ class ServiceCredentialBindingsController < ApplicationController
 
     render status: :ok, json: parameters
   rescue ServiceBindingRead::NotSupportedError
-    raise CloudController::Errors::ApiError.
-      new_from_details('ServiceFetchBindingParametersNotSupported').
-      with_response_code(502)
+    raise CloudController::Errors::ApiError.new_from_details('ServiceFetchBindingParametersNotSupported')
   end
 
   private

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -968,7 +968,7 @@ RSpec.describe 'v3 service credential bindings' do
         it 'fails as can not be done' do
           api_call.call(admin_headers)
 
-          expect(last_response).to have_status_code(502)
+          expect(last_response).to have_status_code(400)
         end
       end
 
@@ -1092,7 +1092,7 @@ RSpec.describe 'v3 service credential bindings' do
         it 'fails as can not be done' do
           api_call.call(admin_headers)
 
-          expect(last_response).to have_status_code(502)
+          expect(last_response).to have_status_code(400)
         end
       end
 


### PR DESCRIPTION
* A short explanation of the proposed change:

Fix for #3693. Change http code 502 to 400 when parameters are being requested for a service binding, but the broker does not support fetching the service binding.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
