### PR TITLE
Keep /v2/info endpoint when v2 is disabled

### DIFF
--- a/app/controllers/runtime/info_controller.rb
+++ b/app/controllers/runtime/info_controller.rb
@@ -4,6 +4,26 @@ module VCAP::CloudController
 
     get '/v2/info', :read
     def read
+      unless @config.get(:temporary_enable_v2)
+        return Oj.dump({
+                         name: @config.get(:info, :name),
+                         build: @config.get(:info, :build),
+                         support: 'CF API v2 is disabled',
+                         version: @config.get(:info, :version),
+                         description: @config.get(:info, :description),
+                         authorization_endpoint: @config.get(:login, :url),
+                         token_endpoint: config.get(:uaa, :url),
+                         min_cli_version: @config.get(:info, :min_cli_version),
+                         min_recommended_cli_version: @config.get(:info, :min_recommended_cli_version),
+                         app_ssh_endpoint: @config.get(:info, :app_ssh_endpoint),
+                         app_ssh_host_key_fingerprint: @config.get(:info, :app_ssh_host_key_fingerprint),
+                         app_ssh_oauth_client: @config.get(:info, :app_ssh_oauth_client),
+                         doppler_logging_endpoint: @config.get(:doppler, :url),
+                         api_version: '',
+                         osbapi_version: VCAP::CloudController::Constants::OSBAPI_VERSION
+                       }, mode: :compat)
+      end
+
       info = {
         name: @config.get(:info, :name),
         build: @config.get(:info, :build),

--- a/app/controllers/runtime/info_controller.rb
+++ b/app/controllers/runtime/info_controller.rb
@@ -4,26 +4,6 @@ module VCAP::CloudController
 
     get '/v2/info', :read
     def read
-      unless @config.get(:temporary_enable_v2)
-        return Oj.dump({
-                         name: @config.get(:info, :name),
-                         build: @config.get(:info, :build),
-                         support: 'CF API v2 is disabled',
-                         version: @config.get(:info, :version),
-                         description: @config.get(:info, :description),
-                         authorization_endpoint: @config.get(:login, :url),
-                         token_endpoint: config.get(:uaa, :url),
-                         min_cli_version: @config.get(:info, :min_cli_version),
-                         min_recommended_cli_version: @config.get(:info, :min_recommended_cli_version),
-                         app_ssh_endpoint: @config.get(:info, :app_ssh_endpoint),
-                         app_ssh_host_key_fingerprint: @config.get(:info, :app_ssh_host_key_fingerprint),
-                         app_ssh_oauth_client: @config.get(:info, :app_ssh_oauth_client),
-                         doppler_logging_endpoint: @config.get(:doppler, :url),
-                         api_version: '',
-                         osbapi_version: VCAP::CloudController::Constants::OSBAPI_VERSION
-                       }, mode: :compat)
-      end
-
       info = {
         name: @config.get(:info, :name),
         build: @config.get(:info, :build),
@@ -47,6 +27,11 @@ module VCAP::CloudController
       info[:custom] = @config.get(:info, :custom) if @config.get(:info, :custom)
 
       info[:user] = user.guid if user
+
+      unless @config.get(:temporary_enable_v2)
+        info[:support] = 'CF API v2 is disabled'
+        info[:api_version] = ''
+      end
 
       Oj.dump(info, mode: :compat)
     end

--- a/spec/unit/controllers/runtime/info_controller_spec.rb
+++ b/spec/unit/controllers/runtime/info_controller_spec.rb
@@ -61,6 +61,25 @@ module VCAP::CloudController
         expect(hash['min_recommended_cli_version']).to eq('min_recommended_cli_version')
       end
 
+      it 'returns limited info when cc.temporary_enable_v2 is disabled' do
+        TestConfig.override(temporary_enable_v2: false)
+
+        get '/v2/info'
+        hash = Oj.load(last_response.body)
+        expect(hash['name']).to eq(TestConfig.config[:info][:name])
+        expect(hash['build']).to eq(TestConfig.config[:info][:build])
+        expect(hash['support']).to eq('CF API v2 is disabled')
+        expect(hash['version']).to eq(TestConfig.config[:info][:version])
+        expect(hash['description']).to eq(TestConfig.config[:info][:description])
+        expect(hash['authorization_endpoint']).to eq(TestConfig.config[:login][:url])
+        expect(hash['token_endpoint']).to eq(TestConfig.config[:uaa][:url])
+        expect(hash['app_ssh_endpoint']).to eq(TestConfig.config[:info][:app_ssh_endpoint])
+        expect(hash['app_ssh_host_key_fingerprint']).to eq(TestConfig.config[:info][:app_ssh_host_key_fingerprint])
+        expect(hash['app_ssh_oauth_client']).to eq(TestConfig.config[:info][:app_ssh_oauth_client])
+        expect(hash['api_version']).to eq('')
+        expect(hash['osbapi_version']).to eq(VCAP::CloudController::Constants::OSBAPI_VERSION)
+      end
+
       describe 'custom fields' do
         context 'without custom fields in config' do
           before { TestConfig.override(info: {}) }


### PR DESCRIPTION

* A short explanation of the proposed change:
/v2/info was currently excluded from v2 rate limiting. Don't rate limit and keep /v2/info even when CF API v2 is switched off.  
* An explanation of the use cases your change solves
/v2/info endpoint is still available when cc.temporary_enable_v2=false and indicates that v2 is disabled. 
* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
