### PR TITLE
Fix setting strategy and max in flight for stopped app deployments

### DIFF
--- a/app/actions/deployment_create.rb
+++ b/app/actions/deployment_create.rb
@@ -175,8 +175,8 @@ module VCAP::CloudController
           original_web_process_instance_count: desired_instances(app.oldest_web_process, previous_deployment),
           revision_guid: revision&.guid,
           revision_version: revision&.version,
-          strategy: DeploymentModel::ROLLING_STRATEGY,
-          max_in_flight: message.options ? message.options[:max_in_flight] : 1
+          strategy: message.strategy,
+          max_in_flight: message.max_in_flight
         )
 
         MetadataUpdate.update(deployment, message)

--- a/spec/unit/actions/deployment_create_spec.rb
+++ b/spec/unit/actions/deployment_create_spec.rb
@@ -493,6 +493,9 @@ module VCAP::CloudController
           end
 
           context 'when the app is stopped' do
+            let(:max_in_flight) { 3 }
+            let(:strategy) { 'canary' }
+
             before do
               app.update(desired_state: ProcessModel::STOPPED)
               app.save
@@ -525,6 +528,8 @@ module VCAP::CloudController
               expect(deployment.previous_droplet).to eq(original_droplet)
               expect(deployment.original_web_process_instance_count).to eq(3)
               expect(deployment.last_healthy_at).to eq(deployment.created_at)
+              expect(deployment.strategy).to eq('canary')
+              expect(deployment.max_in_flight).to eq(3)
             end
 
             it 'records an audit event for the deployment' do
@@ -548,7 +553,7 @@ module VCAP::CloudController
                                              'type' => nil,
                                              'revision_guid' => app.latest_revision.guid,
                                              'request' => message.audit_hash,
-                                             'strategy' => 'rolling'
+                                             'strategy' => 'canary'
                                            })
             end
 


### PR DESCRIPTION
* Use existing `max_in_flight` method which handles default/null behaviour
* Pick correct strategy

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
