### PR TITLE
Bigint Migration for 'events' Table (Step 1)

### DIFF
--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -138,8 +138,8 @@ Rails/DangerousColumnNames: # Disabled, in comparison to active_record we need t
 Rails/SkipsModelValidations: # We don`t want any model at all in migrations and migration specs
   Enabled: true
   Exclude:
-    - db/migrations/*
-    - spec/migrations/*
+    - db/migrations/**/*
+    - spec/migrations/**/*
 
 #### ENABLED SECTION
 Gemspec/DeprecatedAttributeAssignment:

--- a/db/migrations/20250327142351_bigint_migration_events_step1.rb
+++ b/db/migrations/20250327142351_bigint_migration_events_step1.rb
@@ -1,0 +1,22 @@
+require 'database/bigint_migration'
+
+Sequel.migration do
+  up do
+    if database_type == :postgres && !VCAP::BigintMigration.opt_out?
+      if VCAP::BigintMigration.table_empty?(self, :events)
+        VCAP::BigintMigration.change_pk_to_bigint(self, :events)
+      else
+        VCAP::BigintMigration.add_bigint_column(self, :events)
+        VCAP::BigintMigration.create_trigger_function(self, :events)
+      end
+    end
+  end
+
+  down do
+    if database_type == :postgres
+      VCAP::BigintMigration.revert_pk_to_integer(self, :events)
+      VCAP::BigintMigration.drop_trigger_function(self, :events)
+      VCAP::BigintMigration.drop_bigint_column(self, :events)
+    end
+  end
+end

--- a/lib/cloud_controller/config_schemas/base/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/api_schema.rb
@@ -100,6 +100,7 @@ module VCAP::CloudController
             optional(:max_migration_statement_runtime_in_seconds) => Integer,
             optional(:migration_psql_concurrent_statement_timeout_in_seconds) => Integer,
             optional(:migration_psql_worker_memory_kb) => Integer,
