### PR TITLE
Drop constraint quota_definitions_name_key

### DIFF
--- a/db/migrations/20240808118000_drop_unique_constraint_quota_definitions_name_key.rb
+++ b/db/migrations/20240808118000_drop_unique_constraint_quota_definitions_name_key.rb
@@ -1,0 +1,35 @@
+Sequel.migration do
+  no_transaction # to use the 'concurrently' option
+
+  up do
+    if self.class.name.match?(/mysql/i)
+      VCAP::Migration.with_concurrent_timeout(self) do
+        alter_table :quota_definitions do
+          drop_constraint :name
+        end
+      end
+    elsif self.class.name.match?(/postgres/i)
+      VCAP::Migration.with_concurrent_timeout(self) do
+        alter_table :quota_definitions do
+          drop_constraint :quota_definitions_name_key
+        end
+      end
+    end
+  end
+
+  down do
+    if self.class.name.match?(/mysql/i)
+      VCAP::Migration.with_concurrent_timeout(self) do
+        alter_table :quota_definitions do
+          add_unique_constraint :name, name: :name
+        end
+      end
+    elsif self.class.name.match?(/postgres/i)
+      VCAP::Migration.with_concurrent_timeout(self) do
+        alter_table :quota_definitions do
+          add_unique_constraint :name, name: :quota_definitions_name_key
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
On the name column in quota_defintions there were two unique constraints/indexes. One unique index with name qd_name_index, which is similar in postgres and mysql, and then an unique constraint on column name with name in postgres=```quota_definitions_name_key``` and name in mysql=```name```.
Since the unique index already exists, we don't need the unique constraint. Dropping it with this migration.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
