### PR TITLE
Remove unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'json-schema'
 gem 'loggregator_emitter', '~> 5.0'
 gem 'membrane', '~> 1.0'
 gem 'mime-types', '~> 3.6'
-gem 'mock_redis'
 gem 'multipart-parser'
 gem 'netaddr', '>= 2.0.4'
 gem 'net-ssh'
@@ -62,7 +61,6 @@ gem 'fog-local'
 gem 'fog-openstack'
 
 gem 'cf-uaa-lib', '~> 4.0.4'
-gem 'vcap-concurrency', git: 'https://github.com/cloudfoundry/vcap-concurrency.git', ref: '2a5b0179'
 
 group :db do
   gem 'mysql2', '~> 0.5.6'
@@ -76,6 +74,7 @@ end
 group :test do
   gem 'codeclimate-test-reporter', '>= 1.0.8', require: false
   gem 'machinist', '~> 1.0.6'
+  gem 'mock_redis'
   gem 'parallel_tests'
   gem 'rack-test'
   gem 'rspec', '~> 3.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/cloudfoundry/vcap-concurrency.git
-  revision: 2a5b0179642cb3d3e7f912a6453ec5731979d115
-  ref: 2a5b0179
-  specs:
-    vcap-concurrency (0.1.0)
-
-GIT
   remote: https://github.com/fog/fog-azure-rm.git
   revision: 379e352cce817f8e67618062bf7095095d8f5c4c
   branch: fog-arm-cf
@@ -682,7 +675,6 @@ DEPENDENCIES
   talentbox-delayed_job_sequel (~> 4.3.0)
   thin
   timecop
-  vcap-concurrency!
   vmstat (~> 2.3)
   webmock (> 2.3.1)
 


### PR DESCRIPTION
I don't think these gems are used/can be moved to the :test group

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
