### PR TITLE
Attempt to fix flaky threaded worker logging test

### DIFF
--- a/spec/unit/lib/delayed_job/threaded_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/threaded_worker_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe Delayed::ThreadedWorker do
     end
 
     it 'sets the worker name in the Steno context' do
-      steno_data_spy = spy('data')
+      steno_data_spy = {}
+      allow(steno_data_spy).to receive(:[]=).and_call_original
       allow(Steno.config.context).to receive(:data).and_return(steno_data_spy)
 
       worker.start


### PR DESCRIPTION
This test occasionally fails in CI with:
`can't convert RSpec::Mocks::Double to Hash (RSpec::Mocks::Double#to_hash gives RSpec::Mocks::Double)`

It is difficult to reproduce, but I think that using a true Hash instead of a spy may make it more reliable

Example failure:
https://github.com/cloudfoundry/cloud_controller_ng/actions/runs/15833920407/job/44685199774?pr=4416

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
