### PR TITLE
Add option to check for deprecated stacks in pre-start rake task

### DIFF
--- a/app/models/runtime/stack.rb
+++ b/app/models/runtime/stack.rb
@@ -100,6 +100,10 @@ module VCAP::CloudController
         @hash['stacks']
       end
 
+      def deprecated_stacks
+        @hash['deprecated_stacks']
+      end
+
       def default
         @hash['default']
       end
@@ -112,7 +116,10 @@ module VCAP::CloudController
             'description' => String,
             optional('build_rootfs_image') => String,
             optional('run_rootfs_image') => String
-          }]
+          }],
+          optional('deprecated_stacks') => [
+            String
+          ]
         }
       end
     end

--- a/config/stacks.yml
+++ b/config/stacks.yml
@@ -3,8 +3,4 @@ default: "cflinuxfs4"
 stacks:
   - name: "cflinuxfs4"
     description: "test cflinuxfs4 entry"
-
-
-
-
 deprecated_stacks: [ 'cflinuxfs3' ]

--- a/config/stacks.yml
+++ b/config/stacks.yml
@@ -3,3 +3,8 @@ default: "cflinuxfs4"
 stacks:
   - name: "cflinuxfs4"
     description: "test cflinuxfs4 entry"
+
+
+
+
+deprecated_stacks: [ 'cflinuxfs3' ]

--- a/lib/cloud_controller/check_stacks.rb
+++ b/lib/cloud_controller/check_stacks.rb
@@ -1,0 +1,19 @@
+require 'models/runtime/buildpack_lifecycle_data_model'
+require 'models/runtime/stack'
+
+module VCAP::CloudController
+  class CheckStacks
+    attr_reader :config
+
+    def initialize(config)
+      @config = config
+    end
+
+    def logger
+      @logger ||= Steno.logger('cc.install_buildpacks')
+    end
+
+    def validate_stacks
+    end
+  end
+end

--- a/lib/cloud_controller/config.rb
+++ b/lib/cloud_controller/config.rb
@@ -107,14 +107,7 @@ module VCAP::CloudController
     end
 
     def configure_components
-      Encryptor.db_encryption_key = get(:db_encryption_key)
-
-      if get(:database_encryption)
-        Encryptor.database_encryption_keys = get(:database_encryption)[:keys]
-        Encryptor.current_encryption_key_label = get(:database_encryption)[:current_key_label]
-        Encryptor.pbkdf2_hmac_iterations = get(:database_encryption)[:pbkdf2_hmac_iterations]
-      end
-
+      load_db_encryption_key
       dependency_locator = CloudController::DependencyLocator.instance
       dependency_locator.config = self
 
@@ -122,6 +115,16 @@ module VCAP::CloudController
 
       ProcessObserver.configure(dependency_locator.stagers, dependency_locator.runners)
       @schema_class.configure_components(self)
+    end
+
+    def load_db_encryption_key
+      Encryptor.db_encryption_key = get(:db_encryption_key)
+
+      return unless get(:database_encryption)
+
+      Encryptor.database_encryption_keys = get(:database_encryption)[:keys]
+      Encryptor.current_encryption_key_label = get(:database_encryption)[:current_key_label]
+      Encryptor.pbkdf2_hmac_iterations = get(:database_encryption)[:pbkdf2_hmac_iterations]
     end
 
     def get(*keys)

--- a/lib/tasks/stack_check.rake
+++ b/lib/tasks/stack_check.rake
@@ -1,23 +1,10 @@
 namespace :stacks do
   desc 'Check Installed Stacks'
   task stack_check: :environment do
-    VCAP::CloudController::Encryptor.db_encryption_key = RakeConfig.config.get(:db_encryption_key)
-    require 'models/runtime/buildpack_lifecycle_data_model'
-    require 'models/runtime/stack'
+    require 'cloud_controller/check_stacks'
 
