### PR TITLE
Add GenericEnqueuer for consistent job priorities

### DIFF
--- a/app/actions/app_delete.rb
+++ b/app/actions/app_delete.rb
@@ -97,7 +97,7 @@ module VCAP::CloudController
 
     def delete_buildpack_cache(app)
       delete_job = Jobs::V3::BuildpackCacheDelete.new(app.guid)
-      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(delete_job)
+      Jobs::GenericEnqueuer.shared.enqueue(delete_job, priority_increment: Jobs::REDUCED_PRIORITY)
     end
 
     def logger

--- a/app/actions/buildpack_delete.rb
+++ b/app/actions/buildpack_delete.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController
         end
         if buildpack.key
           blobstore_delete = Jobs::Runtime::BlobstoreDelete.new(buildpack.key, :buildpack_blobstore)
-          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(blobstore_delete)
+          Jobs::GenericEnqueuer.shared.enqueue(blobstore_delete, priority_increment: Jobs::REDUCED_PRIORITY)
         end
       end
 

--- a/app/actions/droplet_copy.rb
+++ b/app/actions/droplet_copy.rb
@@ -60,7 +60,7 @@ module VCAP::CloudController
       new_droplet.buildpack_lifecycle_data(reload: true)
 
       copy_job = Jobs::V3::DropletBitsCopier.new(@source_droplet.guid, new_droplet.guid)
-      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(copy_job)
+      Jobs::GenericEnqueuer.shared.enqueue(copy_job)
     end
   end
 end

--- a/app/actions/droplet_delete.rb
+++ b/app/actions/droplet_delete.rb
@@ -16,7 +16,7 @@ module VCAP::CloudController
 
         if droplet.blobstore_key
           blobstore_delete = Jobs::Runtime::BlobstoreDelete.new(droplet.blobstore_key, :droplet_blobstore)
-          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(blobstore_delete)
+          Jobs::GenericEnqueuer.shared.enqueue(blobstore_delete, priority_increment: Jobs::REDUCED_PRIORITY)
         end
 
         Repositories::DropletEventRepository.record_delete(

--- a/app/actions/mixins/bindings_delete.rb
+++ b/app/actions/mixins/bindings_delete.rb
@@ -1,5 +1,6 @@
 require 'jobs/queues'
 require 'jobs/enqueuer'
+require 'jobs/generic_enqueuer'
 require 'jobs/v3/delete_binding_job'
 require 'jobs/v3/delete_service_binding_job_factory'
 
@@ -19,7 +20,7 @@ module VCAP::CloudController
           result = binding_delete_action.delete(binding)
           unless result[:finished]
             polling_job = DeleteBindingJob.new(type, binding.guid, user_audit_info:)
-            Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(polling_job)
+            Jobs::GenericEnqueuer.shared.enqueue_pollable(polling_job)
             unbinding_operation_in_progress!(binding)
           end
         rescue StandardError => e

--- a/app/actions/package_copy.rb
+++ b/app/actions/package_copy.rb
@@ -20,7 +20,7 @@ module VCAP::CloudController
       package.db.transaction do
         package.save
 
-        @enqueued_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::V3::PackageBitsCopier.new(source_package.guid, package.guid)) if source_package.type == 'bits'
+        @enqueued_job = Jobs::GenericEnqueuer.shared.enqueue(Jobs::V3::PackageBitsCopier.new(source_package.guid, package.guid)) if source_package.type == 'bits'
 
         record_audit_event(package, source_package, user_audit_info) if record_event
       end

--- a/app/actions/package_delete.rb
+++ b/app/actions/package_delete.rb
@@ -1,3 +1,5 @@
+require 'jobs/generic_enqueuer'
+
 module VCAP::CloudController
   class PackageDelete
     def initialize(user_audit_info)
@@ -10,7 +12,7 @@ module VCAP::CloudController
       packages.each do |package|
         unless package.docker?
           package_src_delete_job = create_package_source_deletion_job(package)
-          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(package_src_delete_job) if package_src_delete_job
+          Jobs::GenericEnqueuer.shared.enqueue(package_src_delete_job, priority_increment: Jobs::REDUCED_PRIORITY) if package_src_delete_job
         end
 
         package.destroy

