### PR TITLE
Orphan mitigation for instances/bindings in state "create failed"

### DIFF
--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -32,9 +32,8 @@ module VCAP::CloudController
 
         ServiceBinding.new.tap do |b|
           ServiceBinding.db.transaction do
-            existing_binding = binding
-            binding.destroy if existing_binding
-            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding) if existing_binding
+            binding&.destroy
+            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding) if binding
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_INITIAL_OPERATION

--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -32,7 +32,9 @@ module VCAP::CloudController
 
         ServiceBinding.new.tap do |b|
           ServiceBinding.db.transaction do
-            binding.destroy if binding
+            existing_binding = binding
+            binding.destroy if existing_binding
+            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding) if existing_binding
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_INITIAL_OPERATION

--- a/app/actions/service_credential_binding_app_create.rb
+++ b/app/actions/service_credential_binding_app_create.rb
@@ -32,8 +32,10 @@ module VCAP::CloudController
 
         ServiceBinding.new.tap do |b|
           ServiceBinding.db.transaction do
-            binding&.destroy
-            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding) if binding
+            if binding
+              binding.destroy
+              VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding)
+            end
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_INITIAL_OPERATION

--- a/app/actions/service_credential_binding_key_create.rb
+++ b/app/actions/service_credential_binding_key_create.rb
@@ -27,9 +27,8 @@ module VCAP::CloudController
 
         ServiceKey.new.tap do |b|
           ServiceKey.db.transaction do
-            existing_key = key
-            key.destroy if existing_key
-            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(key) if existing_key
+            key&.destroy
+            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(key) if key
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_INITIAL_OPERATION

--- a/app/actions/service_credential_binding_key_create.rb
+++ b/app/actions/service_credential_binding_key_create.rb
@@ -27,8 +27,10 @@ module VCAP::CloudController
 
         ServiceKey.new.tap do |b|
           ServiceKey.db.transaction do
-            key&.destroy
-            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(key) if key
+            if key
+              key.destroy
+              VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(key)
+            end
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_INITIAL_OPERATION

--- a/app/actions/service_credential_binding_key_create.rb
+++ b/app/actions/service_credential_binding_key_create.rb
@@ -27,7 +27,9 @@ module VCAP::CloudController
 
         ServiceKey.new.tap do |b|
           ServiceKey.db.transaction do
-            key.destroy if key
+            existing_key = key
+            key.destroy if existing_key
+            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(key) if existing_key
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_INITIAL_OPERATION

--- a/app/actions/service_route_binding_create.rb
+++ b/app/actions/service_route_binding_create.rb
@@ -26,8 +26,10 @@ module VCAP::CloudController
 
         RouteBinding.new.tap do |b|
           RouteBinding.db.transaction do
-            binding&.destroy
-            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding) if binding
+            if binding
+              binding.destroy
+              VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding)
+            end
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_INITIAL_OPERATION

--- a/app/actions/service_route_binding_create.rb
+++ b/app/actions/service_route_binding_create.rb
@@ -26,9 +26,8 @@ module VCAP::CloudController
 
         RouteBinding.new.tap do |b|
           RouteBinding.db.transaction do
-            existing_binding = binding
-            binding.destroy if existing_binding
-            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding) if existing_binding
+            binding&.destroy
+            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding) if binding
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_INITIAL_OPERATION

--- a/app/actions/service_route_binding_create.rb
+++ b/app/actions/service_route_binding_create.rb
@@ -26,7 +26,9 @@ module VCAP::CloudController
 
         RouteBinding.new.tap do |b|
           RouteBinding.db.transaction do
-            binding.destroy if binding
+            existing_binding = binding
+            binding.destroy if existing_binding
+            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_bind(binding) if existing_binding
             b.save_with_attributes_and_new_operation(
               binding_details,
               CREATE_INITIAL_OPERATION

--- a/app/actions/v3/service_instance_create_managed.rb
+++ b/app/actions/v3/service_instance_create_managed.rb
@@ -40,9 +40,10 @@ module VCAP::CloudController
 
         ManagedServiceInstance.new.tap do |i|
           ManagedServiceInstance.db.transaction do
-            instance_in_state_create_failed = instance&.create_failed?
-            instance.destroy if instance_in_state_create_failed
-            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_provision(instance) if instance_in_state_create_failed
+            if instance&.create_failed?
+              instance.destroy
+              VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_provision(instance)
+            end
             i.save_with_new_operation(attr, last_operation)
             MetadataUpdate.update(i, message)
           end

--- a/app/actions/v3/service_instance_create_managed.rb
+++ b/app/actions/v3/service_instance_create_managed.rb
@@ -1,4 +1,5 @@
 require 'services/service_brokers/service_client_provider'
+require 'services/service_brokers/v2/orphan_mitigator'
 require 'actions/mixins/service_instance_create'
 require 'actions/metadata_update'
 
@@ -39,7 +40,9 @@ module VCAP::CloudController
 
         ManagedServiceInstance.new.tap do |i|
           ManagedServiceInstance.db.transaction do
-            instance.destroy if instance&.create_failed?
+            instance_in_state_create_failed = instance&.create_failed?
+            instance.destroy if instance_in_state_create_failed
+            VCAP::Services::ServiceBrokers::V2::OrphanMitigator.new.cleanup_failed_provision(instance) if instance_in_state_create_failed
             i.save_with_new_operation(attr, last_operation)
             MetadataUpdate.update(i, message)
           end

--- a/spec/unit/actions/service_credential_binding_app_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_app_create_spec.rb
@@ -79,8 +79,12 @@ module VCAP::CloudController
             end
 
             context "when the last binding operation is in 'create failed' state" do
+              let(:fake_orphan_mitigator) { double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
+
               before do
                 binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })
