### PR TITLE
Test that shared service isntances don't result in duplicate results

### DIFF
--- a/spec/unit/fetchers/service_instance_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_instance_list_fetcher_spec.rb
@@ -26,6 +26,11 @@ module VCAP::CloudController
         expect(fetcher.fetch(message, omniscient: true).all).to contain_exactly(msi_1, msi_2, msi_3, upsi, ssi)
       end
 
+      it 'does not contain duplicates' do
+        ssi.add_shared_space(space_1)
+        expect(fetcher.fetch(message, omniscient: true).all).to contain_exactly(msi_1, msi_2, msi_3, upsi, ssi)
+      end
+
       it 'fetches nothing for users who cannot see any spaces' do
         expect(fetcher.fetch(message, readable_spaces_dataset: Space.where(id: -1).select(:guid)).all).to be_empty
       end


### PR DESCRIPTION
* when a service instance is shared with two or more spaces the user can see, the left join in the fetcher can result in duplicates



* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
