### PR TITLE
Validate checksums when fetching cached files for app packaging

### DIFF
--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -613,6 +613,11 @@
   http_code: 502
   message: "Deletion of app %s failed because one or more associated resources could not be deleted.\n\n%s"
 
+150010:
+  name: ResourceChecksumMismatch
+  http_code: 500
+  message: "One or more cached resources did not match the given checksum. They have been deleted; please retry package upload."
+
 160001:
   name: AppBitsUploadInvalid
   http_code: 400

--- a/spec/api/documentation/app_bits_api_spec.rb
+++ b/spec/api/documentation/app_bits_api_spec.rb
@@ -35,8 +35,8 @@ RSpec.resource 'Apps', type: %i[api legacy_api] do
 
   let(:fingerprints) do
     [
-      { fn: 'path/to/content.txt', size: 123, sha1: 'b907173290db6a155949ab4dc9b2d019dea0c901' },
-      { fn: 'path/to/code.jar', size: 123, sha1: 'ff84f89760317996b9dd180ab996b079f418396f' }
+      { fn: 'path/to/content.txt', size: 123, sha1: 'da39a3ee5e6b4b0d3255bfef95601890afd80709' },
+      { fn: 'path/to/code.jar', size: 123, sha1: 'da39a3ee5e6b4b0d3255bfef95601890afd80709' }
     ]
   end
 

--- a/spec/request/v2/apps_spec.rb
+++ b/spec/request/v2/apps_spec.rb
@@ -1649,7 +1649,7 @@ RSpec.describe 'Apps' do
       TestConfig.config[:directories][:tmpdir] = File.dirname(valid_zip.path)
       upload_params = {
         application: valid_zip,
-        resources: [{ fn: 'a/b/c', size: 1, sha1: 'sha' }].to_json
+        resources: [{ fn: 'a/b/c', size: 1, sha1: 'da39a3ee5e6b4b0d3255bfef95601890afd80709' }].to_json
       }
       put "/v2/apps/#{process.guid}/bits", upload_params, headers_for(user)
     end

--- a/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
+++ b/spec/unit/controllers/runtime/app_bits_upload_controller_spec.rb
@@ -117,7 +117,7 @@ module VCAP::CloudController
           end
 
           context 'with at least one resource and no application' do
-            let(:req_body) { { resources: Oj.dump([{ 'fn' => 'lol', 'sha1' => 'abc', 'size' => 2048 }]) } }
+            let(:req_body) { { resources: Oj.dump([{ 'fn' => 'lol', 'sha1' => 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size' => 2048 }]) } }
 
             before do
               # rack_test overrides 'CONTENT_TYPE' header with 'boundary' which causes errors when the request does not contain an application
@@ -132,7 +132,7 @@ module VCAP::CloudController
           end
 
           context 'with at least one resource and an application' do
-            let(:req_body) { { resources: Oj.dump([{ 'fn' => 'lol', 'sha1' => 'abc', 'size' => 2048 }]), application: valid_zip } }
+            let(:req_body) { { resources: Oj.dump([{ 'fn' => 'lol', 'sha1' => 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'size' => 2048 }]), application: valid_zip } }
 
             it 'succeeds to upload' do
               make_request


### PR DESCRIPTION
Although resource matching stores files by their sha1 checksum, when later fetching the resource to include in app packaging, the bits packer does not validate the checksum still matches.  The packer will still include the corrupted file, and users (most likely) won't receive an error until the staging process.  This state is only recoverable by clearing the resource cache, which relies on operator intervention.

With this change, when a bad checksum is found, the cached resource(s) are deleted, and an error is raised, causing faster feedback. Since the cached resources have been deleted, a second push/package upload should succeed.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
