### PR TITLE
Explicitly declare permissions on GH Action workflows that lacked them

### DIFF
--- a/.github/workflows/bump_bbs_protos.yml
+++ b/.github/workflows/bump_bbs_protos.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   update-protos:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: hmarr/debug-action@v3
       - name: Checkout ccng

--- a/.github/workflows/deploy_v3_docs.yml
+++ b/.github/workflows/deploy_v3_docs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   dummy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Dummy Step
         run: echo "This is a dummy action to ensure visibility"


### PR DESCRIPTION
It's recommended by Github to explicitly declare the minimum set of permissions each Github Actions workflow needs. Most of our workflows have them declared, but these two were missing them.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