--- a/app/actions/routing/route_delete.rb
+++ b/app/actions/routing/route_delete.rb
@@ -15,7 +15,7 @@ module VCAP::CloudController
     end
 
     def delete_async(route:, recursive:)
-      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(do_delete(recursive, route))
+      Jobs::GenericEnqueuer.shared.enqueue(do_delete(recursive, route))
     end
 
     def delete_unmapped_route(route:)

--- a/app/actions/service_broker_create.rb
+++ b/app/actions/service_broker_create.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
           service_event_repository.record_broker_event_with_request(:create, broker, message.audit_hash)
 
           synchronization_job = SynchronizeBrokerCatalogJob.new(broker.guid, user_audit_info: service_event_repository.user_audit_info)
-          pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(synchronization_job)
+          pollable_job = Jobs::GenericEnqueuer.shared.enqueue_pollable(synchronization_job)
         end
 
         { pollable_job: }

--- a/app/actions/services/locks/deleter_lock.rb
+++ b/app/actions/services/locks/deleter_lock.rb
@@ -49,7 +49,7 @@ module VCAP::CloudController
 
     def enqueue_and_unlock!(attributes_to_update, job)
       service_instance.save_and_update_operation(attributes_to_update)
-      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
+      Jobs::GenericEnqueuer.shared.enqueue(job)
       @needs_unlock = false
     end
 

--- a/app/actions/services/locks/updater_lock.rb
+++ b/app/actions/services/locks/updater_lock.rb
@@ -47,7 +47,7 @@ module VCAP::CloudController
     end
 
     def enqueue_unlock!(job)
-      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
+      Jobs::GenericEnqueuer.shared.enqueue(job)
       @needs_unlock = false
     end
 

--- a/app/actions/services/service_instance_create.rb
+++ b/app/actions/services/service_instance_create.rb
@@ -48,7 +48,7 @@ module VCAP::CloudController
         @services_event_repository.user_audit_info,
         request_attrs
       )
-      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
+      Jobs::GenericEnqueuer.shared.enqueue(job)
       @services_event_repository.record_service_instance_event(:start_create, service_instance, request_attrs)
     end
 

--- a/app/actions/space_delete.rb
+++ b/app/actions/space_delete.rb
@@ -56,7 +56,7 @@ module VCAP::CloudController
         result = service_instance_deleter.delete
         unless result[:finished]
           polling_job = V3::DeleteServiceInstanceJob.new(service_instance.guid, @services_event_repository.user_audit_info)
-          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(polling_job)
+          Jobs::GenericEnqueuer.shared.enqueue_pollable(polling_job)
           errors << CloudController::Errors::ApiError.new_from_details('AsyncServiceInstanceOperationInProgress', service_instance.name)
         end
       rescue StandardError => e

--- a/app/actions/v2/services/service_binding_create.rb
+++ b/app/actions/v2/services/service_binding_create.rb
@@ -52,7 +52,7 @@ module VCAP::CloudController
 
           binding.save_with_new_operation({ type: 'create', state: 'in progress', broker_provided_operation: binding_result[:operation] })
           job = Jobs::Services::ServiceBindingStateFetch.new(binding.guid, @user_audit_info, message.audit_hash)
-          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
+          Jobs::GenericEnqueuer.shared.enqueue(job)
           Repositories::ServiceBindingEventRepository.record_start_create(binding, @user_audit_info, message.audit_hash, manifest_triggered: @manifest_triggered)
         else
           binding.save

--- a/app/actions/v2/services/service_binding_delete.rb
+++ b/app/actions/v2/services/service_binding_delete.rb
@@ -19,7 +19,7 @@ module VCAP::CloudController
     end
 
     def background_delete_request(service_binding)
-      Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::DeleteActionJob.new(ServiceBinding, service_binding.guid, self))
+      Jobs::GenericEnqueuer.shared.enqueue(Jobs::DeleteActionJob.new(ServiceBinding, service_binding.guid, self))
     end
 
     def delete(service_bindings)
