### PR TITLE
Add logging of service metadata during instance create/update/delete

### DIFF
--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -312,22 +312,9 @@ class ServiceInstancesV3Controller < ApplicationController
     action.preflight!
     if action.update_broker_needed?
 
-      service_plan_relations = if message.service_plan_guid
-                                 { Sequel[:service_plans][:guid] => message.service_plan_guid }
-                                 ServicePlan.eager_graph(service: :service_broker).
-                                   where(Sequel[:service_plans][:guid] => message.service_plan_guid).
-                                   all
-                               else
-                                 { Sequel[:service_plans][:id] => service_instance.service_plan_id }
-                                 ServicePlan.eager_graph(service: :service_broker).
-                                   where(Sequel[:service_plans][:id] => service_instance.service_plan_id).
-                                   all
-                               end
-
-      service_plan = service_plan_relations[0]
-      plan_name = service_plan.name
-      service_name = service_plan.service.name
-      broker_name = service_plan.service.service_broker.name
+      plan_name = service_instance.service_plan.name
+      service_name = service_instance.service_plan.service.label
+      broker_name = service_instance.service_plan.service.service_broker.name
 
       logger.info(
         "Updating managed service instance with name '#{service_instance.name}' " \

--- a/app/controllers/v3/service_instances_controller.rb
+++ b/app/controllers/v3/service_instances_controller.rb
@@ -312,8 +312,10 @@ class ServiceInstancesV3Controller < ApplicationController
     action.preflight!
 
     if action.update_broker_needed?
+      # enqueue_update will reload the service instance and we loose the eagerly loaded associations
+      service_instance_with_eager_load = service_instance.dup
       update_job = action.enqueue_update
-      log_service_instance_update(message, service_instance)
+      log_service_instance_update(message, service_instance_with_eager_load)
       head :accepted, 'Location' => url_builder.build_url(path: "/v3/jobs/#{update_job.guid}")
     else
       service_instance = action.update_sync

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1080,6 +1080,12 @@ RSpec.describe 'V3 service instances' do
       end
       let(:instance) { VCAP::CloudController::ServiceInstance.last }
       let(:job) { VCAP::CloudController::PollableJobModel.last }
+      let(:mock_logger) { instance_double(Steno::Logger, info: nil) }
+
+      before do
+        allow(Steno).to receive(:logger).and_call_original
+        allow(Steno).to receive(:logger).with('cc.api').and_return(mock_logger)
+      end
 
       it 'creates a service instance in the database' do
         api_call.call(space_dev_headers)
@@ -1105,6 +1111,17 @@ RSpec.describe 'V3 service instances' do
         expect(job.operation).to eq('service_instance.create')
         expect(job.resource_guid).to eq(instance.guid)
         expect(job.resource_type).to eq('service_instances')
+      end
+
+      it 'logs the correct names when creating a managed service instance' do
+        api_call.call(space_dev_headers)
+
+        expect(mock_logger).to have_received(:info).with(
+          "Creating managed service instance with name '#{instance.name}' " \
+          "using service plan '#{service_plan.name}' " \
+          "from service offering '#{service_plan.service.name}' " \
+          "provided by broker '#{service_plan.service.service_broker.name}'."
+        )
       end
 
       context 'when the name has already been taken' do
@@ -1847,6 +1864,12 @@ RSpec.describe 'V3 service instances' do
           }
         end
         let(:job) { VCAP::CloudController::PollableJobModel.last }
+        let(:mock_logger) { instance_double(Steno::Logger, info: nil) }
+
+        before do
+          allow(Steno).to receive(:logger).and_call_original
+          allow(Steno).to receive(:logger).with('cc.api').and_return(mock_logger)
+        end
 
         it 'responds with a pollable job' do
           api_call.call(space_dev_headers)
@@ -1880,6 +1903,17 @@ RSpec.describe 'V3 service instances' do
           expect(service_instance).to have_labels(
             { prefix: 'pre.fix', key_name: 'to_delete', value: 'value' },
             { prefix: 'pre.fix', key_name: 'tail', value: 'fluffy' }
+          )
+        end
+
+        it 'logs the correct names when updating a managed service instance' do
+          api_call.call(space_dev_headers)
+
+          expect(mock_logger).to have_received(:info).with(
+            "Updating managed service instance with name '#{service_instance.name}' " \
+            "using service plan '#{original_service_plan.name}' " \
+            "from service offering '#{service_offering.name}' " \
+            "provided by broker '#{original_service_plan.service.service_broker.name}'."
           )
         end
 
@@ -2970,6 +3004,12 @@ RSpec.describe 'V3 service instances' do
                }).
           to_return(status: broker_status_code, body: broker_response.to_json, headers: {})
       end
