### PR TITLE
Fix managed_service_instances dataset for spaces

### DIFF
--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -50,7 +50,8 @@ module VCAP::CloudController
 
     one_to_many :events, primary_key: :guid, key: :space_guid
     one_to_many :service_instances
-    one_to_many :managed_service_instances
+    one_to_many :managed_service_instances,
+                dataset: -> { VCAP::CloudController::ServiceInstance.filter(is_gateway_service: true) }
     many_to_many :service_instances_shared_from_other_spaces,
                  left_key: :target_space_guid,
                  left_primary_key: :guid,

--- a/spec/unit/models/runtime/space_spec.rb
+++ b/spec/unit/models/runtime/space_spec.rb
@@ -115,6 +115,19 @@ module VCAP::CloudController
         end
       end
 
+      describe 'dataset managed_service_instances' do
+        subject(:space) { Space.make }
+
+        it 'includes managed service instances and no user provided service instances' do
+          managed_service_instance = ManagedServiceInstance.make(space:)
+          user_provided_service_instance = UserProvidedServiceInstance.make(space:)
+
+          managed_instances = space.managed_service_instances
+          expect(managed_instances).to include(managed_service_instance)
+          expect(managed_instances).not_to include(user_provided_service_instance)
+        end
+      end
+
       describe 'domains' do
         subject(:space) { Space.make(organization:) }
         let(:organization) { Organization.make }


### PR DESCRIPTION
* A short explanation of the proposed change:
The managed_service_instances dataset for a space should only include managed services (where "is_gateway_service" is true) and no user-provided services.

* An explanation of the use cases your change solves
Consistent behavior with the organization managed_service_instances dataset.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
