### PR TITLE
Adjust rate limits for service-related endpoints.

### DIFF
--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -6,7 +6,7 @@ module CloudFoundry
     RateLimitEndpoint = Struct.new(:endpoint_pattern, :request_methods)
 
     RATE_LIMITED_ENDPOINTS = [
-      RateLimitEndpoint.new(%r{\A/v2/(service_instances|service_credential_bindings|service_route_bindings)}, %w[PUT POST DELETE PATCH]),
+      RateLimitEndpoint.new(%r{\A/v2/(service_instances|service_bindings|service_keys)}, %w[PUT POST DELETE]),
       RateLimitEndpoint.new(%r{\A/v3/(service_instances|service_credential_bindings|service_route_bindings)/.+/parameters\z}, %w[GET])
     ].freeze
 

--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -3,7 +3,7 @@ require 'redis'
 
 module CloudFoundry
   module Middleware
-    RateLimitEndpoint = Struct.new(:endpoint_pattern, :methods)
+    RateLimitEndpoint = Struct.new(:endpoint_pattern, :request_methods)
 
     RATE_LIMITED_ENDPOINTS = [
       RateLimitEndpoint.new(%r{\A/v2/(service_instances|service_credential_bindings|service_route_bindings)}, %w[PUT POST DELETE PATCH]),

--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -7,8 +7,7 @@ module CloudFoundry
 
     RATE_LIMITED_ENDPOINTS = [
       RateLimitEndpoint.new(%r{\A/v2/(service_instances|service_credential_bindings|service_route_bindings)}, %w[PUT POST DELETE PATCH]),
-      RateLimitEndpoint.new(%r{\A/v3/(service_instances|service_credential_bindings|service_route_bindings)/.+/parameters\z}, %w[GET]),
-      RateLimitEndpoint.new(%r{\A/v3/(service_instances|service_credential_bindings|service_route_bindings)}, %w[PUT])
+      RateLimitEndpoint.new(%r{\A/v3/(service_instances|service_credential_bindings|service_route_bindings)/.+/parameters\z}, %w[GET])
     ].freeze
 
     class ConcurrentRequestCounter

--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -113,14 +113,14 @@ module CloudFoundry
 
       def apply_rate_limiting?(env)
         request = ActionDispatch::Request.new(env)
-        !admin? && rate_limit_method?(request)
+        !admin? && is_rate_limited_service_request?(request)
       end
 
       def admin?
         VCAP::CloudController::SecurityContext.admin? || VCAP::CloudController::SecurityContext.admin_read_only?
       end
 
-      def rate_limit_method?(request)
+      def is_rate_limited_service_request?(request)
         RATE_LIMITED_ENDPOINTS.any? do |endpoint|
           endpoint.endpoint_pattern.match?(request.fullpath) && endpoint.request_methods.include?(request.method)
         end

--- a/middleware/service_broker_rate_limiter.rb
+++ b/middleware/service_broker_rate_limiter.rb
@@ -123,7 +123,7 @@ module CloudFoundry
 
       def rate_limit_method?(request)
         RATE_LIMITED_ENDPOINTS.any? do |endpoint|
-          endpoint.endpoint_pattern.match?(request.fullpath) && endpoint.methods.include?(request.method)
+          endpoint.endpoint_pattern.match?(request.fullpath) && endpoint.request_methods.include?(request.method)
         end
       end
 

--- a/spec/unit/middleware/service_broker_rate_limiter_spec.rb
+++ b/spec/unit/middleware/service_broker_rate_limiter_spec.rb
@@ -61,6 +61,85 @@ module CloudFoundry
           expect(status).to eq(200)
         end
 
+        describe 'service endpoints' do
+          shared_examples 'rate-limited service endpoint' do
+            before do
+              allow(app).to receive(:call) do
+                sleep(1)
+                [200, {}, 'a body']
+              end
+            end
+
+            it 'does not allow more than the max number of concurrent requests' do
+              threads = 2.times.map { Thread.new { middleware.call(env) } }
+              statuses = threads.map(&:join).map(&:value).map(&:first)
+
+              expect(statuses).to include(200)
+              expect(statuses).to include(429)
+              expect(app).to have_received(:call).once
+              expect(logger).to have_received(:info).with("Service broker concurrent rate limit exceeded for user '#{user_guid}'")
+            end
+          end
+
+          context 'v2 rate limited service endpoints' do
+            v2_rate_limited_service_endpoints = %w[/v2/service_instances /v2/service_bindings /v2/service_keys]
+
+            methods = %w[PUT POST DELETE]
+
+            v2_rate_limited_service_endpoints.each do |endpoint|
+              methods.each do |method|
+                context "#{endpoint} #{method} - rate-limited" do
+                  let(:path) { endpoint }
+                  let(:request_method) { method }
+                  let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: endpoint, method: method) }
+
+                  include_examples 'rate-limited service endpoint'
+                end
+              end
+            end
+          end
+
+          context 'v3 rate limited GET service endpoints' do
+            v3_rate_limited_service_endpoints = %w[/v3/service_instances/:guid/parameters /v3/service_credential_bindings/:guid/parameters
+                                                   /v3/service_route_bindings/:guid/parameters]
+
+            v3_rate_limited_service_endpoints.each do |endpoint|
+              context "#{endpoint} GET - rate-limited" do
+                let(:path) { endpoint.gsub(':guid', instance.guid.to_s) }
+                let(:request_method) { 'GET' }
+                let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: path, method: request_method) }
+
+                include_examples 'rate-limited service endpoint'
+              end
+            end
+          end
+
+          context 'v3 non rate limited service endpoints' do
+            v3_not_rate_limited_service_endpoints = %w[/v3/service_instances /v3/service_credential_bindings /v3/service_route_bindings]
+
+            methods = %w[POST PATCH DELETE]
+
+            v3_not_rate_limited_service_endpoints.each do |endpoint|
+              methods.each do |method|
+                context "#{endpoint} #{method} - non-rate-limited" do
+                  let(:path) { endpoint }
+                  let(:request_method) { method }
+                  let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: endpoint, method: method) }
+
+                  it 'allows concurrent requests without limits' do
+                    threads = 2.times.map { Thread.new { middleware.call(env) } }
+                    statuses = threads.map(&:join).map(&:value).map(&:first)
+
+                    expect(statuses).to all(eq(200))
+                    expect(app).to have_received(:call).twice
+                    expect(logger).not_to have_received(:info)
+                  end
+                end
+              end
+            end
+          end
+        end
+
         describe 'errors' do
           let(:max_concurrent_requests) { 0 }
 
