### PR TITLE
Fix excessive whitespace in v3 docs

### DIFF
--- a/docs/v3/source/layouts/layout.erb
+++ b/docs/v3/source/layouts/layout.erb
@@ -29,6 +29,7 @@ table_of_contents = extract_table_of_contents(html)
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title><%= current_page.data.title || "API Documentation" %></title>
+    <%= stylesheet_link_tag "custom", :media => "screen" %>
     <%= favicon_tag 'favicon.ico' %>
 
     <%= stylesheet_link_tag :screen, media: :screen %>

--- a/docs/v3/source/stylesheets/custom.css
+++ b/docs/v3/source/stylesheets/custom.css
@@ -1,0 +1,5 @@
+
+/* Ensures that divs with the class 'highlight' don't take up the full width of the page preventing excessive whitespace */
+.highlight {
+    display: inline;
+}


### PR DESCRIPTION
Fix excessive whitespace in v3 docs:
- Changed .highlight div from block to inline display to prevent unwanted spacing.
- Inline display prevents extra line breaks and full-width behavior of block elements, resolving layout issue in multi-column setup.

The excessive whitespace was introduced with version 3.165.0 where new `<div class="highlight">` elements were added. Those `divs` wrap the request examples in the right column.
It is unclear what caused this change. 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
