### PR TITLE
Add thread based delayed workers

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -346,7 +346,7 @@ module VCAP::CloudController
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
               optional(:priorities) => Hash,
-              optional(:threads) => Integer
+              optional(:thread_count) => Integer
             },
 
             # perm settings no longer have any effect but are preserved here

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -345,7 +345,8 @@ module VCAP::CloudController
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
-              optional(:priorities) => Hash
+              optional(:priorities) => Hash,
+              optional(:threads) => Integer
             },
 
             # perm settings no longer have any effect but are preserved here

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -346,7 +346,7 @@ module VCAP::CloudController
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
               optional(:priorities) => Hash,
-              optional(:thread_count) => Integer
+              optional(:number_of_worker_threads) => Integer
             },
 
             # perm settings no longer have any effect but are preserved here

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -172,7 +172,7 @@ module VCAP::CloudController
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
               optional(:priorities) => Hash,
-              optional(:thread_count) => Integer
+              optional(:number_of_worker_threads) => Integer
             },
 
             volume_services_enabled: bool,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -172,7 +172,7 @@ module VCAP::CloudController
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
               optional(:priorities) => Hash,
-              optional(:threads) => Integer
+              optional(:thread_count) => Integer
             },
 
             volume_services_enabled: bool,

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -171,7 +171,8 @@ module VCAP::CloudController
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
-              optional(:priorities) => Hash
+              optional(:priorities) => Hash,
+              optional(:threads) => Integer
             },
 
             volume_services_enabled: bool,

--- a/lib/delayed_job/delayed_worker.rb
+++ b/lib/delayed_job/delayed_worker.rb
@@ -23,8 +23,8 @@ class CloudController::DelayedWorker
     Delayed::Worker.max_attempts = 3
     Delayed::Worker.max_run_time = config.get(:jobs, :global, :timeout_in_seconds) + 1
     Delayed::Worker.logger = logger
-    thread_count = config.get(:jobs, :thread_count)
-    worker = thread_count.nil? ? Delayed::Worker.new(@queue_options) : ThreadedWorker.new(thread_count, @queue_options)
+    num_worker_threads = config.get(:jobs, :number_of_worker_threads)
+    worker = num_worker_threads.nil? ? Delayed::Worker.new(@queue_options) : ThreadedWorker.new(num_worker_threads, @queue_options)
     worker.name = @queue_options[:worker_name]
     worker.start
   end

