### PR TITLE
Allow enqueuer to enqueue multiple jobs with the same instance

### DIFF
--- a/app/actions/app_delete.rb
+++ b/app/actions/app_delete.rb
@@ -97,7 +97,7 @@ module VCAP::CloudController
 
     def delete_buildpack_cache(app)
       delete_job = Jobs::V3::BuildpackCacheDelete.new(app.guid)
-      Jobs::Enqueuer.new(delete_job, queue: Jobs::Queues.generic).enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(delete_job)
     end
 
     def logger

--- a/app/actions/buildpack_delete.rb
+++ b/app/actions/buildpack_delete.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
         end
         if buildpack.key
           blobstore_delete = Jobs::Runtime::BlobstoreDelete.new(buildpack.key, :buildpack_blobstore)
-          Jobs::Enqueuer.new(blobstore_delete, queue: Jobs::Queues.generic).enqueue
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(blobstore_delete)
         end
       end
 

--- a/app/actions/buildpack_upload.rb
+++ b/app/actions/buildpack_upload.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController
       logger.info("uploading buildpacks bits for buildpack #{buildpack.guid}")
 
       upload_job = Jobs::V3::BuildpackBits.new(buildpack.guid, message.bits_path, message.bits_name)
-      Jobs::Enqueuer.new(upload_job, queue: Jobs::Queues.local(config)).enqueue_pollable
+      Jobs::Enqueuer.new(queue: Jobs::Queues.local(config)).enqueue_pollable(upload_job)
     end
 
     private

--- a/app/actions/droplet_copy.rb
+++ b/app/actions/droplet_copy.rb
@@ -60,7 +60,7 @@ module VCAP::CloudController
       new_droplet.buildpack_lifecycle_data(reload: true)
 
       copy_job = Jobs::V3::DropletBitsCopier.new(@source_droplet.guid, new_droplet.guid)
-      Jobs::Enqueuer.new(copy_job, queue: Jobs::Queues.generic).enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(copy_job)
     end
   end
 end

--- a/app/actions/droplet_delete.rb
+++ b/app/actions/droplet_delete.rb
@@ -16,7 +16,7 @@ module VCAP::CloudController
 
         if droplet.blobstore_key
           blobstore_delete = Jobs::Runtime::BlobstoreDelete.new(droplet.blobstore_key, :droplet_blobstore)
-          Jobs::Enqueuer.new(blobstore_delete, queue: Jobs::Queues.generic).enqueue
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(blobstore_delete)
         end
 
         Repositories::DropletEventRepository.record_delete(

--- a/app/actions/droplet_upload.rb
+++ b/app/actions/droplet_upload.rb
@@ -20,7 +20,7 @@ module VCAP::CloudController
           droplet.space.organization_guid
         )
 
-        enqueued_job = Jobs::Enqueuer.new(upload_job, queue: Jobs::Queues.local(config)).enqueue_pollable
+        enqueued_job = Jobs::Enqueuer.new(queue: Jobs::Queues.local(config)).enqueue_pollable(upload_job)
       end
 
       enqueued_job

--- a/app/actions/mixins/bindings_delete.rb
+++ b/app/actions/mixins/bindings_delete.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
           result = binding_delete_action.delete(binding)
           unless result[:finished]
             polling_job = DeleteBindingJob.new(type, binding.guid, user_audit_info:)
-            Jobs::Enqueuer.new(polling_job, queue: Jobs::Queues.generic).enqueue_pollable
+            Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(polling_job)
             unbinding_operation_in_progress!(binding)
           end
         rescue StandardError => e

--- a/app/actions/package_copy.rb
+++ b/app/actions/package_copy.rb
@@ -20,12 +20,7 @@ module VCAP::CloudController
       package.db.transaction do
         package.save
 
-        if source_package.type == 'bits'
-          @enqueued_job = Jobs::Enqueuer.new(
-            Jobs::V3::PackageBitsCopier.new(source_package.guid, package.guid),
-            queue: Jobs::Queues.generic
-          ).enqueue
-        end
+        @enqueued_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::V3::PackageBitsCopier.new(source_package.guid, package.guid)) if source_package.type == 'bits'
 
         record_audit_event(package, source_package, user_audit_info) if record_event
       end

--- a/app/actions/package_delete.rb
+++ b/app/actions/package_delete.rb
@@ -10,7 +10,7 @@ module VCAP::CloudController
       packages.each do |package|
         unless package.docker?
           package_src_delete_job = create_package_source_deletion_job(package)
-          Jobs::Enqueuer.new(package_src_delete_job, queue: Jobs::Queues.generic).enqueue if package_src_delete_job
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(package_src_delete_job) if package_src_delete_job
         end
 
         package.destroy

--- a/app/actions/package_upload.rb
+++ b/app/actions/package_upload.rb
@@ -14,7 +14,7 @@ module VCAP::CloudController
         package.state = PackageModel::PENDING_STATE
         package.save
 
-        enqueued_job = Jobs::Enqueuer.new(upload_job, queue: Jobs::Queues.local(config)).enqueue
+        enqueued_job = Jobs::Enqueuer.new(queue: Jobs::Queues.local(config)).enqueue(upload_job)
 
         record_upload(package, user_audit_info) if record_event
       end

--- a/app/actions/routing/route_delete.rb
+++ b/app/actions/routing/route_delete.rb
@@ -15,8 +15,7 @@ module VCAP::CloudController
     end
 
     def delete_async(route:, recursive:)
-      deletion_job = do_delete(recursive, route)
-      Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(do_delete(recursive, route))
     end
 
     def delete_unmapped_route(route:)

--- a/app/actions/service_broker_create.rb
+++ b/app/actions/service_broker_create.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
           service_event_repository.record_broker_event_with_request(:create, broker, message.audit_hash)
 
           synchronization_job = SynchronizeBrokerCatalogJob.new(broker.guid, user_audit_info: service_event_repository.user_audit_info)
-          pollable_job = Jobs::Enqueuer.new(synchronization_job, queue: Jobs::Queues.generic).enqueue_pollable
+          pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(synchronization_job)
         end
 
         { pollable_job: }

--- a/app/actions/services/locks/deleter_lock.rb
+++ b/app/actions/services/locks/deleter_lock.rb
@@ -49,8 +49,7 @@ module VCAP::CloudController
 
     def enqueue_and_unlock!(attributes_to_update, job)
       service_instance.save_and_update_operation(attributes_to_update)
-      enqueuer = Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic)
-      enqueuer.enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
       @needs_unlock = false
     end
 

--- a/app/actions/services/locks/updater_lock.rb
+++ b/app/actions/services/locks/updater_lock.rb
@@ -47,8 +47,7 @@ module VCAP::CloudController
     end
 
     def enqueue_unlock!(job)
-      enqueuer = Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic)
-      enqueuer.enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
       @needs_unlock = false
     end
 

--- a/app/actions/services/service_instance_create.rb
+++ b/app/actions/services/service_instance_create.rb
@@ -48,8 +48,7 @@ module VCAP::CloudController
         @services_event_repository.user_audit_info,
         request_attrs
       )
-      enqueuer = Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic)
-      enqueuer.enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
       @services_event_repository.record_service_instance_event(:start_create, service_instance, request_attrs)
     end
 

--- a/app/actions/space_delete.rb
+++ b/app/actions/space_delete.rb
@@ -56,7 +56,7 @@ module VCAP::CloudController
         result = service_instance_deleter.delete
         unless result[:finished]
           polling_job = V3::DeleteServiceInstanceJob.new(service_instance.guid, @services_event_repository.user_audit_info)
-          Jobs::Enqueuer.new(polling_job, queue: Jobs::Queues.generic).enqueue_pollable
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(polling_job)
           errors << CloudController::Errors::ApiError.new_from_details('AsyncServiceInstanceOperationInProgress', service_instance.name)
         end
       rescue StandardError => e

--- a/app/actions/v2/services/service_binding_create.rb
+++ b/app/actions/v2/services/service_binding_create.rb
@@ -52,8 +52,7 @@ module VCAP::CloudController
 
           binding.save_with_new_operation({ type: 'create', state: 'in progress', broker_provided_operation: binding_result[:operation] })
           job = Jobs::Services::ServiceBindingStateFetch.new(binding.guid, @user_audit_info, message.audit_hash)
-          enqueuer = Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic)
-          enqueuer.enqueue
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
           Repositories::ServiceBindingEventRepository.record_start_create(binding, @user_audit_info, message.audit_hash, manifest_triggered: @manifest_triggered)
         else
           binding.save

--- a/app/actions/v2/services/service_binding_delete.rb
+++ b/app/actions/v2/services/service_binding_delete.rb
@@ -19,10 +19,7 @@ module VCAP::CloudController
     end
 
     def background_delete_request(service_binding)
