### PR TITLE
Prevent 500 on parallel object creation

### DIFF
--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -40,7 +40,13 @@ module VCAP::CloudController
             MetadataUpdate.update(b, message)
           end
         end
-      rescue Sequel::ValidationFailed, Sequel::UniqueConstraintViolation => e
+      rescue Sequel::ValidationFailed => e
+        if e.message.include?('app_guid and name unique')
+          raise UnprocessableCreate.new("The binding name is invalid. App binding names must be unique. The app already has a binding with name '#{message.name}'.")
+        elsif e.message.include?('service_instance_guid and app_guid unique')
+          raise UnprocessableCreate.new('The app is already bound to the service instance.')
+        end
+
         raise UnprocessableCreate.new(e.full_message)
       end
 

--- a/app/actions/space_create.rb
+++ b/app/actions/space_create.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
     attr_reader :user_audit_info
 
     def validation_error!(error)
-      error!('Name must be unique per organization') if error.is_a?(Space::DBNameUniqueRaceError) || error.errors.on(%i[organization_id name])&.include?(:unique)
+      error!('Name must be unique per organization') if error.errors.on(%i[organization_id name])&.include?(:unique)
       error!(error.message)
     end
 

--- a/app/actions/space_update.rb
+++ b/app/actions/space_update.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
     end
 
     def validation_error!(error, space)
