### PR TITLE
Remove obsolete shutdown cc uploader function and corresponding test

### DIFF
--- a/lib/cloud_controller/drain.rb
+++ b/lib/cloud_controller/drain.rb
@@ -58,22 +58,6 @@ module VCAP
         send_signal('KILL', pid, process_name)
       end
 
-      def shutdown_cc_uploader(pid_path)
-        pid = File.read(pid_path).to_i
-        process_name = File.basename(pid_path, '.pid')
-        # Initiate shutdown.
-        send_signal('TERM', pid, process_name)
-
-        # Wait some additional time for cc_uploader to be terminated; otherwise write an error log message.
-        log_shutdown_error(pid, process_name) unless wait_for_shutdown(pid, process_name, CC_UPLOADER_FINAL_TIMEOUT_SECONDS)
-
-        # force shutdown
-        return if terminated?(pid, process_name)
-
-        log_info("Forcefully shutting down process '#{process_name}' with pid '#{pid}'")
-        send_signal('KILL', pid, process_name)
-      end
-
       private
 
       def send_signal(signal, pid, process_name)

--- a/spec/unit/lib/cloud_controller/drain_spec.rb
+++ b/spec/unit/lib/cloud_controller/drain_spec.rb
@@ -159,40 +159,5 @@ module VCAP::CloudController
         end
       end
     end
-
-    describe '#shutdown_cc_uploader' do
-      it 'sends TERM to the cc_uploader process specified in the pid file' do
-        expect(Process).to receive(:kill).with('TERM', pid)
-
-        drain.shutdown_cc_uploader(pid_path)
-
-        log_contents do |log|
-          expect(log).to include("Sending signal 'TERM' to process '#{pid_name}' with pid '#{pid}'")
-        end
-      end
-
-      it 'waits 900s after sending TERM' do
-        allow(Process).to receive(:getpgid).with(pid).and_return(1)
-
-        drain.shutdown_cc_uploader(pid_path)
-
-        expect(drain).to have_received(:sleep).exactly(900).times
-        log_contents do |log|
-          expect(log).to include("Process '#{pid_name}' with pid '#{pid}' is still running - this indicates an error in the shutdown procedure!")
-        end
-      end
-
-      it 'sends KILL to the cc_uploader process if it is still running after 900s' do
-        allow(Process).to receive(:getpgid).with(pid).and_return(1)
-        allow(Process).to receive(:kill).with('TERM', pid)
-        expect(Process).to receive(:kill).with('KILL', pid)
-
-        drain.shutdown_cc_uploader(pid_path)
-
-        log_contents do |log|
-          expect(log).to include("Forcefully shutting down process '#{pid_name}' with pid '#{pid}'")
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Draining for cc uploader is handled in cc uploader

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
