### PR TITLE
Better error message and support logs for /v3/service_offerings and plans

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -430,7 +430,7 @@ class ServiceInstancesV3Controller < ApplicationController
   end
 
   def service_plan_not_visible_in_space!
-    unprocessable!('Invalid service plan. Ensure that the service plan is visible in your current space.')
+    unprocessable!('Invalid service plan. Ensure that the service plan is visible in your current space and still available in the broker\'s catalog.')
   end
 
   def invalid_service_plan_relation!

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -255,7 +255,7 @@ class ServiceInstancesV3Controller < ApplicationController
   def create_managed(message, space:)
     service_plan = ServicePlan.first(guid: message.service_plan_guid)
     unprocessable_service_plan! unless service_plan_valid?(service_plan)
-    service_plan_not_visible_in_space! unless resource_exists_in_space?(service_plan, space)
+    service_plan_not_visible_in_space! unless service_plan_exists_in_space?(service_plan, space)
 
     action = V3::ServiceInstanceCreateManaged.new(user_audit_info, message.audit_hash)
     VCAP::CloudController::ManagedServiceInstance.db.transaction do
@@ -397,10 +397,10 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def service_plan_valid?(service_plan)
     service_plan &&
-    visible_to_current_user?(plan: service_plan)
+      visible_to_current_user?(plan: service_plan)
   end
 
-  def resource_exists_in_space?(service_plan, space)
+  def service_plan_exists_in_space?(service_plan, space)
     service_plan.visible_in_space?(space)
   end
 
@@ -409,7 +409,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
     service_plan = ServicePlan.first(guid: message.service_plan_guid)
     unprocessable_service_plan! unless service_plan_valid?(service_plan)
-    service_plan_not_visible_in_space! unless resource_exists_in_space?(service_plan, service_instance.space)
+    service_plan_not_visible_in_space! unless service_plan_exists_in_space?(service_plan, service_instance.space)
     invalid_service_plan_relation! unless service_plan.service == service_instance.service
   end
 

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -255,8 +255,9 @@ class ServiceInstancesV3Controller < ApplicationController
   def create_managed(message, space:)
     service_plan = ServicePlan.first(guid: message.service_plan_guid)
     unprocessable_service_plan! unless service_plan_valid?(service_plan)
-    unavailable_service_plan!(service_plan.name) unless service_plan_active?(service_plan)
-    service_plan_not_visible_in_space! unless service_plan_exists_in_space?(service_plan, space)
+    unavailable_service_plan!(service_plan.name, service_plan.guid) unless service_plan_active?(service_plan)
+    service_plan_not_visible_in_space!(service_plan.name, service_plan.guid, space.name, space.guid) \
+      unless service_plan_exists_in_space?(service_plan, space)
 
     action = V3::ServiceInstanceCreateManaged.new(user_audit_info, message.audit_hash)
     VCAP::CloudController::ManagedServiceInstance.db.transaction do
@@ -414,8 +415,9 @@ class ServiceInstancesV3Controller < ApplicationController
 
     service_plan = ServicePlan.first(guid: message.service_plan_guid)
     unprocessable_service_plan! unless service_plan_valid?(service_plan)
-    unavailable_service_plan!(service_plan.name) unless service_plan_active?(service_plan)
-    service_plan_not_visible_in_space! unless service_plan_exists_in_space?(service_plan, service_instance.space)
+    unavailable_service_plan!(service_plan.name, service_plan.guid) unless service_plan_active?(service_plan)
+    service_plan_not_visible_in_space!(service_plan.name, service_plan.guid, space.name, space.guid) \
+      unless service_plan_exists_in_space?(service_plan, service_instance.space)
     invalid_service_plan_relation! unless service_plan.service == service_instance.service
   end
 
@@ -435,13 +437,14 @@ class ServiceInstancesV3Controller < ApplicationController
     unprocessable!('Invalid service plan. Ensure that the service plan exists, is available, and you have access to it.')
   end
 
