### PR TITLE
Add dynamic job priorities

### DIFF
--- a/app/jobs/enqueuer.rb
+++ b/app/jobs/enqueuer.rb
@@ -43,7 +43,7 @@ module VCAP::CloudController
         request_id = ::VCAP::Request.current_id
         timeout_job = TimeoutJob.new(job, job_timeout)
         logging_context_job = LoggingContextJob.new(timeout_job, request_id)
-        @opts[:priority] = job_priority unless job_priority.nil?
+        @opts[:priority] = job_priority unless @opts[:priority] || job_priority.nil?
         Delayed::Job.enqueue(logging_context_job, @opts)
       end
 

--- a/app/jobs/reoccurring_job.rb
+++ b/app/jobs/reoccurring_job.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
         elsif next_enqueue_would_exceed_maximum_duration?
           expire!
         else
-          enqueue_next_job(pollable_job)
+          enqueue_next_job(pollable_job, current_delayed_job.priority)
         end
       end
 
@@ -75,10 +75,11 @@ module VCAP::CloudController
         raise CloudController::Errors::ApiError.new_from_details('JobTimeout')
       end
 
-      def enqueue_next_job(pollable_job)
+      def enqueue_next_job(pollable_job, priority)
         opts = {
           queue: Jobs::Queues.generic,
-          run_at: Delayed::Job.db_time_now + next_execution_in
+          run_at: Delayed::Job.db_time_now + next_execution_in,
+          priority: priority
         }
 
         @retry_number += 1

--- a/app/models/runtime/pollable_job_model.rb
+++ b/app/models/runtime/pollable_job_model.rb
@@ -46,5 +46,9 @@ module VCAP::CloudController
 
       pollable_job
     end
+
+    def self.number_of_active_jobs_by_user(user_guid)
+      PollableJobModel.where(state: %w[PROCESSING POLLING], user_guid: user_guid).count
+    end
   end
 end

