### PR TITLE
Update CF V3 API definition

### DIFF
--- a/docs/v3/source/includes/resources/routes/_list_shared_spaces.md.erb
+++ b/docs/v3/source/includes/resources/routes/_list_shared_spaces.md.erb
@@ -8,6 +8,7 @@ Example Request
 
 ```shell
 curl "https://api.example.org/v3/routes/[guid]/relationships/shared_spaces" \
+  -X GET \
   -H "Authorization: bearer [token]" \
   -H "Content-type: application/json"
 ```


### PR DESCRIPTION
Update _list_shared_spaces.md.erb
In all the example request sections the "curl" command contains explicit "-X" parameter. In this endpoint it does not and it is kind of inconsistent.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch
