### PR TITLE
Fix select query for service offerings

### DIFF
--- a/app/fetchers/service_offering_list_fetcher.rb
+++ b/app/fetchers/service_offering_list_fetcher.rb
@@ -4,12 +4,14 @@ module VCAP::CloudController
   class ServiceOfferingListFetcher < BaseServiceListFetcher
     class << self
       def fetch(message, omniscient: false, readable_orgs_query: nil, readable_spaces_query: nil, eager_loaded_associations: [])
-        super(Service,
-              message,
-              omniscient:,
-              readable_orgs_query:,
-              readable_spaces_query:,
-              eager_loaded_associations:)
+        dataset = super(Service,
+                        message,
+                        omniscient:,
+                        readable_orgs_query:,
+                        readable_spaces_query:,
+                        eager_loaded_associations:)
+        # for service offerings there might be an overlap between the UNIONed subqueries (i.e. one plan is public and another one is org restricted)
+        dataset.distinct
       end
 
       private

--- a/spec/unit/fetchers/service_offering_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_offering_list_fetcher_spec.rb
@@ -18,6 +18,21 @@ module VCAP::CloudController
         end
       end
 
+      context 'service offering with both public and org restricted plans' do
+        let(:org) { Organization.make }
+        let(:readable_orgs) { [org] }
+
+        it 'shows unique results' do
+          service_offering = Service.make(label: "with-public-and-org-restricted-plans-#{Sham.name}")
+          ServicePlan.make(public: true, active: true, service: service_offering)
+          service_plan = ServicePlan.make(public: false, service: service_offering)
+          ServicePlanVisibility.make(organization: org, service_plan: service_plan)
+
+          service_offerings = fetcher.fetch(message, readable_orgs_query:).all
+          expect(service_offerings).to contain_exactly(service_offering)
+        end
+      end
+
       describe 'visibility of offerings' do
         let!(:public_offering_1) { make_public_offering }
         let!(:public_offering_2) { make_public_offering(number_of_plans: 2) }


### PR DESCRIPTION
The service offerings list fetcher returned duplicates in case an offering had both a public plan and another plan that was org restricted. Thus a `DISTINCT` has been added to the outer select query.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
