### PR TITLE
Only emit TASK_STOPPED usage events when necessary

### DIFF
--- a/app/repositories/app_usage_event_repository.rb
+++ b/app/repositories/app_usage_event_repository.rb
@@ -8,6 +8,10 @@ module VCAP::CloudController
         AppUsageEvent.find(guid:)
       end
 
+      def find_by_task_and_state(task:, state:)
+        AppUsageEvent.find(task_guid: task.guid, state: state)
+      end
+
       def create_from_process(process, state_name=nil)
         AppUsageEvent.create(
           state: state_name || process.state,

--- a/spec/unit/lib/cloud_controller/diego/task_completion_handler_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_completion_handler_spec.rb
@@ -4,7 +4,7 @@ require 'cloud_controller/diego/task_completion_handler'
 module VCAP::CloudController
   module Diego
     RSpec.describe TaskCompletionHandler do
-      let!(:task) { TaskModel.make }
+      let!(:task) { TaskModel.make(:pending) }
       let(:handler) { TaskCompletionHandler.new }
       let(:logger) { instance_double(Steno::Logger, info: nil, error: nil, warn: nil) }
 
@@ -13,6 +13,10 @@ module VCAP::CloudController
       end
 
       describe '#complete_task' do
+        before do
+          task.update(state: TaskModel::RUNNING_STATE)
+        end
+
         context 'when the task succeeds' do
           let(:response) do
             {

--- a/spec/unit/lib/cloud_controller/diego/tasks_sync_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/tasks_sync_spec.rb
@@ -42,6 +42,8 @@ module VCAP::CloudController
         context 'when a running CC task is missing from BBS' do
           let!(:running_task) { TaskModel.make(:running, created_at: 1.minute.ago) }
           let!(:canceling_task) { TaskModel.make(:canceling, created_at: 1.minute.ago) }
+          let!(:start_event_for_running_task) { AppUsageEvent.make(task_guid: running_task.guid, state: 'TASK_STARTED') }
+          let!(:start_event_for_canceling_task) { AppUsageEvent.make(task_guid: canceling_task.guid, state: 'TASK_STARTED') }
           let(:bbs_tasks) { [] }
 
           it 'marks the tasks as failed' do


### PR DESCRIPTION
- Fixes a bug around duplicate task_stop events (see https://github.com/cloudfoundry/cloud_controller_ng/issues/3757)

- Updates the hook in TaskModel to only create TASK_STOPPED events when there is a corresponding TASK_STARTED event and a TASK_STOPPED event has not already been created

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
