### PR TITLE
Optimize DISTINCT queries

### DIFF
--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -228,13 +228,13 @@ class SpacesV3Controller < ApplicationController
   def fetch_running_security_group_guids(space)
     space_level_groups = SecurityGroup.where(spaces: space)
     global_groups = SecurityGroup.where(running_default: true)
-    space_level_groups.union(global_groups).map(&:guid)
+    space_level_groups.union(global_groups).select_map(:guid)
   end
 
   def fetch_staging_security_group_guids(space)
     space_level_groups = SecurityGroup.where(staging_spaces: space)
     global_groups = SecurityGroup.where(staging_default: true)
-    space_level_groups.union(global_groups).distinct.map(&:guid)
+    space_level_groups.union(global_groups).distinct.select_map(:guid)
   end
 
   def space_not_found!

--- a/app/decorators/field_service_instance_broker_decorator.rb
+++ b/app/decorators/field_service_instance_broker_decorator.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController
                 join(:service_plans, service_id: :services__id).
                 join(:service_instances, service_plan_id: :service_plans__id).
                 where(service_instances__id: managed_service_instances.map(&:id)).
-                distinct.
+                distinct(:service_brokers__created_at, :service_brokers__guid).
                 order_by(:service_brokers__created_at, :service_brokers__guid).
                 select(:service_brokers__name, :service_brokers__guid, :service_brokers__created_at).
                 all

--- a/app/decorators/field_service_instance_offering_decorator.rb
+++ b/app/decorators/field_service_instance_offering_decorator.rb
@@ -20,7 +20,7 @@ module VCAP::CloudController
                   join(:service_plans, service_id: :services__id).
                   join(:service_instances, service_plan_id: :service_plans__id).
                   where(service_instances__id: managed_service_instances.map(&:id)).
-                  distinct.
+                  distinct(:services__created_at, :services__guid).
                   order_by(:services__created_at, :services__guid).
                   select(:services__label, :services__guid, :services__description, :services__tags, :services__extra, :services__service_broker_id, :services__created_at).
                   all

--- a/app/fetchers/base_service_list_fetcher.rb
+++ b/app/fetchers/base_service_list_fetcher.rb
@@ -161,7 +161,7 @@ module VCAP::CloudController
       def join_plan_org_visibilities(dataset)
         dataset = join_service_plans(dataset)
         dataset = join(dataset, :inner, :service_plan_visibilities, service_plan_id: Sequel[:service_plans][:id])
-        dataset.distinct # service plans can have multiple visibilities
+        distinct(dataset) # service plans can have multiple visibilities
       end
 
       def join_service_brokers(dataset)
@@ -187,13 +187,13 @@ module VCAP::CloudController
       def join_plan_spaces(dataset)
         dataset = join_plan_orgs(dataset)
         dataset = join(dataset, :inner, Sequel[:spaces].as(:plan_spaces), organization_id: Sequel[:plan_orgs][:id])
-        dataset.distinct # organizations can have multiple spaces
+        distinct(dataset) # organizations can have multiple spaces
       end
 
       def join_service_instances(dataset)
         dataset = join_service_plans(dataset)
         dataset = join(dataset, :inner, :service_instances, service_plan_id: Sequel[:service_plans][:id])
-        dataset.distinct # service plans can have multiple instances
+        distinct(dataset) # service plans can have multiple instances
       end
 
       def join(dataset, type, table, on)
@@ -201,6 +201,10 @@ module VCAP::CloudController
           return dataset if j.table_expr == table
         end
         dataset.join_table(type, table, on)
+      end
+
+      def distinct(dataset)
+        dataset.distinct(Sequel.qualify(dataset.model.table_name, :id))
       end
     end
   end

--- a/app/fetchers/organization_quota_list_fetcher.rb
+++ b/app/fetchers/organization_quota_list_fetcher.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
         if message.requested? :organization_guids
           dataset = dataset.
                     join(:organizations, quota_definition_id: :id).
-                    where(organizations__guid: message.organization_guids).distinct.
+                    where(organizations__guid: message.organization_guids).distinct(:id).
                     qualify(:quota_definitions)
 
           dataset = dataset.where(organizations__guid: readable_org_guids_query) if readable_org_guids_query

--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
 
         filter(dataset, message).
           select_all(:service_instances).
-          distinct
+          distinct(:service_instances__id)
       end
 
       private

--- a/app/fetchers/service_offering_list_fetcher.rb
+++ b/app/fetchers/service_offering_list_fetcher.rb
@@ -33,7 +33,7 @@ module VCAP::CloudController
 
       def join_service_plans(dataset)
         dataset = join(dataset, :inner, :service_plans, service_id: Sequel[:services][:id])
-        dataset.distinct # services can have multiple plans
+        distinct(dataset) # services can have multiple plans
       end
 
       def join_services(dataset)
@@ -43,7 +43,7 @@ module VCAP::CloudController
       def distinct_union(dataset)
         # The UNIONed :services datasets (permissions granted on org level for plans / permissions
         # granted on space level for brokers / public plans) might contain duplicate entries.
-        dataset.distinct
+        distinct(dataset)
       end
     end
   end

