### PR TITLE
Improve draining of delayed worker

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -349,8 +349,7 @@ module VCAP::CloudController
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
-              optional(:priorities) => Hash,
-              optional(:number_of_worker_threads) => Integer
+              optional(:priorities) => Hash
             },
 
             # perm settings no longer have any effect but are preserved here

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -174,8 +174,7 @@ module VCAP::CloudController
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },
-              optional(:priorities) => Hash,
-              optional(:number_of_worker_threads) => Integer
+              optional(:priorities) => Hash
             },
 
             volume_services_enabled: bool,

--- a/lib/delayed_job/delayed_worker.rb
+++ b/lib/delayed_job/delayed_worker.rb
@@ -32,7 +32,7 @@ class CloudController::DelayedWorker
     BackgroundJobEnvironment.new(config).setup_environment(readiness_port)
 
     logger = Steno.logger('cc-worker-clear-locks')
-    logger.info("Clearing pending locks with options #{@queue_options}")
+    logger.info("Clearing pending locks with options {#{@queue_options.map { |k, v| "#{k}: #{v.inspect}" }.join(', ')}}")
     setup_app_log_emitter(config, logger)
 
     worker = get_initialized_delayed_worker(config, logger)

--- a/lib/delayed_job/threaded_worker.rb
+++ b/lib/delayed_job/threaded_worker.rb
@@ -32,7 +32,7 @@ module Delayed
 
       @num_threads.times do |thread_index|
         thread = Thread.new do
-          Thread.current[:thread_name] = "thread:#{thread_index + 1}"
+          Thread.current[:thread_index] = thread_index
           threaded_start
         rescue Exception => e # rubocop:disable Lint/RescueException
           say "Unexpected error: #{e.message}\n#{e.backtrace.join("\n")}", 'error'
@@ -49,10 +49,13 @@ module Delayed
       raise 'Unexpected error occurred in one of the worker threads' if @unexpected_error
     end
 
+    def names_with_threads
+      base_name = name
+      @num_threads.times.map { |thread_index| extended_name_with_thread_index(base_name, thread_index) }
+    end
+
     def name
-      base_name = super
-      thread_name = Thread.current[:thread_name]
-      thread_name.nil? ? base_name : "#{base_name} #{thread_name}"
+      extended_name_with_thread_index(super)
     end
 
     def stop
@@ -64,7 +67,7 @@ module Delayed
           Thread.new do
             t.join(@grace_period_seconds)
             if t.alive?
-              say "Killing thread '#{t[:thread_name]}'"
+              say "Killing thread '#{t[:thread_index]}'"
               t.kill
             end
           end
@@ -97,6 +100,19 @@ module Delayed
           break if stop?
         end
       end
+    end
+
+    private
+
+    def extended_name_with_thread_index(base_name, thread_index=nil)
+      raise ArgumentError.new('base_name cannot be nil or empty') if base_name.nil? || base_name.empty?
+
+      thread_index = Thread.current[:thread_index] if thread_index.nil?
+      thread_name = "thread:#{thread_index + 1}" if thread_index.is_a? Integer
+
+      return base_name if thread_name.nil?
+
+      "#{base_name} #{thread_name}"
     end
   end
 end

--- a/lib/delayed_job/threaded_worker.rb
+++ b/lib/delayed_job/threaded_worker.rb
@@ -28,7 +28,7 @@ module Delayed
         raise SignalException.new('INT') if self.class.raise_signal_exceptions && self.class.raise_signal_exceptions != :term
       end
 
-      say "Starting threaded delayed worker with #{@num_threads} threads"
+      say "Starting threaded delayed worker with #{@num_threads} threads and grace period of #{@grace_period_seconds} seconds"
 
       @num_threads.times do |thread_index|
         thread = Thread.new do

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -11,6 +11,18 @@ namespace :jobs do
     end
   end
 
+  desc 'Clear locks for the current delayed worker.'
+  task :clear_locks_for_current_worker, [:name] => :environment do |_t, args|
+    puts RUBY_DESCRIPTION
+    puts "Clearing pending locks for worker: #{args.name}"
+    args.with_defaults(name: ENV.fetch('HOSTNAME', nil))
+
+    RakeConfig.context = :worker
+
+    CloudController::DelayedWorker.new(queues: [],
+                                       name: args.name).clear_locks!
+  end
+
   desc 'Start a delayed_job worker that works on jobs that require access to local resources.'
 
   task :local, [:name] => :environment do |_t, args|

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -37,9 +37,11 @@ namespace :jobs do
   end
 
   desc 'Start a delayed_job worker.'
-  task :generic, [:name] => :environment do |_t, args|
+  task :generic, %i[name num_threads thread_grace_period_seconds] => :environment do |_t, args|
     puts RUBY_DESCRIPTION
     args.with_defaults(name: ENV.fetch('HOSTNAME', nil))
+    args.with_defaults(num_threads: nil)
+    args.with_defaults(thread_grace_period_seconds: nil)
 
     RakeConfig.context = :worker
     queues = [
@@ -62,7 +64,6 @@ namespace :jobs do
       'prune_excess_app_revisions'
     ]
 
-    CloudController::DelayedWorker.new(queues: queues,
-                                       name: args.name).start_working
+    CloudController::DelayedWorker.new(queues: queues, name: args.name, num_threads: args.num_threads, thread_grace_period_seconds: args.thread_grace_period_seconds).start_working
   end
 end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -11,8 +11,8 @@ namespace :jobs do
     end
   end
 
-  desc 'Clear locks for the current delayed worker.'
-  task :clear_locks_for_current_worker, [:name] => :environment do |_t, args|
+  desc 'Clear pending locks for the current delayed worker.'
+  task :clear_pending_locks, [:name] => :environment do |_t, args|
     puts RUBY_DESCRIPTION
     puts "Clearing pending locks for worker: #{args.name}"
     args.with_defaults(name: ENV.fetch('HOSTNAME', nil))

--- a/spec/unit/lib/cloud_controller/drain_spec.rb
+++ b/spec/unit/lib/cloud_controller/drain_spec.rb
@@ -14,8 +14,9 @@ module VCAP::CloudController
     end
 
     let(:pid) { 23_456 }
+    let(:pid_name) { 'pidfile' }
     let(:pid_dir) { Dir.mktmpdir }
-    let(:pid_path) { File.join(pid_dir, 'pidfile') }
+    let(:pid_path) { File.join(pid_dir, pid_name) }
 
     before do
       File.write(pid_path, pid)
@@ -38,7 +39,7 @@ module VCAP::CloudController
         drain.shutdown_nginx(pid_path)
 
         log_contents do |log|
-          expect(log).to match(/Sending signal '\w+' to process '\w+' with pid '\d+'/)
+          expect(log).to include("Sending signal 'QUIT' to process '#{pid_name}' with pid '#{pid}'")
         end
       end
 
@@ -50,8 +51,9 @@ module VCAP::CloudController
 
         expect(drain).to have_received(:sleep).twice
         log_contents do |log|
-          expect(log).to match(/Waiting \d+s for process '\w+' with pid '\d+' to shutdown/)
-          expect(log).to match(/Process '\w+' with pid '\d+' is not running/)
+          expect(log).to include("Waiting 30s for process '#{pid_name}' with pid '#{pid}' to shutdown")
+          expect(log).to include("Waiting 29s for process '#{pid_name}' with pid '#{pid}' to shutdown")
+          expect(log).to include("Process '#{pid_name}' with pid '#{pid}' is not running")
         end
       end
 
@@ -84,7 +86,7 @@ module VCAP::CloudController
 
         expect(drain).to have_received(:sleep).exactly(40).times
         log_contents do |log|
-          expect(log).to match(/Process '\w+' with pid '\d+' is still running - this indicates an error in the shutdown procedure!/)
+          expect(log).to include("Process '#{pid_name}' with pid '#{pid}' is still running - this indicates an error in the shutdown procedure!")
         end
       end
     end
@@ -96,7 +98,7 @@ module VCAP::CloudController
         drain.shutdown_cc(pid_path)
 
         log_contents do |log|
-          expect(log).to match(/Sending signal '\w+' to process '\w+' with pid '\d+'/)
+          expect(log).to match("Sending signal 'TERM' to process '#{pid_name}' with pid '#{pid}'")
         end
       end
 
@@ -107,7 +109,7 @@ module VCAP::CloudController
 
         expect(drain).to have_received(:sleep).exactly(20).times
         log_contents do |log|
-          expect(log).to match(/Process '\w+' with pid '\d+' is still running - this indicates an error in the shutdown procedure!/)
+          expect(log).to match("Process '#{pid_name}' with pid '#{pid}' is still running - this indicates an error in the shutdown procedure!")
         end
       end
     end

--- a/spec/unit/lib/delayed_job/delayed_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_worker_spec.rb
@@ -18,15 +18,51 @@ RSpec.describe CloudController::DelayedWorker do
   end
 
   describe '#initialize' do
-    it 'sets the correct queue options' do
+    it 'sets the correct default queue options' do
       worker_instance = CloudController::DelayedWorker.new(options)
       expect(worker_instance.instance_variable_get(:@queue_options)).to eq({
                                                                              min_priority: nil,
                                                                              max_priority: nil,
-                                                                             queues: 'default',
+                                                                             queues: options[:queues],
                                                                              worker_name: options[:name],
                                                                              quiet: true
                                                                            })
+      expect(worker_instance.instance_variable_get(:@queue_options)).not_to include(:num_threads)
+      expect(worker_instance.instance_variable_get(:@queue_options)).not_to include(:grace_period_seconds)
+    end
+
+    context 'when num_threads parameter is set' do
+      before { options[:num_threads] = 5 }
+
+      it 'sets the number of threads if specified in the queue options' do
+        worker_instance = CloudController::DelayedWorker.new(options)
+        expect(worker_instance.instance_variable_get(:@queue_options)).to include(num_threads: 5)
+        expect(worker_instance.instance_variable_get(:@queue_options)).not_to include(:grace_period_seconds)
+      end
+
+      it 'does not set num_threads if value is not greater than 0' do
+        options[:num_threads] = 0
+        worker_instance = CloudController::DelayedWorker.new(options)
+        expect(worker_instance.instance_variable_get(:@queue_options)).not_to include(:num_threads)
+      end
+
+      it 'sets the grace period if specified in the queue options' do
+        options[:thread_grace_period_seconds] = 32
+        worker_instance = CloudController::DelayedWorker.new(options)
+        expect(worker_instance.instance_variable_get(:@queue_options)).to include(grace_period_seconds: 32)
+      end
+
+      it 'does not set grace_period_seconds if value is not greater than 0' do
+        options[:thread_grace_period_seconds] = 0
+        worker_instance = CloudController::DelayedWorker.new(options)
+        expect(worker_instance.instance_variable_get(:@queue_options)).not_to include(:grace_period_seconds)
+      end
+    end
+
+    it 'does not set grace_period_seconds if num_threads is not set' do
+      options[:thread_grace_period_seconds] = 32
+      worker_instance = CloudController::DelayedWorker.new(options)
+      expect(worker_instance.instance_variable_get(:@queue_options)).not_to include(:grace_period_seconds)
     end
   end
 
@@ -53,19 +89,25 @@ RSpec.describe CloudController::DelayedWorker do
       before do
         allow(Delayed).to receive(:remove_const).with(:Worker)
         allow(Delayed).to receive(:const_set).with(:Worker, Delayed::ThreadedWorker)
-
-        TestConfig.config[:jobs].merge!(number_of_worker_threads: 7)
+        options[:num_threads] = 7
       end
 
       it 'creates a ThreadedWorker with the specified number of threads' do
         expect(Delayed).to receive(:remove_const).with(:Worker).once
         expect(Delayed).to receive(:const_set).with(:Worker, Delayed::ThreadedWorker).once
         expect(environment).to receive(:setup_environment).with(nil)
-        expect(Delayed::Worker).to receive(:new).with({ max_priority: nil, min_priority: nil, num_threads: 7, queues: 'default', quiet: true,
+        expect(Delayed::Worker).to receive(:new).with({ max_priority: nil, min_priority: nil, num_threads: 7, queues: options[:queues], quiet: true,
                                                         worker_name: options[:name] }).and_return(threaded_worker)
         expect(threaded_worker).to receive(:name=).with(options[:name])
         expect(threaded_worker).to receive(:start)
 
+        cc_delayed_worker.start_working
+      end
+
+      it 'sets the grace period' do
+        options[:thread_grace_period_seconds] = 32
+        expect(Delayed::Worker).to receive(:new).with({ max_priority: nil, min_priority: nil, num_threads: 7, grace_period_seconds: 32, queues: options[:queues], quiet: true,
+                                                        worker_name: options[:name] }).and_return(threaded_worker)
         cc_delayed_worker.start_working
       end
     end

--- a/spec/unit/lib/delayed_job/threaded_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/threaded_worker_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Delayed::ThreadedWorker do
     end
 
     it 'logs the start and shutdown messages' do
-      expect(worker).to receive(:say).with("Starting threaded delayed worker with #{options[:num_threads]} threads")
+      expect(worker).to receive(:say).with("Starting threaded delayed worker with #{options[:num_threads]} threads and grace period of #{options[:grace_period_seconds]} seconds")
       worker.start
     end
 


### PR DESCRIPTION
This change improves the draining behavior of the delayed workers:
- Add `shutdown_delayed_worker` method to `Drain` class which configurable timeout
- Add `jobs:clear_pending_locks` rake task to clear pending job locks in the delayed jobs table for the given worker.

Additionally it allows operators to set the number of delayed worker threads and the grace period after which threads will be killed via the jobs rake task.

Changes will be integrated into capi release with a follow up PR.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
