### PR TITLE
Fix cc.requests.outstanding.gauge when using puma web server

### DIFF
--- a/lib/cloud_controller/metrics/request_metrics.rb
+++ b/lib/cloud_controller/metrics/request_metrics.rb
@@ -3,33 +3,21 @@ require 'statsd'
 module VCAP::CloudController
   module Metrics
     class RequestMetrics
-      def initialize(statsd=CloudController::DependencyLocator.instance.statsd_client, prometheus_updater=CloudController::DependencyLocator.instance.prometheus_updater)
-        @counter = 0
-        @statsd = statsd
+      def initialize(statsd_updater=CloudController::DependencyLocator.instance.statsd_updater, prometheus_updater=CloudController::DependencyLocator.instance.prometheus_updater)
+        @statsd_updater = statsd_updater
         @prometheus_updater = prometheus_updater
       end
 
       def start_request
-        @counter += 1
-        @statsd.gauge('cc.requests.outstanding.gauge', @counter)
-        @statsd.increment 'cc.requests.outstanding'
-
+        @statsd_updater.start_request
         @prometheus_updater.increment_gauge_metric(:cc_requests_outstanding_total)
       end
 
       def complete_request(status)
-        http_status_code = "#{status.to_s[0]}XX"
-        http_status_metric = "cc.http_status.#{http_status_code}"
-        @counter -= 1
-        @statsd.gauge('cc.requests.outstanding.gauge', @counter)
-        @statsd.batch do |batch|
-          batch.decrement 'cc.requests.outstanding'
-          batch.increment 'cc.requests.completed'
-          batch.increment http_status_metric
-        end
+        @statsd_updater.complete_request(status)
 
-        @prometheus_updater.decrement_gauge_metric(:cc_requests_outstanding_total)
         @prometheus_updater.increment_counter_metric(:cc_requests_completed_total)
+        @prometheus_updater.decrement_gauge_metric(:cc_requests_outstanding_total)
       end
     end
   end

--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
 
       request_logs = VCAP::CloudController::Logs::RequestLogs.new(Steno.logger('cc.api'))
 
-      request_metrics = VCAP::CloudController::Metrics::RequestMetrics.new(CloudController::DependencyLocator.instance.statsd_client,
+      request_metrics = VCAP::CloudController::Metrics::RequestMetrics.new(CloudController::DependencyLocator.instance.statsd_updater,
                                                                            CloudController::DependencyLocator.instance.prometheus_updater)
       builder = RackAppBuilder.new
       app     = builder.build(@config, request_metrics, request_logs)


### PR DESCRIPTION
https://github.com/cloudfoundry/cloud_controller_ng/issues/1312 introduced `cc.requests.outstanding.gauge` which holds the counter in memory. With the introduction of puma there may be multiple processes, so each would emit its own value for this metric. This would cause the gauge to flop between values. This metric is listed as an important kpi for capi scaling https://docs.cloudfoundry.org/running/managing-cf/scaling-cloud-controller.html#cloud_controller_ng. 

This fix for puma will instead uses Redis for the gauge.

* Refactor requests_metric to use statsd_updater
* Statsd_updater now contains statsd requests logic
* Add Redis/Inmemory store to statsd_updager
* Add a missing mutex to counter for thread safety for the in memory implementation.
* Chose to prefix the entry in redis with `metrics:` but open to feedback here.

Inspired by https://github.com/cloudfoundry/cloud_controller_ng/commit/4539e596ab6ae64556b170e4387633e9ebd55292

An alternative considered, was to read the prometheus metric and re-emit that to StatsD, however we observed performance degradation. Presumably because of the number of reads from disk for the [DirectFileStorage](https://github.com/prometheus/client_ruby?tab=readme-ov-file#directfilestore-caveats-and-things-to-keep-in-mind) to aggregate the metric across processes and so Redis seemed the best approach.

cc @sethboyles / @pivotalgeorge

---

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
