### PR TITLE
Service broker client: Set 'X-Api-Info-Location' according to 'temporary_enable_v2'

### DIFF
--- a/lib/services/service_brokers/v2/http_client.rb
+++ b/lib/services/service_brokers/v2/http_client.rb
@@ -17,7 +17,8 @@ module VCAP::Services
         @auth_password = attrs.fetch(:auth_password)
         @verify_mode = verify_certs? ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
         @broker_client_timeout = VCAP::CloudController::Config.config.get(:broker_client_timeout_seconds)
-        @header_api_info_location = "#{VCAP::CloudController::Config.config.get(:external_domain)}/v2/info"
+        api_info_path = VCAP::CloudController::Config.config.get(:temporary_enable_v2) ? '/v2/info' : '/'
+        @header_api_info_location = "#{VCAP::CloudController::Config.config.get(:external_domain)}#{api_info_path}"
         @logger = logger || Steno.logger('cc.service_broker.v2.http_client')
       end
 

--- a/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
@@ -149,6 +149,40 @@ module VCAP::Services::ServiceBrokers::V2
         end
       end
 
+      context 'X-Api-Info-Location' do
+        context 'when temporary_enable_v2 is true' do
+          before do
+            TestConfig.config[:temporary_enable_v2] = true
+          end
+
+          it 'sets the info location to /v2/info' do
+            make_request
+
+            expect(a_request(http_method, full_url).
+              with(basic_auth:).
+              with(query: hash_including({})).
+              with(headers: { 'X-Api-Info-Location' => 'api2.vcap.me/v2/info' })).
+              to have_been_made
+          end
+        end
+
+        context 'when temporary_enable_v2 is false' do
+          before do
+            TestConfig.config[:temporary_enable_v2] = false
+          end
+
+          it 'sets the info location to /' do
+            make_request
+
+            expect(a_request(http_method, full_url).
+              with(basic_auth:).
+              with(query: hash_including({})).
+              with(headers: { 'X-Api-Info-Location' => 'api2.vcap.me/' })).
+              to have_been_made
+          end
+        end
+      end
+
       context 'X-Broker-Api-Originating-Identity' do
         context 'when user guid is set in the SecurityContext' do
           before do

--- a/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
@@ -66,12 +66,12 @@ module VCAP::Services::ServiceBrokers::V2
           to have_been_made
       end
 
-      it 'sets the X-Api-Info-Location header to the /v2/info endpoint at the external address' do
+      it 'sets the X-Api-Info-Location header to the correct endpoint at the external address' do
         make_request
         expect(a_request(http_method, full_url).
           with(basic_auth:).
           with(query: hash_including({})).
-          with(headers: { 'X-Api-Info-Location' => "#{TestConfig.config[:external_domain]}/v2/info" })).
+          with(headers: { 'X-Api-Info-Location' => "#{TestConfig.config[:external_domain]}#{TestConfig.config[:temporary_enable_v2] ? '/v2/info' : '/'}" })).
           to have_been_made
       end
 
@@ -86,7 +86,8 @@ module VCAP::Services::ServiceBrokers::V2
         expect(fake_logger).to have_received(:debug).with(match(/X-VCAP-Request-ID"=>"[[:alnum:]-]+/))
         expect(fake_logger).to have_received(:debug).with(match(/X-Broker-API-Request-Identity"=>"[[:alnum:]-]+/))
         expect(fake_logger).to have_received(:debug).with(match(/X-Broker-Api-Version"=>"2\.15/))
-        expect(fake_logger).to have_received(:debug).with(match(%r{X-Api-Info-Location"=>"api2\.vcap\.me/v2/info}))
+        api_info_path = TestConfig.config[:temporary_enable_v2] ? '/v2/info' : '/'
+        expect(fake_logger).to have_received(:debug).with(match(/X-Api-Info-Location"=>"api2\.vcap\.me#{api_info_path}/))
       end
 
       context 'when an https URL is used' do


### PR DESCRIPTION
* A short explanation of the proposed change:
For the service broker http client, set the 'X-Api-Info-Location' header to the `/v2/info` endpoint if `temporary_enable_v2` is `true`, and root context `/` if `false`.

* An explanation of the use cases your change solves
Part of the v2 deprecation story: https://github.com/cloudfoundry/community/pull/941

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4034

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests] -> will be run in https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/gyro-exp-tests where v2 is completely disabled
