### PR TITLE
Don't add a Steno sink in test env

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -107,7 +107,7 @@ logging:
   anonymize_ips: false
   format:
     timestamp: 'rfc3339'
-  stdout_sink_enabled: true
+  stdout_sink_enabled: false
 
 log_audit_events: false
 

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -65,6 +65,7 @@ module VCAP::CloudController
               level: String, # debug, info, etc.
               file: String, # Log file to use
               syslog: String, # Name to associate with syslog messages (should start with 'vcap.')
+              optional(:stdout_sink_enabled) => bool,
               optional(:anonymize_ips) => bool,
               optional(:format) => {
                 optional(:timestamp) => String

--- a/lib/cloud_controller/config_schemas/base/migrate_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/migrate_schema.rb
@@ -34,7 +34,8 @@ module VCAP::CloudController
             logging: {
               level: String, # debug, info, etc.
               file: String, # Log file to use
-              syslog: String # Name to associate with syslog messages (should start with 'vcap.')
+              syslog: String, # Name to associate with syslog messages (should start with 'vcap.')
+              optional(:stdout_sink_enabled) => bool
             }
           }
         end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -276,7 +276,9 @@ namespace :db do
 
   def logging_output
     VCAP::CloudController::StenoConfigurer.new(RakeConfig.config.get(:logging)).configure do |steno_config_hash|
-      steno_config_hash[:sinks] << Steno::Sink::IO.new($stdout)
+      if RakeConfig.config.get(:logging, :stdout_sink_enabled).nil? || RakeConfig.config.get(:logging, :stdout_sink_enabled)
+        steno_config_hash[:sinks] << Steno::Sink::IO.new($stdout)
+      end
     end
   end
 

--- a/spec/tasks/db_spec.rb
+++ b/spec/tasks/db_spec.rb
@@ -5,14 +5,33 @@ RSpec.describe 'db.rake', type: :migration do
   let(:db_migrator) { instance_double(DBMigrator) }
 
   describe ':migrate' do
+    let(:stdout_sink_enabled) { true }
+    let(:logging_config) do
+      {
+        logging: {
+          stdout_sink_enabled: stdout_sink_enabled,
+          level: 'debug2',
+          syslog: 'vcap.example',
+          file: '/tmp/cloud_controller.log',
+          anonymize_ips: false,
+          format: { timestamp: 'rfc3339' }
+        }
+      }
+    end
+
     before do
+      TestConfig.override(**logging_config)
       allow(RakeConfig).to receive(:config).and_return(TestConfig.config_instance)
       allow(DBMigrator).to receive(:from_config).and_return(db_migrator)
       allow(db_migrator).to receive(:apply_migrations)
     end
 
+    after do
+      Steno.config.sinks.delete_if { |sink| sink.instance_variable_get(:@io) == $stdout }
+    end
+
     it 'logs to configured sinks + STDOUT' do
-      Rake::Task['db:migrate'].invoke
+      Rake::Task['db:migrate'].execute
 
       # From test config:
       expect(Steno.config.sinks).to include(an_instance_of(Steno::Sink::Syslog))
@@ -20,6 +39,55 @@ RSpec.describe 'db.rake', type: :migration do
 
       # From db.rake:
       expect(Steno.config.sinks).to include(an_instance_of(Steno::Sink::IO).and(satisfy { |sink| sink.instance_variable_get(:@io) == $stdout }))
+    end
+
+    describe 'steno sink' do
+      let(:logging_config) do
+        {
+          logging: {
+            stdout_sink_enabled: stdout_sink_enabled,
+            level: 'debug2',
+            file: '/tmp/cloud_controller.log',
+            anonymize_ips: false,
+            format: { timestamp: 'rfc3339' }
+          }
+        }
+      end
+
+      context 'when `stdout_sink_enabled` is `true`' do
+        it 'configures steno logger with stdout sink' do
+          Rake::Task['db:migrate'].execute
+          expect(Steno.logger('cc.db.migrations').instance_variable_get(:@sinks).length).to eq(2)
+        end
+      end
+
+      context 'when `stdout_sink_enabled` is not set' do
+        let(:logging_config) do
+          {
+            logging: {
+              level: 'debug2',
+              file: '/tmp/cloud_controller.log',
+              anonymize_ips: false,
+              format: { timestamp: 'rfc3339' }
+            }
+          }
+        end
+
+        it 'configures steno logger with stdout sink' do
+          Rake::Task['db:migrate'].invoke
+
+          expect(Steno.logger('cc.db.migrations').instance_variable_get(:@sinks).length).to eq(2)
+        end
+      end
+
+      context 'when `stdout_sink_enabled` is `false`' do
+        let(:stdout_sink_enabled) { false }
+
+        it 'configures steno logger without stdout sink' do
+          Rake::Task['db:migrate'].execute
+          expect(Steno.logger('cc.db.migrations').instance_variable_get(:@sinks).length).to eq(1)
+        end
+      end
     end
   end
 end

--- a/spec/unit/lib/bosh_errand_environment_spec.rb
+++ b/spec/unit/lib/bosh_errand_environment_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe BoshErrandEnvironment do
   describe '#initialize' do
     it 'configures steno logger with stdout sink' do
       bosh_errand_environment.setup_environment
-      expect(Steno.logger('cc.errand').instance_variable_get(:@sinks).length).to be(2)
+      expect(Steno.logger('cc.errand').instance_variable_get(:@sinks).length).to eq(2)
     end
 
     context 'when `stdout_sink_enabled` is `false`' do
@@ -25,7 +25,7 @@ RSpec.describe BoshErrandEnvironment do
 
       it 'configures steno logger wo stdout sink' do
         bosh_errand_environment.setup_environment
-        expect(Steno.logger('cc.errand').instance_variable_get(:@sinks).length).to be(1)
+        expect(Steno.logger('cc.errand').instance_variable_get(:@sinks).length).to eq(1)
       end
     end
   end


### PR DESCRIPTION
* this gets applied to the entire test run in GithubActions and makes the test output hard to read

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
