### PR TITLE
Drop constraint quota_definitions_name_key

### DIFF
--- a/db/migrations/20240808118000_drop_unique_constraint_quota_definitions_name_key.rb
+++ b/db/migrations/20240808118000_drop_unique_constraint_quota_definitions_name_key.rb
@@ -1,0 +1,31 @@
+Sequel.migration do
+  up do
+    if self.class.name.match?(/mysql/i)
+      alter_table :quota_definitions do
+        drop_constraint :name, if_exists: true
+      end
+    elsif self.class.name.match?(/postgres/i)
+      alter_table :quota_definitions do
+        drop_constraint :quota_definitions_name_key, if_exists: true
+      end
+    end
+  end
+
+  down do
+    if self.class.name.match?(/mysql/i)
+      # mysql 5 is not so smart as mysql 8, prevent Mysql2::Error: Duplicate key name 'name'
+      alter_table :quota_definitions do
+        # rubocop:disable Sequel/ConcurrentIndex
+        drop_index :name, name: :name if @db.indexes(:quota_definitions).include?(:name)
+        # rubocop:enable Sequel/ConcurrentIndex
+      end
+      alter_table :quota_definitions do
+        add_unique_constraint :name, name: :name, if_not_exists: true
+      end
+    elsif self.class.name.match?(/postgres/i)
+      alter_table :quota_definitions do
+        add_unique_constraint :name, name: :quota_definitions_name_key, if_not_exists: true
+      end
+    end
+  end
+end

--- a/spec/migrations/20240808118000_drop_unique_constraint_quota_definitions_name_key_spec.rb
+++ b/spec/migrations/20240808118000_drop_unique_constraint_quota_definitions_name_key_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to add or remove unique constraint on name column in quota_definitions table', isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20240808118000_drop_unique_constraint_quota_definitions_name_key_spec.rb' }
+  end
+  describe 'up migration' do
+    context 'the unique constraint on name column exists' do
+      it 'removes the unique constraint' do
+        if db.database_type == :mysql
+          expect(db.indexes(:quota_definitions)).to include(:name)
+        elsif db.database_type == :postgres
+          expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
+        end
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+        if db.database_type == :mysql
+          expect(db.indexes(:quota_definitions)).not_to include(:name)
+        elsif db.database_type == :postgres
+          expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
+        end
+      end
+
+      context 'the unique constraint on name column does not exist' do
+        it 'does not throw an error' do
+          expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+          if db.database_type == :mysql
+            expect(db.indexes(:quota_definitions)).not_to include(:name)
+          elsif db.database_type == :postgres
+            expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
+          end
+          expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+          if db.database_type == :mysql
+            expect(db.indexes(:quota_definitions)).not_to include(:name)
+          elsif db.database_type == :postgres
+            expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
+          end
+        end
+      end
+    end
+  end
+
+  describe 'down migration' do
+    context 'unique constraint on name column does not exist' do
+      before do
+        Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+      end
+
+      it 'adds the unique constraint' do
+        if db.database_type == :mysql
+          expect(db.indexes(:quota_definitions)).not_to include(:name)
+        elsif db.database_type == :postgres
+          expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
+        end
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
+        if db.database_type == :mysql
+          expect(db.indexes(:quota_definitions)).to include(:name)
+        elsif db.database_type == :postgres
+          expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
+        end
+      end
+    end
+
+    context 'unique constraint on name column does exist' do
+      it 'does not fail' do
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
+        if db.database_type == :mysql
+          expect(db.indexes(:quota_definitions)).to include(:name)
+        elsif db.database_type == :postgres
+          expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
+        end
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
+        if db.database_type == :mysql
+          expect(db.indexes(:quota_definitions)).to include(:name)
+        elsif db.database_type == :postgres
+          expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20240808118000_drop_unique_constraint_quota_definitions_name_key_spec.rb
+++ b/spec/migrations/20240808118000_drop_unique_constraint_quota_definitions_name_key_spec.rb
@@ -6,73 +6,113 @@ RSpec.describe 'migration to add or remove unique constraint on name column in q
     let(:migration_filename) { '20240808118000_drop_unique_constraint_quota_definitions_name_key_spec.rb' }
   end
   describe 'up migration' do
-    context 'the unique constraint on name column exists' do
-      it 'removes the unique constraint' do
-        if db.database_type == :mysql
-          expect(db.indexes(:quota_definitions)).to include(:name)
-        elsif db.database_type == :postgres
-          expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
-        end
-        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
-        if db.database_type == :mysql
-          expect(db.indexes(:quota_definitions)).not_to include(:name)
-        elsif db.database_type == :postgres
-          expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
-        end
+    context 'mysql' do
+      before do
+        skip if db.database_type != :mysql
       end
 