-  def unavailable_service_plan!(service_plan)
-    unprocessable!("Invalid service plan. The service plan #{service_plan} has been removed from the service broker's catalog." \
+  def unavailable_service_plan!(service_plan, service_plan_guid)
+    unprocessable!("Invalid service plan. The service plan #{service_plan} with guid #{service_plan_guid} has been removed from the service broker's catalog." \
                    'It is not possible to create new service instances using this plan.')
   end
 
-  def service_plan_not_visible_in_space!
-    unprocessable!('Invalid service plan. Ensure that the service plan is visible in your current space.')
+  def service_plan_not_visible_in_space!(service_plan, service_plan_guid, space_name, space_guid)
+    unprocessable!("Invalid service plan. Ensure that the service plan #{service_plan} with guid #{service_plan_guid} \
+is visible in your current space #{space_name} with guid #{space_guid}.")
   end
 
   def invalid_service_plan_relation!

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -436,7 +436,8 @@ class ServiceInstancesV3Controller < ApplicationController
   end
 
   def unavailable_service_plan!(service_plan)
-    unprocessable!("Invalid service plan. The service plan #{service_plan} has been removed from the service broker's catalog. It is not possible to create new service instances using this plan.")
+    unprocessable!("Invalid service plan. The service plan #{service_plan} has been removed from the service broker's catalog." \
+                   'It is not possible to create new service instances using this plan.')
   end
 
   def service_plan_not_visible_in_space!

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -438,13 +438,13 @@ class ServiceInstancesV3Controller < ApplicationController
   end
 
   def unavailable_service_plan!(service_plan, service_plan_guid)
-    unprocessable!("Invalid service plan. The service plan #{service_plan} with guid #{service_plan_guid} has been removed from the service broker's catalog." \
+    unprocessable!("Invalid service plan. The service plan '#{service_plan}' with guid '#{service_plan_guid}' has been removed from the service broker's catalog." \
                    'It is not possible to create new service instances using this plan.')
   end
 
   def service_plan_not_visible_in_space!(service_plan, service_plan_guid, space_name, space_guid)
-    unprocessable!("Invalid service plan. Ensure that the service plan #{service_plan} with guid #{service_plan_guid} \
-is visible in your current space #{space_name} with guid #{space_guid}.")
+    unprocessable!("Invalid service plan. Ensure that the service plan '#{service_plan}' with guid '#{service_plan_guid}' \
+is visible in your current space '#{space_name}' with guid '#{space_guid}'.")
   end
 
   def invalid_service_plan_relation!

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -415,7 +415,7 @@ class ServiceInstancesV3Controller < ApplicationController
     service_plan = ServicePlan.first(guid: message.service_plan_guid)
     unprocessable_service_plan! unless service_plan_valid?(service_plan)
     unavailable_service_plan!(service_plan) unless service_plan_active?(service_plan)
-    service_plan_not_visible_in_space!(service_plan, space) unless service_plan_exists_in_space?(service_plan, service_instance.space)
+    service_plan_not_visible_in_space!(service_plan, service_instance.space) unless service_plan_exists_in_space?(service_plan, service_instance.space)
     invalid_service_plan_relation! unless service_plan.service == service_instance.service
   end
 
@@ -442,7 +442,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def service_plan_not_visible_in_space!(service_plan, space)
     unprocessable!('Invalid service plan. This could be due to a space-scoped broker which is offering the service plan ' \
-                   "'#{service_plan.name}' with guid '#{service_plan.guid} in another space or that the plan " \
+                   "'#{service_plan.name}' with guid '#{service_plan.guid}' in another space or that the plan " \
                    'is not enabled in this organization. Ensure that the service plan is visible in your current space ' \
                    "'#{space.name}' with guid '#{space.guid}'.")
   end

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1276,7 +1276,8 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => "Invalid service plan. The service plan #{service_plan.name} has been removed from the service broker\'s catalog. It is not possible to create new service instances using this plan.",
+                        'detail' => "Invalid service plan. The service plan #{service_plan.name} has been removed from the service broker's catalog." \
+                                    'It is not possible to create new service instances using this plan.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })
@@ -2413,7 +2414,8 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => "Invalid service plan. The service plan #{service_plan.name} has been removed from the service broker\'s catalog. It is not possible to create new service instances using this plan.",
+                        'detail' => "Invalid service plan. The service plan #{service_plan.name} has been removed from the service broker's catalog." \
+                                    'It is not possible to create new service instances using this plan.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1260,8 +1260,8 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => "Invalid service plan. Ensure that the service plan #{service_plan.name} with \
-guid #{service_plan_guid} is visible in your current space #{space.name} with guid #{space.guid}.",
+                        'detail' => "Invalid service plan. Ensure that the service plan '#{service_plan.name}' with \
+guid '#{service_plan_guid}' is visible in your current space '#{space.name}' with guid '#{space.guid}'.",
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })
@@ -1277,7 +1277,7 @@ guid #{service_plan_guid} is visible in your current space #{space.name} with gu
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => "Invalid service plan. The service plan #{service_plan.name} with guid #{service_plan.guid} " \
+                        'detail' => "Invalid service plan. The service plan '#{service_plan.name}' with guid '#{service_plan.guid}' " \
                                     "has been removed from the service broker's catalog." \
                                     'It is not possible to create new service instances using this plan.',
                         'title' => 'CF-UnprocessableEntity',
