### PR TITLE
Don't schedule a delayed job for "docker" package deletion

### DIFF
--- a/app/actions/package_delete.rb
+++ b/app/actions/package_delete.rb
@@ -8,8 +8,11 @@ module VCAP::CloudController
       packages = Array(packages)
 
       packages.each do |package|
-        package_src_delete_job = create_package_source_deletion_job(package)
-        Jobs::Enqueuer.new(package_src_delete_job, queue: Jobs::Queues.generic).enqueue if package_src_delete_job
+        unless package.docker?
+          package_src_delete_job = create_package_source_deletion_job(package)
+          Jobs::Enqueuer.new(package_src_delete_job, queue: Jobs::Queues.generic).enqueue if package_src_delete_job
+        end
+
         package.destroy
 
         Repositories::PackageEventRepository.record_app_package_delete(


### PR DESCRIPTION
* A short explanation of the proposed change:
Don't schedule blob deletion background jobs when a Docker app is deleted.

* An explanation of the use cases your change solves
For Docker apps, the packages do not have an associated blob in the blobstore. So it's not necessary to schedule a delayed job. If there is a large number of packages, this can even lead to a temporary overload scenario of the cc-workers.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4102

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
