### PR TITLE
Handle rate limited UAA

### DIFF
--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -58,6 +58,9 @@ class RolesController < ApplicationController
     render status: :created, json: Presenters::V3::RolePresenter.new(role)
   rescue RoleCreate::Error => e
     unprocessable!(e)
+  rescue UaaRateLimited
+    headers['Retry-After'] = rand(5..20).to_s
+    raise CloudController::Errors::V3::ApiError.new_from_details('UaaRateLimited')
   rescue UaaUnavailable
     raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
   end

--- a/app/controllers/v3/users_controller.rb
+++ b/app/controllers/v3/users_controller.rb
@@ -54,6 +54,9 @@ class UsersController < ApplicationController
     else
       render status: :created, json: Presenters::V3::UserPresenter.new(user, uaa_users: User.uaa_users_info([user.guid]))
     end
+  rescue UaaRateLimited
+    headers['Retry-After'] = rand(5..20).to_s
+    raise CloudController::Errors::V3::ApiError.new_from_details('UaaRateLimited')
   rescue VCAP::CloudController::UaaUnavailable
     raise CloudController::Errors::ApiError.new_from_details('UaaUnavailable')
   rescue UserCreate::Error => e

--- a/errors/v3.yml
+++ b/errors/v3.yml
@@ -12,3 +12,8 @@
   name: ServiceBrokerGone
   http_code: 422
   message: "The service broker was removed before the synchronization completed"
+
+20008:
+  name: UaaRateLimited
+  http_code: 429
+  message: "The UAA is currently rate limited. Please try again later"

--- a/lib/cloud_controller/uaa/errors.rb
+++ b/lib/cloud_controller/uaa/errors.rb
@@ -30,4 +30,10 @@ module VCAP::CloudController
       'The UAA returned an unexpected error'
     end
   end
+
+  class UaaRateLimited < UaaError
+    def message
+      'The UAA is currently rate limited. Please try again later'
+    end
+  end
 end

--- a/lib/cloud_controller/uaa/uaa_client.rb
+++ b/lib/cloud_controller/uaa/uaa_client.rb
@@ -102,6 +102,14 @@ module VCAP::CloudController
       raise e unless e.info['error'] == 'scim_resource_already_exists'
 
       { 'id' => e.info['user_id'] }
+    rescue CF::UAA::BadResponse => e
+      unless e.message == 'invalid status response: 429'
+        logger.error("UAA request for creating a user failed: #{e.inspect}")
+        raise UaaUnavailable
+      end
+
+      logger.warn("UAA request for creating a user ran into rate limits: #{e.inspect}")
+      raise UaaRateLimited
     rescue CF::UAA::UAAError => e
       logger.error("UAA request for creating a user failed: #{e.inspect}")
       raise UaaUnavailable


### PR DESCRIPTION
* A short explanation of the proposed change:
UAA might return 429 responses. This is especially relevant for the newly added UAA shadow user creation https://github.com/cloudfoundry/cloud_controller_ng/pull/4113
* An explanation of the use cases your change solves
This changes the error code the CC returns to the user if UAA responded with 429. Before that the user got back a 503 "CF-UaaUnavailable". Now CC returns 429 "CF-UaaRateLimited" including a random Retry-After header. (UAA does not return a Retry-After header yet).
* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