--- a/lib/delayed_job/delayed_worker.rb
+++ b/lib/delayed_job/delayed_worker.rb
@@ -1,3 +1,5 @@
+require 'delayed_job/threaded_worker'
+
 class CloudController::DelayedWorker
   def initialize(options)
     @queue_options = {
@@ -21,7 +23,8 @@ class CloudController::DelayedWorker
     Delayed::Worker.max_attempts = 3
     Delayed::Worker.max_run_time = config.get(:jobs, :global, :timeout_in_seconds) + 1
     Delayed::Worker.logger = logger
-    worker = Delayed::Worker.new(@queue_options)
+    num_threads = config.get(:jobs, :threads)
+    worker = num_threads.nil? ? Delayed::Worker.new(@queue_options) : ThreadedWorker.new(num_threads, @queue_options)
     worker.name = @queue_options[:worker_name]
     worker.start
   end

--- a/lib/delayed_job/delayed_worker.rb
+++ b/lib/delayed_job/delayed_worker.rb
@@ -23,8 +23,8 @@ class CloudController::DelayedWorker
     Delayed::Worker.max_attempts = 3
     Delayed::Worker.max_run_time = config.get(:jobs, :global, :timeout_in_seconds) + 1
     Delayed::Worker.logger = logger
-    num_threads = config.get(:jobs, :threads)
-    worker = num_threads.nil? ? Delayed::Worker.new(@queue_options) : ThreadedWorker.new(num_threads, @queue_options)
+    thread_count = config.get(:jobs, :thread_count)
+    worker = thread_count.nil? ? Delayed::Worker.new(@queue_options) : ThreadedWorker.new(thread_count, @queue_options)
     worker.name = @queue_options[:worker_name]
     worker.start
   end

--- a/lib/delayed_job/threaded_worker.rb
+++ b/lib/delayed_job/threaded_worker.rb
@@ -1,9 +1,7 @@
 require 'socket'
 
 class ThreadedWorker < Delayed::Worker
-  DEFAULT_THREAD_COUNT = 4
-
-  def initialize(options={}, thread_count=DEFAULT_THREAD_COUNT)
+  def initialize(thread_count, options={})
     super(options)
     @thread_count = thread_count
     @threads = []

--- a/lib/delayed_job/threaded_worker.rb
+++ b/lib/delayed_job/threaded_worker.rb
@@ -14,7 +14,7 @@ class ThreadedWorker < Delayed::Worker
   def start
     trap_signals
 
-    say 'Starting multi-threaded job worker'
+    say "Starting multi-threaded job worker with #{@thread_count} threads"
 
     @thread_count.times do |i|
       thread_name = generate_thread_name(i + 1)

--- a/lib/delayed_job/threaded_worker.rb
+++ b/lib/delayed_job/threaded_worker.rb
@@ -1,7 +1,7 @@
 class ThreadedWorker < Delayed::Worker
-  def initialize(thread_count, options={}, grace_period_seconds=30)
+  def initialize(num_threads, options={}, grace_period_seconds=30)
     super(options)
-    @thread_count = thread_count
+    @num_threads = num_threads
     @threads = []
     @unexpected_error = false
     @mutex = Mutex.new
@@ -27,9 +27,9 @@ class ThreadedWorker < Delayed::Worker
       raise SignalException.new('INT') if self.class.raise_signal_exceptions && self.class.raise_signal_exceptions != :term
     end
 
-    say "Starting threaded delayed worker with #{@thread_count} threads"
+    say "Starting threaded delayed worker with #{@num_threads} threads"
 
-    @thread_count.times do |thread_index|
+    @num_threads.times do |thread_index|
       thread = Thread.new do
         Thread.current[:thread_name] = "thread:#{thread_index + 1}"
         threaded_start

--- a/lib/delayed_job/threaded_worker.rb
+++ b/lib/delayed_job/threaded_worker.rb
@@ -1,0 +1,106 @@
+require 'socket'
+
+class ThreadedWorker < Delayed::Worker
+  DEFAULT_THREAD_COUNT = 4
+
+  def initialize(options={}, thread_count=DEFAULT_THREAD_COUNT)
+    super(options)
+    @thread_count = thread_count
+    @threads = []
+    @stop_signal = false
+    @name_prefix = options[:worker_name] || 'worker'
+  end
+
+  def start
+    trap_signals
+
+    say 'Starting multi-threaded job worker'
+
+    @thread_count.times do |i|
+      thread_name = generate_thread_name(i + 1)
+      @threads << Thread.new do
+        thread_name(thread_name)
+        threaded_work_off
+      end
+    end
+
+    @threads.each(&:join) # Wait for threads to finish
+  end
+
+  def name
+    Thread.current[:name] || @name
+  end
+
+  def name=(name)
+    # Set the instance variable for compatibility && ensure thread-local storage is also updated
+    @name = name
+    Thread.current[:name] = name
+  end
+
+  private
+
+  def generate_thread_name(thread_index)
+    if @name
+      "#{@name}-thread:#{thread_index}"
+    else
+      "#{@name_prefix}-host:#{Socket.gethostname} pid:#{Process.pid} thread:#{thread_index}"
+    end
+  end
+
+  def thread_name(name)
+    # Store the name in thread-local storage && Set the name in the instance variable for compatibility
+    Thread.current[:name] = name
+    self.name = name
+  end
+
+  def stop_signal?
+    @stop_signal
+  end
+
+  def threaded_work_off
+    retry_attempts = 0
+
+    until stop_signal?
+      begin
+        runtime = Benchmark.realtime do
+          @result = work_off(100) # Attempt to process one job
+        end
+
+        count = @result[0] + @result[1]
+
+        if count.zero?
+          sleep(self.class.sleep_delay) unless stop_signal?
+        else
+          say sprintf("#{count} jobs processed at %.4f j/s, %d failed", count / runtime, @result.last)
+        end
+      rescue StandardError => e
+        say "Thread #{name} encountered an error: #{e.message}. Restarting thread..."
+        retry_attempts += 1
+        if retry_attempts >= 5
+          say "Thread #{name} has failed #{retry_attempts} times. Exiting to prevent infinite loop."
+          break
+        end
+        sleep(1) # Adding a delay before retrying
+        retry
+      end
+    end
+
+    say 'Stop signal received. Exiting.'
+  end
+
+  def trap_signals
+    trap('TERM') { initiate_shutdown }
+    trap('INT')  { initiate_shutdown }
+  end
+
+  def initiate_shutdown
+    return if @stop_signal
+
+    Thread.new { say 'Initiating shutdown...' }
+    @stop_signal = true
+
+    # Allow threads to finish current jobs
+    @threads.each { |t| t.join(30) } # Wait up to 30 seconds for each thread to finish (like monit)
+    Thread.new { say 'All threads have finished. Exiting.' }
+  end
+end

--- a/lib/delayed_job/threaded_worker.rb
+++ b/lib/delayed_job/threaded_worker.rb
@@ -34,10 +34,8 @@ class ThreadedWorker < Delayed::Worker
         Thread.current[:thread_name] = "thread:#{thread_index + 1}"
         threaded_start
       rescue Exception => e # rubocop:disable Lint/RescueException
-        @mutex.synchronize do
-          say "Unexpected error: #{e.message}\n#{e.backtrace.join("\n")}", 'error'
-          @unexpected_error = true
-        end
+        say "Unexpected error: #{e.message}\n#{e.backtrace.join("\n")}", 'error'
+        @mutex.synchronize { @unexpected_error = true }
         stop
       end
       @mutex.synchronize do
@@ -53,7 +51,7 @@ class ThreadedWorker < Delayed::Worker
   def name
     base_name = super
     thread_name = Thread.current[:thread_name]
-    thread_name ? "#{base_name} #{thread_name}" : base_name
+    thread_name.nil? ? base_name : "#{base_name} #{thread_name}"
   end
 
   def stop

--- a/spec/unit/lib/delayed_job/delayed_job_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_job_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe 'delayed_job' do
   describe 'version' do
     it 'is not updated' do
-      expect(Gem.loaded_specs['delayed_job'].version).to eq('4.1.11'), 'revisit monkey patch in lib/delayed_job/quit_trap.rb'
+      expect(Gem.loaded_specs['delayed_job'].version).to eq('4.1.11'),
+                                                         'revisit monkey patch in lib/delayed_job/quit_trap.rb + review the changes related to lib/delayed_job/threaded_worker.rb'
     end
   end
 end

--- a/spec/unit/lib/delayed_job/delayed_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_worker_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe CloudController::DelayedWorker do
     end
 
     context 'when the number of threads is specified' do
-      before { TestConfig.config[:jobs].merge!(thread_count: 7) }
+      before { TestConfig.config[:jobs].merge!(number_of_worker_threads: 7) }
 
       it 'creates a ThreadedWorker with the specified number of threads' do
         expect(environment).to receive(:setup_environment).with(nil)

--- a/spec/unit/lib/delayed_job/delayed_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_worker_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe CloudController::DelayedWorker do
     end
 
     context 'when the number of threads is specified' do
-      before { TestConfig.config[:jobs].merge!(threads: 7) }
+      before { TestConfig.config[:jobs].merge!(thread_count: 7) }
 
       it 'creates a ThreadedWorker with the specified number of threads' do
         expect(environment).to receive(:setup_environment).with(nil)

--- a/spec/unit/lib/delayed_job/delayed_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_worker_spec.rb
@@ -5,13 +5,16 @@ require 'delayed_job/delayed_worker'
 RSpec.describe CloudController::DelayedWorker do
   let(:options) { { queues: 'default', name: 'test_worker' } }
   let(:environment) { instance_double(BackgroundJobEnvironment, setup_environment: nil) }
-  let(:worker) { instance_double(Delayed::Worker, start: nil) }
+  let(:delayed_worker) { instance_double(Delayed::Worker, start: nil) }
+  let(:threaded_worker) { instance_double(ThreadedWorker, start: nil) }
 
   before do
     allow(RakeConfig).to receive(:config).and_return(TestConfig.config_instance)
     allow(BackgroundJobEnvironment).to receive(:new).with(anything).and_return(environment)
-    allow(Delayed::Worker).to receive(:new).and_return(worker)
-    allow(worker).to receive(:name=).with(anything)
+    allow(Delayed::Worker).to receive(:new).and_return(delayed_worker)
+    allow(delayed_worker).to receive(:name=).with(anything)
+    allow(ThreadedWorker).to receive(:new).and_return(threaded_worker)
+    allow(threaded_worker).to receive(:name=).with(anything)
   end
 
   describe '#initialize' do
@@ -28,22 +31,36 @@ RSpec.describe CloudController::DelayedWorker do
   end
 
   describe '#start_working' do
-    let(:worker_instance) { CloudController::DelayedWorker.new(options) }
+    let(:cc_delayed_worker) { CloudController::DelayedWorker.new(options) }
 
     it 'sets up the environment and starts the worker' do
-      expect(environment).to receive(:setup_environment).with(anything)
-      expect(worker).to receive(:name=).with('test_worker')
-      expect(worker).to receive(:start)
+      expect(environment).to receive(:setup_environment).with(nil)
+      expect(Delayed::Worker).to receive(:new).with(anything).and_return(delayed_worker)
+      expect(delayed_worker).to receive(:name=).with('test_worker')
+      expect(delayed_worker).to receive(:start)
 
-      worker_instance.start_working
+      cc_delayed_worker.start_working
     end
 
     it 'configures Delayed::Worker settings' do
-      worker_instance.start_working
+      cc_delayed_worker.start_working
 
       expect(Delayed::Worker.destroy_failed_jobs).to be false
       expect(Delayed::Worker.max_attempts).to eq(3)
       expect(Delayed::Worker.max_run_time).to eq(14_401)
+    end
+
+    context 'when the number of threads is specified' do
+      before { TestConfig.config[:jobs].merge!(threads: 7) }
+
+      it 'creates a ThreadedWorker with the specified number of threads' do
+        expect(environment).to receive(:setup_environment).with(nil)
+        expect(ThreadedWorker).to receive(:new).with(7, anything).and_return(threaded_worker)
+        expect(threaded_worker).to receive(:name=).with('test_worker')
+        expect(threaded_worker).to receive(:start)
+
+        cc_delayed_worker.start_working
+      end
     end
   end
 end

--- a/spec/unit/lib/delayed_job/threaded_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/threaded_worker_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+require 'delayed_job'
+require 'delayed_job/threaded_worker'
+
+RSpec.describe ThreadedWorker do
+  let(:options) { { worker_name: 'test_worker' } }
+  let(:thread_count) { 2 }
+  let(:worker) { ThreadedWorker.new(options, thread_count) }
+
+  describe '#initialize' do
+    it 'initializes with given options and thread count' do
+      expect(worker.instance_variable_get(:@thread_count)).to eq(thread_count)
+      expect(worker.instance_variable_get(:@name_prefix)).to eq('test_worker')
+    end
+
+    it 'initializes with default thread count when not specified' do
+      worker_default = ThreadedWorker.new(options)
+      expect(worker_default.instance_variable_get(:@thread_count)).to eq(ThreadedWorker::DEFAULT_THREAD_COUNT)
+    end
+  end
+
+  describe '#start' do
+    before do
+      allow(worker).to receive(:trap_signals)
+      allow(worker).to receive(:say)
+      allow(worker).to receive(:threaded_work_off)
+    end
+
+    it 'starts the specified number of threads' do
+      expect(Thread).to receive(:new).exactly(thread_count).times.and_call_original
+      worker.start
+      expect(worker.instance_variable_get(:@threads).size).to eq(thread_count)
+    end
+  end
+
+  describe '#name' do
+    it 'returns the current thread name if set' do
+      Thread.current[:name] = 'thread_name'
+      expect(worker.name).to eq('thread_name')
+    end
+
+    it 'returns the instance name if thread name is not set' do
+      worker.name = 'instance_name'
+      expect(worker.name).to eq('instance_name')
+    end
+  end
+
+  describe '#name=' do
+    it 'sets the name for the instance and thread-local storage' do
+      worker.name = 'new_name'
+      expect(worker.instance_variable_get(:@name)).to eq('new_name')
+      expect(Thread.current[:name]).to eq('new_name')
+    end
+  end
+
+  describe '#stop_signal?' do
+    it 'returns the value of the stop signal' do
+      worker.instance_variable_set(:@stop_signal, true)
+      expect(worker.send(:stop_signal?)).to be true
+    end
+  end
+
+  describe '#generate_thread_name' do
+    it 'generates the correct thread name when instance name is set' do
+      worker.name = 'instance_name'
+      expect(worker.send(:generate_thread_name, 1)).to eq('instance_name-thread:1')
+    end
+
+    it 'generates the correct thread name when instance name is not set' do
+      hostname = Socket.gethostname
+      pid = Process.pid
+      expected_name = "test_worker-host:#{hostname} pid:#{pid} thread:1"
+      expect(worker.send(:generate_thread_name, 1)).to eq(expected_name)
+    end
+  end
+
+  describe '#threaded_work_off' do
+    before do
+      allow(worker).to receive(:say)
+      allow(worker).to receive(:sleep).and_return(nil)
+      allow(ThreadedWorker).to receive(:sleep_delay).and_return(0)
+    end
+
+    it 'processes jobs and sleeps when no jobs are found' do
+      allow(worker).to receive(:work_off).and_return([0, 0])
+
+      # Ensure the loop exits after 2nd iteration
+      allow(worker).to receive(:stop_signal?).and_return(false, false, true)
+
+      worker.send(:threaded_work_off)
+      expect(worker).to have_received(:sleep).with(0)
+    end
+
+    it 'processes jobs and logs the results' do
+      allow(worker).to receive(:work_off).and_return([5, 2])
+
+      # Ensure the loop exits after 1st iteration
+      allow(worker).to receive(:stop_signal?).and_return(false, true)
+
+      expect(worker).to receive(:say).with(%r{7 jobs processed at \d+\.\d+ j/s, 2 failed}).once
+      worker.send(:threaded_work_off)
+    end
+
+    it 'handles exceptions and retries up to 5 times' do
+      allow(worker).to receive(:work_off).and_raise(StandardError.new('test error'))
+      allow(worker).to receive(:sleep)
+
+      # Ensure the loop exits after 5th iteration
+      allow(worker).to receive(:stop_signal?).and_return(false, false, false, false, true)
+
+      expect(worker).to receive(:say).with(/Thread .* encountered an error: test error. Restarting thread.../).exactly(5).times
+      expect(worker).to receive(:say).with(/Thread .* has failed 5 times. Exiting to prevent infinite loop./).once
+      worker.send(:threaded_work_off)
+    end
+
+    it 'exits gracefully when stop signal is received' do
+      # Ensure the loop exits immediately
+      allow(worker).to receive(:stop_signal?).and_return(true)
+
+      expect(worker).to receive(:say).with('Stop signal received. Exiting.').once
+      worker.send(:threaded_work_off)
+    end
+  end
+
+  describe 'signal trapping' do
+    before do
+      allow(worker).to receive(:say)
+      allow(worker).to receive(:threaded_work_off)
+      allow(Thread).to receive(:new).and_call_original
+    end
+
+    it 'traps TERM and INT signals and initiates shutdown' do
+      expect(worker).to receive(:trap).with('TERM').and_call_original
+      expect(worker).to receive(:trap).with('INT').and_call_original
+      worker.start
+    end
+
+    it 'sets stop_signal to true on shutdown' do
+      allow(worker).to receive(:trap).and_call_original
+      worker.start
+      worker.send(:initiate_shutdown)
+      expect(worker.instance_variable_get(:@stop_signal)).to be true
+    end
+  end
+end

--- a/spec/unit/lib/delayed_job/threaded_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/threaded_worker_spec.rb
@@ -3,138 +3,173 @@ require 'delayed_job'
 require 'delayed_job/threaded_worker'
 
 RSpec.describe ThreadedWorker do
-  let(:options) { { worker_name: 'test_worker' } }
   let(:thread_count) { 2 }
-  let(:worker) { ThreadedWorker.new(thread_count, options) }
+  let(:grace_period_seconds) { 5 }
+  let(:worker) { ThreadedWorker.new(thread_count, {}, grace_period_seconds) }
+  let(:worker_name) { 'instance_name' }
+
+  before do
+    allow(worker).to receive(:say)
+    allow(worker).to receive_messages(work_off: [5, 2], sleep: nil)
+
+    worker.name = worker_name
+  end
 
   describe '#initialize' do
-    it 'initializes with given options and thread count' do
+    it 'sets up the thread count' do
       expect(worker.instance_variable_get(:@thread_count)).to eq(thread_count)
-      expect(worker.instance_variable_get(:@name_prefix)).to eq('test_worker')
+    end
+
+    it 'sets up the grace period' do
+      expect(worker.instance_variable_get(:@grace_period_seconds)).to eq(grace_period_seconds)
+    end
+
+    it 'sets up the grace period to 30 seconds by default' do
+      worker = ThreadedWorker.new(thread_count)
+      expect(worker.instance_variable_get(:@grace_period_seconds)).to eq(30)
     end
   end
 
   describe '#start' do
     before do
-      allow(worker).to receive(:trap_signals)
-      allow(worker).to receive(:say)
-      allow(worker).to receive(:threaded_work_off)
+      allow(worker).to receive(:threaded_start)
+      allow(worker.instance_variable_get(:@mutex)).to receive(:synchronize).and_call_original
+    end
+
+    it 'sets up signal traps for all signals' do
+      expect(worker).to receive(:trap).with('TERM')
+      expect(worker).to receive(:trap).with('INT')
+      expect(worker).to receive(:trap).with('QUIT')
+      worker.start
     end
 
     it 'starts the specified number of threads' do
-      expect(Thread).to receive(:new).exactly(thread_count).times.and_call_original
+      expect(worker).to receive(:threaded_start).exactly(thread_count).times
+
       worker.start
-      expect(worker.instance_variable_get(:@threads).size).to eq(thread_count)
+
+      expect(worker.instance_variable_get(:@threads).length).to eq(2)
+      expect(worker.instance_variable_get(:@mutex)).to have_received(:synchronize).twice
+    end
+
+    it 'logs the start and shutdown messages' do
+      expect(worker).to receive(:say).with('Starting threaded delayed worker with 2 threads')
+      worker.start
+    end
+
+    it 'sets the thread_name variable for each thread' do
+      worker.start
+      worker.instance_variable_get(:@threads).each_with_index do |thread, index|
+        expect(thread[:thread_name]).to eq("thread:#{index + 1}")
+      end
+    end
+
+    it 'logs the error and stops the worker when an unexpected error occurs' do
+      allow(worker).to receive(:threaded_start).and_raise(StandardError.new('test error'))
+      allow(worker).to receive(:stop)
+      expect { worker.start }.to raise_error('Unexpected error occurred in one of the worker threads')
+      expect(worker.instance_variable_get(:@unexpected_error)).to be true
     end
   end
 
   describe '#name' do
-    it 'returns the current thread name if set' do
-      Thread.current[:name] = 'thread_name'
-      expect(worker.name).to eq('thread_name')
-    end
-
-    it 'returns the instance name if thread name is not set' do
-      worker.name = 'instance_name'
-      expect(worker.name).to eq('instance_name')
+    it 'returns the instance name if thread name is set' do
+      allow(Thread.current).to receive(:[]).with(:thread_name).and_return('some-thread-name')
+      expect(worker.name).to eq('instance_name some-thread-name')
     end
   end
 
-  describe '#name=' do
-    it 'sets the name for the instance and thread-local storage' do
-      worker.name = 'new_name'
-      expect(worker.instance_variable_get(:@name)).to eq('new_name')
-      expect(Thread.current[:name]).to eq('new_name')
+  describe '#stop' do
+    it 'logs the shutdown message' do
+      queue = Queue.new
+      allow(worker).to(receive(:say)) { |message| queue.push(message) }
+
+      worker.stop
+      expect(queue.pop).to eq('Shutting down worker threads gracefully...')
+    end
+
+    it 'sets the exit flag in the parent worker' do
+      worker.stop
+      sleep 0.1 until worker.instance_variable_get(:@exit)
+      expect(worker.instance_variable_get(:@exit)).to be true
+    end
+
+    it 'allows threads to finish their work without being killed prematurely' do
+      allow(worker).to receive(:threaded_start) do
+        5.times do
+          break if worker.instance_variable_get(:@exit)
+
+          sleep 0.5
+        end
+      end
+
+      worker_thread = Thread.new { worker.start }
+      sleep(0.5)
+      expect(worker.instance_variable_get(:@threads).all?(&:alive?)).to be true
+      worker.instance_variable_get(:@threads).each { |t| allow(t).to receive(:kill).and_call_original }
+
+      Thread.new { worker.stop }.join
+      worker.instance_variable_get(:@threads).each(&:join)
+      expect(worker.instance_variable_get(:@threads).all?(&:alive?)).to be false
+      worker_thread.join
+      worker.instance_variable_get(:@threads).each { |t| expect(t).not_to have_received(:kill) }
+    end
+
+    it 'kills threads that exceed the grace period during shutdown' do
+      worker = ThreadedWorker.new(thread_count, {}, 3)
+      allow(worker).to receive(:threaded_start) do
+        10.times do
+          break if worker.instance_variable_get(:@exit)
+
+          sleep 4
+        end
+      end
+
+      worker_thread = Thread.new { worker.start }
+      sleep(0.5)
+      expect(worker.instance_variable_get(:@threads).all?(&:alive?)).to be true
+      worker.instance_variable_get(:@threads).each { |t| allow(t).to receive(:kill).and_call_original }
+
+      Thread.new { worker.stop }.join
+      worker.instance_variable_get(:@threads).each(&:join)
+      expect(worker.instance_variable_get(:@threads).all?(&:alive?)).to be false
+      worker_thread.join
+      expect(worker.instance_variable_get(:@threads)).to all(have_received(:kill))
     end
   end
 
-  describe '#stop_signal?' do
-    it 'returns the value of the stop signal' do
-      worker.instance_variable_set(:@stop_signal, true)
-      expect(worker.send(:stop_signal?)).to be true
-    end
-  end
-
-  describe '#generate_thread_name' do
-    it 'generates the correct thread name when instance name is set' do
-      worker.name = 'instance_name'
-      expect(worker.send(:generate_thread_name, 1)).to eq('instance_name-thread:1')
-    end
-
-    it 'generates the correct thread name when instance name is not set' do
-      hostname = Socket.gethostname
-      pid = Process.pid
-      expected_name = "test_worker-host:#{hostname} pid:#{pid} thread:1"
-      expect(worker.send(:generate_thread_name, 1)).to eq(expected_name)
-    end
-  end
-
-  describe '#threaded_work_off' do
+  describe '#threaded_start' do
     before do
-      allow(worker).to receive(:say)
-      allow(worker).to receive(:sleep).and_return(nil)
-      allow(ThreadedWorker).to receive(:sleep_delay).and_return(0)
+      allow(worker).to receive(:stop?).and_return(false, true)
+      allow(worker).to receive(:reload!).and_call_original
     end
 
-    it 'processes jobs and sleeps when no jobs are found' do
+    it 'runs the work_off loop twice' do
+      worker.threaded_start
+      expect(worker).to have_received(:work_off).twice
+    end
+
+    it 'logs the number of jobs processed' do
+      expect(worker).to receive(:say).with(%r{7 jobs processed at \d+\.\d+ j/s, 2 failed}).twice
+      worker.threaded_start
+    end
+
+    it 'reloads the worker if stop is not set' do
       allow(worker).to receive(:work_off).and_return([0, 0])
-
-      # Ensure the loop exits after 2nd iteration
-      allow(worker).to receive(:stop_signal?).and_return(false, false, true)
-
-      worker.send(:threaded_work_off)
-      expect(worker).to have_received(:sleep).with(0)
+      worker.threaded_start
+      expect(worker).to have_received(:reload!).once
     end
 
-    it 'processes jobs and logs the results' do
-      allow(worker).to receive(:work_off).and_return([5, 2])
+    context 'when exit_on_complete is set' do
+      before do
+        allow(worker.class).to receive(:exit_on_complete).and_return(true)
+        allow(worker).to receive(:work_off).and_return([0, 0])
+      end
 
-      # Ensure the loop exits after 1st iteration
-      allow(worker).to receive(:stop_signal?).and_return(false, true)
-
-      expect(worker).to receive(:say).with(%r{7 jobs processed at \d+\.\d+ j/s, 2 failed}).once
-      worker.send(:threaded_work_off)
-    end
-
-    it 'handles exceptions and retries up to 5 times' do
-      allow(worker).to receive(:work_off).and_raise(StandardError.new('test error'))
-      allow(worker).to receive(:sleep)
-
-      # Ensure the loop exits after 5th iteration
-      allow(worker).to receive(:stop_signal?).and_return(false, false, false, false, true)
-
-      expect(worker).to receive(:say).with(/Thread .* encountered an error: test error. Restarting thread.../).exactly(5).times
-      expect(worker).to receive(:say).with(/Thread .* has failed 5 times. Exiting to prevent infinite loop./).once
-      worker.send(:threaded_work_off)
-    end
-
-    it 'exits gracefully when stop signal is received' do
-      # Ensure the loop exits immediately
-      allow(worker).to receive(:stop_signal?).and_return(true)
-
-      expect(worker).to receive(:say).with('Stop signal received. Exiting.').once
-      worker.send(:threaded_work_off)
-    end
-  end
-
-  describe 'signal trapping' do
-    before do
-      allow(worker).to receive(:say)
-      allow(worker).to receive(:threaded_work_off)
-      allow(Thread).to receive(:new).and_call_original
-    end
-
-    it 'traps TERM and INT signals and initiates shutdown' do
-      expect(worker).to receive(:trap).with('TERM').and_call_original
-      expect(worker).to receive(:trap).with('INT').and_call_original
-      worker.start
-    end
-
-    it 'sets stop_signal to true on shutdown' do
-      allow(worker).to receive(:trap).and_call_original
-      worker.start
-      worker.send(:initiate_shutdown)
-      expect(worker.instance_variable_get(:@stop_signal)).to be true
+      it 'exits the worker when no more jobs are available' do
+        expect(worker).to receive(:say).with('No more jobs available. Exiting')
+        worker.threaded_start
+      end
     end
   end
 end

--- a/spec/unit/lib/delayed_job/threaded_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/threaded_worker_spec.rb
@@ -5,17 +5,12 @@ require 'delayed_job/threaded_worker'
 RSpec.describe ThreadedWorker do
   let(:options) { { worker_name: 'test_worker' } }
   let(:thread_count) { 2 }
-  let(:worker) { ThreadedWorker.new(options, thread_count) }
+  let(:worker) { ThreadedWorker.new(thread_count, options) }
 
   describe '#initialize' do
     it 'initializes with given options and thread count' do
       expect(worker.instance_variable_get(:@thread_count)).to eq(thread_count)
       expect(worker.instance_variable_get(:@name_prefix)).to eq('test_worker')
-    end
-
-    it 'initializes with default thread count when not specified' do
-      worker_default = ThreadedWorker.new(options)
-      expect(worker_default.instance_variable_get(:@thread_count)).to eq(ThreadedWorker::DEFAULT_THREAD_COUNT)
     end
   end
 

--- a/spec/unit/lib/delayed_job/threaded_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/threaded_worker_spec.rb
@@ -3,9 +3,9 @@ require 'delayed_job'
 require 'delayed_job/threaded_worker'
 
 RSpec.describe ThreadedWorker do
-  let(:thread_count) { 2 }
+  let(:num_threads) { 2 }
   let(:grace_period_seconds) { 5 }
-  let(:worker) { ThreadedWorker.new(thread_count, {}, grace_period_seconds) }
+  let(:worker) { ThreadedWorker.new(num_threads, {}, grace_period_seconds) }
   let(:worker_name) { 'instance_name' }
 
   before do
@@ -17,7 +17,7 @@ RSpec.describe ThreadedWorker do
 
   describe '#initialize' do
     it 'sets up the thread count' do
-      expect(worker.instance_variable_get(:@thread_count)).to eq(thread_count)
+      expect(worker.instance_variable_get(:@num_threads)).to eq(num_threads)
     end
 
     it 'sets up the grace period' do
@@ -25,7 +25,7 @@ RSpec.describe ThreadedWorker do
     end
 
     it 'sets up the grace period to 30 seconds by default' do
-      worker = ThreadedWorker.new(thread_count)
+      worker = ThreadedWorker.new(num_threads)
       expect(worker.instance_variable_get(:@grace_period_seconds)).to eq(30)
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe ThreadedWorker do
     end
 
     it 'starts the specified number of threads' do
-      expect(worker).to receive(:threaded_start).exactly(thread_count).times
+      expect(worker).to receive(:threaded_start).exactly(num_threads).times
 
       worker.start
 
@@ -116,7 +116,7 @@ RSpec.describe ThreadedWorker do
     end
 
     it 'kills threads that exceed the grace period during shutdown' do
-      worker = ThreadedWorker.new(thread_count, {}, 3)
+      worker = ThreadedWorker.new(num_threads, {}, 3)
       allow(worker).to receive(:threaded_start) do
         10.times do
           break if worker.instance_variable_get(:@exit)

--- a/spec/unit/lib/delayed_job/threaded_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/threaded_worker_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe ThreadedWorker do
 
     it 'allows threads to finish their work without being killed prematurely' do
       allow(worker).to receive(:threaded_start) do
-        5.times { sleep grace_period_seconds / 2 until worker.instance_variable_get(:@exit) == true }
+        sleep grace_period_seconds / 2 until worker.instance_variable_get(:@exit) == true
       end
 
       worker_thread = Thread.new { worker.start }
@@ -107,9 +107,8 @@ RSpec.describe ThreadedWorker do
     end
 
     it 'kills threads that exceed the grace period during shutdown' do
-      worker = ThreadedWorker.new(num_threads, {}, 3)
       allow(worker).to receive(:threaded_start) do
-        10.times { sleep grace_period_seconds * 2 until worker.instance_variable_get(:@exit) == true }
+        sleep grace_period_seconds * 2 until worker.instance_variable_get(:@exit) == true
       end
 
       worker_thread = Thread.new { worker.start }


### PR DESCRIPTION
Currently operators can configure the number of delayed job workers for the generic queue with two parameters:
-  number of cc-worker VMs in the cf bosh deployment
-  number of worker processes on each VM (capi parameter `number_of_workers`)

Most delayed jobs however are limited by I/O (e.g. database queries) and don't do a lot of processing in ruby.
To increase the throughput on a single worker VM while reducing resource consumption (threads vs processes) this change introduces the option to run multiple delayed worker threads in a single process. 
The number of workers calculates like this: `num_cc_workers X number_processes X num_threads` 

Tests comparing 8 worker processes versus 8 worker threads show that the throughput is the same while the memory consumption is  ~60% lower. Allowing operators to run more workers on a single VM.

All threads have a graceful shutdown period of 30 seconds ([like monit](https://mmonit.com/monit/documentation/monit.html#LIMITS)) so that long running jobs have a chance to finish.
In case a thread crashes with an error a graceful shutdown is triggered and the whole process will exit with an error. Delayed::Job already catches all errors during job execution (https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/worker.rb#L241-L244).



* Links to any other associated PRs
  - https://github.com/cloudfoundry/capi-release/pull/447

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats) -> Tested on a bbl env