-      Jobs::Enqueuer.new(
-        Jobs::DeleteActionJob.new(ServiceBinding, service_binding.guid, self),
-        queue: Jobs::Queues.generic
-      ).enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::DeleteActionJob.new(ServiceBinding, service_binding.guid, self))
     end
 
     def delete(service_bindings)
@@ -42,8 +39,7 @@ module VCAP::CloudController
           service_binding.save_with_new_operation({ type: 'delete', state: 'in progress', broker_provided_operation: broker_response[:operation] })
 
           job = VCAP::CloudController::Jobs::Services::ServiceBindingStateFetch.new(service_binding.guid, @user_audit_info, {})
-          enqueuer = Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic)
-          enqueuer.enqueue
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
           Repositories::ServiceBindingEventRepository.record_start_delete(service_binding, @user_audit_info)
         else
           service_binding.destroy

--- a/app/actions/v3/service_broker_update.rb
+++ b/app/actions/v3/service_broker_update.rb
@@ -58,7 +58,7 @@ module VCAP::CloudController
             previous_broker_state,
             user_audit_info: service_event_repository.user_audit_info
           )
-          pollable_job = Jobs::Enqueuer.new(synchronization_job, queue: Jobs::Queues.generic).enqueue_pollable
+          pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(synchronization_job)
         end
 
         pollable_job

--- a/app/actions/v3/service_instance_update_managed.rb
+++ b/app/actions/v3/service_instance_update_managed.rb
@@ -83,7 +83,7 @@ module VCAP::CloudController
             user_audit_info: user_audit_info,
             audit_hash: message.audit_hash
           )
-          pollable_job = Jobs::Enqueuer.new(update_job, queue: Jobs::Queues.generic).enqueue_pollable
+          pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(update_job)
           lock.asynchronous_unlock!
         ensure
           lock.unlock_and_fail! if lock.present? && lock.needs_unlock?

--- a/app/controllers/base/model_controller.rb
+++ b/app/controllers/base/model_controller.rb
@@ -82,7 +82,7 @@ module VCAP::CloudController::RestController
 
     def run_or_enqueue_deletion_job(deletion_job)
       if async?
-        job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue
+        job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(deletion_job)
         [HTTP::ACCEPTED, JobPresenter.new(job).to_json]
       else
         deletion_job.perform

--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -197,7 +197,7 @@ module VCAP::CloudController
         BuildpackLifecycleDataModel.create(droplet:)
 
         droplet_upload_job = Jobs::V2::UploadDropletFromUser.new(droplet_path, droplet.guid)
-        enqueued_job       = Jobs::Enqueuer.new(droplet_upload_job, queue: Jobs::Queues.local(config)).enqueue
+        enqueued_job       = Jobs::Enqueuer.new(queue: Jobs::Queues.local(config)).enqueue(droplet_upload_job)
       end
 
       [HTTP::CREATED, JobPresenter.new(enqueued_job).to_json]

--- a/app/controllers/runtime/buildpacks_cache_controller.rb
+++ b/app/controllers/runtime/buildpacks_cache_controller.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
     def delete
       raise CloudController::Errors::ApiError.new_from_details('NotAuthorized') unless SecurityContext.roles.admin?
 
-      job = Jobs::Enqueuer.new(Jobs::Runtime::BuildpackCacheCleanup.new, queue: Jobs::Queues.generic).enqueue
+      job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::Runtime::BuildpackCacheCleanup.new)
       [HTTP::ACCEPTED, JobPresenter.new(job).to_json]
     end
   end

--- a/app/controllers/runtime/stagings_controller.rb
+++ b/app/controllers/runtime/stagings_controller.rb
@@ -74,7 +74,7 @@ module VCAP::CloudController
       check_content_digest
 
       upload_job = Jobs::V3::BuildpackCacheUpload.new(local_path: upload_path, app_guid: guid, stack_name: stack_name)
-      Jobs::Enqueuer.new(upload_job, queue: Jobs::Queues.local(config)).enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.local(config)).enqueue(upload_job)
 
       HTTP::OK
     end
@@ -119,7 +119,7 @@ module VCAP::CloudController
 
       droplet_upload_job = Jobs::V3::DropletUpload.new(upload_path, droplet.guid, skip_state_transition: true)
 
-      Jobs::Enqueuer.new(droplet_upload_job, queue: Jobs::Queues.local(config)).enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.local(config)).enqueue(droplet_upload_job)
     end
 
     def droplet_from_build(build, guid)

--- a/app/controllers/services/lifecycle/service_instance_deprovisioner.rb
+++ b/app/controllers/services/lifecycle/service_instance_deprovisioner.rb
@@ -16,7 +16,7 @@ module VCAP::CloudController
 
       warnings = []
       if async && !accepts_incomplete
-        enqueued_job = Jobs::Enqueuer.new(delete_job, queue: Jobs::Queues.generic).enqueue
+        enqueued_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(delete_job)
       else
         warnings = delete_job.perform
       end

--- a/app/controllers/v3/admin_actions_controller.rb
+++ b/app/controllers/v3/admin_actions_controller.rb
@@ -4,7 +4,7 @@ class AdminActionsController < ApplicationController
   def clear_buildpack_cache
     unauthorized! unless permission_queryer.can_write_globally?
 
-    pollable_job = Jobs::Enqueuer.new(Jobs::V3::BuildpackCacheCleanup.new, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(Jobs::V3::BuildpackCacheCleanup.new)
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end
 end

--- a/app/controllers/v3/apps_controller.rb
+++ b/app/controllers/v3/apps_controller.rb
@@ -151,7 +151,7 @@ class AppsV3Controller < ApplicationController
     delete_action = AppDelete.new(user_audit_info)
     deletion_job  = VCAP::CloudController::Jobs::DeleteActionJob.new(AppModel, app.guid, delete_action)
 
-    job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable do |pollable_job|
+    job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job) do |pollable_job|
       DeleteAppErrorTranslatorJob.new(pollable_job)
     end
     VCAP::AppLogEmitter.emit(app.guid, "Enqueued job to delete app with guid #{app.guid}")
@@ -234,7 +234,7 @@ class AppsV3Controller < ApplicationController
     suspended! unless permission_queryer.is_space_active?(space.id)
 
     delete_job = Jobs::V3::BuildpackCacheDelete.new(app.guid)
-    job = Jobs::Enqueuer.new(delete_job, queue: Jobs::Queues.generic).enqueue_pollable
+    job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(delete_job)
 
     VCAP::AppLogEmitter.emit(app.guid, "Enqueued job to delete app buildpack cache with app guid #{app.guid}")
 

--- a/app/controllers/v3/buildpacks_controller.rb
+++ b/app/controllers/v3/buildpacks_controller.rb
@@ -66,7 +66,7 @@ class BuildpacksController < ApplicationController
 
     delete_action = BuildpackDelete.new
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Buildpack, buildpack.guid, delete_action)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/domains_controller.rb
+++ b/app/controllers/v3/domains_controller.rb
@@ -106,7 +106,7 @@ class DomainsController < ApplicationController
 
     delete_action = DomainDelete.new
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Domain, domain.guid, delete_action)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/droplets_controller.rb
+++ b/app/controllers/v3/droplets_controller.rb
@@ -86,7 +86,7 @@ class DropletsController < ApplicationController
 
     delete_action = DropletDelete.new(user_audit_info)
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(DropletModel, droplet.guid, delete_action)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/organization_quotas_controller.rb
+++ b/app/controllers/v3/organization_quotas_controller.rb
@@ -80,7 +80,7 @@ class OrganizationQuotasController < ApplicationController
     delete_action = OrganizationQuotaDeleteAction.new
 
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(QuotaDefinition, organization_quota.guid, delete_action, 'organization_quota')
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -91,7 +91,7 @@ class OrganizationsV3Controller < ApplicationController
     service_event_repository = VCAP::CloudController::Repositories::ServiceEventRepository.new(user_audit_info)
     delete_action = OrganizationDelete.new(SpaceDelete.new(user_audit_info, service_event_repository), user_audit_info)
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Organization, org.guid, delete_action)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/packages_controller.rb
+++ b/app/controllers/v3/packages_controller.rb
@@ -142,7 +142,7 @@ class PackagesController < ApplicationController
 
     delete_action = PackageDelete.new(user_audit_info)
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(PackageModel, package.guid, delete_action)
-    job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head HTTP::ACCEPTED, 'Location' => url_builder.build_url(path: "/v3/jobs/#{job.guid}")
   end

