### PR TITLE
Add prometheus metrics to cc workers

### DIFF
--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -37,6 +37,10 @@ module VCAP::CloudController
 
             log_audit_events: bool,
 
+            directories: {
+              tmpdir: String,
+            },
+
             stacks_file: String,
             newrelic_enabled: bool,
 

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -143,6 +143,9 @@ module VCAP::CloudController
               optional(:port) => Integer
             },
 
+            optional(:publish_metrics) => bool,
+            optional(:prometheus_port) => Integer,
+
             skip_cert_verify: bool,
 
             optional(:routing_api) => {

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -38,7 +38,7 @@ module VCAP::CloudController
             log_audit_events: bool,
 
             directories: {
-              tmpdir: String,
+              tmpdir: String
             },
 
             stacks_file: String,

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -72,7 +72,7 @@ module VCAP::CloudController
 
     def self.add_connection_metrics_extension(db)
       # only add the metrics for api processes. Otherwise e.g. rake db:migrate would also initialize metric updaters, which need additional config
-      return if Object.const_defined?(:RakeConfig)
+      return if Object.const_defined?(:RakeConfig) && RakeConfig.context != :worker
 
       db.extension(:connection_metrics)
       # so that we gather connection metrics from the beginning

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -71,7 +71,7 @@ module VCAP::CloudController
     end
 
     def self.add_connection_metrics_extension(db)
-      # only add the metrics for api processes. Otherwise e.g. rake db:migrate would also initialize metric updaters, which need additional config
+      # only add the metrics for api and cc-worker processes. Otherwise e.g. rake db:migrate would also initialize metric updaters, which need additional config
       return if Object.const_defined?(:RakeConfig) && RakeConfig.context != :worker
 
       db.extension(:connection_metrics)

--- a/lib/cloud_controller/dependency_locator.rb
+++ b/lib/cloud_controller/dependency_locator.rb
@@ -74,6 +74,10 @@ module CloudController
       @dependencies[:prometheus_updater] || register(:prometheus_updater, VCAP::CloudController::Metrics::PrometheusUpdater.new)
     end
 
+    def cc_worker_prometheus_updater
+      @dependencies[:cc_worker_prometheus_updater] || register(:cc_worker_prometheus_updater, VCAP::CloudController::Metrics::PrometheusUpdater.new(cc_worker: true))
+    end
+
     def statsd_updater
       @dependencies[:statsd_updater] || register(:statsd_updater, VCAP::CloudController::Metrics::StatsdUpdater.new(statsd_client))
     end

--- a/lib/cloud_controller/metrics/custom_process_id.rb
+++ b/lib/cloud_controller/metrics/custom_process_id.rb
@@ -1,0 +1,23 @@
+# Storing the metrics of several worker processes on cc-worker VMs in a DirectFileStore residing in a single directory
+# did not work because the different processes are isolated by bpm and several processes used the same pid within their container.
+# This pid is used for the filename and resulted in corrupted data because several processes were writing data to the same files.
+# When requiring this file, the process_id method of the MetricStore will be overridden to first check for `INDEX` in
+# env variables before returning the actual pid. The `INDEX` is provided for cc-worker processes.
+
+module CustomProcessId
+  def process_id
+    ENV.fetch('INDEX', Process.pid).to_i
+  end
+end
+
+module Prometheus
+  module Client
+    module DataStores
+      class DirectFileStore
+        class MetricStore
+          prepend CustomProcessId
+        end
+      end
+    end
+  end
+end

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -36,15 +36,7 @@ module VCAP::CloudController::Metrics
       { type: :gauge, name: :cc_running_tasks_total, docstring: 'Total running tasks', aggregation: :most_recent },
       { type: :gauge, name: :cc_running_tasks_memory_bytes, docstring: 'Total memory consumed by running tasks', aggregation: :most_recent },
       { type: :gauge, name: :cc_users_total, docstring: 'Number of users', aggregation: :most_recent },
-      { type: :gauge, name: :cc_deployments_in_progress_total, docstring: 'Number of in progress deployments', aggregation: :most_recent },
-      { type: :gauge, name: :cc_acquired_db_connections_total, labels: %i[process_type], docstring: 'Number of acquired DB connections' },
-      { type: :histogram, name: :cc_db_connection_hold_duration_seconds, docstring: 'The time threads were holding DB connections', buckets: CONNECTION_DURATION_BUCKETS },
-      # cc_connection_pool_timeouts_total must be a gauge metric, because otherwise we cannot match them with processes
-      { type: :gauge, name: :cc_db_connection_pool_timeouts_total, labels: %i[process_type],
-        docstring: 'Number of threads which failed to acquire a free DB connection from the pool within the timeout' },
-      { type: :gauge, name: :cc_open_db_connections_total, labels: %i[process_type], docstring: 'Number of open DB connections (acquired + available)' },
-      { type: :histogram, name: :cc_db_connection_wait_duration_seconds, docstring: 'The time threads were waiting for an available DB connection',
-        buckets: CONNECTION_DURATION_BUCKETS }
+      { type: :gauge, name: :cc_deployments_in_progress_total, docstring: 'Number of in progress deployments', aggregation: :most_recent }
     ].freeze
 
     THIN_METRICS = [
@@ -63,15 +55,34 @@ module VCAP::CloudController::Metrics
       { type: :gauge, name: :cc_puma_worker_backlog, docstring: 'Puma worker: backlog', labels: %i[index pid], aggregation: :most_recent }
     ].freeze
 
