### PR TITLE
Fix add|drop_index syntax

### DIFF
--- a/db/migrations/20231113105256_add_service_plan_id_index.rb
+++ b/db/migrations/20231113105256_add_service_plan_id_index.rb
@@ -1,9 +1,11 @@
 Sequel.migration do
+  no_transaction # to use the 'concurrently' option
+
   up do
-    add_index :service_plan_visibilities, :service_plan_id, name: :spv_service_plan_id_index, options: [:concurrently] if database_type == :postgres
+    add_index :service_plan_visibilities, :service_plan_id, name: :spv_service_plan_id_index, concurrently: true if database_type == :postgres
   end
 
   down do
-    drop_index :service_plan_visibilities, nil, name: :spv_service_plan_id_index, options: [:concurrently] if database_type == :postgres
+    drop_index :service_plan_visibilities, nil, name: :spv_service_plan_id_index, concurrently: true if database_type == :postgres
   end
 end

--- a/db/migrations/20240219113000_add_routes_space_id_index.rb
+++ b/db/migrations/20240219113000_add_routes_space_id_index.rb
@@ -1,9 +1,11 @@
 Sequel.migration do
+  no_transaction # to use the 'concurrently' option
+
   up do
-    add_index :routes, :space_id, name: :routes_space_id_index, options: %i[if_not_exists concurrently] if database_type == :postgres
+    add_index :routes, :space_id, name: :routes_space_id_index, if_not_exists: true, concurrently: true if database_type == :postgres
   end
 
   down do
-    drop_index :routes, :space_id, name: :routes_space_id_index, options: %i[if_exists concurrently] if database_type == :postgres
+    drop_index :routes, :space_id, name: :routes_space_id_index, if_exists: true, concurrently: true if database_type == :postgres
   end
 end

--- a/db/migrations/20240222131500_change_delayed_jobs_reserve_index.rb
+++ b/db/migrations/20240222131500_change_delayed_jobs_reserve_index.rb
@@ -1,17 +1,19 @@
 Sequel.migration do
+  no_transaction # to use the 'concurrently' option
+
   up do
     if database_type == :postgres
-      drop_index :delayed_jobs, nil, name: :delayed_jobs_reserve, options: %i[if_exists concurrently]
+      drop_index :delayed_jobs, nil, name: :delayed_jobs_reserve, if_exists: true, concurrently: true
       add_index :delayed_jobs, %i[queue locked_at locked_by failed_at run_at priority],
-                where: { failed_at: nil }, name: :delayed_jobs_reserve, options: %i[if_not_exists concurrently]
+                where: { failed_at: nil }, name: :delayed_jobs_reserve, if_not_exists: true, concurrently: true
     end
   end
 
   down do
     if database_type == :postgres
-      drop_index :delayed_jobs, nil, name: :delayed_jobs_reserve, options: %i[if_exists concurrently]
+      drop_index :delayed_jobs, nil, name: :delayed_jobs_reserve, if_exists: true, concurrently: true
       add_index :delayed_jobs, %i[queue locked_at locked_by failed_at run_at priority],
-                name: :delayed_jobs_reserve, options: %i[if_not_exists concurrently]
+                name: :delayed_jobs_reserve, if_not_exists: true, concurrently: true
     end
   end
 end

--- a/spec/migrations/20231113105256_add_service_plan_id_index_spec.rb
+++ b/spec/migrations/20231113105256_add_service_plan_id_index_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to add the service_plan_id index', isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20231113105256_add_service_plan_id_index.rb' }
+  end
+
+  it 'succeeds' do
+    Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true)
+  end
+end

--- a/spec/migrations/20240219113000_add_routes_space_id_index_spec.rb
+++ b/spec/migrations/20240219113000_add_routes_space_id_index_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to add the routes_space_id index', isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20240219113000_add_routes_space_id_index.rb' }
+  end
+
+  it 'succeeds' do
+    Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true)
+  end
+end

--- a/spec/migrations/20240222131500_change_delayed_jobs_reserve_index_spec.rb
+++ b/spec/migrations/20240222131500_change_delayed_jobs_reserve_index_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to change the delayed_jobs_reserve index', isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20240222131500_change_delayed_jobs_reserve_index.rb' }
+  end
+
+  it 'succeeds' do
+    Sequel::Migrator.run(db, migration_to_test, allow_missing_migration_files: true)
+  end
+end

--- a/spec/migrations/helpers/matchers.rb
+++ b/spec/migrations/helpers/matchers.rb
@@ -1,0 +1,17 @@
+RSpec::Matchers.define :add_index_options do
+  description { 'options for add_index' }
+
+  match do |passed_options|
+    options = passed_options.keys
+    !options.delete(:name).nil? && (options - %i[where if_not_exists concurrently]).empty?
+  end
+end
+
+RSpec::Matchers.define :drop_index_options do
+  description { 'options for drop_index' }
+
+  match do |passed_options|
+    options = passed_options.keys
+    !options.delete(:name).nil? && (options - %i[if_exists concurrently]).empty?
+  end
+end

--- a/spec/migrations/helpers/migration_shared_context.rb
+++ b/spec/migrations/helpers/migration_shared_context.rb
@@ -1,3 +1,5 @@
+require 'migrations/helpers/matchers'
+
 def mktmpsubdir(tmpdir, name)
   dir = File.join(tmpdir, name)
   Dir.mkdir(dir)
@@ -11,6 +13,9 @@ RSpec.shared_context 'migration' do
   let(:db) { Sequel::Model.db }
 
   before do
+    allow(db).to receive(:add_index).with(anything, anything, add_index_options).and_call_original
+    allow(db).to receive(:drop_index).with(anything, anything, drop_index_options).and_call_original
+
     Sequel.extension :migration
 
     # Find all migrations


### PR DESCRIPTION
Wrong syntax:
```
options: %i[if_exists concurrently]
```

Correct syntax:
```
if_exists: true, concurrently: true
```

As this changes already released migrations, it is only relevant for foundations where these have not been applied yet (e.g. due to skipping the latest CAPI release).

Furthermore 'copy-and-paste' errors will be prevented when new migrations are created.

The `migration_shared_context` has been enhanced by spying on `add|drop_index` invocations, checking for valid options.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
