### PR TITLE
Remove BOSH cli download from action.yml

### DIFF
--- a/.github/workflows/composite/setup/action.yml
+++ b/.github/workflows/composite/setup/action.yml
@@ -2,10 +2,6 @@ name: "setup"
 description: "Configure Ubuntu to run Cloud_Controller_NG and its tests"
 
 inputs:
-  BOSH_CLI_VERSION:
-    description: "Bosh CLI Version"
-    required: true
-    default: 6.4.17
   WORKING_DIRECTORY:
     description: "The Current Work Directory from which installs specifically bundle installs should take place"
     required: true
@@ -35,8 +31,6 @@ runs:
         wget \
         zip \
         zlib1g-dev
-        
-        sudo wget -O /usr/local/bin/bosh https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${{ inputs.BOSH_CLI_VERSION }}-linux-amd64 && sudo chmod +x /usr/local/bin/bosh
       shell: bash
       working-directory: ${{ inputs.WORKING_DIRECTORY }}
     - name: Setup Bundler


### PR DESCRIPTION
Looks like we don't need it...

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
