### PR TITLE
Add max_in_flight to /v3/deployments

### DIFF
--- a/app/actions/deployment_create.rb
+++ b/app/actions/deployment_create.rb
@@ -49,7 +49,8 @@ module VCAP::CloudController
             original_web_process_instance_count: desired_instances(app.oldest_web_process, previous_deployment),
             revision_guid: revision&.guid,
             revision_version: revision&.version,
-            strategy: DeploymentModel::ROLLING_STRATEGY
+            strategy: DeploymentModel::ROLLING_STRATEGY,
+            max_in_flight: message.options ? message.options[:max_in_flight] : 1
           )
           MetadataUpdate.update(deployment, message)
 
@@ -168,7 +169,8 @@ module VCAP::CloudController
           original_web_process_instance_count: desired_instances(app.oldest_web_process, previous_deployment),
           revision_guid: revision&.guid,
           revision_version: revision&.version,
-          strategy: DeploymentModel::ROLLING_STRATEGY
+          strategy: DeploymentModel::ROLLING_STRATEGY,
+          max_in_flight: message.options ? message.options[:max_in_flight] : 1
         )
 
         MetadataUpdate.update(deployment, message)

--- a/app/messages/deployment_create_message.rb
+++ b/app/messages/deployment_create_message.rb
@@ -7,6 +7,7 @@ module VCAP::CloudController
       droplet
       revision
       strategy
+      options
     ]
 
     validates_with NoAdditionalKeysValidator

--- a/app/presenters/v3/deployment_presenter.rb
+++ b/app/presenters/v3/deployment_presenter.rb
@@ -19,6 +19,9 @@ module VCAP::CloudController::Presenters::V3
           }
         },
         strategy: deployment.strategy,
+        options: {
+          max_in_flight: deployment.max_in_flight
+        },
         droplet: {
           guid: deployment.droplet_guid
         },

--- a/db/migrations/20240709231741_add_max_in_flight_to_deployment.rb
+++ b/db/migrations/20240709231741_add_max_in_flight_to_deployment.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:deployments) do
+      add_column :max_in_flight, Integer, null: false, default: 1
+    end
+  end
+end

--- a/lib/cloud_controller/deployment_updater/updater.rb
+++ b/lib/cloud_controller/deployment_updater/updater.rb
@@ -84,7 +84,7 @@ module VCAP::CloudController
           end
 
           scale_down_oldest_web_process_with_instances
-          deploying_web_process.update(instances: deploying_web_process.instances + 1)
+          deploying_web_process.update(instances: deploying_web_process.instances + deployment.max_in_flight)
         end
       end
 
@@ -135,12 +135,12 @@ module VCAP::CloudController
       def scale_down_oldest_web_process_with_instances
         process = oldest_web_process_with_instances
 
-        if process.instances == 1 && is_interim_process?(process)
+        if process.instances <= deployment.max_in_flight && is_interim_process?(process)
           process.destroy
           return
         end
 
-        process.update(instances: process.instances - 1)
+        process.update(instances: [(process.instances - deployment.max_in_flight), 0].max)
       end
 
       def finalize_deployment

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -44,6 +44,9 @@ RSpec.describe 'Deployments' do
             }
           },
           'strategy' => 'rolling',
+          'options' => {
+            'max_in_flight' => 1
+          },
           'droplet' => {
             'guid' => droplet.guid
           },
@@ -142,6 +145,9 @@ RSpec.describe 'Deployments' do
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
+                                                        'options' => {
+                                                          'max_in_flight' => 1
+                                                        },
                                                         'droplet' => {
                                                           'guid' => other_droplet.guid
                                                         },
@@ -225,6 +231,9 @@ RSpec.describe 'Deployments' do
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
+                                                        'options' => {
+                                                          'max_in_flight' => 1
+                                                        },
                                                         'droplet' => {
                                                           'guid' => other_droplet.guid
                                                         },
