### PR TITLE
Fix flaky stager test

### DIFF
--- a/spec/unit/lib/cloud_controller/diego/stager_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/stager_spec.rb
@@ -114,7 +114,7 @@ module VCAP::CloudController
                       'package_guid' => package.guid,
                       'staging_guid' => build.guid,
                       'error' => 'something is very wrong',
-                      'backtrace' => array_including(/and_raise/)
+                      'backtrace' => array_including(/send_stage_package_request/)
                     }
                   )
                 )


### PR DESCRIPTION
### A short explanation of the proposed change:
This test fails regularly in the GitHub actions. Not sure this change solves the problem, but checking for `and_raise` does not seem to be semantically correct, because this comes from the Mock. Checking for the tested method to be present in the backtrace makes more sense.

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
