### PR TITLE
Wrong app instance state returned by process stats endpoint during graceful shutdown

### DIFF
--- a/docs/v3/source/includes/resources/processes/_stats_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats_object.md.erb
@@ -13,7 +13,7 @@ Name | Type | Description
 ---- | ---- | -----------
 **type** | _string_ | Process type; a unique identifier for processes belonging to an app
 **index** | _integer_ | The zero-based index of running instances
-**state** | _string_ | The state of the instance; valid values are `RUNNING`, `CRASHED`, `STARTING`, `DOWN`
+**state** | _string_ | The state of the instance; valid values are `RUNNING`, `CRASHED`, `STARTING`, `STOPPING`, `DOWN`
 **routable** | _boolean_ | Whether or not the instance is routable (determined by the readiness check of the app). If app readiness checks and routability are unsupported by Diego, this will return as `null`.
 **usage** | _object_ | Object containing actual usage data for the instance; the value is `{}` when usage data is unavailable
 **usage.time** | _[timestamp](#timestamps)_ | The time when the usage was requested

--- a/lib/cloud_controller/diego/constants.rb
+++ b/lib/cloud_controller/diego/constants.rb
@@ -34,6 +34,7 @@ module VCAP::CloudController
 
     LRP_STARTING = 'STARTING'.freeze
     LRP_RUNNING  = 'RUNNING'.freeze
+    LRP_STOPPING = 'STOPPING'.freeze
     LRP_CRASHED  = 'CRASHED'.freeze
     LRP_DOWN     = 'DOWN'.freeze
     LRP_UNKNOWN  = 'UNKNOWN'.freeze


### PR DESCRIPTION
This change solves issue #3780.
After stopping an app, cloud controller immediately returns state `DOWN` when calling `GET /v3/apps/:guid/processes/:type/stats` even if the app is still in graceful shutdown period. The goal is to not simply to report `DOWN` for an app instance when the desired LRP is not found but it should request the actual LRP additionally to determine the instance state.

* A short explanation of the proposed change:
If no running instance is found, instead of just returning state `DOWN`, now there is a check for the actual LRP state and if there is an actual LRP, state will be set to `STOPPING`.

* An explanation of the use cases your change solves
After stopping an app, cloud controller will return state `STOPPING` when calling `GET /v3/apps/:guid/processes/:type/stats` as long as the app is still in graceful shutdown period and there exists still an actual LRP.


* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
