### PR TITLE
Fix application rename with CNB lifecycle

### DIFF
--- a/lib/cloud_controller/diego/lifecycles/app_cnb_lifecycle.rb
+++ b/lib/cloud_controller/diego/lifecycles/app_cnb_lifecycle.rb
@@ -16,6 +16,8 @@ module VCAP::CloudController
     end
 
     def valid?
+      return true if message.class.name.match?(/AppUpdateMessage/i)
+
       !buildpacks.empty?
     end
 

--- a/spec/unit/lib/cloud_controller/diego/lifecycles/app_cnb_lifecycle_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/lifecycles/app_cnb_lifecycle_spec.rb
@@ -102,6 +102,14 @@ module VCAP::CloudController
         it 'invalid' do
           expect(lifecycle.valid?).to be(false)
         end
+
+        context 'during an update' do
+          let(:message) { VCAP::CloudController::AppUpdateMessage.new(request) }
+
+          it 'valid' do
+            expect(lifecycle.valid?).to be(true)
+          end
+        end
       end
 
       context 'with buildpacks' do


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

The `valid` method of the `AppCNBLifecycle` always returned false during `cf rename` due to no buildpacks being set in the `AppUpdateMessage`

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
