### PR TITLE
Fix quota issue when cancelling deployment

### DIFF
--- a/lib/cloud_controller/deployment_updater/actions/cancel.rb
+++ b/lib/cloud_controller/deployment_updater/actions/cancel.rb
@@ -21,9 +21,9 @@ module VCAP::CloudController
             prior_web_process = find_interim_web_process || app.oldest_web_process
             prior_web_process.lock!
 
-            prior_web_process.update(instances: deployment.original_web_process_instance_count)
-
             app.web_processes.reject { |p| p.guid == prior_web_process.guid }.map(&:destroy)
+
+            prior_web_process.update(instances: deployment.original_web_process_instance_count)
 
             deployment.update(
               state: DeploymentModel::CANCELED_STATE,


### PR DESCRIPTION
Ensure we do not hit a quota when cancelling a deployment by destroying the deployment web processes before restoring the originals. Since both these operations are handled by diego this reorder should not effect app availability.

We may want to improve this logic in the future to cancel more gracefully by ensuring app availability.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
