### PR TITLE
Revert "build(deps-dev): bump rubocop from 1.62.1 to 1.63.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ group :test do
   gem 'rspec-its'
   gem 'rspec-rails', '~> 6.1.2'
   gem 'rspec-wait'
-  gem 'rubocop', '~> 1.63.0'
+  gem 'rubocop', '~> 1.62.1'
   gem 'rubocop-rails', '~> 2.24'
   gem 'rubocop-rspec', '~> 2.26'
   gem 'rubocop-sequel', '~> 0.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
       rdoc
       reline (>= 0.4.2)
     jaro_winkler (1.5.6)
-    json (2.7.2)
+    json (2.7.1)
     json-diff (0.4.1)
     json-schema (4.1.1)
       addressable (>= 2.8)
@@ -466,7 +466,7 @@ GEM
       activesupport (>= 3.0.0)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0)
-    rubocop (1.63.0)
+    rubocop (1.62.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -658,7 +658,7 @@ DEPENDENCIES
   rspec-rails (~> 6.1.2)
   rspec-wait
   rspec_api_documentation (>= 6.1.0)
-  rubocop (~> 1.63.0)
+  rubocop (~> 1.62.1)
   rubocop-rails (~> 2.24)
   rubocop-rspec (~> 2.26)
   rubocop-sequel (~> 0.3.4)


### PR DESCRIPTION
Reverts cloudfoundry/cloud_controller_ng#3727