### PR TITLE
Use tcp on port 3000 for puma when nginx socket is empty

### DIFF
--- a/lib/cloud_controller/runners/puma_runner.rb
+++ b/lib/cloud_controller/runners/puma_runner.rb
@@ -10,7 +10,11 @@ module VCAP::CloudController
 
       puma_config = Puma::Configuration.new do |conf|
         if config.get(:nginx, :use_nginx)
-          conf.bind "unix://#{config.get(:nginx, :instance_socket)}"
+          if config.get(:nginx, :instance_socket).nil? || config.get(:nginx, :instance_socket).empty?
+            conf.bind 'tcp://0.0.0.0:3000'
+          else
+            conf.bind "unix://#{config.get(:nginx, :instance_socket)}"
+          end
         else
           conf.bind "tcp://0.0.0.0:#{config.get(:external_port)}"
         end

--- a/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
+++ b/spec/unit/lib/cloud_controller/runners/puma_runner_spec.rb
@@ -49,6 +49,15 @@ module VCAP::CloudController
         expect(puma_launcher.config.final_options[:binds].first).to eq("unix://#{socket}")
       end
 
+      context 'when socket is not configured' do
+        let(:socket) { '' }
+
+        it 'binds to the nginx default port 3000' do
+          subject
+          expect(puma_launcher.config.final_options[:binds].first).to eq('tcp://0.0.0.0:3000')
+        end
+      end
+
       context 'when not using nginx' do
         let(:use_nginx) { false }
 


### PR DESCRIPTION
The current dev setup uses nginx to forward requests to CC. `devenv.sh` script sets the nginx_socket to empty string as socket communication can be problematic depending on the OS and Docker setup. In this case Thin would open a tcp connection to port 3000. This change does the same for Puma.

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
