### PR TITLE
Introduce a limit to number of destinations per rule

### DIFF
--- a/app/messages/validators/security_group_rule_validator.rb
+++ b/app/messages/validators/security_group_rule_validator.rb
@@ -11,6 +11,8 @@ class RulesValidator < ActiveModel::Validator
     type
   ].freeze
 
+  MAX_DESTINATIONS_PER_RULE = 6000
+
   def validate(record)
     unless record.rules.is_a?(Array)
       record.errors.add :rules, 'must be an array'
@@ -28,7 +30,10 @@ class RulesValidator < ActiveModel::Validator
       add_rule_error("protocol must be 'tcp', 'udp', 'icmp', or 'all'", record, index) unless valid_protocol(rule[:protocol])
 
       if valid_destination_type(rule[:destination], record, index)
-        rule[:destination].split(',').each do |d|
+        rules = rule[:destination].split(',')
+        add_rule_error("maximum destinations per rule exceeded - must be under #{MAX_DESTINATIONS_PER_RULE}", record, index) unless rules.length <= MAX_DESTINATIONS_PER_RULE
+
+        rules.each do |d|
           validate_destination(d, record, index)
         end
       end

--- a/spec/unit/messages/validators/security_group_rule_validator_spec.rb
+++ b/spec/unit/messages/validators/security_group_rule_validator_spec.rb
@@ -388,6 +388,22 @@ module VCAP::CloudController::Validators
             expect(subject.errors.full_messages).to include expected_error
           end
         end
+
+        context 'more than 6000 destinations per rule' do
+          let(:rules) do
+            [
+              {
+                protocol: 'all',
+                destination: (['192.168.1.3'] * 7000).join(',')
+              }
+            ]
+          end
+
+          it 'throws an error' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.full_messages).to include 'Rules[0]: maximum destinations per rule exceeded - must be under 6000'
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Introduces a 6000 destination per ASG rule limit when using comma-delimited destinations.

* An explanation of the use cases your change solves

Previously extremely large lists of destinations would result in "stack level too deep" errors while validating destinations due to a recursive function. Other systems consumign the comma-delimited destinations have limits of 6k destinations per rule, so this is following suit. 

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
