### PR TITLE
Prevent 500 on parallel service instance creation

### DIFF
--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -110,6 +110,15 @@ module VCAP::CloudController
       end
     end
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('si_space_id_name_index')
+
+      errors.add(:name, :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_presence :name
       validates_presence :space


### PR DESCRIPTION
We observed 500 responses on ```POST /v3/service_instances``` when requests run in parallel and the db is small.
This occurs if the one POST bypasses the other one and inserts the record into the db after the first POST has passed the validate function but before the actual insert. This leads to a ```PG::UniqueViolation: ERROR: duplicate key value violates unique constraint``` which is not caught and thus results in a 500 response. To prevent this, we add a Sequel::UniqueConstraintViolation rescue to catch the ```PG::UniqueViolation``` error and to return an adequate 422 error "The service instance name is taken.."


* A short explanation of the proposed change:
Do not return 500 on parallel service instance creation on small db but a 422.

* An explanation of the use cases your change solves
We observed 500 responses on ```POST /v3/service_instances``` when requests run in parallel and the db is small. Now an appropriate error is returned.


* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
