### PR TITLE
dont use await to import from cheerio

### DIFF
--- a/docs/v3/gulpfile.js
+++ b/docs/v3/gulpfile.js
@@ -5,7 +5,7 @@ import express from 'express';
 import { glob } from 'glob';
 import { LinkChecker } from 'linkinator';
 
-const cheerio = await import('cheerio');
+import * as cheerio from 'cheerio';
 
 function displayErrors(err, stdout, stderr) {
   if (err) {


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