--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -86,7 +86,7 @@ class RolesController < ApplicationController
     role_owner = fetch_role_owner_with_name(role)
     delete_action = RoleDeleteAction.new(user_audit_info, role_owner)
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Role, role.guid, delete_action)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/routes_controller.rb
+++ b/app/controllers/v3/routes_controller.rb
@@ -119,7 +119,7 @@ class RoutesController < ApplicationController
 
     delete_action = RouteDeleteAction.new(user_audit_info)
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Route, route.guid, delete_action)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/security_groups_controller.rb
+++ b/app/controllers/v3/security_groups_controller.rb
@@ -157,7 +157,7 @@ class SecurityGroupsController < ApplicationController
     delete_action = SecurityGroupDeleteAction.new
 
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(SecurityGroup, security_group.guid, delete_action)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/service_brokers_controller.rb
+++ b/app/controllers/v3/service_brokers_controller.rb
@@ -122,7 +122,7 @@ class ServiceBrokersController < ApplicationController
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(ServiceBroker, service_broker.guid, delete_action)
 
     service_broker.update(state: ServiceBrokerStateEnum::DELETE_IN_PROGRESS)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/service_credential_bindings_controller.rb
+++ b/app/controllers/v3/service_credential_bindings_controller.rb
@@ -255,7 +255,7 @@ class ServiceCredentialBindingsController < ApplicationController
       audit_hash: message.audit_hash,
       parameters: message.parameters
     )
-    pollable_job = Jobs::Enqueuer.new(bind_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(bind_job)
     pollable_job.guid
   end
 
@@ -265,7 +265,7 @@ class ServiceCredentialBindingsController < ApplicationController
       binding_guid,
       user_audit_info:
     )
-    pollable_job = Jobs::Enqueuer.new(bind_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(bind_job)
     pollable_job.guid
   end
 

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -267,7 +267,7 @@ class ServiceInstancesV3Controller < ApplicationController
         audit_hash: message.audit_hash
       )
 
-      pollable_job = Jobs::Enqueuer.new(provision_job, queue: Jobs::Queues.generic).enqueue_pollable
+      pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(provision_job)
 
       head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
     end
@@ -349,7 +349,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def enqueue_delete_job(service_instance)
     delete_job = V3::DeleteServiceInstanceJob.new(service_instance.guid, user_audit_info)
-    pollable_job = Jobs::Enqueuer.new(delete_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(delete_job)
     pollable_job.guid
   end
 

--- a/app/controllers/v3/service_route_bindings_controller.rb
+++ b/app/controllers/v3/service_route_bindings_controller.rb
@@ -157,7 +157,7 @@ class ServiceRouteBindingsController < ApplicationController
       audit_hash: message.audit_hash,
       parameters: message.parameters
     )
-    pollable_job = Jobs::Enqueuer.new(bind_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(bind_job)
     pollable_job.guid
   end
 
@@ -167,7 +167,7 @@ class ServiceRouteBindingsController < ApplicationController
       binding_guid,
       user_audit_info:
     )
-    pollable_job = Jobs::Enqueuer.new(bind_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(bind_job)
     pollable_job.guid
   end
 

--- a/app/controllers/v3/space_manifests_controller.rb
+++ b/app/controllers/v3/space_manifests_controller.rb
@@ -36,7 +36,7 @@ class SpaceManifestsController < ApplicationController
     apply_manifest_job = Jobs::SpaceApplyManifestActionJob.new(space, app_guid_message_hash, apply_manifest_action, user_audit_info)
 
     app_guid_message_hash.each { |app_guid, message| record_apply_manifest_audit_event(AppModel.find(guid: app_guid), message, space) }
-    job = Jobs::Enqueuer.new(apply_manifest_job, queue: Jobs::Queues.generic).enqueue_pollable
+    job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(apply_manifest_job)
 
     url_builder = Presenters::ApiUrlBuilder
     head HTTP::ACCEPTED, 'Location' => url_builder.build_url(path: "/v3/jobs/#{job.guid}")

--- a/app/controllers/v3/space_quotas_controller.rb
+++ b/app/controllers/v3/space_quotas_controller.rb
@@ -141,7 +141,7 @@ class SpaceQuotasController < ApplicationController
     delete_action = SpaceQuotaDeleteAction.new
 
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(SpaceQuotaDefinition, space_quota.guid, delete_action, 'space_quota')
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -90,7 +90,7 @@ class SpacesV3Controller < ApplicationController
     service_event_repository = VCAP::CloudController::Repositories::ServiceEventRepository.new(user_audit_info)
     delete_action = SpaceDelete.new(user_audit_info, service_event_repository)
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Space, space.guid, delete_action)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end
@@ -144,7 +144,7 @@ class SpacesV3Controller < ApplicationController
     suspended! unless permission_queryer.is_space_active?(space.id)
 
     deletion_job = VCAP::CloudController::Jobs::V3::SpaceDeleteUnmappedRoutesJob.new(space)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/controllers/v3/users_controller.rb
+++ b/app/controllers/v3/users_controller.rb
@@ -85,7 +85,7 @@ class UsersController < ApplicationController
 
     delete_action = UserDeleteAction.new
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(User, user.guid, delete_action)
-    pollable_job = Jobs::Enqueuer.new(deletion_job, queue: Jobs::Queues.generic).enqueue_pollable
+    pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 
     head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{pollable_job.guid}")
   end

--- a/app/jobs/enqueuer.rb
+++ b/app/jobs/enqueuer.rb
@@ -9,20 +9,19 @@ require 'securerandom'
 module VCAP::CloudController
   module Jobs
     class Enqueuer
-      def initialize(job, opts={})
-        @job = job
+      def initialize(opts={})
         @opts = opts
         @timeout_calculator = JobTimeoutCalculator.new(VCAP::CloudController::Config.config)
         @priority_overwriter = JobPriorityOverwriter.new(VCAP::CloudController::Config.config)
         load_delayed_job_plugins
       end
 
-      def enqueue
-        enqueue_job(@job)
+      def enqueue(job)
+        enqueue_job(job)
       end
 
-      def enqueue_pollable(existing_guid: nil)
-        wrapped_job = PollableJobWrapper.new(@job, existing_guid:)
+      def enqueue_pollable(job, existing_guid: nil)
+        wrapped_job = PollableJobWrapper.new(job, existing_guid:)
 
         wrapped_job = yield wrapped_job if block_given?
 
@@ -30,9 +29,9 @@ module VCAP::CloudController
         PollableJobModel.find_by_delayed_job(delayed_job)
       end
 
-      def run_inline
+      def run_inline(job)
         run_immediately do
-          Delayed::Job.enqueue(TimeoutJob.new(@job, job_timeout), @opts)
+          Delayed::Job.enqueue(TimeoutJob.new(job, job_timeout(job)), @opts)
         end
       end
 
@@ -41,8 +40,9 @@ module VCAP::CloudController
       def enqueue_job(job)
         @opts['guid'] = SecureRandom.uuid
         request_id = ::VCAP::Request.current_id
-        timeout_job = TimeoutJob.new(job, job_timeout)
+        timeout_job = TimeoutJob.new(job, job_timeout(job))
         logging_context_job = LoggingContextJob.new(timeout_job, request_id)
+        job_priority = job_priority(job)
         @opts[:priority] = job_priority unless @opts[:priority] || job_priority.nil?
         Delayed::Job.enqueue(logging_context_job, @opts)
       end
@@ -51,14 +51,22 @@ module VCAP::CloudController
         @load_delayed_job_plugins ||= Delayed::Worker.new
       end
 
-      def job_timeout
-        return @timeout_calculator.calculate(@job.try(:job_name_in_configuration), @opts[:queue]) if @opts[:queue]
+      def job_timeout(job)
+        unwrapped_job = unwrap_job(job)
+        return @timeout_calculator.calculate(unwrapped_job.try(:job_name_in_configuration), @opts[:queue]) if @opts[:queue]
 
-        @timeout_calculator.calculate(@job.try(:job_name_in_configuration))
+        @timeout_calculator.calculate(unwrapped_job.try(:job_name_in_configuration))
       end
 
-      def job_priority
-        @priority_overwriter.get(@job.try(:display_name)) || @priority_overwriter.get(@job.try(:job_name_in_configuration)) || @priority_overwriter.get(@job.class.name)
+      def job_priority(job)
+        unwrapped_job = unwrap_job(job)
+        @priority_overwriter.get(unwrapped_job.try(:display_name)) ||
+          @priority_overwriter.get(unwrapped_job.try(:job_name_in_configuration)) ||
+          @priority_overwriter.get(unwrapped_job.class.name)
+      end
+
+      def unwrap_job(job)
+        job.is_a?(PollableJobWrapper) ? job.handler : job
       end
 
       def run_immediately

--- a/app/jobs/reoccurring_job.rb
+++ b/app/jobs/reoccurring_job.rb
@@ -83,7 +83,7 @@ module VCAP::CloudController
         }
 
         @retry_number += 1