-      error!("Organization '#{space.organization.name}' already contains a space with name '#{space.name}'.") if error.is_a?(Space::DBNameUniqueRaceError) || error.errors.on(%i[
+      error!("Organization '#{space.organization.name}' already contains a space with name '#{space.name}'.") if error.errors.on(%i[
         organization_id name
       ])&.include?(:unique)
       error!(error.message)

--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -76,6 +76,15 @@ module VCAP::CloudController
       self.enable_ssh = Config.config.get(:default_app_ssh_access) if enable_ssh.nil?
     end
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('apps_v3_space_guid_name_index')
+
+      errors.add(%i[space_guid name], :unique)
+      raise validation_failed_error
+    end
+
     def validate
       super
       validates_presence :name

--- a/app/models/runtime/domain.rb
+++ b/app/models/runtime/domain.rb
@@ -85,6 +85,15 @@ module VCAP::CloudController
     add_association_dependencies labels: :destroy
     add_association_dependencies annotations: :destroy
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('domains_name_index')
+
+      errors.add(:name, :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_presence :name
       validates_unique :name, dataset: Domain.dataset

--- a/app/models/runtime/helpers/organization_role_mixin.rb
+++ b/app/models/runtime/helpers/organization_role_mixin.rb
@@ -13,6 +13,16 @@ module VCAP::CloudController
       self.guid ||= SecureRandom.uuid
     end
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      unique_indexes = %w[org_users_idx org_auditors_idx org_managers_idx org_billing_managers_idx]
+      raise e unless unique_indexes.any? { |pattern| e.message.include?(pattern) }
+
+      errors.add(%i[organization_id user_id], :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_unique %i[organization_id user_id]
       validates_presence :organization_id

--- a/app/models/runtime/isolation_segment_model.rb
+++ b/app/models/runtime/isolation_segment_model.rb
@@ -19,6 +19,15 @@ module VCAP::CloudController
     add_association_dependencies labels: :destroy
     add_association_dependencies annotations: :destroy
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('isolation_segment_name_unique_constraint')
+
+      errors.add(:name, :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_format ISOLATION_SEGMENT_MODEL_REGEX, :name, message: Sequel.lit('Isolation Segment names can only contain non-blank unicode characters')
 

--- a/app/models/runtime/organization.rb
+++ b/app/models/runtime/organization.rb
@@ -207,6 +207,15 @@ module VCAP::CloudController
       super
     end
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('organizations_name_index')
+
+      errors.add(:name, :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_presence :name
       validates_unique :name

--- a/app/models/runtime/space_quota_definition.rb
+++ b/app/models/runtime/space_quota_definition.rb
@@ -25,6 +25,15 @@ module VCAP::CloudController
 
     add_association_dependencies spaces: :nullify
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('sqd_org_id_index')
+
+      errors.add(%i[organization_id name], :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_presence :name
       validates_presence :non_basic_services_allowed

--- a/app/models/runtime/stack.rb
+++ b/app/models/runtime/stack.rb
@@ -30,6 +30,15 @@ module VCAP::CloudController
 
     strip_attributes :name
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('stacks_name_index')
+
+      errors.add(:name, :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_presence :name
       validates_unique :name

--- a/app/models/runtime/user.rb
+++ b/app/models/runtime/user.rb
@@ -76,6 +76,15 @@ module VCAP::CloudController
                       :audited_space_guids,
                       :default_space_guid
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('users_guid_index')
+
+      errors.add(:guid, :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_presence :guid
       validates_unique :guid

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -41,7 +41,8 @@ module VCAP::CloudController
       if e.message.include?('unique_service_binding_app_guid_name')
         errors.add(%i[app_guid name], :unique)
         raise validation_failed_error
-      elsif e.message.include?('Duplicate entry')
+        # mysql
+      elsif e.message.include?('Duplicate entry') || e.message.include?('unique_service_binding_service_instance_guid_app_guid')
         errors.add(%i[service_instance_guid app_guid], :unique)
         raise validation_failed_error
       else

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -41,7 +41,7 @@ module VCAP::CloudController
       if e.message.include?('unique_service_binding_app_guid_name')
         errors.add(%i[app_guid name], :unique)
         raise validation_failed_error
-      elsif  e.message.include?('unique_service_binding_service_instance_guid_app_guid')
+      elsif e.message.include?('unique_service_binding_service_instance_guid_app_guid')
         errors.add(%i[service_instance_guid app_guid], :unique)
         raise validation_failed_error
       else

--- a/app/models/services/service_binding.rb
+++ b/app/models/services/service_binding.rb
@@ -41,8 +41,7 @@ module VCAP::CloudController
       if e.message.include?('unique_service_binding_app_guid_name')
         errors.add(%i[app_guid name], :unique)
         raise validation_failed_error
-        # mysql
-      elsif e.message.include?('Duplicate entry') || e.message.include?('unique_service_binding_service_instance_guid_app_guid')
+      elsif  e.message.include?('unique_service_binding_service_instance_guid_app_guid')
         errors.add(%i[service_instance_guid app_guid], :unique)
         raise validation_failed_error
       else

--- a/app/models/services/service_broker.rb
+++ b/app/models/services/service_broker.rb
@@ -20,6 +20,15 @@ module VCAP::CloudController
 
     set_field_as_encrypted :auth_password
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('service_brokers_name_index')
+
+      errors.add(:name, :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_presence :name
       validates_presence :broker_url

--- a/app/models/services/service_key.rb
+++ b/app/models/services/service_key.rb
@@ -37,6 +37,15 @@ module VCAP::CloudController
 
     delegate :space, to: :service_instance
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('svc_key_name_instance_id_index')
+
+      errors.add(%i[name service_instance_id], :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_presence :name
       validates_presence :service_instance

--- a/spec/unit/actions/app_create_spec.rb
+++ b/spec/unit/actions/app_create_spec.rb
@@ -200,7 +200,7 @@ module VCAP::CloudController
         end
       end
 
-      context 'parallel creation of apps' do
+      context 'when creating apps concurrently' do
         it 'ensures one creation is successful and the other fails due to name conflict' do
           # First request, should succeed
           expect do

--- a/spec/unit/actions/domain_create_spec.rb
+++ b/spec/unit/actions/domain_create_spec.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
           end
         end
 
-        context 'while doing parallel creation of apps' do
+        context 'when creating domains concurrently' do
           let(:internal) { true }
           let(:p_name) { 'perfect.domain-1.example.com' }
           let(:message) do

--- a/spec/unit/actions/domain_create_spec.rb
+++ b/spec/unit/actions/domain_create_spec.rb
@@ -33,6 +33,33 @@ module VCAP::CloudController
           end
         end
 
+        context 'while doing parallel creation of apps' do
+          let(:internal) { true }
+          let(:p_name) { 'perfect.domain-1.example.com' }
+          let(:message) do
+            DomainCreateMessage.new({
+                                      name: p_name,
+                                      internal: internal,
+                                      metadata: metadata
+                                    })
+          end
+
+          it 'ensures one creation is successful and the other fails due to name conflict' do
+            # First request, should succeed
+            expect do
+              subject.create(message:)
+            end.not_to raise_error
+
+            # Mock the validation for the second request to simulate the race condition and trigger a unique constraint violation
+            allow_any_instance_of(Domain).to receive(:validate).and_return(true)
+
+            # Second request, should fail with correct error
+            expect do
+              subject.create(message:)
+            end.to raise_error(DomainCreate::Error, 'The domain name "perfect.domain-1.example.com" is already in use')
+          end
+        end
+
         context 'when the error is a uniqueness error' do
           let(:existing_domain) { SharedDomain.make }
           let(:message) { DomainCreateMessage.new({ name: existing_domain.name }) }

--- a/spec/unit/actions/service_broker_create_spec.rb
+++ b/spec/unit/actions/service_broker_create_spec.rb
@@ -132,6 +132,23 @@ module VCAP
           end
         end
       end
+
+      describe 'when creating a service broker with the same name concurrently' do
+        it 'ensures one creation is successful and the other fails due to name conflict' do
+          # First request, should succeed
+          expect do
+            action.create(message)
+          end.not_to raise_error
+
+          # Mock the validation for the second request to simulate the race condition and trigger a unique constraint violation
+          allow_any_instance_of(ServiceBroker).to receive(:validate).and_return(true)
+
+          # Second request, should fail with correct error
+          expect do
+            action.create(message)
+          end.to raise_error(V3::ServiceBrokerCreate::InvalidServiceBroker)
+        end
+      end
     end
   end
 end

--- a/spec/unit/actions/service_credential_binding_app_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_app_create_spec.rb
@@ -167,7 +167,8 @@ module VCAP::CloudController
               # Second request, should fail with correct error
               expect do
                 action.precursor(service_instance2, app:, message:)
-              end.to raise_error(ServiceBindingCreate::UnprocessableCreate)
+              end.to raise_error(ServiceBindingCreate::UnprocessableCreate,
+                                 "The binding name is invalid. App binding names must be unique. The app already has a binding with name 'foo'.")
             end
           end
 
@@ -189,9 +190,7 @@ module VCAP::CloudController
 
               # Mock the validation for the second request to simulate the race condition and trigger a
               # unique constraint violation on service_instance_guid + app_guid
-              # allow_any_instance_of(ServiceCredentialBindingAppCreate).to receive(:validate_binding!).and_return(true)
               allow_any_instance_of(ServiceBinding).to receive(:validate).and_return(true)
-              # binding = instance_double(ServiceBinding, destroy: false)
               allow(ServiceBinding).to receive(:first).with(service_instance:, app:).and_return(nil)
 
               # Second request, should fail with correct error

--- a/spec/unit/actions/service_credential_binding_key_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_key_create_spec.rb
@@ -252,30 +252,22 @@ module VCAP::CloudController
         end
 
         context 'when creating keys with the same name concurrently' do
-          let(:service_instance2) { ManagedServiceInstance.make(space:) }
-          let(:name2) { 'some-binding-name23' }
-          let(:message2) do
-            VCAP::CloudController::ServiceCredentialKeyBindingCreateMessage.new(
-              {
-                name: name2
-              }
-            )
-          end
+          let(:service_instance) { ManagedServiceInstance.make(space:) }
 
           it 'ensures one creation is successful and the other fails due to name conflict' do
             # First request, should succeed
             expect do
-              action.precursor(service_instance2, message: message2)
+              action.precursor(service_instance, message:)
             end.not_to raise_error
 
             # Mock the validation for the second request to simulate the race condition and trigger a unique constraint violation
             allow_any_instance_of(ServiceKey).to receive(:validate).and_return(true)
-            allow(ServiceKey).to receive(:first).with(service_instance: service_instance2, name: name2).and_return(nil)
+            allow(ServiceKey).to receive(:first).with(service_instance:, name:).and_return(nil)
 
             expect do
-              action.precursor(service_instance2, message: message2)
+              action.precursor(service_instance, message:)
             end.to raise_error(ServiceBindingCreate::UnprocessableCreate,
-                               "The binding name is invalid. Key binding names must be unique. The service instance already has a key binding with name 'some-binding-name23'.")
+                               "The binding name is invalid. Key binding names must be unique. The service instance already has a key binding with name 'some-binding-name'.")
           end
         end
       end

--- a/spec/unit/actions/service_credential_binding_key_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_key_create_spec.rb
@@ -267,11 +267,11 @@ module VCAP::CloudController
             expect do
               action.precursor(service_instance2, message: message2)
             end.not_to raise_error
+
             # Mock the validation for the second request to simulate the race condition and trigger a unique constraint violation
-            allow_any_instance_of(ServiceCredentialBindingKeyCreate).to receive(:validate_key!).and_return(true)
             allow_any_instance_of(ServiceKey).to receive(:validate).and_return(true)
-            key = instance_double(ServiceKey, destroy: false)
-            allow(ServiceKey).to receive(:first).with(service_instance: service_instance2, name: name2).and_return(key)
+            allow(ServiceKey).to receive(:first).with(service_instance: service_instance2, name: name2).and_return(nil)
+
             expect do
               action.precursor(service_instance2, message: message2)
             end.to raise_error(ServiceBindingCreate::UnprocessableCreate,

--- a/spec/unit/isolation_segment_create_spec.rb
+++ b/spec/unit/isolation_segment_create_spec.rb
@@ -59,7 +59,7 @@ module VCAP::CloudController
           # Second request, should fail with correct error
           expect do
             IsolationSegmentCreate.create(message)
-          end.to raise_error(IsolationSegmentCreate::Error, "name unique")
+          end.to raise_error(IsolationSegmentCreate::Error, 'name unique')
         end
       end
     end

--- a/spec/unit/isolation_segment_create_spec.rb
+++ b/spec/unit/isolation_segment_create_spec.rb
@@ -44,6 +44,24 @@ module VCAP::CloudController
           end.to raise_error(IsolationSegmentCreate::Error, 'blork is busted')
         end
       end
+
+      context 'when creating isolation segments concurrently' do
+        it 'ensures one creation is successful and the other fails due to name conflict' do
+          # First request, should succeed
+          message = VCAP::CloudController::IsolationSegmentCreateMessage.new(name: 'foobar')
+          expect do
+            IsolationSegmentCreate.create(message)
+          end.not_to raise_error
+
+          # Mock the validation for the second request to simulate the race condition and trigger a unique constraint violation
+          allow_any_instance_of(IsolationSegmentModel).to receive(:validate).and_return(true)
+
+          # Second request, should fail with correct error
+          expect do
+            IsolationSegmentCreate.create(message)
+          end.to raise_error(IsolationSegmentCreate::Error)
+        end
+      end
     end
   end
 end

--- a/spec/unit/isolation_segment_create_spec.rb
+++ b/spec/unit/isolation_segment_create_spec.rb
@@ -59,7 +59,7 @@ module VCAP::CloudController
           # Second request, should fail with correct error
           expect do
             IsolationSegmentCreate.create(message)
-          end.to raise_error(IsolationSegmentCreate::Error)
+          end.to raise_error(IsolationSegmentCreate::Error, "name unique")
         end
       end
     end

--- a/spec/unit/models/runtime/space_spec.rb
+++ b/spec/unit/models/runtime/space_spec.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
             dup_space = Space.new(organization_guid: space.organization.guid, name: space.name)
             expect do
               dup_space.save(validate: false)
-            end.to raise_error(Space::DBNameUniqueRaceError)
+            end.to raise_error(Sequel::ValidationFailed)
           end
 
           it 'does not translate db errors not about name uniqueness' do


### PR DESCRIPTION
While fixing #3899, we found further possible occurrences of 500 errors in severel _create actions when doing parallel requests. In this PR we want to address them by adding an around_save to the corresponding model in which we catch Sequel::UniqueConstraintViolation errors for the case when  ne POST bypasses the other one and inserts the record into the db after the first POST has passed the validate function but before the actual insert.

* A short explanation of the proposed change:
Adding an around_save to the corresponding model in which we catch Sequel::UniqueConstraintViolation errors for the case when  ne POST bypasses the other one and inserts the record into the db after the first POST has passed the validate function but before the actual insert
* An explanation of the use cases your change solves
No more 500 errors on parallel request execution

* Links to any other associated PRs
#3899
#3924
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