@@ -106,80 +185,6 @@ module CloudFoundry
                 _, response_headers, = middleware.call(user_env)
                 expect(response_headers['Retry-After'].to_i).to be_between((broker_timeout * 0.5).floor, (broker_timeout * 1.5).ceil)
               end
-            end
-          end
-        end
-
-        shared_examples 'rate-limited endpoint' do
-          it 'does not allow more than the max number of concurrent requests' do
-            allow(app).to receive(:call) do
-              sleep(1)
-              [200, {}, 'a body']
-            end
-
-            threads = 2.times.map { Thread.new { middleware.call(env) } }
-            statuses = threads.map(&:join).map(&:value).map(&:first)
-
-            expect(statuses).to include(200)
-            expect(statuses).to include(429)
-            expect(app).to have_received(:call).once
-            expect(logger).to have_received(:info).with("Service broker concurrent rate limit exceeded for user '#{user_guid}'")
-          end
-        end
-
-        v2_rate_limited_service_endpoints = %w[/v2/service_instances /v2/service_bindings /v2/service_keys]
-
-        methods = %w[PUT POST DELETE]
-
-        v2_rate_limited_service_endpoints.each do |endpoint|
-          methods.each do |method|
-            context "#{endpoint} #{method} endpoint" do
-              let(:path) { endpoint }
-              let(:request_method) { method }
-              let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: endpoint, method: method) }
-
-              include_examples 'rate-limited endpoint'
-            end
-          end
-        end
-
-        v3_rate_limited_service_endpoints = %w[/v3/service_instances/:guid/parameters /v3/service_credential_bindings/:guid/parameters /v3/service_route_bindings/:guid/parameters]
-
-        v3_rate_limited_service_endpoints.each do |endpoint|
-          context "#{endpoint} GET" do
-            let(:path) { endpoint.gsub(':guid', instance.guid.to_s) }
-            let(:request_method) { 'GET' }
-            let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: path, method: request_method) }
-
-            include_examples 'rate-limited endpoint'
-          end
-        end
-      end
-
-      describe 'excluded requests' do
-        shared_examples 'non-rate-limited endpoint' do
-          it 'allows concurrent requests without limits' do
-            threads = 2.times.map { Thread.new { middleware.call(env) } }
-            statuses = threads.map(&:join).map(&:value).map(&:first)
-
-            expect(statuses).to all(eq(200))
-            expect(app).to have_received(:call).twice
-            expect(logger).not_to have_received(:info)
-          end
-        end
-
-        v3_not_rate_limited_service_endpoints = %w[/v3/service_instances /v3/service_credential_bindings /v3/service_route_bindings]
-
-        methods = %w[POST PATCH DELETE]
-
-        v3_not_rate_limited_service_endpoints.each do |endpoint|
-          methods.each do |method|
-            context "#{endpoint} #{method} - non-rate-limited" do
-              let(:path) { endpoint }
-              let(:request_method) { method }
-              let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: endpoint, method: method) }
-
-              include_examples 'non-rate-limited endpoint'
             end
           end
         end

