### PR TITLE
add 'current_droplet' to app's relationships

### DIFF
--- a/app/presenters/v3/app_presenter.rb
+++ b/app/presenters/v3/app_presenter.rb
@@ -31,6 +31,11 @@ module VCAP::CloudController
                 data: {
                   guid: app.space_guid
                 }
+              },
+              current_droplet: {
+                data: {
+                  guid: app.droplet_guid
+                }
               }
             },
             metadata: {

--- a/docs/v3/source/includes/api_resources/_apps.erb
+++ b/docs/v3/source/includes/api_resources/_apps.erb
@@ -33,6 +33,11 @@
             "data": {
               "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
             }
+          },
+          "current_droplet": {
+            "data": {
+              "guid": "585bc3c1-3743-497d-88b0-403ad6b56d16"
+            }
           }
         },
         "links": {
@@ -100,6 +105,11 @@
           "space": {
             "data": {
               "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+            }
+          },
+          "droplet": {
+            "data": {
+              "guid": "585bc3c1-3743-497d-88b0-403ad6b56d16"
             }
           }
         },
@@ -174,6 +184,11 @@
       "data": {
         "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
       }
+    },
+    "current_droplet": {
+      "data": {
+        "guid": "585bc3c1-3743-497d-88b0-403ad6b56d16"
+      }
     }
   },
   "links": {
@@ -244,6 +259,11 @@
     "space": {
       "data": {
         "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+      }
+    },
+    "current_droplet": {
+      "data": {
+        "guid": "585bc3c1-3743-497d-88b0-403ad6b56d16"
       }
     }
   },

--- a/docs/v3/source/includes/resources/apps/_object.md.erb
+++ b/docs/v3/source/includes/resources/apps/_object.md.erb
@@ -16,7 +16,7 @@ Name | Type | Description
 **state** | _string_ | Current desired state of the app; valid values are `STOPPED` or `STARTED`
 **lifecycle** | [_lifecycle object_](#the-lifecycle-object) | Provides the default lifecycle object for the application. This lifecycle will be used when staging and running the application. The staging lifecycle can be overridden on [builds](#builds)
 **relationships.space** | [_to-one relationship_](#to-one-relationships) | The space the app is contained in
-**relationships.droplet** | [_to-one relationship_](#to-one-relationships) | The current droplet use by the application
+**relationships.droplet** | [_to-one relationship_](#to-one-relationships) | The current droplet used by the application
 **metadata.labels** | [_label object_](#labels) | Labels applied to the app
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations added to the app
 **links** | [_links object_](#links) | Links to related resources

--- a/docs/v3/source/includes/resources/apps/_object.md.erb
+++ b/docs/v3/source/includes/resources/apps/_object.md.erb
@@ -16,7 +16,7 @@ Name | Type | Description
 **state** | _string_ | Current desired state of the app; valid values are `STOPPED` or `STARTED`
 **lifecycle** | [_lifecycle object_](#the-lifecycle-object) | Provides the default lifecycle object for the application. This lifecycle will be used when staging and running the application. The staging lifecycle can be overridden on [builds](#builds)
 **relationships.space** | [_to-one relationship_](#to-one-relationships) | The space the app is contained in
-**relationships.droplet** | [_to-one relationship_](#to-one-relationships) | The current droplet used by the application
+**relationships.current_droplet** | [_to-one relationship_](#to-one-relationships) | The current droplet used by the application
 **metadata.labels** | [_label object_](#labels) | Labels applied to the app
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations added to the app
 **links** | [_links object_](#links) | Links to related resources

--- a/docs/v3/source/includes/resources/apps/_object.md.erb
+++ b/docs/v3/source/includes/resources/apps/_object.md.erb
@@ -16,6 +16,7 @@ Name | Type | Description
 **state** | _string_ | Current desired state of the app; valid values are `STOPPED` or `STARTED`
 **lifecycle** | [_lifecycle object_](#the-lifecycle-object) | Provides the default lifecycle object for the application. This lifecycle will be used when staging and running the application. The staging lifecycle can be overridden on [builds](#builds)
 **relationships.space** | [_to-one relationship_](#to-one-relationships) | The space the app is contained in
+**relationships.droplet** | [_to-one relationship_](#to-one-relationships) | The current droplet use by the application
 **metadata.labels** | [_label object_](#labels) | Labels applied to the app
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations added to the app
 **links** | [_links object_](#links) | Links to related resources

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Apps' do
   let(:stack) { VCAP::CloudController::Stack.make }
   let(:user_email) { Sham.email }
   let(:user_name) { 'some-username' }
+  let(:droplet_guid_regex) { /^[a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8}$/ }
 
   describe 'POST /v3/apps' do
     let(:buildpack) { VCAP::CloudController::Buildpack.make(stack: stack.name) }
@@ -59,7 +60,8 @@ RSpec.describe 'Apps' do
             data: { buildpacks: [buildpack.name], stack: stack.name }
           },
           relationships: {
-            space: { data: { guid: space.guid } }
+            space: { data: { guid: space.guid } },
+            current_droplet: { data: { guid: nil } }
           },
           metadata: {
             labels: {
@@ -156,6 +158,11 @@ RSpec.describe 'Apps' do
               'space' => {
                 'data' => {
                   'guid' => space.guid
+                }
+              },
+              'current_droplet' => {
+                'data' => {
+                  'guid' => nil
                 }
               }
             },
@@ -278,6 +285,11 @@ RSpec.describe 'Apps' do
                 'data' => {
                   'guid' => space.guid
                 }
+              },
+              'current_droplet' => {
+                'data' => {
+                  'guid' => nil
+                }
               }
             },
             'created_at' => iso8601,
@@ -374,7 +386,8 @@ RSpec.describe 'Apps' do
             data: { buildpacks: [], stack: app_model1.lifecycle_data.stack }
           },
           relationships: {
-            space: { data: { guid: space.guid } }
+            space: { data: { guid: space.guid } },
+            current_droplet: { data: { guid: nil } }
           },
           metadata: {
             labels: {},
@@ -410,7 +423,8 @@ RSpec.describe 'Apps' do
             data: { buildpacks: [], stack: app_model2.lifecycle_data.stack }
           },
           relationships: {
-            space: { data: { guid: space2.guid } }
+            space: { data: { guid: space2.guid } },
+            current_droplet: { data: { guid: nil } }
           },
           metadata: {
             labels: {},
@@ -565,6 +579,11 @@ RSpec.describe 'Apps' do
                     'data' => {
                       'guid' => space.guid
                     }
+                  },
+                  'current_droplet' => {
+                    'data' => {
+                      'guid' => nil
+                    }
                   }
                 },
                 'created_at' => iso8601,
@@ -598,6 +617,11 @@ RSpec.describe 'Apps' do
                   'space' => {
                     'data' => {
                       'guid' => space.guid
+                    }
+                  },
+                  'current_droplet' => {
+                    'data' => {
+                      'guid' => nil
                     }
                   }
                 },
@@ -1284,6 +1308,7 @@ RSpec.describe 'Apps' do
       app_model.lifecycle_data.buildpacks = [buildpack.name]
       app_model.lifecycle_data.stack = stack.name
       app_model.lifecycle_data.save
+      app_model.droplet_guid = 'a-droplet-guid'
       app_model.add_process(VCAP::CloudController::ProcessModel.make(instances: 1))
       app_model.add_process(VCAP::CloudController::ProcessModel.make(instances: 2))
     end
@@ -1303,7 +1328,8 @@ RSpec.describe 'Apps' do
             data: { buildpacks: [buildpack.name], stack: app_model.lifecycle_data.stack }
           },
           relationships: {
-            space: { data: { guid: space.guid } }
+            space: { data: { guid: space.guid } },
+            current_droplet: { data: { guid: app_model.droplet_guid } }
           },
           metadata: {
             labels: {},
@@ -1368,6 +1394,11 @@ RSpec.describe 'Apps' do
                 'data' => {
                   'guid' => space.guid
                 }
+              },
+              'current_droplet' => {
+                'data' => {
+                  'guid' => app_model.droplet_guid
+                }
               }
             },
             'links' => {
@@ -1413,6 +1444,11 @@ RSpec.describe 'Apps' do
               'space' => {
                 'data' => {
                   'guid' => space.guid
+                }
+              },
+              'current_droplet' => {
+                'data' => {
+                  'guid' => app_model.droplet_guid
                 }
               }
             },
@@ -2059,6 +2095,11 @@ RSpec.describe 'Apps' do
             'data' => {
               'guid' => space.guid
             }
+          },
+          'current_droplet' => {
+            'data' => {
+              'guid' => nil
+            }
           }
         },
         'created_at' => iso8601,
@@ -2243,6 +2284,7 @@ RSpec.describe 'Apps' do
         desired_state: 'STOPPED'
       )
     end
+    let(:droplet_guid_regex) { /^[a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8}$/ }
 
     context 'app lifecycle is buildpack' do
       let!(:droplet) do
@@ -2282,6 +2324,11 @@ RSpec.describe 'Apps' do
               'space' => {
                 'data' => {
                   'guid' => space.guid
+                }
+              },
+              'current_droplet' => {
+                'data' => {
+                  'guid' => app_model.droplet.guid
                 }
               }
             },
@@ -2617,6 +2664,11 @@ RSpec.describe 'Apps' do
               'data' => {
                 'guid' => space.guid
               }
+            },
+            'current_droplet' => {
+              'data' => {
+                'guid' => droplet_guid_regex
+              }
             }
           },
           'links' => {
@@ -2779,6 +2831,11 @@ RSpec.describe 'Apps' do
               'space' => {
                 'data' => {
                   'guid' => space.guid
+                }
+              },
+              'current_droplet' => {
+                'data' => {
+                  'guid' => droplet.guid
                 }
               }
             },

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe 'Apps' do
   let(:stack) { VCAP::CloudController::Stack.make }
   let(:user_email) { Sham.email }
   let(:user_name) { 'some-username' }
-  let(:droplet_guid_regex) { /^[a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8}$/ }
 
   describe 'POST /v3/apps' do
     let(:buildpack) { VCAP::CloudController::Buildpack.make(stack: stack.name) }
@@ -1308,7 +1307,6 @@ RSpec.describe 'Apps' do
       app_model.lifecycle_data.buildpacks = [buildpack.name]
       app_model.lifecycle_data.stack = stack.name
       app_model.lifecycle_data.save
-      app_model.droplet_guid = 'a-droplet-guid'
       app_model.add_process(VCAP::CloudController::ProcessModel.make(instances: 1))
       app_model.add_process(VCAP::CloudController::ProcessModel.make(instances: 2))
     end
@@ -2284,7 +2282,6 @@ RSpec.describe 'Apps' do
         desired_state: 'STOPPED'
       )
     end
-    let(:droplet_guid_regex) { /^[a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8}$/ }
 
     context 'app lifecycle is buildpack' do
       let!(:droplet) do
@@ -2328,7 +2325,7 @@ RSpec.describe 'Apps' do
               },
               'current_droplet' => {
                 'data' => {
-                  'guid' => app_model.droplet.guid
+                  'guid' => droplet.guid
                 }
               }
             },
@@ -2667,7 +2664,7 @@ RSpec.describe 'Apps' do
             },
             'current_droplet' => {
               'data' => {
-                'guid' => droplet_guid_regex
+                'guid' => droplet.guid
               }
             }
           },

