### PR TITLE
Use deferred join to improve pagination performance

### DIFF
--- a/lib/cloud_controller/paging/sequel_paginator.rb
+++ b/lib/cloud_controller/paging/sequel_paginator.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
       records, count = if can_paginate_with_window_function?(dataset)
                          paginate_with_window_function(dataset, per_page, page, table_name)
                        else
-                         paginate_with_extension(dataset, per_page, page)
+                         paginate_with_extension(dataset, per_page, page, table_name)
                        end
 
       PaginatedResult.new(records, count, pagination_options)
@@ -34,20 +34,53 @@ module VCAP::CloudController
 
     def paginate_with_window_function(dataset, per_page, page, table_name)
       dataset = dataset.from_self if dataset.opts[:distinct]
-      dataset = if dataset.opts[:graph]
-                  dataset.add_graph_aliases(pagination_total_results: [table_name, :pagination_total_results, Sequel.function(:count).*.over])
-                else
-                  dataset.select_append(Sequel.as(Sequel.function(:count).*.over, :pagination_total_results))
-                end
-      records = dataset.limit(per_page, (page - 1) * per_page).all
+
+      paged_dataset = dataset.limit(per_page, (page - 1) * per_page)
+
+      paged_dataset = if dataset.opts[:graph]
+                        paged_dataset.add_graph_aliases(pagination_total_results: [table_name, :pagination_total_results, Sequel.function(:count).*.over])
+                      elsif from_is_table?(dataset)
+                        dataset.join_table(
+                          :inner,
+                          paged_dataset.select(Sequel[table_name][:id].as(:tmp_deferred_id)).
+                              select_append(Sequel.as(Sequel.function(:count).*.over, :pagination_total_results)).
+                              as(:tmp_deferred_table),
+                          Sequel[table_name][:id] => Sequel[:tmp_deferred_table][:tmp_deferred_id]
+                        ).select_append(:pagination_total_results)
+                      else
+                        paged_dataset.select_append(Sequel.as(Sequel.function(:count).*.over, :pagination_total_results))
+                      end
+
+      records = paged_dataset.all
+
       count = records.any? ? records.first[:pagination_total_results] : 0
-      records.each { |x| x.values.delete(:pagination_total_results) }
+      records.each do |x|
+        x.values.delete(:pagination_total_results)
+        x.values.delete(:tmp_deferred_id)
+      end
       [records, count]
     end
 
-    def paginate_with_extension(dataset, per_page, page)
-      query = dataset.extension(:pagination).paginate(page, per_page)
-      [query.all, query.pagination_record_count]
+    def paginate_with_extension(dataset, per_page, page, table_name)
+      paged_dataset = dataset.extension(:pagination).paginate(page, per_page)
+      count = paged_dataset.pagination_record_count
+
+      if from_is_table?(dataset)
+        paged_dataset = dataset.join_table(
+          :inner,
+          paged_dataset.select(Sequel[table_name][:id].as(:tmp_deferred_id)).as(:tmp_deferred_table),
+          Sequel[table_name][:id] => Sequel[:tmp_deferred_table][:tmp_deferred_id]
+        )
+      end
+
+      records = paged_dataset.all
+      records.each { |x| x.values.delete(:tmp_deferred_id) }
+
+      [records, count]
+    end
+
+    def from_is_table?(dataset)
+      [Symbol, String].include?(dataset.opts[:from].first.class)
     end
   end
 end

--- a/lib/cloud_controller/paging/sequel_paginator.rb
+++ b/lib/cloud_controller/paging/sequel_paginator.rb
@@ -54,6 +54,7 @@ module VCAP::CloudController
       records = paged_dataset.all
 
       count = records.any? ? records.first[:pagination_total_results] : 0
+
       records.each do |x|
         x.values.delete(:pagination_total_results)
         x.values.delete(:tmp_deferred_id)
@@ -74,7 +75,9 @@ module VCAP::CloudController
       end
 
       records = paged_dataset.all
-      records.each { |x| x.values.delete(:tmp_deferred_id) }
+
+      has_tmp_deferred_id = records.first&.keys&.include?(:tmp_deferred_id)
+      records.each { |x| x.values.delete(:tmp_deferred_id) } if has_tmp_deferred_id
 
       [records, count]
     end


### PR DESCRIPTION
When tables have large number of records, pagination using LIMIT and increasing values for OFFSET result
in inefficient queries. Instead of performing the pagination on the whole table,
this technique performs the pagination on a subset of the data. The subset is generated
by a subquery that only looks at the ID column (which is indexed) and then rejoins the result
to the original table. This improve DB query times generated by the SequelPaginator on both
MySQL and Postgres.

This technique has been implemented and works for both pagination using OVER window functions and
without.

Sequel gem supports eager loading and eager graph loading which introduces complications for this
technique, therefore we do not yet support this technique for this method.

Additionally, some paginated queries are not generated from a table, but are simply the result of a
subquery, for example Roles is a union of a permissions, we also explicitly do not perform this
technique on these requests as there is no natural ID field that will have been indexed. We only
do deferred joins when the SQL query "FROM" is from a table (e.g. :apps, "apps").