-        Jobs::Enqueuer.new(self, opts).enqueue_pollable(existing_guid: pollable_job.guid)
+        Jobs::Enqueuer.new(opts).enqueue_pollable(self, existing_guid: pollable_job.guid)
       end
     end
   end

--- a/app/jobs/runtime/expired_blob_cleanup.rb
+++ b/app/jobs/runtime/expired_blob_cleanup.rb
@@ -23,17 +23,11 @@ module VCAP::CloudController
         end
 
         def enqueue_droplet_delete_job(droplet_guid)
-          Jobs::Enqueuer.new(
-            Jobs::Runtime::DeleteExpiredDropletBlob.new(droplet_guid),
-            queue: Jobs::Queues.generic
-          ).enqueue
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::Runtime::DeleteExpiredDropletBlob.new(droplet_guid))
         end
 
         def enqueue_package_delete_job(package_guid)
-          Jobs::Enqueuer.new(
-            Jobs::Runtime::DeleteExpiredPackageBlob.new(package_guid),
-            queue: Jobs::Queues.generic
-          ).enqueue
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::Runtime::DeleteExpiredPackageBlob.new(package_guid))
         end
 
         def logger

--- a/app/jobs/runtime/orphaned_blobs_cleanup.rb
+++ b/app/jobs/runtime/orphaned_blobs_cleanup.rb
@@ -165,7 +165,7 @@ module VCAP::CloudController
 
             logger.info("Enqueuing deletion of orphaned blob #{orphaned_blob.blob_key} inside directory_key #{directory_key}")
             blobstore_delete_job = BlobstoreDelete.new(unpartitioned_blob_key, blobstore_type)
-            Jobs::Enqueuer.new(blobstore_delete_job, queue: Jobs::Queues.generic, priority: VCAP::CloudController::Clock::LOW_PRIORITY).enqueue
+            Jobs::Enqueuer.new(queue: Jobs::Queues.generic, priority: VCAP::CloudController::Clock::LOW_PRIORITY).enqueue(blobstore_delete_job)
 
             VCAP::CloudController::Repositories::OrphanedBlobEventRepository.record_delete(directory_key, orphaned_blob.blob_key)
             orphaned_blob.delete

--- a/app/jobs/v2/services/asynchronous_operations.rb
+++ b/app/jobs/v2/services/asynchronous_operations.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
         def enqueue_again
           opts = { queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now + next_execution_in }
           self.retry_number += 1
-          Jobs::Enqueuer.new(self, opts).enqueue
+          Jobs::Enqueuer.new(opts).enqueue(self)
         end
 
         def default_polling_exponential_backoff

--- a/lib/cloud_controller/bits_expiration.rb
+++ b/lib/cloud_controller/bits_expiration.rb
@@ -44,17 +44,11 @@ module VCAP::CloudController
     private
 
     def enqueue_droplet_delete_job(droplet_guid)
-      Jobs::Enqueuer.new(
-        Jobs::Runtime::DeleteExpiredDropletBlob.new(droplet_guid),
-        queue: Jobs::Queues.generic
-      ).enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::Runtime::DeleteExpiredDropletBlob.new(droplet_guid))
     end
 
     def enqueue_package_delete_job(package_guid)
-      Jobs::Enqueuer.new(
-        Jobs::Runtime::DeleteExpiredPackageBlob.new(package_guid),
-        queue: Jobs::Queues.generic
-      ).enqueue
+      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::Runtime::DeleteExpiredPackageBlob.new(package_guid))
     end
 
     def filter_non_expirable(dataset, storage_count)

--- a/lib/cloud_controller/clock/clock.rb
+++ b/lib/cloud_controller/clock/clock.rb
@@ -20,7 +20,7 @@ module VCAP::CloudController
 
       schedule_job(job_opts) do
         job = yield
-        Jobs::Enqueuer.new(job, queue: name, priority: priority).enqueue
+        Jobs::Enqueuer.new(queue: name, priority: priority).enqueue(job)
       end
     end
 
@@ -33,7 +33,7 @@ module VCAP::CloudController
 
       schedule_job(job_opts) do
         job = yield
-        Jobs::Enqueuer.new(job, queue: name).enqueue
+        Jobs::Enqueuer.new(queue: name).enqueue(job)
       end
     end
 
@@ -48,7 +48,7 @@ module VCAP::CloudController
 
       schedule_job(job_opts) do
         job = yield
-        Jobs::Enqueuer.new(job, queue: name).run_inline
+        Jobs::Enqueuer.new(queue: name).run_inline(job)
       end
     end
 

--- a/lib/cloud_controller/install_buildpacks.rb
+++ b/lib/cloud_controller/install_buildpacks.rb
@@ -73,7 +73,7 @@ module VCAP::CloudController
 
     def enqueue_remaining_jobs(jobs)
       jobs.drop(1).each do |job|
-        VCAP::CloudController::Jobs::Enqueuer.new(job, queue: VCAP::CloudController::Jobs::Queues.local(config)).enqueue
+        VCAP::CloudController::Jobs::Enqueuer.new(queue: VCAP::CloudController::Jobs::Queues.local(config)).enqueue(job)
       end
     end
   end

--- a/lib/services/service_brokers/v2/orphan_mitigator.rb
+++ b/lib/services/service_brokers/v2/orphan_mitigator.rb
@@ -14,7 +14,7 @@ module VCAP::Services
           )
 
           opts = { queue: VCAP::CloudController::Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }
-          VCAP::CloudController::Jobs::Enqueuer.new(orphan_deprovision_job, opts).enqueue
+          VCAP::CloudController::Jobs::Enqueuer.new(opts).enqueue(orphan_deprovision_job)
         end
 
         def cleanup_failed_bind(service_binding)
@@ -25,7 +25,7 @@ module VCAP::Services
           )
 
           opts = { queue: VCAP::CloudController::Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }
-          VCAP::CloudController::Jobs::Enqueuer.new(unbind_job, opts).enqueue
+          VCAP::CloudController::Jobs::Enqueuer.new(opts).enqueue(unbind_job)
         end
 
         def cleanup_failed_key(service_key)
@@ -36,7 +36,7 @@ module VCAP::Services
           )
 
           opts = { queue: VCAP::CloudController::Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }
-          VCAP::CloudController::Jobs::Enqueuer.new(key_delete_job, opts).enqueue
+          VCAP::CloudController::Jobs::Enqueuer.new(opts).enqueue(key_delete_job)
         end
       end
     end

--- a/spec/api/documentation/job_api_spec.rb
+++ b/spec/api/documentation/job_api_spec.rb
@@ -37,7 +37,7 @@ RSpec.resource 'Jobs', type: %i[api legacy_api] do
     end
 
     describe 'When a job has failed with a known failure from v2.yml' do
-      before { VCAP::CloudController::Jobs::Enqueuer.new(KnownFailingJob.new).enqueue }
+      before { VCAP::CloudController::Jobs::Enqueuer.new.enqueue(KnownFailingJob.new) }
 
       example 'Retrieve Job with known failure' do
         guid = Delayed::Job.last.guid
@@ -67,7 +67,7 @@ RSpec.resource 'Jobs', type: %i[api legacy_api] do
         end
       end
 
-      before { VCAP::CloudController::Jobs::Enqueuer.new(UnknownFailingJob.new).enqueue }
+      before { VCAP::CloudController::Jobs::Enqueuer.new.enqueue(UnknownFailingJob.new) }
 
       example 'Retrieve Job with unknown failure' do
         job_last = Delayed::Job.last
@@ -94,7 +94,7 @@ RSpec.resource 'Jobs', type: %i[api legacy_api] do
     describe 'For a queued job' do
       class SuccessfulJob < FakeJob; end
 
-      before { VCAP::CloudController::Jobs::Enqueuer.new(SuccessfulJob.new).enqueue }
+      before { VCAP::CloudController::Jobs::Enqueuer.new.enqueue(SuccessfulJob.new) }
 
       example 'Retrieve Job that is queued' do
         guid = Delayed::Job.last.guid
@@ -110,7 +110,7 @@ RSpec.resource 'Jobs', type: %i[api legacy_api] do
     describe 'For a successfully executed job' do
       class SuccessfulJob < FakeJob; end
 
-      before { VCAP::CloudController::Jobs::Enqueuer.new(SuccessfulJob.new).enqueue }
+      before { VCAP::CloudController::Jobs::Enqueuer.new.enqueue(SuccessfulJob.new) }
 
       example 'Retrieve Job that was successful' do
         guid = Delayed::Job.last.guid

--- a/spec/request/jobs_spec.rb
+++ b/spec/request/jobs_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Jobs' do
   describe 'running a pollable job that emits warnings' do
     it 'contains these warnings in the job representation' do
       job = TestJob.new(user.guid)
