### PR TITLE
fix: Rename least-connection load-balancing algorithm consistently

### DIFF
--- a/app/messages/route_options_message.rb
+++ b/app/messages/route_options_message.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
   class RouteOptionsMessage < BaseMessage
     VALID_MANIFEST_ROUTE_OPTIONS = %i[loadbalancing].freeze
     VALID_ROUTE_OPTIONS = %i[loadbalancing].freeze
-    VALID_LOADBALANCING_ALGORITHMS = %w[round-robin least-connections].freeze
+    VALID_LOADBALANCING_ALGORITHMS = %w[round-robin least-connection].freeze
 
     register_allowed_keys VALID_ROUTE_OPTIONS
     validates_with NoAdditionalKeysValidator

--- a/docs/v3/source/includes/resources/routes/_route_options_object.md.erb
+++ b/docs/v3/source/includes/resources/routes/_route_options_object.md.erb
@@ -9,4 +9,4 @@ Example Route-Options object
 
 | Name              | Type     | Description                                                                                          |
 |-------------------|----------|------------------------------------------------------------------------------------------------------|
-| **loadbalancing** | _string_ | The load-balancer associated with this route. Valid values are 'round-robin' and 'least-connections' |
+| **loadbalancing** | _string_ | The load-balancer associated with this route. Valid values are 'round-robin' and 'least-connection' |

--- a/spec/request/space_manifests_spec.rb
+++ b/spec/request/space_manifests_spec.rb
@@ -685,7 +685,7 @@ Route 'https://#{route.host}.#{route.domain.name}' contains invalid route option
                 'routes' => [
                   { 'route' => "https://#{route.host}.#{shared_domain.name}",
                     'options' => {
-                      'loadbalancing' => 'least-connections'
+                      'loadbalancing' => 'least-connection'
                     } }
                 ] }
             ]
@@ -699,7 +699,7 @@ Route 'https://#{route.host}.#{route.domain.name}' contains invalid route option
           Delayed::Worker.new.work_off
           expect(VCAP::CloudController::PollableJobModel.find(guid: job_guid)).to be_complete, VCAP::CloudController::PollableJobModel.find(guid: job_guid).cf_api_error
           app1_model.reload
-          expect(app1_model.routes.first.options).to eq({ 'loadbalancing' => 'least-connections' })
+          expect(app1_model.routes.first.options).to eq({ 'loadbalancing' => 'least-connection' })
         end
 
         it 'does not modify any route options when the options hash is not provided' do
@@ -787,7 +787,7 @@ Route 'https://#{route.host}.#{route.domain.name}': options must be an object")
 
           expect(last_response.status).to eq(422)
           expect(last_response).to have_error_message("For application '#{app1_model.name}': \
-Invalid value for 'loadbalancing' for Route 'https://#{route.host}.#{route.domain.name}'; Valid values are: 'round-robin, least-connections'")
+Invalid value for 'loadbalancing' for Route 'https://#{route.host}.#{route.domain.name}'; Valid values are: 'round-robin, least-connection'")
 
           app1_model.reload
           expect(app1_model.routes.first.options).to eq({ 'loadbalancing' => 'round-robin' })
@@ -817,7 +817,7 @@ Invalid value for 'loadbalancing' for Route 'https://#{route.host}.#{route.domai
 
             expect(last_response).to have_status_code(422)
             expect(last_response).to have_error_message("For application '#{app1_model.name}': \
-Cannot use loadbalancing value 'unsupported-lb-algorithm' for Route 'https://#{route.host}.#{route.domain.name}'; Valid values are: 'round-robin, least-connections'")
+Cannot use loadbalancing value 'unsupported-lb-algorithm' for Route 'https://#{route.host}.#{route.domain.name}'; Valid values are: 'round-robin, least-connection'")
           end
         end
 

--- a/spec/unit/actions/route_update_spec.rb
+++ b/spec/unit/actions/route_update_spec.rb
@@ -190,7 +190,7 @@ module VCAP::CloudController
           let(:body) do
             {
               options: {
-                loadbalancing: 'least-connections'
+                loadbalancing: 'least-connection'
               }
             }
           end
@@ -200,7 +200,7 @@ module VCAP::CloudController
             subject.update(route:, message:)
             route.reload
 
-            expect(route.options).to include({ 'loadbalancing' => 'least-connections' })
+            expect(route.options).to include({ 'loadbalancing' => 'least-connection' })
           end
         end
 

--- a/spec/unit/messages/manifest_routes_update_message_spec.rb
+++ b/spec/unit/messages/manifest_routes_update_message_spec.rb
@@ -293,7 +293,7 @@ module VCAP::CloudController
           msg = ManifestRoutesUpdateMessage.new(body)
 
           expect(msg.valid?).to be(false)