@@ -2416,7 +2416,7 @@ guid #{service_plan_guid} is visible in your current space #{space.name} with gu
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => "Invalid service plan. The service plan #{service_plan.name} with guid #{service_plan.guid} " \
+                        'detail' => "Invalid service plan. The service plan '#{service_plan.name}' with guid '#{service_plan.guid}' " \
                                     "has been removed from the service broker's catalog." \
                                     'It is not possible to create new service instances using this plan.',
                         'title' => 'CF-UnprocessableEntity',

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1261,7 +1261,7 @@ RSpec.describe 'V3 service instances' do
             expect(parsed_response['errors']).to include(
               include({
                         'detail' => 'Invalid service plan. This could be due to a space-scoped broker which is offering the service plan ' \
-                                    "'#{service_plan.name}' with guid '#{service_plan.guid} in another space or that the plan " \
+                                    "'#{service_plan.name}' with guid '#{service_plan.guid}' in another space or that the plan " \
                                     'is not enabled in this organization. Ensure that the service plan is visible in your current space ' \
                                     "'#{space.name}' with guid '#{space.guid}'.",
                         'title' => 'CF-UnprocessableEntity',
@@ -2402,6 +2402,26 @@ RSpec.describe 'V3 service instances' do
             expect(parsed_response['errors']).to include(
               include({
                         'detail' => 'Invalid service plan. Ensure that the service plan exists, is available, and you have access to it.',
+                        'title' => 'CF-UnprocessableEntity',
+                        'code' => 10_008
+                      })
+            )
+          end
+        end
+
+        context 'not enabled in that org' do
+          let(:service_plan) { VCAP::CloudController::ServicePlan.make(public: false, active: true) }
+          let(:service_plan_guid) { service_plan.guid }
+
+          it 'fails saying the plan is invalid' do
+            api_call.call(admin_headers)
+            expect(last_response).to have_status_code(422)
+            expect(parsed_response['errors']).to include(
+              include({
+                        'detail' => 'Invalid service plan. This could be due to a space-scoped broker which is offering the service plan ' \
+                                    "'#{service_plan.name}' with guid '#{service_plan.guid}' in another space or that the plan " \
+                                    'is not enabled in this organization. Ensure that the service plan is visible in your current space ' \
+                                    "'#{space.name}' with guid '#{space.guid}'.",
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1260,8 +1260,10 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => "Invalid service plan. Ensure that the service plan '#{service_plan.name}' with \
-guid '#{service_plan_guid}' is visible in your current space '#{space.name}' with guid '#{space.guid}'.",
+                        'detail' => 'Invalid service plan. This could be due to a space-scoped broker which is offering the service plan ' \
+                                    "'#{service_plan.name}' with guid '#{service_plan.guid} in another space or that the plan " \
+                                    'is not enabled in this organization. Ensure that the service plan is visible in your current space ' \
+                                    "'#{space.name}' with guid '#{space.guid}'.",
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })
@@ -1278,7 +1280,7 @@ guid '#{service_plan_guid}' is visible in your current space '#{space.name}' wit
             expect(parsed_response['errors']).to include(
               include({
                         'detail' => "Invalid service plan. The service plan '#{service_plan.name}' with guid '#{service_plan.guid}' " \
-                                    "has been removed from the service broker's catalog." \
+                                    "has been removed from the service broker's catalog. " \
                                     'It is not possible to create new service instances using this plan.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
@@ -2417,7 +2419,7 @@ guid '#{service_plan_guid}' is visible in your current space '#{space.name}' wit
             expect(parsed_response['errors']).to include(
               include({
                         'detail' => "Invalid service plan. The service plan '#{service_plan.name}' with guid '#{service_plan.guid}' " \
-                                    "has been removed from the service broker's catalog." \
+                                    "has been removed from the service broker's catalog. " \
                                     'It is not possible to create new service instances using this plan.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1260,7 +1260,7 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => 'Invalid service plan. Ensure that the service plan exists, is available, and you have access to it.',
+                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })
@@ -2413,7 +2413,7 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => 'Invalid service plan. Ensure that the service plan exists, is available, and you have access to it.',
+                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1260,7 +1260,7 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space and still available in the broker\'s catalog.',
+                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })
@@ -1276,7 +1276,7 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space and still available in the broker\'s catalog.',
+                        'detail' => "Invalid service plan. The service plan #{service_plan.name} has been removed from the service broker\'s catalog. It is not possible to create new service instances using this plan.",
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })
@@ -2413,7 +2413,7 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space and still available in the broker\'s catalog.',
+                        'detail' => "Invalid service plan. The service plan #{service_plan.name} has been removed from the service broker\'s catalog. It is not possible to create new service instances using this plan.",
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1260,7 +1260,7 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space.',
+                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space and still available in the broker\'s catalog.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })
@@ -1276,7 +1276,7 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => 'Invalid service plan. Ensure that the service plan exists, is available, and you have access to it.',
+                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space and still available in the broker\'s catalog.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })
@@ -2413,7 +2413,7 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space.',
+                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space and still available in the broker\'s catalog.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1260,7 +1260,8 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => 'Invalid service plan. Ensure that the service plan is visible in your current space.',
+                        'detail' => "Invalid service plan. Ensure that the service plan #{service_plan.name} with \
+guid #{service_plan_guid} is visible in your current space #{space.name} with guid #{space.guid}.",
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
                       })
@@ -1276,7 +1277,8 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => "Invalid service plan. The service plan #{service_plan.name} has been removed from the service broker's catalog." \
+                        'detail' => "Invalid service plan. The service plan #{service_plan.name} with guid #{service_plan.guid} " \
+                                    "has been removed from the service broker's catalog." \
                                     'It is not possible to create new service instances using this plan.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008
@@ -2414,7 +2416,8 @@ RSpec.describe 'V3 service instances' do
             expect(last_response).to have_status_code(422)
             expect(parsed_response['errors']).to include(
               include({
-                        'detail' => "Invalid service plan. The service plan #{service_plan.name} has been removed from the service broker's catalog." \
+                        'detail' => "Invalid service plan. The service plan #{service_plan.name} with guid #{service_plan.guid} " \
+                                    "has been removed from the service broker's catalog." \
                                     'It is not possible to create new service instances using this plan.',
                         'title' => 'CF-UnprocessableEntity',
                         'code' => 10_008


### PR DESCRIPTION
Users may be confused why they receive a 422 with error message "Invalid service plan. Ensure that the service plan exists, is available, and you have access to it." [unprocessable_service_plan!](https://github.com/cloudfoundry/cloud_controller_ng/blob/f10b4c29bd27bbd89faf3d86109abd4d544b2a97/app/controllers/v3/service_instances_controller.rb#L423) when trying to create a service instance.
The root cause of this can have different origins:
1) service plan does not exist
2) user can not see the service plan in any org
3) user can see service plan in one of his orgs but service plan got removed and is still in use by service instances (service plan is set to active=false)
4) user sees the plan in of his orgs but not in the one he is creating the service instance in 


* A short explanation of the proposed change:
Split the error into different errors depending on the root cause. Error message will stay the same if user can not see the service plan in any org. 
For case 1 and 2 error message will stay:
```Invalid service plan. Ensure that the service plan exists, is available, and you have access to it.```
For case 3 error message will now be:
```Invalid service plan. The service plan 'service_plan' with guid 'some-guid' has been removed from the service broker's catalog. It is not possible to create new service instances using this plan.```
For case 4 error message will now be:
```Invalid service plan. This could be due to a space-scoped broker which is offering the service plan 'service_plan.name' with guid 'service_plan.guid' in another space or that the plan is not enabled in this organization. Ensure that the service plan is visible in your current space 'space.name' with guid 'space.guid'.```


* An explanation of the use cases your change solves
More fine granulated error messages, helping the user to solve the error better.
* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
