### PR TITLE
Remove foreign key contraint in table job_warnings on 'fk_jobs_id'

### DIFF
--- a/db/migrations/20250116144231_remove_unnecessary_fk_in_job_warnings.rb
+++ b/db/migrations/20250116144231_remove_unnecessary_fk_in_job_warnings.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    unless foreign_key_list(:job_warnings).empty?
+      alter_table :job_warnings do
+        drop_foreign_key :fk_jobs_id
+      end
+    end
+  end
+end

--- a/spec/migrations/20250116144231_remove_unnecessary_fk_in_job_warnings_spec.rb
+++ b/spec/migrations/20250116144231_remove_unnecessary_fk_in_job_warnings_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe "migration to remove foreign key constraint on table 'job_warnings' and column 'fk_jobs_id'", isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20250116144231_remove_unnecessary_fk_in_job_warnings.rb' }
+  end
+
+  describe 'job_warnings table' do
+    it 'removes the fk constraint as well as the column' do
+      Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+
+      expect(db.foreign_key_list(:job_warnings)).to be_empty
+      expect(db[:job_warnings].columns).not_to include(:fk_jobs_id)
+    end
+
+    context 'foreign key constraint does not exist' do
+      before do
+        unless db.foreign_key_list(:job_warnings).empty?
+          db.alter_table(:job_warnings) do
+            drop_foreign_key :fk_jobs_id
+          end
+        end
+      end
+
+      it 'does not fail' do
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
* A short explanation of the proposed change:

Deletion of foreign key constraint in `job_warnings` table on `fk_jobs_id`. This also deletes the column `fk_jobs_id`.
This will drastically increase the speed of the cleanup job of the pollable jobs table.

* An explanation of the use cases your change solves

The job_warnings table was created in a wrong way. There are two columns 'job_id' and 'fk_jobs_id'. There is a foreign key constraint on 'fk_jobs_id', which references jobs(id). CC coding never inserts data into 'fk_jobs_id', but only into 'job_id'. So the foreign key constraint is not needed but causes way slower cleanup of pollable jobs, which can even run into DB statement timeouts and cause an ever growing table. CC already takes care of deleting job_warnings when jobs are deleted.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