@@ -39,7 +39,7 @@ module VCAP::CloudController
           service_binding.save_with_new_operation({ type: 'delete', state: 'in progress', broker_provided_operation: broker_response[:operation] })
 
           job = VCAP::CloudController::Jobs::Services::ServiceBindingStateFetch.new(service_binding.guid, @user_audit_info, {})
-          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(job)
+          Jobs::GenericEnqueuer.shared.enqueue(job)
           Repositories::ServiceBindingEventRepository.record_start_delete(service_binding, @user_audit_info)
         else
           service_binding.destroy

--- a/app/actions/v3/service_broker_update.rb
+++ b/app/actions/v3/service_broker_update.rb
@@ -58,7 +58,7 @@ module VCAP::CloudController
             previous_broker_state,
             user_audit_info: service_event_repository.user_audit_info
           )
-          pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(synchronization_job)
+          pollable_job = Jobs::GenericEnqueuer.shared.enqueue_pollable(synchronization_job)
         end
 
         pollable_job

--- a/app/actions/v3/service_instance_update_managed.rb
+++ b/app/actions/v3/service_instance_update_managed.rb
@@ -83,7 +83,7 @@ module VCAP::CloudController
             user_audit_info: user_audit_info,
             audit_hash: message.audit_hash
           )
-          pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(update_job)
+          pollable_job = Jobs::GenericEnqueuer.shared.enqueue_pollable(update_job)
           lock.asynchronous_unlock!
         ensure
           lock.unlock_and_fail! if lock.present? && lock.needs_unlock?

--- a/app/jobs/cc_job.rb
+++ b/app/jobs/cc_job.rb
@@ -1,6 +1,14 @@
 module VCAP::CloudController
   module Jobs
     class CCJob
+      def before(delayed_job)
+        GenericEnqueuer.shared(priority: delayed_job.priority)
+      end
+
+      def after(_delayed_job)
+        GenericEnqueuer.reset!
+      end
+
       def reschedule_at(time, attempts)
         time + (attempts**4) + 5
       end

--- a/app/jobs/generic_enqueuer.rb
+++ b/app/jobs/generic_enqueuer.rb
@@ -1,0 +1,20 @@
+module VCAP::CloudController
+  module Jobs
+    REDUCED_PRIORITY = 50
+
+    class GenericEnqueuer < Enqueuer
+      def self.shared(priority: nil)
+        stored_instance = Thread.current[:generic_enqueuer]
+        return stored_instance if stored_instance && priority.nil?
+
+        new_instance = new(queue: Jobs::Queues.generic, priority: priority)
+        Thread.current[:generic_enqueuer] ||= new_instance
+        new_instance
+      end
+
+      def self.reset!
+        Thread.current[:generic_enqueuer] = nil
+      end
+    end
+  end
+end

--- a/app/jobs/reoccurring_job.rb
+++ b/app/jobs/reoccurring_job.rb
@@ -13,7 +13,7 @@ module VCAP::CloudController
         elsif next_enqueue_would_exceed_maximum_duration?
           expire!
         else
-          enqueue_next_job(pollable_job, current_delayed_job.priority)
+          enqueue_next_job(pollable_job)
         end
       end
 
@@ -75,15 +75,10 @@ module VCAP::CloudController
         raise CloudController::Errors::ApiError.new_from_details('JobTimeout')
       end
 
-      def enqueue_next_job(pollable_job, priority)
-        opts = {
-          queue: Jobs::Queues.generic,
-          run_at: Delayed::Job.db_time_now + next_execution_in,
-          priority: priority
-        }
-
+      def enqueue_next_job(pollable_job)
+        run_at = Delayed::Job.db_time_now + next_execution_in
         @retry_number += 1
-        Jobs::Enqueuer.new(opts).enqueue_pollable(self, existing_guid: pollable_job.guid)
+        Jobs::GenericEnqueuer.shared.enqueue_pollable(self, existing_guid: pollable_job.guid, run_at: run_at, preserve_priority: true)
       end
     end
   end

