### PR TITLE
allow shared service users to determine which spaces their service is in

### DIFF
--- a/app/controllers/services/service_instances_controller.rb
+++ b/app/controllers/services/service_instances_controller.rb
@@ -241,8 +241,6 @@ module VCAP::CloudController
       service_instance = find_service_instance(guid)
       validate_service_instance_access(service_instance)
 
-      validate_access(:read, service_instance.space)
-
       associated_controller = VCAP::CloudController::SpacesController
       associated_path = "#{self.class.url_for_guid(guid, service_instance)}/shared_to"
 

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -189,7 +189,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def shared_spaces_usage_summary
     service_instance = ServiceInstance.first(guid: hashed_params[:guid])
-    service_instance_not_found! unless service_instance.present? && can_read_from_space?(service_instance.space)
+    service_instance_not_found! unless service_instance.present? && can_read_service_instance?(service_instance)
 
     render status: :ok, json: Presenters::V3::SharedSpacesUsageSummaryPresenter.new(service_instance)
   end

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -173,7 +173,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def relationships_shared_spaces
     service_instance = ServiceInstance.first(guid: hashed_params[:guid])
-    resource_not_found!(:service_instance) unless service_instance && can_read_from_space?(service_instance.space)
+    resource_not_found!(:service_instance) unless service_instance && can_read_service_instance?(service_instance)
 
     message = SharedSpacesShowMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?

--- a/docs/v3/source/includes/resources/service_instances/_get_shared_spaces_usage_summary.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_get_shared_spaces_usage_summary.md.erb
@@ -26,7 +26,7 @@ This endpoint returns the number of bound apps in spaces where the service insta
 #### Definition
 `GET /v3/service_instances/:guid/relationships/shared_spaces/usage_summary`
 
-#### Permitted roles (in the service instance's originating space)
+#### Permitted roles
  |
 --- | ---
 Admin |
@@ -36,3 +36,4 @@ Org Manager |
 Space Auditor |
 Space Developer |
 Space Manager |
+Space Supporter |

--- a/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list_shared_spaces.md.erb
@@ -38,7 +38,7 @@ Resource            | Allowed Keys
 space | `guid`, `name`, `relationships.organization`
 space.organization| `guid`, `name`
 
-#### Permitted roles (in the service instance's originating space)
+#### Permitted roles
  |
 --- |
 Admin |

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -4058,10 +4058,10 @@ RSpec.describe 'V3 service instances' do
       end
     end
 
-    it 'respond with 404 when the user cannot read the originating space' do
+    it 'respond with 200 when the user cannot read the originating space, but has access to the service instance' do
       set_current_user_as_role(role: 'space_developer', org: other_space.organization, space: other_space, user: user)
       get "/v3/service_instances/#{instance.guid}/relationships/shared_spaces", nil, user_header
-      expect(last_response.status).to eq(404)
+      expect(last_response.status).to eq(200)
     end
 
     describe 'fields' do

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -4188,14 +4188,14 @@ RSpec.describe 'V3 service instances' do
       end
     end
 
-    context 'when the user cannot read from the originating space' do
-      it 'responds with 404 Not Found' do
+    context 'when the user has access to the service through a shared space' do
+      it 'responds with 200 ok' do
         user = VCAP::CloudController::User.make
         set_current_user_as_role(role: 'space_developer', org: space_2.organization, space: space_2, user: user)
 
         api_call.call(headers_for(user))
 
-        expect(last_response).to have_status_code(404)
+        expect(last_response).to have_status_code(200)
       end
     end
   end

--- a/spec/unit/controllers/services/service_instances_controller_spec.rb
+++ b/spec/unit/controllers/services/service_instances_controller_spec.rb
@@ -4642,10 +4642,9 @@ module VCAP::CloudController
                   )
                 end
 
-                it 'has a 403 http status code' do
+                it 'has a 200 http status code' do
                   get "/v2/service_instances/#{instance.guid}/shared_to"
-                  expect(last_response.status).to eq(403)
-                  expect(Oj.load(last_response.body)['description']).to eq('You are not authorized to perform the requested action')
+                  expect(last_response.status).to eq(200), "Expected 200, got: #{last_response.status}, role: #{role}"
                 end
               end
             end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

allow shared serivce users to determine which spaces their service is in

* An explanation of the use cases your change solves

Allows users of shared services to determine which spaces have access to a service without making a service_instaces request for each space they have access to. 

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
