### PR TITLE
Add feature flag db.enable_paginate_window

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -100,7 +100,8 @@ module VCAP::CloudController
               optional(:connection_expiration_timeout) => Integer,
               optional(:connection_expiration_random_delay) => Integer,
               optional(:ssl_verify_hostname) => bool,
-              optional(:ca_cert_path) => String
+              optional(:ca_cert_path) => String,
+              optional(:enable_paginate_window) => bool
             },
 
             optional(:redis) => {

--- a/lib/cloud_controller/config_schemas/base/migrate_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/migrate_schema.rb
@@ -19,7 +19,8 @@ module VCAP::CloudController
               :connection_validation_timeout => Integer,
               optional(:log_db_queries) => bool,
               optional(:ssl_verify_hostname) => bool,
-              optional(:ca_cert_path) => String
+              optional(:ca_cert_path) => String,
+              optional(:enable_paginate_window) => bool
             },
 
             db_encryption_key: enum(String, NilClass),

--- a/lib/cloud_controller/paging/sequel_paginator.rb
+++ b/lib/cloud_controller/paging/sequel_paginator.rb
@@ -25,7 +25,10 @@ module VCAP::CloudController
     end
 
     def can_paginate_with_window_function?(dataset)
-      dataset.supports_window_functions? && (!dataset.opts[:distinct] || !dataset.requires_unique_column_names_in_subquery_select_list?)
+      enable_paginate_window = true if Config.config.get(:db, :enable_paginate_window).nil?
+      enable_paginate_window = Config.config.get(:db, :enable_paginate_window) unless Config.config.get(:db, :enable_paginate_window).nil?
+
+      enable_paginate_window && dataset.supports_window_functions? && (!dataset.opts[:distinct] || !dataset.requires_unique_column_names_in_subquery_select_list?)
     end
 
     private

--- a/lib/cloud_controller/paging/sequel_paginator.rb
+++ b/lib/cloud_controller/paging/sequel_paginator.rb
@@ -25,8 +25,7 @@ module VCAP::CloudController
     end
 
     def can_paginate_with_window_function?(dataset)
-      enable_paginate_window = true if Config.config.get(:db, :enable_paginate_window).nil?
-      enable_paginate_window = Config.config.get(:db, :enable_paginate_window) unless Config.config.get(:db, :enable_paginate_window).nil?
+      enable_paginate_window = Config.config.get(:db, :enable_paginate_window).nil? ? true : Config.config.get(:db, :enable_paginate_window)
 
       enable_paginate_window && dataset.supports_window_functions? && (!dataset.opts[:distinct] || !dataset.requires_unique_column_names_in_subquery_select_list?)
     end

--- a/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
+++ b/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
@@ -205,7 +205,7 @@ module VCAP::CloudController
         end
       end
 
-      context 'window controll config flag' do
+      context 'enable_paginate_window config flag' do
         let(:dataset) { AppModel.dataset }
         let!(:app_1) { AppModel.make(guid: '1', created_at: '2024-05-15T17:23:01Z') }
         let!(:app_2) { AppModel.make(guid: '2', created_at: '2024-05-15T17:23:02Z') }
@@ -213,14 +213,14 @@ module VCAP::CloudController
         let!(:app_4) { AppModel.make(guid: '4', created_at: '2024-05-15T17:23:04Z') }
 
         context 'not defined' do
-          it 'uses window function' do
+          it 'uses window function if supported' do
             options = { page:, per_page: }
             pagination_options = PaginationOptions.new(options)
 
             paginated_result = nil
             expect do
               paginated_result = paginator.get_page(dataset, pagination_options)
-            end.to have_queried_db_times(/select/i, 1)
+            end.to have_queried_db_times(/select/i, dataset.supports_window_functions? ? 1 : 2)
             expect(paginated_result.total).to be > 1
           end
         end
@@ -238,14 +238,14 @@ module VCAP::CloudController
             TestConfig.override(**my_config)
           end
 
-          it 'uses window function' do
+          it 'uses window function if supported' do
             options = { page:, per_page: }
             pagination_options = PaginationOptions.new(options)
 
             paginated_result = nil
             expect do
               paginated_result = paginator.get_page(dataset, pagination_options)
-            end.to have_queried_db_times(/select/i, 1)
+            end.to have_queried_db_times(/select/i, dataset.supports_window_functions? ? 1 : 2)
             expect(paginated_result.total).to be > 1
           end
         end
@@ -263,7 +263,7 @@ module VCAP::CloudController
             TestConfig.override(**my_config)
           end
 
-          it 'uses window function' do
+          it 'does not use window function' do
             options = { page:, per_page: }
             pagination_options = PaginationOptions.new(options)
 

--- a/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
+++ b/spec/unit/lib/cloud_controller/paging/sequel_paginator_spec.rb
@@ -204,6 +204,77 @@ module VCAP::CloudController
           expect(paginated_result.total).to be > 1
         end
       end
+
+      context 'window controll config flag' do
+        let(:dataset) { AppModel.dataset }
+        let!(:app_1) { AppModel.make(guid: '1', created_at: '2024-05-15T17:23:01Z') }
+        let!(:app_2) { AppModel.make(guid: '2', created_at: '2024-05-15T17:23:02Z') }
+        let!(:app_3) { AppModel.make(guid: '3', created_at: '2024-05-15T17:23:03Z') }
+        let!(:app_4) { AppModel.make(guid: '4', created_at: '2024-05-15T17:23:04Z') }
+
+        context 'not defined' do
+          it 'uses window function' do
+            options = { page:, per_page: }
+            pagination_options = PaginationOptions.new(options)
+
+            paginated_result = nil
+            expect do
+              paginated_result = paginator.get_page(dataset, pagination_options)
+            end.to have_queried_db_times(/select/i, 1)
+            expect(paginated_result.total).to be > 1
+          end
+        end
+
+        context 'set to true' do
+          let(:my_config) do
+            {
+              db: {
+                enable_paginate_window: true
+              }
+            }
+          end
+
+          before do
+            TestConfig.override(**my_config)
+          end
+
+          it 'uses window function' do
+            options = { page:, per_page: }
+            pagination_options = PaginationOptions.new(options)
+
+            paginated_result = nil
+            expect do
+              paginated_result = paginator.get_page(dataset, pagination_options)
+            end.to have_queried_db_times(/select/i, 1)
+            expect(paginated_result.total).to be > 1
+          end
+        end
+
+        context 'set to false' do
+          let(:my_config) do
+            {
+              db: {
+                enable_paginate_window: false
+              }
+            }
+          end
+
+          before do
+            TestConfig.override(**my_config)
+          end
+
+          it 'uses window function' do
+            options = { page:, per_page: }
+            pagination_options = PaginationOptions.new(options)
+
+            paginated_result = nil
+            expect do
+              paginated_result = paginator.get_page(dataset, pagination_options)
+            end.to have_queried_db_times(/select/i, 2)
+            expect(paginated_result.total).to be > 1
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request, please provide us with the following:

* A short explanation of the proposed change:
This feature flag, if not present, will default to the current behavior of using the window pagination, but when it is set to false, it will fall back on using the other pagination method when accessing the database.

* An explanation of the use cases your change solves
This change will allow the operator to disable the window for pagination for all the tables in a single place. Will also allow us to debug possible performance issues with the window pagination in other tables.

* Links to any other associated PRs

* [ x ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ x ] I have viewed, signed, and submitted the Contributor License Agreement

* [ x ] I have made this pull request to the `main` branch

* [ x ] I have run all the unit tests using `bundle exec rake`

* [  ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
