### PR TITLE
Remove duplicate mapping key

### DIFF
--- a/errors/v2.yml
+++ b/errors/v2.yml
@@ -214,11 +214,6 @@
   message: "The service instance name is taken: %s"
 
 60003:
-  name: ServiceInstanceServiceBindingWrongSpace
-  http_code: 400
-  message: "The service instance and the service binding are in different app spaces: %s"
-
-60003:
   name: ServiceInstanceInvalid
   http_code: 400
   message: "The service instance is invalid: %s"
@@ -1024,19 +1019,14 @@
   message: "Resource inside space %s must first be deleted, or specify recursive delete."
 
 290013:
-  name: OrganizationRolesDeletionTimeout
+  name: SpaceRolesDeletionTimeout
   http_code: 524
-  message: "Deletion of roles for organization %s timed out before all roles could be deleted"
+  message: "Deletion of roles for space %s timed out before all roles could be deleted"
 
 290014:
   name: OrganizationRolesDeletionFailed
   http_code: 502
   message: "Failed to delete one or more roles for organization %s"
-
-290013:
-  name: SpaceRolesDeletionTimeout
-  http_code: 524
-  message: "Deletion of roles for space %s timed out before all roles could be deleted"
 
 290016:
   name: SpaceRolesDeletionFailed


### PR DESCRIPTION
The error codes `60003` and `290013` appear twice. While many YAML parsers can cope with duplicate mapping keys, many parser will error out.
External tools, like for example
[go-cfclient's gen_error.go](https://github.com/cloudfoundry/go-cfclient/blob/main/tools/gen_error.go), cannot update to more recent major versions of their YAML parser library:

```shell
yaml: unmarshal errors:
  line 221: mapping key "60003" already defined at line 216
  line 1036: mapping key "290013" already defined at line 1026
panic: yaml: unmarshal errors:
	  line 221: mapping key "60003" already defined at line 216
	  line 1036: mapping key "290013" already defined at line 1026
```

Cloud Controller uses `psych` to parse the errors/*.yml files. Psych uses the latest occurence of a key. Therefore, the most recent duplicate key can be picked to stay in the errors files.

```
irb(main):001> require 'psych'
=> true
irb(main):002> filepath = "errors/v2.yml"
=> "errors/v2.yml"
irb(main):003* content = File.open(filepath) do |f|
irb(main):004*   Psych.safe_load(f, strict_integer: true)
irb(main):005> end; nil
=> nil
irb(main):006> content[60003]
=> {"name"=>"ServiceInstanceInvalid", "http_code"=>400, "message"=>"The service instance is invalid: %s"}
irb(main):007> content[290013]
=> {"name"=>"SpaceRolesDeletionTimeout", "http_code"=>524, "message"=>"Deletion of roles for space %s timed out before all roles could be deleted"}
```

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
