### PR TITLE
Perform stack check by loading models without waiting on migrations

### DIFF
--- a/lib/tasks/stack_check.rake
+++ b/lib/tasks/stack_check.rake
@@ -2,6 +2,9 @@ namespace :stacks do
   desc 'Check Installed Stacks'
   task stack_check: :environment do
     logger = Steno.logger('cc.stack')
+    db = VCAP::CloudController::DB.connect(RakeConfig.config.get(:db), logger)
+    next unless db.table_exists?(:stacks)
+
     VCAP::CloudController::DB.load_models_without_migrations_check(RakeConfig.config.get(:db), logger)
     RakeConfig.config.load_db_encryption_key
     require 'models/runtime/buildpack_lifecycle_data_model'

--- a/lib/tasks/stack_check.rake
+++ b/lib/tasks/stack_check.rake
@@ -2,7 +2,7 @@ namespace :stacks do
   desc 'Check Installed Stacks'
   task stack_check: :environment do
     logger = Steno.logger('cc.stack')
-    VCAP::CloudController::DB.load_models(RakeConfig.config.get(:db), logger)
+    VCAP::CloudController::DB.load_models_without_migrations_check(RakeConfig.config.get(:db), logger)
     RakeConfig.config.load_db_encryption_key
     require 'models/runtime/buildpack_lifecycle_data_model'
     require 'models/runtime/stack'


### PR DESCRIPTION
We do this because we want to be able to call the stack checker prior to running migrations. This is so that if the stack checker fails the deployment then new migrations will not have run and we are left a clean state.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
