### PR TITLE
Catch CipherError and TypeError in run_cipher and raise EncryptorError

### DIFF
--- a/app/controllers/v3/application_controller.rb
+++ b/app/controllers/v3/application_controller.rb
@@ -93,7 +93,7 @@ class ApplicationController < ActionController::Base
   rescue_from CloudController::Errors::CompoundError, with: :handle_compound_error
   rescue_from ActionDispatch::Http::Parameters::ParseError, with: :handle_invalid_request_body
   rescue_from Sequel::DatabaseConnectionError, Sequel::DatabaseDisconnectError, with: :handle_db_connection_error
-  rescue_from OpenSSL::Cipher::CipherError, with: :handle_key_derivation_error
+  rescue_from VCAP::CloudController::Encryptor::EncryptorError, with: :handle_key_derivation_error
 
   def configuration
     Config.config

--- a/errors/v3.yml
+++ b/errors/v3.yml
@@ -18,7 +18,7 @@
   http_code: 429
   message: "The UAA is currently rate limited. Please try again later"
 
-10001:
+10081:
   name: InternalServerError
   http_code: 500
   message: "%s"

--- a/lib/cloud_controller/encryptor.rb
+++ b/lib/cloud_controller/encryptor.rb
@@ -9,6 +9,8 @@ module VCAP::CloudController
   module Encryptor
     ENCRYPTION_ITERATIONS = 2048
 
+    class EncryptorError < StandardError; end
+
     class << self
       ALGORITHM = 'AES-128-CBC'.freeze
 
@@ -87,6 +89,8 @@ module VCAP::CloudController
           cipher.iv = salt
         end
         cipher.update(input) << cipher.final
+      rescue OpenSSL::Cipher::CipherError, TypeError => e
+        raise EncryptorError.new("Encryption/Decryption failed: #{e.message}")
       end
 
       def deprecated_short_salt?(salt)

--- a/lib/cloud_controller/validate_database_keys.rb
+++ b/lib/cloud_controller/validate_database_keys.rb
@@ -56,7 +56,8 @@ module VCAP::CloudController
               iterations: sentinel_model.encryption_iterations
             )
           # A failed decryption occasionally results in a CipherError: bad decrypt instead of a garbled string
-          rescue OpenSSL::Cipher::CipherError
+          # This is now caught inside Encryptor and re-raised as EncryptorError
+          rescue VCAP::CloudController::Encryptor::EncryptorError
             labels_with_changed_keys << label_string
             next
           end

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -3406,7 +3406,7 @@ RSpec.describe 'Apps' do
 
       it 'fails to decrypt the environment variables and returns a 500 error' do
         app_model # ensure that app model is created before run_cipher is mocked to throw an error
-        allow(VCAP::CloudController::Encryptor).to receive(:run_cipher).and_raise(OpenSSL::Cipher::CipherError)
+        allow(VCAP::CloudController::Encryptor).to receive(:run_cipher).and_raise(VCAP::CloudController::Encryptor::EncryptorError)
         api_call.call(admin_headers)
 
         expect(last_response).to have_status_code(500)

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -920,7 +920,7 @@ RSpec.describe 'V3 service brokers' do
 
       it 'fails to decrypt the broker data and returns a 500 error' do
         broker # ensure the broker is created before run_cipher is mocked to throw an error
-        allow(VCAP::CloudController::Encryptor).to receive(:run_cipher).and_raise(OpenSSL::Cipher::CipherError)
+        allow(VCAP::CloudController::Encryptor).to receive(:run_cipher).and_raise(VCAP::CloudController::Encryptor::EncryptorError)
         api_call.call(admin_headers)
 
         expect(last_response).to have_status_code(500)

--- a/spec/request/service_credential_bindings_spec.rb
+++ b/spec/request/service_credential_bindings_spec.rb
@@ -631,7 +631,7 @@ RSpec.describe 'v3 service credential bindings' do
 
       it 'fails to decrypt the credentials and returns a 500 error' do
         app_binding # ensure that binding is created before run_cipher is mocked to throw an error
