### PR TITLE
Fix a typo in CF V3 API definition

### DIFF
--- a/docs/v3/source/includes/api_resources/_deployments.erb
+++ b/docs/v3/source/includes/api_resources/_deployments.erb
@@ -73,7 +73,7 @@
     "cancel": {
       "href": "https://api.example.org/v3/deployments/59c3d133-2b83-46f3-960e-7765a129aea4/actions/cancel",
       "method": "POST"
-    }
+    },
     "continue": {
       "href": "https://api.example.org/v3/deployments/59c3d133-2b83-46f3-960e-7765a129aea4/actions/continue",
       "method": "POST"


### PR DESCRIPTION
Add a missing "," which makes the Example response json for the "POST /v3/deployments" endpoint invalid.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