-    deprecated_stack = 'cflinuxfs3'
-    stack_config = VCAP::CloudController::Stack::ConfigFile.new(RakeConfig.config.get(:stacks_file))
-    configured_stacks = stack_config.stacks
-    deprecated_stack_in_config = (configured_stacks.find { |stack| stack['name'] == deprecated_stack }).nil?
-
-    exit(0) if deprecated_stack_in_config
-
-    logger = Steno.logger('cc.stack')
-    VCAP::CloudController::DB.connect(RakeConfig.config.get(:db), logger)
-    deprecated_stack_in_db = VCAP::CloudController::Stack.first(name: deprecated_stack).present?
-    if deprecated_stack_in_db
-      logger.error('rake task \'stack_check\' failed, ' + deprecated_stack + ' is not supported')
-      exit(1)
+    BackgroundJobEnvironment.new(RakeConfig.config).setup_environment do
+      VCAP::CloudController::CheckStacks.new(RakeConfig.config).validate_stacks
     end
   end
 end

--- a/lib/tasks/stack_check.rake
+++ b/lib/tasks/stack_check.rake
@@ -1,4 +1,4 @@
-namespace :buildpacks do
+namespace :stacks do
   desc 'Check Installed Stacks'
   task stack_check: :environment do
     VCAP::CloudController::Encryptor.db_encryption_key = RakeConfig.config.get(:db_encryption_key)
@@ -7,12 +7,8 @@ namespace :buildpacks do
 
     deprecated_stack = 'cflinuxfs3'
     stack_config = VCAP::CloudController::Stack::ConfigFile.new(RakeConfig.config.get(:stacks_file))
-    p stack_config.stacks
     configured_stacks = stack_config.stacks
     deprecated_stack_in_config = (configured_stacks.find { |stack| stack['name'] == deprecated_stack }).nil?
-    p(configured_stacks.find { |stack| stack['name'] == deprecated_stack })
-    p deprecated_stack_in_config
-    p deprecated_stack_in_config.nil?
 
     exit(0) if deprecated_stack_in_config
 

--- a/lib/tasks/stack_check.rake
+++ b/lib/tasks/stack_check.rake
@@ -1,0 +1,27 @@
+namespace :buildpacks do
+  desc 'Check Installed Stacks'
+  task stack_check: :environment do
+    VCAP::CloudController::Encryptor.db_encryption_key = RakeConfig.config.get(:db_encryption_key)
+    require 'models/runtime/buildpack_lifecycle_data_model'
+    require 'models/runtime/stack'
+
+    deprecated_stack = 'cflinuxfs3'
+    stack_config = VCAP::CloudController::Stack::ConfigFile.new(RakeConfig.config.get(:stacks_file))
+    p stack_config.stacks
+    configured_stacks = stack_config.stacks
+    deprecated_stack_in_config = (configured_stacks.find { |stack| stack['name'] == deprecated_stack }).nil?
+    p(configured_stacks.find { |stack| stack['name'] == deprecated_stack })
+    p deprecated_stack_in_config
+    p deprecated_stack_in_config.nil?
+
+    exit(0) if deprecated_stack_in_config
+
+    logger = Steno.logger('cc.stack')
+    VCAP::CloudController::DB.connect(RakeConfig.config.get(:db), logger)
+    deprecated_stack_in_db = VCAP::CloudController::Stack.first(name: deprecated_stack).present?
+    if deprecated_stack_in_db
+      logger.error('rake task \'stack_check\' failed, ' + deprecated_stack + ' is not supported')
+      exit(1)
+    end
+  end
+end

--- a/lib/tasks/stack_check.rake
+++ b/lib/tasks/stack_check.rake
@@ -1,7 +1,8 @@
 namespace :stacks do
   desc 'Check Installed Stacks'
   task stack_check: :environment do
