### PR TITLE
Use DISTINCT instead of DINSTINCT ON for /v3/service_instances

### DIFF
--- a/app/fetchers/service_instance_list_fetcher.rb
+++ b/app/fetchers/service_instance_list_fetcher.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
 
         filter(dataset, message).
           select_all(:service_instances).
-          distinct(:service_instances__id)
+          distinct
       end
 
       private


### PR DESCRIPTION
On large foundations using PostgreSQL DISTINCT ON might lead to wrong query plans making the resulting execution very slow.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
