### PR TITLE
Fix typo in sample response JSON in API docs

### DIFF
--- a/docs/v3/source/includes/api_resources/_domains.erb
+++ b/docs/v3/source/includes/api_resources/_domains.erb
@@ -87,7 +87,7 @@
           "href": "https://api.example.org/routing/v1/router_groups/5806148f-cce6-4d86-7fbd-aa269e3f6f3f"
         }
       }
-    },
+    }
   ]
 }
 <% end %>


### PR DESCRIPTION
Remove an obsolete symbol (comma) which makes the example response JSON invalid

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