-    def initialize(registry=Prometheus::Client.registry)
+    DB_CONNECTION_POOL_METRICS = [
+      { type: :gauge, name: :cc_acquired_db_connections_total, labels: %i[process_type], docstring: 'Number of acquired DB connections' },
+      { type: :histogram, name: :cc_db_connection_hold_duration_seconds, docstring: 'The time threads were holding DB connections', buckets: CONNECTION_DURATION_BUCKETS },
+      # cc_connection_pool_timeouts_total must be a gauge metric, because otherwise we cannot match them with processes
+      { type: :gauge, name: :cc_db_connection_pool_timeouts_total, labels: %i[process_type],
+        docstring: 'Number of threads which failed to acquire a free DB connection from the pool within the timeout' },
+      { type: :gauge, name: :cc_open_db_connections_total, labels: %i[process_type], docstring: 'Number of open DB connections (acquired + available)' },
+      { type: :histogram, name: :cc_db_connection_wait_duration_seconds, docstring: 'The time threads were waiting for an available DB connection',
+        buckets: CONNECTION_DURATION_BUCKETS }
+    ].freeze
+
+    def initialize(registry: Prometheus::Client.registry, cc_worker: false)
       self.class.allow_pid_label
 
       @registry = registry
 
       # Register all metrics, to initialize them for discoverability
+      DB_CONNECTION_POOL_METRICS.each { |metric| register(metric) }
+
+      return if cc_worker
+
       METRICS.each { |metric| register(metric) }
       THIN_METRICS.each { |metric| register(metric) } if VCAP::CloudController::Config.config&.get(:webserver) == 'thin'
       PUMA_METRICS.each { |metric| register(metric) } if VCAP::CloudController::Config.config&.get(:webserver) == 'puma'
+    end
+
+    def registry
+      @registry
     end
 
     def update_gauge_metric(metric, value, labels: {})

--- a/lib/cloud_controller/metrics/prometheus_updater.rb
+++ b/lib/cloud_controller/metrics/prometheus_updater.rb
@@ -81,10 +81,6 @@ module VCAP::CloudController::Metrics
       PUMA_METRICS.each { |metric| register(metric) } if VCAP::CloudController::Config.config&.get(:webserver) == 'puma'
     end
 
-    def registry
-      @registry
-    end
-
     def update_gauge_metric(metric, value, labels: {})
       @registry.get(metric).set(value, labels:)
     end

--- a/lib/delayed_job/delayed_worker.rb
+++ b/lib/delayed_job/delayed_worker.rb
@@ -130,7 +130,7 @@ class CloudController::DelayedWorker
 
     Thread.new do
       server = Puma::Server.new(metrics_app)
-      server.add_tcp_listener '0.0.0.0', config.get(:prometheus_port) || 9394
+      server.add_tcp_listener '127.0.0.1', config.get(:prometheus_port) || 9394
       server.run
     end
   end

--- a/lib/delayed_job/delayed_worker.rb
+++ b/lib/delayed_job/delayed_worker.rb
@@ -1,4 +1,7 @@
 require 'delayed_job/threaded_worker'
+require 'rack'
+require 'puma'
+require 'prometheus/middleware/exporter'
 
 class CloudController::DelayedWorker
   def initialize(options)
@@ -9,6 +12,8 @@ class CloudController::DelayedWorker
       worker_name: options[:name],
       quiet: true
     }
