### PR TITLE
Remove redundant duplicate keys from cc config

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -154,16 +154,6 @@ route_services_enabled: true
 volume_services_enabled: true
 disable_private_domain_cross_space_context_path_route_sharing: false
 
-# App staging parameters
-staging:
-  # Max duration for staging process
-  timeout_in_seconds: 120 # secs
-  minimum_staging_memory_mb: 1024
-  minimum_staging_disk_mb: 4096
-  auth:
-    user: zxsfhgjg
-    password: ZNVfdase9
-
 quota_definitions:
   default:
     memory_limit: 10240
@@ -338,9 +328,6 @@ db:
   log_db_queries: true
   read_timeout: 3600
   connection_validation_timeout: 3600
-
-staging:
-  minimum_staging_file_descriptor_limit: 4200
 
 index: 0
 name: api


### PR DESCRIPTION
Remove duplicate `staging` keys from `cloud_controller.yml` file. This block already exists in the file:
```
staging:
  timeout_in_seconds: 42
  expiration_in_secons: 42
  minimum_staging_memory_mb: 42
  minimum_staging_disk_mb: 42
  minimum_staging_file_descriptor_limit: 42
  auth:
    user: 'bob'
    password: 'laura'
```
https://github.com/cloudfoundry/cloud_controller_ng/blob/main/config/cloud_controller.yml#L355-L363

This file is used https://github.com/cloudfoundry/cloud_controller_ng/blob/main/.devcontainer/scripts/setupDevelopmentEnvironment.sh#L47 but it does not inspect the staging object.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [n/a] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