-    VCAP::CloudController::DB.load_models(RakeConfig.config.get(:db), @logger)
+    logger = Steno.logger('cc.stack')
+    VCAP::CloudController::DB.load_models(RakeConfig.config.get(:db), logger)
     RakeConfig.config.configure_components
     require 'models/runtime/buildpack_lifecycle_data_model'
     require 'models/runtime/stack'

--- a/lib/tasks/stack_check.rake
+++ b/lib/tasks/stack_check.rake
@@ -3,7 +3,7 @@ namespace :stacks do
   task stack_check: :environment do
     logger = Steno.logger('cc.stack')
     VCAP::CloudController::DB.load_models(RakeConfig.config.get(:db), logger)
-    RakeConfig.config.configure_components
+    RakeConfig.config.load_db_encryption_key
     require 'models/runtime/buildpack_lifecycle_data_model'
     require 'models/runtime/stack'
     require 'cloud_controller/check_stacks'

--- a/lib/tasks/stack_check.rake
+++ b/lib/tasks/stack_check.rake
@@ -1,10 +1,14 @@
 namespace :stacks do
   desc 'Check Installed Stacks'
   task stack_check: :environment do
+    logger = Steno.logger('cc.stack')
+    VCAP::CloudController::Encryptor.db_encryption_key = RakeConfig.config.get(:db_encryption_key)
+    VCAP::CloudController::DB.connect(RakeConfig.config.get(:db), logger)
+
+    require 'models/runtime/buildpack_lifecycle_data_model'
+    require 'models/runtime/stack'
     require 'cloud_controller/check_stacks'
 
-    BackgroundJobEnvironment.new(RakeConfig.config).setup_environment do
-      VCAP::CloudController::CheckStacks.new(RakeConfig.config).validate_stacks
-    end
+    VCAP::CloudController::CheckStacks.new(RakeConfig.config).validate_stacks
   end
 end

--- a/lib/tasks/stack_check.rake
+++ b/lib/tasks/stack_check.rake
@@ -1,10 +1,8 @@
 namespace :stacks do
   desc 'Check Installed Stacks'
   task stack_check: :environment do
-    logger = Steno.logger('cc.stack')
-    VCAP::CloudController::Encryptor.db_encryption_key = RakeConfig.config.get(:db_encryption_key)
-    VCAP::CloudController::DB.connect(RakeConfig.config.get(:db), logger)
-
+    VCAP::CloudController::DB.load_models(RakeConfig.config.get(:db), @logger)
+    RakeConfig.config.configure_components
     require 'models/runtime/buildpack_lifecycle_data_model'
     require 'models/runtime/stack'
     require 'cloud_controller/check_stacks'

--- a/spec/fixtures/config/invalid_stacks.yml
+++ b/spec/fixtures/config/invalid_stacks.yml
@@ -1,2 +1,4 @@
 stacks:
   - unknown_key: true
+
+deprecated_stacks: {} 

--- a/spec/fixtures/config/stacks.yml
+++ b/spec/fixtures/config/stacks.yml
@@ -7,3 +7,6 @@ stacks:
     description: "default-stack-description"
   - name: "cider"
     description: "cider-description"
+
+deprecated_stacks:
+  - old_stack

--- a/spec/unit/lib/cloud_controller/check_stacks_spec.rb
+++ b/spec/unit/lib/cloud_controller/check_stacks_spec.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
     let(:cflinuxfs4) { { 'name' => 'cflinuxfs4', 'description' => 'fs4' } }
 
     before do
-      #binding.pry
+      # binding.pry
       Stack.dataset.destroy
       file = Tempfile.new
       file.write(stack_file_contents.to_yaml)
@@ -30,6 +30,22 @@ module VCAP::CloudController
     end
 
     let(:stack_checker) { CheckStacks.new(TestConfig.config_instance) }
