### PR TITLE
Add dummy workflow for v3 docs in main

### DIFF
--- a/.github/workflows/deploy_v3_docs.yml
+++ b/.github/workflows/deploy_v3_docs.yml
@@ -1,0 +1,13 @@
+# This is a dummy workflow just to appear in the UI
+# The actual workflow is defined on the gh-pages branch - deploy_v3_docs.yml
+name: Deploy V3 API Docs to Pages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy Step
+        run: echo "This is a dummy action to ensure visibility"


### PR DESCRIPTION
GH action workflows only show up if they are on the main branch.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
