### PR TITLE
CAPI logs should for request complete should include the response time

### DIFF
--- a/lib/cloud_controller/logs/request_logs.rb
+++ b/lib/cloud_controller/logs/request_logs.rb
@@ -28,10 +28,11 @@ module VCAP::CloudController
 
       def complete_request(request_id, status, env, time_taken)
         return if @incomplete_requests.delete(request_id).nil?
+
         request = ActionDispatch::Request.new(env)
-        @logger.info("Completed #{status} vcap-request-id: #{request_id}", 
+        @logger.info("Completed #{status} vcap-request-id: #{request_id}",
                      { status_code: status,
-                       time_taken: time_taken,
+                       time_taken_in_ms: time_taken,
                        request_method: request.request_method,
                        request_fullpath: request.filtered_path })
       end

--- a/lib/cloud_controller/logs/request_logs.rb
+++ b/lib/cloud_controller/logs/request_logs.rb
@@ -26,11 +26,13 @@ module VCAP::CloudController
         @incomplete_requests.store(request_id, env)
       end
 
-      def complete_request(request_id, status)
+      def complete_request(request_id, status, env, time_taken)
         return if @incomplete_requests.delete(request_id).nil?
-
-        @logger.info("Completed #{status} vcap-request-id: #{request_id}",
-                     { status_code: status })
+        request = ActionDispatch::Request.new(env)
+        @logger.info("Completed #{status} vcap-request-id: #{request_id} Response Time: #{time_taken}", 
+                     { status_code: status,
+                      request_method: request.request_method,
+                      request_fullpath: request.filtered_path })
       end
 
       def log_incomplete_requests

--- a/lib/cloud_controller/logs/request_logs.rb
+++ b/lib/cloud_controller/logs/request_logs.rb
@@ -29,10 +29,11 @@ module VCAP::CloudController
       def complete_request(request_id, status, env, time_taken)
         return if @incomplete_requests.delete(request_id).nil?
         request = ActionDispatch::Request.new(env)
-        @logger.info("Completed #{status} vcap-request-id: #{request_id} Response Time: #{time_taken}", 
+        @logger.info("Completed #{status} vcap-request-id: #{request_id}", 
                      { status_code: status,
-                      request_method: request.request_method,
-                      request_fullpath: request.filtered_path })
+                       time_taken: time_taken,
+                       request_method: request.request_method,
+                       request_fullpath: request.filtered_path })
       end
 
       def log_incomplete_requests

--- a/middleware/request_logs.rb
+++ b/middleware/request_logs.rb
@@ -9,10 +9,12 @@ module CloudFoundry
       def call(env)
         request_id = env['cf.request_id']
         @request_logs.start_request(request_id, env)
+        start_time = Time.now
 
         status, headers, body = @app.call(env)
 
-        @request_logs.complete_request(request_id, status)
+        time_taken = Time.now - start_time
+        @request_logs.complete_request(request_id, status, env, time_taken)
 
         [status, headers, body]
       end

--- a/middleware/request_logs.rb
+++ b/middleware/request_logs.rb
@@ -14,6 +14,7 @@ module CloudFoundry
         status, headers, body = @app.call(env)
         # convert to milliseconds
         time_taken = (Time.now - start_time) * 1000
+        time_taken = time_taken.to_i
         @request_logs.complete_request(request_id, status, env, time_taken)
 
         [status, headers, body]

--- a/middleware/request_logs.rb
+++ b/middleware/request_logs.rb
@@ -12,8 +12,8 @@ module CloudFoundry
         start_time = Time.now
 
         status, headers, body = @app.call(env)
-
-        time_taken = Time.now - start_time
+        # convert to milliseconds
+        time_taken = (Time.now - start_time) * 1000
         @request_logs.complete_request(request_id, status, env, time_taken)
 
         [status, headers, body]

--- a/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
@@ -47,13 +47,13 @@ module VCAP::CloudController::Logs
 
           it 'logs the completion of the request' do
             request_logs.complete_request(request_id, status, env, time_taken)