+
+    describe 'there deprecated stacks is nil' do
+      let(:stack_file_contents) do
+        {
+          'default' => 'cflinuxfs4',
+          'stacks' => [
+            cflinuxfs3,
+            cflinuxfs4
+          ]
+        }
+      end
+
+      it 'does nothing' do
+        expect { stack_checker.validate_stacks }.not_to raise_error
+      end
+    end
 
     describe 'there are no deprecated stacks' do
       let(:stack_file_contents) do
@@ -56,7 +72,7 @@ module VCAP::CloudController
             cflinuxfs3,
             cflinuxfs4
           ],
-          'deprecated_stacks' => [ 'cflinuxfs3' ]
+          'deprecated_stacks' => ['cflinuxfs3']
         }
       end
 

--- a/spec/unit/lib/cloud_controller/check_stacks_spec.rb
+++ b/spec/unit/lib/cloud_controller/check_stacks_spec.rb
@@ -1,40 +1,105 @@
-require 'db_spec_helper'
+require 'spec_helper'
 require 'yaml'
 require 'cloud_controller/check_stacks'
+require 'tasks/rake_config'
+
 module VCAP::CloudController
   RSpec.describe CheckStacks do
-    describe 'check for deprecated stacks' do
+    let(:stack_file_contents) do
+      {
+        'default' => 'cflinuxfs4',
+        'stacks' => [
+          cflinuxfs4
+        ],
+        'deprecated_stacks' => 'cflinuxfs3'
+      }
+    end
+
+    let(:cflinuxfs3) { { 'name' => 'cflinuxfs3', 'description' => 'fs3' } }
+    let(:cflinuxfs4) { { 'name' => 'cflinuxfs4', 'description' => 'fs4' } }
+
+    before do
+      #binding.pry
+      Stack.dataset.destroy
+      file = Tempfile.new
+      file.write(stack_file_contents.to_yaml)
+      file.close
+      Stack.configure(file)
+      Stack.populate
+      TestConfig.override(stacks_file: file.path)
+    end
+
+    let(:stack_checker) { CheckStacks.new(TestConfig.config_instance) }
+
+    describe 'there are no deprecated stacks' do
       let(:stack_file_contents) do
         {
-          default: 'cflinuxfs4',
-          stacks: [
-            { name: 'cflinuxfs4', description: 'fs4' }
-          ]
+          'default' => 'cflinuxfs4',
+          'stacks' => [
+            cflinuxfs3,
+            cflinuxfs4
+          ],
+          'deprecated_stacks' => []
         }
       end
 
-      before do
-        file = Tempfile.new
-        file.write(stack_file_contents.to_yaml)
-        TestConfig.override(stacks_file: file.path)
+      it 'does nothing' do
+        expect { stack_checker.validate_stacks }.not_to raise_error
+      end
+    end
+
+    describe 'the deprecated stack is in the config' do
+      let(:stack_file_contents) do
+        {
+          'default' => 'cflinuxfs4',
+          'stacks' => [
+            cflinuxfs3,
+            cflinuxfs4
+          ],
+          'deprecated_stacks' => [ 'cflinuxfs3' ]
+        }
       end
 
-      let(:stack_checker) { CheckStacks.new(TestConfig.config_instance) }
+      describe 'the deprecated stack is in the db' do
+        it 'does not raise an error' do
+          expect { stack_checker.validate_stacks }.not_to raise_error
+        end
+      end
 
-      describe 'the deprecated stack is in the config' do
-        it 'exits 0' do
-          stack_config = VCAP::CloudController::Stack::ConfigFile.new(RakeConfig.config.get(:stacks_file))
-          expect(stack_config.stacks).to eq ['cflinuxfs4']
+      describe 'the deprecated stack is not in the db' do
+        before do
+          Stack.first(name: 'cflinuxfs3').destroy
+        end
+
+        it 'does not raise an error' do
+          expect { stack_checker.validate_stacks }.not_to raise_error
         end
       end
     end
 
