### PR TITLE
Prevent 500 on parallel org quota creation

### DIFF
--- a/app/models/runtime/quota_definition.rb
+++ b/app/models/runtime/quota_definition.rb
@@ -19,6 +19,15 @@ module VCAP::CloudController
                       :app_instance_limit, :app_task_limit, :total_service_keys, :total_reserved_route_ports,
                       :log_rate_limit
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('qd_name_index')
+
+      errors.add(:name, :unique)
+      raise validation_failed_error
+    end
+
     def validate
       validates_presence :name
       validates_unique :name


### PR DESCRIPTION
To apply this change the migration from
https://github.com/cloudfoundry/cloud_controller_ng/pull/3952 needs to be in first. That's why we created the adoption to prevent 500 on concurrent requests for organization_quota_create separately from #3918. The explanation of the proposed change and explanation of the use cases your change solves is the same as in #3899 and #3918.

* Links to any other associated PRs
#3952
#3899
#3918

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
