### PR TITLE
Bump postgres version in gh workflows

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["postgres:10", "postgres:11", "postgres:16"]
+        image: ["postgres:13", "postgres:15", "postgres:16"]
     services:
       postgres:
         image: ${{ matrix.image }}

--- a/.github/workflows/unit_tests_backwards_compatibility.yml
+++ b/.github/workflows/unit_tests_backwards_compatibility.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        image: ["postgres:10", "postgres:11", "postgres:16"]
+        image: ["postgres:13", "postgres:15", "postgres:16"]
     services:
       postgres:
         image: ${{ matrix.image }}


### PR DESCRIPTION
PostgreSQL v10 and v11 already reached there EOL: https://www.postgresql.org/support/versioning/


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
