### PR TITLE
Raise error if a previous packer job attempt is detected

### DIFF
--- a/lib/cloud_controller/packager/local_bits_packer.rb
+++ b/lib/cloud_controller/packager/local_bits_packer.rb
@@ -14,11 +14,11 @@ module CloudController
         tmp_dir = VCAP::CloudController::Config.config.get(:directories, :tmpdir)
         local_bits_packer_path = File.join(tmp_dir, "local_bits_packer-#{blobstore_key}")
 
-        begin
-          Dir.mkdir(local_bits_packer_path)
-        rescue StandardError => e
-          raise ConflictError.new("Found a leftover directory that might be from the previous worker’s unfinished job: #{e.message}")
+        if Dir.exist?(local_bits_packer_path)
+          raise ConflictError.new("Found a leftover directory that might be from the previous worker's unfinished job: #{local_bits_packer_path}")
         end
+
+        Dir.mkdir(local_bits_packer_path)
 
         begin
           complete_package_path = match_resources_and_validate_package(local_bits_packer_path, uploaded_package_zip, cached_files_fingerprints)

--- a/spec/unit/lib/cloud_controller/packager/local_bits_packer_spec.rb
+++ b/spec/unit/lib/cloud_controller/packager/local_bits_packer_spec.rb
@@ -325,6 +325,33 @@ module CloudController::Packager
           end
         end
       end
+
+      describe 'temporary directory cleanup' do
+        let(:local_bits_packer_path) { File.join(local_tmp_dir, "local_bits_packer-#{blobstore_key}") }
+
+        context 'when the package is successfully uploaded and processed' do
+          it 'removes the temporary directory created for packaging' do
+            allow_any_instance_of(CloudController::Blobstore::FogClient).to receive(:cp_to_blobstore)
+            allow(Digester).to receive(:new).and_return(instance_double(Digester, digest_path: 'fake-digest'))
+            expect(FileUtils).to receive(:remove_dir).with(local_bits_packer_path).and_call_original
+            packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
+          end
+        end
+
+        context 'when an exception is raised during processing' do
+          it 'removes the temporary directory created for packaging' do
+            allow(File).to receive(:join).and_call_original
+            allow(Dir).to receive(:exist?).and_return(false)
+            allow(Dir).to receive(:mkdir)
+
+            expect(FileUtils).to receive(:remove_dir).with(local_bits_packer_path)
+            expect do
+              allow_any_instance_of(CloudController::Blobstore::FogClient).to receive(:cp_to_blobstore).and_raise(StandardError)
+              packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
+            end.to raise_error(StandardError)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/unit/lib/cloud_controller/packager/local_bits_packer_spec.rb
+++ b/spec/unit/lib/cloud_controller/packager/local_bits_packer_spec.rb
@@ -149,6 +149,15 @@ module CloudController::Packager
         end
       end
 
+      context 'when there are leftovers from the previous run on the filesystem' do
+        it 'raises an informative error' do
+          Dir.mkdir(File.join(local_tmp_dir, "local_bits_packer-#{blobstore_key}"))
+          expect do
+            packer.send_package_to_blobstore(blobstore_key, uploaded_files_path, cached_files_fingerprints)
+          end.to raise_error(ConflictError, /unfinished job/)
+        end
+      end
+
       context 'when the app bits are too large' do
         let(:max_package_size) { 1 }
 


### PR DESCRIPTION
This could be helpful if a previous attempt crashed.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
