### PR TITLE
Fix typo in update routes destination endpoint

### DIFF
--- a/docs/v3/source/includes/resources/routes/_update_destination.md.erb
+++ b/docs/v3/source/includes/resources/routes/_update_destination.md.erb
@@ -5,7 +5,7 @@ Example Request
 ```
 
 ```shell
-curl "https://api.example.org/v3/routes/[guid]/destinations/[guid]" \
+curl "https://api.example.org/v3/routes/[guid]/destinations/[destination_guid]" \
   -X PATCH \
   -H "Authorization: bearer [token]"
   -d '{"protocol": "http2"}'
@@ -44,7 +44,7 @@ Content-Type: application/json
 This endpoint updates the protocol of a route destination (app, port and weight cannot be updated)
 
 #### Definition
-`PATCH /v3/routes/:guid/destinations/:guid`
+`PATCH /v3/routes/:guid/destinations/:destination_guid`
 
 #### Optional parameters
 


### PR DESCRIPTION
There are two parameters with one and the same name. The second one should be "destination_guid" as it is in the rest routes-destinations-related endpoints.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
