### PR TITLE
Improve error message when cnb buildback fail to download

### DIFF
--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -1372,7 +1372,7 @@
 430002:
   name: CNBDownloadBuildpackFailed 
   http_code: 400
-  message: "cnb: downloading buildpacks failed: Please verify that the provided buildpacks are valid and credentials (if necessary) have been provided."
+  message: "cnb: downloading buildpacks failed: This may be caused by a wrong url, invalid buildpack or invalid credentials. Check the staging logs for more details."
 
 430003:
   name: CNBDetectFailed            

--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -1372,7 +1372,7 @@
 430002:
   name: CNBDownloadBuildpackFailed 
   http_code: 400
-  message: "cnb: downloading buildpacks failed"
+  message: "cnb: downloading buildpacks failed: Please verify that the provided buildpacks are valid and credentials (if necessary) have been provided."
 
 430003:
   name: CNBDetectFailed            


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Improve error message

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
