### PR TITLE
Add Canary deployments

### DIFF
--- a/app/actions/deployment_continue.rb
+++ b/app/actions/deployment_continue.rb
@@ -23,9 +23,6 @@ module VCAP::CloudController
       private
 
       def reject_invalid_state!(deployment)
-        # TODO: do we want better api errors? e.g.
-        # - this deployment will eventually be continuable
-        # - this deployment is not continuable
         raise InvalidStatus.new("Cannot continue a deployment with status: #{deployment.status_value} and reason: #{deployment.status_reason}")
       end
 

--- a/app/actions/deployment_continue.rb
+++ b/app/actions/deployment_continue.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
       private
 
       def reject_invalid_state!(deployment)
-        # TODO do we want better api errors? e.g. 
+        # TODO: do we want better api errors? e.g.
         # - this deployment will eventually be continuable
         # - this deployment is not continuable
         raise InvalidStatus.new("Cannot continue a deployment with status: #{deployment.status_value} and reason: #{deployment.status_reason}")

--- a/app/actions/deployment_continue.rb
+++ b/app/actions/deployment_continue.rb
@@ -1,0 +1,45 @@
+module VCAP::CloudController
+  class DeploymentContinue
+    class Error < StandardError
+    end
+    class InvalidStatus < Error
+    end
+
+    class << self
+      def continue(deployment:, user_audit_info:)
+        deployment.db.transaction do
+          deployment.lock!
+          reject_invalid_state!(deployment) unless deployment.continuable?
+
+          record_audit_event(deployment, user_audit_info)
+          deployment.update(
+            state: DeploymentModel::DEPLOYING_STATE,
+            status_value: DeploymentModel::ACTIVE_STATUS_VALUE,
+            status_reason: DeploymentModel::DEPLOYING_STATUS_REASON
+          )
+        end
+      end
+
+      private
+
+      def reject_invalid_state!(deployment)
+        # TODO do we want better api errors? e.g. 
+        # - this deployment will eventually be continuable
+        # - this deployment is not continuable
+        raise InvalidStatus.new("Cannot continue a deployment with status: #{deployment.status_value} and reason: #{deployment.status_reason}")
+      end
+
+      def record_audit_event(deployment, user_audit_info)
+        app = deployment.app
+        Repositories::DeploymentEventRepository.record_continue(
+          deployment,
+          deployment.droplet,
+          user_audit_info,
+          app.name,
+          app.space_guid,
+          app.space.organization_guid
+        )
+      end
+    end
+  end
+end

--- a/app/jobs/runtime/prune_completed_deployments.rb
+++ b/app/jobs/runtime/prune_completed_deployments.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
                                   select(:id)
 
             deployments_to_delete = deployments_dataset.
-                                    exclude(state: [DeploymentModel::DEPLOYING_STATE, DeploymentModel::CANCELING_STATE]).
+                                    exclude(state: DeploymentModel::ACTIVE_STATES).
                                     exclude(id: deployments_to_keep)
 
             delete_count = DeploymentDelete.delete(deployments_to_delete)

--- a/app/messages/deployment_create_message.rb
+++ b/app/messages/deployment_create_message.rb
@@ -11,7 +11,7 @@ module VCAP::CloudController
 
     validates_with NoAdditionalKeysValidator
     validates :strategy,
-              inclusion: { in: %w[rolling], message: "'%<value>s' is not a supported deployment strategy" },
+              inclusion: { in: %w[rolling canary], message: "'%<value>s' is not a supported deployment strategy" },
               allow_nil: true
     validate :mutually_exclusive_droplet_sources
 

--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -132,7 +132,7 @@ module VCAP::CloudController
     end
 
     def deploying?
-      deployments_dataset.where(state: DeploymentModel::DEPLOYING_STATE).any?
+      deployments_dataset.where(state: DeploymentModel::PROGRESSING_STATES).any?
     end
 
     def self.user_visibility_filter(user)

--- a/app/models/runtime/deployment_model.rb
+++ b/app/models/runtime/deployment_model.rb
@@ -28,6 +28,17 @@ module VCAP::CloudController
       CANARY_STRATEGY = 'canary'.freeze
     ].freeze
 
+    PROGRESSING_STATES = [
+      DEPLOYING_STATE,
+      PREPAUSED_STATE,
+      PAUSED_STATE
+    ].freeze
+
+    ACTIVE_STATES = [
+      *DeploymentModel::PROGRESSING_STATES,
+      DeploymentModel::CANCELING_STATE
+    ].freeze
+
     many_to_one :app,
                 class: 'VCAP::CloudController::AppModel',
                 primary_key: :guid,
@@ -67,7 +78,7 @@ module VCAP::CloudController
 
     dataset_module do
       def deploying_count
-        where(state: DeploymentModel::DEPLOYING_STATE).count
+        where(state: DeploymentModel::PROGRESSING_STATES).count
       end
     end
 
@@ -77,11 +88,7 @@ module VCAP::CloudController
     end
 
     def deploying?
-      # represents states that are still progressing forward
-      deploying_states = [DeploymentModel::DEPLOYING_STATE,
-                          DeploymentModel::PAUSED_STATE,
-                          DeploymentModel::PREPAUSED_STATE]
-      deploying_states.include?(state)
+      DeploymentModel::PROGRESSING_STATES.include?(state)
     end
 
     def cancelable?

--- a/app/models/runtime/deployment_model.rb
+++ b/app/models/runtime/deployment_model.rb
@@ -2,6 +2,8 @@ module VCAP::CloudController
   class DeploymentModel < Sequel::Model(:deployments)
     DEPLOYMENT_STATES = [
       DEPLOYING_STATE = 'DEPLOYING'.freeze,
+      PREPAUSED_STATE = 'PREPAUSED'.freeze,
+      PAUSED_STATE = 'PAUSED'.freeze,
       DEPLOYED_STATE = 'DEPLOYED'.freeze,
       CANCELING_STATE = 'CANCELING'.freeze,
       CANCELED_STATE = 'CANCELED'.freeze
@@ -13,15 +15,17 @@ module VCAP::CloudController
     ].freeze
 
     STATUS_REASONS = [
-      DEPLOYED_STATUS_REASON = 'DEPLOYED'.freeze,
       DEPLOYING_STATUS_REASON = 'DEPLOYING'.freeze,
+      PAUSED_STATUS_REASON = 'PAUSED'.freeze,
+      DEPLOYED_STATUS_REASON = 'DEPLOYED'.freeze,
       CANCELED_STATUS_REASON = 'CANCELED'.freeze,
       CANCELING_STATUS_REASON = 'CANCELING'.freeze,
       SUPERSEDED_STATUS_REASON = 'SUPERSEDED'.freeze
     ].freeze
 
     DEPLOYMENT_STRATEGIES = [
-      ROLLING_STRATEGY = 'rolling'.freeze
+      ROLLING_STRATEGY = 'rolling'.freeze,
+      CANARY_STRATEGY = 'canary'.freeze
     ].freeze
 
     many_to_one :app,
@@ -80,6 +84,10 @@ module VCAP::CloudController
       valid_states_for_cancel = [DeploymentModel::DEPLOYING_STATE,
                                  DeploymentModel::CANCELING_STATE]
       valid_states_for_cancel.include?(state)
+    end
+
+    def continuable?
+      state == DeploymentModel::PAUSED_STATE
     end
 
     private

--- a/app/models/runtime/deployment_model.rb
+++ b/app/models/runtime/deployment_model.rb
@@ -35,8 +35,8 @@ module VCAP::CloudController
     ].freeze
 
     ACTIVE_STATES = [
-      *DeploymentModel::PROGRESSING_STATES,
-      DeploymentModel::CANCELING_STATE
+      *PROGRESSING_STATES,
+      CANCELING_STATE
     ].freeze
 
     many_to_one :app,
@@ -92,11 +92,7 @@ module VCAP::CloudController
     end
 
     def cancelable?
-      valid_states_for_cancel = [DeploymentModel::DEPLOYING_STATE,
-                                 DeploymentModel::CANCELING_STATE,
-                                 DeploymentModel::PAUSED_STATE,
-                                 DeploymentModel::PREPAUSED_STATE]
-      valid_states_for_cancel.include?(state)
+      DeploymentModel::ACTIVE_STATES.include?(state)
     end
 
     def continuable?

--- a/app/models/runtime/deployment_model.rb
+++ b/app/models/runtime/deployment_model.rb
@@ -77,12 +77,18 @@ module VCAP::CloudController
     end
 
     def deploying?
