### PR TITLE
Configure DB Connection Pool Type

### DIFF
--- a/lib/cloud_controller/db_connection/options_factory.rb
+++ b/lib/cloud_controller/db_connection/options_factory.rb
@@ -37,6 +37,7 @@ module VCAP::CloudController
             log_level: opts[:log_level],
             max_connections: opts[:max_connections],
             pool_timeout: opts[:pool_timeout],
+            pool_class: :threaded,
             read_timeout: opts[:read_timeout],
             sql_mode: %i[strict_trans_tables strict_all_tables no_zero_in_date]
           }


### PR DESCRIPTION
* A short explanation of the proposed change:

Configure DB connection pool type to `threaded`.

* An explanation of the use cases your change solves

Sequel changed the default pool type, with which our extensions were not tested. With this PR we prevent that another pool type is used automatically.

* Links to any other associated PRs

Unblocking the following dependency bump: https://github.com/cloudfoundry/cloud_controller_ng/pull/4006

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