+
+    @publish_metrics = options.fetch(:publish_metrics, false)
     return unless options[:num_threads] && options[:num_threads].to_i > 0
 
     @queue_options[:num_threads] = options[:num_threads].to_i
@@ -17,6 +22,7 @@ class CloudController::DelayedWorker
 
   def start_working
     config = RakeConfig.config
+    setup_metrics_endpoint if @publish_metrics
     BackgroundJobEnvironment.new(config).setup_environment(readiness_port)
 
     logger = Steno.logger('cc-worker')
@@ -91,5 +97,35 @@ class CloudController::DelayedWorker
 
   def is_first_generic_worker_on_machine?
     RakeConfig.context != :api && ENV['INDEX']&.to_i == 1
+  end
+
+  def setup_metrics_endpoint
+    prometheus_dir = File.join(RakeConfig.config.get(:directories, :tmpdir), 'prometheus')
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: prometheus_dir)
+    return unless is_first_generic_worker_on_machine?
+
+    FileUtils.mkdir_p(prometheus_dir)
+
+    # Resetting metrics on startup
+    Dir["#{prometheus_dir}/*.bin"].each do |file_path|
+      File.unlink(file_path)
+    end
+
+    metrics_app = Rack::Builder.new do
+      use Prometheus::Middleware::Exporter, path: '/metrics'
+
+      map '/' do
+        run lambda { |env|
+          # Return 404 for any other request
+          ['404', { 'Content-Type' => 'text/plain' }, ['Not Found']]
+        }
+      end
+    end
+
+    Thread.new do
+      server = Puma::Server.new(metrics_app)
+      server.add_tcp_listener '0.0.0.0', 9394
+      server.run
+    end
   end
 end

--- a/lib/sequel/extensions/connection_metrics.rb
+++ b/lib/sequel/extensions/connection_metrics.rb
@@ -24,9 +24,9 @@ module Sequel
       pool.instance_exec do
         sync do
           @prometheus_updater = if process_type == 'cc-worker'
-            CloudController::DependencyLocator.instance.cc_worker_prometheus_updater
+                                  CloudController::DependencyLocator.instance.cc_worker_prometheus_updater
                                 else
-            CloudController::DependencyLocator.instance.prometheus_updater
+                                  CloudController::DependencyLocator.instance.prometheus_updater
                                 end
           @connection_info = {}
         end

--- a/lib/sequel/extensions/connection_metrics.rb
+++ b/lib/sequel/extensions/connection_metrics.rb
@@ -23,7 +23,11 @@ module Sequel
 
       pool.instance_exec do
         sync do
-          @prometheus_updater = CloudController::DependencyLocator.instance.prometheus_updater
+          @prometheus_updater = if process_type == 'cc-worker'
+            CloudController::DependencyLocator.instance.cc_worker_prometheus_updater
+                                else
+            CloudController::DependencyLocator.instance.prometheus_updater
+                                end
           @connection_info = {}
         end
       end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -66,10 +66,12 @@ namespace :jobs do
 
     ENV['PROCESS_TYPE'] = 'cc-worker'
 
+    publish_metrics = RakeConfig.config.get(:publish_metrics) || false
+
     CloudController::DelayedWorker.new(queues: queues,
                                        name: args.name,
                                        num_threads: args.num_threads,
                                        thread_grace_period_seconds: args.thread_grace_period_seconds,
-                                       publish_metrics: true).start_working
+                                       publish_metrics: publish_metrics).start_working
   end
 end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -65,6 +65,7 @@ namespace :jobs do
     ]
 
     ENV['PROCESS_TYPE'] = 'cc-worker'
+    require 'cloud_controller/metrics/custom_process_id'
 
     publish_metrics = RakeConfig.config.get(:publish_metrics) || false
 

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -64,6 +64,12 @@ namespace :jobs do
       'prune_excess_app_revisions'
     ]
 
-    CloudController::DelayedWorker.new(queues: queues, name: args.name, num_threads: args.num_threads, thread_grace_period_seconds: args.thread_grace_period_seconds).start_working
+    ENV['PROCESS_TYPE'] = 'cc-worker'
+
+    CloudController::DelayedWorker.new(queues: queues,
+                                       name: args.name,
+                                       num_threads: args.num_threads,
+                                       thread_grace_period_seconds: args.thread_grace_period_seconds,
+                                       publish_metrics: true).start_working
   end
 end

