### PR TITLE
Add db connection metrics

### DIFF
--- a/lib/cloud_controller/runner.rb
+++ b/lib/cloud_controller/runner.rb
@@ -29,6 +29,11 @@ module VCAP::CloudController
       secrets_hash = parse_secrets
       parse_config(secrets_hash)
 
+      # DB connection metrics have a label to determine whether the process accessing the connection is the
+      # main or a worker process. We need to set this env variable before `setup_db` otherwise the main process
+      # will show up twice in the metrics as main and worker. Thin metrics will be labeled with main as well.
+      ENV['PROCESS_TYPE'] = 'main'
+
       setup_cloud_controller
 
       request_logs = VCAP::CloudController::Logs::RequestLogs.new(Steno.logger('cc.api'))

--- a/lib/sequel/extensions/connection_metrics.rb
+++ b/lib/sequel/extensions/connection_metrics.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#
+# The connection_metrics extension enhances a database's
+# connection pool to store metrics about the use of connections.
+# Whenever a connection is acquired or released the number of
+# currently acquired connections is emitted. Same for making new
+# connections and disconnecting them from the DB. Example of use:
+#
+#   DB.extension(:connection_metrics)
+#
+# Note that this extension has been only tested with a
+# connection pool type :threaded. To use it with other
+# connection pool types it might need adjustments.
+#
+# Related module: Sequel::ConnectionMetrics
+
+module Sequel
+  module ConnectionMetrics
+    # Initialize the data structures used by this extension.
+    def self.extended(pool)
+      raise Error.new('cannot load connection_metrics extension if using a connection pool type different than :threaded') unless pool.pool_type == :threaded
+
+      pool.instance_exec do
+        sync do
+          @prometheus_updater = CloudController::DependencyLocator.instance.prometheus_updater
+          @connection_info = {}
+        end
+      end
+    end
+
+    private
+
+    def acquire(thread)
+      begin
+        if (conn = super)
+          acquired_at = Time.now.utc
+          @prometheus_updater.increment_gauge_metric(:cc_acquired_db_connections_total, labels: { process_type: })
+          @connection_info[thread] ||= {}
+          @connection_info[thread][:acquired_at] = acquired_at
+        end
+      rescue Sequel::PoolTimeout
+        @prometheus_updater.increment_gauge_metric(:cc_db_connection_pool_timeouts_total, labels: { process_type: })
+        raise
+      ensure
+        # acquire calls assign_connection, where the thread possibly has to wait for a free connection.
+        # For both cases, when the thread acquires a connection in time, or when it runs into a PoolTimeout,
+        # we emmit the time the thread waited for a connection.
+        if @connection_info[thread] && @connection_info[thread].key?(:waiting_since)
+          @prometheus_updater.update_histogram_metric :cc_db_connection_wait_duration_seconds, (Time.now.utc - @connection_info[thread][:waiting_since]).seconds
+          @connection_info[thread].delete(:waiting_since)
+        end
+      end
+      conn
+    end
+
+    def assign_connection(thread)
+      # if assign_connection does not return a connection, the pool is exhausted and the thread has to wait
+      unless (conn = super)
+        waiting_since = Time.now.utc
+        @connection_info[thread] = { waiting_since: } unless @connection_info[thread] && @connection_info[thread].key?(:waiting_since)
+      end
+      conn
+    end
+
+    def make_new(server)
+      conn = super
+      @prometheus_updater.update_gauge_metric(:cc_open_db_connections_total, size, labels: { process_type: })
+      conn
+    end
+
+    def disconnect_connection(conn)
+      super
+      @prometheus_updater.update_gauge_metric(:cc_open_db_connections_total, size, labels: { process_type: })
+    end
+
+    def release(thread)
+      super
+
+      # acquired_at should be always set, but as a safeguard we check that it is present before accessing
+      if @connection_info[thread] && @connection_info[thread].key?(:acquired_at)
+        @prometheus_updater.update_histogram_metric :cc_db_connection_hold_duration_seconds, (Time.now.utc - @connection_info[thread][:acquired_at]).seconds
+      end
+
+      @prometheus_updater.decrement_gauge_metric(:cc_acquired_db_connections_total, labels: { process_type: })
+      @connection_info.delete(thread)
+    end
+
+    def process_type
+      ENV.fetch('PROCESS_TYPE', nil)
+    end
+  end
+
+  Database.register_extension(:connection_metrics) { |db| db.pool.extend(ConnectionMetrics) }
+end

--- a/spec/unit/lib/cloud_controller/runner_spec.rb
+++ b/spec/unit/lib/cloud_controller/runner_spec.rb
@@ -66,6 +66,12 @@ module VCAP::CloudController
         end
       end
 
+      it 'sets environment variable `PROCESS_TYPE` to `main`' do
+        subject
+
+        expect(ENV.fetch('PROCESS_TYPE')).to eq('main')
+      end
+
       describe 'setting max db connections per process for puma' do
         context 'when max db connections per process value is specified' do
           before do