-      pollable_job = VCAP::CloudController::Jobs::Enqueuer.new(job, queue: VCAP::CloudController::Jobs::Queues.generic).enqueue_pollable
+      pollable_job = VCAP::CloudController::Jobs::Enqueuer.new(queue: VCAP::CloudController::Jobs::Queues.generic).enqueue_pollable(job)
       job_guid = pollable_job.guid
 
       execute_all_jobs(expected_successes: 1, expected_failures: 0)

--- a/spec/request/v2/service_instances_spec.rb
+++ b/spec/request/v2/service_instances_spec.rb
@@ -516,7 +516,7 @@ RSpec.describe 'ServiceInstances' do
           VCAP::CloudController::UserAuditInfo.new(user_guid: user.guid, user_email: 'test@example.org'),
           {}
         )
-        VCAP::CloudController::Jobs::Enqueuer.new(job).enqueue
+        VCAP::CloudController::Jobs::Enqueuer.new.enqueue(job)
 
         allow(broker_client).to receive(:fetch_service_instance_last_operation).and_return(
           last_operation: {

--- a/spec/unit/controllers/services/lifecycle/service_instance_deprovisioner_spec.rb
+++ b/spec/unit/controllers/services/lifecycle/service_instance_deprovisioner_spec.rb
@@ -129,8 +129,8 @@ module VCAP::CloudController
 
           it 'enqueues a job' do
             fake_enqueuer = instance_double(Jobs::Enqueuer)
-            expect(Jobs::Enqueuer).to receive(:new).with(duck_type(:perform), { queue: Jobs::Queues.generic }).and_return(fake_enqueuer)
-            expect(fake_enqueuer).to receive(:enqueue).once
+            expect(Jobs::Enqueuer).to receive(:new).with({ queue: Jobs::Queues.generic }).and_return(fake_enqueuer)
+            expect(fake_enqueuer).to receive(:enqueue).with(duck_type(:perform)).once
 
             deprovisioner.deprovision_service_instance(service_instance, accepts_incomplete, async)
           end

--- a/spec/unit/jobs/deserialization_spec.rb
+++ b/spec/unit/jobs/deserialization_spec.rb
@@ -82,7 +82,7 @@ module VCAP::CloudController
         end
 
         it 'equals dumped job yaml' do
-          VCAP::CloudController::Jobs::Enqueuer.new(job).enqueue_pollable
+          VCAP::CloudController::Jobs::Enqueuer.new.enqueue_pollable(job)
           jobs_in_db = Sequel::Model.db.fetch('SELECT handler FROM delayed_jobs').all
           expect(jobs_in_db.size).to eq(1)
 
@@ -348,7 +348,7 @@ module VCAP::CloudController
         end
 
         it 'equals dumped job yaml' do
-          VCAP::CloudController::Jobs::Enqueuer.new(job).enqueue
+          VCAP::CloudController::Jobs::Enqueuer.new.enqueue(job)
           jobs_in_db = Sequel::Model.db.fetch('SELECT handler FROM delayed_jobs').all
           expect(jobs_in_db.size).to eq(1)
 

--- a/spec/unit/jobs/enqueuer_async_spec.rb
+++ b/spec/unit/jobs/enqueuer_async_spec.rb
@@ -69,7 +69,7 @@ module VCAP::CloudController::Jobs
         Delayed::Worker.plugins << BeforeAfterEnqueueHook  # Collecting state via callback
         Delayed::Worker.plugins << AfterEnqueueHook
 
-        Enqueuer.new(wrapped_job, opts).enqueue_pollable
+        Enqueuer.new(opts).enqueue_pollable(wrapped_job)
         job_state = TestDelayedPlugin.callback_counts
 
         # We are testing an asynchronous event to verify that the PollableJobModel is updated before DelayedJob

--- a/spec/unit/jobs/pollable_job_wrapper_spec.rb
+++ b/spec/unit/jobs/pollable_job_wrapper_spec.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController::Jobs
       let(:job) { DeleteActionJob.new(VCAP::CloudController::DropletModel, 'fake', delete_action) }
 
       it 'creates a job record and marks the job model as completed' do
-        enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+        enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
 
         job_record = VCAP::CloudController::PollableJobModel.find(delayed_job_guid: enqueued_job.guid)
         expect(job_record).not_to be_nil, "Expected to find PollableJobModel with delayed_job_guid '#{enqueued_job.guid}', but did not"
@@ -49,15 +49,15 @@ module VCAP::CloudController::Jobs
 
           before do
             stub_const('VCAP::CloudController::SecurityContext', security_context)
-            VCAP::CloudController::Jobs::Enqueuer.new(PollableJobWrapper.new(job)).enqueue
-            VCAP::CloudController::Jobs::Enqueuer.new(PollableJobWrapper.new(job)).enqueue
-            VCAP::CloudController::Jobs::Enqueuer.new(PollableJobWrapper.new(job)).enqueue
+            VCAP::CloudController::Jobs::Enqueuer.new.enqueue(PollableJobWrapper.new(job))
+            VCAP::CloudController::Jobs::Enqueuer.new.enqueue(PollableJobWrapper.new(job))
+            VCAP::CloudController::Jobs::Enqueuer.new.enqueue(PollableJobWrapper.new(job))
           end
 
           it 'adds +1 to base priority for each active job' do
             TestConfig.config[:jobs][:priorities] = { 'droplet.delete': 20 }
 
-            enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+            enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
             expect(enqueued_job.priority).to eq(23)
           end
 
@@ -71,14 +71,14 @@ module VCAP::CloudController::Jobs
             it 'does not change its delayed job\'s base priority' do
               TestConfig.config[:jobs][:priorities] = { 'droplet.delete': 20 }
 
-              enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+              enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
               expect(enqueued_job.priority).to eq(20)
             end
 
             it 'uses nil for the user_guid' do
               TestConfig.config[:jobs][:priorities] = { 'droplet.delete': 20 }
 
-              enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+              enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
 
               job_record = VCAP::CloudController::PollableJobModel.find(delayed_job_guid: enqueued_job.guid)
               expect(job_record.user_guid).to be_nil
@@ -94,15 +94,15 @@ module VCAP::CloudController::Jobs
 
           before do
             stub_const('VCAP::CloudController::SecurityContext', security_context)
-            VCAP::CloudController::Jobs::Enqueuer.new(PollableJobWrapper.new(job)).enqueue
-            VCAP::CloudController::Jobs::Enqueuer.new(PollableJobWrapper.new(job)).enqueue
-            VCAP::CloudController::Jobs::Enqueuer.new(PollableJobWrapper.new(job)).enqueue
+            VCAP::CloudController::Jobs::Enqueuer.new.enqueue(PollableJobWrapper.new(job))
+            VCAP::CloudController::Jobs::Enqueuer.new.enqueue(PollableJobWrapper.new(job))
+            VCAP::CloudController::Jobs::Enqueuer.new.enqueue(PollableJobWrapper.new(job))
           end
 
           it 'does not change its delayed job\'s base priority' do
             TestConfig.config[:jobs][:priorities] = { 'droplet.delete': 20 }
 
-            enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+            enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
             expect(enqueued_job.priority).to eq(20)
           end
         end
@@ -116,7 +116,7 @@ module VCAP::CloudController::Jobs
           jobs_before_enqueue = VCAP::CloudController::PollableJobModel.all.length
           expect(jobs_before_enqueue).to eq(1)
 
-          enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+          enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
 
           jobs_after_enqueue = VCAP::CloudController::PollableJobModel.all.length
           expect(jobs_after_enqueue).to eq(1)
@@ -140,15 +140,15 @@ module VCAP::CloudController::Jobs
 
             before do
               stub_const('VCAP::CloudController::SecurityContext', security_context)
-              VCAP::CloudController::Jobs::Enqueuer.new(PollableJobWrapper.new(job)).enqueue
-              VCAP::CloudController::Jobs::Enqueuer.new(PollableJobWrapper.new(job)).enqueue
-              VCAP::CloudController::Jobs::Enqueuer.new(PollableJobWrapper.new(job)).enqueue
+              VCAP::CloudController::Jobs::Enqueuer.new.enqueue(PollableJobWrapper.new(job))
+              VCAP::CloudController::Jobs::Enqueuer.new.enqueue(PollableJobWrapper.new(job))
+              VCAP::CloudController::Jobs::Enqueuer.new.enqueue(PollableJobWrapper.new(job))
             end
 
             it 'does not change its delayed job\'s base priority' do
               TestConfig.config[:jobs][:priorities] = { 'droplet.delete': 20 }
 
-              enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+              enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
               expect(enqueued_job.priority).to eq(20)
             end
           end
@@ -162,7 +162,7 @@ module VCAP::CloudController::Jobs
           end
 
           it 'updates the existing job state accordingly' do
-            enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+            enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
             job_record = VCAP::CloudController::PollableJobModel.find(delayed_job_guid: enqueued_job.guid)
             expect(job_record.state).to eq('ABRACADABRA')
           end
@@ -178,7 +178,7 @@ module VCAP::CloudController::Jobs
 
         context 'when there is an associated job model' do
           it 'marks the job model failed and records errors' do
-            enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+            enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
             job_model = VCAP::CloudController::PollableJobModel.make(delayed_job_guid: enqueued_job.guid, state: 'PROCESSING')
 
             execute_all_jobs(expected_successes: 0, expected_failures: 1)
@@ -196,7 +196,7 @@ module VCAP::CloudController::Jobs
 
         context 'when there is NOT an associated job model' do
           it 'does NOT choke' do
-            VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+            VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
 
             execute_all_jobs(expected_successes: 0, expected_failures: 1)
           end
@@ -229,7 +229,7 @@ module VCAP::CloudController::Jobs
         let(:expected_warnings) { [{ detail: 'warning 1' }, { detail: 'warning 2' }] }
 
         it 'records all warnings' do
-          enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+          enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
           job_model = VCAP::CloudController::PollableJobModel.make(delayed_job_guid: enqueued_job.guid, state: 'PROCESSING')
 
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
@@ -245,7 +245,7 @@ module VCAP::CloudController::Jobs
         let(:expected_warnings) { nil }
 
         it 'has empty list of warnings' do
-          enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new(pollable_job).enqueue
+          enqueued_job = VCAP::CloudController::Jobs::Enqueuer.new.enqueue(pollable_job)
           job_model = VCAP::CloudController::PollableJobModel.make(delayed_job_guid: enqueued_job.guid, state: 'PROCESSING')
 
           execute_all_jobs(expected_successes: 1, expected_failures: 0)

--- a/spec/unit/jobs/reoccurring_job_spec.rb
+++ b/spec/unit/jobs/reoccurring_job_spec.rb
@@ -42,13 +42,13 @@ module VCAP
       it 'can be enqueued' do
         expect(PollableJobModel.all).to be_empty
 
-        pollable_job = Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+        pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new)
 
         expect(PollableJobModel.first).to eq(pollable_job)
       end
 
       it 'runs a first time' do
-        Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+        Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new)
 
         number_of_calls_to_job = Delayed::Job.last.payload_object.handler.handler.handler.calls
         expect(number_of_calls_to_job).to eq(0)