--- a/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/metrics/prometheus_updater_spec.rb
@@ -3,7 +3,7 @@ require 'cloud_controller/metrics/prometheus_updater'
 
 module VCAP::CloudController::Metrics
   RSpec.describe PrometheusUpdater do
-    let(:updater) { PrometheusUpdater.new(prom_client) }
+    let(:updater) { PrometheusUpdater.new(registry: prom_client) }
     let(:tmpdir) { Dir.mktmpdir }
     let(:prom_client) do
       Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: tmpdir)

--- a/spec/unit/lib/sequel/extensions/connection_metrics_spec.rb
+++ b/spec/unit/lib/sequel/extensions/connection_metrics_spec.rb
@@ -9,136 +9,171 @@ RSpec.describe Sequel::ConnectionMetrics do
   let(:prometheus_updater) { spy(VCAP::CloudController::Metrics::PrometheusUpdater) }
   let(:thread) { double('Thread') }
 
-  before do
-    db.loggers << logger
-    db.sql_log_level = :info
-    db.extension(:connection_metrics)
-
-    allow(thread).to receive(:alive?).and_return(true)
-
-    db.pool.instance_variable_set(:@prometheus_updater, prometheus_updater)
-
-    ENV['PROCESS_TYPE'] = 'puma_worker'
-  end
-
   after do
     db.disconnect
   end
 
-  it 'initializes the prometheus_updater and connection_info' do
-    expect(db.pool.instance_variable_get(:@prometheus_updater)).to eq(prometheus_updater)
-    expect(db.pool.instance_variable_get(:@connection_info)).to be_a(Hash)
-  end
-
-  describe 'acquire' do
-    context 'when acquire returns a connection' do
-      it 'increments the acquired DB connections metric' do
-        expect(prometheus_updater).to receive(:increment_gauge_metric).with(:cc_acquired_db_connections_total, labels: { process_type: 'puma_worker' })
-
-        db.pool.send(:acquire, thread)
-      end
-
-      it 'stores the timestamp when the connection was acquired' do
-        db.pool.send(:acquire, thread)
-        expect(db.pool.instance_variable_get(:@connection_info)[thread]).to have_key(:acquired_at)
-      end
-    end
-
-    context 'when the pool is exhausted and throws a PoolTimeout' do
+  describe 'initialize' do
+    context 'api process' do
       before do
-        # actually acquire throws the exception, but when mocking like this the extension would also be mocked away
-        allow(db.pool).to receive(:assign_connection).and_raise(Sequel::PoolTimeout)
+        db.loggers << logger
+        db.sql_log_level = :info
+        db.extension(:connection_metrics)
+
+        allow(thread).to receive(:alive?).and_return(true)
+
+        db.pool.instance_variable_set(:@prometheus_updater, prometheus_updater)
+
+        ENV['PROCESS_TYPE'] = 'puma_worker'
       end
 
-      it 'increments the connection pool timeouts metric and raises' do
-        expect(prometheus_updater).to receive(:increment_gauge_metric).with(:cc_db_connection_pool_timeouts_total, labels: { process_type: 'puma_worker' })
-
-        expect { db.pool.send(:acquire, thread) }.to raise_error(Sequel::PoolTimeout)
-      end
-
-      it 'emits the time the thread waited for the connection' do
-        db.pool.instance_variable_set(:@connection_info, db.pool.instance_variable_get(:@connection_info).merge!({ thread => { waiting_since: Time.now - 60 } }))
-        expect(prometheus_updater).to receive(:update_histogram_metric).with(:cc_db_connection_wait_duration_seconds, an_instance_of(ActiveSupport::Duration))
-
-        expect { db.pool.send(:acquire, thread) }.to raise_error(Sequel::PoolTimeout)
-      end
-    end
-  end
-
-  describe 'assign_connection' do
-    context 'when assign_connection returns a connection' do
-      it 'does not set the waiting_since timestamp' do
-        db.pool.send(:assign_connection, thread)
-        expect(db.pool.instance_variable_get(:@connection_info)[thread]).to be_nil
+      it 'initializes the prometheus_updater and connection_info' do
+        expect(db.pool.instance_variable_get(:@prometheus_updater)).to eq(prometheus_updater)
+        expect(db.pool.instance_variable_get(:@connection_info)).to be_a(Hash)
       end
     end
 
-    context 'when assign_connection does not return a connection' do
+    context 'cc-worker process' do
       before do