--- a/spec/unit/lib/sequel/extensions/connection_metrics_spec.rb
+++ b/spec/unit/lib/sequel/extensions/connection_metrics_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+
+RSpec.describe Sequel::ConnectionMetrics do
+  let(:db_config) { DbConfig.new }
+  # each test will have their own db connection pool. This helps to isolate the test from each other.
+  let(:db) { VCAP::CloudController::DB.connect(db_config.config, db_config.db_logger) }
+  let(:logs) { StringIO.new }
+  let(:logger) { Logger.new(logs) }
+  let(:prometheus_updater) { spy(VCAP::CloudController::Metrics::PrometheusUpdater) }
+  let(:thread) { double('Thread') }
+
+  before do
+    db.loggers << logger
+    db.sql_log_level = :info
+    db.extension(:connection_metrics)
+
+    allow(thread).to receive(:alive?).and_return(true)
+
+    db.pool.instance_variable_set(:@prometheus_updater, prometheus_updater)
+
+    ENV['PROCESS_TYPE'] = 'puma_worker'
+  end
+
+  after do
+    db.disconnect
+  end
+
+  it 'initializes the prometheus_updater and connection_info' do
+    expect(db.pool.instance_variable_get(:@prometheus_updater)).to eq(prometheus_updater)
+    expect(db.pool.instance_variable_get(:@connection_info)).to be_a(Hash)
+  end
+
+  describe 'acquire' do
+    context 'when acquire returns a connection' do
+      it 'increments the acquired DB connections metric' do
+        expect(prometheus_updater).to receive(:increment_gauge_metric).with(:cc_acquired_db_connections_total, labels: { process_type: 'puma_worker' })
+
+        db.pool.send(:acquire, thread)
+      end
+
+      it 'stores the timestamp when the connection was acquired' do
+        db.pool.send(:acquire, thread)
+        expect(db.pool.instance_variable_get(:@connection_info)[thread]).to have_key(:acquired_at)
+      end
+    end
+
+    context 'when the pool is exhausted and throws a PoolTimeout' do
+      before do
+        # actually acquire throws the exception, but when mocking like this the extension would also be mocked away
+        allow(db.pool).to receive(:assign_connection).and_raise(Sequel::PoolTimeout)
+      end
+
+      it 'increments the connection pool timeouts metric and raises' do
+        expect(prometheus_updater).to receive(:increment_gauge_metric).with(:cc_db_connection_pool_timeouts_total, labels: { process_type: 'puma_worker' })
+
+        expect { db.pool.send(:acquire, thread) }.to raise_error(Sequel::PoolTimeout)
+      end
+
+      it 'emits the time the thread waited for the connection' do
+        db.pool.instance_variable_set(:@connection_info, db.pool.instance_variable_get(:@connection_info).merge!({ thread => { waiting_since: Time.now - 60 } }))
+        expect(prometheus_updater).to receive(:update_histogram_metric).with(:cc_db_connection_wait_duration_seconds, an_instance_of(ActiveSupport::Duration))
+
+        expect { db.pool.send(:acquire, thread) }.to raise_error(Sequel::PoolTimeout)
+      end
+    end
+  end
+
+  describe 'assign_connection' do
+    context 'when assign_connection returns a connection' do
+      it 'does not set the waiting_since timestamp' do
+        db.pool.send(:assign_connection, thread)
+        expect(db.pool.instance_variable_get(:@connection_info)[thread]).to be_nil
+      end
+    end
+
+    context 'when assign_connection does not return a connection' do
+      before do
+        db.pool.instance_variable_set(:@max_size, 1)
+        db.pool.send(:acquire, thread)
+      end
+
+      it 'stores the timestamp since when the thread is waiting for the connection' do
+        waiting_since = nil
+        Timecop.freeze do
+          waiting_since = Time.now
+          expect(db.pool.send(:assign_connection, thread)).to be_nil
+        end
+        expect(db.pool.instance_variable_get(:@connection_info)[thread][:waiting_since]).to eq(waiting_since)
+      end
+    end
+  end
+
+  describe 'make_new' do
+    it 'sets the open db connection metric to the current size of the pool' do
+      expect(prometheus_updater).to receive(:update_gauge_metric).with(:cc_open_db_connections_total, an_instance_of(Integer), labels: { process_type: 'puma_worker' })
+      db.pool.send(:make_new, thread)
+    end
+  end
+
+  describe 'disconnect_connection' do
+    let(:conn) { db.pool.send(:acquire, thread) }
+
+    it 'sets the open db connection metric to the current size of the pool' do
+      expect(prometheus_updater).to receive(:update_gauge_metric).with(:cc_open_db_connections_total, an_instance_of(Integer), labels: { process_type: 'puma_worker' })
+      db.pool.send(:disconnect_connection, conn)
+    end
+  end
+
+  describe 'release' do
+    before do
+      db.pool.send(:acquire, thread)
+    end
+
+    it 'emits the db connection hold duration' do
+      acquired_at = Time.now - 5
+      db.pool.instance_variable_set(:@connection_info, db.pool.instance_variable_get(:@connection_info).merge!({ thread => { acquired_at: } }))
+
+      Timecop.freeze do
+        hold_duration = Time.now - acquired_at
+        expect(prometheus_updater).to receive(:update_histogram_metric).with(:cc_db_connection_hold_duration_seconds, hold_duration)
+        db.pool.send(:release, thread)
+      end
+    end
+
+    it 'decrements the acquired db connection metric' do
+      expect(prometheus_updater).to receive(:decrement_gauge_metric).with(:cc_acquired_db_connections_total, labels: { process_type: 'puma_worker' })
+      db.pool.send(:release, thread)
+    end
+
+    it 'deletes the connection info' do
+      db.pool.send(:release, thread)
+      expect(db.pool.instance_variable_get(:@connection_info)[:thread]).to be_nil
+    end
+
+    context 'when the acquired_at timestamp is missing' do
+      before do
+        db.pool.instance_variable_set(:@connection_info, {})
+      end
+
+      it 'does not crash' do
+        db.pool.send(:release, thread)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### A short explanation of the proposed change:

Add metrics about DB connection usage.

### An explanation of the use cases your change solves

To better understand the DB connection usage, especially when using Puma, we introduce metrics which track how many connections have been opened, are currently used, available and the hold and wait duration.

### Links to any other associated PRs
None

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
