### PR TITLE
Enable fit/fcontext focusing in rspecs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,8 +91,7 @@ each_run_block = proc do
 
   # each-run here?
   RSpec.configure do |rspec_config|
-    rspec_config.filter_run focus: true
-    rspec_config.run_all_when_everything_filtered = true
+    rspec_config.filter_run_when_matching :focus
 
     rspec_config.mock_with :rspec do |mocks|
       mocks.verify_partial_doubles = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,6 +91,9 @@ each_run_block = proc do
 
   # each-run here?
   RSpec.configure do |rspec_config|
+    rspec_config.filter_run focus: true
+    rspec_config.run_all_when_everything_filtered = true
+
     rspec_config.mock_with :rspec do |mocks|
       mocks.verify_partial_doubles = true
     end


### PR DESCRIPTION

* A short explanation of the proposed change:

Allows developers to focus rspec tests via `fit` or `fcontext` 


* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