-      context 'the unique constraint on name column does not exist' do
+      it 'removes the unique constraint' do
+        expect(db.indexes(:quota_definitions)).to include(:name)
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+        expect(db.indexes(:quota_definitions)).not_to include(:name)
+      end
+
+      context 'unique constraint on name column does not exist' do
+        before do
+          db.drop_index :quota_definitions, :name, name: :name
+        end
+
         it 'does not throw an error' do
+          expect(db.indexes(:quota_definitions)).not_to include(:name)
           expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
-          if db.database_type == :mysql
-            expect(db.indexes(:quota_definitions)).not_to include(:name)
-          elsif db.database_type == :postgres
-            expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
+          expect(db.indexes(:quota_definitions)).not_to include(:name)
+        end
+      end
+    end
+
+    context 'postgres' do
+      before do
+        skip if db.database_type != :postgres
+      end
+
+      it 'removes the unique constraint' do
+        expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+        expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
+      end
+
+      context 'unique constraint on name column does not exist' do
+        before do
+          db.alter_table :quota_definitions do
+            drop_constraint :quota_definitions_name_key
           end
+        end
+
+        it 'does not throw an error' do
+          expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
           expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
-          if db.database_type == :mysql
-            expect(db.indexes(:quota_definitions)).not_to include(:name)
-          elsif db.database_type == :postgres
-            expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
-          end
+          expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
         end
       end
     end
   end
 
   describe 'down migration' do
-    context 'unique constraint on name column does not exist' do
+    before do
+      Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+    end
+
+    context 'mysql' do
       before do
-        Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+        skip if db.database_type != :mysql
       end
 
       it 'adds the unique constraint' do
-        if db.database_type == :mysql
-          expect(db.indexes(:quota_definitions)).not_to include(:name)
-        elsif db.database_type == :postgres
-          expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
-        end
+        expect(db.indexes(:quota_definitions)).not_to include(:name)
         expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
-        if db.database_type == :mysql
+        expect(db.indexes(:quota_definitions)).to include(:name)
+      end
+
+      context 'unique constraint on name column already exists' do
+        before do
+          Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+
+          db.alter_table :quota_definitions do
+            add_index :name, name: :name
+          end
+        end
+
+        it 'does not fail' do
           expect(db.indexes(:quota_definitions)).to include(:name)
-        elsif db.database_type == :postgres
-          expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
+          expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
+          expect(db.indexes(:quota_definitions)).to include(:name)
         end
       end
     end
 
-    context 'unique constraint on name column does exist' do
-      it 'does not fail' do
+    context 'postgres' do
+      before do
+        skip if db.database_type != :postgres
+      end
+
+      it 'adds the unique constraint' do
+        expect(db.indexes(:quota_definitions)).not_to include(:quota_definitions_name_key)
         expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
-        if db.database_type == :mysql
-          expect(db.indexes(:quota_definitions)).to include(:name)
-        elsif db.database_type == :postgres
-          expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
+        expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
+      end
+
+      context 'unique constraint on name column already exists' do
+        before do
+          Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+
+          db.alter_table :quota_definitions do
+            add_unique_constraint :name, name: :quota_definitions_name_key
+          end
         end
-        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
-        if db.database_type == :mysql
-          expect(db.indexes(:quota_definitions)).to include(:name)
-        elsif db.database_type == :postgres
+
+        it 'does not fail' do
+          expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
+          expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
           expect(db.indexes(:quota_definitions)).to include(:quota_definitions_name_key)
         end
       end


### PR DESCRIPTION
~~This PR waits for issue[ #3949](https://github.com/cloudfoundry/cloud_controller_ng/issues/3949), if support for Mysql5.7 will be stopped.~~ -> MySQL 5.7 might be removed in Q1/Q2 2025. Adjusted this PR to support the old version.

On the name column in quota_defintions there were two unique constraints/indexes. One unique index with name qd_name_index, which is similar in postgres and mysql, and then an unique constraint on column name with name in postgres=```quota_definitions_name_key``` and name in mysql=```name```. These index/constraint are created during table creation:
```
    create_table :quota_definitions do
      VCAP::Migration.common(self, :qd)

      String :name, null: false, unique: true, case_insensitive: true
      Boolean :non_basic_services_allowed, null: false
      Integer :total_services, null: false
      Integer :memory_limit, null: false

      index :name, unique: true
    end
```
The ```unique: true``` in line ```String :name, null: false, unique: true, case_insensitive: true``` creates the unique constraint.
Since there is an unique index created on column name ``` index :name, unique: true``` (later renamed to qd_name_index), we don't need the unique constraint. Dropping it with this migration.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
