### PR TITLE
feat: notify diego of route updates

### DIFF
--- a/app/actions/route_update.rb
+++ b/app/actions/route_update.rb
@@ -6,6 +6,10 @@ module VCAP::CloudController
 
         route.save
         MetadataUpdate.update(route, message)
+
+        route.apps.each do |process|
+          ProcessRouteHandler.new(process).notify_backend_of_route_update
+        end
       end
 
       route

--- a/app/actions/route_update.rb
+++ b/app/actions/route_update.rb
@@ -2,16 +2,15 @@ module VCAP::CloudController
   class RouteUpdate
     def update(route:, message:)
       Route.db.transaction do
-        route.options = route.options.symbolize_keys.merge(message.options).compact if message.requested?(:options)
-
+        if message.requested?(:options)
+          route.options = route.options.symbolize_keys.merge(message.options).compact
+          route.apps.each do |process|
+            ProcessRouteHandler.new(process).notify_backend_of_route_update
+          end
+        end
         route.save
         MetadataUpdate.update(route, message)
-
-        route.apps.each do |process|
-          ProcessRouteHandler.new(process).notify_backend_of_route_update
-        end
       end
-
       route
     end
   end

--- a/app/actions/route_update.rb
+++ b/app/actions/route_update.rb
@@ -2,14 +2,15 @@ module VCAP::CloudController
   class RouteUpdate
     def update(route:, message:)
       Route.db.transaction do
-        if message.requested?(:options)
-          route.options = route.options.symbolize_keys.merge(message.options).compact
-          route.apps.each do |process|
-            ProcessRouteHandler.new(process).notify_backend_of_route_update
-          end
-        end
+        route.options = route.options.symbolize_keys.merge(message.options).compact if message.requested?(:options)
         route.save
         MetadataUpdate.update(route, message)
+      end
+
+      if message.requested?(:options)
+        route.apps.each do |process|
+          ProcessRouteHandler.new(process).notify_backend_of_route_update
+        end
       end
       route
     end

--- a/spec/unit/actions/route_update_spec.rb
+++ b/spec/unit/actions/route_update_spec.rb
@@ -41,7 +41,8 @@ module VCAP::CloudController
     end
 
     let(:message) { RouteUpdateMessage.new(body) }
-    let(:route) { Route.make }
+    let(:space) { Space.make }
+    let(:route) { Route.make(space:) }
 
     subject { RouteUpdate.new }
     describe '#update metadata' do
@@ -143,6 +144,13 @@ module VCAP::CloudController
 
           it 'adds no options' do
             expect(message).to be_valid
+
+            fake_route_handler = instance_double(ProcessRouteHandler)
+            process = ProcessModelFactory.make(space: space, state: 'STARTED', diego: false)
+            RouteMappingModel.make(app: process.app, route: route, process_type: process.type)
+            allow(ProcessRouteHandler).to receive(:new).with(process).and_return(fake_route_handler)
+            expect(fake_route_handler).to receive(:notify_backend_of_route_update)
+
             subject.update(route:, message:)
             route.reload
             expect(route.options).to eq({})
@@ -160,8 +168,14 @@ module VCAP::CloudController
 
           it 'adds the route option' do
             expect(message).to be_valid
-            subject.update(route:, message:)
 
+            fake_route_handler = instance_double(ProcessRouteHandler)
+            process = ProcessModelFactory.make(space: space, state: 'STARTED', diego: false)
+            RouteMappingModel.make(app: process.app, route: route, process_type: process.type)
+            allow(ProcessRouteHandler).to receive(:new).with(process).and_return(fake_route_handler)
+            expect(fake_route_handler).to receive(:notify_backend_of_route_update)
+
+            subject.update(route:, message:)
             route.reload
             expect(route[:options]).to eq('{"loadbalancing":"round-robin"}')
           end
@@ -180,6 +194,13 @@ module VCAP::CloudController
 
           it 'modifies nothing' do
             expect(message).to be_valid
+
+            fake_route_handler = instance_double(ProcessRouteHandler)
+            process = ProcessModelFactory.make(space: space, state: 'STARTED', diego: false)
+            RouteMappingModel.make(app: process.app, route: route, process_type: process.type)
+            allow(ProcessRouteHandler).to receive(:new).with(process).and_return(fake_route_handler)
+            expect(fake_route_handler).to receive(:notify_backend_of_route_update)
+
             subject.update(route:, message:)
             route.reload
             expect(route.options).to include({ 'loadbalancing' => 'round-robin' })
@@ -197,6 +218,13 @@ module VCAP::CloudController
 
           it 'updates the option' do
             expect(message).to be_valid
+
+            fake_route_handler = instance_double(ProcessRouteHandler)
+            process = ProcessModelFactory.make(space: space, state: 'STARTED', diego: false)
+            RouteMappingModel.make(app: process.app, route: route, process_type: process.type)
+            allow(ProcessRouteHandler).to receive(:new).with(process).and_return(fake_route_handler)
+            expect(fake_route_handler).to receive(:notify_backend_of_route_update)
+
             subject.update(route:, message:)
             route.reload
 
@@ -215,6 +243,13 @@ module VCAP::CloudController
 
           it 'removes this option' do
             expect(message).to be_valid
+
+            fake_route_handler = instance_double(ProcessRouteHandler)
+            process = ProcessModelFactory.make(space: space, state: 'STARTED', diego: false)
+            RouteMappingModel.make(app: process.app, route: route, process_type: process.type)
+            allow(ProcessRouteHandler).to receive(:new).with(process).and_return(fake_route_handler)
+            expect(fake_route_handler).to receive(:notify_backend_of_route_update)
+
             subject.update(route:, message:)
             route.reload
             expect(route.options).to eq({})


### PR DESCRIPTION
After updating a route via the new update route endpoint, it was only stored in the database. Since routes can be changed without restarting the application this commit adds logic to also push the update to diego.

Resolves: https://github.com/cloudfoundry/cloud_controller_ng/issues/4286

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
