### PR TITLE
Fix query metrics logging if log_db_queries==false

### DIFF
--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -37,9 +37,9 @@ module VCAP::CloudController
         end
 
         db.extension(:query_length_logging)
-        db.extension(:request_query_metrics)
         db.opts[:query_size_log_threshold] = opts[:query_size_log_threshold]
       end
+      db.extension(:request_query_metrics)
       db.default_collate = 'utf8_bin' if db.database_type == :mysql
       add_connection_expiration_extension(db, opts)
       add_connection_validator_extension(db, opts)


### PR DESCRIPTION
* don't log 0 values for total_db_query_time_in_ms/db_query_count if db.log_db_queries==false

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