-      state == DEPLOYING_STATE
+      # represents states that are still progressing forward
+      deploying_states = [DeploymentModel::DEPLOYING_STATE,
+                          DeploymentModel::PAUSED_STATE,
+                          DeploymentModel::PREPAUSED_STATE]
+      deploying_states.include?(state)
     end
 
     def cancelable?
       valid_states_for_cancel = [DeploymentModel::DEPLOYING_STATE,
-                                 DeploymentModel::CANCELING_STATE]
+                                 DeploymentModel::CANCELING_STATE,
+                                 DeploymentModel::PAUSED_STATE,
+                                 DeploymentModel::PREPAUSED_STATE]
       valid_states_for_cancel.include?(state)
     end
 

--- a/app/presenters/v3/deployment_presenter.rb
+++ b/app/presenters/v3/deployment_presenter.rb
@@ -76,6 +76,13 @@ module VCAP::CloudController::Presenters::V3
             method: 'POST'
           }
         end
+      end.tap do |links|
+        if deployment.continuable?
+          links[:continue] = {
+            href: url_builder.build_url(path: "/v3/deployments/#{deployment.guid}/actions/continue"),
+            method: 'POST'
+          }
+        end
       end
     end
   end

--- a/app/repositories/deployment_event_repository.rb
+++ b/app/repositories/deployment_event_repository.rb
@@ -11,7 +11,8 @@ module VCAP::CloudController
           droplet_guid: droplet&.guid,
           type: type,
           revision_guid: deployment.revision_guid,
-          request: params
+          request: params,
+          strategy: deployment.strategy
         }
 
         Event.create(
@@ -40,6 +41,30 @@ module VCAP::CloudController
 
         Event.create(
           type: EventTypes::APP_DEPLOYMENT_CANCEL,
+          actor: user_audit_info.user_guid,
+          actor_type: 'user',
+          actor_name: user_audit_info.user_email,
+          actor_username: user_audit_info.user_name,
+          actee: deployment.app_guid,
+          actee_type: 'app',
+          actee_name: v3_app_name,
+          timestamp: Sequel::CURRENT_TIMESTAMP,
+          metadata: metadata,
+          space_guid: space_guid,
+          organization_guid: org_guid
+        )
+      end
+
+      def self.record_continue(deployment, droplet, user_audit_info, v3_app_name, space_guid, org_guid)
+        VCAP::AppLogEmitter.emit(deployment.app_guid, "Continuing deployment for app with guid #{deployment.app_guid}")
+
+        metadata = {
+          deployment_guid: deployment.guid,
+          droplet_guid: droplet&.guid
+        }
+
+        Event.create(
+          type: EventTypes::APP_DEPLOYMENT_CONTINUE,
           actor: user_audit_info.user_guid,
           actor_type: 'user',
           actor_name: user_audit_info.user_email,

--- a/app/repositories/event_types.rb
+++ b/app/repositories/event_types.rb
@@ -47,6 +47,7 @@ module VCAP::CloudController
         APP_REVISION_ENV_VARS_SHOW = 'audit.app.revision.environment_variables.show'.freeze,
         APP_DEPLOYMENT_CANCEL = 'audit.app.deployment.cancel'.freeze,
         APP_DEPLOYMENT_CREATE = 'audit.app.deployment.create'.freeze,
+        APP_DEPLOYMENT_CONTINUE = 'audit.app.deployment.continue'.freeze,
         APP_COPY_BITS = 'audit.app.copy-bits'.freeze,
         APP_UPLOAD_BITS = 'audit.app.upload-bits'.freeze,
         APP_APPLY_MANIFEST = 'audit.app.apply_manifest'.freeze,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
   get '/deployments/', to: 'deployments#index'
   get '/deployments/:guid', to: 'deployments#show'
   post '/deployments/:guid/actions/cancel', to: 'deployments#cancel'
+  post '/deployments/:guid/actions/continue', to: 'deployments#continue'
 
   # domains
   post '/domains', to: 'domains#create'

--- a/docs/v3/source/includes/api_resources/_deployments.erb
+++ b/docs/v3/source/includes/api_resources/_deployments.erb
@@ -9,7 +9,7 @@
       "last_successful_healthcheck": "2018-04-25T22:42:10Z"
     }
   },
-  "strategy": "rolling",
+  "strategy": "canary",
   "droplet": {
     "guid": "44ccfa61-dbcf-4a0d-82fe-f668e9d2a962"
   },
@@ -48,6 +48,10 @@
     },
     "cancel": {
       "href": "https://api.example.org/v3/deployments/59c3d133-2b83-46f3-960e-7765a129aea4/actions/cancel",
+      "method": "POST"
+    }
+    "continue": {
+      "href": "https://api.example.org/v3/deployments/59c3d133-2b83-46f3-960e-7765a129aea4/actions/continue",
       "method": "POST"
     }
   }

