### PR TITLE
Print output of blobstore benchmark again

### DIFF
--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -92,6 +92,10 @@ Rails/Blank: # Alters logic if NilOrEmpty is true
 Rails/Present:  # Alters logic if NotNilAndNotEmpty is true
   NotNilAndNotEmpty: false
 
+Rails/Output: # Exclude for blobstore benchmark
+  Exclude:
+    - lib/cloud_controller/benchmark/blobstore.rb
+
 Naming/FileName:
   Exclude:
     - Guardfile

--- a/lib/cloud_controller/benchmark/blobstore.rb
+++ b/lib/cloud_controller/benchmark/blobstore.rb
@@ -9,34 +9,34 @@ module VCAP::CloudController
         resource_dir = generate_resources
 
         resource_timing = resource_match(resource_dir)
-        Rails.logger.debug { "resource match timing: #{resource_timing * 1000}ms" }
+        puts("resource match timing: #{resource_timing * 1000}ms")
 
         zip_output_dir = Dir.mktmpdir
         zip_file = zip_resources(resource_dir, zip_output_dir)
 
         package_guid, resource_timing = upload_package(zip_file)
-        Rails.logger.debug { "package upload timing: #{resource_timing * 1000}ms" }
+        puts("package upload timing: #{resource_timing * 1000}ms")
 
         resource_timing = download_package(package_guid, resource_dir)
-        Rails.logger.debug { "package download timing: #{resource_timing * 1000}ms" }
+        puts("package download timing: #{resource_timing * 1000}ms")
 
         bytes_read, resource_timing = download_buildpacks(resource_dir)
-        Rails.logger.debug { "downloaded #{Buildpack.count} buildpacks, total #{bytes_read} bytes read" }
-        Rails.logger.debug { "buildpack download timing: #{resource_timing * 1000}ms" }
+        puts("downloaded #{Buildpack.count} buildpacks, total #{bytes_read} bytes read")
+        puts("buildpack download timing: #{resource_timing * 1000}ms")
 
         droplet_guid, resource_timing = upload_droplet(zip_file)
-        Rails.logger.debug { "droplet upload timing: #{resource_timing * 1000}ms" }
+        puts("droplet upload timing: #{resource_timing * 1000}ms")
 
         resource_timing = download_droplet(droplet_guid, resource_dir)
-        Rails.logger.debug { "droplet download timing: #{resource_timing * 1000}ms" }
+        puts("droplet download timing: #{resource_timing * 1000}ms")
 
         big_droplet_file = Tempfile.new('big-droplet', resource_dir)
         big_droplet_file.write('abc' * 1024 * 1024 * 100)
         big_droplet_guid, resource_timing = upload_droplet(big_droplet_file.path)
-        Rails.logger.debug { "big droplet upload timing: #{resource_timing * 1000}ms" }
+        puts("big droplet upload timing: #{resource_timing * 1000}ms")
 
         resource_timing = download_droplet(big_droplet_guid, resource_dir)
-        Rails.logger.debug { "big droplet download timing: #{resource_timing * 1000}ms" }
+        puts("big droplet download timing: #{resource_timing * 1000}ms")
       ensure
         FileUtils.remove_dir(resource_dir, true)
         FileUtils.remove_dir(zip_output_dir, true)


### PR DESCRIPTION
After enabling rubocop for rails the output of the blobstore benchmark is no longer shown. This change restores the previous `puts` for logging instead of `Rails.logger`.

Related commit: 796a5744d9200447c54ba65c6368ffaa2f183f9b


* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