+      let(:mock_logger) { instance_double(Steno::Logger, info: nil) }
+
+      before do
+        allow(Steno).to receive(:logger).and_call_original
+        allow(Steno).to receive(:logger).with('cc.api').and_return(mock_logger)
+      end
 
       it 'responds with job resource' do
         api_call.call(admin_headers)
@@ -2982,6 +3022,17 @@ RSpec.describe 'V3 service instances' do
         expect(job.operation).to eq('service_instance.delete')
         expect(job.resource_guid).to eq(instance.guid)
         expect(job.resource_type).to eq('service_instance')
+      end
+
+      it 'logs the correct names when deleting a managed service instance' do
+        api_call.call(admin_headers)
+
+        expect(mock_logger).to have_received(:info).with(
+          "Deleting managed service instance with name '#{instance.name}' " \
+          "using service plan '#{instance.service_plan.name}' " \
+          "from service offering '#{instance.service_plan.service.name}' " \
+          "provided by broker '#{instance.service_plan.service.service_broker.name}'."
+        )
       end
 
       describe 'the pollable job' do

--- a/spec/request/service_instances_spec.rb
+++ b/spec/request/service_instances_spec.rb
@@ -1906,15 +1906,39 @@ RSpec.describe 'V3 service instances' do
           )
         end
 
-        it 'logs the correct names when updating a managed service instance' do
-          api_call.call(space_dev_headers)
+        describe 'logging of updates' do
+          it 'logs info including the change of service plans' do
+            api_call.call(space_dev_headers)
 
-          expect(mock_logger).to have_received(:info).with(
-            "Updating managed service instance with name '#{service_instance.name}' " \
-            "using service plan '#{original_service_plan.name}' " \
-            "from service offering '#{service_offering.name}' " \
-            "provided by broker '#{original_service_plan.service.service_broker.name}'."
-          )
+            expect(mock_logger).to have_received(:info).with(
+              "Updating managed service instance with name '#{service_instance.name}' " \
+              "changing plan from '#{original_service_plan.name}' to '#{new_service_plan.name}' " \
+              "from service offering '#{service_offering.name}' " \
+              "provided by broker '#{original_service_plan.service.service_broker.name}'."
+            )
+          end
+
+          context 'when service plan does not change' do
+            let(:request_body) do
+              {
+                parameters: {
+                  foo: 'bar',
+                  baz: 'qux'
+                }
+              }
+            end
+
+            it 'logs info accordingly' do
+              api_call.call(space_dev_headers)
+
+              expect(mock_logger).to have_received(:info).with(
+                "Updating managed service instance with name '#{service_instance.name}' " \
+                "using service plan '#{original_service_plan.name}' " \
+                "from service offering '#{service_offering.name}' " \
+                "provided by broker '#{original_service_plan.service.service_broker.name}'."
+              )
+            end
+          end
         end
 
         describe 'the pollable job' do

--- a/spec/unit/actions/v3/service_instance_update_managed_spec.rb
+++ b/spec/unit/actions/v3/service_instance_update_managed_spec.rb
@@ -75,6 +75,28 @@ module VCAP::CloudController
       end
 
       describe '#preflight!' do
+        context 'when changes were requested' do
+          let(:body) do
+            {
+              name: 'new-name',
+              relationships: {
+                service_plan: {
+                  data: {
+                    guid: new_plan.guid
+                  }
+                }
+              }
+            }
+          end
+
+          let(:new_plan) { ServicePlan.make(service: original_service_offering) }
+
+          it 'does not change the original service instance object' do
+            action.preflight!
+            expect(original_instance.changed_columns).not_to be_any
+          end
+        end
+
         describe 'invalid name updates' do
           context 'when the new name is already taken' do
             let(:instance_in_same_space) { ServiceInstance.make(space: original_instance.space) }


### PR DESCRIPTION
Inform operators which service plan, service offering and broker is involved in service instance creation/update/deletion

* A short explanation of the proposed change:
Add names of service plan, service offering and broker as logging information for service instance creation/update/deletion.
This change updates fetch_writable_service_instance to eagerly load associated service_plan, service, and service_broker relationships for managed service instances. This avoids N+1 queries when accessing these associations later in the request lifecycle.

* An explanation of the use cases your change solves
This change improves operator visibility by logging service plan names, offerings, and broker names during service instance creation, update, and deletion.
Previously, logs only included GUIDs or IDs, requiring manual lookups or customer input to identify the service involved. With this change, operators can directly see which service is affected, making it easier to diagnose issues and support users/customers more efficiently.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [X] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
