### PR TITLE
Add ability to specify the process user in manifests

### DIFF
--- a/app/messages/app_manifest_message.rb
+++ b/app/messages/app_manifest_message.rb
@@ -262,6 +262,7 @@ module VCAP::CloudController
     def process_update_attributes_from_process(params)
       mapping = {}
       mapping[:command] = params[:command] || 'null' if params.key?(:command)
+      mapping[:user] = params[:user] if params.key?(:user)
       mapping[:health_check_http_endpoint] = params[:health_check_http_endpoint] if params.key?(:health_check_http_endpoint)
       mapping[:health_check_timeout] = params[:health_check_timeout] if params.key?(:health_check_timeout)
       mapping[:health_check_invocation_timeout] = params[:health_check_invocation_timeout] if params.key?(:health_check_invocation_timeout)

--- a/app/messages/manifest_process_update_message.rb
+++ b/app/messages/manifest_process_update_message.rb
@@ -5,6 +5,7 @@ module VCAP::CloudController
   class ManifestProcessUpdateMessage < BaseMessage
     register_allowed_keys %i[
       command
+      user
       health_check_http_endpoint
       health_check_invocation_timeout
       health_check_type
@@ -33,6 +34,12 @@ module VCAP::CloudController
               string: true,
               length: { in: 1..4096, message: 'must be between 1 and 4096 characters' },
               if: proc { |a| a.requested?(:command) }
+
+    validates :user,
+              string: true,
+              allow_nil: true,
+              length: { in: 1..255, message: 'must be between 1 and 255 characters' },
+              if: proc { |a| a.requested?(:user) }
 
     validates :health_check_type,
               inclusion: {

--- a/app/presenters/v3/app_manifest_presenters/process_properties_presenter.rb
+++ b/app/presenters/v3/app_manifest_presenters/process_properties_presenter.rb
@@ -16,6 +16,7 @@ module VCAP::CloudController
               'disk_quota' => add_units(process.disk_quota),
               'log-rate-limit-per-second' => add_units_log_rate_limit(process.log_rate_limit),
               'command' => process.command,
+              'user' => process.user,
               'health-check-type' => process.health_check_type,
               'health-check-http-endpoint' => process.health_check_http_endpoint,
               'health-check-invocation-timeout' => process.health_check_invocation_timeout,

--- a/docs/v3/source/includes/resources/manifests/_object.md.erb
+++ b/docs/v3/source/includes/resources/manifests/_object.md.erb
@@ -54,6 +54,7 @@ applications:
     memory: 500M
     log-rate-limit-per-second: 1KB
     timeout: 10
+    user: vcap
   - type: worker
     command: start-worker.sh
     disk_quota: 1G
@@ -122,6 +123,7 @@ Name | Type | Description
 ---- | ---- | -----------
 **type** | _string_ | **(Required)** The identifier for the processes to be configured
 **command** | _string_ | The command used to start the process; this overrides start commands from [Procfiles](#procfiles) and buildpacks
+**user** | _string_ | The user under which the process runs
 **disk_quota** | _string_ | The disk limit for all instances of the web process; <br>this attribute requires a unit of measurement: `B`, `K`, `KB`, `M`, `MB`, `G`, `GB`, `T`, or `TB` in upper case or lower case
 **health-check-http-endpoint** | _string_ | Endpoint called to determine if the app is healthy
 **health-check-interval** | _integer_ | The interval in seconds between health check requests

--- a/spec/unit/messages/app_manifest_message_spec.rb
+++ b/spec/unit/messages/app_manifest_message_spec.rb
@@ -721,6 +721,7 @@ module VCAP::CloudController
                 'readiness_health_check_http_endpoint' => 'potato potahto',
                 'readiness_health_check_interval' => 'yucca',
                 'command' => '',
+                'user' => '',
                 'timeout' => 'yam'
               }
             end
@@ -738,6 +739,7 @@ module VCAP::CloudController
                 'readiness_health_check_invocation_timeout' => 'cat-jicima',
                 'readiness_health_check_interval' => -1,
                 'command' => '',
+                'user' => '',
                 'timeout' => 'yam'
               }
             end
@@ -751,10 +753,11 @@ module VCAP::CloudController
             it 'includes the type of the process in the error message' do
               message = AppManifestMessage.create_from_yml(params_from_yaml)
               expect(message).not_to be_valid
-              expect(message.errors).to have(27).items
+              expect(message.errors).to have(29).items
 
               expected_errors = [
                 'Process "type1": Command must be between 1 and 4096 characters',
+                'Process "type1": User must be between 1 and 255 characters',
                 'Process "type1": Disk quota must use a supported unit: B, K, KB, M, MB, G, GB, T, or TB',
                 'Process "type1": Log rate limit per second is not a number',
                 'Process "type1": Instances must be greater than or equal to 0',
@@ -770,6 +773,7 @@ module VCAP::CloudController
                 'Process "type1": Readiness health check http endpoint must be a valid URI path',
                 'Process "type1": Readiness health check type must be "http" to set a health check HTTP endpoint',
                 'Process "type2": Command must be between 1 and 4096 characters',
+                'Process "type2": User must be between 1 and 255 characters',
                 'Process "type2": Disk quota must use a supported unit: B, K, KB, M, MB, G, GB, T, or TB',
                 'Process "type2": Log rate limit per second must use a supported unit: B, K, KB, M, MB, G, GB, T, or TB',
                 'Process "type2": Instances is not a number',

--- a/spec/unit/messages/manifest_process_update_message_spec.rb
+++ b/spec/unit/messages/manifest_process_update_message_spec.rb
@@ -62,6 +62,59 @@ module VCAP::CloudController
             expect(message.errors[:command]).to include('must be between 1 and 4096 characters')
           end
         end
+
+        context 'when command is just right' do
+          let(:params) { { command: './start.sh' } }
+
+          it 'is valid' do
+            expect(message).to be_valid
+          end
+        end
+      end
+
+      describe 'user' do
+        context 'when user is not a string' do
+          let(:params) { { user: 32.77 } }
+
+          it 'is valid' do
+            expect(message).not_to be_valid
+            expect(message.errors[:user]).to include('must be a string')
+          end
+        end
+
+        context 'when user is nil' do
+          let(:params) { { user: nil } }
+
+          it 'is not valid' do
+            expect(message).to be_valid
+          end
+        end
+
+        context 'when user is too long' do
+          let(:params) { { user: 'a' * 256 } }
+
+          it 'is not valid' do
+            expect(message).not_to be_valid
+            expect(message.errors[:user]).to include('must be between 1 and 255 characters')
+          end
+        end
+
+        context 'when user is empty' do
+          let(:params) { { user: '' } }
+
+          it 'is not valid' do
+            expect(message).not_to be_valid
+            expect(message.errors[:user]).to include('must be between 1 and 255 characters')
+          end
+        end
+
+        context 'when user is just right' do
+          let(:params) { { command: 'vcap' } }
+
+          it 'is valid' do
+            expect(message).to be_valid
+          end
+        end
       end
 
       describe 'health_check_type' do

--- a/spec/unit/presenters/v3/app_manifest_presenters/process_properties_presenter_spec.rb
+++ b/spec/unit/presenters/v3/app_manifest_presenters/process_properties_presenter_spec.rb
@@ -67,6 +67,60 @@ module VCAP::CloudController::Presenters::V3::AppManifestPresenters
                              'timeout' => 30
                            })
       end