-        db.pool.instance_variable_set(:@max_size, 1)
-        db.pool.send(:acquire, thread)
+        ENV['PROCESS_TYPE'] = 'cc-worker'
+        allow(VCAP::CloudController::Metrics::PrometheusUpdater).to receive(:new).and_return(VCAP::CloudController::Metrics::PrometheusUpdater.new(cc_worker: true))
+
+        db.loggers << logger
+        db.sql_log_level = :info
+        db.extension(:connection_metrics)
+
+        allow(thread).to receive(:alive?).and_return(true)
       end
 
-      it 'stores the timestamp since when the thread is waiting for the connection' do
-        waiting_since = nil
-        Timecop.freeze do
-          waiting_since = Time.now
-          expect(db.pool.send(:assign_connection, thread)).to be_nil
-        end
-        expect(db.pool.instance_variable_get(:@connection_info)[thread][:waiting_since]).to eq(waiting_since)
+      it 'initializes the prometheus_updater and for cc-worker' do
+        expect(VCAP::CloudController::Metrics::PrometheusUpdater).to have_received(:new).with({ cc_worker: true })
       end
     end
   end
 
-  describe 'make_new' do
-    it 'sets the open db connection metric to the current size of the pool' do
-      expect(prometheus_updater).to receive(:update_gauge_metric).with(:cc_open_db_connections_total, an_instance_of(Integer), labels: { process_type: 'puma_worker' })
-      db.pool.send(:make_new, thread)
-    end
-  end
-
-  describe 'disconnect_connection' do
-    let(:conn) { db.pool.send(:acquire, thread) }
-
-    it 'sets the open db connection metric to the current size of the pool' do
-      expect(prometheus_updater).to receive(:update_gauge_metric).with(:cc_open_db_connections_total, an_instance_of(Integer), labels: { process_type: 'puma_worker' })
-      db.pool.send(:disconnect_connection, conn)
-    end
-  end
-
-  describe 'release' do
+  describe 'methods' do
     before do
-      db.pool.send(:acquire, thread)
+      db.loggers << logger
+      db.sql_log_level = :info
+      db.extension(:connection_metrics)
+
+      allow(thread).to receive(:alive?).and_return(true)
+
+      db.pool.instance_variable_set(:@prometheus_updater, prometheus_updater)
+
+      ENV['PROCESS_TYPE'] = 'puma_worker'
     end
 
-    it 'emits the db connection hold duration' do
-      acquired_at = Time.now - 5
-      db.pool.instance_variable_set(:@connection_info, db.pool.instance_variable_get(:@connection_info).merge!({ thread => { acquired_at: } }))
+    describe 'acquire' do
+      context 'when acquire returns a connection' do
+        it 'increments the acquired DB connections metric' do
+          expect(prometheus_updater).to receive(:increment_gauge_metric).with(:cc_acquired_db_connections_total, labels: { process_type: 'puma_worker' })
 
-      Timecop.freeze do
-        hold_duration = Time.now - acquired_at
-        expect(prometheus_updater).to receive(:update_histogram_metric).with(:cc_db_connection_hold_duration_seconds, hold_duration)
-        db.pool.send(:release, thread)
+          db.pool.send(:acquire, thread)
+        end
+
+        it 'stores the timestamp when the connection was acquired' do
+          db.pool.send(:acquire, thread)
+          expect(db.pool.instance_variable_get(:@connection_info)[thread]).to have_key(:acquired_at)
+        end
+      end
+
+      context 'when the pool is exhausted and throws a PoolTimeout' do
+        before do
+          # actually acquire throws the exception, but when mocking like this the extension would also be mocked away
+          allow(db.pool).to receive(:assign_connection).and_raise(Sequel::PoolTimeout)
+        end
+
+        it 'increments the connection pool timeouts metric and raises' do
+          expect(prometheus_updater).to receive(:increment_gauge_metric).with(:cc_db_connection_pool_timeouts_total, labels: { process_type: 'puma_worker' })
+
+          expect { db.pool.send(:acquire, thread) }.to raise_error(Sequel::PoolTimeout)
+        end
+
+        it 'emits the time the thread waited for the connection' do
+          db.pool.instance_variable_set(:@connection_info, db.pool.instance_variable_get(:@connection_info).merge!({ thread => { waiting_since: Time.now - 60 } }))
+          expect(prometheus_updater).to receive(:update_histogram_metric).with(:cc_db_connection_wait_duration_seconds, an_instance_of(ActiveSupport::Duration))
+
+          expect { db.pool.send(:acquire, thread) }.to raise_error(Sequel::PoolTimeout)
+        end
       end
     end
 
