### PR TITLE
v3 docs: Remove newlines after `Definition` section title

### DIFF
--- a/docs/v3/source/includes/resources/app_usage_events/_delete.md.erb
+++ b/docs/v3/source/includes/resources/app_usage_events/_delete.md.erb
@@ -22,7 +22,6 @@ Content-Type: application/json
 Destroys all existing events. Populates new usage events, one for each started app. All populated events will have a `created_at` value of current time. There is the potential race condition if apps are currently being started, stopped, or scaled. The seeded usage events will have the same guid as the app.
 
 #### Definition
-
 `POST /v3/app_usage_events/actions/destructively_purge_all_and_reseed`
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/app_usage_events/_get.md.erb
+++ b/docs/v3/source/includes/resources/app_usage_events/_get.md.erb
@@ -24,7 +24,6 @@ Content-Type: application/json
 Retrieve an app usage event.
 
 #### Definition
-
 `GET /v3/app_usage_events/:guid`
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/app_usage_events/_list.md.erb
+++ b/docs/v3/source/includes/resources/app_usage_events/_list.md.erb
@@ -24,7 +24,6 @@ Content-Type: application/json
 Retrieve all app usage events the user has access to.
 
 #### Definition
-
 `GET /v3/app_usage_events`
 
 #### Query parameters

--- a/docs/v3/source/includes/resources/apps/_get_current_droplet_relationship.md.erb
+++ b/docs/v3/source/includes/resources/apps/_get_current_droplet_relationship.md.erb
@@ -25,7 +25,6 @@ Content-Type: application/json
 This endpoint retrieves the current droplet relationship for an app.
 
 #### Definition
-
 `GET /v3/apps/:guid/relationships/current_droplet`
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/info/_get.md.erb
+++ b/docs/v3/source/includes/resources/info/_get.md.erb
@@ -32,7 +32,6 @@ Content-Type: application/json
 ```
 
 #### Definition
-
 `GET /v3/info`
 
 #### Authentication

--- a/docs/v3/source/includes/resources/info/_get_usage_summary.md.erb
+++ b/docs/v3/source/includes/resources/info/_get_usage_summary.md.erb
@@ -23,7 +23,6 @@ Content-Type: application/json
 This endpoint retrieves a high-level summary of usage across the entire Cloud Foundry installation.
 
 #### Definition
-
 `GET /v3/info/usage_summary`
 
 #### Usage summary object

--- a/docs/v3/source/includes/resources/manifests/_create_diff.md
+++ b/docs/v3/source/includes/resources/manifests/_create_diff.md
@@ -60,7 +60,6 @@ Name           | Type | Description
 **value** | _any_ | For `add` and `replace` operations, the new value; otherwise key is omitted
 
 #### Definition
-
 `POST /v3/spaces/:guid/manifest_diff`
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/organization_quotas/_get.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_get.md.erb
@@ -24,7 +24,6 @@ Content-Type: application/json
 This endpoint gets an individual organization quota resource.
 
 #### Definition
-
 `GET /v3/organization_quotas/:guid`
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
@@ -24,7 +24,6 @@ Content-Type: application/json
 This endpoint lists all organization quota resources.
 
 #### Definition
-
 `GET /v3/organization_quotas`
 
 

--- a/docs/v3/source/includes/resources/roles/_get.md.erb
+++ b/docs/v3/source/includes/resources/roles/_get.md.erb
@@ -24,7 +24,6 @@ Content-Type: application/json
 This endpoint gets an individual role resource.
 
 #### Definition
-
 `GET /v3/roles/:guid`
 
 #### Query parameters

--- a/docs/v3/source/includes/resources/service_usage_events/_delete.md.erb
+++ b/docs/v3/source/includes/resources/service_usage_events/_delete.md.erb
@@ -21,7 +21,6 @@ Content-Type: application/json
 
 Destroys all existing events. Populates new usage events, one for each existing service instance. All populated events will have a `created_at` value of current time. There is the potential race condition if service instances are currently being created or deleted. The seeded usage events will have the same guid as the service instance.
 #### Definition
-
 `POST /v3/service_usage_events/actions/destructively_purge_all_and_reseed`
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/service_usage_events/_get.md.erb
+++ b/docs/v3/source/includes/resources/service_usage_events/_get.md.erb
@@ -24,7 +24,6 @@ Content-Type: application/json
 Retrieve a service usage event.
 
 #### Definition
-
 `GET /v3/service_usage_events/:guid`
 
 #### Permitted roles

--- a/docs/v3/source/includes/resources/service_usage_events/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_usage_events/_list.md.erb
@@ -24,7 +24,6 @@ Content-Type: application/json
 Retrieve all service usage events the user has access to.
 
 #### Definition
-
 `GET /v3/service_usage_events`
 
 #### Query parameters

--- a/docs/v3/source/includes/resources/space_quotas/_list.md.erb
+++ b/docs/v3/source/includes/resources/space_quotas/_list.md.erb
@@ -24,7 +24,6 @@ Content-Type: application/json
 This endpoint lists all space quota resources that the user has permission to view (see [getting a space quota](#get-a-space-quota)).
 
 #### Definition
-
 `GET /v3/space_quotas`
 
 


### PR DESCRIPTION
Remove all newlines after the sections named `Definition`.

I want to parse the v3 docs to get all documented endpoints (from section `Definition`) to compare that with what [Korifi](https://github.com/cloudfoundry/korifi/blob/main/docs/api.md) has to offer right now. This can help to create a list of endpoints for the Korifi http handler and return HTTP status 'not implemented' (501) or similar in an half automated way.
If you know an easier approach, please let me know.

But basically my inner monk saw the 'inconsistency' during research of the CC API docs and I had to fix it :-)

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