--- a/spec/request/stacks_spec.rb
+++ b/spec/request/stacks_spec.rb
@@ -399,6 +399,11 @@ RSpec.describe 'Stacks Request' do
                     'data' => {
                       'guid' => space.guid
                     }
+                  },
+                  'current_droplet' => {
+                    'data' => {
+                      'guid' => nil
+                    }
                   }
                 },
                 'created_at' => iso8601,
@@ -462,6 +467,11 @@ RSpec.describe 'Stacks Request' do
                     'data' => {
                       'guid' => space.guid
                     }
+                  },
+                  'current_droplet' => {
+                    'data' => {
+                      'guid' => nil
+                    }
                   }
                 },
                 'created_at' => iso8601,
@@ -498,6 +508,11 @@ RSpec.describe 'Stacks Request' do
                   'space' => {
                     'data' => {
                       'guid' => space2.guid
+                    }
+                  },
+                  'current_droplet' => {
+                    'data' => {
+                      'guid' => nil
                     }
                   }
                 },

--- a/spec/unit/presenters/v3/app_presenter_spec.rb
+++ b/spec/unit/presenters/v3/app_presenter_spec.rb
@@ -52,6 +52,7 @@ module VCAP::CloudController::Presenters::V3
         expect(result[:lifecycle][:data][:stack]).to eq('the-happiest-stack')
         expect(result[:lifecycle][:data][:buildpacks]).to eq(['git://***:***@github.com/repo', 'limabean'])
         expect(result[:relationships][:space][:data][:guid]).to eq(app.space.guid)
