### PR TITLE
Issue 4404: Add support for "icmpv6" protocol to ASGs

### DIFF
--- a/app/models/runtime/security_group.rb
+++ b/app/models/runtime/security_group.rb
@@ -71,7 +71,7 @@ module VCAP::CloudController
         validation_errors = case protocol
                             when 'tcp', 'udp'
                               CloudController::TransportRuleValidator.validate(stringified_rule)
-                            when 'icmp'
+                            when 'icmp', 'icmpv6'
                               CloudController::ICMPRuleValidator.validate(stringified_rule)
                             when 'all'
                               CloudController::RuleValidator.validate(stringified_rule)

--- a/docs/v3/source/includes/api_resources/_security_groups.erb
+++ b/docs/v3/source/includes/api_resources/_security_groups.erb
@@ -22,6 +22,13 @@
       "description": "Allow ping requests to private services"
     },
     {
+      "protocol": "icmpv6",
+      "destination": "::/0",
+      "type": -1,
+      "code": -1,
+      "description": "Allow all ICMPv6 traffic"
+    },
+    {
       "protocol": "tcp",
       "destination": "1.1.1.1,2.2.2.2/24,10.0.0.0-10.0.0.255",
       "ports": "80,443,8080",

--- a/docs/v3/source/includes/resources/security_groups/_object.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_object.md.erb
@@ -25,8 +25,8 @@ Name | Type | Description
 
 | Name | Type | Description | Required | Default
 | ---- | ---- | ----------- | -------- | -------
-| **protocol** | _string_ | Protocol type Valid values are `tcp`, `udp`, `icmp`, or `all` | yes | N/A |
-| **destination** | _string_ | The destination where the rule applies. Must be a singular Valid CIDR, IP address, or IP address range unless `cc.security_groups.enable_comma_delimited_destinations` is enabled. Then, the destination can be a comma-delimited string of CIDRs, IP addresses, or IP address ranges. Octets within destinations cannot contain leading zeros; eg. `10.0.0.0/24` is valid, but `010.00.000.0/24` is *not*.  | yes | N/A |
+| **protocol** | _string_ | Protocol type Valid values are `tcp`, `udp`, `icmp`, `icmpv6` or `all` | yes | N/A |
+| **destination** | _string_ | The destination where the rule applies. Must be a singular valid CIDR, IP address, or IP address range unless `cc.security_groups.enable_comma_delimited_destinations` is enabled. Then, the destination can be a comma-delimited string of CIDRs, IP addresses, or IP address ranges. Octets within destinations cannot contain leading zeros; eg. `10.0.0.0/24` is valid, but `010.00.000.0/24` is *not*. For `icmp`, only IPv4 addresses are allowed and for `icmpv6` only IPv6 addresses. | yes | N/A |
 | **ports** | _string_ | Ports that the rule applies to; can be a single port (`9000`), a comma-separated list (`9000,9001`), or a range (`9000-9200`) | no | `null` |
 | **type** | _integer_ |[Type](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types) required for ICMP protocol; valid values are between -1 and 255 (inclusive), where -1 allows all | no | `null` |
 | **code** | _integer_ |[Code](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-codes) required for ICMP protocol; valid values are between -1 and 255 (inclusive), where -1 allows all | no | `null` |

--- a/lib/cloud_controller/rule_validator.rb
+++ b/lib/cloud_controller/rule_validator.rb
@@ -77,6 +77,10 @@ module CloudController
       ipv4 || ipv6
     end
 
+    def self.ipv6_enabled?
+      config.get(:enable_ipv6)
+    end
+
     def self.comma_delimited_destinations_enabled?
       config.get(:security_groups, :enable_comma_delimited_destinations)
     end

--- a/spec/unit/messages/validators/security_group_rule_validator_spec.rb
+++ b/spec/unit/messages/validators/security_group_rule_validator_spec.rb
@@ -1408,6 +1408,23 @@ module VCAP::CloudController::Validators
           end
         end
 
+        context 'icmpv6 protocol contains an IPv6 destination range' do
+          let(:rules) do
+            [
+              {
+                protocol: 'icmpv6',
+                destination: '2001:0db8::1-2001:0db8::ff',
+                type: -1,
+                code: 255
+              }
+            ]
+          end
+
+          it 'is valid' do
+            expect(subject).to be_valid
+          end
+        end
+
         context 'icmpv6 protocol contains a comma-delimited list of IPv6 destinations' do
           before do
             TestConfig.config[:security_groups][:enable_comma_delimited_destinations] = true

--- a/spec/unit/messages/validators/security_group_rule_validator_spec.rb
+++ b/spec/unit/messages/validators/security_group_rule_validator_spec.rb
@@ -1251,6 +1251,23 @@ module VCAP::CloudController::Validators
         end
       end
 
+      context 'icmp protocol contains an IPv4 destination range' do
+        let(:rules) do
+          [
+            {
+              protocol: 'icmp',
+              destination: '1.0.0.1-1.0.0.200',
+              type: -1,
+              code: 255
+            }
+          ]
+        end
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+
       context 'the icmp rules are not provided when the protocol is icmp' do
         let(:rules) do
           [

--- a/spec/unit/messages/validators/security_group_rule_validator_spec.rb
+++ b/spec/unit/messages/validators/security_group_rule_validator_spec.rb
@@ -1503,7 +1503,6 @@ module VCAP::CloudController::Validators
             expect(subject.errors.full_messages).to include 'Rules[0]: code is required for protocols of type ICMP'
           end
         end
-
       end
     end
   end

--- a/spec/unit/models/runtime/security_group_spec.rb
+++ b/spec/unit/models/runtime/security_group_spec.rb
@@ -19,6 +19,15 @@ module VCAP::CloudController
       }.merge(attrs)
     end
 
+    def build_icmpv6_rule(attrs={})
+      {
+        'protocol' => 'icmpv6',
+        'type' => 0,
+        'code' => 0,
+        'destination' => '::/0'
+      }.merge(attrs)
+    end
+
     def build_all_rule(attrs={})
       {
         'protocol' => 'all',
@@ -601,8 +610,32 @@ module VCAP::CloudController
                   end
                 end
 
+                context 'when it is a valid IPv6 CIDR' do
+                  before do
+                    TestConfig.config[:enable_ipv6] = true
+                  end
+
+                  let(:rule) { build_icmpv6_rule('destination' => '2001:db8::/32') }
+
+                  it 'is valid' do
+                    expect(subject).to be_valid
+                  end
+                end
+
                 context 'when it is a valid range' do
                   let(:rule) { build_icmp_rule('destination' => '1.1.1.1-2.2.2.2') }
+
+                  it 'is valid' do
+                    expect(subject).to be_valid
+                  end
+                end
+
+                context 'when it is a valid IPv6 range' do
+                  before do
+                    TestConfig.config[:enable_ipv6] = true
+                  end
+
+                  let(:rule) { build_icmpv6_rule('destination' => '2001:0db8::1-2001:0db8::ff') }
 
                   it 'is valid' do
                     expect(subject).to be_valid


### PR DESCRIPTION
* A short explanation of the proposed change:

Support for "impv6" validation in ASGs:
* "icmpv6" can be used if "enable_ipv6" is configured
* "icmp" destinations may only consist of IPv4 addresses
* "icmpv6" destinations may only consist of IPv6 addresses

* An explanation of the use cases your change solves

Part of the IPv6 support story.

* Links to any other associated PRs

https://github.com/cloudfoundry/cloud_controller_ng/issues/4404

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`
```
Finished in 60 minutes 20 seconds (files took 34.13 seconds to load)
31109 examples, 0 failures, 19 pending

Randomized with seed 42945
```

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
