### PR TITLE
Add feature flags to v1 app manifests

### DIFF
--- a/app/actions/app_apply_manifest.rb
+++ b/app/actions/app_apply_manifest.rb
@@ -28,6 +28,8 @@ module VCAP::CloudController
       app = AppModel.first(guid: app_guid)
       app_instance_not_found!(app_guid) unless app
 
+      AppFeatureUpdate.bulk_update(app, message.manifest_features_update_message)
+
       message.manifest_process_update_messages.each do |manifest_process_update_msg|
         if manifest_process_update_msg.requested_keys == [:type] && manifest_process_update_msg.type == 'web'
           # ignore trivial messages, most likely from manifest

--- a/app/actions/app_feature_update.rb
+++ b/app/actions/app_feature_update.rb
@@ -2,13 +2,13 @@ module VCAP::CloudController
   class AppFeatureUpdate
     def self.update(feature_name, app, message)
       case feature_name
-      when AppFeaturesController::SSH_FEATURE
+      when AppFeatures::SSH_FEATURE
         app.update(enable_ssh: message.enabled)
-      when AppFeaturesController::REVISIONS_FEATURE
+      when AppFeatures::REVISIONS_FEATURE
         app.update(revisions_enabled: message.enabled)
-      when AppFeaturesController::SERVICE_BINDING_K8S_FEATURE
+      when AppFeatures::SERVICE_BINDING_K8S_FEATURE
         app.update(service_binding_k8s_enabled: message.enabled)
-      when AppFeaturesController::FILE_BASED_VCAP_SERVICES_FEATURE
+      when AppFeatures::FILE_BASED_VCAP_SERVICES_FEATURE
         app.update(file_based_vcap_services_enabled: message.enabled)
       end
     end

--- a/app/actions/space_diff_manifest.rb
+++ b/app/actions/space_diff_manifest.rb
@@ -51,6 +51,8 @@ module VCAP::CloudController
 
             remove_default_missing_fields(existing_value, key, value) if nested_attribute_exists
 
+            remove_unspecified_app_features(existing_value, key, value)
+
             # To preserve backwards compability, we've decided to skip diffs that satisfy this conditon
             next if !nested_attribute_exists && %w[disk_quota disk-quota memory].include?(key)
 
@@ -210,6 +212,11 @@ module VCAP::CloudController
             end
           end
         end
+      end
+
+      def remove_unspecified_app_features(existing_value, key, value)
+        # Only show the diff for features that are specified in the manifest
+        existing_value.slice!(*value.keys) if key == 'features'
       end
     end
   end

--- a/app/controllers/v3/app_features_controller.rb
+++ b/app/controllers/v3/app_features_controller.rb
@@ -6,17 +6,14 @@ require 'presenters/v3/app_service_binding_k8s_feature_presenter'
 require 'presenters/v3/app_file_based_vcap_services_feature_presenter'
 require 'presenters/v3/app_ssh_status_presenter'
 require 'actions/app_feature_update'
+require 'models/helpers/app_features'
 
 class AppFeaturesController < ApplicationController
   include AppSubResource
 
-  SSH_FEATURE = 'ssh'.freeze
-  REVISIONS_FEATURE = 'revisions'.freeze
-  SERVICE_BINDING_K8S_FEATURE = 'service-binding-k8s'.freeze
-  FILE_BASED_VCAP_SERVICES_FEATURE = 'file-based-vcap-services'.freeze
-
-  TRUSTED_APP_FEATURES = [SSH_FEATURE, SERVICE_BINDING_K8S_FEATURE, FILE_BASED_VCAP_SERVICES_FEATURE].freeze
-  UNTRUSTED_APP_FEATURES = [REVISIONS_FEATURE].freeze
+  TRUSTED_APP_FEATURES = [VCAP::CloudController::AppFeatures::SSH_FEATURE, VCAP::CloudController::AppFeatures::SERVICE_BINDING_K8S_FEATURE,
+                          VCAP::CloudController::AppFeatures::FILE_BASED_VCAP_SERVICES_FEATURE].freeze
+  UNTRUSTED_APP_FEATURES = [VCAP::CloudController::AppFeatures::REVISIONS_FEATURE].freeze
   APP_FEATURES = (TRUSTED_APP_FEATURES + UNTRUSTED_APP_FEATURES).freeze
 
   def index
