### PR TITLE
fix: CPU Entitlement is zero when stats are missing

### DIFF
--- a/docs/v3/source/includes/api_resources/_processes.erb
+++ b/docs/v3/source/includes/api_resources/_processes.erb
@@ -237,7 +237,7 @@
       "state": "STARTING",
       "usage": {
         "cpu": 0,
-        "cpu_entitlement": null,
+        "cpu_entitlement": 0,
         "disk": 0,
         "log_rate": 0,
         "mem": 0,

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -88,7 +88,7 @@ module VCAP::CloudController
         {
           time: formatted_current_time,
           cpu: 0,
-          cpu_entitlement: nil,
+          cpu_entitlement: 0,
           mem: 0,
           disk: 0,
           log_rate: 0

--- a/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
@@ -241,12 +241,12 @@ module VCAP::CloudController
             [container_metric_batch]
           end
 
-          it 'sets all the stats to their nullish value' do
+          it 'sets all the stats to zero' do
             result, = instances_reporter.stats_for_app(process)
             expect(result[0][:stats][:usage]).to eq({
                                                       time: formatted_current_time,
                                                       cpu: 0,
-                                                      cpu_entitlement: nil,
+                                                      cpu_entitlement: 0,
                                                       mem: 0,
                                                       disk: 0,
                                                       log_rate: 0
@@ -378,7 +378,7 @@ module VCAP::CloudController
               expect(result[0][:stats][:usage]).to eq({
                                                         time: formatted_current_time,
                                                         cpu: 0,
-                                                        cpu_entitlement: nil,
+                                                        cpu_entitlement: 0,
                                                         mem: 0,
                                                         disk: 0,
                                                         log_rate: 0


### PR DESCRIPTION
- In #3641 we exposed CPU Entitlement in process stats and returned null when stats are not yet available in Log Cache.
- Change missing process stats to instead have CPU Entitlement of zero for consistency with other existing metrics. Recent versions of the cf CLI will show zero rather than an empty column for CPU Entitlement.
- CPU Entitlement may still be null when the metric is not available on the deployment.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
