### PR TITLE
Expire packages in "Docker" lifecycle

### DIFF
--- a/lib/cloud_controller/diego/docker/staging_completion_handler.rb
+++ b/lib/cloud_controller/diego/docker/staging_completion_handler.rb
@@ -25,6 +25,11 @@ module VCAP::CloudController
           }
         end
 
+        def staging_complete(payload, with_start=false)
+          super
+          BitsExpiration.new.expire_packages!(build.app)
+        end
+
         private
 
         def handle_missing_droplet!(_payload)

--- a/spec/unit/lib/cloud_controller/diego/docker/staging_completion_handler_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/docker/staging_completion_handler_spec.rb
@@ -48,6 +48,11 @@ module VCAP::CloudController
               subject.staging_complete(payload)
             end
 
+            it 'expires any old packages' do
+              expect_any_instance_of(BitsExpiration).to receive(:expire_packages!)
+              subject.staging_complete(payload)
+            end
+
             context 'when staging result is returned' do
               before do
                 payload[:result][:process_types] = {


### PR DESCRIPTION
* A short explanation of the proposed change:
Mark Docker packages as "EXPIRED" so that they can be properly cleaned up.

* An explanation of the use cases your change solves
There is no place where Docker packages are marked as "EXPIRED". This can lead to a high number of packages in "READY" state. So call the `expire_packages!` method when staging completed.

I haven't found a better place for this method call. There is no "PackageUploadHandler" class for the Docker lifecycle.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