@@ -56,11 +53,12 @@ class AppFeaturesController < ApplicationController
     unprocessable!(message.errors.full_messages) unless message.valid?
 
     if message.enabled && both_service_binding_features_enabled?(app, name)
-      unprocessable!("'#{FILE_BASED_VCAP_SERVICES_FEATURE}' and '#{SERVICE_BINDING_K8S_FEATURE}' features cannot be enabled at the same time.")
+      unprocessable!("'#{VCAP::CloudController::AppFeatures::FILE_BASED_VCAP_SERVICES_FEATURE}' and '#{VCAP::CloudController::AppFeatures::SERVICE_BINDING_K8S_FEATURE}' " \
+                     'features cannot be enabled at the same time.')
     end
 
-    AppFeatureUpdate.update(hashed_params[:name], app, message)
-    render status: :ok, json: feature_presenter_for(hashed_params[:name], app)
+    AppFeatureUpdate.update(name, app, message)
+    render status: :ok, json: feature_presenter_for(name, app)
   end
 
   def ssh_enabled
@@ -87,10 +85,10 @@ class AppFeaturesController < ApplicationController
 
   def feature_presenter_for(feature_name, app)
     presenters = {
-      SSH_FEATURE => Presenters::V3::AppSshFeaturePresenter,
-      REVISIONS_FEATURE => Presenters::V3::AppRevisionsFeaturePresenter,
-      SERVICE_BINDING_K8S_FEATURE => Presenters::V3::AppServiceBindingK8sFeaturePresenter,
-      FILE_BASED_VCAP_SERVICES_FEATURE => Presenters::V3::AppFileBasedVcapServicesFeaturePresenter
+      VCAP::CloudController::AppFeatures::SSH_FEATURE => Presenters::V3::AppSshFeaturePresenter,
+      VCAP::CloudController::AppFeatures::REVISIONS_FEATURE => Presenters::V3::AppRevisionsFeaturePresenter,
+      VCAP::CloudController::AppFeatures::SERVICE_BINDING_K8S_FEATURE => Presenters::V3::AppServiceBindingK8sFeaturePresenter,
+      VCAP::CloudController::AppFeatures::FILE_BASED_VCAP_SERVICES_FEATURE => Presenters::V3::AppFileBasedVcapServicesFeaturePresenter
     }
     presenters[feature_name].new(app)
   end
@@ -105,9 +103,9 @@ class AppFeaturesController < ApplicationController
   end
 
   def both_service_binding_features_enabled?(app, feature_name)
-    if feature_name == FILE_BASED_VCAP_SERVICES_FEATURE
+    if feature_name == VCAP::CloudController::AppFeatures::FILE_BASED_VCAP_SERVICES_FEATURE
       app.service_binding_k8s_enabled
-    elsif feature_name == SERVICE_BINDING_K8S_FEATURE
+    elsif feature_name == VCAP::CloudController::AppFeatures::SERVICE_BINDING_K8S_FEATURE
       app.file_based_vcap_services_enabled
     end
   end

--- a/app/jobs/space_apply_manifest_action_job.rb
+++ b/app/jobs/space_apply_manifest_action_job.rb
@@ -26,7 +26,8 @@ module VCAP::CloudController
                AppApplyManifest::ServiceBindingError,
                SidecarCreate::InvalidSidecar,
                SidecarUpdate::InvalidSidecar,
-               ProcessScale::SidecarMemoryLessThanProcessMemory => e
+               ProcessScale::SidecarMemoryLessThanProcessMemory,
+               AppFeatureUpdate::InvalidCombination => e
 
           app_name = AppModel.find(guid: app_guid)&.name
           error_message = app_name ? "For application '#{app_name}': #{e.message}" : e.message

--- a/app/messages/manifest_features_update_message.rb
+++ b/app/messages/manifest_features_update_message.rb
@@ -1,0 +1,25 @@
+require 'messages/base_message'
+
+module VCAP::CloudController
+  class ManifestFeaturesUpdateMessage < BaseMessage
+    register_allowed_keys [:features]
+
+    validates_with NoAdditionalKeysValidator
+
+    validate :features do
+      errors.add(:features, 'must be a map of valid feature names to booleans (true = enabled, false = disabled)') unless is_valid(features)
+    end
+
+    private
+
+    def is_valid(features)
+      return false unless features.is_a?(Hash) && features.any?
+
+      features.all? { |feature, enabled| valid_feature?(feature) && [true, false].include?(enabled) }
+    end
+
+    def valid_feature?(feature)
+      AppFeatures.all_features.include?(feature.to_s)
+    end
+  end
+end

