### PR TITLE
Fix space usage summary

### DIFF
--- a/app/presenters/v3/space_usage_summary_presenter.rb
+++ b/app/presenters/v3/space_usage_summary_presenter.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController::Presenters::V3
           started_instances: started_instances,
           memory_in_mb: space.memory_used,
           routes: space.routes_dataset.count,
-          service_instances: space.service_instances_dataset.count,
+          service_instances: space.managed_service_instances_dataset.count,
           reserved_ports: VCAP::CloudController::SpaceReservedRoutePorts.new(space).count,
           domains: space.organization.owned_private_domains_dataset.count,
           per_app_tasks: space.running_and_pending_tasks_count,

--- a/spec/unit/presenters/v3/space_usage_summary_presenter_spec.rb
+++ b/spec/unit/presenters/v3/space_usage_summary_presenter_spec.rb
@@ -42,8 +42,9 @@ module VCAP::CloudController::Presenters::V3
       let(:broker) { VCAP::CloudController::ServiceBroker.make }
       let(:service) { VCAP::CloudController::Service.make(service_broker: broker) }
       let(:service_plan) { VCAP::CloudController::ServicePlan.make(service: service, public: true) }
-      let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space:, service_plan:) }
-      let!(:service_key) { VCAP::CloudController::ServiceKey.make(service_instance:) }
+      let!(:user_provided_service_instance) { VCAP::CloudController::UserProvidedServiceInstance.make(space:) }
+      let(:managed_service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space:, service_plan:) }
+      let!(:service_key) { VCAP::CloudController::ServiceKey.make(service_instance: managed_service_instance) }
 
       describe '#to_hash' do
         let(:result) { SpaceUsageSummaryPresenter.new(space).to_hash }


### PR DESCRIPTION
* A short explanation of the proposed change:
Only count managed service instances, not user provided service instances. This is consistent with the org usage summary and the global info usage summary.

* An explanation of the use cases your change solves
Shows space usage summary with number of managed service instances.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4468

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