--- a/app/jobs/runtime/expired_blob_cleanup.rb
+++ b/app/jobs/runtime/expired_blob_cleanup.rb
@@ -23,11 +23,11 @@ module VCAP::CloudController
         end
 
         def enqueue_droplet_delete_job(droplet_guid)
-          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::Runtime::DeleteExpiredDropletBlob.new(droplet_guid))
+          Jobs::GenericEnqueuer.shared.enqueue(Jobs::Runtime::DeleteExpiredDropletBlob.new(droplet_guid))
         end
 
         def enqueue_package_delete_job(package_guid)
-          Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue(Jobs::Runtime::DeleteExpiredPackageBlob.new(package_guid))
+          Jobs::GenericEnqueuer.shared.enqueue(Jobs::Runtime::DeleteExpiredPackageBlob.new(package_guid))
         end
 
         def logger

--- a/app/jobs/v2/services/asynchronous_operations.rb
+++ b/app/jobs/v2/services/asynchronous_operations.rb
@@ -23,9 +23,9 @@ module VCAP::CloudController
         end
 
         def enqueue_again
-          opts = { queue: Jobs::Queues.generic, run_at: Delayed::Job.db_time_now + next_execution_in }
+          run_at_time = Delayed::Job.db_time_now + next_execution_in
           self.retry_number += 1
-          Jobs::Enqueuer.new(opts).enqueue(self)
+          Jobs::GenericEnqueuer.shared.enqueue(self, run_at: run_at_time)
         end
 
         def default_polling_exponential_backoff

--- a/lib/services/service_brokers/v2/orphan_mitigator.rb
+++ b/lib/services/service_brokers/v2/orphan_mitigator.rb
@@ -13,8 +13,7 @@ module VCAP::Services
             service_instance.service_plan.guid
           )
 
-          opts = { queue: VCAP::CloudController::Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }
-          VCAP::CloudController::Jobs::Enqueuer.new(opts).enqueue(orphan_deprovision_job)
+          VCAP::CloudController::Jobs::GenericEnqueuer.shared.enqueue(orphan_deprovision_job, run_at: Delayed::Job.db_time_now)
         end
 
         def cleanup_failed_bind(service_binding)
@@ -24,8 +23,7 @@ module VCAP::Services
             binding_info
           )
 
-          opts = { queue: VCAP::CloudController::Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }
-          VCAP::CloudController::Jobs::Enqueuer.new(opts).enqueue(unbind_job)
+          VCAP::CloudController::Jobs::GenericEnqueuer.shared.enqueue(unbind_job, run_at: Delayed::Job.db_time_now)
         end
 
         def cleanup_failed_key(service_key)
@@ -35,8 +33,7 @@ module VCAP::Services
             service_key.service_instance.guid
           )
 
-          opts = { queue: VCAP::CloudController::Jobs::Queues.generic, run_at: Delayed::Job.db_time_now }
-          VCAP::CloudController::Jobs::Enqueuer.new(opts).enqueue(key_delete_job)
+          VCAP::CloudController::Jobs::GenericEnqueuer.shared.enqueue(key_delete_job, run_at: Delayed::Job.db_time_now)
         end
       end
     end

--- a/spec/unit/actions/buildpack_delete_spec.rb
+++ b/spec/unit/actions/buildpack_delete_spec.rb
@@ -36,9 +36,9 @@ module VCAP::CloudController
         it 'first deletes the database record and afterwards the blob' do
           expect(buildpack).to receive(:destroy).ordered
           expect(Jobs::Runtime::BlobstoreDelete).to receive(:new).ordered
-          enqueue_job_dbl = double('Jobs::Enqueuer')
-          expect(Jobs::Enqueuer).to receive(:new).and_return(enqueue_job_dbl).ordered
-          expect(enqueue_job_dbl).to receive(:enqueue).ordered
+          generic_enqueuer_dbl = double('Jobs::GenericEnqueuer')
+          expect(Jobs::GenericEnqueuer).to receive(:shared).and_return(generic_enqueuer_dbl).ordered
+          expect(generic_enqueuer_dbl).to receive(:enqueue).ordered
 
           buildpack_delete.delete([buildpack])
         end

