### PR TITLE
Remove unused em-http-request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'allowy', '>= 2.1.0'
 gem 'clockwork', require: false
 gem 'cloudfront-signer'
 gem 'digest-xxhash'
-gem 'em-http-request', '~> 1.1'
 gem 'eventmachine', '~> 1.2.7'
 gem 'fluent-logger'
 gem 'googleapis-common-protos', '>= 1.3.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,6 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
-    cookiejar (0.3.3)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -148,14 +147,6 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.1)
     e2mmap (0.1.0)
-    em-http-request (1.1.7)
-      addressable (>= 2.3.4)
-      cookiejar (!= 0.3.1)
-      em-socksify (>= 0.3)
-      eventmachine (>= 1.0.3)
-      http_parser.rb (>= 0.6.0)
-    em-socksify (0.3.2)
-      eventmachine (>= 1.0.0.beta.4)
     erubi (1.13.0)
     eventmachine (1.2.7)
     excon (0.112.0)
@@ -275,7 +266,6 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    http_parser.rb (0.6.0)
     httpclient (2.8.3)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
@@ -609,7 +599,6 @@ DEPENDENCIES
   codeclimate-test-reporter (>= 1.0.8)
   debug (~> 1.9)
   digest-xxhash
-  em-http-request (~> 1.1)
   eventmachine (~> 1.2.7)
   fluent-logger
   fog-aliyun

--- a/lib/vcap/services/api/async_requests.rb
+++ b/lib/vcap/services/api/async_requests.rb
@@ -1,6 +1,4 @@
 # Copyright (c) 2009-2011 VMware, Inc.
-require 'eventmachine'
-require 'em-http-request'
 require 'httpclient'
 
 require 'vcap/services/api/const'
@@ -13,38 +11,6 @@ module VCAP
 end
 
 module VCAP::Services::Api
-  class AsyncHttpRequest
-    class << self
-      def new(url, token, verb, timeout, msg=VCAP::Services::Api::EMPTY_REQUEST)
-        req = {
-          head: {
-            VCAP::Services::Api::GATEWAY_TOKEN_HEADER => token,
-            'Content-Type' => 'application/json'
-          },
-          body: msg.encode
-        }
-        if timeout
-          EM::HttpRequest.new(url, inactivity_timeout: timeout).send(verb.to_sym, req)
-        else
-          EM::HttpRequest.new(url).send(verb.to_sym, req)
-        end
-      end
-
-      def request(url, token, verb, timeout, msg=VCAP::Services::Api::EMPTY_REQUEST)
-        req = new(url, token, verb, timeout, msg)
-        f = Fiber.current
-        req.callback { f.resume(req) }
-        req.errback  { f.resume(req) }
-        http = Fiber.yield
-        raise UnexpectedResponse.new("Error sending request #{msg.extract.to_json} to gateway #{@url}: #{http.error}") unless http.error.empty?
-
-        code = http.response_header.status.to_i
-        body = http.response
-        [code, body]
-      end
-    end
-  end
-
   module SynchronousHttpRequest
     def self.request(url, token, verb, _timeout, msg=VCAP::Services::Api::EMPTY_REQUEST)
       header = {
@@ -55,32 +21,6 @@ module VCAP::Services::Api
       client = HTTPClient.new
       msg = client.request(verb.to_sym, url, body:, header:)
       [msg.code, msg.body]
-    end
-  end
-
-  class AsyncHttpMultiPartUpload
-    class << self
-      def new(url, timeout, multipart, head={})
-        req = {
-          head: head,
-          body: '',
-          multipart: multipart
-        }
-
-        if timeout
-          EM::HttpRequest.new(url, inactivity_timeout: timeout).post req
-        else
-          EM::HttpRequest.new(url).post req
-        end
-      end
-
-      def fibered(url, timeout, multipart, head={})
-        req = new(url, timeout, multipart, head)
-        f = Fiber.current
-        req.callback { f.resume(req) }
-        req.errback { f.resume(req) }
-        Fiber.yield
-      end
     end
   end
 end


### PR DESCRIPTION
* this gem is blocking us from upgrading to Ruby 3.3, but it seems we don't actually use it

https://github.com/cloudfoundry/cloud_controller_ng/issues/3559

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
