### PR TITLE
Increase the GitHub action timeouts

### DIFF
--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   Test-Docs:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: hmarr/debug-action@v3
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
 
   Test-Postgres:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +72,7 @@ jobs:
 
   Test-Mysql:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit_tests_backwards_compatibility.yml
+++ b/.github/workflows/unit_tests_backwards_compatibility.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   Test-Postgres-Backwards-Compatibillity:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -80,7 +80,7 @@ jobs:
 
   Test-Mysql-Backwards-Compatibillity:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 3


### PR DESCRIPTION
It would also be worth checking why tests became slower and how to improve the test execution performance - but to decrease the number of cancelled tests, the timeout is increased from 30 to 60 minutes.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
