### PR TITLE
Remove v2 section from / if temporary_enable_v2 == false

### DIFF
--- a/app/controllers/runtime/root_controller.rb
+++ b/app/controllers/runtime/root_controller.rb
@@ -15,13 +15,6 @@ module VCAP::CloudController
             href: api_url_builder.build_url
           },
 
-          cloud_controller_v2: {
-            href: api_url_builder.build_url(path: '/v2'),
-            meta: {
-              version: VCAP::CloudController::Constants::API_VERSION
-            }
-          },
-
           cloud_controller_v3: {
             href: api_url_builder.build_url(path: '/v3'),
             meta: {
@@ -71,6 +64,10 @@ module VCAP::CloudController
         }
       }
 
+      if config.get(:temporary_enable_v2)
+        response[:links].merge!(cloud_controller_v2(api_url_builder))
+      end
+
       [200, Oj.dump(response, mode: :compat)]
     end
 
@@ -90,6 +87,17 @@ module VCAP::CloudController
       return if config.get(:routing_api).blank?
 
       { href: config.get(:routing_api, :url) }
+    end
+
+    def cloud_controller_v2(api_url_builder)
+      { cloud_controller_v2:
+          {
+            href: api_url_builder.build_url(path: '/v2'),
+            meta: {
+              version: VCAP::CloudController::Constants::API_VERSION
+            }
+          }
+      }
     end
   end
 end

--- a/app/controllers/runtime/root_controller.rb
+++ b/app/controllers/runtime/root_controller.rb
@@ -64,9 +64,7 @@ module VCAP::CloudController
         }
       }
 
-      if config.get(:temporary_enable_v2)
-        response[:links].merge!(cloud_controller_v2(api_url_builder))
-      end
+      response[:links].merge!(cloud_controller_v2(api_url_builder)) if config.get(:temporary_enable_v2)
 
       [200, Oj.dump(response, mode: :compat)]
     end
@@ -90,7 +88,8 @@ module VCAP::CloudController
     end
 
     def cloud_controller_v2(api_url_builder)
-      { cloud_controller_v2:
+      {
+        cloud_controller_v2:
           {
             href: api_url_builder.build_url(path: '/v2'),
             meta: {

--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -279,6 +279,8 @@ rate_limiter_v2_api:
   global_admin_limit: 20000
   reset_interval_in_minutes: 60
 
+temporary_enable_v2: true
+
 max_concurrent_service_broker_requests: 0
 
 diego:

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -322,6 +322,8 @@ module VCAP::CloudController
               reset_interval_in_minutes: Integer
             },
 
+            optional(:temporary_enable_v2) => bool,
+
             allow_app_ssh_access: bool,
 
             optional(:external_host) => String,

--- a/spec/unit/controllers/runtime/root_controller_spec.rb
+++ b/spec/unit/controllers/runtime/root_controller_spec.rb
@@ -26,6 +26,18 @@ module VCAP::CloudController
         )
       end
 
+      context 'temporary_enable_v2 is false' do
+        before do
+          TestConfig.override(temporary_enable_v2: false)
+        end
+
+        it 'returns no cloud controller v2 link with metadata' do
+          get '/'
+          hash = Oj.load(last_response.body)
+          expect(hash['links']['cloud_controller_v2']).to be_nil
+        end
+      end
+
       it 'returns a cloud controller v3 link with metadata' do
         get '/'
         hash = Oj.load(last_response.body)


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
If "temporary_enable_v2" parameter is false, remove "cloud_controller_v2" section from root endpoint.

* An explanation of the use cases your change solves
Part of the v2 deprecation story: https://github.com/cloudfoundry/community/pull/941

* Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/pull/480

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
