### PR TITLE
Add migration file for task_guid index to app_usage_events table

### DIFF
--- a/db/migrations/20150113201824_fix_created_at_column.rb
+++ b/db/migrations/20150113201824_fix_created_at_column.rb
@@ -1,5 +1,5 @@
 Sequel.migration do
-  TABLE_NAMES = %w[
+  table_names = %w[
     app_events
     app_usage_events
     apps
@@ -33,7 +33,7 @@ Sequel.migration do
 
   up do
     if self.class.name.match?(/mysql/i)
-      TABLE_NAMES.each do |table|
+      table_names.each do |table|
         run <<-SQL.squish
         ALTER TABLE #{table} MODIFY created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
         SQL
@@ -43,7 +43,7 @@ Sequel.migration do
 
   down do
     if self.class.name.match?(/mysql/i)
-      TABLE_NAMES.each do |table|
+      table_names.each do |table|
         run <<-SQL.squish
         ALTER TABLE #{table} MODIFY created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
         SQL

--- a/db/migrations/20240529195136_add_task_guid_index_to_app_usage_events.rb
+++ b/db/migrations/20240529195136_add_task_guid_index_to_app_usage_events.rb
@@ -1,0 +1,35 @@
+Sequel.migration do
+  # adding an index concurrently cannot be done within a transaction
+  no_transaction
+
+  up do
+    if database_type == :postgres
+      VCAP::Migration.with_concurrent_timeout(self) do
+        add_index :app_usage_events, :task_guid, name: :app_usage_events_task_guid_index, if_not_exists: true, concurrently: true
+      end
+
+    elsif database_type == :mysql
+      alter_table :app_usage_events do
+        # rubocop:disable Sequel/ConcurrentIndex
+        add_index :task_guid, name: :app_usage_events_task_guid_index unless @db.indexes(:app_usage_events).include?(:app_usage_events_task_guid_index)
+        # rubocop:enable Sequel/ConcurrentIndex
+      end
+    end
+  end
+
+  down do
+    if database_type == :postgres
+      VCAP::Migration.with_concurrent_timeout(self) do
+        drop_index :app_usage_events, :task_guid, name: :app_usage_events_task_guid_index, if_exists: true, concurrently: true
+      end
+    end
+
+    if database_type == :mysql
+      alter_table :app_usage_events do
+        # rubocop:disable Sequel/ConcurrentIndex
+        drop_index :task_guid, name: :app_usage_events_task_guid_index if @db.indexes(:app_usage_events).include?(:app_usage_events_task_guid_index)
+        # rubocop:enable Sequel/ConcurrentIndex
+      end
+    end
+  end
+end

--- a/spec/migrations/20240314131908_add_user_guid_to_jobs_table_spec.rb
+++ b/spec/migrations/20240314131908_add_user_guid_to_jobs_table_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'migrations/helpers/migration_shared_context'
 
-RSpec.describe 'migration to add user_guid column to jobs table and add an index for that column', isolation: :truncation do
+RSpec.describe 'migration to add user_guid column to jobs table and add an index for that column', isolation: :truncation, type: :migration do
   include_context 'migration' do
     let(:migration_filename) { '20240314131908_add_user_guid_to_jobs_table.rb' }
   end

--- a/spec/migrations/20240529195136_add_task_guid_index_to_app_usage_events_spec.rb
+++ b/spec/migrations/20240529195136_add_task_guid_index_to_app_usage_events_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to add an index for task_guid on app_usage_events table', isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20240529195136_add_task_guid_index_to_app_usage_events.rb' }
+  end
+
+  describe 'app_usage_events table' do
+    describe 'up migration' do
+      context 'index does not exist' do
+        it 'adds an index on the task_guid column' do
+          expect(db.indexes(:app_usage_events)).not_to include(:app_usage_events_task_guid_index)
+          expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+          expect(db.indexes(:app_usage_events)).to include(:app_usage_events_task_guid_index)
+        end
+      end
+
+      context 'index already exists' do
+        before do
+          db.add_index :app_usage_events, :task_guid, name: :app_usage_events_task_guid_index
+        end
+
+        it 'does not fail' do
+          expect(db.indexes(:app_usage_events)).to include(:app_usage_events_task_guid_index)
+          expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+          expect(db.indexes(:app_usage_events)).to include(:app_usage_events_task_guid_index)
+        end
+      end
+    end
+
+    describe 'down migration' do
+      context 'index does not exist' do
+        before do
+          Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+          db.drop_index :app_usage_events, :task_guid, name: :app_usage_events_task_guid_index
+        end
+
+        it 'does not fail' do
+          expect(db.indexes(:app_usage_events)).not_to include(:app_usage_events_task_guid_index)
+          expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
+          expect(db.indexes(:app_usage_events)).not_to include(:app_usage_events_task_guid_index)
+        end
+      end
+
+      context 'index does exist' do
+        before do
+          Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+        end
+
+        it 'removes the index' do
+          expect(db.indexes(:app_usage_events)).to include(:app_usage_events_task_guid_index)
+          expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
+          expect(db.indexes(:app_usage_events)).not_to include(:app_usage_events_task_guid_index)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change is to add index on task_guid of app_usage_events table. This index helps it to speed up the search on app-usage_events table since it tends to have large dataset. 

Usecase: When the app_usage_events table has large dataset, CAPI health check was timing out which resulted in CAPI endpoint being unregistered. The RCA revealed that search on this table was taking longer. Adding this index helps solve the issue.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
