### PR TITLE
Add OpenSSL::OpenSSLError to Fog RetryableClient config

### DIFF
--- a/lib/cloud_controller/blobstore/client_provider.rb
+++ b/lib/cloud_controller/blobstore/client_provider.rb
@@ -44,7 +44,7 @@ module CloudController
           # and intermittent GCS blobstore download errors
           errors = [Excon::Errors::BadRequest, Excon::Errors::SocketError, SystemCallError,
                     Excon::Errors::InternalServerError, Excon::Errors::ServiceUnavailable,
-                    Google::Apis::ServerError, Google::Apis::TransmissionError]
+                    Google::Apis::ServerError, Google::Apis::TransmissionError, OpenSSL::OpenSSLError]
           retryable_client = RetryableClient.new(client:, errors:, logger:)
 
           Client.new(ErrorHandlingClient.new(SafeDeleteClient.new(retryable_client, root_dir)))


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
On GCP we see sporadic OpenSSLErrors (unexpected eof) -> try to remediate with retries.

* An explanation of the use cases your change solves
Failing blobstore operations on GCP.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
