### PR TITLE
Remove queue parameter for worker

### DIFF
--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -167,9 +167,6 @@ module VCAP::CloudController
 
             jobs: {
               global: { timeout_in_seconds: Integer },
-              queues: {
-                optional(:cc_generic) => { timeout_in_seconds: Integer }
-              },
               optional(:enable_dynamic_job_priorities) => bool,
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },


### PR DESCRIPTION
So far this parameter is only supported for the cc-generic queue for which jobs are only enqueued on API nodes.
Related to #3945 

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
