### PR TITLE
Log worker name in steno logger

### DIFF
--- a/lib/delayed_job/delayed_worker.rb
+++ b/lib/delayed_job/delayed_worker.rb
@@ -61,6 +61,7 @@ class CloudController::DelayedWorker
 
     worker = Delayed::Worker.new(@queue_options)
     worker.name = @queue_options[:worker_name]
+    Steno.config.context.data[:worker_name] = worker.name
     worker
   end
 

--- a/lib/delayed_job/threaded_worker.rb
+++ b/lib/delayed_job/threaded_worker.rb
@@ -33,6 +33,7 @@ module Delayed
       @num_threads.times do |thread_index|
         thread = Thread.new do
           Thread.current[:thread_index] = thread_index
+          Steno.config.context.data[:worker_name] = name # override logged worker name with thread specific name
           threaded_start
         rescue Exception => e # rubocop:disable Lint/RescueException
           say "Unexpected error: #{e.message}\n#{e.backtrace.join("\n")}", 'error'

--- a/spec/unit/lib/delayed_job/threaded_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/threaded_worker_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe Delayed::ThreadedWorker do
       expect { worker.start }.to raise_error('Unexpected error occurred in one of the worker threads')
       expect(worker.instance_variable_get(:@unexpected_error)).to be true
     end
+
+    it 'sets the worker name in the Steno context' do
+      steno_data_spy = spy('data')
+      allow(Steno.config.context).to receive(:data).and_return(steno_data_spy)
+
+      worker.start
+      worker.instance_variable_get(:@threads).each_with_index do |_, index|
+        expect(steno_data_spy).to have_received(:[]=).with(:worker_name, "#{worker_name} thread:#{index + 1}")
+      end
+    end
   end
 
   describe '#names_with_threads' do


### PR DESCRIPTION
Logging the worker name will make it easier to analyse the logs of particular worker process/thread.
The worker name will be added as an additional key in the data field where e.g. the request_id is already logged.
Example:
```
{"timestamp":"2025-01-14T09:51:48.249447000Z","message":"(0.001651s) (app/actions/organization_delete.rb:33:in `block (2 levels) in delete') (query_length=43) DELETE FROM \"organizations\" WHERE \"id\" = 32","log_level":"debug","source":"cc.background","data":{"worker_name":"cc_global_worker_generic thread:7","request_guid":"0728f0f0-7f96-420c-ab2d-1a3768bb7047"},"thread_id":39340,"fiber_id":39360,"process_id":68504,"file":"/Users/bommel/.rbenv/versions/3.2.6/lib/ruby/gems/3.2.0/gems/sequel-5.88.0/lib/sequel/database/logging.rb","lineno":88,"method":"public_send"}
```

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
