### PR TITLE
App state is not updating in cf cli and appsman ui when the app is down

### DIFF
--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -49,12 +49,14 @@ module VCAP::CloudController
 
         bbs_instances_client.lrp_instances(process).each do |actual_lrp|
           next unless actual_lrp.actual_lrp_key.index < process.instances
+
           # if an LRP already exists with the same index use the one with the latest since value
 
           if lrp_instances.include?(actual_lrp.actual_lrp_key.index)
-          
+
             existing_lrp = lrp_instances[actual_lrp.actual_lrp_key.index]
-            next if (actual_lrp.since < existing_lrp.since)
+            next if actual_lrp.since < existing_lrp.since
+
             lrp_instances.delete(actual_lrp.actual_lrp_key.index)
             result.delete(actual_lrp.actual_lrp_key.index)
             lrp_instances[actual_lrp.actual_lrp_key.index] = actual_lrp
@@ -66,7 +68,7 @@ module VCAP::CloudController
           result[actual_lrp.actual_lrp_key.index] = info
           lrp_instances[actual_lrp.actual_lrp_key.index] = actual_lrp
         end
-  
+
         fill_unreported_instances_with_down_instances(result, process, flat: false)
 
         warnings = [log_cache_errors].compact

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -51,9 +51,7 @@ module VCAP::CloudController
           next unless actual_lrp.actual_lrp_key.index < process.instances
 
           # if an LRP already exists with the same index use the one with the latest since value
-
           if lrp_instances.include?(actual_lrp.actual_lrp_key.index)
-
             existing_lrp = lrp_instances[actual_lrp.actual_lrp_key.index]
             next if actual_lrp.since < existing_lrp.since
 

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -54,10 +54,6 @@ module VCAP::CloudController
           if lrp_instances.include?(actual_lrp.actual_lrp_key.index)
             existing_lrp = lrp_instances[actual_lrp.actual_lrp_key.index]
             next if actual_lrp.since < existing_lrp.since
-
-            lrp_instances.delete(actual_lrp.actual_lrp_key.index)
-            result.delete(actual_lrp.actual_lrp_key.index)
-            lrp_instances[actual_lrp.actual_lrp_key.index] = actual_lrp
           end
 
           lrp_state = state || LrpStateTranslator.translate_lrp_state(actual_lrp)

--- a/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_stats_reporter.rb
@@ -70,7 +70,6 @@ module VCAP::CloudController
         fill_unreported_instances_with_down_instances(result, process, flat: false)
 
         warnings = [log_cache_errors].compact
-
         [result, warnings]
       end
 

--- a/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
@@ -148,6 +148,52 @@ module VCAP::CloudController
           end
         end
 
+        context 'when there are multiple lrps with the same index' do
+          let(:bbs_actual_lrps_response) { [actual_lrp_1, actual_lrp_2, actual_lrp_3, actual_lrp_4] }
+          let(:actual_lrp_1) do
+            make_actual_lrp(
+              instance_guid: '', index: 0, state: ::Diego::ActualLRPState::UNCLAIMED, error: 'some-details', since: two_days_ago_since_epoch_ns
+            ).tap do |actual_lrp|
+              actual_lrp.actual_lrp_net_info = lrp_1_net_info
+            end
+          end
+          let(:actual_lrp_2) do
+            make_actual_lrp(
+              instance_guid: 'instance-a', index: 0, state: ::Diego::ActualLRPState::RUNNING, error: 'some-details', since: two_days_ago_since_epoch_ns-1000
+            ).tap do |actual_lrp|
+              actual_lrp.actual_lrp_net_info = lrp_1_net_info
+            end
+          end
+
+          let(:actual_lrp_3) do
+            make_actual_lrp(
+              instance_guid: '', index: 1, state: ::Diego::ActualLRPState::UNCLAIMED, error: 'some-details', since: two_days_ago_since_epoch_ns
+            ).tap do |actual_lrp|
+              actual_lrp.actual_lrp_net_info = lrp_1_net_info
+            end
+          end
+
+          let(:actual_lrp_4) do
+            make_actual_lrp(
+              instance_guid: 'instance-b', index: 1, state: ::Diego::ActualLRPState::CLAIMED, error: 'some-details', since: two_days_ago_since_epoch_ns-1000
+            ).tap do |actual_lrp|
+              actual_lrp.actual_lrp_net_info = lrp_1_net_info
+            end
+          end
+
+          before do
+            allow(bbs_instances_client).to receive_messages(lrp_instances: bbs_actual_lrps_response, desired_lrp_instance: bbs_desired_lrp_response)
+          end
+
+          it 'shows all correct state for all instances' do
+            result, = instances_reporter.stats_for_app(process)
+            expect(result[0][:state]).to eq('DOWN')
+            expect(result[1][:state]).to eq('DOWN')
+          end
+        end
+
+
+
         context 'when a NoRunningInstances error is thrown for desired_lrp and it exists an actual_lrp' do
           let(:error) { CloudController::Errors::NoRunningInstances.new('No running instances ruh roh') }
           let(:expected_stopping_response) do