@@ -60,7 +60,7 @@ module VCAP
       end
 
       it 're-enqueues itself with a new delayed job' do
-        pollable_job = Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+        pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new)
         expect(PollableJobModel.all).to have(1).job
 
         execute_all_jobs(expected_successes: 1, expected_failures: 0, jobs_to_execute: 1)
@@ -73,7 +73,7 @@ module VCAP
       it 'keeps the delayed job\'s priority when re-enqueuing' do
         TestConfig.config[:jobs][:priorities] = { 'fake-job': 20 }
 
-        pollable_job = Jobs::Enqueuer.new(FakeJob.new, { queue: Jobs::Queues.generic, priority: 22 }).enqueue_pollable
+        pollable_job = Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, priority: 22 }).enqueue_pollable(FakeJob.new)
         expect(Delayed::Job.where(guid: PollableJobModel.first.delayed_job_guid).first[:priority]).to eq(22)
 
         execute_all_jobs(expected_successes: 1, expected_failures: 0, jobs_to_execute: 1)
@@ -90,7 +90,7 @@ module VCAP
         enqueued_time = 0
 
         Timecop.freeze do
-          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(job)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
           enqueued_time = Time.now
         end
@@ -121,7 +121,7 @@ module VCAP
             enqueued_time = 0
 
             Timecop.freeze do
-              Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+              Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new)
               execute_all_jobs(expected_successes: 1, expected_failures: 0)
               enqueued_time = Time.now
             end
@@ -144,7 +144,7 @@ module VCAP
             enqueued_time = 0
 
             Timecop.freeze do
-              Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+              Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new)
               execute_all_jobs(expected_successes: 1, expected_failures: 0)
               enqueued_time = Time.now
             end
@@ -167,7 +167,7 @@ module VCAP
             enqueued_time = 0
 
             Timecop.freeze do
-              Jobs::Enqueuer.new(FakeJob.new(retry_after: [20, 30]), queue: Jobs::Queues.generic).enqueue_pollable
+              Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new(retry_after: [20, 30]))
               execute_all_jobs(expected_successes: 1, expected_failures: 0)
               enqueued_time = Time.now
             end
@@ -204,7 +204,7 @@ module VCAP
           enqueued_time = 0
 
           Timecop.freeze do
-            Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
+            Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(job)
             enqueued_time = Time.now
           end
 
@@ -228,7 +228,7 @@ module VCAP
           enqueued_time = 0
 
           Timecop.freeze do
-            Jobs::Enqueuer.new(FakeJob.new(retry_after: [20, 30]), queue: Jobs::Queues.generic).enqueue_pollable
+            Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new(retry_after: [20, 30]))
             execute_all_jobs(expected_successes: 1, expected_failures: 0)
             enqueued_time = Time.now
           end
@@ -257,7 +257,7 @@ module VCAP
           enqueued_time = 0
 
           Timecop.freeze do
-            Jobs::Enqueuer.new(FakeJob.new(retry_after: [20]), queue: Jobs::Queues.generic).enqueue_pollable
+            Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new(retry_after: [20]))
             execute_all_jobs(expected_successes: 1, expected_failures: 0)
             enqueued_time = Time.now
           end
@@ -287,7 +287,7 @@ module VCAP
           enqueued_time = 0
 
           Timecop.freeze do
-            Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+            Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new)
             execute_all_jobs(expected_successes: 1, expected_failures: 0)
             enqueued_time = Time.now
           end
@@ -313,7 +313,7 @@ module VCAP
       end
 
       it 'continues to run until finished' do
-        Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+        Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new)
 
         10.times do
           Timecop.travel(61.seconds)
@@ -331,7 +331,7 @@ module VCAP
         end
 
         it 'completes with a failed state' do
-          Jobs::Enqueuer.new(FakeFailingJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeFailingJob.new)
 
           execute_all_jobs(expected_successes: 0, expected_failures: 1)
           expect(PollableJobModel.first.state).to eq('FAILED')
@@ -344,7 +344,7 @@ module VCAP
 
       context 'timeout' do
         it 'marks the job failed with a timeout error' do
-          Jobs::Enqueuer.new(FakeJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeJob.new)
 
           Timecop.freeze(Time.now + VCAP::CloudController::Config.config.get(:broker_client_max_async_poll_duration_minutes).minute + 1) do
             execute_all_jobs(expected_successes: 0, expected_failures: 1, jobs_to_execute: 1)
@@ -364,7 +364,7 @@ module VCAP
             end
           end
 
-          Jobs::Enqueuer.new(FakeTimeoutJob.new, queue: Jobs::Queues.generic).enqueue_pollable
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(FakeTimeoutJob.new)
 
           Timecop.freeze(Time.now + VCAP::CloudController::Config.config.get(:broker_client_max_async_poll_duration_minutes).minute + 1) do
             execute_all_jobs(expected_successes: 0, expected_failures: 1, jobs_to_execute: 1)
@@ -377,7 +377,7 @@ module VCAP
           job.polling_interval_seconds = 1.minute
           job.maximum_duration_seconds = 2.minutes
 
-          Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic).enqueue_pollable
+          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(job)
 
           Timecop.freeze(61.seconds.after(Time.now)) do
             execute_all_jobs(expected_successes: 0, expected_failures: 1, jobs_to_execute: 1)

--- a/spec/unit/jobs/runtime/orphaned_blobs_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/orphaned_blobs_cleanup_spec.rb
@@ -479,8 +479,8 @@ module VCAP::CloudController
               expect(BlobstoreDelete).to have_received(:new).with('buildpack-to-be-deleted', :buildpack_blobstore)
               expect(BlobstoreDelete).to have_received(:new).with('droplet-to-be-deleted/droplet', :droplet_blobstore)
               expect(BlobstoreDelete).to have_received(:new).with('resource-to-be-deleted', :legacy_global_app_bits_cache)
-              expect(Jobs::Enqueuer).to have_received(:new).exactly(4).times.with(blobstore_delete, hash_including(queue: Jobs::Queues.generic, priority: 100))
-              expect(enqueuer).to have_received(:enqueue).exactly(4).times
+              expect(Jobs::Enqueuer).to have_received(:new).exactly(4).times.with(hash_including(queue: Jobs::Queues.generic, priority: 100))
+              expect(enqueuer).to have_received(:enqueue).exactly(4).times.with(blobstore_delete)
 
               expect(packages_orphaned_blob).not_to exist
               expect(buildpacks_orphaned_blob).not_to exist

