### PR TITLE
Fix app crash events for apps using rolling deployments

### DIFF
--- a/app/controllers/internal/app_crashed_controller.rb
+++ b/app/controllers/internal/app_crashed_controller.rb
@@ -7,18 +7,18 @@ module VCAP::CloudController
     allow_unauthenticated_access
 
     post '/internal/v4/apps/:process_guid/crashed', :crashed
-    def crashed(process_guid)
+    def crashed(lrp_process_guid)
       crash_payload = crashed_request
 
-      app_guid = Diego::ProcessGuid.cc_process_guid(process_guid)
+      cc_process_guid = Diego::ProcessGuid.cc_process_guid(lrp_process_guid)
 
-      process = ProcessModel.find(guid: app_guid)
-      raise CloudController::Errors::NotFound.new_from_details('ProcessNotFound', app_guid) unless process
+      process = ProcessModel.find(guid: cc_process_guid)
+      raise CloudController::Errors::NotFound.new_from_details('ProcessNotFound', cc_process_guid) unless process
 
-      crash_payload['version'] = Diego::ProcessGuid.cc_process_version(process_guid)
+      crash_payload['version'] = Diego::ProcessGuid.cc_process_version(lrp_process_guid)
 
       Repositories::ProcessEventRepository.record_crash(process, crash_payload)
-      Repositories::AppEventRepository.new.create_app_crash_event(process, crash_payload)
+      Repositories::AppEventRepository.new.create_app_crash_event(process.app, crash_payload)
 
       [200, '{}']
     end


### PR DESCRIPTION
This change updates the endpoint to make app crash events for the app guid instead of the process guid which should resolve the rolling deployment issue and support crash events for non-web process types.

The internal app crash event endpoint assumed that the web process guid == app guid (legacy behavior from the v2->v3 data model migrations). Rolling deployments create new web processes that have different guids which made it so this endpoint no longer created events associated with the parent app.

Issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/2587

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