--- a/spec/unit/jobs/cc_job_spec.rb
+++ b/spec/unit/jobs/cc_job_spec.rb
@@ -3,12 +3,41 @@ require 'spec_helper'
 module VCAP::CloudController
   module Jobs
     RSpec.describe CCJob, job_context: :worker do
+      before { GenericEnqueuer.reset! } # Reset singleton instance to ensure clean tests
+
       describe '#reschedule_at' do
         it 'uses the default from Delayed::Job' do
           time = Time.now
           attempts = 5
           job = CCJob.new
           expect(job.reschedule_at(time, attempts)).to eq(time + (attempts**4) + 5)
+        end
+      end
+
+      describe '#before' do
+        class DummyDelayedJob
+          attr_reader :priority
+
+          def initialize(priority:)
+            @priority = priority
+          end
+        end
+
+        it 'creates a new GenericEnqueuer with the priority from the job' do
+          job = CCJob.new
+          job.before(DummyDelayedJob.new(priority: 5))
+          expect(Thread.current[:generic_enqueuer].instance_values['opts'][:priority]).to eq(5)
+        end
+      end
+
+      describe '#after' do
+        it 'resets the GenericEnqueuer' do
+          job = CCJob.new
+          expect(Thread.current[:generic_enqueuer]).to be_nil
+          job.before(DummyDelayedJob.new(priority: 5))
+          expect(Thread.current[:generic_enqueuer]).to be_a(GenericEnqueuer)
+          job.after(nil)
+          expect(Thread.current[:generic_enqueuer]).to be_nil
         end
       end
     end

--- a/spec/unit/jobs/generic_enqueuer_spec.rb
+++ b/spec/unit/jobs/generic_enqueuer_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'jobs/generic_enqueuer'
+require 'jobs/cc_job'
+
+module VCAP::CloudController::Jobs
+  RSpec.describe GenericEnqueuer do
+    let(:generic_enqueuer) { GenericEnqueuer }
+
+    class DummyPerformJob < VCAP::CloudController::Jobs::CCJob
+      def perform
+        # dummy
+      end
+    end
+
+    class DummyWrappingJob < VCAP::CloudController::Jobs::CCJob
+      def perform
+        sub_job = DummyPerformJob.new
+        GenericEnqueuer.shared.enqueue(sub_job)
+      end
+    end
+
+    before do
+      # Reset singleton instance to ensure clean tests
+      Thread.current[:generic_enqueuer] = nil
+    end
+
+    describe '.shared' do
+      it 'returns the same instance when called multiple times' do
+        enqueuer1 = generic_enqueuer.shared
+        enqueuer2 = generic_enqueuer.shared
+
+        expect(enqueuer1).to be(enqueuer2)
+      end
+
+      it 'creates a new instance if a priority is provided' do
+        enqueuer1 = generic_enqueuer.shared(priority: 5)
+        enqueuer2 = generic_enqueuer.shared(priority: 5)
+
+        expect(enqueuer1).not_to be(enqueuer2)
+      end
+
+      it 'returns a new instance without a priority (uses the default of Delayed::Job)' do
+        enqueuer = generic_enqueuer.shared
+        expect(enqueuer.instance_variable_get(:@opts)[:priority]).to be_nil
+      end
+
+      it 'ensures calling shared with a priority always returns a new instance' do
+        enqueuer_default = generic_enqueuer.shared
+        enqueuer_with_priority = generic_enqueuer.shared(priority: 5)
+
+        expect(enqueuer_default).not_to be(enqueuer_with_priority)
+      end
+    end
+
+    describe '#enqueue' do
+      let(:job) { DummyPerformJob.new }
+
+      it 'ensures a job with no priority explicitly set defaults to DelayedJob behavior' do
+        generic_enqueuer.shared.enqueue(job)
+
+        expect(Delayed::Job.count).to eq(1)
+        expect(Delayed::Job.first.priority).to eq(0)
+      end
+
+      it 'enqueues a job with the correct priority' do
+        generic_enqueuer.shared(priority: 4).enqueue(job)
+
+        expect(Delayed::Job.count).to eq(1)
+        expect(Delayed::Job.first.priority).to eq(4)
+      end
+    end
+
+    describe 'priority inheritance' do
+      it 'ensures the same GenericEnqueuer instance is used for sub-jobs' do
+        VCAP::CloudController::Jobs::GenericEnqueuer.shared(priority: 7).enqueue(DummyWrappingJob.new)
+        expect(Delayed::Job.count).to eq(1)
+        expect(Delayed::Job.first.priority).to eq(7)
+
+        execute_all_jobs(expected_successes: 1, expected_failures: 0, jobs_to_execute: 1)
+        expect(Delayed::Job.count).to eq(1)
+        expect(Delayed::Job.first.priority).to eq(7)
+      end
+    end
+  end
+end

