### PR TITLE
Make STOPPING state optional

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -393,3 +393,4 @@ max_manifest_service_binding_poll_duration_in_seconds: 60
 update_metric_tags_on_rename: true
 
 app_log_revision: true
+app_instance_stopping_state: true

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -381,7 +381,8 @@ module VCAP::CloudController
               dataset: String
             },
 
-            update_metric_tags_on_rename: bool
+            update_metric_tags_on_rename: bool,
+            app_instance_stopping_state: bool
           }
         end
         # rubocop:enable Metrics/BlockLength

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -85,9 +85,10 @@ module VCAP::CloudController
         if bbs_instances_client.lrp_instances(process).empty?
           [fill_unreported_instances_with_down_instances({}, process, flat: false), []]
         else
+          state = Config.config.get(:app_instance_stopping_state) ? VCAP::CloudController::Diego::LRP_STOPPING : VCAP::CloudController::Diego::LRP_DOWN
           # case when no desired_lrp exists but an actual_lrp
-          logger.debug('Actual LRP found, setting state to STOPPING', process_guid: process.guid)
-          actual_lrp_info(process, nil, nil, nil, nil, VCAP::CloudController::Diego::LRP_STOPPING)
+          logger.debug("Actual LRP found, setting state to #{state}", process_guid: process.guid)
+          actual_lrp_info(process, nil, nil, nil, nil, state)
         end
       rescue CloudController::Errors::NoRunningInstances => e
         logger.info('stats_for_app.error', error: e.to_s)

--- a/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
@@ -198,6 +198,39 @@ module VCAP::CloudController
           it 'shows all instances as "STOPPING" state' do
             expect(instances_reporter.stats_for_app(process)).to eq([expected_stopping_response, []])
           end
+
+          context 'when "app_instance_stopping_state" is false' do
+            before do
+              TestConfig.override(app_instance_stopping_state: false)
+            end
+
+            let(:expected_down_response) do
+              {
+                0 => {
+                  state: 'DOWN',
+                  routable: is_routable,
+                  stats: {
+                    name: process.name,
+                    uris: process.uris,
+                    host: 'lrp-host',
+                    port: 2222,
+                    net_info: lrp_1_net_info.to_h,
+                    uptime: two_days_in_seconds,
+                    mem_quota: nil,
+                    disk_quota: nil,
+                    log_rate_limit: nil,
+                    fds_quota: process.file_descriptors,
+                    usage: {}
+                  },
+                  details: 'some-details'
+                }
+              }
+            end
+
+            it 'shows all instances as "DOWN" state' do
+              expect(instances_reporter.stats_for_app(process)).to eq([expected_down_response, []])
+            end
+          end
         end
 
         context 'when a NoRunningInstances error is thrown for desired_lrp and it does not exist an actual_lrp' do


### PR DESCRIPTION
* new STOPPING state could be viewed as a breaking change

related: https://github.com/cloudfoundry/capi-release/pull/473
