### PR TITLE
Replace paketo gcr references with docker.io

### DIFF
--- a/spec/support/fakes/blueprints.rb
+++ b/spec/support/fakes/blueprints.rb
@@ -689,7 +689,7 @@ module VCAP::CloudController
   end
 
   CNBLifecycleDataModel.blueprint(:all_fields) do
-    buildpacks { ['docker://gcr.io/paketo-buildpacks/nodejs'] }
+    buildpacks { ['docker://docker.io/paketobuildpacks/nodejs'] }
     stack { Stack.make.name }
     app_guid { Sham.guid }
     droplet { DropletModel.make }

--- a/spec/unit/lib/cloud_controller/diego/cnb/lifecycle_data_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/cnb/lifecycle_data_spec.rb
@@ -11,7 +11,7 @@ module VCAP::CloudController
           data.build_artifacts_cache_download_uri = 'build_artifact_download'
           data.build_artifacts_cache_upload_uri   = 'build_artifact_upload'
           data.droplet_upload_uri                 = 'droplet_upload'
-          data.buildpacks                         = ['docker://gcr.io/paketo-buildpacks/nodejs']
+          data.buildpacks                         = ['docker://docker.io/paketobuildpacks/nodejs']
           data.stack                              = 'stack'
           data.buildpack_cache_checksum           = 'bp-cache-checksum'
           data.app_bits_checksum                  = { type: 'sha256', value: 'package-checksum' }
@@ -26,7 +26,7 @@ module VCAP::CloudController
             build_artifacts_cache_download_uri: 'build_artifact_download',
             build_artifacts_cache_upload_uri: 'build_artifact_upload',
             droplet_upload_uri: 'droplet_upload',
-            buildpacks: ['docker://gcr.io/paketo-buildpacks/nodejs'],
+            buildpacks: ['docker://docker.io/paketobuildpacks/nodejs'],
             stack: 'stack',
             buildpack_cache_checksum: 'bp-cache-checksum',
             app_bits_checksum: { type: 'sha256', value: 'package-checksum' },

--- a/spec/unit/lib/cloud_controller/diego/cnb/staging_action_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/cnb/staging_action_builder_spec.rb
@@ -123,16 +123,16 @@ module VCAP::CloudController
             ::Diego::Bbs::Models::RunAction.new(
               path: '/tmp/lifecycle/builder',
               user: 'vcap',
-              args: ['--cache-dir', '/tmp/cache', '--cache-output', '/tmp/cache-output.tgz', '--buildpack', 'gcr.io/paketo-buildpacks/node-start', '--buildpack',
-                     'gcr.io/paketo-buildpacks/node-engine', '--pass-env-var', 'FOO', '--pass-env-var', 'BAR'],
+              args: ['--cache-dir', '/tmp/cache', '--cache-output', '/tmp/cache-output.tgz', '--buildpack', 'docker.io/paketobuildpacks/node-start', '--buildpack',
+                     'docker.io/paketobuildpacks/node-engine', '--pass-env-var', 'FOO', '--pass-env-var', 'BAR'],
               env: bbs_env
             )
           end
 
           let(:buildpacks) do
             [
-              { name: 'custom', url: 'gcr.io/paketo-buildpacks/node-start', skip_detect: false },
-              { name: 'custom', url: 'gcr.io/paketo-buildpacks/node-engine', skip_detect: false }
+              { name: 'custom', url: 'docker.io/paketobuildpacks/node-start', skip_detect: false },
+              { name: 'custom', url: 'docker.io/paketobuildpacks/node-engine', skip_detect: false }
             ]
           end
 

--- a/spec/unit/models/runtime/cnb_lifecycle_data_model_spec.rb
+++ b/spec/unit/models/runtime/cnb_lifecycle_data_model_spec.rb
@@ -96,7 +96,7 @@ module VCAP::CloudController
       context 'when using a custom buildpack' do
         context 'when using multiple buildpacks' do
           subject(:lifecycle_data) do
-            CNBLifecycleDataModel.new(buildpacks: ['https://github.com/buildpacks/the-best', 'gcr.io/paketo-buildpacks/nodejs'])
+            CNBLifecycleDataModel.new(buildpacks: ['https://github.com/buildpacks/the-best', 'docker.io/paketobuildpacks/nodejs'])
           end
 
           it 'returns true' do
@@ -125,7 +125,7 @@ module VCAP::CloudController
         { buildpacks: buildpacks || [], stack: 'cflinuxfs4' }
       end
       let(:buildpacks) { [buildpack] }
-      let(:buildpack) { 'http://gcr.io/paketo-buildpacks/nodejs' }
+      let(:buildpack) { 'http://docker.io/paketobuildpacks/nodejs' }
       let(:stack) { 'cflinuxfs4' }
 
       before do


### PR DESCRIPTION
Paketo is switching from gcr to dockerhub:
https://blog.paketo.io/posts/paketo-gcr-registry-sunset/


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
