### PR TITLE
Explicitly configure worker sleep delay

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -33,6 +33,7 @@ system_hostnames:
 jobs:
   global:
     timeout_in_seconds: 14400
+    worker_sleep_delay_in_seconds: 5
   queues: {}
 
 app_usage_events:

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -335,7 +335,10 @@ module VCAP::CloudController
             default_app_ssh_access: bool,
 
             jobs: {
-              global: { timeout_in_seconds: Integer },
+              global: {
+                timeout_in_seconds: Integer,
+                worker_sleep_delay_in_seconds: Integer
+              },
               queues: {
                 optional(:cc_generic) => { timeout_in_seconds: Integer }
               },

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -161,7 +161,10 @@ module VCAP::CloudController
             default_app_ssh_access: bool,
 
             jobs: {
-              global: { timeout_in_seconds: Integer },
+              global: {
+                timeout_in_seconds: Integer,
+                worker_sleep_delay_in_seconds: Integer
+              },
               queues: {
                 optional(:cc_generic) => { timeout_in_seconds: Integer }
               },

--- a/lib/delayed_job/delayed_worker.rb
+++ b/lib/delayed_job/delayed_worker.rb
@@ -48,6 +48,7 @@ class CloudController::DelayedWorker
     Delayed::Worker.destroy_failed_jobs = false
     Delayed::Worker.max_attempts = 3
     Delayed::Worker.max_run_time = config.get(:jobs, :global, :timeout_in_seconds) + 1
+    Delayed::Worker.sleep_delay = config.get(:jobs, :global, :worker_sleep_delay_in_seconds)
     Delayed::Worker.logger = logger
 
     unless @queue_options[:num_threads].nil?

--- a/spec/unit/lib/delayed_job/delayed_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_worker_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe CloudController::DelayedWorker do
       expect(Delayed::Worker.destroy_failed_jobs).to be false
       expect(Delayed::Worker.max_attempts).to eq(3)
       expect(Delayed::Worker.max_run_time).to eq(14_401)
+      expect(Delayed::Worker.sleep_delay).to eq(5)
     end
 
     context 'when the number of threads is specified' do


### PR DESCRIPTION
The default worker sleep delay in delayed_job is 5 seconds. Reducing this value could reduce the database load when there aren't many jobs to process.

* Links to any other associated PRs: https://github.com/cloudfoundry/capi-release/pull/499

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
