### PR TITLE
Add OSBAPI version to /v3/info

### DIFF
--- a/app/controllers/v3/info_controller.rb
+++ b/app/controllers/v3/info_controller.rb
@@ -16,6 +16,14 @@ class InfoController < ApplicationController
     info.version = config.get(:info, :version) || 0
     info.support_address = config.get(:info, :support_address) || ''
 
+    osbapi_version_file = Rails.root.join('config/osbapi_version').to_s
+    if File.exist?(osbapi_version_file)
+      info.osbapi_version = File.read(osbapi_version_file).strip
+    else
+      info.osbapi_version = ''
+      Rails.logger.warn("OSBAPI version file not found at #{osbapi_version_file}")
+    end
+
     render status: :ok, json: VCAP::CloudController::Presenters::V3::InfoPresenter.new(info)
   end
 
@@ -29,5 +37,5 @@ class InfoController < ApplicationController
 end
 
 class Info
-  attr_accessor :build, :min_cli_version, :min_recommended_cli_version, :custom, :description, :name, :version, :support_address
+  attr_accessor :build, :min_cli_version, :min_recommended_cli_version, :custom, :description, :name, :version, :support_address, :osbapi_version
 end

--- a/app/presenters/v3/info_presenter.rb
+++ b/app/presenters/v3/info_presenter.rb
@@ -15,6 +15,7 @@ module VCAP::CloudController::Presenters::V3
         description: info.description,
         name: info.name,
         version: info.version,
+        osbapi_version: info.osbapi_version,
         links: {
           self: { href: build_self },
           support: { href: info.support_address }

--- a/docs/v3/source/includes/api_resources/_info.erb
+++ b/docs/v3/source/includes/api_resources/_info.erb
@@ -11,6 +11,7 @@
   "description": "Put your apps here!",
   "name": "Cloud Foundry",
   "version": 123,
+  "osbapi_version": 456,
   "links": {
     "self": { "href": "http://api.example.com/v3/info" } ,
     "support": { "href": "http://support.example.com" }
@@ -29,6 +30,7 @@
   "description": "",
   "name": "",
   "version": 0,
+  "osbapi_version": "",
   "links": {
     "self": { "href": "http://api.example.com/v3/info" } ,
     "support": { "href": "" }

--- a/docs/v3/source/includes/api_resources/_info.erb
+++ b/docs/v3/source/includes/api_resources/_info.erb
@@ -11,7 +11,7 @@
   "description": "Put your apps here!",
   "name": "Cloud Foundry",
   "version": 123,
-  "osbapi_version": 456,
+  "osbapi_version": "2.15",
   "links": {
     "self": { "href": "http://api.example.com/v3/info" } ,
     "support": { "href": "http://support.example.com" }

--- a/spec/request/info_spec.rb
+++ b/spec/request/info_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Info Request' do
           description: '',
           name: '',
           version: 0,
+          osbapi_version: 0,
           links: {
             self: { href: "#{link_prefix}/v3/info" },
             support: { href: '' }

--- a/spec/request/info_spec.rb
+++ b/spec/request/info_spec.rb
@@ -14,11 +14,20 @@ RSpec.describe 'Info Request' do
         description: TestConfig.config[:info][:description],
         name: TestConfig.config[:info][:name],
         version: TestConfig.config[:info][:version],
+        osbapi_version: TestConfig.config[:info][:osbapi_version],
         links: {
           self: { href: "#{link_prefix}/v3/info" },
           support: { href: TestConfig.config[:info][:support_address] }
         }
       }
+    end
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(Rails.root.join('config/osbapi_version').to_s).and_return(true)
+      allow(File).to receive(:read).with(Rails.root.join('config/osbapi_version').to_s).and_return('1.0.0')
+
+      TestConfig.override(info: TestConfig.config[:info].merge(osbapi_version: '1.0.0'))
     end
 
     it 'includes data from the config' do
@@ -38,7 +47,7 @@ RSpec.describe 'Info Request' do
           description: '',
           name: '',
           version: 0,
-          osbapi_version: 0,
+          osbapi_version: '',
           links: {
             self: { href: "#{link_prefix}/v3/info" },
             support: { href: '' }
@@ -48,6 +57,7 @@ RSpec.describe 'Info Request' do
 
       before do
         TestConfig.override(info: nil)
+        allow(File).to receive(:exist?).with(Rails.root.join('config/osbapi_version').to_s).and_return(false)
       end
 
       it 'includes has proper empty values' do


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

OSBAPI version is not shown in the response of v3/info endpoint. With this change, v3/info response will contain the OSBAPI version.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
