### PR TITLE
Don't assume a process with > 0 instances exists

### DIFF
--- a/lib/cloud_controller/deployment_updater/actions/scale.rb
+++ b/lib/cloud_controller/deployment_updater/actions/scale.rb
@@ -28,8 +28,7 @@ module VCAP::CloudController
 
             app.lock!
 
-            oldest_web_process_with_instances.lock!
-            deploying_web_process.lock!
+            app.web_processes.each(&:lock!)
 
             deployment.update(
               status_value: DeploymentModel::ACTIVE_STATUS_VALUE,
@@ -51,11 +50,6 @@ module VCAP::CloudController
         end
 
         private
-
-        def oldest_web_process_with_instances
-          # TODO: lock all web processes?  We might alter all of them, depending on max-in-flight size
-          @oldest_web_process_with_instances ||= app.web_processes.select { |process| process.instances > 0 }.min_by { |p| [p.created_at, p.id] }
-        end
 
         def instance_count_summary
           @instance_count_summary ||= instance_reporters.instance_count_summary(deploying_web_process)

--- a/spec/unit/lib/cloud_controller/deployment_updater/actions/scale_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/actions/scale_spec.rb
@@ -89,6 +89,15 @@ module VCAP::CloudController
       }.by(1)
     end
 
+    context 'when the app has been scaled to 0 instances' do
+      let(:current_web_instances) { 0 }
+      let(:target_total_instance_count) { 0 }
+
+      it 'finishes scaling' do
+        expect(subject.call).to be true
+      end
+    end
+
     context 'when the max_in_flight is set to 2' do
       let(:deployment) do
         DeploymentModel.make(


### PR DESCRIPTION
* also lock all web_processes for an app during a scaling action

Resolves https://github.com/cloudfoundry/cloud_controller_ng/issues/4250

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
