### PR TITLE
Do not allow ASGs with leading zeros

### DIFF
--- a/app/messages/validators/security_group_rule_validator.rb
+++ b/app/messages/validators/security_group_rule_validator.rb
@@ -135,6 +135,9 @@ class RulesValidator < ActiveModel::Validator
 
     address_list = destination.split('-')
 
+    zeros_error_message = 'destination octets cannot contain leading zeros'
+    add_rule_error(zeros_error_message, record, index) unless CloudController::RuleValidator.no_leading_zeros(address_list)
+
     if address_list.length == 1
       add_rule_error(error_message, record, index) unless CloudController::RuleValidator.parse_ip(address_list.first)
 

--- a/docs/v3/source/includes/resources/security_groups/_object.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_object.md.erb
@@ -26,7 +26,7 @@ Name | Type | Description
 | Name | Type | Description | Required | Default
 | ---- | ---- | ----------- | -------- | -------
 | **protocol** | _string_ | Protocol type Valid values are `tcp`, `udp`, `icmp`, or `all` | yes | N/A |
-| **destination** | _string_ | The destination where the rule applies. Must be a singular Valid CIDR, IP address, or IP address range unless `cc.security_groups.enable_comma_delimited_destinations` is enabled. Then, the destination can be a comma-delimited string of CIDRs, IP addresses, or IP address ranges.  | yes | N/A |
+| **destination** | _string_ | The destination where the rule applies. Must be a singular Valid CIDR, IP address, or IP address range unless `cc.security_groups.enable_comma_delimited_destinations` is enabled. Then, the destination can be a comma-delimited string of CIDRs, IP addresses, or IP address ranges. Octets within destinations cannot contain leading zeros; eg. `10.0.0.0/24` is valid, but `010.00.000.0/24` is *not*.  | yes | N/A |
 | **ports** | _string_ | Ports that the rule applies to; can be a single port (`9000`), a comma-separated list (`9000,9001`), or a range (`9000-9200`) | no | `null` |
 | **type** | _integer_ |[Type](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types) required for ICMP protocol; valid values are between -1 and 255 (inclusive), where -1 allows all | no | `null` |
 | **code** | _integer_ |[Code](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-codes) required for ICMP protocol; valid values are between -1 and 255 (inclusive), where -1 allows all | no | `null` |

--- a/spec/unit/messages/security_group_create_message_spec.rb
+++ b/spec/unit/messages/security_group_create_message_spec.rb
@@ -189,6 +189,56 @@ module VCAP::CloudController
             expect(subject).not_to be_valid
           end
         end
+
+        context 'when the rule contains leading zeros' do
+          context 'in a CIDR' do
+            let(:rules) do
+              [
+                {
+                  protocol: 'tcp',
+                  destination: '010.000.0.0/24',
+                  ports: '443,80,8080'
+                }
+              ]
+            end
+
+            it 'is invalid' do
+              expect(subject).not_to be_valid
+            end
+          end
+
+          context 'in a range' do
+            let(:rules) do
+              [
+                {
+                  protocol: 'tcp',
+                  destination: '1.0.0.000-1.0.0.200',
+                  ports: '443,80,8080'
+                }
+              ]
+            end
+
+            it 'is invalid' do
+              expect(subject).not_to be_valid
+            end
+          end
+
+          context 'in an IP' do
+            let(:rules) do
+              [
+                {
+                  protocol: 'tcp',
+                  destination: '010.000.000.053',
+                  ports: '443,80,8080'
+                }
+              ]
+            end
+
+            it 'is invalid' do
+              expect(subject).not_to be_valid
+            end
+          end
+        end
       end
 
       describe 'globally_enabled' do

--- a/spec/unit/messages/validators/security_group_rule_validator_spec.rb
+++ b/spec/unit/messages/validators/security_group_rule_validator_spec.rb
@@ -179,6 +179,90 @@ module VCAP::CloudController::Validators
         end
       end
 
+      context 'when there is a leading zero in an octet' do
+        context 'in a CIDR' do
+          let(:rules) do
+            [
+              {
+                protocol: 'tcp',
+                destination: '10.000.0.0/24',
+                ports: '443'
+              },
+              {
+                protocol: 'tcp',
+                destination: '10.0.0.000/24',
+                ports: '443'
+              }
+            ]
+          end
+
+          it 'is not valid' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.full_messages).to include 'Rules[0]: destination octets cannot contain leading zeros'
+            expect(subject.errors.full_messages).to include 'Rules[1]: destination octets cannot contain leading zeros'
+          end
+        end
+
+        context 'in an IP range' do
+          let(:rules) do
+            [
+              {
+                protocol: 'tcp',
+                destination: '1.0.0.000-1.0.0.200',
+                ports: '443'
+              }
+            ]
+          end
+
+          it 'is not valid' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.full_messages).to include 'Rules[0]: destination octets cannot contain leading zeros'
+          end
+        end
+
+        context 'in an IP' do
+          let(:rules) do
+            [
+              {
+                protocol: 'tcp',
+                destination: '010.0.0.53',
+                ports: '443'
+              },
+              {
+                protocol: 'tcp',
+                destination: '10.000.0.53',
+                ports: '443'
+              },
+              {
+                protocol: 'tcp',
+                destination: '10.0.000.53',
+                ports: '443'
+              },
+              {
+                protocol: 'tcp',
+                destination: '10.0.0.053',
+                ports: '443'
+              },
+              {
+                protocol: 'tcp',
+                destination: '010.000.000.053',
+                ports: '443'
+              }
+            ]
+          end
+
+          it 'is not valid' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.full_messages.length).to eq(5)
+            expect(subject.errors.full_messages).to include 'Rules[0]: destination octets cannot contain leading zeros'
+            expect(subject.errors.full_messages).to include 'Rules[1]: destination octets cannot contain leading zeros'
+            expect(subject.errors.full_messages).to include 'Rules[2]: destination octets cannot contain leading zeros'
+            expect(subject.errors.full_messages).to include 'Rules[3]: destination octets cannot contain leading zeros'
+            expect(subject.errors.full_messages).to include 'Rules[4]: destination octets cannot contain leading zeros'
+          end
+        end
+      end
+
       context 'when the destination field is not a valid CIDR or IP range' do
         let(:rules) do
           [


### PR DESCRIPTION
### A short explanation of the proposed change:

This change adds validation logic to prevent the creation of ASGs with leading zeros in addresses. e.g.
- `10.0.0.0/8` and `192.168.1.156` are valid 
- `010.000.000.0/0` `10.0.000.10` are no longer valid.

The motivation for this change in behavior is to prevent malformed IPs from making their way into the CC database to begin with. We only want to accept valid addresses in ASG destinations going forward.

### An explanation of the use cases your change solves

Cloud controller blindly stores the ASG destinations in the database and then passes the value off to downstream clients. Not all downstream clients have the same IP parsing functionality that ruby does, therefore jobs like `vxlan-policy-agent` in silk can stop working when a destination with leading zeros is bound via `cf bind-security-group`; when these problems happen, they tend to also take down the diego cell too by preventing routing to all running containers.

### Links to any other associated PRs, etc...

- [#187494337](https://www.pivotaltracker.com/story/show/187494337)
- https://github.com/cloudfoundry/silk-release/pull/130

### Checkboxes
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