--- a/spec/unit/middleware/service_broker_rate_limiter_spec.rb
+++ b/spec/unit/middleware/service_broker_rate_limiter_spec.rb
@@ -8,7 +8,7 @@ module CloudFoundry
       let(:path_info) { '/v3/service_instances' }
       let(:user_guid) { SecureRandom.uuid }
       let(:user_env) { { 'cf.user_guid' => user_guid, 'PATH_INFO' => path_info } }
-      let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/service_instances', method: 'PUT') }
+      let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/service_instances', method: 'POST') }
       let(:max_concurrent_requests) { 1 }
       let(:broker_timeout) { 60 }
       let(:middleware) do
@@ -25,7 +25,7 @@ module CloudFoundry
       end
 
       describe 'included requests' do
-        let(:request_method) { 'PUT' }
+        let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/service_instances', method: 'PUT') }
 
         it 'allows a service broker request within the limit' do
           status, = middleware.call(user_env)

--- a/spec/unit/middleware/service_broker_rate_limiter_spec.rb
+++ b/spec/unit/middleware/service_broker_rate_limiter_spec.rb
@@ -25,7 +25,7 @@ module CloudFoundry
       end
 
       describe 'included requests' do
-        let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/service_instances', method: 'PUT') }
+        let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v2/service_instances', method: 'PUT') }
 
         it 'allows a service broker request within the limit' do
           status, = middleware.call(user_env)
@@ -120,7 +120,7 @@ module CloudFoundry
       end
 
       describe 'excluded requests' do
-        let(:request_method) { 'POST' }
+        let(:fake_request) { instance_double(ActionDispatch::Request, fullpath: '/v3/service_instances', method: 'POST') }
 
         it 'allows requests that are no longer rate limited' do
           status, = middleware.call(user_env)

--- a/spec/unit/middleware/service_broker_rate_limiter_spec.rb
+++ b/spec/unit/middleware/service_broker_rate_limiter_spec.rb
@@ -130,7 +130,7 @@ module CloudFoundry
           expect(status).to eq(200)
 
           statuses = 2.times.map { middleware.call(user_env).first }
-          expect(statuses).to match_array([200, 200])
+          expect(statuses).to contain_exactly(200, 200)
         end
       end
 


### PR DESCRIPTION
Most if not all service broker operations for the CF API v3 have been moved into background jobs and are asynchronous operations. This means that the service broker operation can't block anymore the CF API v3 requests (which returns a 202 and a link to the polling job). After reviewing /v3/service related endpoints, we adapted the rate limiting:
- v3 service related endpoints that never interact with SBs synchronously are removed from rate limiting (```POST```, ```PATCH```, ```DELETE``` ```/v3/[service_instances|service_credential_bindings|service_route_bindings]```)
- v3 GET methods that interact with SBs synchronously are added to rate limiting (```/v3/(service_instances|service_credential_bindings|service_route_bindings)/.+/parameters```)

* A short explanation of the proposed change:
- v3 service related endpoints that never interact with SBs synchronously are removed from rate limiting (POST, PATCH, DELETE /v3/[service_instances|service_credential_bindings|service_route_bindings])
- v3 GET methods that interact with SBs synchronously are added to rate limiting (/v3/(service_instances|service_credential_bindings|service_route_bindings)/.+/parameters)

* An explanation of the use cases your change solves
Remove obsolete rate limiting

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
