### PR TITLE
Add "max_valid_packages_stored" to worker config

### DIFF
--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -83,6 +83,7 @@ module VCAP::CloudController
 
             packages: {
               max_package_size: Integer,
+              max_valid_packages_stored: Integer,
               app_package_directory_key: String,
               fog_connection: Hash,
               fog_aws_storage_options: Hash,


### PR DESCRIPTION
* is needed for https://github.com/cloudfoundry/cloud_controller_ng/pull/4111

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add the config parameter "max_valid_packages_stored" to the "cloud_controller_worker" job.

* An explanation of the use cases your change solves
This is needed for https://github.com/cloudfoundry/cloud_controller_ng/pull/4111

* Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/pull/492

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
