### PR TITLE
Bump delayed_jobs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     declarative (0.0.20)
-    delayed_job (4.1.11)
+    delayed_job (4.1.12)
       activesupport (>= 3.0, < 8.0)
     diff-lcs (1.5.1)
     digest-xxhash (0.2.8)

--- a/spec/unit/lib/delayed_job/delayed_job_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_job_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'delayed_job' do
   describe 'version' do
     it 'is not updated' do
-      expect(Gem.loaded_specs['delayed_job'].version).to eq('4.1.11'),
+      expect(Gem.loaded_specs['delayed_job'].version).to eq('4.1.12'),
                                                          'revisit monkey patch in lib/delayed_job/quit_trap.rb + review the changes related to lib/delayed_job/threaded_worker.rb'
     end
   end


### PR DESCRIPTION
* A short explanation of the proposed change:

Bump delayed_jobs sequel, which fixes issue displayed currently in deprecation warning:
```
DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will be removed in Rails 8.0.
Use Ruby's built-in BasicObject instead.
 (called from <top (required)> at /Users/D071102/dev/capi-release/src/cloud_controller_ng/lib/cloud_controller.rb:5)
```

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
