### PR TITLE
Fix db encryption key loading

### DIFF
--- a/lib/cloud_controller/db_migrator.rb
+++ b/lib/cloud_controller/db_migrator.rb
@@ -5,7 +5,7 @@ class DBMigrator
   SEQUEL_MIGRATIONS = File.join(MIGRATIONS_DIR, 'migrations')
 
   def self.from_config(config, db_logger)
-    VCAP::CloudController::Encryptor.db_encryption_key = config.get(:db_encryption_key)
+    config.load_db_encryption_key
     db = VCAP::CloudController::DB.connect(config.get(:db), db_logger)
     new(db, config.get(:max_migration_duration_in_minutes), config.get(:max_migration_statement_runtime_in_seconds), config.get(:migration_psql_worker_memory_kb))
   end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -124,7 +124,7 @@ namespace :db do
 
     logging_output
     db_logger = Steno.logger('cc.db.migrations')
-    VCAP::CloudController::Encryptor.db_encryption_key = RakeConfig.config.get(:db_encryption_key)
+    RakeConfig.config.load_db_encryption_key
     db = VCAP::CloudController::DB.connect(RakeConfig.config.get(:db), db_logger)
 
     latest_migration_in_db = db[:schema_migrations].order(Sequel.desc(:filename)).first[:filename]


### PR DESCRIPTION
Currently we only load from the old decrepcated method of encryption keys. This fixes this to use all encrytpion key methods specified in https://github.com/cloudfoundry/capi-release/blob/develop/jobs/cloud_controller_ng/spec#L773-L782.

Fixes #3908

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
