### PR TITLE
Allow use of Puma's automatic worker count configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'addressable'
 gem 'allowy', '>= 2.1.0'
 gem 'clockwork', require: false
 gem 'cloudfront-signer'
+gem 'concurrent-ruby'
 gem 'digest-xxhash'
 gem 'eventmachine', '~> 1.2.7'
 gem 'fluent-logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -595,6 +595,7 @@ DEPENDENCIES
   clockwork
   cloudfront-signer
   codeclimate-test-reporter (>= 1.0.8)
+  concurrent-ruby
   debug (~> 1.10)
   digest-xxhash
   eventmachine (~> 1.2.7)

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -267,6 +267,7 @@ module VCAP::CloudController
 
             webserver: String, # thin or puma
             optional(:puma) => {
+              automatic_worker_count: bool,
               workers: Integer,
               max_threads: Integer,
               optional(:max_db_connections_per_process) => Integer

--- a/lib/cloud_controller/runners/puma_runner.rb
+++ b/lib/cloud_controller/runners/puma_runner.rb
@@ -8,6 +8,7 @@ module VCAP::CloudController
     def initialize(config, app, logger, periodic_updater, request_logs)
       @logger = logger
 
+      ENV['WEB_CONCURRENCY'] = 'auto' if config.get(:puma, :automatic_worker_count)
       puma_config = Puma::Configuration.new do |conf|
         if config.get(:nginx, :use_nginx)
           if config.get(:nginx, :instance_socket).nil? || config.get(:nginx, :instance_socket).empty?
@@ -19,7 +20,7 @@ module VCAP::CloudController
           conf.bind "tcp://0.0.0.0:#{config.get(:external_port)}"
         end
 
-        conf.workers(config.get(:puma, :workers) || 1)
+        conf.workers(config.get(:puma, :workers) || 1) unless config.get(:puma, :automatic_worker_count)
         num_threads = config.get(:puma, :max_threads) || 1
         conf.threads(num_threads, num_threads)
 


### PR DESCRIPTION
https://github.com/cloudfoundry/capi-release/pull/500

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