-    describe 'the deprecated stack is in the db and not the config' do
-      it 'logs an error and exits 1'
-    end
+    describe 'when the deprecated stack is not in the config' do
+      let(:stack_file_contents) do
+        {
+          'default' => 'cflinuxfs4',
+          'stacks' => [cflinuxfs4],
+          'deprecated_stacks' => ['cflinuxfs3']
+        }
+      end
 
-    describe 'the deprecated stack is not in the db or the config' do
-      it 'exits 0' do
+      describe 'the deprecated stack is in the db' do
+        before do
+          Stack.make(name: 'cflinuxfs3')
+        end
+
+        it 'logs an error and exits 1' do
+          expect { stack_checker.validate_stacks }.to raise_error "rake task 'stack_check' failed, stack 'cflinuxfs3' not supported"
+        end
+      end
+
+      describe 'the deprecated stack is not in the db' do
+        it 'does not raise an error' do
+          expect { stack_checker.validate_stacks }.not_to raise_error
+        end
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/check_stacks_spec.rb
+++ b/spec/unit/lib/cloud_controller/check_stacks_spec.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
 
     let(:stack_checker) { CheckStacks.new(TestConfig.config_instance) }
 
-    describe 'there deprecated stacks is nil' do
+    describe 'the deprecated stacks is nil' do
       let(:stack_file_contents) do
         {
           'default' => 'cflinuxfs4',

--- a/spec/unit/lib/cloud_controller/check_stacks_spec.rb
+++ b/spec/unit/lib/cloud_controller/check_stacks_spec.rb
@@ -19,7 +19,6 @@ module VCAP::CloudController
     let(:cflinuxfs4) { { 'name' => 'cflinuxfs4', 'description' => 'fs4' } }
 
     before do
-      # binding.pry
       Stack.dataset.destroy
       file = Tempfile.new
       file.write(stack_file_contents.to_yaml)

--- a/spec/unit/lib/cloud_controller/check_stacks_spec.rb
+++ b/spec/unit/lib/cloud_controller/check_stacks_spec.rb
@@ -1,0 +1,41 @@
+require 'db_spec_helper'
+require 'yaml'
+require 'cloud_controller/check_stacks'
+module VCAP::CloudController
+  RSpec.describe CheckStacks do
+    describe 'check for deprecated stacks' do
+      let(:stack_file_contents) do
+        {
+          default: 'cflinuxfs4',
+          stacks: [
+            { name: 'cflinuxfs4', description: 'fs4' }
+          ]
+        }
+      end
+
+      before do
+        file = Tempfile.new
+        file.write(stack_file_contents.to_yaml)
+        TestConfig.override(stacks_file: file.path)
+      end
+
+      let(:stack_checker) { CheckStacks.new(TestConfig.config_instance) }
+
+      describe 'the deprecated stack is in the config' do
+        it 'exits 0' do
+          stack_config = VCAP::CloudController::Stack::ConfigFile.new(RakeConfig.config.get(:stacks_file))
+          expect(stack_config.stacks).to eq ['cflinuxfs4']
+        end
+      end
+    end
+
+    describe 'the deprecated stack is in the db and not the config' do
+      it 'logs an error and exits 1'
+    end
+
+    describe 'the deprecated stack is not in the db or the config' do
+      it 'exits 0' do
+      end
+    end
+  end
+end

--- a/spec/unit/models/runtime/stack_spec.rb
+++ b/spec/unit/models/runtime/stack_spec.rb
@@ -45,7 +45,8 @@ module VCAP::CloudController
 
         {
           default: 'default => Missing key',
-          stacks: 'name => Missing key'
+          stacks: 'name => Missing key',
+          deprecated_stacks: 'deprecated_stacks => Expected instance of Array, given instance of Hash }'
         }.each do |key, expected_error|
           it "requires #{key} (validates via '#{expected_error}')" do
             expect do


### PR DESCRIPTION

* Add optional check to ensure operators can upgrade without hanging dependencies to old or unwanted stacks

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