--- a/docs/v3/source/includes/resources/audit_events/_header.md.erb
+++ b/docs/v3/source/includes/resources/audit_events/_header.md.erb
@@ -14,6 +14,7 @@ For more information, see the [Cloud Foundry docs](https://docs.cloudfoundry.org
 - `audit.app.delete-request`
 - `audit.app.deployment.cancel`
 - `audit.app.deployment.create`
+- `audit.app.deployment.continue`
 - `audit.app.droplet.create`
 - `audit.app.droplet.delete`
 - `audit.app.droplet.download`

--- a/docs/v3/source/includes/resources/deployments/_continue.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_continue.md.erb
@@ -1,0 +1,30 @@
+### Continue a deployment
+
+```
+Example Request
+```
+
+```shell
+curl "https://api.example.org/v3/deployments/[guid]/actions/continue" \
+  -X POST \
+  -H "Authorization: bearer [token]"
+```
+
+```
+Example Response
+```
+
+```http
+HTTP/1.1 200 OK
+
+```
+
+#### Definition
+`POST /v3/deployments/:guid/actions/continue`
+
+#### Permitted roles
+ |
+--- |
+Admin |
+Space Developer |
+Space Supporter |

--- a/docs/v3/source/includes/resources/deployments/_header.md
+++ b/docs/v3/source/includes/resources/deployments/_header.md
@@ -15,4 +15,4 @@ Deployment strategies supported:
 * [Rolling deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) allows for
 applications to be deployed without incurring downtime by gradually rolling out instances.
 
-* Canary deployments deploys a single instance to be evaluated, if deemed successful the deployment can be resumed via the [continue action](#continue-a-deployment). The deployment then continues like a rolling deployment.
+* Canary deployments deploys a single instance to be evaluated, if deemed successful the deployment can be resumed via the [continue action](#continue-a-deployment). The deployment then continues like a rolling deployment. This feature is experimental and is subject to change.

--- a/docs/v3/source/includes/resources/deployments/_header.md
+++ b/docs/v3/source/includes/resources/deployments/_header.md
@@ -8,7 +8,11 @@ They can either:
 
 * Roll an app back to a specific [revision](#revisions) along with its associated droplet
 
+Deployments are different than the traditional method of pushing app updates which performs start/stop deployments.
 
-It is possible to use [rolling deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) for
-applications without incurring downtime. This is different from the traditional method of pushing app updates which performs start/stop deployments.
+Deployment strategies supported:
 
+* [Rolling deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) allows for
+applications to be deployed without incurring downtime by gradually rolling out instances.
+
+* Canary deployments deploys a single instance to be evaluated, if deemed successful the deployment can be resumed via the [continue action](#continue-a-deployment). The deployment then continues like a rolling deployment.

--- a/docs/v3/source/includes/resources/deployments/_header.md
+++ b/docs/v3/source/includes/resources/deployments/_header.md
@@ -15,4 +15,4 @@ Deployment strategies supported:
 * [Rolling deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) allows for
 applications to be deployed without incurring downtime by gradually rolling out instances.
 
-* Canary deployments deploys a single instance to be evaluated, if deemed successful the deployment can be resumed via the [continue action](#continue-a-deployment). The deployment then continues like a rolling deployment. This feature is experimental and is subject to change.
+* Canary deployments deploy a single instance and pause for user evaluation. If the canary instance is deemed successful, the deployment can be resumed via the [continue action](#continue-a-deployment). The deployment then continues like a rolling deployment. This feature is experimental and is subject to change.

--- a/docs/v3/source/includes/resources/deployments/_list.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_list.md.erb
@@ -32,7 +32,7 @@ Name | Type | Description
 ---- | ---- | ------------
 **app_guids** | _list of strings_ | Comma-delimited list of app guids to filter by
 **states** | _list of strings_ | Comma-delimited list of states to filter by
-**status_reasons** | _list of strings_ | Comma-delimited list of status reasons to filter by;<br>valid values include `DEPLOYING`, `CANCELING`, `DEPLOYED`, `CANCELED`, `SUPERSEDED`
+**status_reasons** | _list of strings_ | Comma-delimited list of status reasons to filter by;<br>valid values include `DEPLOYING`, `PAUSED`, `CANCELING`, `DEPLOYED`, `CANCELED`, `SUPERSEDED`
 **status_values** | _list of strings_ | Comma-delimited list of status values to filter by;<br>valid values include `ACTIVE` and `FINALIZED`
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/deployments/_object.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_object.md.erb
@@ -16,7 +16,7 @@ Name | Type | Description
 **status.reason** | _string_ | The reason for the status of the deployment;<br>following list represents valid values:<br>1. If **status.value** is `ACTIVE`<br>- `DEPLOYING`<br>- `PAUSED` (only valid for canary deployments) <br>- `CANCELING`<br>2. If **status.value** is `FINALIZED`<br>- `DEPLOYED`<br>- `CANCELED`<br>- `SUPERSEDED` (another deployment created for app before completion)<br>
 **status.details.last_successful_healthcheck** | _[timestamp](#timestamps)_ | Timestamp of the last successful healthcheck
 **status.details.last_status_change** | _[timestamp](#timestamps)_ | Timestamp of last change to status.value or status.reason
-**strategy** | _string_ | Strategy used for the deployment; supported strategies are `rolling` and `canary`
+**strategy** | _string_ | Strategy used for the deployment; supported strategies are `rolling` and `canary` (experimental)
 **droplet.guid** | _string_ | The droplet guid that the deployment is transitioning the app to
 **previous_droplet.guid** | _string_ | The app's [current droplet guid](#get-current-droplet-association-for-an-app) before the deployment was created
 **new_processes** | _array_ | List of processes created as part of the deployment

--- a/docs/v3/source/includes/resources/deployments/_object.md.erb
+++ b/docs/v3/source/includes/resources/deployments/_object.md.erb
@@ -13,10 +13,10 @@ Name | Type | Description
 **created_at** | _[timestamp](#timestamps)_ | The time with zone when the object was created
 **updated_at** | _[timestamp](#timestamps)_ | The time with zone when the object was last updated
 **status.value** | _string_ | The current status of the deployment; valid values are `ACTIVE` (meaning in progress) and `FINALIZED` (meaning finished, either successfully or not)
-**status.reason** | _string_ | The reason for the status of the deployment;<br>following list represents valid values:<br>1. If **status.value** is `ACTIVE`<br>- `DEPLOYING`<br>- `CANCELING`<br>2. If **status.value** is `FINALIZED`<br>- `DEPLOYED`<br>- `CANCELED`<br>- `SUPERSEDED` (another deployment created for app before completion)<br>
+**status.reason** | _string_ | The reason for the status of the deployment;<br>following list represents valid values:<br>1. If **status.value** is `ACTIVE`<br>- `DEPLOYING`<br>- `PAUSED` (only valid for canary deployments) <br>- `CANCELING`<br>2. If **status.value** is `FINALIZED`<br>- `DEPLOYED`<br>- `CANCELED`<br>- `SUPERSEDED` (another deployment created for app before completion)<br>
 **status.details.last_successful_healthcheck** | _[timestamp](#timestamps)_ | Timestamp of the last successful healthcheck
 **status.details.last_status_change** | _[timestamp](#timestamps)_ | Timestamp of last change to status.value or status.reason
-**strategy** | _string_ | Strategy used for the deployment; supported strategies are `rolling` only
+**strategy** | _string_ | Strategy used for the deployment; supported strategies are `rolling` and `canary`
 **droplet.guid** | _string_ | The droplet guid that the deployment is transitioning the app to
 **previous_droplet.guid** | _string_ | The app's [current droplet guid](#get-current-droplet-association-for-an-app) before the deployment was created
 **new_processes** | _array_ | List of processes created as part of the deployment

--- a/docs/v3/source/index.html.md
+++ b/docs/v3/source/index.html.md
@@ -120,6 +120,7 @@ includes:
   - resources/deployments/list
   - resources/deployments/update
   - resources/deployments/cancel
+  - resources/deployments/continue
   - resources/domains/header
   - resources/domains/object
   - resources/domains/create

--- a/lib/cloud_controller/deployment_updater/dispatcher.rb
+++ b/lib/cloud_controller/deployment_updater/dispatcher.rb
@@ -11,6 +11,7 @@ module VCAP::CloudController
 
           deployments_to_scale = DeploymentModel.where(state: DeploymentModel::DEPLOYING_STATE).all
           deployments_to_cancel = DeploymentModel.where(state: DeploymentModel::CANCELING_STATE).all
+          deployments_to_canary = DeploymentModel.where(state: DeploymentModel::PREPAUSED_STATE).all
 
           begin
             workpool = WorkPool.new(50)
@@ -22,8 +23,14 @@ module VCAP::CloudController
               end
             end
 
-            logger.info("canceling #{deployments_to_cancel.size} deployments")
+            logger.info("canarying #{deployments_to_canary.size} deployments")
+            deployments_to_canary.each do |deployment|
+              workpool.submit(deployment, logger) do |d, l|
+                Updater.new(d, l).canary
+              end
+            end
 
+            logger.info("canceling #{deployments_to_cancel.size} deployments")
             deployments_to_cancel.each do |deployment|
               workpool.submit(deployment, logger) do |d, l|
                 Updater.new(d, l).cancel

--- a/lib/cloud_controller/deployment_updater/updater.rb
+++ b/lib/cloud_controller/deployment_updater/updater.rb
@@ -213,7 +213,7 @@ module VCAP::CloudController
       end
 
       def canary_ready?
-        ready_to_scale? # todo
+        ready_to_scale?
       end
 
       def ready_to_scale?

--- a/lib/cloud_controller/deployment_updater/updater.rb
+++ b/lib/cloud_controller/deployment_updater/updater.rb
@@ -80,6 +80,7 @@ module VCAP::CloudController
               status_value: DeploymentModel::ACTIVE_STATUS_VALUE,
               status_reason: DeploymentModel::PAUSED_STATUS_REASON
             )
+            logger.info("paused-canary-deployment-for-#{deployment.guid}")
           end
         end
       end

--- a/lib/cloud_controller/deployment_updater/updater.rb
+++ b/lib/cloud_controller/deployment_updater/updater.rb
@@ -15,6 +15,13 @@ module VCAP::CloudController
         end
       end
 
+      def canary
+        with_error_logging('error-canarying-deployment') do
+          canary_deployment
+          logger.info("ran-canarying-deployment-for-#{deployment.guid}")
+        end
+      end
+
       def cancel
         with_error_logging('error-canceling-deployment') do
           cancel_deployment
@@ -56,6 +63,24 @@ module VCAP::CloudController
             status_value: DeploymentModel::FINALIZED_STATUS_VALUE,
             status_reason: DeploymentModel::CANCELED_STATUS_REASON
           )
+        end
+      end
+
+      def canary_deployment
+        deployment.db.transaction do
+          deployment.lock!
+          return unless deployment.state == DeploymentModel::PREPAUSED_STATE
+
+          scale_canceled_web_processes_to_zero
+
+          if canary_ready?
+            deployment.update(
+              last_healthy_at: Time.now,
+              state: DeploymentModel::PAUSED_STATE,
+              status_value: DeploymentModel::ACTIVE_STATUS_VALUE,
+              status_reason: DeploymentModel::PAUSED_STATUS_REASON
+            )
+          end
         end
       end
 
@@ -184,6 +209,10 @@ module VCAP::CloudController
         app.processes.reject(&:web?).each do |process|
           process.update(command: deploying_web_process.revision.commands_by_process_type[process.type])
         end
+      end
+
+      def canary_ready?
+        ready_to_scale? # todo
       end
 
       def ready_to_scale?

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -1064,18 +1064,18 @@ RSpec.describe 'Deployments' do
         get "/v3/deployments/#{deployment.guid}", nil, user_header
         parsed_response = Oj.load(last_response.body)
         expect(parsed_response['links']['continue']).to eq({
-          'href' => "#{link_prefix}/v3/deployments/#{deployment.guid}/actions/continue",
-          'method' => 'POST'
-        })
+                                                             'href' => "#{link_prefix}/v3/deployments/#{deployment.guid}/actions/continue",
+                                                             'method' => 'POST'
+                                                           })
       end
 
       it 'includes the cancel action in the links' do
         get "/v3/deployments/#{deployment.guid}", nil, user_header
         parsed_response = Oj.load(last_response.body)
         expect(parsed_response['links']['cancel']).to eq({
-          'href' => "#{link_prefix}/v3/deployments/#{deployment.guid}/actions/cancel",
-          'method' => 'POST'
-        })
+                                                           'href' => "#{link_prefix}/v3/deployments/#{deployment.guid}/actions/cancel",
+                                                           'method' => 'POST'
+                                                         })
       end
     end
 
@@ -1149,7 +1149,6 @@ RSpec.describe 'Deployments' do
                                                                status_reason: VCAP::CloudController::DeploymentModel::SUPERSEDED_STATUS_REASON)
       end
 
-
       let!(:deployment6) do
         VCAP::CloudController::DeploymentModelTestFactory.make(app: app5, droplet: droplet5,
                                                                previous_droplet: droplet5,
@@ -1159,7 +1158,7 @@ RSpec.describe 'Deployments' do
                                                                status_reason: VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON)
       end
 
-      # TODO add pause states and any other canary related states
+      # TODO: add pause states and any other canary related states
 
       def json_for_deployment(deployment, app_model, droplet, status_value, status_reason, cancel_link=true)
         {
@@ -1577,14 +1576,13 @@ RSpec.describe 'Deployments' do
     end
   end
 
-
   describe 'POST /v3/deployments/:guid/actions/continue' do
-    let(:state) {  }
+    let(:state) {}
     let(:deployment) do
       VCAP::CloudController::DeploymentModelTestFactory.make(
         app: app_model,
         droplet: droplet,
-        state: state,
+        state: state
       )
     end
 
@@ -1652,7 +1650,7 @@ RSpec.describe 'Deployments' do
         expect(last_response.status).to eq(422), last_response.body
       end
     end
-    # TODO how much do we want to test here ?
+    # TODO: how much do we want to test here ?
     #
     # context 'when the deployment is not a canary' do
     # note from Seth: I don't think we need this case, what if we add the `pause` action :)
@@ -1663,7 +1661,7 @@ RSpec.describe 'Deployments' do
     # context 'when the deployment is superseeded' do
     # end
 
-    # todo: understand this
+    # TODO: understand this
     context 'with a running deployment' do
       let(:state) { VCAP::CloudController::DeploymentModel::PAUSED_STATE }
       let(:api_call) { ->(user_headers) { post "/v3/deployments/#{deployment.guid}/actions/continue", {}.to_json, user_headers } }

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -561,6 +561,7 @@ RSpec.describe 'Deployments' do
 
       let(:create_request) do
         {
+          strategy: 'canary',
           relationships: {
             app: {
               data: {
@@ -592,7 +593,7 @@ RSpec.describe 'Deployments' do
             'telemetry-time' => Time.now.to_datetime.rfc3339,
             'create-deployment' => {
               'api-version' => 'v3',
-              'strategy' => 'rolling',
+              'strategy' => 'canary',
               'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
               'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid)
             }
@@ -612,7 +613,7 @@ RSpec.describe 'Deployments' do
             'telemetry-time' => Time.now.to_datetime.rfc3339,
             'rolled-back-app' => {
               'api-version' => 'v3',
-              'strategy' => 'rolling',
+              'strategy' => 'canary',
               'app-id' => OpenSSL::Digest::SHA256.hexdigest(app_model.guid),
               'user-id' => OpenSSL::Digest::SHA256.hexdigest(user.guid),
               'revision-id' => OpenSSL::Digest::SHA256.hexdigest(revision.guid)
@@ -733,6 +734,67 @@ RSpec.describe 'Deployments' do
                                                             }
                                                           },
                                                           'strategy' => 'rolling',
+                                                          'droplet' => {
+                                                            'guid' => droplet.guid
+                                                          },
+                                                          'revision' => {
+                                                            'guid' => app_model.latest_revision.guid,
+                                                            'version' => app_model.latest_revision.version
+                                                          },
+                                                          'previous_droplet' => {
+                                                            'guid' => droplet.guid
+                                                          },
+                                                          'new_processes' => [{
+                                                            'guid' => deployment.deploying_web_process.guid,
+                                                            'type' => deployment.deploying_web_process.type
+                                                          }],
+                                                          'created_at' => iso8601,
+                                                          'updated_at' => iso8601,
+                                                          'metadata' => metadata,
+                                                          'relationships' => {
+                                                            'app' => {
+                                                              'data' => {
+                                                                'guid' => app_model.guid
+                                                              }
+                                                            }
+                                                          },
+                                                          'links' => {
+                                                            'self' => {
+                                                              'href' => "#{link_prefix}/v3/deployments/#{deployment.guid}"
+                                                            },
+                                                            'app' => {
+                                                              'href' => "#{link_prefix}/v3/apps/#{app_model.guid}"
+                                                            },
+                                                            'cancel' => {
+                                                              'href' => "#{link_prefix}/v3/deployments/#{deployment.guid}/actions/cancel",
+                                                              'method' => 'POST'
+                                                            }
+                                                          }
+                                                        })
+        end
+      end
+
+      context 'when strategy "canary" is provided' do
+        let(:strategy) { 'canary' }
+        let(:user) { make_developer_for_space(space) }
+
+        it 'creates a deployment with strategy "canary" when "strategy":"canary" is provided' do
+          post '/v3/deployments', create_request.to_json, user_header
+          expect(last_response.status).to eq(201), last_response.body
+
+          deployment = VCAP::CloudController::DeploymentModel.last
+
+          expect(parsed_response).to be_a_response_like({
+                                                          'guid' => deployment.guid,
+                                                          'status' => {
+                                                            'value' => VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
+                                                            'reason' => VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON,
+                                                            'details' => {
+                                                              'last_successful_healthcheck' => iso8601,
+                                                              'last_status_change' => iso8601
+                                                            }
+                                                          },
+                                                          'strategy' => 'canary',
                                                           'droplet' => {
                                                             'guid' => droplet.guid
                                                           },
@@ -1054,6 +1116,18 @@ RSpec.describe 'Deployments' do
                                                                status_reason: VCAP::CloudController::DeploymentModel::SUPERSEDED_STATUS_REASON)
       end
 
+
+      let!(:deployment6) do
+        VCAP::CloudController::DeploymentModelTestFactory.make(app: app5, droplet: droplet5,
+                                                               previous_droplet: droplet5,
+                                                               strategy: 'canary',
+                                                               status_value: VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
+                                                               state: VCAP::CloudController::DeploymentModel::DEPLOYING_STATE,
+                                                               status_reason: VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON)
+      end
+
+      # TODO add pause states and any other canary related states
+
       def json_for_deployment(deployment, app_model, droplet, status_value, status_reason, cancel_link=true)
         {
           guid: deployment.guid,
@@ -1065,7 +1139,7 @@ RSpec.describe 'Deployments' do
               last_status_change: iso8601
             }
           },
-          strategy: 'rolling',
+          strategy: deployment.strategy,
           droplet: {
             guid: droplet.guid
           },
@@ -1116,7 +1190,7 @@ RSpec.describe 'Deployments' do
         parsed_response = Oj.load(last_response.body)
         expect(parsed_response).to match_json_response({
                                                          pagination: {
-                                                           total_results: 5,
+                                                           total_results: 6,
                                                            total_pages: 3,
                                                            first: {
                                                              href: "#{link_prefix}/v3/deployments?page=1&per_page=2"
@@ -1249,6 +1323,9 @@ RSpec.describe 'Deployments' do
               response_objects: [
                 json_for_deployment(deployment, app_model, droplet,
                                     VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
+                                    VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON),
+                json_for_deployment(deployment6, app5, droplet5,
+                                    VCAP::CloudController::DeploymentModel::ACTIVE_STATUS_VALUE,
                                     VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON)
               ]
             )
@@ -1264,7 +1341,7 @@ RSpec.describe 'Deployments' do
           context 'pagination' do
             let(:pagination_hsh) do
               {
-                total_results: 1,
+                total_results: 2,
                 total_pages: 1,
                 first: { href: "#{link_prefix}#{url}?page=1&per_page=50&#{query.gsub(',', '%2C')}" },
                 last: { href: "#{link_prefix}#{url}?page=1&per_page=50&#{query.gsub(',', '%2C')}" },
@@ -1463,6 +1540,83 @@ RSpec.describe 'Deployments' do
         deployment.reload
         expect(deployment.status_value).to eq(VCAP::CloudController::DeploymentModel::FINALIZED_STATUS_VALUE)
         expect(deployment.status_reason).to eq(VCAP::CloudController::DeploymentModel::CANCELED_STATUS_REASON)
+      end
+    end
+  end
+
+
+  describe 'POST /v3/deployments/:guid/actions/continue' do
+    let(:state) {  }
+    let(:deployment) do
+      VCAP::CloudController::DeploymentModelTestFactory.make(
+        app: app_model,
+        droplet: droplet,
+        state: state,
+      )
+    end
+
+    context 'when the deployment is in paused state' do
+      let(:user) { make_developer_for_space(space) }
+      let(:state) { VCAP::CloudController::DeploymentModel::PAUSED_STATE }
+
+      it 'transitions the deployment from paused to deploying' do
+        post "/v3/deployments/#{deployment.guid}/actions/continue", {}.to_json, user_header
+        expect(last_response.status).to eq(200), last_response.body
+        expect(last_response.body).to be_empty
+
+        deployment.reload
+        expect(deployment.state).to eq(VCAP::CloudController::DeploymentModel::DEPLOYING_STATE)
+        expect(deployment.status_reason).to eq(VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON)
+      end
+    end
+
+    context 'when the deployment is in a prepaused state' do
+      let(:user) { make_developer_for_space(space) }
+      let(:state) { VCAP::CloudController::DeploymentModel::PREPAUSED_STATE }
+
+      it 'returns 422 with an error' do
+        post "/v3/deployments/#{deployment.guid}/actions/continue", {}.to_json, user_header
+        expect(last_response.status).to eq(422), last_response.body
+      end
+    end
+
+    # TODO how much do we want to test here ?
+    #
+    # context 'when the deployment is not a canary' do
+    #   let(:state) { VCAP::CloudController::DeploymentModel::PREPAUSED_STATE }
+
+    # end
+    # context 'when the deployment is not in a state where it will never pause' do
+    #   let(:state) { VCAP::CloudController::DeploymentModel::DEPLOYING_STATE }
+    # end
+
+    # context 'when the deployment is superseeded' do
+    # end
+
+    # todo: understand this
+    context 'with a running deployment' do
+      let(:state) { VCAP::CloudController::DeploymentModel::PAUSED_STATE }
+      let(:api_call) { ->(user_headers) { post "/v3/deployments/#{deployment.guid}/actions/continue", {}.to_json, user_headers } }
+      let(:expected_codes_and_responses) do
+        h = Hash.new(code: 404)
+        h['admin'] = h['space_developer'] = h['space_supporter'] = { code: 200 }
+        h
+      end
+
+      it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
+
+      context 'when organization is suspended' do
+        let(:expected_codes_and_responses) do
+          h = super()
+          %w[space_developer space_supporter].each { |r| h[r] = { code: 404 } }
+          h
+        end
+
+        before do
+          org.update(status: VCAP::CloudController::Organization::SUSPENDED)
+        end
+
+        it_behaves_like 'permissions for single object endpoint', ALL_PERMISSIONS
       end
     end
   end

--- a/spec/request/deployments_spec.rb
+++ b/spec/request/deployments_spec.rb
@@ -1158,8 +1158,6 @@ RSpec.describe 'Deployments' do
                                                                status_reason: VCAP::CloudController::DeploymentModel::DEPLOYING_STATUS_REASON)
       end
 
-      # TODO: add pause states and any other canary related states
-
       def json_for_deployment(deployment, app_model, droplet, status_value, status_reason, cancel_link=true)
         {
           guid: deployment.guid,
@@ -1650,18 +1648,7 @@ RSpec.describe 'Deployments' do
         expect(last_response.status).to eq(422), last_response.body
       end
     end
-    # TODO: how much do we want to test here ?
-    #
-    # context 'when the deployment is not a canary' do
-    # note from Seth: I don't think we need this case, what if we add the `pause` action :)
-    #   let(:state) { VCAP::CloudController::DeploymentModel::PREPAUSED_STATE }
 
-    # end
-
-    # context 'when the deployment is superseeded' do
-    # end
-
-    # TODO: understand this
     context 'with a running deployment' do
       let(:state) { VCAP::CloudController::DeploymentModel::PAUSED_STATE }
       let(:api_call) { ->(user_headers) { post "/v3/deployments/#{deployment.guid}/actions/continue", {}.to_json, user_headers } }

--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -195,6 +195,7 @@ module VCAP::CloudController
     droplet { DropletModel.make(app:) }
     deploying_web_process { ProcessModel.make(app: app, type: "web-deployment-#{Sham.guid}") }
     original_web_process_instance_count { 1 }
+    strategy { 'rolling' }
   end
 
   DeploymentProcessModel.blueprint do

--- a/spec/unit/actions/deployment_continue_spec.rb
+++ b/spec/unit/actions/deployment_continue_spec.rb
@@ -75,7 +75,6 @@ module VCAP::CloudController
         end
       end
 
-      # #Q: Do we want this to be idempotent on continuing deploying deploys? If we do, we need to distinguish from the test above..
       context 'when the deployment is in the DEPLOYING state' do
         let(:state) { DeploymentModel::DEPLOYING_STATE }
         let(:status_value) { DeploymentModel::ACTIVE_STATUS_VALUE }

--- a/spec/unit/actions/deployment_continue_spec.rb
+++ b/spec/unit/actions/deployment_continue_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+require 'actions/deployment_continue'
+require 'cloud_controller/deployment_updater/dispatcher'
+
+module VCAP::CloudController
+  RSpec.describe DeploymentContinue do
+    let(:space) { Space.make }
+    let(:instance_count) { 6 }
+    let(:app) { AppModel.make }
+    let(:droplet) { DropletModel.make(app: app, process_types: { 'web' => 'the net' }) }
+    let(:original_web_process) { ProcessModelFactory.make(space: space, instances: 1, state: 'STARTED', app: app) }
+    let(:deploying_web_process) { ProcessModelFactory.make(space: space, instances: instance_count, state: 'STARTED', app: app, type: 'web-deployment-deployment-guid') }
+    let(:status_reason) { nil }
+    let!(:deployment) do
+      VCAP::CloudController::DeploymentModel.make(
+        state: state,
+        status_value: status_value,
+        status_reason: status_reason,
+        droplet: droplet,
+        app: original_web_process.app,
+        deploying_web_process: deploying_web_process,
+      )
+    end
+
+    let(:user_audit_info) { UserAuditInfo.new(user_guid: '1234', user_email: 'eric@example.com', user_name: 'eric') }
+
+    describe '.continue' do
+      context 'when the deployment is in the PAUSED state' do
+        let(:state) { DeploymentModel::PAUSED_STATE }
+        let(:status_value) { DeploymentModel::ACTIVE_STATUS_VALUE }
+        let(:status_reason) { DeploymentModel::DEPLOYING_STATUS_REASON }
+
+        it 'sets the deployments status to DEPLOYING' do
+          expect(deployment.state).not_to eq(DeploymentModel::DEPLOYING_STATE)
+
+          DeploymentContinue.continue(deployment:, user_audit_info:)
+          deployment.reload
+
+          expect(deployment.state).to eq(DeploymentModel::DEPLOYING_STATE)
+          expect(deployment.status_value).to eq(DeploymentModel::ACTIVE_STATUS_VALUE)
+          expect(deployment.status_reason).to eq(DeploymentModel::DEPLOYING_STATUS_REASON)
+        end
+
+        it 'records an audit event for the continue deployment' do
+          DeploymentContinue.continue(deployment:, user_audit_info:)
+
+          event = VCAP::CloudController::Event.find(type: 'audit.app.deployment.continue')
+          expect(event).not_to be_nil
+          expect(event.actor).to eq('1234')
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq('eric@example.com')
+          expect(event.actor_username).to eq('eric')
+          expect(event.actee).to eq(app.guid)
+          expect(event.actee_type).to eq('app')
+          expect(event.actee_name).to eq(app.name)
+          expect(event.timestamp).to be
+          expect(event.space_guid).to eq(app.space_guid)
+          expect(event.organization_guid).to eq(app.space.organization.guid)
+          expect(event.metadata).to eq({
+                                         'droplet_guid' => droplet.guid,
+                                         'deployment_guid' => deployment.guid
+                                       })
+        end
+      end
+
+      context 'when the deployment is in the PREPAUSED state' do
+        let(:state) { DeploymentModel::PREPAUSED_STATE }
+        let(:status_value) { DeploymentModel::ACTIVE_STATUS_VALUE }
+        let(:status_reason) { DeploymentModel::DEPLOYING_STATUS_REASON }
+
+        it 'raises an error' do
+          expect do
+            DeploymentContinue.continue(deployment:, user_audit_info:)
+          end.to raise_error(DeploymentContinue::InvalidStatus, 'Cannot continue a deployment with status: ACTIVE and reason: DEPLOYING')
+        end
+      end
+
+      ##Q: Do we want this to be idempotent on continuing deploying deploys? If we do, we need to distinguish from the test above..
+      context 'when the deployment is in the DEPLOYING state' do
+        let(:state) { DeploymentModel::DEPLOYING_STATE }
+        let(:status_value) { DeploymentModel::ACTIVE_STATUS_VALUE }
+        let(:status_reason) { DeploymentModel::DEPLOYING_STATUS_REASON }
+
+        it 'raises an error' do
+          expect do
+            DeploymentContinue.continue(deployment:, user_audit_info:)
+          end.to raise_error(DeploymentContinue::InvalidStatus, 'Cannot continue a deployment with status: ACTIVE and reason: DEPLOYING')
+        end
+      end
+
+      context 'when the deployment is in the DEPLOYED state' do
+        let(:state) { DeploymentModel::DEPLOYED_STATE }
+        let(:status_value) { DeploymentModel::FINALIZED_STATUS_VALUE }
+        let(:status_reason) { DeploymentModel::DEPLOYED_STATUS_REASON }
+
+        it 'raises an error' do
+          expect do
+            DeploymentContinue.continue(deployment:, user_audit_info:)
+          end.to raise_error(DeploymentContinue::InvalidStatus, 'Cannot continue a deployment with status: FINALIZED and reason: DEPLOYED')
+        end
+      end
+
+      context 'when the deployment is in the CANCELED state' do
+        let(:state) { DeploymentModel::CANCELED_STATE }
+        let(:status_value) { DeploymentModel::FINALIZED_STATUS_VALUE }
+        let(:status_reason) { DeploymentModel::CANCELED_STATUS_REASON }
+
+        it 'raises an error' do
+          expect do
+            DeploymentContinue.continue(deployment:, user_audit_info:)
+          end.to raise_error(DeploymentContinue::InvalidStatus, 'Cannot continue a deployment with status: FINALIZED and reason: CANCELED')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/actions/deployment_continue_spec.rb
+++ b/spec/unit/actions/deployment_continue_spec.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
         status_reason: status_reason,
         droplet: droplet,
         app: original_web_process.app,
-        deploying_web_process: deploying_web_process,
+        deploying_web_process: deploying_web_process
       )
     end
 
@@ -75,7 +75,7 @@ module VCAP::CloudController
         end
       end
 
-      ##Q: Do we want this to be idempotent on continuing deploying deploys? If we do, we need to distinguish from the test above..
+      # #Q: Do we want this to be idempotent on continuing deploying deploys? If we do, we need to distinguish from the test above..
       context 'when the deployment is in the DEPLOYING state' do
         let(:state) { DeploymentModel::DEPLOYING_STATE }
         let(:status_value) { DeploymentModel::ACTIVE_STATUS_VALUE }

--- a/spec/unit/actions/deployment_create_spec.rb
+++ b/spec/unit/actions/deployment_create_spec.rb
@@ -151,7 +151,8 @@ module VCAP::CloudController
                                            'deployment_guid' => deployment.guid,
                                            'type' => nil,
                                            'revision_guid' => RevisionModel.last.guid,
-                                           'request' => message.audit_hash
+                                           'request' => message.audit_hash,
+                                           'strategy' => 'rolling'
                                          })
           end
 
@@ -318,7 +319,8 @@ module VCAP::CloudController
                                            'deployment_guid' => deployment.guid,
                                            'type' => nil,
                                            'revision_guid' => app.latest_revision.guid,
-                                           'request' => message.audit_hash
+                                           'request' => message.audit_hash,
+                                           'strategy' => 'rolling'
                                          })
           end
 
@@ -375,7 +377,8 @@ module VCAP::CloudController
                                              'deployment_guid' => deployment.guid,
                                              'type' => nil,
                                              'revision_guid' => app_without_current_droplet.latest_revision.guid,
-                                             'request' => message.audit_hash
+                                             'request' => message.audit_hash,
+                                             'strategy' => 'rolling'
                                            })
             end
           end
@@ -541,7 +544,8 @@ module VCAP::CloudController
                                              'deployment_guid' => deployment.guid,
                                              'type' => nil,
                                              'revision_guid' => app.latest_revision.guid,
-                                             'request' => message.audit_hash
+                                             'request' => message.audit_hash,
+                                             'strategy' => 'rolling'
                                            })
             end
 
@@ -711,7 +715,8 @@ module VCAP::CloudController
                                              'deployment_guid' => deployment.guid,
                                              'type' => nil,
                                              'revision_guid' => app.latest_revision.guid,
-                                             'request' => message.audit_hash
+                                             'request' => message.audit_hash,
+                                             'strategy' => 'rolling'
                                            })
             end
 
@@ -870,7 +875,8 @@ module VCAP::CloudController
                                          'deployment_guid' => deployment.guid,
                                          'type' => 'rollback',
                                          'revision_guid' => RevisionModel.last.guid,
-                                         'request' => message.audit_hash
+                                         'request' => message.audit_hash,
+                                         'strategy' => 'rolling'
                                        })
         end
 
