### PR TITLE
Improve process stats instance_ports API doc

### DIFF
--- a/docs/v3/source/includes/resources/processes/_stats_object.md.erb
+++ b/docs/v3/source/includes/resources/processes/_stats_object.md.erb
@@ -24,7 +24,7 @@ Name | Type | Description
 **usage.log_rate** | _integer_ | The current logging usage of the instance
 **host** | _string_ | The host the instance is running on
 **instance_internal_ip** | _string_ | The internal IP address of the instance
-**instance_ports** | _object_ | JSON array of port mappings between the network-exposed port used to communicate with the app (`external`) and port opened to the running process that it can listen on (`internal`)
+**instance_ports** | _object_ | JSON array of port mappings between the network-exposed port used to communicate with the app (`external`) and port opened to the running process that it can listen on (`internal`). Clients shall interprete `0` and `null` as non-existing port.
 **uptime** | _integer_ | The uptime in seconds for the instance
 **mem_quota** | _integer_ | The current maximum memory allocated for the instance; the value is `null` when memory quota data is unavailable
 **disk_quota** | _integer_ | The current maximum disk allocated for the instance; the value is `null` when disk quota data is unavailable


### PR DESCRIPTION
A non-existing port can be represented as `0` or as `null`. Clients should understand both values.

See also #4403 for more details on inconstant representation of non-existing ports.
