### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Helpful Resources
 
 * [V3 API Docs](http://v3-apidocs.cloudfoundry.org)
-* [V2 API Docs](http://apidocs.cloudfoundry.org)
+* [V2 API Docs](http://v2-apidocs.cloudfoundry.org)
 * [Continuous Integration Pipelines](https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team)
 * [Notes on V3 Architecture](https://github.com/cloudfoundry/cloud_controller_ng/wiki/Notes-on-V3-Architecture)
 * [capi-release](https://github.com/cloudfoundry/capi-release) - The bosh release used to deploy cloud controller

--- a/docs/v3/source/includes/introduction/_introduction.md
+++ b/docs/v3/source/includes/introduction/_introduction.md
@@ -20,6 +20,6 @@ We recommend reaching out to Slack first as we will be most responsive there.
 
 ## More resources
 
-* The [Cloud Foundry V2 API](http://apidocs.cloudfoundry.org/) is still available for interacting with Cloud Foundry.
+* The [Cloud Foundry V2 API](http://v2-apidocs.cloudfoundry.org/) is still available for interacting with Cloud Foundry.
 * [Running Tasks](https://docs.cloudfoundry.org/devguide/using-tasks.html)
 * [V3 API Documentation Source Code](https://github.com/cloudfoundry/cloud_controller_ng/tree/main/docs/v3)


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)