### PR TITLE
Improve error handling for already deleted resources

### DIFF
--- a/app/actions/app_delete.rb
+++ b/app/actions/app_delete.rb
@@ -52,6 +52,8 @@ module VCAP::CloudController
         end
         logger.info("Deleted app: #{app.guid}")
       end
+
+      []
     end
 
     def delete_without_event(apps)

--- a/app/actions/organization_delete.rb
+++ b/app/actions/organization_delete.rb
@@ -35,6 +35,8 @@ module VCAP::CloudController
           Repositories::OrganizationEventRepository.new.record_organization_delete_request(org, @user_audit_info, { recursive: true })
         end
       end
+
+      []
     end
 
     def timeout_error(dataset)

--- a/app/actions/v2/organization_delete.rb
+++ b/app/actions/v2/organization_delete.rb
@@ -21,6 +21,7 @@ module VCAP::CloudController
             org.destroy
           end
         end
+        []
       end
 
       def timeout_error(dataset)

--- a/app/jobs/delete_action_job.rb
+++ b/app/jobs/delete_action_job.rb
@@ -30,10 +30,10 @@ module VCAP::CloudController
         end
 
         # Ignore errors if the target resource has already been deleted (e.g., by a parallel job)
-        quoted_table_name = @model_class.db.quote_identifier(@model_class.table_name)
+        quoted_table_name = model_class.db.quote_identifier(model_class.table_name)
         errors.reject! { |err| err.is_a?(Sequel::NoExistingObject) && err.message.include?("DELETE FROM #{quoted_table_name}") } unless errors.frozen?
 
-        raise errors.first unless errors&.empty?
+        raise errors.first unless errors.empty?
 
         warnings
       end

--- a/app/jobs/delete_action_job.rb
+++ b/app/jobs/delete_action_job.rb
@@ -31,7 +31,7 @@ module VCAP::CloudController
 
         # Ignore errors if the target resource has already been deleted (e.g., by a parallel job)
         quoted_table_name = @model_class.db.quote_identifier(@model_class.table_name)
-        errors.reject! { |err| err.is_a?(Sequel::NoExistingObject) && err.message.include?("DELETE FROM #{quoted_table_name}") }
+        errors.reject! { |err| err.is_a?(Sequel::NoExistingObject) && err.message.include?("DELETE FROM #{quoted_table_name}") } unless errors.frozen?
 
         raise errors.first unless errors&.empty?
 

--- a/app/jobs/delete_action_job.rb
+++ b/app/jobs/delete_action_job.rb
@@ -17,11 +17,21 @@ module VCAP::CloudController
         logger.info("Deleting model class '#{model_class}' with guid '#{resource_guid}'")
 
         dataset = model_class.where(guid: resource_guid)
-        if delete_action_can_return_warnings?
-          errors, warnings = delete_action.delete(dataset)
-        else
-          errors = delete_action.delete(dataset)
+        errors = []
+
+        begin
+          if delete_action_can_return_warnings?
+            errors, warnings = delete_action.delete(dataset)
+          else
+            errors = delete_action.delete(dataset)
+          end
+        rescue StandardError => e
+          errors << e
         end
+
+        # Ignore errors if the target resource has already been deleted (e.g., by a parallel job)
+        quoted_table_name = @model_class.db.quote_identifier(@model_class.table_name)
+        errors.reject! { |err| err.is_a?(Sequel::NoExistingObject) && err.message.include?("DELETE FROM #{quoted_table_name}") }
 
         raise errors.first unless errors&.empty?
 

--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -263,6 +263,10 @@ module VCAP::CloudController
 
     def destroy_route_bindings
       errors = RouteBindingDelete.new.delete(route_binding_dataset)
+
+      quoted_table_name = RouteBinding.db.quote_identifier(RouteBinding.table_name)
+      errors.reject! { |e| e.is_a?(Sequel::NoExistingObject) && e.message.include?("DELETE FROM #{quoted_table_name}") }
+
       raise errors.first unless errors.empty?
     end
 


### PR DESCRIPTION
If a user triggers two DELETE requests for the same resource within a few milliseconds two deletion jobs are created. If both jobs are be executed in parallel it might happen that one of them fails with a `Sequel::NoExistingObject` error. This change prevents this by catching those errors but only if the error message originates from the current model/ table. Therefore it is ensured that similar error messages when e.g. deleting sub resources still result in job failures.

The same applies if a user unbind routes but also deletes the route itself within a very short time period. For this case the route model now also catches `Sequel::NoExistingObject` errors related to route bindings.

Additionally, the error handling in the DeleteActionJob was improved to catch errors when the actions itself don't handle them.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
