### PR TITLE
Update the state for each actual LRP when no state is given

### DIFF
--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -48,9 +48,9 @@ module VCAP::CloudController
         bbs_instances_client.lrp_instances(process).each do |actual_lrp|
           next unless actual_lrp.actual_lrp_key.index < process.instances
 
-          state ||= LrpStateTranslator.translate_lrp_state(actual_lrp)
+          lrp_state = state || LrpStateTranslator.translate_lrp_state(actual_lrp)
 
-          info = build_info(state, actual_lrp, process, stats, quota_stats, log_cache_errors)
+          info = build_info(lrp_state, actual_lrp, process, stats, quota_stats, log_cache_errors)
           info[:isolation_segment] = isolation_segment unless isolation_segment.nil?
           result[actual_lrp.actual_lrp_key.index] = info
         end


### PR DESCRIPTION
There is a discrepancy in how CAPI is reporting the status of an app (starting vs running state) when scaling the said application. When there are multiple instances of an app, instead of app moving from starting to running state, the application directly moves to running. This PR fixes the issue. Issue is a side effect of [this](https://github.com/cloudfoundry/cloud_controller_ng/commit/be8af0a75bc2c6b7d411d7d397a994906fb69b6d) commit.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
