### PR TITLE
Fix MetadataError string formatting

### DIFF
--- a/app/models/helpers/metadata_error.rb
+++ b/app/models/helpers/metadata_error.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
     end
 
     def to_s
-      "#<MetadataError is_valid:#{is_valid?} message:#{message}"
+      "#<MetadataError is_valid:#{is_valid?} message:#{message}>"
     end
   end
 end


### PR DESCRIPTION
## Summary
- add missing `>` in `MetadataError#to_s`

## Testing
- `bundle --version` *(fails: version `3.2.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684144e902b483208a640008b7f173fb