--- a/spec/unit/jobs/reoccurring_job_spec.rb
+++ b/spec/unit/jobs/reoccurring_job_spec.rb
@@ -74,11 +74,11 @@ module VCAP
         TestConfig.config[:jobs][:priorities] = { 'fake-job': 20 }
 
         pollable_job = Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, priority: 22 }).enqueue_pollable(FakeJob.new)
-        expect(Delayed::Job.where(guid: PollableJobModel.first.delayed_job_guid).first[:priority]).to eq(22)
+        expect(Delayed::Job.where(guid: PollableJobModel.first.delayed_job_guid).first[:priority]).to eq(42)
 
         execute_all_jobs(expected_successes: 1, expected_failures: 0, jobs_to_execute: 1)
 
-        expect(Delayed::Job.where(guid: PollableJobModel.first.delayed_job_guid).first[:priority]).to eq(22)
+        expect(Delayed::Job.where(guid: PollableJobModel.first.delayed_job_guid).first[:priority]).to eq(42)
         expect(PollableJobModel.first.delayed_job_guid).not_to eq(pollable_job.delayed_job_guid)
       end
 

--- a/spec/unit/lib/services/service_brokers/v2/orphan_mitigator_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/orphan_mitigator_spec.rb
@@ -13,13 +13,11 @@ module VCAP::Services
       describe 'cleanup_failed_provision' do
         it 'enqueues a deprovison job' do
           mock_enqueuer = double(:enqueuer, enqueue: nil)
-          allow(VCAP::CloudController::Jobs::Enqueuer).to receive(:new).and_return(mock_enqueuer)
+          allow(VCAP::CloudController::Jobs::GenericEnqueuer).to receive(:shared).and_return(mock_enqueuer)
 
           OrphanMitigator.new.cleanup_failed_provision(service_instance)
 
-          expect(VCAP::CloudController::Jobs::Enqueuer).to have_received(:new) do |opts|
-            expect(opts[:queue]).to eq VCAP::CloudController::Jobs::Queues.generic
-          end
+          expect(VCAP::CloudController::Jobs::GenericEnqueuer).to have_received(:shared)
 
           expect(mock_enqueuer).to have_received(:enqueue) do |job|
             expect(job).to be_a VCAP::CloudController::Jobs::Services::DeleteOrphanedInstance
@@ -47,20 +45,20 @@ module VCAP::Services
           let(:mock_enqueuer) { double(:enqueuer, enqueue: nil) }
 
           before do
-            allow(VCAP::CloudController::Jobs::Enqueuer).to receive(:new).and_return(mock_enqueuer)
+            Timecop.freeze
+            allow(VCAP::CloudController::Jobs::GenericEnqueuer).to receive(:shared).and_return(mock_enqueuer)
             OrphanMitigator.new.cleanup_failed_bind(binding)
           end
 
           it 'enqueues an unbind job' do
-            expect(VCAP::CloudController::Jobs::Enqueuer).to have_received(:new) do |opts|
-              expect(opts[:queue]).to eq VCAP::CloudController::Jobs::Queues.generic
-            end
+            expect(VCAP::CloudController::Jobs::GenericEnqueuer).to have_received(:shared)
 
-            expect(mock_enqueuer).to have_received(:enqueue) do |job|
+            expect(mock_enqueuer).to have_received(:enqueue) do |job, run_at:|
               expect(job).to be_a VCAP::CloudController::Jobs::Services::DeleteOrphanedBinding
               expect(job.name).to eq 'service-instance-unbind'
               expect(job.binding_info.guid).to eq binding.guid
               expect(job.binding_info.service_instance_guid).to eq binding.service_instance.guid
