### PR TITLE
Filter cnb credentials from log output

### DIFF
--- a/app/messages/app_manifest_message.rb
+++ b/app/messages/app_manifest_message.rb
@@ -118,8 +118,9 @@ module VCAP::CloudController
     end
 
     def audit_hash
-      overrides = original_yaml['env'] ? { 'env' => Presenters::Censorship::PRIVATE_DATA_HIDDEN } : {}
-      original_yaml.merge(overrides)
+      overrideEnv = original_yaml['env'] ? { 'env' => Presenters::Censorship::PRIVATE_DATA_HIDDEN } : {}
+      overrideCNB = original_yaml['cnb-credentials'] ? { 'cnb-credentials' => Presenters::Censorship::PRIVATE_DATA_HIDDEN } : {}
+      original_yaml.merge(overrideEnv).merge(overrideCNB)
     end
 
     def app_lifecycle_hash

--- a/app/messages/app_manifest_message.rb
+++ b/app/messages/app_manifest_message.rb
@@ -118,9 +118,9 @@ module VCAP::CloudController
     end
 
     def audit_hash
-      overrideEnv = original_yaml['env'] ? { 'env' => Presenters::Censorship::PRIVATE_DATA_HIDDEN } : {}
-      overrideCNB = original_yaml['cnb-credentials'] ? { 'cnb-credentials' => Presenters::Censorship::PRIVATE_DATA_HIDDEN } : {}
-      original_yaml.merge(overrideEnv).merge(overrideCNB)
+      override_env = original_yaml['env'] ? { 'env' => Presenters::Censorship::PRIVATE_DATA_HIDDEN } : {}
+      override_cnb = original_yaml['cnb-credentials'] ? { 'cnb-credentials' => Presenters::Censorship::PRIVATE_DATA_HIDDEN } : {}
+      original_yaml.merge(override_env).merge(override_cnb)
     end
 
     def app_lifecycle_hash

--- a/spec/unit/messages/app_manifest_message_spec.rb
+++ b/spec/unit/messages/app_manifest_message_spec.rb
@@ -1323,6 +1323,12 @@ module VCAP::CloudController
             { 'route' => 'existing.example.com' },
             { 'route' => 'another.example.com' }
           ],
+          'cnb-credentials' => {
+            'example.org' => {
+              'username' => 'foo',
+              'password' => 'bar'
+            }
+          },
           'processes' => [{
             'type' => 'type',
             'command' => 'command',
@@ -1349,6 +1355,7 @@ module VCAP::CloudController
             { 'route' => 'existing.example.com' },
             { 'route' => 'another.example.com' }
           ],
+          'cnb-credentials' => '[PRIVATE DATA HIDDEN]',
           'processes' => [{
             'type' => 'type',
             'command' => 'command',


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

After introducing the ability to pull protected Cloud Native Buildpacks in https://github.com/cloudfoundry/cloud_controller_ng/pull/3855, this PR redacts the actual credentials in the logs.

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
