### PR TITLE
Add log to diego stager error case

### DIFF
--- a/lib/cloud_controller/diego/stager.rb
+++ b/lib/cloud_controller/diego/stager.rb
@@ -33,6 +33,11 @@ module VCAP::CloudController
       rescue CloudController::Errors::ApiError => e
         raise e
       rescue StandardError => e
+        logger.error('stage.package.error',
+                     package_guid: staging_details.package.guid,
+                     staging_guid: staging_details.staging_guid,
+                     error: e,
+                     backtrace: e.backtrace)
         raise CloudController::Errors::ApiError.new_from_details('StagerError', e)
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,6 +110,7 @@ each_run_block = proc do
     rspec_config.include TimeHelpers
     rspec_config.include LinkHelpers
     rspec_config.include BackgroundJobHelpers
+    rspec_config.include LogHelpers
 
     rspec_config.include ServiceBrokerHelpers
     rspec_config.include UserHelpers

--- a/spec/support/log_helpers.rb
+++ b/spec/support/log_helpers.rb
@@ -1,0 +1,30 @@
+module LogHelpers
+  class TailedLogs
+    def initialize(io_log)
+      @io_log = io_log
+    end
+
+    def read
+      @io_log.string.split("\n").map { |l| Oj.load(l) }
+    end
+  end
+
+  def tail_logs(&block)
+    steno_config_backup = ::Steno.config
+
+    begin
+      io_log = ::StringIO.new
+      io_sink = ::Steno::Sink::IO.new(io_log, codec: ::Steno::Codec::JsonRFC3339.new)
+      ::Steno.init(::Steno::Config.new(
+                     sinks: steno_config_backup.sinks + [io_sink],
+                     codec: steno_config_backup.codec,
+                     context: steno_config_backup.context,
+                     default_log_level: 'all'
+                   ))
+
+      block.yield(TailedLogs.new(io_log))
+    ensure
+      ::Steno.init(steno_config_backup)
+    end
+  end
+end


### PR DESCRIPTION
- Without this log, the stack trace for the underlying error is lost, which makes debugging difficult
- Add helper for testing log output. This makes it easier to validate the correct information is logged, without having to manually test.

---

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
