### PR TITLE
Fix typo in cloud_controller.yml

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -354,7 +354,7 @@ security_event_logging:
 
 staging:
   timeout_in_seconds: 42
-  expiration_in_secons: 42
+  expiration_in_seconds: 42
   minimum_staging_memory_mb: 42
   minimum_staging_disk_mb: 42
   minimum_staging_file_descriptor_limit: 42


### PR DESCRIPTION
Fix typo in key.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [n/a] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
