### PR TITLE
Document health check interval in manifest docs

### DIFF
--- a/docs/v3/source/includes/resources/manifests/_object.md.erb
+++ b/docs/v3/source/includes/resources/manifests/_object.md.erb
@@ -43,6 +43,7 @@ applications:
     disk_quota: 512M
     health-check-http-endpoint: /healthcheck
     health-check-type: http
+    health-check-interval: 5
     health-check-invocation-timeout: 10
     instances: 3
     memory: 500M
@@ -117,6 +118,7 @@ Name | Type | Description
 **command** | _string_ | The command used to start the process; this overrides start commands from [Procfiles](#procfiles) and buildpacks
 **disk_quota** | _string_ | The disk limit for all instances of the web process; <br>this attribute requires a unit of measurement: `B`, `K`, `KB`, `M`, `MB`, `G`, `GB`, `T`, or `TB` in upper case or lower case
 **health-check-http-endpoint** | _string_ | Endpoint called to determine if the app is healthy
+**health-check-interval** | _integer_ | The interval in seconds between health check requests
 **health-check-invocation-timeout** | _integer_ | The timeout in seconds for individual health check requests for http and port health checks
 **health-check-type** | _string_ | Type of health check to perform; `none` is deprecated and an alias to `process`
 **instances** | _integer_ | The number of instances to run


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* Adds missing docs for health check interval to the documentation for the manifest endpoint

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