@@ -344,6 +353,9 @@ RSpec.describe 'Deployments' do
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
+                                                        'options' => {
+                                                          'max_in_flight' => 1
+                                                        },
                                                         'droplet' => {
                                                           'guid' => droplet.guid
                                                         },
@@ -423,6 +435,9 @@ RSpec.describe 'Deployments' do
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
+                                                        'options' => {
+                                                          'max_in_flight' => 1
+                                                        },
                                                         'droplet' => {
                                                           'guid' => other_droplet.guid
                                                         },
@@ -504,6 +519,9 @@ RSpec.describe 'Deployments' do
                                                           }
                                                         },
                                                         'strategy' => 'rolling',
+                                                        'options' => {
+                                                          'max_in_flight' => 1
+                                                        },
                                                         'droplet' => {
                                                           'guid' => other_droplet.guid
                                                         },
@@ -672,6 +690,9 @@ RSpec.describe 'Deployments' do
                                                             }
                                                           },
                                                           'strategy' => 'rolling',
+                                                          'options' => {
+                                                            'max_in_flight' => 1
+                                                          },
                                                           'droplet' => {
                                                             'guid' => droplet.guid
                                                           },
@@ -733,6 +754,9 @@ RSpec.describe 'Deployments' do
                                                             }
                                                           },
                                                           'strategy' => 'rolling',
+                                                          'options' => {
+                                                            'max_in_flight' => 1
+                                                          },
                                                           'droplet' => {
                                                             'guid' => droplet.guid
                                                           },
@@ -852,6 +876,9 @@ RSpec.describe 'Deployments' do
                                                         }
                                                       },
                                                       'strategy' => 'rolling',
+                                                      'options' => {
+                                                        'max_in_flight' => 1
+                                                      },
                                                       'droplet' => {
                                                         'guid' => droplet.guid
                                                       },
@@ -957,6 +984,9 @@ RSpec.describe 'Deployments' do
         'updated_at' => iso8601,
         'metadata' => metadata,
         'strategy' => 'rolling',
+        'options' => {
+          'max_in_flight' => 1
+        },
         'relationships' => {
           'app' => {
             'data' => {
@@ -1066,6 +1096,9 @@ RSpec.describe 'Deployments' do
             }
           },
           strategy: 'rolling',
+          options: {
+            max_in_flight: 1
+          },
           droplet: {
             guid: droplet.guid
           },
@@ -1361,6 +1394,9 @@ RSpec.describe 'Deployments' do
                                                               }
                                                             },
                                                             'strategy' => 'rolling',
+                                                            'options' => {
+                                                              'max_in_flight' => 1
+                                                            },
                                                             'droplet' => {
                                                               'guid' => droplet.guid
                                                             },

--- a/spec/unit/actions/deployment_create_spec.rb
+++ b/spec/unit/actions/deployment_create_spec.rb
@@ -572,6 +572,28 @@ module VCAP::CloudController
               end
             end
 
+            context 'when the message specifies max_in_flight' do
+              let(:message) do
+                DeploymentCreateMessage.new(options: { max_in_flight: 10 })
+              end
+
+              it 'saves the max_in_flight' do
+                deployment = DeploymentCreate.create(app:, message:, user_audit_info:)
+                expect(deployment.max_in_flight).to eq(10)
+              end
+            end
+
+            context 'when the message does not specify max_in_flight' do
+              let(:message) do
+                DeploymentCreateMessage.new({})
+              end
+
+              it 'sets the default' do
+                deployment = DeploymentCreate.create(app:, message:, user_audit_info:)
+                expect(deployment.max_in_flight).to eq(1)
+              end
+            end
+
             context 'when the app fails to start' do
               before do
                 allow(VCAP::CloudController::AppStart).to receive(:start).and_raise(VCAP::CloudController::AppStart::InvalidApp.new('memory quota_exceeded'))
@@ -658,6 +680,28 @@ module VCAP::CloudController
               end.to change(RevisionModel, :count).by(2)
 
               expect(app.reload.newest_web_process.command).to eq 'something else'
