### PR TITLE
Introduce `max_run_time` handling in `WrappingJob` and `DelayedWorker`

### DIFF
--- a/app/jobs/wrapping_job.rb
+++ b/app/jobs/wrapping_job.rb
@@ -39,6 +39,10 @@ module VCAP::CloudController
         handler.respond_to?(:max_attempts) ? handler.max_attempts : 1
       end
 
+      def max_run_time
+        handler.max_run_time if handler.respond_to?(:max_run_time)
+      end
+
       def reschedule_at(time, attempts)
         handler.reschedule_at(time, attempts) if handler.respond_to?(:reschedule_at)
       end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -74,6 +74,7 @@ namespace :jobs do
       setup_app_log_emitter(config, logger)
       Delayed::Worker.destroy_failed_jobs = false
       Delayed::Worker.max_attempts = 3
+      Delayed::Worker.max_run_time = config.get(:jobs, :global, :timeout_in_seconds) + 1
       Delayed::Worker.logger = logger
       worker = Delayed::Worker.new(@queue_options)
       worker.name = @queue_options[:worker_name]

--- a/spec/unit/jobs/wrapping_job_spec.rb
+++ b/spec/unit/jobs/wrapping_job_spec.rb
@@ -103,6 +103,25 @@ module VCAP::CloudController
         end
       end
 
+      describe '#max_run_time' do
+        let(:handler_with_method) { double('Job', max_run_time: 12) }
+        let(:handler_without_method) { Object.new }
+
+        context 'when the handler implements max_run_time' do
+          it 'returns the max_run_time from the handler' do
+            job = WrappingJob.new(handler_with_method)
+            expect(job.max_run_time).to eq(12)
+          end
+        end
+
+        context 'when the handler does not implement max_run_time' do
+          it 'returns nil' do
+            job = WrappingJob.new(handler_without_method)
+            expect(job.max_run_time).to be_nil
+          end
+        end
+      end
+
       describe '#display_name' do
         subject(:wrapping_job) { WrappingJob.new(handler) }
 


### PR DESCRIPTION
This commit adds support for specifying the delayed_job max_run_time parameter, addressing the previous lack of explicit control which resulted in jobs defaulting to a 4h timeout. In `WrappingJob`, `max_run_time` is now delegated to the handler if available, ensuring delayed_job does not use the 4h default. For `DelayedWorker`, a global `max_run_time` setting is derived from application configuration, correcting the unintended 4h default timeout. Unit tests confirm the correct application of `max_run_time`.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