@@ -970,7 +976,8 @@ module VCAP::CloudController
                                            'deployment_guid' => deployment.guid,
                                            'type' => 'rollback',
                                            'revision_guid' => revision.guid,
-                                           'request' => message.audit_hash
+                                           'request' => message.audit_hash,
+                                           'strategy' => 'rolling'
                                          })
           end
 

--- a/spec/unit/actions/deployment_create_spec.rb
+++ b/spec/unit/actions/deployment_create_spec.rb
@@ -1015,7 +1015,7 @@ module VCAP::CloudController
             expect do
               deployment = DeploymentCreate.create(app:, message:, user_audit_info:)
             end.to change(DeploymentModel, :count).by(1)
-  
+
             expect(deployment.strategy).to eq(DeploymentModel::ROLLING_STRATEGY)
           end
         end
@@ -1029,7 +1029,7 @@ module VCAP::CloudController
             expect do
               deployment = DeploymentCreate.create(app:, message:, user_audit_info:)
             end.to change(DeploymentModel, :count).by(1)
-  
+
             expect(deployment.strategy).to eq(DeploymentModel::CANARY_STRATEGY)
           end
 
@@ -1046,7 +1046,7 @@ module VCAP::CloudController
             expect do
               deployment = DeploymentCreate.create(app:, message:, user_audit_info:)
             end.to change(DeploymentModel, :count).by(1)