+            end
+          end
+
+          context 'when the message specifies max_in_flight' do
+            let(:message) do
+              DeploymentCreateMessage.new(options: { max_in_flight: 10 })
+            end
+
+            it 'saves the max_in_flight' do
+              deployment = DeploymentCreate.create(app:, message:, user_audit_info:)
+              expect(deployment.max_in_flight).to eq(10)
+            end
+          end
+
+          context 'when the message does not specify max_in_flight' do
+            let(:message) do
+              DeploymentCreateMessage.new({})
+            end
+
+            it 'sets the default' do
+              deployment = DeploymentCreate.create(app:, message:, user_audit_info:)
+              expect(deployment.max_in_flight).to eq(1)
             end
           end
 

--- a/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
@@ -39,7 +39,8 @@ module VCAP::CloudController
         app: web_process.app,
         deploying_web_process: deploying_web_process,
         state: 'DEPLOYING',
-        original_web_process_instance_count: original_web_process_instance_count
+        original_web_process_instance_count: original_web_process_instance_count,
+        max_in_flight: 1
       )
     end
 
@@ -67,6 +68,7 @@ module VCAP::CloudController
       end
 
       it 'scales the old web process down by one after the first iteration' do
+        expect(original_web_process_instance_count).to be > current_deploying_instances
         expect do
           subject.scale
         end.to change {
@@ -80,6 +82,34 @@ module VCAP::CloudController
         end.to change {
           deploying_web_process.reload.instances
         }.by(1)
+      end
+
+      context 'when the max_in_flight is set to 2' do
+        let(:deployment) do
+          DeploymentModel.make(
+            app: web_process.app,
+            deploying_web_process: deploying_web_process,
+            state: 'DEPLOYING',
+            original_web_process_instance_count: original_web_process_instance_count,
+            max_in_flight: 2
+          )
+        end
+
+        it 'scales the old web process down by two after the first iteration' do
+          expect do
+            subject.scale
+          end.to change {
+            web_process.reload.instances
+          }.by(-2)
+        end
+
+        it 'scales up the new web process by two' do
+          expect do
+            subject.scale
+          end.to change {
+            deploying_web_process.reload.instances
+          }.by(2)
+        end
       end
 
       context 'when the deployment process has reached original_web_process_instance_count' do
@@ -215,6 +245,23 @@ module VCAP::CloudController
           expect do
             subject.scale
           end.not_to(change(RouteMappingModel, :count))
+        end
+
+        context 'when the max_in_flight is set to 10' do
+          let(:deployment) do
+            DeploymentModel.make(
+              app: web_process.app,
+              deploying_web_process: deploying_web_process,
+              state: 'DEPLOYING',
+              original_web_process_instance_count: original_web_process_instance_count,
+              max_in_flight: 10
+            )
+          end
+
+          it 'does not destroy the web process, but scales it to 0' do
+            subject.scale
+            expect(ProcessModel.find(guid: web_process.guid).instances).to eq 0
+          end
         end
       end
 
@@ -465,6 +512,26 @@ module VCAP::CloudController
           end.to change {
             deploying_web_process.reload.instances
           }.by(1)
+        end
+
+        context 'when the max_in_flight is set to 10' do
+          let(:deployment) do
+            DeploymentModel.make(
+              app: web_process.app,
+              deploying_web_process: deploying_web_process,
+              state: 'DEPLOYING',
+              original_web_process_instance_count: original_web_process_instance_count,
+              max_in_flight: 10
+            )
+          end
+
+          it 'scales up the coerced web process by 10' do
+            expect do
+              subject.scale
+            end.to change {
+              deploying_web_process.reload.instances
+            }.by(10)
+          end
         end
       end
 


### PR DESCRIPTION
__* A short explanation of the proposed change:__
** This exposes a new option for the deployment resource that 
__* An explanation of the use cases your change solves__
** Currently, rolling deploys deploy one instance at a time, but if an app has many instances this can take quite a while
* Links to any other associated PRs
** there is a CLI feature in progress, will link when it is a PR
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
