### PR TITLE
Prevent deletion of current droplet with foreign key

### DIFF
--- a/db/migrations/20240904132000_add_foreign_key_apps_droplet_guid.rb
+++ b/db/migrations/20240904132000_add_foreign_key_apps_droplet_guid.rb
@@ -1,0 +1,44 @@
+def get_column_definition(table, column)
+  fetch("SHOW FULL COLUMNS FROM `#{table}`;").all.find { |c| c[:Field] == column }
+end
+
+def verify_no_other_modification(definition_before, definition_after)
+  definition_after.each do |key, value|
+    raise "Column definition '#{key}' was changed from '#{definition_before[key]}' to '#{value}'" unless value == definition_before[key]
+  end
+end
+
+Sequel.migration do
+  up do
+    if foreign_key_list(:apps).none? { |fk| fk[:name] == :fk_apps_droplet_guid }
+      self[:apps].exclude(droplet_guid: self[:droplets].select(:guid)).exclude(droplet_guid: nil).update(droplet_guid: nil)
+
+      if database_type == :mysql
+        # Ensure that the collation of the foreign key column (apps.droplet_guid) matches the referenced column (droplets.guid)
+        guid_definition = get_column_definition('droplets', 'guid')
+        droplet_guid_definition = get_column_definition('apps', 'droplet_guid')
+
+        unless droplet_guid_definition[:Collation] == guid_definition[:Collation]
+          run("ALTER TABLE `apps` MODIFY COLUMN `droplet_guid` #{droplet_guid_definition[:Type]} COLLATE #{guid_definition[:Collation]};")
+
+          changed_droplet_guid_definition = get_column_definition('apps', 'droplet_guid')
+          raise 'Collation was not changed!' unless changed_droplet_guid_definition[:Collation] == guid_definition[:Collation]
+
+          verify_no_other_modification(droplet_guid_definition.except(:Collation), changed_droplet_guid_definition.except(:Collation))
+        end
+      end
+
+      alter_table :apps do
+        add_foreign_key [:droplet_guid], :droplets, key: :guid, name: :fk_apps_droplet_guid
+      end
+    end
+  end
+
+  down do
+    if foreign_key_list(:apps).any? { |fk| fk[:name] == :fk_apps_droplet_guid }
+      alter_table :apps do
+        drop_foreign_key [:droplet_guid], name: :fk_apps_droplet_guid
+      end
+    end
+  end
+end

--- a/spec/migrations/20240904132000_add_foreign_key_apps_droplet_guid_spec.rb
+++ b/spec/migrations/20240904132000_add_foreign_key_apps_droplet_guid_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe "migration to add foreign key on column 'droplet_guid' in table 'apps'", isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20240904132000_add_foreign_key_apps_droplet_guid.rb' }
+  end
+
+  describe 'apps table' do
+    after do
+      db[:apps].delete
+    end
+
+    context 'before adding the foreign key' do
+      it 'allows inserts with a droplet_guid that does not exist' do
+        expect { db[:apps].insert(guid: 'app_guid', droplet_guid: 'not_exists') }.not_to raise_error
+      end
+    end
+
+    context 'after adding the foreign key' do
+      it 'prevents inserts with a droplet_guid that does not exist' do
+        Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+
+        expect { db[:apps].insert(guid: 'app_guid', droplet_guid: 'not_exists') }.to raise_error(Sequel::ForeignKeyConstraintViolation)
+      end
+
+      it 'removed references to not existing droplets' do
+        db[:droplets].insert(guid: 'droplet_guid', state: 'some_state')
+        db[:apps].insert(guid: 'app_guid', droplet_guid: 'droplet_guid')
+        db[:apps].insert(guid: 'another_app_guid', droplet_guid: 'not_exists')
+
+        Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+
+        expect(db[:apps].where(guid: 'app_guid').get(:droplet_guid)).to eq('droplet_guid')
+        expect(db[:apps].where(guid: 'another_app_guid').get(:droplet_guid)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/models/runtime/app_model_spec.rb
+++ b/spec/unit/models/runtime/app_model_spec.rb
@@ -277,6 +277,12 @@ module VCAP::CloudController
           app_model.droplet = droplet
           expect(app_model).to be_valid
         end
+
+        it 'raises a ValidationFailed error in case the given droplet_guid does not exist' do
+          expect do
+            app_model.update(droplet_guid: 'not-existing')
+          end.to raise_error(Sequel::ValidationFailed, /droplet presence/)
+        end
       end
     end
 


### PR DESCRIPTION
- Add foreign key from `apps.droplet_guid` to `droplets.guid`.
- MySQL only: ensure that the collation of the foreign key column (`apps.droplet_guid`) matches the referenced column (`droplets.guid`).
- Remove invalid current droplet relations (i.e. guid does not exist) before creating the foreign key constraint.
- Add tests for `ForeignKeyConstraintViolation` errors.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
