### PR TITLE
Update list packages per app API description

### DIFF
--- a/docs/v3/source/includes/resources/packages/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/packages/_list_for_app.md.erb
@@ -16,8 +16,8 @@ Example Response
 
 ```http
 HTTP/1.1 200 OK
-```
-```json
+Content-Type: application/json
+
 <%= yield_content :paginated_list_of_associated_packages %>
 ```
 


### PR DESCRIPTION
In all "list" endpoint example responses there is a common pattern:

```http
HTTP/1.1 200 OK
Content-Type: application/json

<%= yield_content :paginated_list_of_[resource] %>
```

This pattern is broken in this case and makes it inconsistent compared to the rest of the documentation

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch
