### PR TITLE
delayed_jobs lock_with_read_ahead for postgres

### DIFF
--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -352,6 +352,7 @@ module VCAP::CloudController
               queues: {
                 optional(:cc_generic) => { timeout_in_seconds: Integer }
               },
+              optional(:read_ahead) => Integer,
               optional(:enable_dynamic_job_priorities) => bool,
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },

--- a/lib/cloud_controller/config_schemas/base/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/clock_schema.rb
@@ -174,6 +174,7 @@ module VCAP::CloudController
             allow_app_ssh_access: bool,
             jobs: {
               global: { timeout_in_seconds: Integer },
+              optional(:read_ahead) => Integer,
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },
               optional(:diego_sync) => { timeout_in_seconds: Integer },

--- a/lib/cloud_controller/config_schemas/base/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/worker_schema.rb
@@ -175,6 +175,7 @@ module VCAP::CloudController
               queues: {
                 optional(:cc_generic) => { timeout_in_seconds: Integer }
               },
+              optional(:read_ahead) => Integer,
               optional(:enable_dynamic_job_priorities) => bool,
               optional(:app_usage_events_cleanup) => { timeout_in_seconds: Integer },
               optional(:blobstore_delete) => { timeout_in_seconds: Integer },

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -85,6 +85,8 @@ module VCAP::CloudController
 
       require 'models'
       require 'delayed_job_sequel'
+      # load monkey patch for sequel backend to support configurable job lock method (postgres only)
+      require 'delayed_job/sequel_patch'
     end
 
     def self.load_models_without_migrations_check(db_config, logger)
@@ -92,6 +94,8 @@ module VCAP::CloudController
 
       require 'models'
       require 'delayed_job_sequel'
+      # load monkey patch for sequel backend to support configurable job lock method (postgres only)
+      require 'delayed_job/sequel_patch'
     end
   end
 end

--- a/lib/delayed_job/sequel_patch.rb
+++ b/lib/delayed_job/sequel_patch.rb
@@ -1,0 +1,25 @@
+require 'delayed/backend/sequel'
+
+module Delayed
+  module Backend
+    module Sequel
+      class Job
+        # monkey patch to allow explicit configuration of job lock method
+        def self.reserve(worker, max_run_time=Worker.max_run_time)
+          ds = ready_to_run(worker.name, max_run_time)
+
+          ds = ds.filter(::Sequel.lit('priority >= ?', Worker.min_priority)) if Worker.min_priority
+          ds = ds.filter(::Sequel.lit('priority <= ?', Worker.max_priority)) if Worker.max_priority
+          ds = ds.filter(queue: Worker.queues) if Worker.queues.any?
+          ds = ds.by_priority
+
+          if Worker.read_ahead > 0
+            lock_with_read_ahead(ds, worker)
+          else
+            lock_with_for_update(ds, worker)
+          end
+        end
+      end
+    end
+  end
+end

--- a/scripts/generate_jobs.rb
+++ b/scripts/generate_jobs.rb
@@ -1,0 +1,16 @@
+# usage: pipe this script into bin/console on a cc-worker vm
+
+begin
+  NUM_JOBS = 1
+  DELAY = 1
+
+  puts "Generating #{NUM_JOBS} dummy job(s) with delay of #{DELAY} seconds"
+  enqueuer = VCAP::CloudController::Jobs::Enqueuer.new(queue: VCAP::CloudController::Jobs::Queues.generic)
+  start_time = Time.now
+  NUM_JOBS.times do
+    dummy_job = VCAP::CloudController::Jobs::Runtime::BlobstoreDelete.new('00000000-0000-0000-0000-000000000000/0000000000000000000000000000000000000000', :droplet_blobstore)
+    enqueuer.enqueue(dummy_job)
+    sleep DELAY
+  end
+  puts "Generated #{NUM_JOBS} dummy job(s) in #{Time.now - start_time} seconds"
+end

--- a/spec/unit/lib/delayed_job/sequel_patch_spec.rb
+++ b/spec/unit/lib/delayed_job/sequel_patch_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe 'sequel_patch' do
+  describe 'version' do
+    it 'is not updated' do
+      expect(Gem.loaded_specs['talentbox-delayed_job_sequel'].version).to eq('4.3.0'),
+                                                                          'revisit monkey patch in lib/delayed_job/sequel_patch.rb'
+    end
+  end
+end


### PR DESCRIPTION
### A short explanation of the proposed change:

- monkey patch for delayed_jobs to allow configurable lock method
- config via jobs.read_ahead (number of jobs to read)
  - postgres default = 0 (use lock_with_for_update)
  - mysql default = 5 (use lock_with_read_ahead)
- jobs.read_ahead = 0: lock_with_for_update = lock jobs using SELECT FOR UPDATE
- jobs.read_ahead > 0: lock_with_read_ahead = optimistic locking of jobs
- add rake task generate_load to create jobs

### An explanation of the use cases your change solves

Using lock_with_for_update showed severe performance problems on postgres when there is a high number of jobs in the queue (>50k). Job processing starves due to row locks and temp IO gets high.
lock_with_read_ahead performs much better under such load situations.

Performance on low/normal job load is comparable.

### Checklist

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
