### PR TITLE
Run GH Actions unit tests on Postgres v17

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["postgres:13", "postgres:15", "postgres:16"]
+        image: ["postgres:13", "postgres:15", "postgres:17"]
     services:
       postgres:
         image: ${{ matrix.image }}

--- a/.github/workflows/unit_tests_backwards_compatibility.yml
+++ b/.github/workflows/unit_tests_backwards_compatibility.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        image: ["postgres:13", "postgres:15", "postgres:16"]
+        image: ["postgres:13", "postgres:15", "postgres:17"]
     services:
       postgres:
         image: ${{ matrix.image }}


### PR DESCRIPTION
* A short explanation of the proposed change:
Update Postgres to v17.

* An explanation of the use cases your change solves
The unit tests should be run with the newest supported Postgres version (plus the oldest supported version and possible additional versions).

* Links to any other associated PRs
https://github.com/cloudfoundry/capi-dockerfiles/pull/58

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`
https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/cc-unit-tests/builds/52

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
N/A
