### PR TITLE
Ensure generic enqueuer is reset correctly 

### DIFF
--- a/spec/unit/jobs/generic_enqueuer_spec.rb
+++ b/spec/unit/jobs/generic_enqueuer_spec.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController::Jobs
 
     before do
       # Reset singleton instance to ensure clean tests
-      Thread.current[:generic_enqueuer] = nil
+      GenericEnqueuer.reset!
     end
 
     describe '.shared' do

--- a/spec/unit/jobs/reoccurring_job_spec.rb
+++ b/spec/unit/jobs/reoccurring_job_spec.rb
@@ -73,6 +73,8 @@ module VCAP
       it 'keeps the delayed job\'s priority when re-enqueuing' do
         TestConfig.config[:jobs][:priorities] = { 'fake-job': 20 }
 
+        Jobs::GenericEnqueuer.reset! # Ensure no previous state interferes
+
         pollable_job = Jobs::Enqueuer.new({ queue: Jobs::Queues.generic, priority: 22 }).enqueue_pollable(FakeJob.new)
         expect(Delayed::Job.where(guid: PollableJobModel.first.delayed_job_guid).first[:priority]).to eq(42)
 


### PR DESCRIPTION
Ensure generic enqueuer is reset correctly. This avoids flaky tests when running tests in parallel.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