+                allow(VCAP::Services::ServiceBrokers::V2::OrphanMitigator).to receive(:new).and_return(fake_orphan_mitigator)
+                allow(fake_orphan_mitigator).to receive(:cleanup_failed_bind).with(binding)
               end
 
               it 'deletes the existing binding and creates a new one' do
@@ -89,6 +93,7 @@ module VCAP::CloudController
                 expect(b.guid).not_to eq(binding.guid)
                 expect(b).to be_create_in_progress
                 expect { binding.reload }.to raise_error Sequel::NoExistingObject
+                expect(fake_orphan_mitigator).to have_received(:cleanup_failed_bind).with(binding)
               end
             end
 

--- a/spec/unit/actions/service_credential_binding_app_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_app_create_spec.rb
@@ -79,7 +79,7 @@ module VCAP::CloudController
             end
 
             context "when the last binding operation is in 'create failed' state" do
-              let(:fake_orphan_mitigator) { double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
+              let(:fake_orphan_mitigator) { instance_double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
 
               before do
                 binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })

--- a/spec/unit/actions/service_credential_binding_key_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_key_create_spec.rb
@@ -67,8 +67,12 @@ module VCAP::CloudController
             end
 
             context "when the last key operation is in 'create failed' state" do
+              let(:fake_orphan_mitigator) { double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
+
               before do
                 binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })
+                allow(VCAP::Services::ServiceBrokers::V2::OrphanMitigator).to receive(:new).and_return(fake_orphan_mitigator)
+                allow(fake_orphan_mitigator).to receive(:cleanup_failed_bind).with(binding)
               end
 
               it 'deletes the existing key and creates a new one' do
@@ -77,6 +81,7 @@ module VCAP::CloudController
                 expect(b.guid).not_to eq(binding.guid)
                 expect(b).to be_create_in_progress
                 expect { binding.reload }.to raise_error Sequel::NoExistingObject
+                expect(fake_orphan_mitigator).to have_received(:cleanup_failed_bind).with(binding)
               end
             end
 

--- a/spec/unit/actions/service_credential_binding_key_create_spec.rb
+++ b/spec/unit/actions/service_credential_binding_key_create_spec.rb
@@ -67,7 +67,7 @@ module VCAP::CloudController
             end
 
             context "when the last key operation is in 'create failed' state" do
-              let(:fake_orphan_mitigator) { double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
+              let(:fake_orphan_mitigator) { instance_double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
 
               before do
                 binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })

--- a/spec/unit/actions/service_route_binding_create_spec.rb
+++ b/spec/unit/actions/service_route_binding_create_spec.rb
@@ -119,8 +119,12 @@ module VCAP::CloudController
             end
 
             context "when the last service route binding operation is in 'create failed' state" do
+              let(:fake_orphan_mitigator) { double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
+
               before do
                 binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })
+                allow(VCAP::Services::ServiceBrokers::V2::OrphanMitigator).to receive(:new).and_return(fake_orphan_mitigator)
+                allow(fake_orphan_mitigator).to receive(:cleanup_failed_bind).with(binding)
               end
 
               it 'deletes the existing binding and creates a new one' do
@@ -129,6 +133,7 @@ module VCAP::CloudController
                 expect(b.guid).not_to eq(binding.guid)
                 expect(b).to be_create_in_progress
                 expect { binding.reload }.to raise_error Sequel::NoExistingObject
+                expect(fake_orphan_mitigator).to have_received(:cleanup_failed_bind).with(binding)
               end
             end
 

--- a/spec/unit/actions/service_route_binding_create_spec.rb
+++ b/spec/unit/actions/service_route_binding_create_spec.rb
@@ -119,7 +119,7 @@ module VCAP::CloudController
             end
 
             context "when the last service route binding operation is in 'create failed' state" do
-              let(:fake_orphan_mitigator) { double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
+              let(:fake_orphan_mitigator) { instance_double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
 
               before do
                 binding.save_with_attributes_and_new_operation({}, { type: 'create', state: 'failed' })

--- a/spec/unit/actions/v3/service_instance_create_managed_spec.rb
+++ b/spec/unit/actions/v3/service_instance_create_managed_spec.rb
@@ -123,7 +123,7 @@ module VCAP::CloudController
           end
 
           context "when the last operation is in state 'create failed'" do
-            let(:fake_orphan_mitigator) { double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
+            let(:fake_orphan_mitigator) { instance_double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
 
             before do
               instance.save_with_new_operation({}, { type: 'create', state: 'failed' })


### PR DESCRIPTION
It might be that a service broker that responds with create failed on a service instance/binding creation keeps
some meta data about the resource. The OSBAPI spec recommends that the platform performs orphan mitigation in such a case. Adding orphan mitigation to instance and binding creations, if they are in state create failed.

* A short explanation of the proposed change:
Adding orphan mitigation to instance and binding creations, if they are in state create failed.
* An explanation of the use cases your change solves
It might be that a service broker that responds with create failed on a service instance/binding creation keeps
some meta data about the resource. The OSBAPI spec recommends that the platform performs orphan mitigation in such a case. 
* Links to any other associated PRs
[3973](https://github.com/cloudfoundry/cloud_controller_ng/pull/3973)
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