-           expect(logger).to have_received(:info).with(
-            /\ACompleted 200 vcap-request-id: ID/,
-            time_taken_in_ms: 30,
-            request_method: 'request_method',
-            request_fullpath: 'filtered_path',
-            status_code: 200
-           )
+            expect(logger).to have_received(:info).with(
+             /\ACompleted 200 vcap-request-id: ID/,
+             time_taken_in_ms: 30,
+             request_method: 'request_method',
+             request_fullpath: 'filtered_path',
+             status_code: 200
+            )
           end
         end
 

--- a/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
@@ -47,7 +47,7 @@ module VCAP::CloudController::Logs
 
           it 'logs the completion of the request' do
             request_logs.complete_request(request_id, status, env, time_taken)
-            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID Response Time: 30/, { request_method: "request_method", request_fullpath: "filtered_path", status_code: 200 })
+            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/, { time_taken: 30, request_method: "request_method", request_fullpath: "filtered_path", status_code: 200 })
           end
         end
 

--- a/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
@@ -47,7 +47,13 @@ module VCAP::CloudController::Logs
 
           it 'logs the completion of the request' do
             request_logs.complete_request(request_id, status, env, time_taken)
-            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/, { time_taken: 30, request_method: "request_method", request_fullpath: "filtered_path", status_code: 200 })
+           expect(logger).to have_received(:info).with(
+            /\ACompleted 200 vcap-request-id: ID/,
+            time_taken_in_ms: 30,
+            request_method: 'request_method',
+            request_fullpath: 'filtered_path',
+            status_code: 200
+           )
           end
         end
 

--- a/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
@@ -48,11 +48,11 @@ module VCAP::CloudController::Logs
           it 'logs the completion of the request' do
             request_logs.complete_request(request_id, status, env, time_taken)
             expect(logger).to have_received(:info).with(
-             /\ACompleted 200 vcap-request-id: ID/,
-             time_taken_in_ms: 30,
-             request_method: 'request_method',
-             request_fullpath: 'filtered_path',
-             status_code: 200
+              /\ACompleted 200 vcap-request-id: ID/,
+              time_taken_in_ms: 30,
+              request_method: 'request_method',
+              request_fullpath: 'filtered_path',
+              status_code: 200
             )
           end
         end

--- a/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
+++ b/spec/unit/lib/cloud_controller/logs/request_logs_spec.rb
@@ -9,6 +9,7 @@ module VCAP::CloudController::Logs
     let(:fake_fullpath) { 'fullpath' }
     let(:fake_request) { double('request', request_method: 'request_method', ip: fake_ip, filtered_path: 'filtered_path', fullpath: fake_fullpath) }
     let(:request_id) { 'ID' }
+    let(:time_taken) { 30 }
     let(:env) { { 'cf.user_guid' => 'user-guid' } }
     let(:status) { 200 }
 
@@ -45,14 +46,14 @@ module VCAP::CloudController::Logs
           end
 
           it 'logs the completion of the request' do
-            request_logs.complete_request(request_id, status)
-            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID/, { status_code: 200 })
+            request_logs.complete_request(request_id, status, env, time_taken)
+            expect(logger).to have_received(:info).with(/Completed 200 vcap-request-id: ID Response Time: 30/, { request_method: "request_method", request_fullpath: "filtered_path", status_code: 200 })
           end
         end
 
         context 'without a matching start request' do
           it 'does not log the completion of the request' do
-            request_logs.complete_request(request_id, status)
+            request_logs.complete_request(request_id, status, env, time_taken)
             expect(logger).not_to have_received(:info)
           end
         end

--- a/spec/unit/middleware/request_logs_spec.rb
+++ b/spec/unit/middleware/request_logs_spec.rb
@@ -21,7 +21,7 @@ module CloudFoundry
 
         it 'calls complete request on request logs after the request' do
           middleware.call(env)
-          expect(request_logs).to have_received(:complete_request).with('ID', 200)
+          expect(request_logs).to have_received(:complete_request).with('ID', 200, { 'cf.request_id' => 'ID' }, be_a(Numeric))
         end
       end
     end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add time taken, request_method and request_full path to complete request log to help with debugging performance issues.

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
