### PR TITLE
Use 3 retries with exp backoff for package upload

### DIFF
--- a/app/jobs/v3/package_bits.rb
+++ b/app/jobs/v3/package_bits.rb
@@ -21,7 +21,11 @@ module VCAP::CloudController
         end
 
         def max_attempts
-          1
+          3
+        end
+
+        def reschedule_at(time, attempts)
+          time + (2**attempts).seconds
         end
       end
     end

--- a/spec/unit/jobs/v3/package_bits_spec.rb
+++ b/spec/unit/jobs/v3/package_bits_spec.rb
@@ -13,6 +13,10 @@ module VCAP::CloudController
 
       it { is_expected.to be_a_valid_job }
 
+      it 'has max_attempts 3' do
+        expect(job.max_attempts).to eq 3
+      end
+
       describe '#perform' do
         let(:package_blobstore) { instance_double(CloudController::Blobstore::Client) }
         let(:tmpdir) { '/tmp/special_temp' }
@@ -27,6 +31,15 @@ module VCAP::CloudController
 
         it 'knows its job name' do
           expect(job.job_name_in_configuration).to equal(:package_bits)
+        end
+      end
+
+      describe '#reschedule_at' do
+        it 'uses exponential backoff' do
+          now = Time.now
+
+          run_at = job.reschedule_at(now, 5)
+          expect(run_at).to eq(now + (2**5).seconds)
         end
       end
     end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Implement retry with a short exponential backoff for the asynchronous package upload. This should remediate blobstore errors, e.g. the sporadic OpenSSL unexpected EOF errors we encounter on GCP/GCS.

* An explanation of the use cases your change solves
More resilience when uploading package bits.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`
```
Finished in 42 minutes 40 seconds (files took 37.13 seconds to load)
30147 examples, 0 failures, 11 pending
```
* [x] I have run [CF Acceptance Tests]
(only ran apps test suite)
```
Ran 56 of 240 Specs in 3616.992 seconds
FAIL! - Suite Timeout Elapsed -- 54 Passed | 2 Failed | 2 Pending | 182 Skipped
--- FAIL: TestCATS (3617.16s)
FAIL
```