### PR TITLE
Reduce queries to DB when collecting routing info

### DIFF
--- a/spec/unit/lib/cloud_controller/diego/protocol/routing_info_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/protocol/routing_info_spec.rb
@@ -423,6 +423,16 @@ module VCAP::CloudController
               end
             end
           end
+
+          context 'when process disappeared' do
+            before do
+              process.destroy
+            end
+
+            it 'return an empty object' do
+              expect(ri).to be_empty
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Previously there were many DB queries when e.g. adding a destination to a route. There were as many queries as route_mappings existed for the process (destination). Further queries then fetched associated routes, domains and route_bindings each in their own query. With this change all those resources are fetched via eager loading, which results in one query per DB table, in this case 5.

* Links to any other associated PRs

Implemented performance tests for adding a destination to an app with many route mappings: https://github.com/cloudfoundry/cf-performance-tests/pull/34


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
