### PR TITLE
Fix issue with displaying Tasks that no longer have a Droplet

### DIFF
--- a/app/models/runtime/task_model.rb
+++ b/app/models/runtime/task_model.rb
@@ -56,8 +56,13 @@ module VCAP::CloudController
       end
     end
 
-    delegate :docker?, to: :droplet
-    delegate :cnb?, to: :droplet
+    def docker?
+      !!droplet&.docker?
+    end
+
+    def cnb?
+      !!droplet&.cnb?
+    end
 
     private
 

--- a/app/presenters/v3/task_presenter.rb
+++ b/app/presenters/v3/task_presenter.rb
@@ -15,7 +15,7 @@ module VCAP::CloudController
                          sequence_id: task.sequence_id,
                          name: task.name,
                          command: task.command,
-                         user: task.run_action_user,
+                         user: presented_user(task),
                          state: task.state,
                          memory_in_mb: task.memory_in_mb,
                          disk_in_mb: task.disk_in_mb,
@@ -35,6 +35,14 @@ module VCAP::CloudController
 
         def task
           @resource
+        end
+
+        def presented_user(task)
+          if task.droplet.present?
+            task.run_action_user
+          else
+            task.user
+          end
         end
 
         def build_links

--- a/spec/unit/presenters/v3/task_presenter_spec.rb
+++ b/spec/unit/presenters/v3/task_presenter_spec.rb
@@ -4,9 +4,11 @@ require 'presenters/v3/task_presenter'
 module VCAP::CloudController::Presenters::V3
   RSpec.describe TaskPresenter do
     subject(:presenter) { TaskPresenter.new(task) }
+    let(:task_user) { nil }
     let(:task) do
       task = VCAP::CloudController::TaskModel.make(
         failure_reason: 'sup dawg',
+        user: task_user,
         memory_in_mb: 2048,
         disk_in_mb: 4048,
         log_rate_limit: 1024,
@@ -81,6 +83,27 @@ module VCAP::CloudController::Presenters::V3
 
         it 'excludes command' do
           expect(result).not_to have_key(:command)
+        end
+      end
+
+      describe 'user' do
+        context 'when the droplet for the task has been deleted' do
+          before do
+            task.droplet.delete
+            task.reload
+          end
+
+          it 'returns the user as nil' do
+            expect(result[:user]).to be_nil
+          end
+
+          context 'when the task has an explicit user set' do
+            let(:task_user) { 'TestUser' }
+
+            it 'returns the user' do
+              expect(result[:user]).to eq('TestUser')
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
- Although a Task must have a Droplet associated with it when it is created, these Droplets will be eventually cleaned up as the app is pushed with newer code over time. This change updates the presenter to return null when a Task's user can no longer be looked up because its droplet has been deleted.
- Fixes https://github.com/cloudfoundry/cloud_controller_ng/issues/4467

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
