### PR TITLE
Add last_status_change to deployments object

### DIFF
--- a/app/models/runtime/deployment_model.rb
+++ b/app/models/runtime/deployment_model.rb
@@ -67,6 +67,11 @@ module VCAP::CloudController
       end
     end
 
+    def before_update
+      super
+      set_status_updated_at
+    end
+
     def deploying?
       state == DEPLOYING_STATE
     end
@@ -75,6 +80,14 @@ module VCAP::CloudController
       valid_states_for_cancel = [DeploymentModel::DEPLOYING_STATE,
                                  DeploymentModel::CANCELING_STATE]
       valid_states_for_cancel.include?(state)
+    end
+
+    private
+
+    def set_status_updated_at
+      return unless column_changed?(:status_reason) || column_changed?(:status_value)
+
+      self.status_updated_at = updated_at
     end
   end
 end

--- a/app/presenters/v3/deployment_presenter.rb
+++ b/app/presenters/v3/deployment_presenter.rb
@@ -14,7 +14,8 @@ module VCAP::CloudController::Presenters::V3
           value: deployment.status_value,
           reason: deployment.status_reason,
           details: {
-            last_successful_healthcheck: deployment.last_healthy_at
+            last_successful_healthcheck: deployment.last_healthy_at,
+            last_status_change: deployment.status_updated_at
           }
         },
         strategy: deployment.strategy,

--- a/db/migrations/20240709234116_add_status_updated_at_to_deployments.rb
+++ b/db/migrations/20240709234116_add_status_updated_at_to_deployments.rb
@@ -1,0 +1,14 @@
+Sequel.migration do
+  up do
+    alter_table(:deployments) do
+      add_column :status_updated_at, DateTime, default: Sequel::CURRENT_TIMESTAMP, null: false
+    end
+    run 'update deployments set status_updated_at = updated_at where updated_at is not null'
+  end
+
+  down do
+    alter_table(:deployments) do
+      drop_column :status_updated_at
+    end
+  end
+end

