### PR TITLE
Use destroy over delete for deleting unmapped routes

### DIFF
--- a/app/actions/space_delete_unmapped_routes.rb
+++ b/app/actions/space_delete_unmapped_routes.rb
@@ -7,7 +7,7 @@ module VCAP::CloudController
         space.routes_dataset.
           exclude(guid: RouteMappingModel.select(:route_guid)).
           exclude(id: RouteBinding.select(:route_id)).
-          delete
+          destroy
       end
     end
   end

--- a/spec/unit/actions/space_delete_unmapped_routes_spec.rb
+++ b/spec/unit/actions/space_delete_unmapped_routes_spec.rb
@@ -71,6 +71,22 @@ module VCAP::CloudController
           expect { unbound_and_unmapped_route.refresh }.to raise_error Sequel::Error, 'Record not found'
         end
       end
+
+      context 'when the unmapped routes have labels and annotations' do
+        let!(:unmapped_route_1) { Route.make(domain: domain, space: space, host: 'unmapped1') }
+        let!(:label_1) { RouteLabelModel.make(key_name: 'k1', value: 'v1', resource_guid: unmapped_route_1.guid) }
+        let!(:annot_1) { RouteAnnotationModel.make(key_name: 'k1', value: 'v1', resource_guid: unmapped_route_1.guid) }
+
+        it 'deletes the labels, annotations and routes' do
+          expect do
+            subject.delete(space)
+          end.to change(VCAP::CloudController::Route, :count).by(-1)
+
+          expect { unmapped_route_1.refresh }.to raise_error Sequel::Error, 'Record not found'
+          expect { label_1.refresh }.to raise_error Sequel::Error, 'Record not found'
+          expect { annot_1.refresh }.to raise_error Sequel::Error, 'Record not found'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This triggers the deletion of associated resources, like labels and annotations.

Otherwise this operation gives a FK error.

`destroy` is required to do that as part of this definition https://github.com/cloudfoundry/cloud_controller_ng/blob/main/app/models/runtime/route.rb#L46 . Since this object has already excluded any route bindings or route mappings, using destroy has no effect on mappings/bindings.

Fixes #4099 

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
