### PR TITLE
Fix typo in sample response JSON in API docs

### DIFF
--- a/docs/v3/source/includes/api_resources/_deployments.erb
+++ b/docs/v3/source/includes/api_resources/_deployments.erb
@@ -109,7 +109,7 @@
       },
       "strategy": "rolling",
       "options" : {
-        "max_in_flight": 1,
+        "max_in_flight": 1
       },
       "droplet": {
         "guid": "44ccfa61-dbcf-4a0d-82fe-f668e9d2a962"


### PR DESCRIPTION
Remove an obsolete symbol (comma) which makes the example response JSON invalid

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