--- a/app/models/helpers/app_features.rb
+++ b/app/models/helpers/app_features.rb
@@ -1,0 +1,19 @@
+module VCAP::CloudController
+  class AppFeatures
+    SSH_FEATURE = 'ssh'.freeze
+    REVISIONS_FEATURE = 'revisions'.freeze
+    SERVICE_BINDING_K8S_FEATURE = 'service-binding-k8s'.freeze
+    FILE_BASED_VCAP_SERVICES_FEATURE = 'file-based-vcap-services'.freeze
+
+    DATABASE_COLUMNS_MAPPING = {
+      SSH_FEATURE => :enable_ssh,
+      REVISIONS_FEATURE => :revisions_enabled,
+      SERVICE_BINDING_K8S_FEATURE => :service_binding_k8s_enabled,
+      FILE_BASED_VCAP_SERVICES_FEATURE => :file_based_vcap_services_enabled
+    }.freeze
+
+    def self.all_features
+      [SSH_FEATURE, REVISIONS_FEATURE, SERVICE_BINDING_K8S_FEATURE, FILE_BASED_VCAP_SERVICES_FEATURE]
+    end
+  end
+end

--- a/app/presenters/v3/app_file_based_vcap_services_feature_presenter.rb
+++ b/app/presenters/v3/app_file_based_vcap_services_feature_presenter.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController::Presenters::V3
   class AppFileBasedVcapServicesFeaturePresenter < BasePresenter
     def to_hash
       {
-        name: AppFeaturesController::FILE_BASED_VCAP_SERVICES_FEATURE,
+        name: VCAP::CloudController::AppFeatures::FILE_BASED_VCAP_SERVICES_FEATURE,
         description: 'Enable file-based VCAP service bindings for the app',
         enabled: app.file_based_vcap_services_enabled
       }

--- a/app/presenters/v3/app_manifest_presenter.rb
+++ b/app/presenters/v3/app_manifest_presenter.rb
@@ -7,6 +7,7 @@ require 'presenters/v3/app_manifest_presenters/metadata_presenter'
 require 'presenters/v3/app_manifest_presenters/process_properties_presenter'
 require 'presenters/v3/app_manifest_presenters/sidecar_properties_presenter'
 require 'presenters/v3/app_manifest_presenters/lifecycle_presenter'
+require 'presenters/v3/app_manifest_presenters/features_presenter'
 
 module VCAP::CloudController
   module Presenters
@@ -17,6 +18,7 @@ module VCAP::CloudController
           AppManifestPresenters::LifecyclePresenter.new,
           AppManifestPresenters::DockerPresenter.new,
           AppManifestPresenters::BuildpackPresenter.new,
+          AppManifestPresenters::FeaturesPresenter.new,
           AppManifestPresenters::ServicesPropertiesPresenter.new,
           AppManifestPresenters::RoutePropertiesPresenter.new,
           AppManifestPresenters::MetadataPresenter.new,

