### PR TITLE
Fix typo in destinations presenter

### DIFF
--- a/app/presenters/v3/route_destination_presenter.rb
+++ b/app/presenters/v3/route_destination_presenter.rb
@@ -35,7 +35,7 @@ module VCAP::CloudController::Presenters::V3
 
     def build_links
       links = {
-        destintions: {
+        destinations: {
           href: url_builder.build_url(path: "/v3/routes/#{destination.route_guid}/destinations")
         }
       }

--- a/docs/v3/source/includes/resources/routes/_update_destination.md.erb
+++ b/docs/v3/source/includes/resources/routes/_update_destination.md.erb
@@ -8,7 +8,7 @@ Example Request
 curl "https://api.example.org/v3/routes/[guid]/destinations/[guid]" \
   -X PATCH \
   -H "Authorization: bearer [token]"
-  -d '{"protocol: "http2"}'
+  -d '{"protocol": "http2"}'
 ```
 
 ```
@@ -31,7 +31,7 @@ Content-Type: application/json
   "port": 8080,
   "protocol": "http2",
   "links": {
-    "self": {
+    "destinations": {
       "href": "https://api.example.org/v3/routes/cbad697f-cac1-48f4-9017-ac08f39dfb31/destinations"
     },
     "route": {

--- a/spec/unit/presenters/v3/route_destination_presenter_spec.rb
+++ b/spec/unit/presenters/v3/route_destination_presenter_spec.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController::Presenters::V3
           port: route_mapping.presented_port,
           protocol: route_mapping.protocol,
           links: {
-            destintions: {
+            destinations: {
               href: "http://api2.vcap.me/v3/routes/#{route.guid}/destinations"
             },
             route: {


### PR DESCRIPTION
* A short explanation of the proposed change:
Fix typo in destinations presenter. `destintions` -> `destinations`

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