--- a/db/migrations/20240314131908_add_user_guid_to_jobs_table.rb
+++ b/db/migrations/20240314131908_add_user_guid_to_jobs_table.rb
@@ -1,0 +1,39 @@
+Sequel.migration do
+  # adding an index concurrently cannot be done within a transaction
+  no_transaction
+
+  up do
+    if database_type == :postgres
+      alter_table :jobs do
+        add_column :user_guid, String, size: 255, if_not_exists: true
+        add_index :user_guid, name: :jobs_user_guid_index, if_not_exists: true, concurrently: true
+      end
+
+    elsif database_type == :mysql
+      alter_table :jobs do
+        add_column :user_guid, String, size: 255 unless @db.schema(:jobs).map(&:first).include?(:user_guid)
+        # rubocop:disable Sequel/ConcurrentIndex
+        add_index :user_guid, name: :jobs_user_guid_index unless @db.indexes(:jobs).include?(:jobs_user_guid_index)
+        # rubocop:enable Sequel/ConcurrentIndex
+      end
+    end
+  end
+
+  down do
+    if database_type == :postgres
+      alter_table :jobs do
+        drop_index  :user_guid, name: :jobs_user_guid_index, if_exists: true, concurrently: true
+        drop_column :user_guid, if_exists: true
+      end
+    end
+
+    if database_type == :mysql
+      alter_table :jobs do
+        # rubocop:disable Sequel/ConcurrentIndex
+        drop_index  :user_guid, name: :jobs_user_guid_index if @db.indexes(:jobs).include?(:jobs_user_guid_index)
+        # rubocop:enable Sequel/ConcurrentIndex
+        drop_column :user_guid if @db.schema(:jobs).map(&:first).include?(:user_guid)
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -335,6 +335,7 @@ module VCAP::CloudController
 
             jobs: {
               global: { timeout_in_seconds: Integer },
+              optional(:enable_dynamic_job_priorities) => bool,
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -167,6 +167,7 @@ module VCAP::CloudController
 
             jobs: {
               global: { timeout_in_seconds: Integer },
+              optional(:enable_dynamic_job_priorities) => bool,
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },

--- a/spec/migrations/20240314131908_add_user_guid_to_jobs_table_spec.rb
+++ b/spec/migrations/20240314131908_add_user_guid_to_jobs_table_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to add user_guid column to jobs table and add an index for that column', isolation: :truncation do
+  include_context 'migration' do
+    let(:migration_filename) { '20240314131908_add_user_guid_to_jobs_table.rb' }
+  end
+
+  describe 'jobs table' do
+    it 'adds a column `user_guid`' do
+      expect(db[:jobs].columns).not_to include(:user_guid)
+      expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true) }.not_to raise_error
+      expect(db[:jobs].columns).to include(:user_guid)
+    end
+
+    it 'adds an index on the user_guid column' do
+      expect(db.indexes(:jobs)).not_to include(:jobs_user_guid_index)
+      expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true) }.not_to raise_error
+      expect(db.indexes(:jobs)).to include(:jobs_user_guid_index)
+    end
+
+    describe 'idempotency of up' do
+      context '`user_guid` column already exists' do
+        before do
+          db.add_column :jobs, :user_guid, String, size: 255
+        end
+
+        it 'does not fail' do
+          expect(db[:jobs].columns).to include(:user_guid)
+          expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true) }.not_to raise_error
+        end
+
+        it 'continues to create the index' do
+          expect(db[:jobs].columns).to include(:user_guid)
+          expect(db.indexes(:jobs)).not_to include(:jobs_user_guid_index)
+          expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true) }.not_to raise_error
+          expect(db.indexes(:jobs)).to include(:jobs_user_guid_index)
+        end
+      end
+
+      context 'index already exists' do
+        before do
+          db.add_column :jobs, :user_guid, String, size: 255
+          db.add_index :jobs, :user_guid, name: :jobs_user_guid_index
+        end
+
+        it 'does not fail' do
+          expect(db.indexes(:jobs)).to include(:jobs_user_guid_index)
+          expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true) }.not_to raise_error
+        end
+      end
+    end
+
+    describe 'idempotency of down' do
+      context 'index does not exist' do
+        before do
+          Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true)
+          db.drop_index :jobs, :user_guid, name: :jobs_user_guid_index
+        end
+
+        it 'does not fail' do
+          expect(db[:jobs].columns).to include(:user_guid)
+          expect(db.indexes(:jobs)).not_to include(:jobs_user_guid_index)
+          expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true, target: 0) }.not_to raise_error
+        end
+
+        it 'continues to remove the `user_guid` column' do
+          expect(db[:jobs].columns).to include(:user_guid)
+          expect(db.indexes(:jobs)).not_to include(:jobs_user_guid_index)
+          expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true, target: 0) }.not_to raise_error
+          expect(db[:jobs].columns).not_to include(:user_guid)
+        end
+      end
+
+      context 'index and column do not exist' do
+        before do
+          Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true)
+          db.drop_index :jobs, :user_guid, name: :jobs_user_guid_index
+          db.drop_column :jobs, :user_guid
+        end
+
+        it 'does not fail' do
+          expect(db[:jobs].columns).not_to include(:user_guid)
+          expect(db.indexes(:jobs)).not_to include(:jobs_user_guid_index)
+          expect { Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true, target: 0) }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### A short explanation of the proposed change:
Currently a single user can send many requests, which will result in delayed_jobs being created and run in the background. Some of those jobs are getting retried, which results in more than one delayed_job per API request.
This can lead to situations where the workers are mainly working off the jobs of this single user, which significantly decreases performance for other users.
 
Therefore we add a "dynamic job priority" functionality, which checks in the jobs table how many active jobs, i.e. jobs in state `POLLING` or `PROCESSING`, the user currently has. For each active job, we add +1 to the base priority of the new job. This will have the following benefits:
- Jobs created by a user will run in the correct sequence in which they have been created (start in the correct order, not necessarily finish in the correct order, because this depends on the runtime of different jobs)
- If a user only runs one job at a time, those jobs won't be deprioritized
- If a user runs many jobs simultaneously, jobs by other users will take priority. Workers will work-off the remaining jobs of that user whenever they have capacity.

We add a new column `user_guid` to the jobs table, to be able to filter for jobs by user.
We also add an index on that column for faster queries.

Additionally we added a config parameter `jobs.enable_dynamic_job_priorities`, which is disabled by default and can be enabled if dynamic job priorities shall be used.

### Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
