### PR TITLE
Workaround changed behavior in Protobuf's Message#to_h

### DIFF
--- a/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
@@ -78,6 +78,17 @@ module VCAP::CloudController
           [container_metric_batch]
         end
 
+        let(:expected_lrp_1_net_info) do
+          {
+            address: 'lrp-host',
+            instance_address: '',
+            ports: [
+              { container_port: DEFAULT_APP_PORT, container_tls_proxy_port: 0, host_port: 2222, host_tls_proxy_port: 0 },
+              { container_port: 1111, container_tls_proxy_port: 0, host_port: 0, host_tls_proxy_port: 0 }
+            ],
+            preferred_address: :UNKNOWN
+          }
+        end
         let(:expected_stats_response) do
           {
             0 => {
@@ -90,7 +101,7 @@ module VCAP::CloudController
                 host: 'lrp-host',
                 instance_guid: 'instance-a',
                 port: 2222,
-                net_info: lrp_1_net_info.to_h,
+                net_info: expected_lrp_1_net_info,
                 uptime: two_days_in_seconds,
                 mem_quota: 1234,
                 disk_quota: 10_234,
@@ -217,7 +228,7 @@ module VCAP::CloudController
                   host: 'lrp-host',
                   instance_guid: 'instance-a',
                   port: 2222,
-                  net_info: lrp_1_net_info.to_h,
+                  net_info: expected_lrp_1_net_info,
                   uptime: two_days_in_seconds,
                   mem_quota: nil,
                   disk_quota: nil,
@@ -272,7 +283,7 @@ module VCAP::CloudController
                     host: 'lrp-host',
                     instance_guid: 'instance-a',
                     port: 2222,
-                    net_info: lrp_1_net_info.to_h,
+                    net_info: expected_lrp_1_net_info,
                     uptime: two_days_in_seconds,
                     mem_quota: nil,
                     disk_quota: nil,
@@ -519,7 +530,7 @@ module VCAP::CloudController
                   host: 'lrp-host',
                   instance_guid: 'instance-a',
                   port: 2222,
-                  net_info: lrp_1_net_info.to_h,
+                  net_info: expected_lrp_1_net_info,
                   uptime: two_days_in_seconds,
                   mem_quota: nil,
                   disk_quota: nil,
@@ -653,7 +664,7 @@ module VCAP::CloudController
                   host: 'lrp-host',
                   instance_guid: 'instance-a',
                   port: 2222,
-                  net_info: lrp_1_net_info.to_h,
+                  net_info: expected_lrp_1_net_info,
                   uptime: two_days_in_seconds,
                   mem_quota: nil,
                   disk_quota: nil,


### PR DESCRIPTION
The behavior of `to_h` for Protobuf objects changed [1]; unset and default values are now being omitted. Thus the update of Protobuf libraries [2] led to an incompatible change as the Cloud Controller returned `null` instead of `0` for the external and internal ports as part of the process stats endpoint.

With this change the hash is created manually by accessing all fields in the Protobuf object(s) directly.

[1] https://github.com/protocolbuffers/protobuf/pull/15234
[2] https://github.com/cloudfoundry/cloud_controller_ng/pull/4359

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