-        allow(VCAP::CloudController::Encryptor).to receive(:run_cipher).and_raise(OpenSSL::Cipher::CipherError)
+        allow(VCAP::CloudController::Encryptor).to receive(:run_cipher).and_raise(VCAP::CloudController::Encryptor::EncryptorError)
         api_call.call(admin_headers)
 
         expect(last_response).to have_status_code(500)

--- a/spec/support/shared_examples/models/encrypted_attribute.rb
+++ b/spec/support/shared_examples/models/encrypted_attribute.rb
@@ -53,7 +53,7 @@ module VCAP::CloudController
 
       begin
         decrypted_value = Encryptor.decrypt(saved_attribute, model.send(attr_salt), label: model.encryption_key_label, iterations: model.encryption_iterations)
-      rescue OpenSSL::Cipher::CipherError
+      rescue VCAP::CloudController::Encryptor::EncryptorError
         errored = true
       end
 

--- a/spec/unit/controllers/v3/application_controller_spec.rb
+++ b/spec/unit/controllers/v3/application_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     def key_derivation_error
-      raise OpenSSL::Cipher::CipherError
+      raise VCAP::CloudController::Encryptor::EncryptorError
     end
 
     def db_disconnect_error
@@ -334,7 +334,7 @@ RSpec.describe ApplicationController, type: :controller do
       end
     end
 
-    it 'rescues from OpenSSL::Cipher::CipherError and renders an error presenter' do
+    it 'rescues from EncryptorError and renders an error presenter' do
       get :key_derivation_error
       expect(response).to have_http_status(:internal_server_error)
       expect(response).to have_error_message(/Error while processing encrypted data/)

--- a/spec/unit/lib/cloud_controller/encryptor_spec.rb
+++ b/spec/unit/lib/cloud_controller/encryptor_spec.rb
@@ -175,6 +175,15 @@ module VCAP::CloudController
 
               expect(result).not_to eq(unencrypted_string)
             end
+
+            it 'raises an EncryptorError' do
+              allow(Encryptor).to receive(:current_encryption_key_label).and_return('foo')
+              encrypted_string = Encryptor.encrypt(unencrypted_string, salt)
+
+              expect do
+                Encryptor.decrypt(encrypted_string, salt, label: 'bar', iterations: encryption_iterations)
+              end.to raise_error(VCAP::CloudController::Encryptor::EncryptorError, %r{Encryption/Decryption failed: })
+            end
           end
         end
       end

--- a/spec/unit/lib/cloud_controller/encryptor_spec.rb
+++ b/spec/unit/lib/cloud_controller/encryptor_spec.rb
@@ -155,7 +155,7 @@ module VCAP::CloudController
 
               result = begin
                 Encryptor.decrypt(encrypted_string, salt, iterations: encryption_iterations)
-              rescue OpenSSL::Cipher::CipherError => e
+              rescue VCAP::CloudController::Encryptor::EncryptorError => e
                 e.message
               end
 
@@ -169,7 +169,7 @@ module VCAP::CloudController
 
               result = begin
                 Encryptor.decrypt(encrypted_string, salt, label: 'death', iterations: encryption_iterations)
-              rescue OpenSSL::Cipher::CipherError => e
+              rescue VCAP::CloudController::Encryptor::EncryptorError => e
                 e.message
               end
 


### PR DESCRIPTION
Wraps OpenSSL::Cipher::CipherError and TypeError in a custom EncryptorError to allow centralized handling in ApplicationController. This enables consistent 500 error responses with clearer messages like "Error while processing encrypted data".

* A short explanation of the proposed change:
This change wraps OpenSSL::Cipher::CipherError and TypeError raised during encryption/decryption in a custom EncryptorError exception. The ApplicationController is updated to catch this new exception.
* An explanation of the use cases your change solves
If a TypeError is raised by OpenSSL::PKCS5.pbkdf2_hmac (e.g., due to a nil or invalid key), or if a CipherError occurs during encryption or decryption, these are now caught and wrapped in a custom EncryptorError. This ensures the error is handled gracefully in the ApplicationController, and the user receives a standardized and meaningful 500 error response.
* Links to any other associated PRs
Improves #4326
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
