### PR TITLE
Change timeout of backwards compatibility tests to 1h

### DIFF
--- a/.github/workflows/unit_tests_backwards_compatibility.yml
+++ b/.github/workflows/unit_tests_backwards_compatibility.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   Test-Postgres-Backwards-Compatibillity:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -80,7 +80,7 @@ jobs:
 
   Test-Mysql-Backwards-Compatibillity:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 3


### PR DESCRIPTION
* A short explanation of the proposed change:
Backwards compatibility tests have been timing out because of the limited resources on github action runners.
* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
