### PR TITLE
Fix flaky timecop specs

### DIFF
--- a/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
+++ b/spec/unit/jobs/services/service_instance_state_fetch_spec.rb
@@ -473,13 +473,15 @@ module VCAP::CloudController
           context 'when enqueuing the job would exceed the max poll duration by the time it runs' do
             let(:state) { 'in progress' }
 
-            it 'does not enqueue another fetch job' do
-              Timecop.freeze(job.end_timestamp - (job.poll_interval * 0.5))
-              run_job(job)
+              it 'does not enqueue another fetch job' do
+                Timecop.freeze(job.end_timestamp - (job.poll_interval * 0.5)) do
+                  run_job(job)
+                end
 
-              Timecop.freeze(Time.now + (job.poll_interval * 2))
-              execute_all_jobs(expected_successes: 0, expected_failures: 0)
-            end
+                Timecop.freeze(Time.now + (job.poll_interval * 2)) do
+                  execute_all_jobs(expected_successes: 0, expected_failures: 0)
+                end
+              end
           end
 
           context 'when the job was migrated before the addition of end_timestamp' do

--- a/spec/unit/lib/cloud_controller/clock/distributed_executor_spec.rb
+++ b/spec/unit/lib/cloud_controller/clock/distributed_executor_spec.rb
@@ -116,12 +116,12 @@ module VCAP::CloudController
 
               DistributedExecutor.new.execute_job name: job_name, interval: 1.minute, fudge: 1.second, timeout: 5.minutes do
                 Delayed::Job.create!(queue: job_name, failed_at: nil, locked_at: Time.now)
-                counter += 1
-                Timecop.travel(Time.now.utc + 1.minute + 2.seconds)
-
-                DistributedExecutor.new.execute_job name: job_name, interval: 1.minute, fudge: 1.second, timeout: 5.minutes do
-                  counter += 2
-                end
+                  counter += 1
+                  Timecop.travel(Time.now.utc + 1.minute + 2.seconds) do
+                    DistributedExecutor.new.execute_job name: job_name, interval: 1.minute, fudge: 1.second, timeout: 5.minutes do
+                      counter += 2
+                    end
+                  end
               end
 
               expect(counter).to eq(1)
@@ -139,11 +139,12 @@ module VCAP::CloudController
                 counter = 0
 
                 DistributedExecutor.new.execute_job name: 'diego_sync', interval: 1.minute, fudge: 1.second, timeout: 5.minutes do
-                  Timecop.travel(Time.now.utc + 1.minute + 1.second)
-                  counter += 1
+                  Timecop.travel(Time.now.utc + 1.minute + 1.second) do
+                    counter += 1
 
-                  DistributedExecutor.new.execute_job name: 'diego_sync', interval: 1.minute, fudge: 1.second, timeout: 5.minutes do
-                    counter += 2
+                    DistributedExecutor.new.execute_job name: 'diego_sync', interval: 1.minute, fudge: 1.second, timeout: 5.minutes do
+                      counter += 2
+                    end
                   end
                 end
 
@@ -162,12 +163,13 @@ module VCAP::CloudController
 
                 DistributedExecutor.new.execute_job name: job_name, interval: 1.minute, fudge: 1.second, timeout: 5.minutes do
                   Delayed::Job.create!(queue: job_name, failed_at: nil, locked_at: Time.now)
-                  Timecop.travel(Time.now.utc + 1.minute + 1.second)
-                  counter += 1
+                    Timecop.travel(Time.now.utc + 1.minute + 1.second) do
+                      counter += 1
 
-                  DistributedExecutor.new.execute_job name: job_name, interval: 1.minute, fudge: 1.second, timeout: 5.minutes do
-                    counter += 2
-                  end
+                      DistributedExecutor.new.execute_job name: job_name, interval: 1.minute, fudge: 1.second, timeout: 5.minutes do
+                        counter += 2
+                      end
+                    end
                 end
 
                 expect(counter).to eq(1)

--- a/spec/unit/lib/cloud_controller/resource_match_spec.rb
+++ b/spec/unit/lib/cloud_controller/resource_match_spec.rb
@@ -62,13 +62,12 @@ module VCAP::CloudController
         let(:maximum_file_size) { 500.megabytes } # this is arbitrary
         let(:minimum_file_size) { 3.kilobytes }
 