+              expect(run_at).to eq Time.now
             end
           end
         end
@@ -93,19 +91,19 @@ module VCAP::Services
       describe 'cleanup_failed_key' do
         it 'enqueues an service_key_delete job' do
           mock_enqueuer = double(:enqueuer, enqueue: nil)
-          allow(VCAP::CloudController::Jobs::Enqueuer).to receive(:new).and_return(mock_enqueuer)
+          Timecop.freeze
+          allow(VCAP::CloudController::Jobs::GenericEnqueuer).to receive(:shared).and_return(mock_enqueuer)
 
           OrphanMitigator.new.cleanup_failed_key(service_key)
 
-          expect(VCAP::CloudController::Jobs::Enqueuer).to have_received(:new) do |opts|
-            expect(opts[:queue]).to eq VCAP::CloudController::Jobs::Queues.generic
-          end
+          expect(VCAP::CloudController::Jobs::GenericEnqueuer).to have_received(:shared)
 
-          expect(mock_enqueuer).to have_received(:enqueue) do |job|
+          expect(mock_enqueuer).to have_received(:enqueue) do |job, run_at:|
             expect(job).to be_a VCAP::CloudController::Jobs::Services::DeleteOrphanedKey
             expect(job.name).to eq 'service-key-delete'
             expect(job.key_guid).to eq service_key.guid
             expect(job.service_instance_guid).to eq service_key.service_instance.guid
+            expect(run_at).to eq Time.now
           end
         end
 


### PR DESCRIPTION
Some delayed jobs enqueue other delayed jobs. For example, an app delete job may enqueue secondary jobs like blobstore deletion and buildpack cache cleanup.
If CAPI is configured with dedicated job priorities or dynamic job priorities is enabled, these secondary jobs might unintentionally receive a higher priority than their primary job. This could lead to less critical jobs, like blobstore deletion, being processed before more critical ones, such as service instance creation.

This change introduces `GenericEnqueuer`, a singleton enqueuer ensuring that all jobs enqueued within the same job execution context inherit the same priority.
It is automatically initialized and destroyed within the CCJob wrapper, ensuring consistent priority propagation. Jobs can now be enqueued using:
`GenericEnqueuer.shared.enqueue(job)`

- **Priority Incrementation:**
  - `enqueue` and `enqueue_pollable` now support an optional `priority_increment` parameter.
  - This increases the priority value (making the job less important), allowing secondary jobs (e.g., blobstore deletion) to have a lower priority than their parent job.
- **Preserving Priority for Re-enqueued Jobs:**
  - The `preserve_priority` flag ensures that re-enqueued jobs retain their previous priority.
  - Prevents unnecessary priority increases on repeated executions.
- **Config Priority Handling:**
  - If a job has a dedicated priority configured, it is added to the current priority and `priority_increment`, ensuring correct propagation.

| Job Type               | Preserve Priority | Config Priority | Increment | Final Priority                       |
|------------------------|-------------------|-----------------|-----------|--------------------------------------|
| **Parent Job**         | ❌ No             | `100`           | `nil`     | **100**                              |
| **Sub-Job A**          | ❌ No             | `200`           | `50`      | **350** (100+200+50)                 |
| **Sub-Job B**          | ❌ No             | `nil`           | `50`      | **150** (100+50)                     |
| **Sub-Job C**          | ❌ No             | `nil`           | `nil`     | **100** (inherits parent)            |
| **Tertiary Job A1**    | ❌ No             | `50`            | `20`      | **420** (350+50+20)                  |
| **Tertiary Job B1**    | ✅ Yes            | `10` (ignored)  | `30`      | **150** (preserved from Sub-Job B)   |
| **Tertiary Job C1**    | ❌ No             | `nil`           | `50`      | **150** (100+50)                     |
| **Re-enqueued Job**    | ✅ Yes            | `20` (ignored)  | `100`     | **42** (original preserved priority) |

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
