### PR TITLE
Reduce logcache timeout from 250 to 10s

### DIFF
--- a/lib/logcache/client.rb
+++ b/lib/logcache/client.rb
@@ -44,13 +44,14 @@ module Logcache
 
     private
 
-    def with_request_error_handling(_source_guid)
+    def with_request_error_handling(source_guid)
       tries ||= 3
       start_time = Time.now
-
-      # convert to milliseconds to get more precise information
-      time_taken = (Time.now - start_time) * 1000
-      logger.info("Response time: #{time_taken.round(2)} ms")
+      time_taken = (Time.now - start_time) * 1000 # convert to milliseconds to get more precise information
+      logger.info("Response time: #{time_taken.round(2)} ms",
+                  { source_id: source_guid,
+                    event: 'log_cache_request',
+                    time_taken_in_ms: time_taken.round(2) })
       yield
     rescue StandardError => e
       raise CloudController::Errors::ApiError.new_from_details('ServiceUnavailable', 'Connection to Log Cache timed out') if e.is_a?(GRPC::DeadlineExceeded)

--- a/lib/logcache/client.rb
+++ b/lib/logcache/client.rb
@@ -47,12 +47,13 @@ module Logcache
     def with_request_error_handling(source_guid)
       tries ||= 3
       start_time = Time.now
-      time_taken = (Time.now - start_time) * 1000 # convert to milliseconds to get more precise information
-      logger.info("Response time: #{time_taken.round(2)} ms",
+
+      result = yield
+      time_taken_in_ms = ((Time.now - start_time) * 1000).to_i # convert to milliseconds to get more precise information
+      logger.info('logcache.response',
                   { source_id: source_guid,
-                    event: 'log_cache_request',
-                    time_taken_in_ms: time_taken.round(2) })
-      yield
+                    time_taken_in_ms: time_taken_in_ms })
+      result
     rescue StandardError => e
       raise CloudController::Errors::ApiError.new_from_details('ServiceUnavailable', 'Connection to Log Cache timed out') if e.is_a?(GRPC::DeadlineExceeded)
 

--- a/lib/logcache/client.rb
+++ b/lib/logcache/client.rb
@@ -47,11 +47,11 @@ module Logcache
     def with_request_error_handling(_source_guid)
       tries ||= 3
       start_time = Time.now
-      yield
 
       # convert to milliseconds to get more precise information
       time_taken = (Time.now - start_time) * 1000
       logger.info("Response time: #{time_taken.round(2)} ms")
+      yield
     rescue StandardError => e
       raise CloudController::Errors::ApiError.new_from_details('ServiceUnavailable', 'Connection to Log Cache timed out') if e.is_a?(GRPC::DeadlineExceeded)
 

--- a/spec/logcache/client_spec.rb
+++ b/spec/logcache/client_spec.rb
@@ -62,11 +62,10 @@ module Logcache
         it 'logs the response time and metadata' do
           client.container_metrics(source_guid: process.guid, envelope_limit: 1000, start_time: 100, end_time: 101)
           expect(mock_logger).to have_received(:info).with(
-            a_string_matching(/Response time: \d+\.\d+ ms/),
+            a_string_matching(/logcache.response/),
             hash_including(
               source_id: process.guid,
-              event: 'log_cache_request',
-              time_taken_in_ms: be_a(Float)
+              time_taken_in_ms: be_a(Integer)
             )
           )
         end

--- a/spec/logcache/client_spec.rb
+++ b/spec/logcache/client_spec.rb
@@ -36,7 +36,7 @@ module Logcache
             with(client_ca, client_key, client_cert).
             and_return(credentials)
           expect(Logcache::V1::Egress::Stub).to receive(:new).
-            with("#{host}:#{port}", credentials, channel_args: channel_arg_hash, timeout: 250).
+            with("#{host}:#{port}", credentials, channel_args: channel_arg_hash, timeout: 10).
             and_return(logcache_service)
           allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
         end
@@ -68,7 +68,7 @@ module Logcache
             with(client_ca, client_key, client_cert).
             and_return(credentials)
           expect(Logcache::V1::Egress::Stub).to receive(:new).
-            with("#{host}:#{port}", credentials, channel_args: channel_arg_hash, timeout: 250).
+            with("#{host}:#{port}", credentials, channel_args: channel_arg_hash, timeout: 10).
             and_return(logcache_service)
           allow(client).to receive(:sleep)
           allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
@@ -99,7 +99,7 @@ module Logcache
             with(client_ca, client_key, client_cert).
             and_return(credentials)
           expect(Logcache::V1::Egress::Stub).to receive(:new).
-            with("#{host}:#{port}", credentials, channel_args: channel_arg_hash, timeout: 250).
+            with("#{host}:#{port}", credentials, channel_args: channel_arg_hash, timeout: 10).
             and_return(logcache_service)
           allow(client).to receive(:sleep)
           allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
@@ -130,7 +130,7 @@ module Logcache
             with(client_ca, client_key, client_cert).
             and_return(credentials)
           expect(Logcache::V1::Egress::Stub).to receive(:new).
-            with("#{host}:#{port}", credentials, channel_args: channel_arg_hash, timeout: 250).
+            with("#{host}:#{port}", credentials, channel_args: channel_arg_hash, timeout: 10).
             and_return(logcache_service)
           allow(client).to receive(:sleep)
           allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
@@ -164,7 +164,7 @@ module Logcache
         before do
           expect(GRPC::Core::ChannelCredentials).not_to receive(:new)
           expect(Logcache::V1::Egress::Stub).to receive(:new).
-            with("#{host}:#{port}", :this_channel_is_insecure, timeout: 250).
+            with("#{host}:#{port}", :this_channel_is_insecure, timeout: 10).
             and_return(logcache_service)
           allow(Logcache::V1::ReadRequest).to receive(:new).and_return(logcache_request)
         end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

A shorter timeout might prevent the CF PUSH timeout because CLI will continue to poll for process stats and a retry may succeed.

* An explanation of the use cases your change solves

If a Cloud Controller request to Log Cache takes too long,  `Connection to Log Cache timed out ` error will be triggered earlier.

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
