### PR TITLE
Fix GET Process endpoint for unstaged docker apps

### DIFF
--- a/app/models/runtime/process_model.rb
+++ b/app/models/runtime/process_model.rb
@@ -579,8 +579,16 @@ module VCAP::CloudController
     def docker_run_action_user
       return DEFAULT_USER unless docker?
 
-      docker_exec_metadata = Oj.load(execution_metadata)
-      container_user = docker_exec_metadata['user']
+      container_user = ''
+      if execution_metadata.present?
+        begin
+          docker_exec_metadata = Oj.load(execution_metadata)
+          container_user = docker_exec_metadata['user']
+        rescue EncodingError
+          container_user = ''
+        end
+      end
+
       container_user.presence || 'root'
     end
 

--- a/spec/unit/models/runtime/process_model_spec.rb
+++ b/spec/unit/models/runtime/process_model_spec.rb
@@ -708,6 +708,30 @@ module VCAP::CloudController
             expect(process.run_action_user).to eq('root')
           end
         end
+
+        context 'when the droplet execution metadata is an empty string' do
+          let(:droplet_execution_metadata) { '' }
+
+          it 'defaults the user to root' do
+            expect(process.run_action_user).to eq('root')
+          end
+        end
+
+        context 'when the droplet execution metadata is nil' do
+          let(:droplet_execution_metadata) { nil }
+
+          it 'defaults the user to root' do
+            expect(process.run_action_user).to eq('root')
+          end
+        end
+
+        context 'when the droplet execution metadata has invalid json' do
+          let(:droplet_execution_metadata) { '{' }
+
+          it 'defaults the user to root' do
+            expect(process.run_action_user).to eq('root')
+          end
+        end
       end
 
       context 'when the process DOES NOT belong to a Docker lifecycle app' do


### PR DESCRIPTION
The user field was added in https://github.com/cloudfoundry/cloud_controller_ng/pull/4407, but this failed for unstaged Docker apps since they do not have JSON-parseable execution metadata.

This fix updates the code to treat empty and unparseable execution metadata the same as an empty JSON object.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)

I ran the Docker subset of CATS that were previously failing. Currently more CATS now.
*Update:* The ~80 CATS from default CAPI BOSH Lite CATS config passed.