-  
+
             expect(deployment.state).to eq(DeploymentModel::PREPAUSED_STATE)
           end
         end
@@ -1056,15 +1056,15 @@ module VCAP::CloudController
 
           it 'defaults to the rolling strategy' do
             deployment = nil
-            
+
             expect do
               deployment = DeploymentCreate.create(app:, message:, user_audit_info:)
             end.to change(DeploymentModel, :count).by(1)
-  
+
             expect(deployment.strategy).to eq(DeploymentModel::ROLLING_STRATEGY)
           end
         end
-      end 
+      end
     end
   end
 end

--- a/spec/unit/jobs/runtime/prune_completed_deployments_spec.rb
+++ b/spec/unit/jobs/runtime/prune_completed_deployments_spec.rb
@@ -58,6 +58,34 @@ module VCAP::CloudController
           expect(DeploymentModel.map(&:id)).to match_array((1..50).to_a)
         end
 
+        it 'does NOT delete any prepaused deployments over the limit' do
+          expect(DeploymentModel.count).to eq(0)
+
+          total = 50
+          (1..50).each do |i|
+            DeploymentModel.make(id: i, state: DeploymentModel::PREPAUSED_STATE, app: app, created_at: Time.now - total + i)
+          end
+
+          job.perform
+
+          expect(DeploymentModel.count).to eq(50)
+          expect(DeploymentModel.map(&:id)).to match_array((1..50).to_a)
+        end
+
+        it 'does NOT delete any paused deployments over the limit' do
+          expect(DeploymentModel.count).to eq(0)
+
+          total = 50
+          (1..50).each do |i|
+            DeploymentModel.make(id: i, state: DeploymentModel::PAUSED_STATE, app: app, created_at: Time.now - total + i)
+          end
+
+          job.perform
+
+          expect(DeploymentModel.count).to eq(50)
+          expect(DeploymentModel.map(&:id)).to match_array((1..50).to_a)
+        end
+
         it 'does NOT delete any canceling deployments over the limit' do
           expect(DeploymentModel.count).to eq(0)
 