--- a/app/presenters/v3/app_manifest_presenters/features_presenter.rb
+++ b/app/presenters/v3/app_manifest_presenters/features_presenter.rb
@@ -1,0 +1,20 @@
+module VCAP::CloudController
+  module Presenters
+    module V3
+      module AppManifestPresenters
+        class FeaturesPresenter
+          def to_hash(app:, **_)
+            features = {}
+            AppFeatures.all_features.each do |feature|
+              features[feature.to_sym] = app.send(AppFeatures::DATABASE_COLUMNS_MAPPING[feature])
+            end
+
+            {
+              features:
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/v3/app_revisions_feature_presenter.rb
+++ b/app/presenters/v3/app_revisions_feature_presenter.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController::Presenters::V3
   class AppRevisionsFeaturePresenter < BasePresenter
     def to_hash
       {
-        name: 'revisions',
+        name: VCAP::CloudController::AppFeatures::REVISIONS_FEATURE,
         description: 'Enable versioning of an application',
         enabled: app.revisions_enabled
       }

--- a/app/presenters/v3/app_service_binding_k8s_feature_presenter.rb
+++ b/app/presenters/v3/app_service_binding_k8s_feature_presenter.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController::Presenters::V3
   class AppServiceBindingK8sFeaturePresenter < BasePresenter
     def to_hash
       {
-        name: AppFeaturesController::SERVICE_BINDING_K8S_FEATURE,
+        name: VCAP::CloudController::AppFeatures::SERVICE_BINDING_K8S_FEATURE,
         description: 'Enable k8s service bindings for the app',
         enabled: app.service_binding_k8s_enabled
       }

--- a/app/presenters/v3/app_ssh_feature_presenter.rb
+++ b/app/presenters/v3/app_ssh_feature_presenter.rb
@@ -4,7 +4,7 @@ module VCAP::CloudController::Presenters::V3
   class AppSshFeaturePresenter < BasePresenter
     def to_hash
       {
-        name: 'ssh',
+        name: VCAP::CloudController::AppFeatures::SSH_FEATURE,
         description: 'Enable SSHing into the app.',
         enabled: app.enable_ssh
       }

--- a/docs/v3/source/includes/resources/manifests/_apply.md
+++ b/docs/v3/source/includes/resources/manifests/_apply.md
@@ -24,7 +24,7 @@ Location: https://api.example.org/v3/jobs/[guid]
 Apply changes specified in a manifest to the named apps and their underlying
 processes. The apps must reside in the space. These changes are additive
 and will not modify any unspecified properties or remove any existing
-environment variables, routes, or services.
+environment variables, app features, routes, or services.
 
 <aside class="notice">
 Apply manifest will only trigger an immediate update for the "instances" property or routing changes. All other properties require an app restart to take effect.

--- a/docs/v3/source/includes/resources/manifests/_get.md
+++ b/docs/v3/source/includes/resources/manifests/_get.md
@@ -22,6 +22,11 @@ Content-Type: application/x-yaml
 applications:
 - name: my-app
   stack: cflinuxfs4
+  features:
+    ssh: true
+    revisions: true
+    service-binding-k8s: false
+    file-based-vcap-services: false
   services:
   - my-service
   routes:

--- a/docs/v3/source/includes/resources/manifests/_object.md.erb
+++ b/docs/v3/source/includes/resources/manifests/_object.md.erb
@@ -19,6 +19,11 @@ applications:
   env:
     VAR1: value1
     VAR2: value2
+  features:
+    ssh: true
+    revisions: true
+    service-binding-k8s: false
+    file-based-vcap-services: false
   routes:
   - route: route.example.com
   - route: another-route.example.com
@@ -94,6 +99,7 @@ Name | Type | Description
 **buildpacks** | _list of strings_ | a) An empty array, which will automatically select the appropriate default buildpack according to the coding language (incompatible with **lifecycle: cnb**) <br>b) An array of one or more URLs pointing to buildpacks <br>c) An array of one or more installed buildpack names <br>Replaces the legacy `buildpack` field
 **docker** | _object_ | If present, the created app will have Docker lifecycle type; the value of this key is ignored by the API but may be used by clients to source the registry address of the image and credentials, if needed; the [generate manifest endpoint](#generate-a-manifest-for-an-app) will return the registry address of the image and username provided with this key
 **env** | _object_ | A key-value mapping of environment variables to be used for the app when running
+**features** | _object_ | A key-value mapping of feature names to booleans (true = enabled, false = disabled)
 **no-route** | _boolean_ | When set to `true`, any routes specified with the `routes` attribute will be ignored and any existing routes will be removed
 **processes** | _array of [process configurations](#space-manifest-process-level-configuration)_ | List of configurations for individual process types
 **random-route** | _boolean_ | Creates a random route for the app if `true`; if `routes` is specified, if the app already has routes, or if `no-route` is specified, this field is ignored regardless of its value

--- a/spec/request/app_manifests_spec.rb
+++ b/spec/request/app_manifests_spec.rb
@@ -93,6 +93,12 @@ RSpec.describe 'App Manifests' do
               'lifecycle' => 'buildpack',
               'buildpacks' => [buildpack.name, buildpack2.name],
               'stack' => buildpack.stack,
+              'features' => {
+                'ssh' => true,
+                'revisions' => true,
+                'service-binding-k8s' => false,
+                'file-based-vcap-services' => false
+              },
               'services' => [service_binding.service_instance_name, service_binding2.service_instance_name],
               'routes' => [
                 {
@@ -199,6 +205,12 @@ RSpec.describe 'App Manifests' do
                 'image' => docker_package.image,
                 'username' => 'xXxMyL1ttlePwnyxXx'
               },
+              'features' => {
+                'ssh' => true,
+                'revisions' => true,
+                'service-binding-k8s' => false,
+                'file-based-vcap-services' => false
+              },
               'services' => [service_binding.service_instance_name, service_binding2.service_instance_name],
               'routes' => [
                 {
@@ -274,6 +286,12 @@ RSpec.describe 'App Manifests' do
               'name' => simple_app.name,
               'lifecycle' => 'buildpack',
               'stack' => 'itaewon_class_best_kdrama',
+              'features' => {
+                'ssh' => true,
+                'revisions' => true,
+                'service-binding-k8s' => false,
+                'file-based-vcap-services' => false
+              },
               'routes' => [
                 {
                   'route' => "#{route.host}.#{route.domain.name}",

--- a/spec/unit/actions/app_feature_update_spec.rb
+++ b/spec/unit/actions/app_feature_update_spec.rb
@@ -5,10 +5,11 @@ require 'messages/app_feature_update_message'
 module VCAP::CloudController
   RSpec.describe AppFeatureUpdate do
     subject(:app_feature_update) { AppFeatureUpdate }
-    let(:app) { AppModel.make(enable_ssh: false, revisions_enabled: false) }
-    let(:message) { AppFeatureUpdateMessage.new(enabled: true) }
+    let(:app) { AppModel.make(enable_ssh: false, revisions_enabled: false, service_binding_k8s_enabled: false, file_based_vcap_services_enabled: false) }
 
     describe '.update' do
+      let(:message) { AppFeatureUpdateMessage.new(enabled: true) }
+
       context 'when the feature name is ssh' do
         it 'updates the enable_ssh column on the app' do
           expect do
@@ -38,6 +39,99 @@ module VCAP::CloudController
           expect do
             AppFeatureUpdate.update('file-based-vcap-services', app, message)
           end.to change { app.reload.file_based_vcap_services_enabled }.to(true)
+        end
+      end
+    end
+
+    describe '.bulk_update' do
+      let(:features) do
+        {
+          ssh: false,
+          revisions: false,
+          'service-binding-k8s': false,
+          'file-based-vcap-services': false
+        }
+      end
+      let(:message) { ManifestFeaturesUpdateMessage.new(features:) }
+
+      context 'when the ssh feature is specified' do
+        before do
+          features[:ssh] = true
+        end
+
+        it 'updates the enable_ssh column on the app' do
+          expect do
+            AppFeatureUpdate.bulk_update(app, message)
+          end.to change { app.reload.enable_ssh }.to(true)
+        end
+      end
+
+      context 'when the revisions feature is specified' do
+        before do
+          features[:revisions] = true
+        end
+
+        it 'updates the revisions_enabled column on the app' do
+          expect do
+            AppFeatureUpdate.bulk_update(app, message)
+          end.to change { app.reload.revisions_enabled }.to(true)
+        end
+      end
+
+      context 'when the service-binding-k8s feature is specified' do
+        before do
+          features[:'service-binding-k8s'] = true
+        end
+
+        it 'updates the service_binding_k8s_enabled column on the app' do
+          expect do
+            AppFeatureUpdate.bulk_update(app, message)
+          end.to change { app.reload.service_binding_k8s_enabled }.to(true)
+        end
+      end
+
+      context 'when the file-based-vcap-services feature is specified' do
+        before do
+          features[:'file-based-vcap-services'] = true
+        end
+
+        it 'updates the file_based_vcap_services_enabled column on the app' do
+          expect do
+            AppFeatureUpdate.bulk_update(app, message)
+          end.to change { app.reload.file_based_vcap_services_enabled }.to(true)
+        end
+      end
+
+      context 'when multiple features are specified' do
+        before do
+          features[:ssh] = true
+          features[:'service-binding-k8s'] = true
+        end
+
+        it 'updates the corresponding columns in a single database call' do
+          expect(app.enable_ssh).to be(false)
+          expect(app.service_binding_k8s_enabled).to be(false)
+
+          expect do
+            AppFeatureUpdate.bulk_update(app, message)
+          end.to have_queried_db_times(/update .apps./i, 1)
+
+          app.reload
+          expect(app.enable_ssh).to be(true)
+          expect(app.service_binding_k8s_enabled).to be(true)
+        end
+      end
+
+      context 'when conflicting features are specified' do
+        before do
+          features[:'service-binding-k8s'] = true
+          features[:'file-based-vcap-services'] = true
+        end
+
+        it 'raises an error' do
+          expect do
+            AppFeatureUpdate.bulk_update(app, message)
+          end.to raise_error(AppFeatureUpdate::InvalidCombination, /'file-based-vcap-services' and 'service-binding-k8s' features cannot be enabled at the same time/)
         end
       end
     end

--- a/spec/unit/actions/space_diff_manifest_spec.rb
+++ b/spec/unit/actions/space_diff_manifest_spec.rb
@@ -503,6 +503,28 @@ module VCAP::CloudController
           end
         end
       end
+
+      context 'when the given manifest contains features' do
+        before do
+          default_manifest['applications'][0]['features'] = {
+            'ssh' => true,                 # unchanged
+            'service-binding-k8s' => true  # changed
+          }
+        end
+
+        it 'does not show unchanged features' do
+          expect(subject).not_to include(hash_including('path' => '/applications/0/features/ssh'))
+        end
+
+        it 'shows changed features' do
+          expect(subject).to include({ 'op' => 'replace', 'path' => '/applications/0/features/service-binding-k8s', 'value' => true, 'was' => false })
+        end
+
+        it 'does not show unspecified features' do
+          expect(subject).not_to include(hash_including('path' => '/applications/0/features/revisions'))
+          expect(subject).not_to include(hash_including('path' => '/applications/0/features/file-based-vcap-services'))
+        end
+      end
     end
   end
 end

--- a/spec/unit/controllers/v3/app_manifests_controller_spec.rb
+++ b/spec/unit/controllers/v3/app_manifests_controller_spec.rb
@@ -16,7 +16,13 @@ RSpec.describe AppManifestsController, type: :controller do
           {
             'name' => app_model.name,
             'lifecycle' => 'buildpack',
-            'stack' => app_model.lifecycle_data.stack
+            'stack' => app_model.lifecycle_data.stack,
+            'features' => {
+              'ssh' => true,
+              'revisions' => true,
+              'service-binding-k8s' => false,
+              'file-based-vcap-services' => false
+            }
           }
         ]
       }.to_yaml

--- a/spec/unit/jobs/space_apply_manifest_action_job_spec.rb
+++ b/spec/unit/jobs/space_apply_manifest_action_job_spec.rb
@@ -58,7 +58,8 @@ module VCAP::CloudController
         AppApplyManifest::ServiceBindingError,
         SidecarCreate::InvalidSidecar,
         SidecarUpdate::InvalidSidecar,
-        ProcessScale::SidecarMemoryLessThanProcessMemory
+        ProcessScale::SidecarMemoryLessThanProcessMemory,
+        AppFeatureUpdate::InvalidCombination
       ].each do |klass|
         it "wraps a #{klass} in an ApiError" do
           allow(apply_manifest_action).to receive(:apply).

--- a/spec/unit/messages/app_manifest_message_spec.rb
+++ b/spec/unit/messages/app_manifest_message_spec.rb
@@ -2200,5 +2200,43 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe '#manifest_features_update_message' do
+      context 'when no features are specified' do
+        let(:parsed_yaml) do
+          { name: 'app' }
+        end
+
+        it 'does not set the features in the message' do
+          message = AppManifestMessage.create_from_yml(parsed_yaml)
+          expect(message).to be_valid
+          expect(message.manifest_features_update_message).not_to be_requested(:features)
+        end
+      end
+
+      context 'when features are specified' do
+        let(:parsed_yaml) do
+          { name: 'app', features: { ssh: true, 'service-binding-k8s': false } }
+        end
+
+        it 'returns a ManifestFeaturesUpdateMessage containing the features' do
+          message = AppManifestMessage.create_from_yml(parsed_yaml)
+          expect(message).to be_valid
+          expect(message.manifest_features_update_message.features).to eq({ ssh: true, 'service-binding-k8s': false })
+        end
+      end
+
+      context 'when an invalid feature is specified' do
+        let(:parsed_yaml) do
+          { features: { invalid_feature: true } }
+        end
+
+        it 'is invalid and contains the correct error message' do
+          message = AppManifestMessage.create_from_yml(parsed_yaml)
+          expect(message).not_to be_valid
+          expect(message.errors[:base]).to include('Features must be a map of valid feature names to booleans (true = enabled, false = disabled)')
+        end
+      end
+    end
   end
 end

--- a/spec/unit/messages/manifest_features_update_message_spec.rb
+++ b/spec/unit/messages/manifest_features_update_message_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  RSpec.describe ManifestFeaturesUpdateMessage do
+    subject(:message) { ManifestFeaturesUpdateMessage.new(params) }
+
+    describe 'validations' do
+      context 'when an unexpected key is requested' do
+        let(:params) { { unexpected: 'key' } }
+
+        it 'is not valid' do
+          expect(message).not_to be_valid
+          expect(message.errors.full_messages[0]).to include("Unknown field(s): 'unexpected'")
+        end
+      end
+
+      context "when 'features' is not a hash" do
+        let(:params) { { features: 'no hash' } }
+
+        it 'is not valid' do
+          expect(message).not_to be_valid
+          expect(message.errors[:features]).to include('must be a map of valid feature names to booleans (true = enabled, false = disabled)')
+        end
+      end
+
+      context "when the 'features' hash is empty" do
+        let(:params) { { features: {} } }
+
+        it 'is not valid' do
+          expect(message).not_to be_valid
+          expect(message.errors[:features]).to include('must be a map of valid feature names to booleans (true = enabled, false = disabled)')
+        end
+      end
+
+      context "when the 'features' hash contains an invalid feature" do
+        let(:params) { { features: { invalid_feature: true } } }
+
+        it 'is not valid' do
+          expect(message).not_to be_valid
+          expect(message.errors[:features]).to include('must be a map of valid feature names to booleans (true = enabled, false = disabled)')
+        end
+      end
+
+      context "when the 'features' hash contains an invalid 'enabled' value" do
+        let(:params) { { features: { ssh: 'sure' } } }
+
+        it 'is not valid' do
+          expect(message).not_to be_valid
+          expect(message.errors[:features]).to include('must be a map of valid feature names to booleans (true = enabled, false = disabled)')
+        end
+      end
+
+      context "when 'features' are given in the right format" do
+        let(:params) { { features: { ssh: true } } }
+
+        it 'is valid' do
+          expect(message).to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/presenters/v3/app_manifest_presenter_spec.rb
+++ b/spec/unit/presenters/v3/app_manifest_presenter_spec.rb
@@ -15,12 +15,12 @@ module VCAP::CloudController::Presenters::V3
       context 'when the app has no associated resources' do
         let(:service_bindings) { [] }
         let(:route_mappings) { [] }
-        let(:environment_variables) { nil }
 
         context 'for buildpack apps' do
-          it 'only returns the application name and stack' do
+          it 'returns the application name and stack' do
             result = AppManifestPresenter.new(app, service_bindings, route_mappings).to_hash
             application = result[:applications].first
+            application.except!(:env, :features)
             expect(application).to eq({ lifecycle: 'buildpack', name: app.name, stack: app.lifecycle_data.stack })
           end
         end
@@ -33,11 +33,24 @@ module VCAP::CloudController::Presenters::V3
             )
           end
 
-          it 'only returns application name' do
+          it 'returns the application name' do
             result = AppManifestPresenter.new(app, service_bindings, route_mappings).to_hash
             application = result[:applications].first
+            application.except!(:env, :features)
             expect(application).to eq({ lifecycle: 'docker', name: app.name })
           end
+        end
+
+        it 'returns the environment variables' do
+          result = AppManifestPresenter.new(app, service_bindings, route_mappings).to_hash
+          application = result[:applications].first
+          expect(application[:env]).to eq(environment_variables)
+        end
+
+        it 'returns the app features' do
+          result = AppManifestPresenter.new(app, service_bindings, route_mappings).to_hash
+          application = result[:applications].first
+          expect(application[:features].keys).to contain_exactly(:ssh, :revisions, :'service-binding-k8s', :'file-based-vcap-services')
         end
 
         context 'when environment variables is an empty hash' do


### PR DESCRIPTION
Allow app features to be set via manifest. Features are specified as follows (per app):
```
features:
    ssh: true
    revisions: true
    service-binding-k8s: false
    file-based-vcap-services: false
```

Features are shown in the generated manifest for an app (`GET /v3/apps/:guid/manifest`) and taken into account when calculating the manifest diff (`POST /v3/spaces/:guid/manifest_diff`).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
