### PR TITLE
Remove cop `Rails/CreateTableWithTimestamps`

### DIFF
--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -76,12 +76,6 @@ Sequel/ColumnDefault: # Exclude for old Migrations
     - !ruby/regexp /db/migrations/202([0-2]).+\.rb$/
     - spec/**/*
 
-Rails/CreateTableWithTimestamps: # Exclude for old Migrations
-  Exclude:
-    - !ruby/regexp /db/migrations/201([0-9]).+\.rb$/
-    - !ruby/regexp /db/migrations/202([0-2]|30[0-7]).+\.rb$/
-    - spec/**/*
-
 Rails/HttpPositionalArguments: # Breaks Code for specs as it`s not rails used there it`s a test framework(racktest)
   Exclude:
     - spec/**/*
@@ -556,4 +550,6 @@ Rails/DynamicFindBy: # Breaks Code
 Rails/FindEach: # Breaks Code
   Enabled: false
 Rails/RedundantActiveRecordAllMethod: # As we use Sequel this breaks code as it matches Sequel functions
+  Enabled: false
+Rails/CreateTableWithTimestamps: # Only works with ActiveRecord but we're using Sequel
   Enabled: false


### PR DESCRIPTION
Cop `Rails/CreateTableWithTimestamps` does not work for Sequel


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
