### PR TITLE
Use DISTINCT only when UNIONing multiple datasets

### DIFF
--- a/app/fetchers/base_service_list_fetcher.rb
+++ b/app/fetchers/base_service_list_fetcher.rb
@@ -58,9 +58,9 @@ module VCAP::CloudController
                     # A single sub-query does not need to be UNIONed (i.e. unauthenticated user retrieving public plans)
                     datasets[0]
                   else
-                    datasets.reduce do |ds1, ds2|
+                    distinct_union(datasets.reduce do |ds1, ds2|
                       ds1.union(ds2, all: true, from_self: false)
-                    end.from_self(alias: klass.table_name)
+                    end.from_self(alias: klass.table_name))
                   end
 
         dataset.eager(eager_loaded_associations)
@@ -146,12 +146,16 @@ module VCAP::CloudController
         super(message, dataset, klass)
       end
 
-      def join_service_plans(dataset)
-        dataset
+      def join_service_plans(_dataset)
+        raise 'method must be implemented in subclass'
       end
 
-      def join_services(dataset)
-        dataset
+      def join_services(_dataset)
+        raise 'method must be implemented in subclass'
+      end
+
+      def distinct_union(_dataset)
+        raise 'method must be implemented in subclass'
       end
 
       def join_plan_org_visibilities(dataset)

--- a/app/fetchers/service_plan_list_fetcher.rb
+++ b/app/fetchers/service_plan_list_fetcher.rb
@@ -48,8 +48,18 @@ module VCAP::CloudController
         super(message, dataset, klass)
       end
 
+      def join_service_plans(dataset)
+        dataset # The ServicePlanListFetcher operates on the :service_plans table, so there is no need for an additional JOIN.
+      end
+
       def join_services(dataset)
         join(dataset, :inner, :services, id: Sequel[:service_plans][:service_id])
+      end
+
+      def distinct_union(dataset)
+        # The UNIONed :service_plans datasets (permissions granted on org level for plans / permissions
+        # granted on space level for brokers / public plans) are already distinct.
+        dataset
       end
     end
   end


### PR DESCRIPTION
When `UNION`ing multiple datasets, invoke _abstract_ method `distinct_union` which is implemented differently by the `ServiceOfferingListFetcher` and the `ServicePlanListFetcher`. For fetched service plans we already know that there is no overlap between the subqueries; for fetched services there can be duplicates and thus a `DISTINCT` has to be added to the query.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
