### PR TITLE
Updating a route destination protocol informs backend

### DIFF
--- a/app/actions/route_destination_update.rb
+++ b/app/actions/route_destination_update.rb
@@ -15,9 +15,8 @@ module VCAP::CloudController
           destination.save
         end
 
-        runners = CloudController::DependencyLocator.instance.runners
         destination.processes.each do |process|
-          notify_backend_of_route_update(process, runners)
+          ProcessRouteHandler.new(process).notify_backend_of_route_update
         end
 
         destination
@@ -25,22 +24,12 @@ module VCAP::CloudController
 
       private
 
-      def notify_backend_of_route_update(process, runners)
-        runners.runner_for_process(process).update_routes if process.staged? && process.started?
-      rescue Diego::Runner::CannotCommunicateWithDiegoError => e
-        logger.error("failed communicating with diego backend: #{e.message}")
-      end
-
       def validate_protocol_matches_route!(destination, message)
         if destination.route&.protocol == 'tcp'
           raise Error.new("Destination protocol must be 'tcp' if the parent route's protocol is 'tcp'") unless message.protocol == 'tcp'
         elsif message.protocol == 'tcp'
           raise Error.new("Destination protocol must be 'http1' or 'http2' if the parent route's protocol is 'http'")
         end
-      end
-
-      def logger
-        @logger ||= Steno.logger('cc.route_destination_update')
       end
     end
   end

--- a/spec/unit/actions/route_destination_update_spec.rb
+++ b/spec/unit/actions/route_destination_update_spec.rb
@@ -6,18 +6,64 @@ module VCAP::CloudController
     subject(:destination_update) { RouteDestinationUpdate }
 
     describe '#update' do
-      let!(:destination) { RouteMappingModel.make({ protocol: 'http1' }) }
+      let(:process) { ProcessModelFactory.make(state: 'STARTED') }
+      let!(:destination) { RouteMappingModel.make({ protocol: 'http1', app_guid: process.app.guid, process_type: process.type }) }
+      let(:runners) { instance_double(Runners, runner_for_process: runner) }
+      let(:runner) { instance_double(Diego::Runner, update_routes: nil) }
 
       let(:message) do
-        VCAP::CloudController::RouteDestinationUpdateMessage.new({
-                                                                   protocol: 'http2'
-                                                                 })
+        VCAP::CloudController::RouteDestinationUpdateMessage.new(
+          {
+            protocol: 'http2'
+          }
+        )
+      end
+
+      before do
+        allow(CloudController::DependencyLocator.instance).to receive(:runners).and_return(runners)
+        # allow(VCAP::CloudController::ProcessObserver).to receive(:updated)
       end
 
       it 'updates the destination record' do
         updated_destination = RouteDestinationUpdate.update(destination, message)
 
         expect(updated_destination.protocol).to eq 'http2'
+      end
+
+      describe 'updating the backend' do
+        context 'when the process is started and staged' do
+          it 'calls the backend runner', isolation: :truncation do
+            RouteDestinationUpdate.update(destination, message)
+            expect(runner).to have_received(:update_routes)
+          end
+        end
+
+        context 'when the process is started but not staged' do
+          before do
+            process.desired_droplet.destroy
+          end
+
+          it 'does not call the backend runner', isolation: :truncation do
+            RouteDestinationUpdate.update(destination, message)
+            expect(runner).not_to have_received(:update_routes)
+          end
+        end
+
+        context 'when the process is not started' do
+          let(:process) { ProcessModelFactory.make(state: 'STOPPED') }
+
+          it 'does not call the backend runner', isolation: :truncation do
+            RouteDestinationUpdate.update(destination, message)
+            expect(runner).not_to have_received(:update_routes)
+          end
+        end
+
+        context 'when an error occurs talking to the backend' do
+          it 'does not raise an error' do
+            allow(runner).to receive(:update_routes).and_raise(VCAP::CloudController::Diego::Runner::CannotCommunicateWithDiegoError)
+            expect { RouteDestinationUpdate.update(destination, message) }.not_to raise_error
+          end
+        end
       end
 
       context 'when the given protocol is incompatible' do

--- a/spec/unit/actions/route_destination_update_spec.rb
+++ b/spec/unit/actions/route_destination_update_spec.rb
@@ -8,8 +8,7 @@ module VCAP::CloudController
     describe '#update' do
       let(:process) { ProcessModelFactory.make(state: 'STARTED') }
       let!(:destination) { RouteMappingModel.make({ protocol: 'http1', app_guid: process.app.guid, process_type: process.type }) }
-      let(:runners) { instance_double(Runners, runner_for_process: runner) }
-      let(:runner) { instance_double(Diego::Runner, update_routes: nil) }
+      let(:process_route_handler) { instance_double(ProcessRouteHandler, notify_backend_of_route_update: nil) }
 
       let(:message) do
         VCAP::CloudController::RouteDestinationUpdateMessage.new(
@@ -20,8 +19,7 @@ module VCAP::CloudController
       end
 
       before do
-        allow(CloudController::DependencyLocator.instance).to receive(:runners).and_return(runners)
-        # allow(VCAP::CloudController::ProcessObserver).to receive(:updated)
+        allow(ProcessRouteHandler).to receive(:new).with(process).and_return(process_route_handler)
       end
 
       it 'updates the destination record' do
@@ -30,40 +28,9 @@ module VCAP::CloudController
         expect(updated_destination.protocol).to eq 'http2'
       end
 
-      describe 'updating the backend' do
-        context 'when the process is started and staged' do
-          it 'calls the backend runner', isolation: :truncation do
-            RouteDestinationUpdate.update(destination, message)
-            expect(runner).to have_received(:update_routes)
-          end
-        end
-
-        context 'when the process is started but not staged' do
-          before do
-            process.desired_droplet.destroy
-          end
-
-          it 'does not call the backend runner', isolation: :truncation do
-            RouteDestinationUpdate.update(destination, message)
-            expect(runner).not_to have_received(:update_routes)
-          end
-        end
-
-        context 'when the process is not started' do
-          let(:process) { ProcessModelFactory.make(state: 'STOPPED') }
-
-          it 'does not call the backend runner', isolation: :truncation do
-            RouteDestinationUpdate.update(destination, message)
-            expect(runner).not_to have_received(:update_routes)
-          end
-        end
-
-        context 'when an error occurs talking to the backend' do
-          it 'does not raise an error' do
-            allow(runner).to receive(:update_routes).and_raise(VCAP::CloudController::Diego::Runner::CannotCommunicateWithDiegoError)
-            expect { RouteDestinationUpdate.update(destination, message) }.not_to raise_error
-          end
-        end
+      it 'notifies the backend of route updates' do
+        RouteDestinationUpdate.update(destination, message)
+        expect(process_route_handler).to have_received(:notify_backend_of_route_update)
       end
 
       context 'when the given protocol is incompatible' do


### PR DESCRIPTION
* A short explanation of the proposed change:

Updates the RouteDestinationUpdate action to behave like other route update endpoints and notifiy Diego immediately

* An explanation of the use cases your change solves

Prior to this change users would need to manually restart their app to get a route destination protocol change to take effect.

* Links to any other associated PRs

Fixes https://github.com/cloudfoundry/cloud_controller_ng/issues/3687

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