--- a/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
@@ -509,8 +509,8 @@ module VCAP::CloudController
     end
 
     describe '#canary' do
-      let(:state) { DeploymentModel::PREPAUSED_STATE}
-      let(:current_deploying_instances) { 1}
+      let(:state) { DeploymentModel::PREPAUSED_STATE }
+      let(:current_deploying_instances) { 1 }
 
       it 'locks the deployment' do
         allow(deployment).to receive(:lock!).and_call_original
@@ -521,7 +521,7 @@ module VCAP::CloudController
       context 'when the canary instance starts succesfully' do
         let(:all_instances_results) do
           {
-            0 => { state: 'RUNNING', uptime: 50, since: 2, routable: true },
+            0 => { state: 'RUNNING', uptime: 50, since: 2, routable: true }
           }
         end
 
@@ -541,18 +541,18 @@ module VCAP::CloudController
         end
 
         it 'does not alter the existing web processes' do
-          # todo verify this actually fails
+          # TODO: verify this actually fails
           expect do
             subject.canary
-          end.not_to change {
-              web_process.reload.instances
-          }
+          end.not_to(change do
+            web_process.reload.instances
+          end)
         end
 
         it 'logs the canary run' do
           subject.canary
           expect(logger).to have_received(:info).with(
-            "ran-canarying-deployment-for-#{deployment.guid}",
+            "ran-canarying-deployment-for-#{deployment.guid}"
           )
         end
       end
