### PR TITLE
Remove mysql 5.7 from unit tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["mysql:5.7", "mysql:8.0", "mysql:8.2"]
+        image: ["mysql:8.0", "mysql:8.2"]
     services:
       mysql:
         image: ${{ matrix.image }}

--- a/.github/workflows/unit_tests_backwards_compatibility.yml
+++ b/.github/workflows/unit_tests_backwards_compatibility.yml
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        image: ["mysql:5.7", "mysql:8.0", "mysql:8.2"]
+        image: ["mysql:8.0", "mysql:8.2"]
     services:
       mysql:
         image: ${{ matrix.image }}


### PR DESCRIPTION
* A short explanation of the proposed change:

Take out mysql 5.7 from the unit test matrix as it is explicitly not supported for [cf-deployment](https://github.com/cloudfoundry/cf-deployment/blob/main/texts/deployment-guide.md#databases).

* An explanation of the use cases your change solves

Allows to use mysql features and rely on bug fixes that are not available in mysql 5.7.
Example: Dropping of duplicated unique constraints in DB migrations.

* Links to any other associated PRs

Fixes #3949 and unblocks #3952

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
