### PR TITLE
Fix backwards compatibility github actions

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -242,26 +242,32 @@ namespace :db do
   end
 
   def migrate
-    logging_output
-    db_logger = Steno.logger('cc.db.migrations')
+    # The following block, which loads the test DB config is only needed for running migrations in parallel (only in tests)
+    # It sets the `DB_CONNECTION_STRING` env variable from `POSTGRES|MYSQL_CONNECTION_PREFIX` + test_database number
     begin
       require_relative '../../spec/support/bootstrap/db_config'
       DbConfig.new
     rescue LoadError
-      # Only needed when running tests
+      # In production the test DB config is not available nor needed, so we ignore this error.
     end
+
+    logging_output
+    db_logger = Steno.logger('cc.db.migrations')
     DBMigrator.from_config(RakeConfig.config, db_logger).apply_migrations
   end
 
   def rollback(number_to_rollback)
-    logging_output
-    db_logger = Steno.logger('cc.db.migrations')
+    # The following block, which loads the test DB config is only needed for running migrations in parallel (only in tests)
+    # It sets the `DB_CONNECTION_STRING` env variable from `POSTGRES|MYSQL_CONNECTION_PREFIX` + test_database number
     begin
       require_relative '../../spec/support/bootstrap/db_config'
       DbConfig.new
     rescue LoadError
-      # Only needed when running tests
+      # In production the test DB config is not available nor needed, so we ignore this error.
     end
+
+    logging_output
+    db_logger = Steno.logger('cc.db.migrations')
     DBMigrator.from_config(RakeConfig.config, db_logger).rollback(number_to_rollback)
   end
 


### PR DESCRIPTION
###  A short explanation of the proposed change:
`bundle exec rake db:parallel:migrate` (which is also used in the backwards compatibility tests) failed since introducing new migration logging (6d2f0fa). The error was `DB_CONNECTION_STRING not set`. This is because when using parallel test execution `POSTGRES_CONNECTION_PREFIX` is used. `DB_CONNECTION_STRING` is set after `DbConfig.new` was called. So the new logging setup has been moved after this command.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