@@ -560,22 +560,22 @@ module VCAP::CloudController
       context 'while the canary instance is still starting' do
         let(:all_instances_results) do
           {
-            0 => { state: 'STARTING', uptime: 50, since: 2, routable: true },
+            0 => { state: 'STARTING', uptime: 50, since: 2, routable: true }
           }
         end
 
         it 'skips the deployment update' do
-            subject.canary
-            expect(deployment.state).to eq(DeploymentModel::PREPAUSED_STATE)
-            expect(deployment.status_value).to eq(DeploymentModel::ACTIVE_STATUS_VALUE)
-            expect(deployment.status_reason).to eq(DeploymentModel::DEPLOYING_STATUS_REASON)
+          subject.canary
+          expect(deployment.state).to eq(DeploymentModel::PREPAUSED_STATE)
+          expect(deployment.status_value).to eq(DeploymentModel::ACTIVE_STATUS_VALUE)
+          expect(deployment.status_reason).to eq(DeploymentModel::DEPLOYING_STATUS_REASON)
         end
       end
 
       context 'when the canary is not routable routable' do
         let(:all_instances_results) do
           {
-            0 => { state: 'RUNNING', uptime: 50, since: 2, routable: false },
+            0 => { state: 'RUNNING', uptime: 50, since: 2, routable: false }
           }
         end
 
@@ -590,7 +590,7 @@ module VCAP::CloudController
       context 'when the canary instance is failing' do
         let(:all_instances_results) do
           {
-            0 => { state: 'FAILING', uptime: 50, since: 2, routable: true },
+            0 => { state: 'FAILING', uptime: 50, since: 2, routable: true }
           }
         end
 
@@ -619,7 +619,7 @@ module VCAP::CloudController
 
         it 'logs the error' do
           subject.canary
