### PR TITLE
Accept zero-padded segments in IPv6 addresses

### DIFF
--- a/lib/cloud_controller/rule_validator.rb
+++ b/lib/cloud_controller/rule_validator.rb
@@ -99,7 +99,8 @@ module CloudController
     private_class_method def self.no_leading_zeros_in_address(address)
       return no_leading_zeros_in_ipv4_address(address) if address.include?('.')
 
-      no_leading_zeros_in_ipv6_address(address) if address.include?(':')
+      # return true for IPv6 addresses, as leading zeros are allowed
+      true
     end
 
     private_class_method def self.no_leading_zeros_in_ipv4_address(address)
@@ -110,19 +111,6 @@ module CloudController
 
           return false if octet_parts[0].length > 1 && octet_parts[0].start_with?('0')
         end
-      end
-
-      true
-    end
-
-    private_class_method def self.no_leading_zeros_in_ipv6_address(address)
-      address.split(':').each do |segment|
-        next unless segment.start_with?('0') && segment.length > 1
-
-        segment_parts = segment.split('/')
-        return false if segment_parts.length < 2
-
-        return false if segment_parts[0].length > 1 && segment_parts[0].start_with?('0')
       end
 
       true

--- a/spec/unit/messages/validators/security_group_rule_validator_spec.rb
+++ b/spec/unit/messages/validators/security_group_rule_validator_spec.rb
@@ -655,7 +655,7 @@ module VCAP::CloudController::Validators
           end
         end
 
-        context 'when there is a leading zero in an octet' do
+        context 'when there is a leading zero in a segment' do
           context 'in a CIDR' do
             let(:rules) do
               [
@@ -672,10 +672,8 @@ module VCAP::CloudController::Validators
               ]
             end
 
-            it 'is not valid' do
-              expect(subject).not_to be_valid
-              expect(subject.errors.full_messages).to include 'Rules[0]: destination octets cannot contain leading zeros'
-              expect(subject.errors.full_messages).to include 'Rules[1]: destination octets cannot contain leading zeros'
+            it 'is valid' do
+              expect(subject).to be_valid
             end
           end
 
@@ -690,9 +688,8 @@ module VCAP::CloudController::Validators
               ]
             end
 
-            it 'is not valid' do
-              expect(subject).not_to be_valid
-              expect(subject.errors.full_messages).to include 'Rules[0]: destination octets cannot contain leading zeros'
+            it 'is valid' do
+              expect(subject).to be_valid
             end
           end
 
@@ -727,14 +724,8 @@ module VCAP::CloudController::Validators
               ]
             end
 
-            it 'is not valid' do
-              expect(subject).not_to be_valid
-              expect(subject.errors.full_messages.length).to eq(5)
-              expect(subject.errors.full_messages).to include 'Rules[0]: destination octets cannot contain leading zeros'
-              expect(subject.errors.full_messages).to include 'Rules[1]: destination octets cannot contain leading zeros'
-              expect(subject.errors.full_messages).to include 'Rules[2]: destination octets cannot contain leading zeros'
-              expect(subject.errors.full_messages).to include 'Rules[3]: destination octets cannot contain leading zeros'
-              expect(subject.errors.full_messages).to include 'Rules[4]: destination octets cannot contain leading zeros'
+            it 'is valid' do
+              expect(subject).to be_valid
             end
           end
         end
@@ -914,7 +905,7 @@ module VCAP::CloudController::Validators
               [
                 {
                   protocol: 'udp',
-                  destination: '2001:db8::1-2001:db8::g,2001:db8::/129,2001:db8:0000::/32,2001:db8::ff-2001:db8::1',
+                  destination: '2001:db8::1-2001:db8::g,2001:db8::/129,2001:db8::ff-2001:db8::1',
                   ports: '8080'
                 }
               ]
@@ -922,7 +913,7 @@ module VCAP::CloudController::Validators
 
             it 'throws an error for every destination' do
               expect(subject).not_to be_valid
-              expect(subject.errors.full_messages.length).to equal(4)
+              expect(subject.errors.full_messages.length).to equal(3)
               expect(subject.errors.full_messages).to include 'Rules[0]: destination must contain valid CIDR(s), IP address(es), or IP address range(s)'
               expect(subject.errors.full_messages).to include 'Rules[0]: destination IP address range is invalid'
 


### PR DESCRIPTION
### A short explanation of the proposed change:
With #4318 we added support for IPv6 addresses for ASGs. This PR removes the check `no_leading_zeros` for IPv6 adresses, as they are also valid and should be accepted.
### An explanation of the use cases your change solves

### Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
