### PR TITLE
Log service plan visibility on create or update service instances

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -435,7 +435,7 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def service_plan_not_visible_to_user!(service_plan)
     user = VCAP::CloudController::SecurityContext.current_user
-    logger.info("Service Plan with guid '#{service_plan.guid}' and id '#{service_plan.id}' is not visible in current org to user with guid '#{user.guid}'.")
+    logger.info("Service Plan with guid '#{service_plan.guid}' and id '#{service_plan.id}' is not visible to user with guid '#{user.guid}'.")
 
     unprocessable!('Invalid service plan. Ensure that the service plan exists, is available, and you have access to it.')
   end

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -254,8 +254,8 @@ class ServiceInstancesV3Controller < ApplicationController
 
   def create_managed(message, space:)
     service_plan = ServicePlan.first(guid: message.service_plan_guid)
-    log_service_plan_visibility(service_plan)
-    unprocessable_service_plan! unless service_plan_valid?(service_plan)
+    service_plan_does_not_exist! unless service_plan
+    service_plan_not_visible_to_user!(service_plan) unless visible_to_current_user?(plan: service_plan)
     unavailable_service_plan!(service_plan) unless service_plan_active?(service_plan)
     service_plan_not_visible_in_space!(service_plan, space) unless service_plan_exists_in_space?(service_plan, space)
 
@@ -397,11 +397,6 @@ class ServiceInstancesV3Controller < ApplicationController
     permission_queryer.can_write_globally?
   end
 
-  def service_plan_valid?(service_plan)
-    service_plan &&
-      visible_to_current_user?(plan: service_plan)
-  end
-
   def service_plan_active?(service_plan)
     service_plan.active?
   end
@@ -414,8 +409,8 @@ class ServiceInstancesV3Controller < ApplicationController
     return unless message.service_plan_guid
 
     service_plan = ServicePlan.first(guid: message.service_plan_guid)
-    log_service_plan_visibility(service_plan)
-    unprocessable_service_plan! unless service_plan_valid?(service_plan)
+    service_plan_does_not_exist! unless service_plan
+    service_plan_not_visible_to_user!(service_plan) unless visible_to_current_user?(plan: service_plan)
     unavailable_service_plan!(service_plan) unless service_plan_active?(service_plan)
     service_plan_not_visible_in_space!(service_plan, service_instance.space) unless service_plan_exists_in_space?(service_plan, service_instance.space)
     invalid_service_plan_relation! unless service_plan.service == service_instance.service
@@ -433,7 +428,15 @@ class ServiceInstancesV3Controller < ApplicationController
     unprocessable!('Invalid space. Ensure that the space exists and you have access to it.')
   end
 
-  def unprocessable_service_plan!
+  def service_plan_does_not_exist!
+    logger.info('Service Plan does not exist.')
+    unprocessable!('Invalid service plan. Ensure that the service plan exists, is available, and you have access to it.')
+  end
+
+  def service_plan_not_visible_to_user!(service_plan)
+    user = VCAP::CloudController::SecurityContext.current_user
+    logger.info("Service Plan with guid '#{service_plan.guid}' and id '#{service_plan.id}' is not visible in current org to user with guid '#{user.guid}'.")
+
     unprocessable!('Invalid service plan. Ensure that the service plan exists, is available, and you have access to it.')
   end
 

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -467,16 +467,4 @@ class ServiceInstancesV3Controller < ApplicationController
   def logger
     @logger ||= Steno.logger('cc.api')
   end
-
-  def log_service_plan_visibility(service_plan)
-    unless service_plan
-      logger.info('Service Plan does not exist.')
-      return
-    end
-
-    return if visible_to_current_user?(plan: service_plan)
-
-    user = VCAP::CloudController::SecurityContext.current_user
-    logger.info("Service Plan with guid '#{service_plan.guid}' and id '#{service_plan.id}' is not visible in current org to user with guid '#{user.guid}'.")
-  end
 end


### PR DESCRIPTION
Enhancement of https://github.com/cloudfoundry/cloud_controller_ng/pull/4230.

For case 1 and 2 a log info is additionally added to have it easier to find the root cause when users get 422 CF-UnprocessableEntity error. Due to security reasons, this is just added as log info and not as error message.


* An explanation of the use cases your change solves
Make it easier to find the root cause when users get 422 CF-UnprocessableEntity error
* Links to any other associated PRs
#4213
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