--- a/docs/v3/source/includes/resources/deployments/_object.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_object.md.erb
@@ -14,7 +14,8 @@ Name | Type | Description
 **updated_at** | _[timestamp](#timestamps)_ | The time with zone when the object was last updated
 **status.value** | _string_ | The current status of the deployment; valid values are `ACTIVE` (meaning in progress) and `FINALIZED` (meaning finished, either successfully or not)
 **status.reason** | _string_ | The reason for the status of the deployment;<br>following list represents valid values:<br>1. If **status.value** is `ACTIVE`<br>- `DEPLOYING`<br>- `CANCELING`<br>2. If **status.value** is `FINALIZED`<br>- `DEPLOYED`<br>- `CANCELED`<br>- `SUPERSEDED` (another deployment created for app before completion)<br>
-**status.details** | _object_ | The details for the status of the deployment shows a timestamp of the last successful healthcheck
+**status.details.last_successful_healthcheck** | _[timestamp](#timestamps)_ | Timestamp of the last successful healthcheck
+**status.details.last_status_change** | _[timestamp](#timestamps)_ | Timestamp of last change to status.value or status.reason
 **strategy** | _string_ | Strategy used for the deployment; supported strategies are `rolling` only
 **droplet.guid** | _string_ | The droplet guid that the deployment is transitioning the app to
 **previous_droplet.guid** | _string_ | The app's [current droplet guid](#get-current-droplet-association-for-an-app) before the deployment was created

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe 'Deployments' do
             'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
             'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
             'details' => {
-              'last_successful_healthcheck' => iso8601
+              'last_successful_healthcheck' => iso8601,
+              'last_status_change' => iso8601
             }
           },
           'strategy' => 'rolling',
@@ -136,7 +137,8 @@ RSpec.describe 'Deployments' do
                                                           'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                                                           'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
                                                           'details' => {
-                                                            'last_successful_healthcheck' => iso8601
+                                                            'last_successful_healthcheck' => iso8601,
+                                                            'last_status_change' => iso8601
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
@@ -218,7 +220,8 @@ RSpec.describe 'Deployments' do
                                                           'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                                                           'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
                                                           'details' => {
-                                                            'last_successful_healthcheck' => iso8601
+                                                            'last_successful_healthcheck' => iso8601,
+                                                            'last_status_change' => iso8601
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
@@ -336,7 +339,8 @@ RSpec.describe 'Deployments' do
                                                           'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                                                           'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
                                                           'details' => {
-                                                            'last_successful_healthcheck' => iso8601
+                                                            'last_successful_healthcheck' => iso8601,
+                                                            'last_status_change' => iso8601
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
@@ -414,7 +418,8 @@ RSpec.describe 'Deployments' do
                                                           'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                                                           'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
                                                           'details' => {
-                                                            'last_successful_healthcheck' => iso8601
+                                                            'last_successful_healthcheck' => iso8601,
+                                                            'last_status_change' => iso8601
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
@@ -494,7 +499,8 @@ RSpec.describe 'Deployments' do
                                                           'value' => VCAP::CloudController::DeploymentModel::FINALIZED_STATUS_VALUE,
                                                           'reason' => VCAP::CloudController::DeploymentModel::DEPLOYED_STATUS_REASON,
                                                           'details' => {
-                                                            'last_successful_healthcheck' => iso8601
+                                                            'last_successful_healthcheck' => iso8601,
+                                                            'last_status_change' => iso8601
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
@@ -661,7 +667,8 @@ RSpec.describe 'Deployments' do
                                                             'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                                                             'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
                                                             'details' => {
-                                                              'last_successful_healthcheck' => iso8601
+                                                              'last_successful_healthcheck' => iso8601,
+                                                              'last_status_change' => iso8601
                                                             }
                                                           },
                                                           'strategy' => 'rolling',
@@ -721,7 +728,8 @@ RSpec.describe 'Deployments' do
                                                             'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                                                             'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
                                                             'details' => {
-                                                              'last_successful_healthcheck' => iso8601
+                                                              'last_successful_healthcheck' => iso8601,
+                                                              'last_status_change' => iso8601
                                                             }
                                                           },
                                                           'strategy' => 'rolling',
@@ -839,7 +847,8 @@ RSpec.describe 'Deployments' do
                                                         'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                                                         'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
                                                         'details' => {
-                                                          'last_successful_healthcheck' => iso8601
+                                                          'last_successful_healthcheck' => iso8601,
+                                                          'last_status_change' => iso8601
                                                         }
                                                       },
                                                       'strategy' => 'rolling',
@@ -929,7 +938,8 @@ RSpec.describe 'Deployments' do
           'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
           'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
           'details' => {
-            'last_successful_healthcheck' => iso8601
+            'last_successful_healthcheck' => iso8601,
+            'last_status_change' => iso8601
           }
         },
         'droplet' => {
@@ -1051,7 +1061,8 @@ RSpec.describe 'Deployments' do
             value: status_value,
             reason: status_reason,
             details: {
-              last_successful_healthcheck: iso8601
+              last_successful_healthcheck: iso8601,
+              last_status_change: iso8601
             }
           },
           strategy: 'rolling',
@@ -1345,7 +1356,8 @@ RSpec.describe 'Deployments' do
                                                               'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                                                               'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
                                                               'details' => {
-                                                                'last_successful_healthcheck' => iso8601
+                                                                'last_successful_healthcheck' => iso8601,
+                                                                'last_status_change' => iso8601
                                                               }
                                                             },
                                                             'strategy' => 'rolling',

--- a/spec/unit/presenters/v3/deployment_presenter_spec.rb
+++ b/spec/unit/presenters/v3/deployment_presenter_spec.rb
@@ -15,6 +15,7 @@ module VCAP::CloudController::Presenters::V3
         previous_droplet: previous_droplet,
         deploying_web_process: process,
         last_healthy_at: '2019-07-12 19:01:54',
+        status_updated_at: '2019-07-11 19:01:54',
         state: deployment_state,
         status_value: VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
         status_reason: VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON
@@ -29,6 +30,7 @@ module VCAP::CloudController::Presenters::V3
         expect(result[:status][:value]).to eq(VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE)
         expect(result[:status][:reason]).to eq(VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON)
         expect(result[:status][:details][:last_successful_healthcheck]).to eq('2019-07-12 19:01:54')
+        expect(result[:status][:details][:last_status_change]).to eq('2019-07-11 19:01:54')
 
         expect(result[:strategy]).to eq('rolling')
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Add a timestamp for the last time that a status changed on a deployment

* An explanation of the use cases your change solves

This will help developers identify how long a Canary Deployment has been in the PAUSED state.

* Links to any other associated PRs
* #3837 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