--- a/app/fetchers/service_plan_visibility_fetcher.rb
+++ b/app/fetchers/service_plan_visibility_fetcher.rb
@@ -24,7 +24,7 @@ module VCAP::CloudController
 
       dataset.
         select_all(:organizations).
-        distinct.
+        distinct(:organizations__id).
         order_by(:id)
     end
   end

--- a/app/fetchers/space_quota_list_fetcher.rb
+++ b/app/fetchers/space_quota_list_fetcher.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
         if message.requested? :space_guids
           dataset = dataset.
                     join(:spaces, space_quota_definition_id: :id).
-                    where(Sequel[:spaces][:guid] => message.space_guids).distinct.
+                    where(Sequel[:spaces][:guid] => message.space_guids).distinct(:id).
                     qualify(:space_quota_definitions)
         end
 

--- a/app/jobs/runtime/prune_completed_builds.rb
+++ b/app/jobs/runtime/prune_completed_builds.rb
@@ -13,8 +13,8 @@ module VCAP::CloudController
           logger.info('Cleaning up old builds')
 
           guids_for_apps_with_builds = BuildModel.
-                                       distinct(:app_guid).
-                                       map(&:app_guid)
+                                       distinct.
+                                       select_map(:app_guid)
 
           guids_for_apps_with_builds.each do |app_guid|
             builds_dataset = BuildModel.where(app_guid:)

--- a/app/jobs/runtime/prune_completed_deployments.rb
+++ b/app/jobs/runtime/prune_completed_deployments.rb
@@ -13,8 +13,8 @@ module VCAP::CloudController
           logger.info('Cleaning up old deployments')
 
           guids_for_apps_with_deployments = DeploymentModel.
-                                            distinct(:app_guid).
-                                            map(&:app_guid)
+                                            distinct.
+                                            select_map(:app_guid)
 
           guids_for_apps_with_deployments.each do |app_guid|
             deployments_dataset = DeploymentModel.where(app_guid:)

--- a/lib/cloud_controller/paging/sequel_paginator.rb
+++ b/lib/cloud_controller/paging/sequel_paginator.rb
@@ -15,6 +15,18 @@ module VCAP::CloudController
 
       dataset = dataset.order_append(Sequel.send(order_direction, Sequel.qualify(table_name, :guid))) if order_by != 'id' && has_guid_column
 
+      distinct_opt = dataset.opts[:distinct]
+      if !distinct_opt.nil? && !distinct_opt.empty? # DISTINCT ON
+        order_opt = dataset.opts[:order]
+        dataset = if order_opt.any? { |o| %i[id guid].include?(o.expression.column.to_sym) }
+                    # If ORDER BY columns are unique, use them for the DISTINCT ON clause.
+                    dataset.distinct(*order_opt.map(&:expression))
+                  else
+                    # Otherwise, use DISTINCT.
+                    dataset.distinct
+                  end
+      end
+
       records, count = if can_paginate_with_window_function?(dataset)
                          paginate_with_window_function(dataset, per_page, page, table_name)
                        else

--- a/spec/support/bootstrap/fake_model_tables.rb
+++ b/spec/support/bootstrap/fake_model_tables.rb
@@ -9,6 +9,7 @@ class FakeModelTables
     tables_for_vcap_relations_spec
     tables_for_sequel_case_insensitive_string_monkeypatch
     tables_for_query_spec
+    tables_for_sequel_paginator_spec
   end
 
   private
@@ -18,6 +19,7 @@ class FakeModelTables
     drop_tables_for_vcap_relations_spec
     drop_tables_for_sequel_case_insensitive_string_monkeypatch
     drop_tables_for_query_spec
+    drop_tables_for_sequel_paginator_spec
   end
 
   def tables_for_model_controller_spec
@@ -271,6 +273,17 @@ class FakeModelTables
     db.drop_table? :magazines
     db.drop_table? :books
     db.drop_table? :authors
+  end
+
+  def tables_for_sequel_paginator_spec
+    db.create_table :table_without_guid do
+      primary_key :id
+      DateTime :created_at
+    end
+  end
+
+  def drop_tables_for_sequel_paginator_spec
+    db.drop_table? :table_without_guid
   end
 
   attr_reader :db


### PR DESCRIPTION
The `DISTINCT` clause instructs the database to ensure that all returned rows are distinct; so the database compares all returned columns. In most cases we simply want to prevent duplicate entries in the result set which can be achieved by a `DISTINCT ON (id)` clause that does the comparison on the 'id' column only and is much more efficient (i.e. for large final or even intermediate result sets the database might need to write them to disk to perform the comparison).

MySQL does not support `DISTINCT ON`, but Sequel translates this transparently to `GROUP BY`.

PostgreSQL has the following restriction: `SELECT DISTINCT ON expressions must match initial ORDER BY expressions`. Thus the `SequelPaginator` has been enhanced to use the `ORDER BY` columns also for the `DISTINCT ON` clause if they are unique (i.e. 'id' or 'guid' included). In case the `ORDER BY` clause is not unique, `DISTINCT` is used instead.

`DISTINCT` statements with a single selected column have not been changed.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
