### PR TITLE
Correct v3 org quota update example in docs

### DIFF
--- a/docs/v3/source/includes/resources/organization_quotas/_update.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_update.md.erb
@@ -28,7 +28,7 @@ curl "https://api.example.org/v3/organization_quotas/[guid]" \
       "total_reserved_ports": 4
     },
     "domains": {
-      "total_private_domains": 7
+      "total_domains": 7
     }
   }'
 ```


### PR DESCRIPTION
* A short explanation of the proposed change:

The correct field for specifying the total amount of private domains an org should be allowed to have is `domains.total_domains`. See https://v3-apidocs.cloudfoundry.org/version/3.164.0/index.html#organization-quotas-in-v3

Fixes https://github.com/cloudfoundry/cloud_controller_ng/issues/3762

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
