### PR TITLE
Add temporary_enable_v2 flag to cc-worker config

### DIFF
--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -21,6 +21,8 @@ module VCAP::CloudController
             default_health_check_timeout: Integer,
             maximum_health_check_timeout: Integer,
 
+            optional(:temporary_enable_v2) => bool,
+
             uaa: {
               internal_url: String,
               optional(:ca_file) => String,


### PR DESCRIPTION
* A short explanation of the proposed change:
Add the `temporary_enable_v2` flag to cc-worker configuration scheme.

* An explanation of the use cases your change solves
Part of v2 deprecation story: https://github.com/cloudfoundry/community/pull/941

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4058
https://github.com/cloudfoundry/capi-release/pull/488

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
-> ran tests on new "gyro" env: https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/gyro-exp-tests/builds/5
Test suite is basically green with this PR. The 4 failing tests must be fixed in CATs.