-          
+
           expect(logger).to have_received(:error).with(
             'error-canarying-deployment',
             deployment_guid: deployment.guid,
@@ -635,11 +635,11 @@ module VCAP::CloudController
           end.not_to raise_error
         end
 
-        # prepaused canary -> canary = OK 
+        # prepaused canary -> canary = OK
         # paused canary -> canary = OK
         # rolling -> canary = Potentially 3 version of the app running at once
         # post pause canary -> canary = Potentially 3 version of the app running at once
-        # prepaused canary -> rolling = OK 
+        # prepaused canary -> rolling = OK
         # paused canary -> rolling = OK
 
         # handle superseed case from paused canary to canary deployment

--- a/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
@@ -541,7 +541,6 @@ module VCAP::CloudController
         end
 
         it 'does not alter the existing web processes' do
-          # TODO: verify this actually fails
           expect do
             subject.canary
           end.not_to(change do
@@ -641,17 +640,6 @@ module VCAP::CloudController
             subject.scale
           end.not_to raise_error
         end
-
-        # prepaused canary -> canary = OK
-        # paused canary -> canary = OK
-        # rolling -> canary = Potentially 3 version of the app running at once
-        # post pause canary -> canary = Potentially 3 version of the app running at once
-        # prepaused canary -> rolling = OK
-        # paused canary -> rolling = OK
-
-        # handle superseed case from paused canary to canary deployment
-        # handle superseed case from rolling deployment to canary deployment
-        # handle supersede case from canceling deployment to canary deployment
       end
 
       context 'when there is an interim deployment that has been SUPERSEDED (CANCELED)' do

--- a/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
@@ -549,6 +549,13 @@ module VCAP::CloudController
           end)
         end
 
+        it 'logs the canary is paused' do
+          subject.canary
+          expect(logger).to have_received(:info).with(
+            "paused-canary-deployment-for-#{deployment.guid}"
+          )
+        end
+
         it 'logs the canary run' do
           subject.canary
           expect(logger).to have_received(:info).with(

--- a/spec/unit/messages/deployment_create_message_spec.rb
+++ b/spec/unit/messages/deployment_create_message_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  RSpec.describe DeploymentCreateMessage do
+    let(:body) do
+      {
+        'strategy' => 'rolling',
+          'relationships' => {
+            'app' => {
+              'data' => {
+                'guid' => '123' 
+              }
+            }
+          }
+      }
+    end
+
+    describe 'validations' do
+      describe 'strategy' do
+        it 'can be rolling' do
+          body['strategy'] = 'rolling'
+          message = DeploymentCreateMessage.new(body)
+          expect(message).to be_valid
+        end
+
+        it 'can be canary' do
+          body['strategy'] = 'canary'
+          message = DeploymentCreateMessage.new(body)
+          expect(message).to be_valid
+        end
+
+        it 'is valid with nil strategy' do
+          body['strategy'] = nil
+          message = DeploymentCreateMessage.new(body)
+          expect(message).to be_valid
+        end
+
+        it 'is not a valid strategy' do
+          body['strategy'] = 'potato'
+          message = DeploymentCreateMessage.new(body)
+          expect(message).not_to be_valid
+          expect(message.errors.full_messages).to include("Strategy 'potato' is not a supported deployment strategy")
+        end
+      end
+
+      describe 'metadata' do
+        context 'when the annotations params are valid' do
+          let(:params) do
+            {
+              'metadata' => {
+                'annotations' => {
+                  'potato' => 'mashed'
+                }
+              }
+            }
+          end
+
+          it 'is valid and correctly parses the annotations' do
+            message = DeploymentCreateMessage.new(params)
+            expect(message).to be_valid
+            expect(message.annotations).to include(potato: 'mashed')
+          end
+        end
+
+        context 'when the annotations params are not valid' do
+          let(:params) do
+            {
+              'metadata' => {
+                'annotations' => 'timmyd'
+              }
+            }
+          end
+
+          it 'is invalid' do
+            message = DeploymentCreateMessage.new(params)
+            expect(message).not_to be_valid
+            expect(message.errors_on(:metadata)).to include('\'annotations\' is not an object')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/messages/deployment_create_message_spec.rb
+++ b/spec/unit/messages/deployment_create_message_spec.rb
@@ -5,13 +5,13 @@ module VCAP::CloudController
     let(:body) do
       {
         'strategy' => 'rolling',
-          'relationships' => {
-            'app' => {
-              'data' => {
-                'guid' => '123' 
-              }
+        'relationships' => {
+          'app' => {
+            'data' => {
+              'guid' => '123'
             }
           }
+        }
       }
     end
 

--- a/spec/unit/models/runtime/deployment_model_spec.rb
+++ b/spec/unit/models/runtime/deployment_model_spec.rb
@@ -70,6 +70,7 @@ module VCAP::CloudController
 
         expect(deployment.deploying?).to be(true)
       end
+
       it 'returns false if the deployment has been deployed' do
         deployment.state = 'DEPLOYED'
 
@@ -140,13 +141,13 @@ module VCAP::CloudController
         expect(deployment.continuable?).to be(false)
       end
 
-      it 'returns false if the deployment is any other state' do
+      it 'returns false if the deployment is DEPLOYING state' do
         deployment.state = DeploymentModel::DEPLOYING_STATE
 
         expect(deployment.continuable?).to be(false)
       end
 
-      it 'returns false if the deployment is any other state' do
+      it 'returns false if the deployment is DEPLOYED state' do
         deployment.state = DeploymentModel::DEPLOYED_STATE
 
         expect(deployment.continuable?).to be(false)
@@ -164,7 +165,6 @@ module VCAP::CloudController
         expect(deployment.continuable?).to be(false)
       end
     end
-
 
     describe '#status_updated_at' do
       let(:deployment) do

--- a/spec/unit/models/runtime/deployment_model_spec.rb
+++ b/spec/unit/models/runtime/deployment_model_spec.rb
@@ -104,6 +104,45 @@ module VCAP::CloudController
       end
     end
 
+    describe '#continuable?' do
+      it 'returns true if the deployment is PAUSED' do
+        deployment.state = DeploymentModel::PAUSED_STATE
+
+        expect(deployment.continuable?).to be(true)
+      end
+
+      it 'returns false if the deployment is PREPAUSED' do
+        deployment.state = DeploymentModel::PREPAUSED_STATE
+
+        expect(deployment.continuable?).to be(false)
+      end
+
+      it 'returns false if the deployment is any other state' do
+        deployment.state = DeploymentModel::DEPLOYING_STATE
+
+        expect(deployment.continuable?).to be(false)
+      end
+
+      it 'returns false if the deployment is any other state' do
+        deployment.state = DeploymentModel::DEPLOYED_STATE
+
+        expect(deployment.continuable?).to be(false)
+      end
+
+      it 'returns true if the deployment is CANCELING' do
+        deployment.state = DeploymentModel::CANCELING_STATE
+
+        expect(deployment.continuable?).to be(false)
+      end
+
+      it 'returns false if the deployment is CANCELED' do
+        deployment.state = DeploymentModel::CANCELED_STATE
+
+        expect(deployment.continuable?).to be(false)
+      end
+    end
+
+
     describe '#status_updated_at' do
       let(:deployment) do
         DeploymentModel.make(

--- a/spec/unit/models/runtime/deployment_model_spec.rb
+++ b/spec/unit/models/runtime/deployment_model_spec.rb
@@ -59,6 +59,17 @@ module VCAP::CloudController
         expect(deployment.deploying?).to be(true)
       end
 
+      it 'returns true if the deployment is PAUSED' do
+        deployment.state = DeploymentModel::PAUSED_STATE
+
+        expect(deployment.deploying?).to be(true)
+      end
+
+      it 'returns true if the deployment is PREPAUSED' do
+        deployment.state = DeploymentModel::PREPAUSED_STATE
+
+        expect(deployment.deploying?).to be(true)
+      end
       it 'returns false if the deployment has been deployed' do
         deployment.state = 'DEPLOYED'
 
@@ -81,6 +92,18 @@ module VCAP::CloudController
     describe '#cancelable?' do
       it 'returns true if the deployment is DEPLOYING' do
         deployment.state = DeploymentModel::DEPLOYING_STATE
+
+        expect(deployment.cancelable?).to be(true)
+      end
+
+      it 'returns true if the deployment is PAUSED' do
+        deployment.state = DeploymentModel::PAUSED_STATE
+
+        expect(deployment.cancelable?).to be(true)
+      end
+
+      it 'returns true if the deployment is PREPAUSED' do
+        deployment.state = DeploymentModel::PREPAUSED_STATE
 
         expect(deployment.cancelable?).to be(true)
       end

--- a/spec/unit/models/runtime/deployment_model_spec.rb
+++ b/spec/unit/models/runtime/deployment_model_spec.rb
@@ -166,6 +166,27 @@ module VCAP::CloudController
       end
     end
 
+    describe 'PROGRESSING_STATES' do
+      it 'contains progressing forward states' do
+        expect(DeploymentModel::PROGRESSING_STATES).to include(
+          DeploymentModel::DEPLOYING_STATE,
+          DeploymentModel::PAUSED_STATE,
+          DeploymentModel::PREPAUSED_STATE
+        )
+      end
+    end
+
+    describe 'ACTIVE_STATES' do
+      it 'contains active states' do
+        expect(DeploymentModel::PROGRESSING_STATES).to include(
+          DeploymentModel::DEPLOYING_STATE,
+          DeploymentModel::PAUSED_STATE,
+          DeploymentModel::PREPAUSED_STATE,
+          DeploymentModel::CANCELING_STATE
+        )
+      end
+    end
+
     describe '#status_updated_at' do
       let(:deployment) do
         DeploymentModel.make(

--- a/spec/unit/models/runtime/deployment_model_spec.rb
+++ b/spec/unit/models/runtime/deployment_model_spec.rb
@@ -178,7 +178,7 @@ module VCAP::CloudController
 
     describe 'ACTIVE_STATES' do
       it 'contains active states' do
-        expect(DeploymentModel::PROGRESSING_STATES).to include(
+        expect(DeploymentModel::ACTIVE_STATES).to include(
           DeploymentModel::DEPLOYING_STATE,
           DeploymentModel::PAUSED_STATE,
           DeploymentModel::PREPAUSED_STATE,

--- a/spec/unit/repositories/deployment_event_repository_spec.rb
+++ b/spec/unit/repositories/deployment_event_repository_spec.rb
@@ -103,7 +103,7 @@ module VCAP::CloudController
 
         it 'creates a new audit.app.deployment.continue event' do
           event = DeploymentEventRepository.record_continue(deployment, droplet, user_audit_info, app.name,
-                                                          app.space.guid, app.space.organization.guid)
+                                                            app.space.guid, app.space.organization.guid)
           event.reload
 
           expect(event.type).to eq('audit.app.deployment.continue')

--- a/spec/unit/repositories/deployment_event_repository_spec.rb
+++ b/spec/unit/repositories/deployment_event_repository_spec.rb
@@ -7,7 +7,7 @@ module VCAP::CloudController
       let(:app) { AppModel.make(name: 'popsicle') }
       let(:user) { User.make }
       let(:droplet) { DropletModel.make }
-      let(:deployment) { DeploymentModel.make(app_guid: app.guid) }
+      let(:deployment) { DeploymentModel.make(app_guid: app.guid, strategy: strategy) }
       let(:email) { 'user-email' }
       let(:user_name) { 'user-name' }
       let(:user_audit_info) { UserAuditInfo.new(user_email: email, user_name: user_name, user_guid: user.guid) }
@@ -15,10 +15,11 @@ module VCAP::CloudController
         { 'foo' => 'bar ' }
       end
       let(:type) { 'rollback' }
+      let(:strategy) { 'canary' }
 
       describe '#record_create_deployment' do
         context 'when a droplet is associated with the deployment' do
-          let(:deployment) { DeploymentModel.make(app_guid: app.guid, droplet_guid: droplet.guid) }
+          let(:deployment) { DeploymentModel.make(app_guid: app.guid, droplet_guid: droplet.guid, strategy: strategy) }
 
           it 'creates a new audit.app.deployment.create event' do
             event = DeploymentEventRepository.record_create(deployment, droplet, user_audit_info, app.name,
@@ -40,6 +41,7 @@ module VCAP::CloudController
             expect(metadata['droplet_guid']).to eq(droplet.guid)
             expect(metadata['request']).to eq(params)
             expect(metadata['type']).to eq(type)
+            expect(metadata['strategy']).to eq(strategy)
           end
         end
 
@@ -79,6 +81,32 @@ module VCAP::CloudController
           event.reload
 
           expect(event.type).to eq('audit.app.deployment.cancel')
+          expect(event.actor).to eq(user.guid)
+          expect(event.actor_type).to eq('user')
+          expect(event.actor_name).to eq(email)
+          expect(event.actor_username).to eq(user_name)
+          expect(event.actee).to eq(deployment.app_guid)
+          expect(event.actee_type).to eq('app')
+          expect(event.actee_name).to eq('popsicle')
+          expect(event.timestamp).not_to be_nil
+          expect(event.space_guid).to eq(app.space.guid)
+          expect(event.organization_guid).to eq(app.organization.guid)
+
+          metadata = event.metadata
+          expect(metadata['deployment_guid']).to eq(deployment.guid)
+          expect(metadata['droplet_guid']).to eq(droplet.guid)
+        end
+      end
+
+      describe 'record_continue_deployment' do
+        let(:deployment) { DeploymentModel.make(app_guid: app.guid) }
+
+        it 'creates a new audit.app.deployment.continue event' do
+          event = DeploymentEventRepository.record_continue(deployment, droplet, user_audit_info, app.name,
+                                                          app.space.guid, app.space.organization.guid)
+          event.reload
+
+          expect(event.type).to eq('audit.app.deployment.continue')
           expect(event.actor).to eq(user.guid)
           expect(event.actor_type).to eq('user')
           expect(event.actor_name).to eq(email)

--- a/spec/unit/repositories/event_types_spec.rb
+++ b/spec/unit/repositories/event_types_spec.rb
@@ -58,6 +58,7 @@ module VCAP::CloudController
            'audit.app.revision.environment_variables.show',
            'audit.app.deployment.cancel',
            'audit.app.deployment.create',
+           'audit.app.deployment.continue',
            'audit.app.copy-bits',
            'audit.app.upload-bits',
            'audit.app.apply_manifest',


### PR DESCRIPTION
New Baras test - https://github.com/cloudfoundry/capi-bara-tests/pull/101

Closes #3837 

## Trying it 
```
cf push dora -i 2

# Trigger a canary deploy
deployment_guid=$(cf curl -X POST /v3/deployments -d "{ \"strategy\": \"canary\", \"relationships\": { \"app\": { \"data\": { \"guid\": [\"$(cf app dora --guid)\"] } } } }" | jq -r .guid)

# Observe that a new canary web process starts
cf apps

# Observe the deployment is in state paused
cf curl  /v3/deployments/$deployment_guid | jq .status

# Continue the deployment
cf curl -X POST /v3/deployments/$deployment_guid/actions/continue

# Observe as the canary app is rolled out and old processes are removed
watch cf apps
```

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
