### PR TITLE
Expire packages in create/update hooks

### DIFF
--- a/app/models/runtime/package_model.rb
+++ b/app/models/runtime/package_model.rb
@@ -39,7 +39,7 @@ module VCAP::CloudController
       super
       return unless column_changed?(:state)
 
-      BitsExpiration.new.expire_packages!(app) if ready? or failed?
+      BitsExpiration.new.expire_packages!(app) if ready? || failed?
     end
 
     def validate

--- a/app/models/runtime/package_model.rb
+++ b/app/models/runtime/package_model.rb
@@ -30,6 +30,18 @@ module VCAP::CloudController
 
     set_field_as_encrypted :docker_password, salt: :docker_password_salt, column: :encrypted_docker_password
 
+    def after_create
+      super
+      BitsExpiration.new.expire_packages!(app) if ready?
+    end
+
+    def after_update
+      super
+      return unless column_changed?(:state)
+
+      BitsExpiration.new.expire_packages!(app) if ready?
+    end
+
     def validate
       validates_max_length 5_000, :docker_password, message: 'can be up to 5,000 characters', allow_nil: true
       validates_includes PACKAGE_STATES, :state, allow_missing: true

--- a/app/models/runtime/package_model.rb
+++ b/app/models/runtime/package_model.rb
@@ -39,7 +39,7 @@ module VCAP::CloudController
       super
       return unless column_changed?(:state)
 
-      BitsExpiration.new.expire_packages!(app) if ready?
+      BitsExpiration.new.expire_packages!(app) if ready? or failed?
     end
 
     def validate

--- a/lib/cloud_controller/packager/package_upload_handler.rb
+++ b/lib/cloud_controller/packager/package_upload_handler.rb
@@ -21,8 +21,6 @@ module CloudController
         end
 
         package.succeed_upload!(checksums)
-
-        VCAP::CloudController::BitsExpiration.new.expire_packages!(package.app)
       ensure
         FileUtils.rm_f(@uploaded_files_path) if @uploaded_files_path
       end

--- a/spec/unit/controllers/runtime/stagings_controller_spec.rb
+++ b/spec/unit/controllers/runtime/stagings_controller_spec.rb
@@ -238,6 +238,7 @@ module VCAP::CloudController
       Fog.unmock!
       TestConfig.override(**staging_config)
       set_current_user_as_admin(user: User.make(guid: '1234'), email: 'joe@joe.com', user_name: 'briggs')
+      allow_any_instance_of(BitsExpiration).to receive(:expire_packages!)
     end
 
     after { FileUtils.rm_rf(workspace) }

--- a/spec/unit/lib/cloud_controller/bits_expiration_spec.rb
+++ b/spec/unit/lib/cloud_controller/bits_expiration_spec.rb
@@ -161,14 +161,12 @@ module VCAP::CloudController
 
       it 'expires old packages' do
         expiration = BitsExpiration.new
-        expiration.expire_packages!(app)
         num_of_packages_to_keep = expiration.packages_storage_count + 1
         remaining_packages      = PackageModel.where(state: PackageModel::READY_STATE, app_guid: app.guid)
         expect(remaining_packages.count).to eq(num_of_packages_to_keep)
       end
 
       it 'does not delete the package related to the current droplet' do
-        BitsExpiration.new.expire_packages!(app)
         app.reload && @current_package.reload
         expect(@current_package.state).to eq(PackageModel::READY_STATE)
       end
@@ -181,7 +179,7 @@ module VCAP::CloudController
       end
 
       it 'enqueues a job to delete the blob' do
-        expect { BitsExpiration.new.expire_packages!(app) }.to change(Delayed::Job, :count).from(0).to(5)
+        expect(Delayed::Job.count).to eq(5)
         expect(Delayed::Job).to(be_all { |j| j.handler.include?('DeleteExpiredPackageBlob') })
       end
     end

--- a/spec/unit/models/runtime/package_model_spec.rb
+++ b/spec/unit/models/runtime/package_model_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 module VCAP::CloudController
   RSpec.describe PackageModel do
+    before do
+      allow_any_instance_of(BitsExpiration).to receive(:expire_packages!)
+    end
+
     describe 'validations' do
       it { is_expected.to validates_includes PackageModel::PACKAGE_STATES, :state, allow_missing: true }
 


### PR DESCRIPTION
* A short explanation of the proposed change:
Call the package expiration in the Sequel hooks after creation or when a package state has changed. This ensures that packages of type "docker" are also properly expired.

* An explanation of the use cases your change solves
Avoids accumulation of large number of packages when Docker apps are pushed repeatedly.

* Links to any other associated PRs
Alternative implementations:
https://github.com/cloudfoundry/cloud_controller_ng/pull/4102
https://github.com/cloudfoundry/cloud_controller_ng/pull/4105

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
