### PR TITLE
Optimize service instances SQL query efficiency

### DIFF
--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -22,7 +22,7 @@ module VCAP::CloudController
         end
 
         filter(dataset, message).
-          select_all(:service_instances).
+          select_all(:service_instances)
       end
 
       private

--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -23,7 +23,6 @@ module VCAP::CloudController
 
         filter(dataset, message).
           select_all(:service_instances).
-          distinct
       end
 
       private


### PR DESCRIPTION
Service instances cannot have duplicate values due to the primary key constraint on GUID, so using distinct is not only redundant but also affects query performance.

Co-authored-by: @shahnavaz


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