See https://planetscale.com/learn/courses/mysql-for-developers/examples/deferred-joins

As an example:

Before:
```
SELECT *
FROM `service_instances`
ORDER BY `service_instances`.`id` ASC
LIMIT 50
OFFSET 9950;
```

After:
```
SELECT *
FROM `service_instances`
INNER JOIN
  (SELECT `service_instances`.`id` AS tmp_id
   FROM `service_instances`
   ORDER BY `service_instances`.`id` ASC
   LIMIT 50
   OFFSET 9950) AS `tmp` ON (`service_instances`.`id` = `tmp`.`tmp_id`)
ORDER BY `service_instances`.`id` ASC;
```

Performance testing:
* Hit the last page of the resource and used page size of 50
* Each test hit the endpoint 20 times and took the average result
* MySQL Server version: 8.0.36-28 Percona XtraDB Cluster (GPL) 8.0.36-28, WSREP version 26.1.4.3
* Postgres 16
* CF deployed on bosh-lite with default cf-deployment (paginate_window=true)
* Events table does not use window functions, Tasks does


## Tasks

### MySQL

| Rows   | Today | Deferred Join | % Faster      | Times Faster |
|--------|-------|---------------|---------------|--------------|
| 100    | 0.411 | 0.404         | 1.70%         | 1.0173       |
| 1,000  | 0.418 | 0.407         | 2.63%         | 1.0270       |
| 10,000 | 0.533 | 0.427         | 19.89%        | 1.2482       |
| 100,000| 3.107 | 0.607         | 80.46%        | 5.1186       |
| 500,000| 13.907| 1.067         | 92.33%        | 13.0337      |
| 1,000,000| 28.600| 1.778       | 93.78%        | 16.0855      |

### PostgreSQL

| Rows   | Today | Deferred Join | % Faster      | Times Faster |
|--------|-------|---------------|---------------|--------------|
| 100    | 0.361 | 0.357         | 1.11%         | 1.0112       |
| 1,000  | 0.353 | 0.359         | -1.70%        | 0.9833       |
| 10,000 | 0.378 | 0.361         | 4.50%         | 1.0471       |
| 100,000| 0.595 | 0.452         | 24.03%        | 1.3164       |
| 500,000| 1.417 | 0.894         | 36.91%        | 1.5850       |
| 1,000,000| 2.637| 1.512        | 42.66%        | 1.7440       |


## Events

### MySQL

| Rows   | Today | Deferred Join | % Faster      | Times Faster |
|--------|-------|---------------|---------------|--------------|
| 100    | 0.304 | 0.303         | 0.33%         | 1.0033       |
| 1000   | 0.301 | 0.304         | -0.99%        | 0.9901       |
| 10,000 | 0.320 | 0.305         | 4.69%         | 1.0492       |
| 100,000| 0.438 | 0.353         | 19.41%        | 1.2408       |
| 500,000| 0.959 | 0.529         | 44.84%        | 1.8129       |
| 1,000,000| 1.823| 0.967         | 46.96%        | 1.8852       |
| 5,000,000| 6.981| 2.329         | 66.64%        | 2.9974       |

### PostgreSQL

| Rows   | Today | Deferred Join | % Faster      | Times Faster |
|--------|-------|---------------|---------------|--------------|
| 100    | 0.296 | 0.295         | 0.34%         | 1.0034       |
| 1,000  | 0.301 | 0.298         | 0.99%         | 1.0101       |
| 10,000 | 0.310 | 0.297         | 4.19%         | 1.0438       |
| 100,000| 0.339 | 0.317         | 6.49%         | 1.0694       |
| 500,000| 0.590 | 0.356         | 39.66%        | 1.6573       |
| 1,000,000| 0.889| 0.458         | 48.48%        | 1.9410       |
| 5,000,000| 3.249| 0.992         | 69.47%        | 3.2752       |


## Events (page_size=5000)

### MySQL

| Rows   | Today | Deferred Join | % Faster      | Times Faster |
|--------|-------|---------------|---------------|--------------|
| 5,000,000| 9.116| 4.546        | 50.13%        | 2.0053       |

### PostgreSQL

| Rows   | Today | Deferred Join | % Faster      | Times Faster |
|--------|-------|---------------|---------------|--------------|
| 5,000,000| 5.158| 3.166        | 38.62%        | 1.6292       |

---
Charts

<img width="647" alt="image" src="https://github.com/user-attachments/assets/120e9988-9c12-4488-9af3-a116e650d949">
<img width="642" alt="image" src="https://github.com/user-attachments/assets/c9cc8fde-654e-45e2-9df3-d708d008c819">
<img width="650" alt="image" src="https://github.com/user-attachments/assets/93d62dbe-9e15-4bca-9df6-4a6478c87f7f">
<img width="644" alt="image" src="https://github.com/user-attachments/assets/50f15a4a-197c-43b8-9d09-17a165a1897d">

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