-        it 'correctly calculates and logs the time for each file size range' do
-          Timecop.freeze
-          allow(ResourcePool.instance).to receive(:resource_known?) do
-            Timecop.freeze(2.seconds.from_now)
-            true
-          end
-          expect(Steno.logger('cc.resource_pool')).to receive(:info).once.with('starting resource matching', {
+          it 'correctly calculates and logs the time for each file size range' do
+            Timecop.freeze do
+              allow(ResourcePool.instance).to receive(:resource_known?) do
+                Timecop.freeze(2.seconds.from_now) { true }
+              end
+              expect(Steno.logger('cc.resource_pool')).to receive(:info).once.with('starting resource matching', {
                                                                                  total_resources_to_match: 6,
                                                                                  resource_count_by_size: {
                                                                                    '1KB or less': 0,
@@ -80,7 +79,7 @@ module VCAP::CloudController
                                                                                  }
                                                                                })
 
-          expect(Steno.logger('cc.resource_pool')).to receive(:info).once.with('done matching resources', {
+              expect(Steno.logger('cc.resource_pool')).to receive(:info).once.with('done matching resources', {
                                                                                  total_resources_to_match: 6,
                                                                                  total_resource_match_time: '12.0 seconds',
                                                                                  resource_count_by_size: {
@@ -100,8 +99,10 @@ module VCAP::CloudController
                                                                                    '1GB or more': '0.0 seconds'
                                                                                  }
                                                                                })
-          ResourceMatch.new(descriptors).match_resources
-        end
+              ResourceMatch.new(descriptors).match_resources
+            end
+
+        after { Timecop.return }
       end
     end
 

--- a/spec/unit/lib/services/service_brokers/v2/orphan_mitigator_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/orphan_mitigator_spec.rb
@@ -50,6 +50,8 @@ module VCAP::Services
             OrphanMitigator.new.cleanup_failed_bind(binding)
           end
 
+          after { Timecop.return }
+
           it 'enqueues an unbind job' do
             expect(VCAP::CloudController::Jobs::GenericEnqueuer).to have_received(:shared)
 
@@ -106,6 +108,8 @@ module VCAP::Services
             expect(run_at).to eq Time.now
           end
         end
+
+        after { Timecop.return }
 
         specify 'the enqueued job has a reschedule_at define such that exponential backoff occurs' do
           now = Time.now

--- a/spec/unit/models/runtime/deployment_model_spec.rb
+++ b/spec/unit/models/runtime/deployment_model_spec.rb
@@ -234,12 +234,10 @@ module VCAP::CloudController
       let(:creation_time) { deployment.created_at }
       let(:update_time) { deployment.created_at + 24.hours }
 
-      before do
-        Timecop.freeze(creation_time)
-      end
-
-      after do
-        Timecop.return
+      around do |example|
+        Timecop.freeze(creation_time) do
+          example.run
+        end
       end
 
       it 'is defaulted with the created_at time' do
@@ -248,23 +246,26 @@ module VCAP::CloudController
 
       it 'updates when status_reason has changed' do
         deployment.status_reason = DeploymentModel::CANCELING_STATUS_REASON
-        Timecop.freeze(update_time)
-        deployment.save
-        expect(deployment.status_updated_at).to eq update_time
+        Timecop.freeze(update_time) do
+          deployment.save
+          expect(deployment.status_updated_at).to eq update_time
+        end
       end
 
       it 'updates when status_value has changed' do
         deployment.status_value = DeploymentModel::FINALIZED_STATUS_VALUE
-        Timecop.freeze(update_time)
-        deployment.save
-        expect(deployment.status_updated_at).to eq update_time
+        Timecop.freeze(update_time) do
+          deployment.save
+          expect(deployment.status_updated_at).to eq update_time
+        end
       end
 
       it 'doesnt update when status_value or status_reason is unchanged' do
         deployment.strategy = 'faux_strategy'
-        Timecop.freeze(update_time)
-        deployment.save
-        expect(deployment.status_updated_at).to eq creation_time
+        Timecop.freeze(update_time) do
+          deployment.save
+          expect(deployment.status_updated_at).to eq creation_time
+        end
       end
     end
 


### PR DESCRIPTION
- ensure nested Timecop calls get returned in `ServiceInstanceStateFetch` specs
- wrap stubbed time freeze in `ResourceMatch` specs
- use around block for consistent time in `DeploymentModel` specs
- close Timecop travel blocks in `DistributedExecutor` specs