+        expect(result[:relationships][:current_droplet][:data][:guid]).to be_nil or eq(app.droplet.guid)
         expect(result[:metadata][:labels]).to eq({})
         expect(result[:metadata][:annotations]).to eq({})
       end

--- a/spec/unit/presenters/v3/app_presenter_spec.rb
+++ b/spec/unit/presenters/v3/app_presenter_spec.rb
@@ -7,7 +7,8 @@ module VCAP::CloudController::Presenters::V3
       VCAP::CloudController::AppModel.make(
         name: 'Davis',
         environment_variables: { 'some' => 'stuff' },
-        desired_state: 'STOPPED'
+        desired_state: 'STOPPED',
+        droplet: VCAP::CloudController::DropletModel.make
       )
     end
 
@@ -52,7 +53,7 @@ module VCAP::CloudController::Presenters::V3
         expect(result[:lifecycle][:data][:stack]).to eq('the-happiest-stack')
         expect(result[:lifecycle][:data][:buildpacks]).to eq(['git://***:***@github.com/repo', 'limabean'])
         expect(result[:relationships][:space][:data][:guid]).to eq(app.space.guid)
-        expect(result[:relationships][:current_droplet][:data][:guid]).to be_nil or eq(app.droplet.guid)
+        expect(result[:relationships][:current_droplet][:data][:guid]).to eq(app.droplet.guid)
         expect(result[:metadata][:labels]).to eq({})
         expect(result[:metadata][:annotations]).to eq({})
       end


### PR DESCRIPTION
The only way to retrieve the current droplet of an application via the API is to go through the `/v3/apps/:app_guid/droplets/current` or `/v3/apps/:app_guid/relationships/current_droplet` endpoints.

In a context where we want to retrieve all the applications (more than 3000 in my case) and their current droplet, it is therefore necessary to make one request per application (more than 3000 requests).

This PR aims to make the current_droplet relationship visible on all endpoints presenting the app object : 
- `/v3/apps`
- `/v3/apps/:app_guid`
- `/v3/stacks/:stack_id/apps`
- ...

See issue #3860 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