+            optional(:skip_bigint_id_migration) => bool,
             db: {
               optional(:database) => Hash, # db connection hash for sequel
               max_connections: Integer, # max connections in the connection pool

--- a/lib/cloud_controller/config_schemas/base/migrate_schema.rb
+++ b/lib/cloud_controller/config_schemas/base/migrate_schema.rb
@@ -10,6 +10,7 @@ module VCAP::CloudController
             optional(:max_migration_statement_runtime_in_seconds) => Integer,
             optional(:migration_psql_concurrent_statement_timeout_in_seconds) => Integer,
             optional(:migration_psql_worker_memory_kb) => Integer,
+            optional(:skip_bigint_id_migration) => bool,
 
             db: {
               optional(:database) => Hash, # db connection hash for sequel

--- a/lib/database/bigint_migration.rb
+++ b/lib/database/bigint_migration.rb
@@ -1,0 +1,83 @@
+module VCAP::BigintMigration
+  class << self
+    def opt_out?
+      opt_out = VCAP::CloudController::Config.config&.get(:skip_bigint_id_migration)
+      opt_out.nil? ? false : opt_out
+    rescue VCAP::CloudController::Config::InvalidConfigPath
+      false
+    end
+
+    def table_empty?(db, table)
+      db[table].empty?
+    end
+
+    def change_pk_to_bigint(db, table)
+      db.set_column_type(table, :id, :Bignum) if column_type(db, table, :id) != 'bigint'
+    end
+
+    def revert_pk_to_integer(db, table)
+      db.set_column_type(table, :id, :integer) if column_type(db, table, :id) == 'bigint'
+    end
+
+    def add_bigint_column(db, table)
+      db.add_column(table, :id_bigint, :Bignum, if_not_exists: true)
+    end
+
+    def drop_bigint_column(db, table)
+      db.drop_column(table, :id_bigint, if_exists: true)
+    end
+
+    def create_trigger_function(db, table)
+      drop_trigger_function(db, table)
+
+      function = <<~FUNC
+        BEGIN
+          NEW.id_bigint := NEW.id;
+          RETURN NEW;
+        END;
+      FUNC
+      db.create_function(function_name(table), function, language: :plpgsql, returns: :trigger)
+      db.create_trigger(table, trigger_name(table), function_name(table), each_row: true, events: :insert)
+    end
+
+    def drop_trigger_function(db, table)
+      db.drop_trigger(table, trigger_name(table), if_exists: true)
+      db.drop_function(function_name(table), if_exists: true)
+    end
+
+    def backfill(logger, db, table, batch_size: 10_000, iterations: -1)
+      raise "table '#{table}' does not contain column 'id_bigint'" unless column_exists?(db, table, :id_bigint)
+
+      logger.info("starting bigint backfill on table '#{table}' (batch_size: #{batch_size}, iterations: #{iterations})")
+      loop do
+        updated_rows = db.
+                       from(table, :batch).
+                       with(:batch, db[table].select(:id).where(id_bigint: nil).order(:id).limit(batch_size).for_update.skip_locked).
+                       where(Sequel.qualify(table, :id) => :batch__id).
+                       update(id_bigint: :batch__id)
+        logger.info("updated #{updated_rows} rows")
+        iterations -= 1 if iterations > 0
+        break if updated_rows < batch_size || iterations == 0
+      end
+      logger.info("finished bigint backfill on table '#{table}'")
+    end
+
+    private
+
+    def column_type(db, table, column)
+      db.schema(table).find { |col, _| col == column }&.dig(1, :db_type)
+    end
+
+    def function_name(table)
+      :"#{table}_set_id_bigint_on_insert"
+    end
+
+    def trigger_name(table)
+      :"trigger_#{function_name(table)}"
+    end
+
+    def column_exists?(db, table, column)
+      db[table].columns.include?(column)
+    end
+  end
+end

--- a/spec/migrations/20250327142351_bigint_migration_events_step1_spec.rb
+++ b/spec/migrations/20250327142351_bigint_migration_events_step1_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'migrations/helpers/bigint_migration_step1_shared_context'
+
+RSpec.describe 'bigint migration - events table - step1', isolation: :truncation, type: :migration do
+  include_context 'bigint migration step1' do
+    let(:migration_filename) { '20250327142351_bigint_migration_events_step1.rb' }
+    let(:table) { :events }
+    let(:insert) do
+      lambda do |db|
+        db[:events].insert(guid: SecureRandom.uuid, timestamp: Time.now.utc, type: 'type',
+                           actor: 'actor', actor_type: 'actor_type',
+                           actee: 'actee', actee_type: 'actee_type')
+      end
+    end
+  end
+end

--- a/spec/migrations/helpers/bigint_migration_step1_shared_context.rb
+++ b/spec/migrations/helpers/bigint_migration_step1_shared_context.rb
@@ -1,0 +1,206 @@
+require 'migrations/helpers/migration_shared_context'
+require 'database/bigint_migration'
+
+RSpec.shared_context 'bigint migration step1' do
+  subject(:run_migration) { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }
+
+  include_context 'migration'
+
+  let(:skip_bigint_id_migration) { nil }
+
+  before do
+    skip unless db.database_type == :postgres
+
+    allow_any_instance_of(VCAP::CloudController::Config).to receive(:get).with(:skip_bigint_id_migration).and_return(skip_bigint_id_migration)
+  end
+
+  describe 'up' do
+    context 'when skip_bigint_id_migration is false' do
+      let(:skip_bigint_id_migration) { false }
+      let(:logger) { double(:logger, info: nil) }
+
+      before do
+        allow(Steno).to receive(:logger).and_return(logger)
+      end
+
+      context 'when the table is empty' do
+        before do
+          db[table].delete
+        end
+
+        it "changes the id column's type to bigint" do
+          expect(db).to have_table_with_column_and_type(table, :id, 'integer')
+
+          run_migration
+
+          expect(db).to have_table_with_column_and_type(table, :id, 'bigint')
+        end
+
+        it 'does not add the id_bigint column' do
+          expect(db).not_to have_table_with_column(table, :id_bigint)
+
+          run_migration
+
+          expect(db).not_to have_table_with_column(table, :id_bigint)
+        end
+
+        describe 'backfill' do
+          before do
+            run_migration
+          end
+
+          it 'fails with a proper error message' do
+            expect do
+              VCAP::BigintMigration.backfill(logger, db, table)
+            end.to raise_error(RuntimeError, /table 'events' does not contain column 'id_bigint'/)
+          end
+        end
+      end
+
+      context 'when the table is not empty' do
+        let!(:old_id) { insert.call(db) }
+
+        it "does not change the id column's type" do
+          expect(db).to have_table_with_column_and_type(table, :id, 'integer')
+
+          run_migration
+
+          expect(db).to have_table_with_column_and_type(table, :id, 'integer')
+        end
+
+        it 'adds the id_bigint column' do
+          expect(db).not_to have_table_with_column(table, :id_bigint)
+
+          run_migration
+
+          expect(db).to have_table_with_column_and_type(table, :id_bigint, 'bigint')
+        end
+
+        it 'creates the trigger function' do
+          expect(db).not_to have_trigger_function_for_table(table)
+
+          run_migration
+
+          expect(db).to have_trigger_function_for_table(table)
+        end
+
+        it 'does not populate the id_bigint column for an existing entry' do
+          run_migration
+
+          expect(db[table].where(id: old_id).get(:id_bigint)).to be_nil
+        end
+
+        it 'automatically populates the id_bigint column for a new entry' do
+          run_migration
+
+          new_id = insert.call(db)
+          expect(db[table].where(id: new_id).get(:id_bigint)).to eq(new_id)
+        end
+
+        describe 'backfill' do
+          before do
+            100.times { insert.call(db) }
+
+            run_migration
+          end
+
+          context 'default batch size' do
+            it 'backfills all entries in a single run' do
+              expect(db).to have_table_with_unpopulated_column(table, :id_bigint)
+
+              expect do
+                VCAP::BigintMigration.backfill(logger, db, table)
+              end.to have_queried_db_times(/update/i, 1)
+
+              expect(db).not_to have_table_with_unpopulated_column(table, :id_bigint)
+            end
+          end
+
+          context 'custom batch size' do
+            let(:batch_size) { 30 }
+
+            it 'backfills entries in multiple runs' do
+              expect(db).to have_table_with_unpopulated_column(table, :id_bigint)
+
+              expect do
+                VCAP::BigintMigration.backfill(logger, db, table, batch_size:)
+              end.to have_queried_db_times(/update/i, 4)
+
+              expect(db).not_to have_table_with_unpopulated_column(table, :id_bigint)
+            end
+
+            context 'limited number of iterations' do
+              let(:iterations) { 2 }
+
+              it 'stops backfilling' do
+                expect(db).to have_table_with_unpopulated_column(table, :id_bigint)
+
+                expect do
+                  VCAP::BigintMigration.backfill(logger, db, table, batch_size:, iterations:)
+                end.to have_queried_db_times(/update/i, 2)
+
+                expect(db).to have_table_with_unpopulated_column(table, :id_bigint)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when skip_bigint_id_migration is true' do
+      let(:skip_bigint_id_migration) { true }
+
+      it "neither changes the id column's type, nor adds the id_bigint column" do
+        expect(db).to have_table_with_column_and_type(table, :id, 'integer')
+        expect(db).not_to have_table_with_column(table, :id_bigint)
+
+        run_migration
+
+        expect(db).to have_table_with_column_and_type(table, :id, 'integer')
+        expect(db).not_to have_table_with_column(table, :id_bigint)
+      end
+    end
+  end
+
+  describe 'down' do
+    subject(:run_rollback) { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }
+
+    context 'when the table is empty' do
+      before do
+        db[table].delete
+        run_migration
+      end
+
+      it "reverts the id column's type to integer" do
+        expect(db).to have_table_with_column_and_type(table, :id, 'bigint')
+
+        run_rollback
+
+        expect(db).to have_table_with_column_and_type(table, :id, 'integer')
+      end
+    end
+
+    context 'when the table is not empty' do
+      before do
+        insert.call(db)
+        run_migration
+      end
+
+      it 'drops the id_bigint column' do
+        expect(db).to have_table_with_column(table, :id_bigint)
+
+        run_rollback
+
+        expect(db).not_to have_table_with_column(table, :id_bigint)
+      end
+
+      it 'drops the trigger function' do
+        expect(db).to have_trigger_function_for_table(table)
+
+        run_rollback
+
+        expect(db).not_to have_trigger_function_for_table(table)
+      end
+    end
+  end
+end

--- a/spec/migrations/helpers/matchers.rb
+++ b/spec/migrations/helpers/matchers.rb
@@ -15,3 +15,44 @@ RSpec::Matchers.define :drop_index_options do
     !options.delete(:name).nil? && (options - %i[if_exists concurrently]).empty?
   end
 end
+
+RSpec::Matchers.define :have_table_with_column do |table, column|
+  match do |db|
+    db[table].columns.include?(column)
+  end
+end
+
+RSpec::Matchers.define :have_table_with_column_and_type do |table, column, type|
+  match do |db|
+    expect(db).to have_table_with_column(table, column)
+
+    db.schema(table).find { |col, _| col == column }&.dig(1, :db_type) == type
+  end
+end
+
+RSpec::Matchers.define :have_trigger_function_for_table do |table|
+  match do |db|
+    function_name = :"#{table}_set_id_bigint_on_insert"
+    trigger_name = :"trigger_#{function_name}"
+
+    function_exists = false
+    db.fetch("SELECT * FROM information_schema.routines WHERE routine_name = '#{function_name}';") do
+      function_exists = true
+    end
+
+    trigger_exists = false
+    db.fetch("SELECT * FROM information_schema.triggers WHERE trigger_name = '#{trigger_name}';") do
+      trigger_exists = true
+    end
+
+    raise 'either function and trigger must exist or none of them' if function_exists != trigger_exists
+
+    trigger_exists
+  end
+end
+
+RSpec::Matchers.define :have_table_with_unpopulated_column do |table, column|
+  match do |db|
+    db[table].where(column => nil).any?
+  end
+end

--- a/spec/unit/lib/database/bigint_migration_spec.rb
+++ b/spec/unit/lib/database/bigint_migration_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'database/bigint_migration'
+
+RSpec.describe VCAP::BigintMigration do
+  let(:skip_bigint_id_migration) { nil }
+
+  before do
+    allow_any_instance_of(VCAP::CloudController::Config).to receive(:get).with(:skip_bigint_id_migration).and_return(skip_bigint_id_migration)
+  end
+
+  describe 'VCAP::BigintMigration.opt_out?' do
+    context 'when skip_bigint_id_migration is false' do
+      let(:skip_bigint_id_migration) { false }
+
+      it 'returns false' do
+        expect(VCAP::BigintMigration.opt_out?).to be(false)
+      end
+    end
+
+    context 'when skip_bigint_id_migration is true' do
+      let(:skip_bigint_id_migration) { true }
+
+      it 'returns true' do
+        expect(VCAP::BigintMigration.opt_out?).to be(true)
+      end
+    end
+
+    context 'when skip_bigint_id_migration is nil' do
+      let(:skip_bigint_id_migration) { nil }
+
+      it 'returns false' do
+        expect(VCAP::BigintMigration.opt_out?).to be(false)
+      end
+    end
+
+    context 'when raising InvalidConfigPath error' do
+      before do
+        allow_any_instance_of(VCAP::CloudController::Config).to receive(:get).with(:skip_bigint_id_migration).and_raise(VCAP::CloudController::Config::InvalidConfigPath)
+      end
+
+      it 'returns false' do
+        expect(VCAP::BigintMigration.opt_out?).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- reusable module `VCAP::BigintMigration`
- implementation of step 1 (the **events**' primary key is not used as foreign key, thus additions will be required when reusing this for other tables)
  - check database type (PostgreSQL only)
  - check opt-out flag
  - check if table is empty
  - change primary key to bigint directly, if table is empty
  - add bigint column and create trigger + function otherwise
- reusable shared_context for tests
- ADR adapted (PostgreSQL only)
- Rake task `db:bigint_backfill` to manually trigger a backfill (optional)

Related PR: https://github.com/cloudfoundry/capi-release/pull/533

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