-          expect(msg.errors.full_messages).to include("Invalid value for 'loadbalancing' for Route 'existing.example.com'; Valid values are: 'round-robin, least-connections'")
+          expect(msg.errors.full_messages).to include("Invalid value for 'loadbalancing' for Route 'existing.example.com'; Valid values are: 'round-robin, least-connection'")
         end
       end
 
@@ -313,7 +313,7 @@ module VCAP::CloudController
 
           expect(msg.valid?).to be(false)
           expect(msg.errors.errors.length).to eq(1)
-          expect(msg.errors.full_messages).to include("Cannot use loadbalancing value 'sushi' for Route 'existing.example.com'; Valid values are: 'round-robin, least-connections'")
+          expect(msg.errors.full_messages).to include("Cannot use loadbalancing value 'sushi' for Route 'existing.example.com'; Valid values are: 'round-robin, least-connection'")
         end
       end
     end

--- a/spec/unit/messages/route_create_message_spec.rb
+++ b/spec/unit/messages/route_create_message_spec.rb
@@ -444,7 +444,7 @@ module VCAP::CloudController
             expect(subject).to be_valid
           end
 
-          context 'when loadbalancing has value least-connections' do
+          context 'when loadbalancing has value least-connection' do
             let(:params) do
               {
                 host: 'some-host',
@@ -452,7 +452,7 @@ module VCAP::CloudController
                   space: { data: { guid: 'space-guid' } },
                   domain: { data: { guid: 'domain-guid' } }
                 },
-                options: { loadbalancing: 'least-connections' }
+                options: { loadbalancing: 'least-connection' }
               }
             end
 
@@ -492,7 +492,7 @@ module VCAP::CloudController
 
             it 'is not valid' do
               expect(subject).not_to be_valid
-              expect(subject.errors[:options]).to include("Loadbalancing must be one of 'round-robin, least-connections' if present")
+              expect(subject.errors[:options]).to include("Loadbalancing must be one of 'round-robin, least-connection' if present")
             end
           end
         end

--- a/spec/unit/messages/route_update_message_spec.rb
+++ b/spec/unit/messages/route_update_message_spec.rb
@@ -28,8 +28,8 @@ module VCAP::CloudController
         expect(message).to be_valid
       end
 
-      it 'accepts options params with least-connections load-balancing algorithm' do
-        message = RouteUpdateMessage.new(params.merge(options: { loadbalancing: 'least-connections' }))
+      it 'accepts options params with least-connection load-balancing algorithm' do
+        message = RouteUpdateMessage.new(params.merge(options: { loadbalancing: 'least-connection' }))
         expect(message).to be_valid
       end
 
@@ -53,7 +53,7 @@ module VCAP::CloudController
       it 'does not accept unknown load-balancing algorithm' do
         message = RouteUpdateMessage.new(params.merge(options: { loadbalancing: 'cheesecake' }))
         expect(message).not_to be_valid
-        expect(message.errors.full_messages[0]).to include("Options Loadbalancing must be one of 'round-robin, least-connections' if present")
+        expect(message.errors.full_messages[0]).to include("Options Loadbalancing must be one of 'round-robin, least-connection' if present")
       end
 
       it 'does not accept unknown option' do

--- a/spec/unit/messages/validators_spec.rb
+++ b/spec/unit/messages/validators_spec.rb
@@ -545,8 +545,8 @@ module VCAP::CloudController::Validators
         expect(message).to be_valid
       end
 
-      it 'successfully validates least-connections load-balancing algorithm' do
-        message = OptionsMessage.new({ options: { loadbalancing: 'least-connections' } })
+      it 'successfully validates least-connection load-balancing algorithm' do
+        message = OptionsMessage.new({ options: { loadbalancing: 'least-connection' } })
         expect(message).to be_valid
       end
 
@@ -575,7 +575,7 @@ module VCAP::CloudController::Validators
       it 'adds invalid load balancer error message to the base class' do
         message = OptionsMessage.new({ options: { loadbalancing: 'donuts' } })
         expect(message).not_to be_valid
-        expect(message.errors_on(:options)).to include("Loadbalancing must be one of 'round-robin, least-connections' if present")
+        expect(message.errors_on(:options)).to include("Loadbalancing must be one of 'round-robin, least-connection' if present")
       end
 
       it 'adds invalid field error message to the base class' do


### PR DESCRIPTION
This Pull-Request provides a fix for the inconsistent naming of the `least-connection` load-balancing algorithm across the Cloud Foundry components (#4198).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
