### PR TITLE
Allow cnb apps to be retrieved

### DIFF
--- a/app/fetchers/app_list_fetcher.rb
+++ b/app/fetchers/app_list_fetcher.rb
@@ -34,15 +34,26 @@ module VCAP::CloudController
         end
 
         if message.requested?(:lifecycle_type)
-          if message.lifecycle_type == BuildpackLifecycleDataModel::LIFECYCLE_TYPE
+          case message.lifecycle_type
+          when BuildpackLifecycleDataModel::LIFECYCLE_TYPE
             dataset = dataset.where(
               guid: BuildpackLifecycleDataModel.
               where(Sequel.~(app_guid: nil)).
               select(:app_guid)
             )
-          elsif message.lifecycle_type == DockerLifecycleDataModel::LIFECYCLE_TYPE
+          when DockerLifecycleDataModel::LIFECYCLE_TYPE
             dataset = dataset.exclude(
               guid: BuildpackLifecycleDataModel.
+              where(Sequel.~(app_guid: nil)).
+              select(:app_guid)
+            ).exclude(
+              guid: CNBLifecycleDataModel.
+              where(Sequel.~(app_guid: nil)).
+              select(:app_guid)
+            )
+          when CNBLifecycleDataModel::LIFECYCLE_TYPE
+            dataset = dataset.where(
+              guid: CNBLifecycleDataModel.
               where(Sequel.~(app_guid: nil)).
               select(:app_guid)
             )

--- a/app/messages/base_message.rb
+++ b/app/messages/base_message.rb
@@ -143,7 +143,7 @@ module VCAP::CloudController
       def validate(record)
         return unless record.requested?(:lifecycle_type)
 
-        valid_lifecycle_types = [BuildpackLifecycleDataModel::LIFECYCLE_TYPE, DockerLifecycleDataModel::LIFECYCLE_TYPE]
+        valid_lifecycle_types = [BuildpackLifecycleDataModel::LIFECYCLE_TYPE, DockerLifecycleDataModel::LIFECYCLE_TYPE, CNBLifecycleDataModel::LIFECYCLE_TYPE]
         return if valid_lifecycle_types.include?(record.lifecycle_type)
 
         record.errors.add(:base, message: "Invalid lifecycle_type: '#{record.lifecycle_type}'")

--- a/lib/cloud_controller/diego/task_environment.rb
+++ b/lib/cloud_controller/diego/task_environment.rb
@@ -23,7 +23,9 @@ module VCAP::CloudController
 
         task_env = task_env.merge('VCAP_PLATFORM_OPTIONS' => credhub_url) if credhub_url.present? && cred_interpolation_enabled?
 
-        task_env = task_env.merge('LANG' => DEFAULT_LANG) if app.lifecycle_type == BuildpackLifecycleDataModel::LIFECYCLE_TYPE
+        if app.lifecycle_type == BuildpackLifecycleDataModel::LIFECYCLE_TYPE || app.lifecycle_type == CNBLifecycleDataModel::LIFECYCLE_TYPE
+          task_env = task_env.merge('LANG' => DEFAULT_LANG)
+        end
         task_env = task_env.merge('DATABASE_URL' => app.database_uri) if app.database_uri
 
         task_env

--- a/spec/unit/fetchers/app_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/app_list_fetcher_spec.rb
@@ -168,11 +168,13 @@ module VCAP::CloudController
       end
 
       context 'when a lifecycle_type is provided' do
-        let!(:docker_app) { AppModel.make(name: 'docker-app', space_guid: space.guid) }
+        let!(:docker_app) { AppModel.make(:docker, name: 'docker-app', space_guid: space.guid) }
+        let!(:cnb_app) { AppModel.make(:cnb, name: 'cnb-app', space_guid: space.guid) }
 
         before do
           docker_app.buildpack_lifecycle_data = nil
           docker_app.save
+          cnb_app.save
         end
 
         context 'of type buildpack' do
@@ -180,6 +182,14 @@ module VCAP::CloudController
 
           it 'returns all of the buildpack apps' do
             expect(apps.all).to contain_exactly(app, sad_app)
+          end
+        end
+
+        context 'of type cnb' do
+          let(:filters) { { lifecycle_type: 'cnb' } }
+
+          it 'returns all of the cnb apps' do
+            expect(apps.all).to contain_exactly(cnb_app)
           end
         end
 

--- a/spec/unit/lib/cloud_controller/diego/task_environment_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/task_environment_spec.rb
@@ -96,6 +96,15 @@ module VCAP::CloudController::Diego
         end
       end
 
+      context 'when the task is for a cnb app' do
+        let(:app) { VCAP::CloudController::AppModel.make(:cnb) }
+
+        it 'sets the LANG environment variable' do
+          constructed_envs = TaskEnvironment.new(app, task, space).build
+          expect(constructed_envs).to include('LANG' => 'en_US.UTF-8')
+        end
+      end
+
       context 'when the app has a route associated with it' do
         let(:expected_vcap_application) do
           {

--- a/spec/unit/messages/base_message_spec.rb
+++ b/spec/unit/messages/base_message_spec.rb
@@ -271,8 +271,14 @@ module VCAP::CloudController
         end
       end
 
-      it 'is valid with an allowed lifecycle_type value' do
+      it 'is valid with docker lifecycle_type value' do
         message = fake_class.new({ lifecycle_type: 'docker' })
+
+        expect(message).to be_valid
+      end
+
+      it 'is valid with cnb lifecycle_type value' do
+        message = fake_class.new({ lifecycle_type: 'cnb' })
 
         expect(message).to be_valid
       end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

Querying apps by lifecycle_type (`cf curl "/v3/apps?lifecycle_type=cnb"`) currently throws an error:

```json
{
  "errors": [
    {
      "detail": "The query parameter is invalid: Invalid lifecycle_type: 'cnb'",
      "title": "CF-BadQueryParameter",
      "code": 10005
    }
  ]
}
```

This PR adds the `cnb` lifecycle type to be valid when querying for apps.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)
* [x] I have viewed, signed, and submitted the Contributor License Agreement
* [x] I have made this pull request to the `main` branch
* [x] I have run all the unit tests using `bundle exec rake`
* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