-    it 'decrements the acquired db connection metric' do
-      expect(prometheus_updater).to receive(:decrement_gauge_metric).with(:cc_acquired_db_connections_total, labels: { process_type: 'puma_worker' })
-      db.pool.send(:release, thread)
+    describe 'assign_connection' do
+      context 'when assign_connection returns a connection' do
+        it 'does not set the waiting_since timestamp' do
+          db.pool.send(:assign_connection, thread)
+          expect(db.pool.instance_variable_get(:@connection_info)[thread]).to be_nil
+        end
+      end
+
+      context 'when assign_connection does not return a connection' do
+        before do
+          db.pool.instance_variable_set(:@max_size, 1)
+          db.pool.send(:acquire, thread)
+        end
+
+        it 'stores the timestamp since when the thread is waiting for the connection' do
+          waiting_since = nil
+          Timecop.freeze do
+            waiting_since = Time.now
+            expect(db.pool.send(:assign_connection, thread)).to be_nil
+          end
+          expect(db.pool.instance_variable_get(:@connection_info)[thread][:waiting_since]).to eq(waiting_since)
+        end
+      end
     end
 
-    it 'deletes the connection info' do
-      db.pool.send(:release, thread)
-      expect(db.pool.instance_variable_get(:@connection_info)[:thread]).to be_nil
+    describe 'make_new' do
+      it 'sets the open db connection metric to the current size of the pool' do
+        expect(prometheus_updater).to receive(:update_gauge_metric).with(:cc_open_db_connections_total, an_instance_of(Integer), labels: { process_type: 'puma_worker' })
+        db.pool.send(:make_new, thread)
+      end
     end
 
-    context 'when the acquired_at timestamp is missing' do
+    describe 'disconnect_connection' do
+      let(:conn) { db.pool.send(:acquire, thread) }
+
+      it 'sets the open db connection metric to the current size of the pool' do
+        expect(prometheus_updater).to receive(:update_gauge_metric).with(:cc_open_db_connections_total, an_instance_of(Integer), labels: { process_type: 'puma_worker' })
+        db.pool.send(:disconnect_connection, conn)
+      end
+    end
+
+    describe 'release' do
       before do
-        db.pool.instance_variable_set(:@connection_info, {})
+        db.pool.send(:acquire, thread)
       end
 
-      it 'does not crash' do
+      it 'emits the db connection hold duration' do
+        acquired_at = Time.now - 5
+        db.pool.instance_variable_set(:@connection_info, db.pool.instance_variable_get(:@connection_info).merge!({ thread => { acquired_at: } }))
+
+        Timecop.freeze do
+          hold_duration = Time.now - acquired_at
+          expect(prometheus_updater).to receive(:update_histogram_metric).with(:cc_db_connection_hold_duration_seconds, hold_duration)
+          db.pool.send(:release, thread)
+        end
+      end
+
+      it 'decrements the acquired db connection metric' do
+        expect(prometheus_updater).to receive(:decrement_gauge_metric).with(:cc_acquired_db_connections_total, labels: { process_type: 'puma_worker' })
         db.pool.send(:release, thread)
+      end
+
+      it 'deletes the connection info' do
+        db.pool.send(:release, thread)
+        expect(db.pool.instance_variable_get(:@connection_info)[:thread]).to be_nil
+      end
+
+      context 'when the acquired_at timestamp is missing' do
+        before do
+          db.pool.instance_variable_set(:@connection_info, {})
+        end
+
+        it 'does not crash' do
+          db.pool.send(:release, thread)
+        end
       end
     end
   end


### PR DESCRIPTION
### A short explanation of the proposed change:
Add a small webserver to the first worker process on cc-worker VM, which publishes cc-worker metrics in a prometheus endpoint. Metrics of all worker processes are stored in the same DirectFileStore, so that we only need one endpoint to publish all their metrics.

### An explanation of the use cases your change solves
Currently we only publish metrics on the API VMs. We are also interested in metrics on worker VMs e.g. DB connection metrics. With this change metrics are being published in the same way and can be scraped using the `prom_scraper` job of the loggregator release.

### Links to any other associated PRs
Configuration in CAPI: https://github.com/cloudfoundry/capi-release/pull/507

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
