### PR TITLE
Fix migration test for MariaDB version used in CAPI pipeline

### DIFF
--- a/spec/migrations/20250225132929_add_apps_file_based_service_binding_feature_columns_spec.rb
+++ b/spec/migrations/20250225132929_add_apps_file_based_service_binding_feature_columns_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'migration to add file-based service binding feature columns to a
           it 'forbids setting both features to true' do
             run_migration
             expect { db[:apps].insert(guid: 'some_app', file_based_vcap_services_enabled: true, service_binding_k8s_enabled: true) }.to(raise_error do |error|
-              expect(error.inspect).to include('only_one_sb_feature_enabled', 'violate')
+              expect(error.inspect).to include('only_one_sb_feature_enabled')
             end)
           end
 


### PR DESCRIPTION
### A short explanation of the proposed change:
MySQL version used to run unit tests in concourse is different from the ones used in GH Actions. Error message is different in that MySQL version. Making test more generic.

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