+
+      context 'nullable fields' do
+        context 'when command is present' do
+          let(:process) do
+            VCAP::CloudController::ProcessModel.make(
+              command: './start-command'
+            )
+          end
+
+          it 'includes command in the hash' do
+            hash = subject.process_hash(process)
+            expect(hash).to include('command' => './start-command')
+          end
+        end
+
+        context 'when command is not present' do
+          let(:process) do
+            VCAP::CloudController::ProcessModel.make(
+              command: nil
+            )
+          end
+
+          it 'does not include command in the hash' do
+            hash = subject.process_hash(process)
+            expect(hash).not_to include('command')
+          end
+        end
+
+        context 'when user is present' do
+          let(:process) do
+            VCAP::CloudController::ProcessModel.make(
+              user: 'ContainerUser'
+            )
+          end
+
+          it 'includes user in the hash' do
+            hash = subject.process_hash(process)
+            expect(hash).to include('user' => 'ContainerUser')
+          end
+        end
+
+        context 'when user is not present' do
+          let(:process) do
+            VCAP::CloudController::ProcessModel.make(
+              user: nil
+            )
+          end
+
+          it 'does not include user in the hash' do
+            hash = subject.process_hash(process)
+            expect(hash).not_to include('user')
+          end
+        end
+      end
     end
 
     describe '#add_units_log_rate_limit' do


### PR DESCRIPTION
Adds rthe ability to specify the process user in manifests and updates manifest generation to include users as well. Specifying `user: ~` will unset it. This builds on https://github.com/cloudfoundry/cloud_controller_ng/pull/4407.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