--- a/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
@@ -159,7 +159,7 @@ module VCAP::CloudController
           end
           let(:actual_lrp_2) do
             make_actual_lrp(
-              instance_guid: 'instance-a', index: 0, state: ::Diego::ActualLRPState::RUNNING, error: 'some-details', since: two_days_ago_since_epoch_ns-1000
+              instance_guid: 'instance-a', index: 0, state: ::Diego::ActualLRPState::RUNNING, error: 'some-details', since: two_days_ago_since_epoch_ns - 1000
             ).tap do |actual_lrp|
               actual_lrp.actual_lrp_net_info = lrp_1_net_info
             end
@@ -175,7 +175,7 @@ module VCAP::CloudController
 
           let(:actual_lrp_4) do
             make_actual_lrp(
-              instance_guid: 'instance-b', index: 1, state: ::Diego::ActualLRPState::CLAIMED, error: 'some-details', since: two_days_ago_since_epoch_ns-1000
+              instance_guid: 'instance-b', index: 1, state: ::Diego::ActualLRPState::CLAIMED, error: 'some-details', since: two_days_ago_since_epoch_ns - 1000
             ).tap do |actual_lrp|
               actual_lrp.actual_lrp_net_info = lrp_1_net_info
             end
@@ -191,8 +191,6 @@ module VCAP::CloudController
             expect(result[1][:state]).to eq('DOWN')
           end
         end
-
-
 
         context 'when a NoRunningInstances error is thrown for desired_lrp and it exists an actual_lrp' do
           let(:error) { CloudController::Errors::NoRunningInstances.new('No running instances ruh roh') }


### PR DESCRIPTION
In some circumstances CAPI will report an app instance is running when it is down.

CAPI iterates over all actual_lrps returned from Diego  and uses the app index as the key, so in the case CAPI will override each app instance information once and the state shown will be determined by the order of the actual lrp instances. 

Example of a duplicate entry from cfdot actual-lrps. Note the process_guid and index are the same.

{
  "process_guid": "57a8e43b-81f9-46e9-9f78-81e15bbfd231-de7f7844-156e-4fc7-9f21-db5d072fb0b7",
  "index": 3,
  "domain": "cf-apps",
  "instance_guid": "",
  "cell_id": "",
  "address": "",
  "ports": null,
  "preferred_address": "UNKNOWN",
  "crash_count": 0,
  "state": "UNCLAIMED",
  "placement_error": "unable to communicate to compatible cells",
  "since": 1739568280529021112,
  "modification_tag": {
    "epoch": "780635af-9208-4d5e-5a08-ea49ebcb3f95",
    "index": 5758
  },
  "presence": "ORDINARY",
  "OptionalRoutable": {
    "routable": false
  },
  "availability_zone": ""
}
{
  "process_guid": "57a8e43b-81f9-46e9-9f78-81e15bbfd231-de7f7844-156e-4fc7-9f21-db5d072fb0b7",
  "index": 3,
  "domain": "cf-apps",
  "instance_guid": "1f3ffac3-be77-45e0-5075-7357",
  "cell_id": "23b06662-20e7-42dd-9377-6d8f10190ec4",
  "address": "10.0.4.17",
  "ports": [
    {
      "container_port": 8080,
      "host_port": 61012,
      "container_tls_proxy_port": 61001,
      "host_tls_proxy_port": 61014
    },
    {
      "container_port": 8080,
      "host_port": 61012,
      "container_tls_proxy_port": 61443,
      "host_tls_proxy_port": 0
    },
    {
      "container_port": 2222,
      "host_port": 61013,
      "container_tls_proxy_port": 61002,
      "host_tls_proxy_port": 61015
    }
  ],
  "instance_address": "10.255.233.24",
  "preferred_address": "HOST",
  "crash_count": 0,
  "state": "RUNNING",
  "since": 1739222044495241579,
  "modification_tag": {
    "epoch": "4a424a13-b5ba-47b7-771a-1a61d99c2524",
    "index": 2
  },
  "presence": "SUSPECT",
  "metric_tags": {
    "app_id": "57a8e43b-81f9-46e9-9f78-81e15bbfd231",
    "app_name": "static",
    "instance_id": "3",
    "organization_id": "c877a084-d65b-4758-9908-90201c6df339",
    "organization_name": "org-1",
    "process_id": "57a8e43b-81f9-46e9-9f78-81e15bbfd231",
    "process_instance_id": "1f3ffac3-be77-45e0-5075-7357",
    "process_type": "web",
    "source_id": "57a8e43b-81f9-46e9-9f78-81e15bbfd231",
    "space_id": "b248d5ab-2948-468b-ad0f-7b1b90e923d1",
    "space_name": "space-1"
  },
  "OptionalRoutable": {
    "routable": true
  },
  "availability_zone": "us-central1-f"
}
Fix
In the case of duplicates, CAPI should look at the since value of the actual_lrp information and take the latest definition.
Tested by killing the diego cell VM bosh delete-vm. Now cf app returns the correct status

instances:      0/2
memory usage:   1024M
     state   since                  cpu    memory     disk       logging        cpu entitlement   details
#0   down    2025-04-15T00:34:03Z   0.0%   0B of 0B   0B of 0B   0B/s of 0B/s                     unable to communicate to compatible cells
#1   down    2025-04-15T00:34:03Z   0.0%   0B of 0B   0B of 0B   0B/s of 0B/s                     unable to communicate to compatible cells


* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
