### PR TITLE
Ensure asg-latest-update is renewed with microsecond precision even in mysql

### DIFF
--- a/app/models/runtime/asg_latest_update.rb
+++ b/app/models/runtime/asg_latest_update.rb
@@ -8,9 +8,9 @@ module VCAP::CloudController
     def self.renew
       old_update = AsgTimestamp.first
       if old_update
-        old_update.update(last_update: Sequel::CURRENT_TIMESTAMP)
+        old_update.update(last_update: Time.now.utc)
       else
-        AsgTimestamp.create(last_update: Sequel::CURRENT_TIMESTAMP)
+        AsgTimestamp.create(last_update: Time.now.utc)
       end
     end
 

--- a/spec/unit/models/runtime/asg_latest_update_spec.rb
+++ b/spec/unit/models/runtime/asg_latest_update_spec.rb
@@ -9,6 +9,13 @@ module VCAP::CloudController
         expect(AsgLatestUpdate.last_update).to be > 1.minute.ago
       end
 
+      it 'upates with microsecond precision' do
+        AsgLatestUpdate.renew
+        last_update = AsgLatestUpdate.last_update
+        AsgLatestUpdate.renew
+        expect(AsgLatestUpdate.last_update).to be > last_update
+      end
+
       context 'when there is no previous update' do
         it 'creates an asgLatestUpdate' do
           last_update = AsgLatestUpdate.last_update


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

There was a bug with the ASG Latest Update modelwhere renewing would insert `CURRENT_TIMESTAMP` which in mysql defaults to second-level precision, even though the database column is set for microsecond precision. This resolves this by creating the timstamp in CAPI instead of relying on the SQL keyword. 

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
