### PR TITLE
Add support for SHA256 fingerprint for diego-ssh

### DIFF
--- a/lib/cloud_controller/diego/app_recipe_builder.rb
+++ b/lib/cloud_controller/diego/app_recipe_builder.rb
@@ -60,7 +60,8 @@ module VCAP::CloudController
           routes[SSH_ROUTES_KEY] = Oj.dump({
                                              container_port: DEFAULT_SSH_PORT,
                                              private_key: ssh_key.private_key,
-                                             host_fingerprint: ssh_key.fingerprint
+                                             host_fingerprint: ssh_key.fingerprint,
+                                             host_256_fingerprint: ssh_key.sha256_fingerprint
                                            })
         end
 

--- a/lib/cloud_controller/diego/ssh_key.rb
+++ b/lib/cloud_controller/diego/ssh_key.rb
@@ -26,6 +26,10 @@ module VCAP
           @fingerprint ||= ::SSHKey.new(key.to_der).sha1_fingerprint
         end
 
+        def sha256_fingerprint
+          @sha256_fingerprint ||= ::SSHKey.new(key.to_der).sha256_fingerprint
+        end
+
         private
 
         def key

--- a/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/app_recipe_builder_spec.rb
@@ -901,7 +901,8 @@ module VCAP::CloudController
               expect(lrp.routes.routes['diego-ssh']).to eq(Oj.dump({
                                                                      container_port: 2222,
                                                                      private_key: ssh_key.private_key,
-                                                                     host_fingerprint: ssh_key.fingerprint
+                                                                     host_fingerprint: ssh_key.fingerprint,
+                                                                     host_256_fingerprint: ssh_key.sha256_fingerprint
                                                                    }))
             end
           end
@@ -1001,7 +1002,8 @@ module VCAP::CloudController
               expect(lrp.routes.routes['diego-ssh']).to eq(Oj.dump({
                                                                      container_port: 2222,
                                                                      private_key: ssh_key.private_key,
-                                                                     host_fingerprint: ssh_key.fingerprint
+                                                                     host_fingerprint: ssh_key.fingerprint,
+                                                                     host_256_fingerprint: ssh_key.sha256_fingerprint
                                                                    }))
             end
           end
@@ -1344,7 +1346,8 @@ module VCAP::CloudController
               expect(lrp.routes.routes['diego-ssh']).to eq(Oj.dump({
                                                                      container_port: 2222,
                                                                      private_key: ssh_key.private_key,
-                                                                     host_fingerprint: ssh_key.fingerprint
+                                                                     host_fingerprint: ssh_key.fingerprint,
+                                                                     host_256_fingerprint: ssh_key.sha256_fingerprint
                                                                    }))
             end
           end

--- a/spec/unit/lib/cloud_controller/diego/ssh_key_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/ssh_key_spec.rb
@@ -39,6 +39,13 @@ module VCAP::CloudController
           expect(ssh_key.fingerprint).to match(/([0-9a-f]{2}:){19}[0-9a-f]{2}/)
         end
       end
+
+      describe '#fingerprint 256' do
+        it 'returns an sha256 fingerprint' do
+          ssh_key = SSHKey.new(1024)
+          expect(ssh_key.sha256_fingerprint).to match(/[a-zA-Z0-9+\/=]{44}/)
+        end
+      end
     end
   end
 end

--- a/spec/unit/lib/cloud_controller/diego/ssh_key_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/ssh_key_spec.rb
@@ -43,7 +43,7 @@ module VCAP::CloudController
       describe '#fingerprint 256' do
         it 'returns an sha256 fingerprint' do
           ssh_key = SSHKey.new(1024)
-          expect(ssh_key.sha256_fingerprint).to match(/[a-zA-Z0-9+\/=]{44}/)
+          expect(ssh_key.sha256_fingerprint).to match(%r{[a-zA-Z0-9+/=]{44}})
         end
       end
     end


### PR DESCRIPTION
Add a new property sha256_fingerprint that diego can use to avoid incompatibilities when updating from sha1 to sha256

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add a new property sha256_fingerprint based on the discussion here https://github.com/cloudfoundry/capi-release/issues/539

Snippet of the sample desired_lrps with the new property

"host_fingerprint":"ca:a7:9f:3b:1a:87:78:10:7d:1a:d5:1b:0d:15:83:82:f4:82:52:1d","host_256_fingerprint":"NLHkJb8nhxGcuiJgib46gVPUOt9iS91TQ2+Nd6mvphM="}

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