--- a/spec/unit/jobs/services/delete_orphaned_binding_spec.rb
+++ b/spec/unit/jobs/services/delete_orphaned_binding_spec.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController
           expect(VCAP::Services::ServiceClientProvider).to receive(:provide).
             with(instance: service_binding.service_instance)
 
-          Jobs::Enqueuer.new(job, { queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue
+          Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue(job)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
 
           expect(client).to have_received(:unbind) do |binding|
@@ -61,7 +61,7 @@ module VCAP::CloudController
 
           start = Delayed::Job.db_time_now
           opts = { queue: Jobs::Queues.generic, run_at: start }
-          Jobs::Enqueuer.new(job, opts).enqueue
+          Jobs::Enqueuer.new(opts).enqueue(job)
 
           run_at_time = start
           10.times do |i|

--- a/spec/unit/jobs/services/delete_orphaned_instance_spec.rb
+++ b/spec/unit/jobs/services/delete_orphaned_instance_spec.rb
@@ -25,7 +25,7 @@ module VCAP::CloudController
             with(instance: service_instance)
           expect(client).to receive(:deprovision).with(service_instance, accepts_incomplete: true)
 
-          Jobs::Enqueuer.new(job, { queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue
+          Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue(job)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
           expect(Delayed::Job.count).to eq 0
         end
@@ -59,7 +59,7 @@ module VCAP::CloudController
 
           start = Delayed::Job.db_time_now
           opts = { queue: Jobs::Queues.generic, run_at: start }
-          Jobs::Enqueuer.new(job, opts).enqueue
+          Jobs::Enqueuer.new(opts).enqueue(job)
 
           run_at_time = start
           10.times do |i|

--- a/spec/unit/jobs/services/delete_orphaned_key_spec.rb
+++ b/spec/unit/jobs/services/delete_orphaned_key_spec.rb
@@ -28,7 +28,7 @@ module VCAP::CloudController
           expect(VCAP::Services::ServiceClientProvider).to receive(:provide).
             with(instance: service_instance)
 
-          Jobs::Enqueuer.new(job, { queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue
+          Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue(job)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
 
           expect(client).to have_received(:unbind).with(service_key)
@@ -64,7 +64,7 @@ module VCAP::CloudController
           Timecop.freeze do
             first_enqueue_time = Delayed::Job.db_time_now
             opts = { queue: Jobs::Queues.generic, run_at: first_enqueue_time }
-            Jobs::Enqueuer.new(job, opts).enqueue
+            Jobs::Enqueuer.new(opts).enqueue(job)
           end
 
           run_at_time = first_enqueue_time

--- a/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_binding_state_fetch_spec.rb
@@ -37,7 +37,7 @@ module VCAP::CloudController
         end
 
         def run_job(job)
-          Jobs::Enqueuer.new(job, { queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue
+          Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue(job)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
         end
 
@@ -620,7 +620,7 @@ module VCAP::CloudController
             let(:last_operation_response) { {} }
 
             before do
-              Jobs::Enqueuer.new(job, { queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue
+              Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue(job)
               Delayed::Worker.new.work_off
             end
 
@@ -773,7 +773,7 @@ module VCAP::CloudController
               job
               TestConfig.override(broker_client_default_async_poll_interval_seconds: new_polling_interval)
 
-              Jobs::Enqueuer.new(job, { queue: Jobs::Queues.generic, run_at: first_run_time }).enqueue
+              Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, run_at: first_run_time }).enqueue(job)
               execute_all_jobs(expected_successes: 1, expected_failures: 0)
               expect(Delayed::Job.count).to eq(1)
 

--- a/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
@@ -58,7 +58,7 @@ module VCAP::CloudController
         end
 
         def run_job(job)
-          Jobs::Enqueuer.new(job, { queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue
+          Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue(job)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
         end
 
@@ -524,7 +524,7 @@ module VCAP::CloudController
               Timecop.freeze(Time.now)
               first_run_time = Time.now
 
-              Jobs::Enqueuer.new(job, { queue: Jobs::Queues.generic, run_at: first_run_time }).enqueue
+              Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, run_at: first_run_time }).enqueue(job)
               execute_all_jobs(expected_successes: 1, expected_failures: 0)
               expect(Delayed::Job.count).to eq(1)
 
@@ -558,7 +558,7 @@ module VCAP::CloudController
               updated_username = 'new-username'
               updated_password = 'new-password'
 
-              Jobs::Enqueuer.new(job, { queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue
+              Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }).enqueue(job)
 
               broker.update({
                               broker_url: updated_url,
@@ -610,7 +610,7 @@ module VCAP::CloudController
 
               job_id = nil
               Timecop.freeze now do
-                enqueued_job = Jobs::Enqueuer.new(job, queue: Jobs::Queues.generic, run_at: Time.now).enqueue
+                enqueued_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic, run_at: Time.now).enqueue(job)
                 job_id = enqueued_job.id
               end
 

--- a/spec/unit/jobs/services/shared/when_broker_returns_retry_after_header.rb
+++ b/spec/unit/jobs/services/shared/when_broker_returns_retry_after_header.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples 'when brokers return Retry-After header' do |last_operatio
           Timecop.freeze(Time.now)
           first_run_time = Time.now
 
-          VCAP::CloudController::Jobs::Enqueuer.new(job, { queue: VCAP::CloudController::Jobs::Queues.generic, run_at: first_run_time }).enqueue
+          VCAP::CloudController::Jobs::Enqueuer.new({ queue: VCAP::CloudController::Jobs::Queues.generic, run_at: first_run_time }).enqueue(job)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
           expect(Delayed::Job.count).to eq(1)
 
@@ -39,7 +39,7 @@ RSpec.shared_examples 'when brokers return Retry-After header' do |last_operatio
           Timecop.freeze(Time.now)
           first_run_time = Time.now
 
-          VCAP::CloudController::Jobs::Enqueuer.new(job, { queue: VCAP::CloudController::Jobs::Queues.generic, run_at: first_run_time }).enqueue
+          VCAP::CloudController::Jobs::Enqueuer.new({ queue: VCAP::CloudController::Jobs::Queues.generic, run_at: first_run_time }).enqueue(job)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
           expect(Delayed::Job.count).to eq(1)
 
@@ -57,7 +57,7 @@ RSpec.shared_examples 'when brokers return Retry-After header' do |last_operatio
           Timecop.freeze(Time.now)
           first_run_time = Time.now
 
-          VCAP::CloudController::Jobs::Enqueuer.new(job, { queue: VCAP::CloudController::Jobs::Queues.generic, run_at: first_run_time }).enqueue
+          VCAP::CloudController::Jobs::Enqueuer.new({ queue: VCAP::CloudController::Jobs::Queues.generic, run_at: first_run_time }).enqueue(job)
           execute_all_jobs(expected_successes: 1, expected_failures: 0)
           expect(Delayed::Job.count).to eq(1)
 

--- a/spec/unit/lib/cloud_controller/clock/clock_spec.rb
+++ b/spec/unit/lib/cloud_controller/clock/clock_spec.rb
@@ -41,8 +41,8 @@ module VCAP::CloudController
         clock.schedule_daily_job(**clock_opts) { some_job_class.new }
 
         expected_job_opts = { queue: job_name, priority: 0 }
-        expect(Jobs::Enqueuer).to have_received(:new).with(instance_of(some_job_class), expected_job_opts)
-        expect(enqueuer).to have_received(:enqueue)
+        expect(Jobs::Enqueuer).to have_received(:new).with(expected_job_opts)
+        expect(enqueuer).to have_received(:enqueue).with(instance_of(some_job_class))
       end
 
       context 'when a job has a priority' do
@@ -70,8 +70,8 @@ module VCAP::CloudController
           clock.schedule_daily_job(**clock_opts) { some_job_class.new }
 
           expected_job_opts = { queue: job_name, priority: priority }
-          expect(Jobs::Enqueuer).to have_received(:new).with(instance_of(some_job_class), expected_job_opts)
-          expect(enqueuer).to have_received(:enqueue)
+          expect(Jobs::Enqueuer).to have_received(:new).with(expected_job_opts)
+          expect(enqueuer).to have_received(:enqueue).with(instance_of(some_job_class))
         end
       end
     end
@@ -97,8 +97,8 @@ module VCAP::CloudController
         clock.schedule_frequent_worker_job(**clock_opts) { some_job_class.new }
 
         expected_job_opts = { queue: job_name }
-        expect(Jobs::Enqueuer).to have_received(:new).with(instance_of(some_job_class), expected_job_opts)
-        expect(enqueuer).to have_received(:enqueue)
+        expect(Jobs::Enqueuer).to have_received(:new).with(expected_job_opts)
+        expect(enqueuer).to have_received(:enqueue).with(instance_of(some_job_class))
       end
     end
 
@@ -127,8 +127,8 @@ module VCAP::CloudController
         clock.schedule_frequent_inline_job(**clock_opts) { some_job_class.new }
 
         expected_job_opts = { queue: job_name }
-        expect(Jobs::Enqueuer).to have_received(:new).with(instance_of(some_job_class), expected_job_opts)
-        expect(enqueuer).to have_received(:run_inline)
+        expect(Jobs::Enqueuer).to have_received(:new).with(expected_job_opts)
+        expect(enqueuer).to have_received(:run_inline).with(instance_of(some_job_class))
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/install_buildpacks_spec.rb
+++ b/spec/unit/lib/cloud_controller/install_buildpacks_spec.rb
@@ -99,10 +99,11 @@ module VCAP::CloudController
             it 'enqueues the rest of the buildpack install jobs' do
               allow(canary_job).to receive(:perform)
 
-              expect(Jobs::Enqueuer).to receive(:new).with(enqueued_job1, queue: 'cc-api-0').ordered.and_return(enqueuer)
-              expect(Jobs::Enqueuer).to receive(:new).with(enqueued_job2, queue: 'cc-api-0').ordered.and_return(enqueuer)
+              expect(Jobs::Enqueuer).to receive(:new).with(queue: 'cc-api-0').ordered.and_return(enqueuer)
+              expect(Jobs::Enqueuer).to receive(:new).with(queue: 'cc-api-0').ordered.and_return(enqueuer)
 
-              expect(enqueuer).to receive(:enqueue).twice
+              expect(enqueuer).to receive(:enqueue).with(enqueued_job1).once
+              expect(enqueuer).to receive(:enqueue).with(enqueued_job2).once
 
               installer.install(TestConfig.config_instance.get(:install_buildpacks))
             end

--- a/spec/unit/lib/delayed_job_plugins/deserialization_retry_spec.rb
+++ b/spec/unit/lib/delayed_job_plugins/deserialization_retry_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DeserializationRetry do
   context 'when a Delayed::Job fails to load because the class is missing' do
     it 'prevents DelayedJob from marking it as failed' do
       handler = VCAP::CloudController::Jobs::Runtime::EventsCleanup.new(10_000)
-      VCAP::CloudController::Jobs::Enqueuer.new(handler).enqueue
+      VCAP::CloudController::Jobs::Enqueuer.new.enqueue(handler)
 
       job = Delayed::Job.last
       job.update handler: job.handler.gsub('EventsCleanup', 'Dan')
@@ -37,7 +37,7 @@ RSpec.describe DeserializationRetry do
     context 'and we have been retrying for more than 24 hours' do
       it 'stops retrying the job' do
         handler = VCAP::CloudController::Jobs::Runtime::EventsCleanup.new(10_000)
-        VCAP::CloudController::Jobs::Enqueuer.new(handler).enqueue
+        VCAP::CloudController::Jobs::Enqueuer.new.enqueue(handler)
 
         job = Delayed::Job.last
         job.update handler: job.handler.gsub('EventsCleanup', 'Dan'), created_at: Delayed::Job.db_time_now - 24.hours - 1.second
@@ -53,7 +53,7 @@ RSpec.describe DeserializationRetry do
   context 'when a Delayed::Job fails to load because of another reason' do
     it 'allows the job to be marked as failed' do
       handler = VCAP::CloudController::Jobs::Runtime::EventsCleanup.new(10_000)
-      VCAP::CloudController::Jobs::Enqueuer.new(handler).enqueue
+      VCAP::CloudController::Jobs::Enqueuer.new.enqueue(handler)
 
       job = Delayed::Job.last
       job.update handler: 'Dan'
@@ -66,7 +66,7 @@ RSpec.describe DeserializationRetry do
   context 'when the Delayed::Job is well formed' do
     it 'executes the job' do
       handler = VCAP::CloudController::Jobs::Runtime::EventsCleanup.new(10_000)
-      VCAP::CloudController::Jobs::Enqueuer.new(handler).enqueue
+      VCAP::CloudController::Jobs::Enqueuer.new.enqueue(handler)
 
       execute_all_jobs(expected_successes: 1, expected_failures: 0)
     end
@@ -80,7 +80,7 @@ RSpec.describe DeserializationRetry do
 
       it 'does not retry' do
         handler = BoomJob.new
-        VCAP::CloudController::Jobs::Enqueuer.new(handler).enqueue
+        VCAP::CloudController::Jobs::Enqueuer.new.enqueue(handler)
 
         job = Delayed::Job.last
         old_run_at = job.run_at

--- a/spec/unit/lib/services/service_brokers/v2/orphan_mitigator_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/orphan_mitigator_spec.rb
@@ -17,16 +17,16 @@ module VCAP::Services
 
           OrphanMitigator.new.cleanup_failed_provision(service_instance)
 
-          expect(VCAP::CloudController::Jobs::Enqueuer).to have_received(:new) do |job, opts|
+          expect(VCAP::CloudController::Jobs::Enqueuer).to have_received(:new) do |opts|
             expect(opts[:queue]).to eq VCAP::CloudController::Jobs::Queues.generic
+          end
 
+          expect(mock_enqueuer).to have_received(:enqueue) do |job|
             expect(job).to be_a VCAP::CloudController::Jobs::Services::DeleteOrphanedInstance
             expect(job.name).to eq 'service-instance-deprovision'
             expect(job.service_instance_guid).to eq service_instance.guid
             expect(job.service_plan_guid).to eq service_instance.service_plan.guid
           end
-
-          expect(mock_enqueuer).to have_received(:enqueue)
         end
 
         specify 'the enqueued job has a reschedule_at define such that exponential backoff occurs' do
@@ -52,16 +52,16 @@ module VCAP::Services
           end
 
           it 'enqueues an unbind job' do
-            expect(VCAP::CloudController::Jobs::Enqueuer).to have_received(:new) do |job, opts|
+            expect(VCAP::CloudController::Jobs::Enqueuer).to have_received(:new) do |opts|
               expect(opts[:queue]).to eq VCAP::CloudController::Jobs::Queues.generic
+            end
 
+            expect(mock_enqueuer).to have_received(:enqueue) do |job|
               expect(job).to be_a VCAP::CloudController::Jobs::Services::DeleteOrphanedBinding
               expect(job.name).to eq 'service-instance-unbind'
               expect(job.binding_info.guid).to eq binding.guid
               expect(job.binding_info.service_instance_guid).to eq binding.service_instance.guid
             end
-
-            expect(mock_enqueuer).to have_received(:enqueue)
           end
         end
 
@@ -97,16 +97,16 @@ module VCAP::Services
 
           OrphanMitigator.new.cleanup_failed_key(service_key)
 
-          expect(VCAP::CloudController::Jobs::Enqueuer).to have_received(:new) do |job, opts|
+          expect(VCAP::CloudController::Jobs::Enqueuer).to have_received(:new) do |opts|
             expect(opts[:queue]).to eq VCAP::CloudController::Jobs::Queues.generic
+          end
 
+          expect(mock_enqueuer).to have_received(:enqueue) do |job|
             expect(job).to be_a VCAP::CloudController::Jobs::Services::DeleteOrphanedKey
             expect(job.name).to eq 'service-key-delete'
             expect(job.key_guid).to eq service_key.guid
             expect(job.service_instance_guid).to eq service_key.service_instance.guid
           end
-
-          expect(mock_enqueuer).to have_received(:enqueue)
         end
 
         specify 'the enqueued job has a reschedule_at define such that exponential backoff occurs' do


### PR DESCRIPTION
Refactor enqueuer so that it can enqueue multiple jobs with the same instance.
This will allow in the future to e.g. pass down an enqueuer instance to ensure consistent priorities.

Instead of providing a job in `initialize` it will be provided in `enqueue(job)`, `enqueue_pollable(job)`, or `run_inline(job)`:

```ruby
class Enqueuer
      def initialize(opts={})
        @opts = opts
        @timeout_calculator = JobTimeoutCalculator.new(VCAP::CloudController::Config.config)
        @priority_overwriter = JobPriorityOverwriter.new(VCAP::CloudController::Config.config)
        load_delayed_job_plugins
      end

      def enqueue(job)
        enqueue_job(job)
      end

      def enqueue_pollable(job, existing_guid: nil)
        wrapped_job = PollableJobWrapper.new(job, existing_guid:)

        wrapped_job = yield wrapped_job if block_given?

        delayed_job = enqueue_job(wrapped_job)
        PollableJobModel.find_by_delayed_job(delayed_job)
      end

      def run_inline(job)
        run_immediately do
          Delayed::Job.enqueue(TimeoutJob.new(job, job_timeout(job)), @opts)
        end
      end



```


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
