### PR TITLE
Use fixed number of Puma threads

### DIFF
--- a/lib/cloud_controller/runners/puma_runner.rb
+++ b/lib/cloud_controller/runners/puma_runner.rb
@@ -16,7 +16,8 @@ module VCAP::CloudController
         end
 
         conf.workers(config.get(:puma, :workers) || 1)
-        conf.threads(0, config.get(:puma, :max_threads) || 1)
+        num_threads = config.get(:puma, :max_threads) || 1
+        conf.threads(num_threads, num_threads)
 
         # In theory there shouldn't be any open connections when shutting down Puma as they have either been gracefully
         # drained or forcefully terminated (after cc.nginx_drain_timeout) by Nginx. Puma has some built-in (i.e. not

--- a/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
+++ b/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
@@ -63,7 +63,7 @@ module VCAP::CloudController
         subject
 
         expect(puma_launcher.config.final_options[:workers]).to eq(num_workers)
-        expect(puma_launcher.config.final_options[:min_threads]).to eq(0)
+        expect(puma_launcher.config.final_options[:min_threads]).to eq(max_threads)
         expect(puma_launcher.config.final_options[:max_threads]).to eq(max_threads)
       end
 
@@ -75,6 +75,7 @@ module VCAP::CloudController
           subject
 
           expect(puma_launcher.config.final_options[:workers]).to eq(1)
+          expect(puma_launcher.config.final_options[:min_threads]).to eq(1)
           expect(puma_launcher.config.final_options[:max_threads]).to eq(1)
         end
       end


### PR DESCRIPTION
Instead of specifying different min and max values for the number of threads and letting Puma start and stop threads on demand, a fixed number of threads is configured (i.e. min = max).

The following graphs show the memory usage of a single Puma worker process before (first graph) and after (second graph) this change has been applied (*):

<img width="1805" alt="dynamic_num_threads" src="https://github.com/cloudfoundry/cloud_controller_ng/assets/618301/0abf72a5-cb61-4fe5-bd9a-68da4b18d6c7">
<img width="1805" alt="fixed_num_threads" src="https://github.com/cloudfoundry/cloud_controller_ng/assets/618301/1167fb6a-caf6-46d7-99b5-d5a4d516d627">

(*)
- on this specific foundation `max_threads` is set to `10`
- the graphs show a timeframe of ~22 hours

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
