### PR TITLE
Fix rotate_database_key_spec

### DIFF
--- a/spec/unit/lib/cloud_controller/errands/rotate_database_key_spec.rb
+++ b/spec/unit/lib/cloud_controller/errands/rotate_database_key_spec.rb
@@ -124,7 +124,7 @@ module VCAP::CloudController
             entity = encrypted_models[klass]
             nilable_string_columns = nilable_columns(entity)
             vals = entity.reload.values.except(*encrypted_columns(entity.class), *nilable_string_columns)
-            expect(vals.values.all?(&:present?)).to be_truthy, "all fields of #{entity.class} need to have values"
+            vals.each { |k, v| expect(v).not_to be_nil, "field #{k} of #{entity.class} does not have a value" }
 
             RotateDatabaseKey.perform(batch_size: 1)
 


### PR DESCRIPTION
- Values must not be `nil`, but can be `false`.
- `false.present?` evaluates to `false`.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
