### PR TITLE
PoC - Generate OpenApi Spec from Sourcecode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ end
 
 group :test do
   gem 'codeclimate-test-reporter', '>= 1.0.8', require: false
+  gem 'factory_bot_rails', require: false
   gem 'machinist', '~> 1.0.6'
   gem 'mock_redis'
   gem 'parallel_tests'
@@ -84,6 +85,7 @@ group :test do
   gem 'rspec-its'
   gem 'rspec-rails', '~> 8.0.1'
   gem 'rspec-wait'
+  gem 'rswag-specs'
   gem 'rubocop', '~> 1.79.1'
   gem 'rubocop-capybara'
   gem 'rubocop-factory_bot'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,11 @@ GEM
     eventmachine (1.2.7)
     excon (1.2.7)
       logger
+    factory_bot (6.5.4)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.0)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
     faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.7)
@@ -480,6 +485,11 @@ GEM
       activesupport (>= 3.0.0)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0)
+    rswag-specs (2.16.0)
+      activesupport (>= 5.2, < 8.1)
+      json-schema (>= 2.2, < 6.0)
+      railties (>= 5.2, < 8.1)
+      rspec-core (>= 2.14)
     rubocop (1.79.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -637,6 +647,7 @@ DEPENDENCIES
   debug (~> 1.11)
   digest-xxhash
   eventmachine (~> 1.2.7)
+  factory_bot_rails
   fluent-logger
   fog-aliyun
   fog-aws
@@ -685,6 +696,7 @@ DEPENDENCIES
   rspec-rails (~> 8.0.1)
   rspec-wait
   rspec_api_documentation (>= 6.1.0)
+  rswag-specs
   rubocop (~> 1.79.1)
   rubocop-capybara
   rubocop-factory_bot

--- a/lib/open_api_auto_generator.rb
+++ b/lib/open_api_auto_generator.rb
@@ -1,0 +1,448 @@
+require 'ostruct'
+
+module OpenApiAutoGenerator
+  def self.schema_from_message(message_class, openapi_spec)
+    return nil unless message_class.respond_to?(:validators) && message_class.respond_to?(:allowed_keys)
+
+    schema = {
+      'type' => 'object',
+      'properties' => {},
+      'required' => []
+    }
+
+    message_class.validators.each do |validator|
+      next unless validator.respond_to?(:attributes)
+
+      validator.attributes.each do |attr|
+        # Clean the attribute name by removing colon prefix
+        clean_attr = attr.to_s.gsub(/^:/, '')
+
+        schema['required'] << clean_attr if validator.is_a?(ActiveModel::Validations::PresenceValidator)
+
+        schema['properties'][clean_attr] = case validator
+                                           when ActiveModel::Validations::PresenceValidator
+                                             { 'type' => 'string' } # Assuming string for presence validation
+                                           when ActiveModel::Validations::FormatValidator
+                                             if validator.options[:with]
+                                               pattern = validator.options[:with]
+                                               # Handle lambda patterns
+                                               pattern = pattern.respond_to?(:source) ? pattern.source : pattern.to_s
+                                               { 'type' => 'string', 'pattern' => pattern }
+                                             else
+                                               { 'type' => 'string' }
+                                             end
+                                           when ActiveModel::Validations::InclusionValidator
+                                             { 'type' => 'string', 'enum' => validator.options[:in] }
+                                           when ActiveModel::Validations::NumericalityValidator
+                                             { 'type' => 'integer' }
+                                           when VCAP::CloudController::AppCreateMessage::LifecycleValidator
+                                             { '$ref' => '#/components/schemas/Lifecycle' }
+                                           when VCAP::CloudController::Validators::ArrayValidator
+                                             { 'type' => 'array', 'items' => { 'type' => 'string' } }
+                                           when VCAP::CloudController::Validators::RelationshipValidator
+                                             { '$ref' => '#/components/schemas/Relationship' }
+                                           else
+                                             # Check for boolean validators (validates :field, boolean: true)
+                                             if validator.class.name.include?('BooleanValidator') ||
+                                                (validator.respond_to?(:options) && validator.options[:boolean] == true)
+                                               { 'type' => 'boolean' }
+                                             elsif validator.respond_to?(:options) && validator.options[:string] == true
+                                               { 'type' => 'string' }
+                                             elsif validator.class.name.include?('NoAdditionalKeysValidator')
+                                               nil # Skip this validator
+                                             elsif defined?(BaseMessage) && validator.class.ancestors.include?(BaseMessage)
+                                               nested_schema = schema_from_message(validator.class, openapi_spec)
+                                               if nested_schema
+                                                 schema_name = "#{validator.class.name.demodulize}Request"
+                                                 openapi_spec['components']['schemas'][schema_name] ||= nested_schema
+                                                 { '$ref' => "#/components/schemas/#{schema_name}" }
+                                               else
+                                                 { 'type' => 'object' }
+                                               end
+                                             else
+                                               { 'type' => 'string' }
+                                             end
+                                           end
+      end
+    end
+
+    message_class.allowed_keys.each do |key|
+      # Clean the key name by removing colon prefix
+      clean_key = key.to_s.gsub(/^:/, '')
+
+      # Skip if we already have this property from validators
+      next if schema['properties'][clean_key]
+
+      # Infer type from key name for common patterns
+      schema['properties'][clean_key] = case clean_key
+                                        when 'suspended'
+                                          { 'type' => 'boolean' }
+                                        when /.*_id$/, 'guid'
+                                          { 'type' => 'string', 'format' => 'uuid' }
+                                        when 'metadata'
+                                          { 'type' => 'object' }
+                                        when 'relationships'
+                                          { 'type' => 'object' }
+                                        else
+                                          { 'type' => 'string' }
+                                        end
+    end
+
+    schema['properties']['lifecycle'] = { '$ref' => '#/components/schemas/BuildpackLifecycle' } if message_class.name == 'VCAP::CloudController::AppCreateMessage'
+
+    schema['required'].uniq!
+    schema
+  end
+
+  def self.schema_from_presenter(presenter_class)
+    return nil unless presenter_class&.instance_methods&.include?(:to_hash)
+
+    # Use predefined schemas based on Cloud Foundry API documentation
+    schema = predefined_schema_for_presenter(presenter_class)
+    return schema if schema
+
+    # Fallback: try to generate from presenter class structure
+    generate_schema_from_presenter_class(presenter_class)
+  rescue StandardError => e
+    puts "Warning: Could not generate schema for #{presenter_class.name}: #{e.message}"
+    nil
+  end
+
+  def self.predefined_schema_for_presenter(presenter_class)
+    case presenter_class.name
+    when 'VCAP::CloudController::Presenters::V3::AppPresenter'
+      {
+        'type' => 'object',
+        'properties' => {
+          'guid' => { 'type' => 'string', 'format' => 'uuid' },
+          'name' => { 'type' => 'string' },
+          'state' => { 'type' => 'string', 'enum' => %w[STARTED STOPPED] },
+          'created_at' => { 'type' => 'string', 'format' => 'date-time' },
+          'updated_at' => { 'type' => 'string', 'format' => 'date-time' },
+          'lifecycle' => {
+            'type' => 'object',
+            'properties' => {
+              'type' => { 'type' => 'string', 'enum' => %w[buildpack docker] },
+              'data' => { 'type' => 'object' }
+            }
+          },
+          'relationships' => {
+            'type' => 'object',
+            'properties' => {
+              'space' => {
+                'type' => 'object',
+                'properties' => {
+                  'data' => {
+                    'type' => 'object',
+                    'properties' => {
+                      'guid' => { 'type' => 'string', 'format' => 'uuid' }
+                    }
+                  }
+                }
+              },
+              'current_droplet' => {
+                'type' => 'object',
+                'properties' => {
+                  'data' => {
+                    'type' => 'object',
+                    'nullable' => true,
+                    'properties' => {
+                      'guid' => { 'type' => 'string', 'format' => 'uuid' }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          'links' => {
+            'type' => 'object',
+            'additionalProperties' => {
+              'type' => 'object',
+              'properties' => {
+                'href' => { 'type' => 'string', 'format' => 'uri' },
+                'method' => { 'type' => 'string' }
+              }
+            }
+          },
+          'metadata' => { '$ref' => '#/components/schemas/Metadata' }
+        },
+        'required' => %w[guid name state created_at updated_at lifecycle relationships links metadata]
+      }
+    when 'VCAP::CloudController::Presenters::V3::OrganizationPresenter'
+      {
+        'type' => 'object',
+        'properties' => {
+          'guid' => { 'type' => 'string', 'format' => 'uuid' },
+          'name' => { 'type' => 'string' },
+          'suspended' => { 'type' => 'boolean' },
+          'created_at' => { 'type' => 'string', 'format' => 'date-time' },
+          'updated_at' => { 'type' => 'string', 'format' => 'date-time' },
+          'relationships' => {
+            'type' => 'object',
+            'properties' => {
+              'quota' => {
+                'type' => 'object',
+                'properties' => {
+                  'data' => {
+                    'type' => 'object',
+                    'nullable' => true,
+                    'properties' => {
+                      'guid' => { 'type' => 'string', 'format' => 'uuid' }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          'links' => { '$ref' => '#/components/schemas/Links' },
+          'metadata' => { '$ref' => '#/components/schemas/Metadata' }
+        },
+        'required' => %w[guid name suspended created_at updated_at relationships links metadata]
+      }
+    when 'VCAP::CloudController::Presenters::V3::SpacePresenter'
+      {
+        'type' => 'object',
+        'properties' => {
+          'guid' => { 'type' => 'string', 'format' => 'uuid' },
+          'name' => { 'type' => 'string' },
+          'created_at' => { 'type' => 'string', 'format' => 'date-time' },
+          'updated_at' => { 'type' => 'string', 'format' => 'date-time' },
+          'relationships' => {
+            'type' => 'object',
+            'properties' => {
+              'organization' => {
+                'type' => 'object',
+                'properties' => {
+                  'data' => {
+                    'type' => 'object',
+                    'properties' => {
+                      'guid' => { 'type' => 'string', 'format' => 'uuid' }
+                    }
+                  }
+                }
+              },
+              'quota' => {
+                'type' => 'object',
+                'properties' => {
+                  'data' => {
+                    'type' => 'object',
+                    'nullable' => true,
+                    'properties' => {
+                      'guid' => { 'type' => 'string', 'format' => 'uuid' }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          'links' => { '$ref' => '#/components/schemas/Links' },
+          'metadata' => { '$ref' => '#/components/schemas/Metadata' }
+        },
+        'required' => %w[guid name created_at updated_at relationships links metadata]
+      }
+    end
+  end
+
+  def self.generate_schema_from_presenter_class(_presenter_class)
+    # Try to analyze the presenter source code for common patterns
+    schema = { 'type' => 'object', 'properties' => {} }
+
+    # Get common fields from base presenter or known patterns
+    common_fields = %w[guid created_at updated_at name]
+    common_fields.each do |field|
+      schema['properties'][field] = infer_field_type(field)
+    end
+
+    # Add metadata and links which are common in CF API
+    schema['properties']['metadata'] = { '$ref' => '#/components/schemas/Metadata' }
+    schema['properties']['links'] = { '$ref' => '#/components/schemas/Links' }
+
+    schema
+  end
+
+  def self.infer_field_type(field_name)
+    case field_name
+    when 'guid'
+      { 'type' => 'string', 'format' => 'uuid' }
+    when /.*_at$/, 'created_at', 'updated_at'
+      { 'type' => 'string', 'format' => 'date-time' }
+    when 'name', 'description', 'title'
+      { 'type' => 'string' }
+    when /.*_count$/, 'version'
+      { 'type' => 'integer' }
+    when 'enabled', 'disabled', 'suspended'
+      { 'type' => 'boolean' }
+    else
+      { 'type' => 'string' }
+    end
+  end
+
+  def self.enhance_schema_with_db_info(schema, model_class)
+    return unless model_class.respond_to?(:db_schema)
+
+    model_class.db_schema.each do |column, db_info|
+      column_str = column.to_s
+      next unless schema['properties'][column_str]
+
+      schema['properties'][column_str]['type'] = db_type_to_openapi_type(db_info[:type])
+      format = db_type_to_openapi_format(db_info[:type])
+      schema['properties'][column_str]['format'] = format if format
+    end
+  end
+
+  def self.mock_model_for_presenter(presenter_class)
+    class_name = presenter_class.name.demodulize.gsub('Presenter', '')
+
+    # Special case for InfoPresenter
+    if presenter_class.name == 'VCAP::CloudController::Presenters::V3::InfoPresenter'
+      # InfoPresenter is a special case
+      begin
+        info = Info.new
+        config = VCAP::CloudController::Config.config
+        if config
+          info.build = config.get(:info, :build) || ''
+          info.min_cli_version = config.get(:info, :min_cli_version) || ''
+          info.min_recommended_cli_version = config.get(:info, :min_recommended_cli_version) || ''
+          info.custom = config.get(:info, :custom) || {}
+          info.description = config.get(:info, :description) || ''
+          info.name = config.get(:info, :name) || ''
+          info.version = config.get(:info, :version) || 0
+          info.support_address = config.get(:info, :support_address) || ''
+        else
+          # If config is not available, set default values
+          info.build = ''
+          info.min_cli_version = ''
+          info.min_recommended_cli_version = ''
+          info.custom = {}
+          info.description = ''
+          info.name = ''
+          info.version = 0
+          info.support_address = ''
+        end
+        osbapi_version_file = Rails.root.join('config/osbapi_version').to_s
+        info.osbapi_version = if File.exist?(osbapi_version_file)
+                                File.read(osbapi_version_file).strip
+                              else
+                                ''
+                              end
+        return info
+      rescue StandardError => e
+        puts "Warning: Could not create Info object: #{e.message}"
+        # Fall back to a simple mock
+        return OpenStruct.new(
+          build: '',
+          min_cli_version: '',
+          min_recommended_cli_version: '',
+          custom: {},
+          description: '',
+          name: '',
+          version: 0,
+          support_address: '',
+          osbapi_version: ''
+        )
+      end
+    end
+
+    # Try different factory names
+    factory_names = [
+      class_name.underscore,
+      class_name.underscore.singularize,
+      "#{class_name.underscore}_model"
+    ]
+
+    factory_names.each do |factory_name_str|
+      factory_name = factory_name_str.to_sym
+      next unless FactoryBot.factories.registered?(factory_name)
+
+      begin
+        return FactoryBot.build(factory_name)
+      rescue StandardError
+        next
+      end
+    end
+
+    nil
+  end
+
+  def self.mock_value_for_column(model_class, column_name)
+    db_schema = model_class.db_schema[column_name]
+    return nil unless db_schema
+
+    case db_schema[:type]
+    when :string
+      'string'
+    when :integer
+      1
+    when :boolean
+      true
+    when :datetime
+      Time.now.utc.iso8601
+    else
+      'unknown'
+    end
+  end
+
+  def self.generate_schema_from_hash(hash)
+    properties = {}
+    hash.each do |key, value|
+      properties[key] = schema_for_value(value)
+    end
+    { 'type' => 'object', 'properties' => properties }
+  end
+
+  def self.db_type_to_openapi_type(db_type)
+    case db_type
+    when :string, :text
+      'string'
+    when :integer, :bigint
+      'integer'
+    when :boolean
+      'boolean'
+    when :datetime, :timestamp
+      'string'
+    when :float, :decimal
+      'number'
+    else
+      'string'
+    end
+  end
+
+  def self.db_type_to_openapi_format(db_type)
+    case db_type
+    when :datetime, :timestamp
+      'date-time'
+    when :float
+      'float'
+    when :decimal
+      'double'
+    when :bigint
+      'int64'
+    end
+  end
+
+  def self.schema_for_value(value)
+    case value
+    when Hash
+      generate_schema_from_hash(value)
+    when Array
+      items = value.empty? ? {} : schema_for_value(value.first)
+      { 'type' => 'array', 'items' => items }
+    when String
+      if value.match?(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/)
+        { 'type' => 'string', 'format' => 'date-time' }
+      elsif value.match?(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/)
+        { 'type' => 'string', 'format' => 'uuid' }
+      else
+        { 'type' => 'string' }
+      end
+    when Integer
+      { 'type' => 'integer' }
+    when TrueClass, FalseClass
+      { 'type' => 'boolean' }
+    when NilClass
+      { 'type' => 'null' }
+    else
+      { 'type' => 'string' }
+    end
+  end
+end

--- a/lib/tasks/generate_openapi.rake
+++ b/lib/tasks/generate_openapi.rake
@@ -1,0 +1,827 @@
+require 'yaml'
+require_relative '../open_api_auto_generator'
+require 'vcap/rest_api'
+require 'factory_bot'
+
+# Load all presenters
+Dir[Rails.root.join('app/presenters/v3/*.rb')].each { |f| require f }
+FactoryBot.find_definitions
+
+namespace :openapi do
+  desc 'Generate OpenAPI specification from code'
+  task :generate, [:output_file] => :environment do |_task, args|
+    output_file = args[:output_file] || 'public/openapi.yaml'
+
+    puts "Generating OpenAPI specification in #{output_file}..."
+
+    openapi_spec = {
+      'openapi' => '3.0.0',
+      'info' => {
+        'title' => 'Cloud Foundry API',
+        'version' => '3.130.0',
+        'description' => 'Cloud Foundry API V3',
+        'termsOfService' => 'https://www.cloudfoundry.org/policies/',
+        'contact' => {
+          'name' => 'Cloud Foundry',
+          'url' => 'https://www.cloudfoundry.org/',
+          'email' => 'cf-dev@lists.cloudfoundry.org'
+        },
+        'license' => {
+          'name' => 'Apache 2.0',
+          'url' => 'https://www.apache.org/licenses/LICENSE-2.0.html'
+        }
+      },
+      'servers' => [
+        { 'url' => 'https://api.example.org' }
+      ],
+      'paths' => {},
+      'tags' => [],
+      'components' => {
+        'schemas' => {},
+        'securitySchemes' => {
+          'bearerAuth' => {
+            'type' => 'http',
+            'scheme' => 'bearer',
+            'bearerFormat' => 'JWT'
+          }
+        },
+        'parameters' => {},
+        'responses' => {
+          'Unauthorized' => {
+            'description' => 'Unauthorized',
+            'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Error' } } }
+          },
+          'Forbidden' => {
+            'description' => 'Forbidden',
+            'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Error' } } }
+          },
+          'NotFound' => {
+            'description' => 'Not Found',
+            'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Error' } } }
+          },
+          'UnprocessableEntity' => {
+            'description' => 'Unprocessable Entity',
+            'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Error' } } }
+          },
+          'BadRequest' => {
+            'description' => 'Bad Request',
+            'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Error' } } }
+          },
+          'InternalServerError' => {
+            'description' => 'Internal Server Error',
+            'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Error' } } }
+          }
+        }
+      },
+      'security' => [
+        { 'bearerAuth' => [] }
+      ],
+      'externalDocs' => {
+        'description' => 'Cloud Foundry API V3 Docs',
+        'url' => 'https://v3-apidocs.cloudfoundry.org/'
+      }
+    }
+
+    # Generate common components first
+    generate_common_parameters(openapi_spec)
+    generate_common_schemas(openapi_spec)
+
+    # Discover and generate schemas from all V3 presenters
+    discover_schemas_from_presenters(openapi_spec)
+
+    tags = {}
+
+    Rails.application.routes.routes.each do |route|
+      next if route.path.spec.to_s.starts_with?('/rails/info/properties')
+
+      # Skip non-API routes
+      next if route.path.spec.to_s.starts_with?('/rails')
+
+      raw_path = route.path.spec.to_s.gsub('(.:format)', '')
+
+      # Add /v3 prefix for API routes (but not for root route)
+      path = if raw_path == '/'
+               raw_path
+             else
+               "/v3#{raw_path}"
+             end
+
+      # Convert route parameters to OpenAPI format
+      path = path.gsub(/:(\w+)/, '{\1}')
+
+      verb = route.verb.downcase
+      next if verb.blank?
+
+      controller_name = route.defaults[:controller]
+      action_name = route.defaults[:action]
+
+      next unless controller_name
+
+      tag_name = if controller_name.include?('_v3')
+                   controller_name.gsub('_v3', '').camelize
+                 else
+                   controller_name.split('/').last.gsub('_v3', '').camelize
+                 end
+      unless tags.key?(tag_name)
+        model_name = "VCAP::CloudController::#{tag_name.singularize}"
+        model_class = model_name.safe_constantize
+        if model_class
+          begin
+            model_file_path = Rails.root.join('app', 'models', 'runtime', "#{model_class.name.demodulize.underscore}.rb")
+            if File.exist?(model_file_path)
+              lines = File.readlines(model_file_path)
+              class_definition_line = lines.index { |l| l.match?(/\s*class\s+#{model_class.name.demodulize}/) }
+              if class_definition_line
+                comment_lines = []
+                (class_definition_line - 1).downto(0) do |i|
+                  line = lines[i].strip
+                  break unless line.starts_with?('#')
+
+                  comment_lines.unshift(line[1..].strip)
+                end
+                tags[tag_name] = comment_lines.join("\n") unless comment_lines.empty?
+              end
+            end
+          rescue StandardError
+            # Not all models will have a file or be easily inspectable.
+          end
+        end
+        tags[tag_name] ||= ''
+      end
+
+      controller_class = if controller_name.include?('_v3')
+                           "#{controller_name.camelize}Controller".safe_constantize
+                         else
+                           "V3::#{controller_name.camelize}Controller".safe_constantize ||
+                             "#{controller_name.camelize}V3Controller".safe_constantize
+                         end
+      description = nil
+      if controller_class&.method_defined?(action_name)
+        begin
+          # Using source_location is not ideal, but it's a way to get comments without
+          # depending on gems that might not be available (like solargraph).
+          file_path, line_number = controller_class.instance_method(action_name).source_location
+          if file_path && line_number
+            lines = File.readlines(file_path)
+            comment_lines = []
+            (line_number - 2).downto(0) do |i|
+              line = lines[i].strip
+              break unless line.starts_with?('#')
+
+              comment_lines.unshift(line[1..].strip)
+            end
+            description = comment_lines.join("\n") unless comment_lines.empty?
+          end
+        rescue NameError
+          # Some controllers might not be easily loadable this way.
+        end
+      end
+
+      # Generate Cloud Foundry style summary and description
+      cf_summary = generate_cf_style_summary(action_name, tag_name, path, verb)
+      cf_description = generate_cf_style_description(action_name, tag_name, path, verb)
+
+      operation = {
+        'summary' => summary_from_comment(description).presence || cf_summary,
+        'description' => description.presence || cf_description,
+        'operationId' => "#{verb}#{path.gsub(%r{[/\{\}]}, '_')}#{action_name.camelize}",
+        'tags' => [tag_name],
+        'parameters' => [],
+        'responses' => {}
+      }
+
+      # Extract path parameters
+      path.scan(/\{(\w+)\}/).each do |param|
+        param_name = param.first
+        operation['parameters'] << if param_name == 'guid'
+                                     { '$ref' => '#/components/parameters/Guid' }
+                                   else
+                                     {
+                                       'name' => param_name,
+                                       'in' => 'path',
+                                       'required' => true,
+                                       'schema' => { 'type' => 'string' }
+                                     }
+                                   end
+      end
+      operation['parameters'].uniq! { |p| p['name'] || p['$ref'] }
+
+      # Define default success response
+      success_status = '200'
+      case action_name
+      when 'create'
+        success_status = '201'
+      when 'destroy'
+        success_status = '202'
+      when 'update'
+        success_status = '200'
+      end
+      operation['responses'][success_status] = { 'description' => 'Successful response' }
+
+      # Add error responses
+      operation['responses']['400'] = { '$ref' => '#/components/responses/BadRequest' }
+      operation['responses']['401'] = { '$ref' => '#/components/responses/Unauthorized' }
+      operation['responses']['403'] = { '$ref' => '#/components/responses/Forbidden' }
+      operation['responses']['404'] = { '$ref' => '#/components/responses/NotFound' }
+      operation['responses']['422'] = { '$ref' => '#/components/responses/UnprocessableEntity' }
+      operation['responses']['500'] = { '$ref' => '#/components/responses/InternalServerError' }
+
+      if action_name == 'index'
+        class_name = controller_name.split('/').last.gsub('_v3', '').camelize
+        list_message_class_name = "VCAP::CloudController::#{class_name}ListMessage"
+        list_message_class = list_message_class_name.safe_constantize
+
+        if list_message_class
+          dynamic_params = discover_list_message_parameters(list_message_class)
+          operation['parameters'].concat(dynamic_params)
+        end
+      end
+
+      # Introspect presenter for response schema
+      presenter_name = map_controller_to_presenter(controller_name)
+      presenter_class_name = "VCAP::CloudController::Presenters::V3::#{presenter_name.camelize}Presenter"
+      presenter_class = presenter_class_name.safe_constantize
+
+      if presenter_class
+        schema_name = presenter_class_name.demodulize.gsub(/Presenter$/, '')
+        schema = OpenApiAutoGenerator.schema_from_presenter(presenter_class)
+
+        if schema && !schema['properties'].empty?
+          openapi_spec['components']['schemas'][schema_name] ||= schema
+          if action_name == 'index'
+            paginated_schema_name = "Paginated#{schema_name}Response"
+            openapi_spec['components']['schemas'][paginated_schema_name] ||= {
+              'type' => 'object',
+              'properties' => {
+                'pagination' => { '$ref' => '#/components/schemas/Pagination' },
+                'resources' => {
+                  'type' => 'array',
+                  'items' => { '$ref' => "#/components/schemas/#{schema_name}" }
+                }
+              }
+            }
+            operation['responses'][success_status]['content'] = {
+              'application/json' => {
+                'schema' => { '$ref' => "#/components/schemas/#{paginated_schema_name}" }
+              }
+            }
+          else
+            operation['responses'][success_status]['content'] = {
+              'application/json' => {
+                'schema' => { '$ref' => "#/components/schemas/#{schema_name}" }
+              }
+            }
+          end
+        end
+      end
+
+      # Introspect message for request schema
+      base_name = controller_name.split('/').last.camelize
+      # Handle special case for v3 controllers (e.g., apps_v3 -> App, not AppV3)
+      base_name = base_name.gsub(/V\d+$/, '') if base_name.end_with?('V3')
+      # Singularize the base name after removing V3 suffix
+      base_name = base_name.singularize
+      message_class_name = "VCAP::CloudController::#{base_name}#{action_name.camelize}Message"
+      message_class = message_class_name.safe_constantize
+      if message_class.respond_to?(:allowed_keys)
+        schema_name = "#{message_class.name.demodulize}Request"
+        schema = OpenApiAutoGenerator.schema_from_message(message_class, openapi_spec)
+        if schema && !schema['properties'].empty?
+          openapi_spec['components']['schemas'][schema_name] ||= schema
+          operation['requestBody'] = {
+            'content' => {
+              'application/json' => {
+                'schema' => { '$ref' => "#/components/schemas/#{schema_name}" }
+              }
+            }
+          }
+        end
+      end
+
+      openapi_spec['paths'][path] ||= {}
+      openapi_spec['paths'][path][verb] = operation
+    end
+
+    openapi_spec['tags'] = tags.map { |name, description| { 'name' => name, 'description' => description } }
+
+    File.write(output_file, openapi_spec.to_yaml)
+
+    puts 'OpenAPI specification generated successfully.'
+  end
+
+  def self.map_controller_to_presenter(controller_name)
+    # Map controller names to presenter names
+    case controller_name
+    when 'apps_v3'
+      'app'
+    when 'organizations_v3'
+      'organization'
+    when 'spaces_v3'
+      'space'
+    when 'service_instances_v3'
+      'service_instance'
+    else
+      controller_name.split('/').last.singularize
+    end
+  end
+
+  def self.summary_from_comment(comment)
+    return '' unless comment
+
+    comment.split("\n").first
+  end
+
+  def self.generate_cf_style_summary(action_name, tag_name, path, verb)
+    # Convert tag name to a descriptive resource name
+    resource_name = case tag_name
+                    when 'Apps' then 'app'
+                    when 'Organizations' then 'organization'
+                    when 'Spaces' then 'space'
+                    when 'Routes' then 'route'
+                    when 'Domains' then 'domain'
+                    when 'Services' then 'service'
+                    when 'ServiceInstances' then 'service instance'
+                    when 'ServiceBrokers' then 'service broker'
+                    when 'ServiceOfferings' then 'service offering'
+                    when 'ServicePlans' then 'service plan'
+                    when 'ServiceCredentialBindings' then 'service credential binding'
+                    when 'ServiceRouteBindings' then 'service route binding'
+                    when 'Buildpacks' then 'buildpack'
+                    when 'Packages' then 'package'
+                    when 'Builds' then 'build'
+                    when 'Deployments' then 'deployment'
+                    when 'Processes' then 'process'
+                    when 'Tasks' then 'task'
+                    when 'Droplets' then 'droplet'
+                    when 'Revisions' then 'revision'
+                    when 'Users' then 'user'
+                    when 'Roles' then 'role'
+                    when 'IsolationSegments' then 'isolation segment'
+                    when 'SecurityGroups' then 'security group'
+                    when 'Stacks' then 'stack'
+                    when 'FeatureFlags' then 'feature flag'
+                    when 'OrganizationQuotas' then 'organization quota'
+                    when 'SpaceQuotas' then 'space quota'
+                    when 'Events' then 'event'
+                    when 'AppUsageEvents' then 'app usage event'
+                    when 'ServiceUsageEvents' then 'service usage event'
+                    when 'EnvironmentVariableGroups' then 'environment variable group'
+                    else
+                      tag_name.downcase.gsub(/([a-z])([A-Z])/, '\1 \2')
+                    end
+
+    # Helper to determine correct article (a/an)
+    article = %w[a e i o u].include?(resource_name[0]) ? 'an' : 'a'
+
+    # Check for specific action patterns
+    case action_name
+    when 'index'
+      if path.include?('relationships')
+        relationship_part = path.split('/relationships/').last
+        relationship_name = relationship_part.tr('_', ' ')
+        "List #{relationship_name} relationship"
+      else
+        "List #{resource_name.pluralize}"
+      end
+    when 'show'
+      if path.include?('relationships')
+        relationship_part = path.split('/relationships/').last
+        relationship_name = relationship_part.tr('_', ' ')
+        "Get #{relationship_name} relationship"
+      else
+        "Get #{article} #{resource_name}"
+      end
+    when 'create'
+      if path.include?('relationships')
+        'Create relationship'
+      else
+        "Create #{article} #{resource_name}"
+      end
+    when 'update'
+      if path.include?('relationships')
+        relationship_part = path.split('/relationships/').last
+        relationship_name = relationship_part.tr('_', ' ')
+        "Update #{relationship_name} relationship"
+      else
+        "Update #{article} #{resource_name}"
+      end
+    when 'destroy', 'delete'
+      if path.include?('relationships')
+        'Delete relationship'
+      else
+        "Delete #{article} #{resource_name}"
+      end
+    when 'start'
+      "Start #{article} #{resource_name}"
+    when 'stop'
+      "Stop #{article} #{resource_name}"
+    when 'restart'
+      "Restart #{article} #{resource_name}"
+    when 'upload'
+      "Upload #{resource_name} bits"
+    when 'download'
+      "Download #{resource_name} bits"
+    when 'stage'
+      "Stage #{article} #{resource_name}"
+    when 'assign_current_droplet'
+      'Assign current droplet'
+    when 'assign'
+      "Assign #{resource_name}"
+    when 'unassign'
+      "Unassign #{resource_name}"
+    when 'share'
+      "Share #{article} #{resource_name}"
+    when 'unshare'
+      "Unshare #{article} #{resource_name}"
+    when 'scale'
+      "Scale #{article} #{resource_name}"
+    when 'stats'
+      "Get #{resource_name} stats"
+    when 'env'
+      "Get #{resource_name} environment"
+    when 'permissions'
+      "Get #{resource_name} permissions"
+    when 'cancel'
+      "Cancel #{article} #{resource_name}"
+    when 'apply_manifest'
+      'Apply manifest'
+    when 'clear_buildpack_cache'
+      'Clear buildpack cache'
+    else
+      # Check for special path patterns
+      if path.include?('/actions/')
+        action_part = path.split('/actions/').last
+        "#{action_part.humanize} #{resource_name}"
+      elsif path.include?('/features/')
+        feature_part = path.split('/features/').last
+        case verb
+        when 'get'
+          if feature_part == 'features'
+            "List #{resource_name} features"
+          else
+            "Get #{resource_name} feature"
+          end
+        when 'patch'
+          "Update #{resource_name} feature"
+        else
+          "#{verb.humanize} #{resource_name} feature"
+        end
+      else
+        action_name.humanize
+      end
+    end
+  end
+
+  def self.generate_cf_style_description(action_name, tag_name, path, _verb)
+    resource_name = case tag_name
+                    when 'Apps' then 'app'
+                    when 'Organizations' then 'organization'
+                    when 'Spaces' then 'space'
+                    when 'Routes' then 'route'
+                    when 'Domains' then 'domain'
+                    when 'Services' then 'service'
+                    when 'ServiceInstances' then 'service instance'
+                    when 'ServiceBrokers' then 'service broker'
+                    when 'ServiceOfferings' then 'service offering'
+                    when 'ServicePlans' then 'service plan'
+                    when 'ServiceCredentialBindings' then 'service credential binding'
+                    when 'ServiceRouteBindings' then 'service route binding'
+                    when 'Buildpacks' then 'buildpack'
+                    when 'Packages' then 'package'
+                    when 'Builds' then 'build'
+                    when 'Deployments' then 'deployment'
+                    when 'Processes' then 'process'
+                    when 'Tasks' then 'task'
+                    when 'Droplets' then 'droplet'
+                    when 'Revisions' then 'revision'
+                    when 'Users' then 'user'
+                    when 'Roles' then 'role'
+                    when 'IsolationSegments' then 'isolation segment'
+                    when 'SecurityGroups' then 'security group'
+                    when 'Stacks' then 'stack'
+                    when 'FeatureFlags' then 'feature flag'
+                    when 'OrganizationQuotas' then 'organization quota'
+                    when 'SpaceQuotas' then 'space quota'
+                    when 'Events' then 'event'
+                    when 'AppUsageEvents' then 'app usage event'
+                    when 'ServiceUsageEvents' then 'service usage event'
+                    when 'EnvironmentVariableGroups' then 'environment variable group'
+                    else
+                      tag_name.downcase.gsub(/([a-z])([A-Z])/, '\1 \2')
+                    end
+
+    case action_name
+    when 'index'
+      if path.include?('relationships')
+        "This endpoint retrieves the #{path.split('/relationships/').last.tr('_', ' ')} relationship."
+      else
+        "This endpoint retrieves the #{resource_name.pluralize} the user has access to."
+      end
+    when 'show'
+      if path.include?('relationships')
+        "This endpoint retrieves the #{path.split('/relationships/').last.tr('_', ' ')} relationship."
+      else
+        "This endpoint retrieves the specified #{resource_name} object."
+      end
+    when 'create'
+      if path.include?('relationships')
+        'This endpoint creates a new relationship.'
+      else
+        "This endpoint creates a new #{resource_name}."
+      end
+    when 'update'
+      if path.include?('relationships')
+        "This endpoint updates the #{path.split('/relationships/').last.tr('_', ' ')} relationship."
+      else
+        "This endpoint updates the specified #{resource_name}."
+      end
+    when 'destroy', 'delete'
+      if path.include?('relationships')
+        'This endpoint deletes the relationship.'
+      else
+        "This endpoint deletes the specified #{resource_name}."
+      end
+    when 'start'
+      "This endpoint starts the specified #{resource_name}."
+    when 'stop'
+      "This endpoint stops the specified #{resource_name}."
+    when 'restart'
+      "This endpoint restarts the specified #{resource_name}."
+    when 'upload'
+      "This endpoint uploads bits for the specified #{resource_name}."
+    when 'download'
+      "This endpoint downloads bits for the specified #{resource_name}."
+    when 'stage'
+      "This endpoint stages the specified #{resource_name}."
+    when 'scale'
+      "This endpoint scales the specified #{resource_name}."
+    when 'stats'
+      "This endpoint retrieves stats for the specified #{resource_name}."
+    when 'env'
+      "This endpoint retrieves environment variables for the specified #{resource_name}."
+    when 'permissions'
+      "This endpoint retrieves permissions for the specified #{resource_name}."
+    when 'clear_buildpack_cache'
+      'This endpoint deletes all of the existing buildpack caches in the blobstore.'
+    else
+      "This endpoint performs the #{action_name} operation on the #{resource_name}."
+    end
+  end
+
+  def self.generate_common_parameters(openapi_spec)
+    # Generate standard pagination and filtering parameters
+    common_params = {
+      'Page' => {
+        'name' => 'page',
+        'in' => 'query',
+        'description' => 'Page to display; valid values are integers >= 1',
+        'schema' => { 'type' => 'integer', 'minimum' => 1, 'default' => 1 }
+      },
+      'PerPage' => {
+        'name' => 'per_page',
+        'in' => 'query',
+        'description' => 'Number of results per page, valid values are 1 through 5000',
+        'schema' => { 'type' => 'integer', 'minimum' => 1, 'maximum' => 5000, 'default' => 50 }
+      },
+      'OrderBy' => {
+        'name' => 'order_by',
+        'in' => 'query',
+        'description' => 'Order results by a specific field. Prepend with - to sort descending.',
+        'schema' => { 'type' => 'string' }
+      },
+      'Guid' => {
+        'name' => 'guid',
+        'in' => 'path',
+        'required' => true,
+        'description' => 'The resource identifier',
+        'schema' => { 'type' => 'string', 'format' => 'uuid' }
+      }
+    }
+
+    # Add timestamp filters
+    %w[created_ats updated_ats].each do |param|
+      common_params[param.camelize] = {
+        'name' => param,
+        'in' => 'query',
+        'description' => 'Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed.',
+        'schema' => { 'type' => 'string' }
+      }
+    end
+
+    # Add common array filters
+    {
+      'Guids' => 'guids',
+      'Names' => 'names',
+      'OrganizationGuids' => 'organization_guids',
+      'SpaceGuids' => 'space_guids'
+    }.each do |key, param|
+      item_type = param.include?('guid') ? { 'type' => 'string', 'format' => 'uuid' } : { 'type' => 'string' }
+      common_params[key] = {
+        'name' => param,
+        'in' => 'query',
+        'description' => "Comma-delimited list of #{param.gsub('_', ' ')} to filter by",
+        'style' => 'form',
+        'explode' => false,
+        'schema' => { 'type' => 'array', 'items' => item_type }
+      }
+    end
+
+    openapi_spec['components']['parameters'].merge!(common_params)
+  end
+
+  def self.generate_common_schemas(openapi_spec)
+    # Generate pagination schema
+    openapi_spec['components']['schemas']['Pagination'] = {
+      'type' => 'object',
+      'properties' => {
+        'total_results' => { 'type' => 'integer' },
+        'total_pages' => { 'type' => 'integer' },
+        'first' => { 'type' => 'object', 'properties' => { 'href' => { 'type' => 'string', 'format' => 'uri' } } },
+        'last' => { 'type' => 'object', 'properties' => { 'href' => { 'type' => 'string', 'format' => 'uri' } } },
+        'next' => { 'type' => 'object', 'nullable' => true, 'properties' => { 'href' => { 'type' => 'string', 'format' => 'uri' } } },
+        'previous' => { 'type' => 'object', 'nullable' => true, 'properties' => { 'href' => { 'type' => 'string', 'format' => 'uri' } } }
+      }
+    }
+
+    # Generate error schema
+    openapi_spec['components']['schemas']['Error'] = {
+      'type' => 'object',
+      'properties' => {
+        'errors' => {
+          'type' => 'array',
+          'items' => {
+            'type' => 'object',
+            'properties' => {
+              'code' => { 'type' => 'integer' },
+              'detail' => { 'type' => 'string' },
+              'title' => { 'type' => 'string' }
+            }
+          }
+        }
+      }
+    }
+
+    # Generate basic components that appear frequently
+    openapi_spec['components']['schemas']['Metadata'] = {
+      'type' => 'object',
+      'properties' => {
+        'labels' => {
+          'type' => 'object',
+          'additionalProperties' => { 'type' => 'string' },
+          'description' => 'Key-value pairs of labels'
+        },
+        'annotations' => {
+          'type' => 'object',
+          'additionalProperties' => { 'type' => 'string' },
+          'description' => 'Key-value pairs of annotations'
+        }
+      },
+      'description' => 'Metadata containing labels and annotations'
+    }
+
+    openapi_spec['components']['schemas']['Links'] = {
+      'type' => 'object',
+      'additionalProperties' => {
+        'type' => 'object',
+        'properties' => {
+          'href' => { 'type' => 'string', 'format' => 'uri' },
+          'method' => { 'type' => 'string' }
+        }
+      }
+    }
+  end
+
+  def self.discover_list_message_parameters(list_message_class)
+    return [] unless list_message_class.respond_to?(:allowed_keys)
+
+    parameters = []
+
+    list_message_class.allowed_keys.each do |key|
+      param_name = key.to_s
+
+      # Skip if parameter already exists
+      next if parameters.any? { |p| p['name'] == param_name }
+
+      # Map to common parameters if available
+      param_ref = case key
+                  when :page
+                    '#/components/parameters/Page'
+                  when :per_page
+                    '#/components/parameters/PerPage'
+                  when :order_by
+                    '#/components/parameters/OrderBy'
+                  when :created_ats
+                    '#/components/parameters/CreatedAts'
+                  when :updated_ats
+                    '#/components/parameters/UpdatedAts'
+                  when :guids
+                    '#/components/parameters/Guids'
+                  when :names
+                    '#/components/parameters/Names'
+                  when :organization_guids
+                    '#/components/parameters/OrganizationGuids'
+                  when :space_guids
+                    '#/components/parameters/SpaceGuids'
+                  end
+
+      if param_ref
+        parameters << { '$ref' => param_ref }
+      else
+        # Generate parameter schema dynamically
+        schema = infer_parameter_schema(key)
+        parameters << {
+          'name' => param_name,
+          'in' => 'query',
+          'description' => humanize_parameter_name(param_name),
+          'schema' => schema
+        }
+      end
+    end
+
+    parameters
+  end
+
+  def self.infer_parameter_schema(key)
+    key_str = key.to_s
+
+    # Check for array parameters
+    if key_str.pluralize == key_str || key_str.include?('_guids') || key_str.include?('_names')
+      item_type = if key_str.include?('guid')
+                    { 'type' => 'string', 'format' => 'uuid' }
+                  else
+                    { 'type' => 'string' }
+                  end
+      return { 'type' => 'array', 'items' => item_type }
+    end
+
+    # Check for boolean parameters
+    return { 'type' => 'boolean' } if key_str.include?('enable') || key_str.include?('disable') || key_str == 'suspended'
+
+    # Check for timestamp parameters
+    return { 'type' => 'string', 'format' => 'date-time' } if key_str.include?('_at') || key_str.include?('timestamp')
+
+    # Default to string
+    { 'type' => 'string' }
+  end
+
+  def self.humanize_parameter_name(param_name)
+    param_name.humanize.downcase.capitalize
+  end
+
+  def self.discover_v3_presenters
+    # Find all V3 presenter files
+    presenter_files = Dir.glob(Rails.root.join('app/presenters/v3/**/*_presenter.rb'))
+
+    presenters = []
+    presenter_files.each do |file|
+      # Extract class name from file path
+      relative_path = file.gsub(Rails.root.to_s + '/', '')
+      class_name = relative_path.
+                   gsub('app/presenters/', '').
+                   gsub('.rb', '').
+                   split('/').
+                   map(&:camelize).
+                   join('::')
+
+      full_class_name = "VCAP::CloudController::Presenters::#{class_name}"
+
+      begin
+        presenter_class = full_class_name.constantize
+        next unless presenter_class.instance_methods.include?(:to_hash)
+
+        presenters << {
+          name: class_name.split('::').last.gsub('Presenter', ''),
+          class: presenter_class,
+          file: relative_path
+        }
+      rescue NameError => e
+        puts "Warning: Could not load presenter class #{full_class_name}: #{e.message}"
+        next
+      end
+    end
+
+    presenters
+  end
+
+  def self.discover_schemas_from_presenters(openapi_spec)
+    presenters = discover_v3_presenters
+
+    presenters.each do |presenter_info|
+      schema_name = presenter_info[:name]
+
+      # Skip MetadataPresenter as it conflicts with our common Metadata schema
+      next if schema_name == 'Metadata'
+
+      schema = OpenApiAutoGenerator.schema_from_presenter(presenter_info[:class])
+
+      if schema
+        openapi_spec['components']['schemas'][schema_name] = schema
+        puts "Generated schema for #{schema_name} from #{presenter_info[:file]}"
+      else
+        puts "Warning: Could not generate schema for #{schema_name}"
+      end
+    end
+
+    openapi_spec
+  end
+end

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,0 +1,11065 @@
+---
+openapi: 3.0.0
+info:
+  title: Cloud Foundry API
+  version: 3.130.0
+  description: Cloud Foundry API V3
+  termsOfService: https://www.cloudfoundry.org/policies/
+  contact:
+    name: Cloud Foundry
+    url: https://www.cloudfoundry.org/
+    email: cf-dev@lists.cloudfoundry.org
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+- url: https://api.example.org
+paths:
+  "/":
+    get:
+      summary: List welcomes
+      description: This endpoint retrieves the welcomes the user has access to.
+      operationId: get_Index
+      tags:
+      - Welcome
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/admin/actions/clear_buildpack_cache":
+    post:
+      summary: Clear buildpack cache
+      description: This endpoint deletes all of the existing buildpack caches in the
+        blobstore.
+      operationId: post_v3_admin_actions_clear_buildpack_cacheClearBuildpackCache
+      tags:
+      - AdminActions
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps":
+    get:
+      summary: List apps
+      description: This endpoint retrieves the apps the user has access to.
+      operationId: get_v3_appsIndex
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/Names"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - name: stacks
+        in: query
+        description: Stacks
+        schema:
+          type: array
+          items:
+            type: string
+      - name: include
+        in: query
+        description: Include
+        schema:
+          type: string
+      - name: lifecycle_type
+        in: query
+        description: Lifecycle type
+        schema:
+          type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedAppResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create an app
+      description: This endpoint creates a new app.
+      operationId: post_v3_appsCreate
+      tags:
+      - Apps
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AppCreateMessageRequest"
+  "/v3/apps/{guid}":
+    get:
+      summary: Get an app
+      description: This endpoint retrieves the specified app object.
+      operationId: get_v3_apps__guid_Show
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AppShowMessageRequest"
+    patch:
+      summary: Update an app
+      description: This endpoint updates the specified app.
+      operationId: patch_v3_apps__guid_Update
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AppUpdateMessageRequest"
+    delete:
+      summary: Delete an app
+      description: This endpoint deletes the specified app.
+      operationId: delete_v3_apps__guid_Destroy
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/actions/start":
+    post:
+      summary: Start an app
+      description: This endpoint starts the specified app.
+      operationId: post_v3_apps__guid__actions_startStart
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/actions/stop":
+    post:
+      summary: Stop an app
+      description: This endpoint stops the specified app.
+      operationId: post_v3_apps__guid__actions_stopStop
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/actions/restart":
+    post:
+      summary: Restart an app
+      description: This endpoint restarts the specified app.
+      operationId: post_v3_apps__guid__actions_restartRestart
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/actions/clear_buildpack_cache":
+    post:
+      summary: Clear buildpack cache
+      description: This endpoint deletes all of the existing buildpack caches in the
+        blobstore.
+      operationId: post_v3_apps__guid__actions_clear_buildpack_cacheClearBuildpackCache
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/env":
+    get:
+      summary: Show env
+      description: This endpoint performs the show_env operation on the app.
+      operationId: get_v3_apps__guid__envShowEnv
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/permissions":
+    get:
+      summary: Show permissions
+      description: This endpoint performs the show_permissions operation on the app.
+      operationId: get_v3_apps__guid__permissionsShowPermissions
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/builds":
+    get:
+      summary: Builds
+      description: This endpoint performs the builds operation on the app.
+      operationId: get_v3_apps__guid__buildsBuilds
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/relationships/current_droplet":
+    patch:
+      summary: Assign current droplet
+      description: This endpoint performs the assign_current_droplet operation on
+        the app.
+      operationId: patch_v3_apps__guid__relationships_current_dropletAssignCurrentDroplet
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    get:
+      summary: Current droplet relationship
+      description: This endpoint performs the current_droplet_relationship operation
+        on the app.
+      operationId: get_v3_apps__guid__relationships_current_dropletCurrentDropletRelationship
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/droplets/current":
+    get:
+      summary: Current droplet
+      description: This endpoint performs the current_droplet operation on the app.
+      operationId: get_v3_apps__guid__droplets_currentCurrentDroplet
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{app_guid}/features":
+    get:
+      summary: List appfeatures
+      description: This endpoint retrieves the appfeatures the user has access to.
+      operationId: get_v3_apps__app_guid__featuresIndex
+      tags:
+      - AppFeatures
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{app_guid}/features/{name}":
+    get:
+      summary: Get an appfeatures
+      description: This endpoint retrieves the specified appfeatures object.
+      operationId: get_v3_apps__app_guid__features__name_Show
+      tags:
+      - AppFeatures
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update an appfeatures
+      description: This endpoint updates the specified appfeatures.
+      operationId: patch_v3_apps__app_guid__features__name_Update
+      tags:
+      - AppFeatures
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AppFeatureUpdateMessageRequest"
+  "/v3/apps/{guid}/ssh_enabled":
+    get:
+      summary: Ssh enabled
+      description: This endpoint performs the ssh_enabled operation on the appfeatures.
+      operationId: get_v3_apps__guid__ssh_enabledSshEnabled
+      tags:
+      - AppFeatures
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/manifest":
+    get:
+      summary: Get an appmanifests
+      description: This endpoint retrieves the specified appmanifests object.
+      operationId: get_v3_apps__guid__manifestShow
+      tags:
+      - AppManifests
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AppManifest"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/revisions":
+    get:
+      summary: List apprevisions
+      description: This endpoint retrieves the apprevisions the user has access to.
+      operationId: get_v3_apps__guid__revisionsIndex
+      tags:
+      - AppRevisions
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: versions
+        in: query
+        description: Versions
+        schema:
+          type: array
+          items:
+            type: string
+      - name: deployable
+        in: query
+        description: Deployable
+        schema:
+          type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/revisions/deployed":
+    get:
+      summary: Deployed
+      description: This endpoint performs the deployed operation on the apprevisions.
+      operationId: get_v3_apps__guid__revisions_deployedDeployed
+      tags:
+      - AppRevisions
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/sidecars":
+    post:
+      summary: Create a sidecars
+      description: This endpoint creates a new sidecars.
+      operationId: post_v3_apps__guid__sidecarsCreate
+      tags:
+      - Sidecars
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Sidecar"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SidecarCreateMessageRequest"
+  "/v3/sidecars/{guid}":
+    get:
+      summary: Get a sidecars
+      description: This endpoint retrieves the specified sidecars object.
+      operationId: get_v3_sidecars__guid_Show
+      tags:
+      - Sidecars
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Sidecar"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a sidecars
+      description: This endpoint updates the specified sidecars.
+      operationId: patch_v3_sidecars__guid_Update
+      tags:
+      - Sidecars
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Sidecar"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SidecarUpdateMessageRequest"
+    delete:
+      summary: Delete a sidecars
+      description: This endpoint deletes the specified sidecars.
+      operationId: delete_v3_sidecars__guid_Destroy
+      tags:
+      - Sidecars
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Sidecar"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/processes/{process_guid}/sidecars":
+    get:
+      summary: Index by process
+      description: This endpoint performs the index_by_process operation on the sidecars.
+      operationId: get_v3_processes__process_guid__sidecarsIndexByProcess
+      tags:
+      - Sidecars
+      parameters:
+      - name: process_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Sidecar"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{app_guid}/sidecars":
+    get:
+      summary: Index by app
+      description: This endpoint performs the index_by_app operation on the sidecars.
+      operationId: get_v3_apps__app_guid__sidecarsIndexByApp
+      tags:
+      - Sidecars
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Sidecar"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/revisions/{revision_guid}/environment_variables":
+    get:
+      summary: Show environment variables
+      description: This endpoint performs the show_environment_variables operation
+        on the revision.
+      operationId: get_v3_revisions__revision_guid__environment_variablesShowEnvironmentVariables
+      tags:
+      - Revisions
+      parameters:
+      - name: revision_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Revision"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/revisions/{revision_guid}":
+    patch:
+      summary: Update a revision
+      description: This endpoint updates the specified revision.
+      operationId: patch_v3_revisions__revision_guid_Update
+      tags:
+      - Revisions
+      parameters:
+      - name: revision_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Revision"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    get:
+      summary: Get a revision
+      description: This endpoint retrieves the specified revision object.
+      operationId: get_v3_revisions__revision_guid_Show
+      tags:
+      - Revisions
+      parameters:
+      - name: revision_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Revision"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{guid}/environment_variables":
+    get:
+      summary: Show environment variables
+      description: This endpoint performs the show_environment_variables operation
+        on the app.
+      operationId: get_v3_apps__guid__environment_variablesShowEnvironmentVariables
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update environment variables
+      description: This endpoint performs the update_environment_variables operation
+        on the app.
+      operationId: patch_v3_apps__guid__environment_variablesUpdateEnvironmentVariables
+      tags:
+      - Apps
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/App"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/processes":
+    get:
+      summary: List processes
+      description: This endpoint retrieves the processes the user has access to.
+      operationId: get_v3_processesIndex
+      tags:
+      - Processes
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: app_guid
+        in: query
+        description: App guid
+        schema:
+          type: string
+      - name: types
+        in: query
+        description: Types
+        schema:
+          type: array
+          items:
+            type: string
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedProcessResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/processes/{process_guid}":
+    get:
+      summary: Get a process
+      description: This endpoint retrieves the specified process object.
+      operationId: get_v3_processes__process_guid_Show
+      tags:
+      - Processes
+      parameters:
+      - name: process_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a process
+      description: This endpoint updates the specified process.
+      operationId: patch_v3_processes__process_guid_Update
+      tags:
+      - Processes
+      parameters:
+      - name: process_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ProcessUpdateMessageRequest"
+  "/v3/processes/{process_guid}/instances/{index}":
+    delete:
+      summary: Terminate
+      description: This endpoint performs the terminate operation on the process.
+      operationId: delete_v3_processes__process_guid__instances__index_Terminate
+      tags:
+      - Processes
+      parameters:
+      - name: process_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: index
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/processes/{process_guid}/actions/scale":
+    post:
+      summary: Scale a process
+      description: This endpoint scales the specified process.
+      operationId: post_v3_processes__process_guid__actions_scaleScale
+      tags:
+      - Processes
+      parameters:
+      - name: process_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ProcessScaleMessageRequest"
+  "/v3/processes/{process_guid}/stats":
+    get:
+      summary: Get process stats
+      description: This endpoint retrieves stats for the specified process.
+      operationId: get_v3_processes__process_guid__statsStats
+      tags:
+      - Processes
+      parameters:
+      - name: process_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{app_guid}/processes":
+    get:
+      summary: List processes
+      description: This endpoint retrieves the processes the user has access to.
+      operationId: get_v3_apps__app_guid__processesIndex
+      tags:
+      - Processes
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: app_guid
+        in: query
+        description: App guid
+        schema:
+          type: string
+      - name: types
+        in: query
+        description: Types
+        schema:
+          type: array
+          items:
+            type: string
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedProcessResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{app_guid}/processes/{type}":
+    get:
+      summary: Get a process
+      description: This endpoint retrieves the specified process object.
+      operationId: get_v3_apps__app_guid__processes__type_Show
+      tags:
+      - Processes
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a process
+      description: This endpoint updates the specified process.
+      operationId: patch_v3_apps__app_guid__processes__type_Update
+      tags:
+      - Processes
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ProcessUpdateMessageRequest"
+  "/v3/apps/{app_guid}/processes/{type}/actions/scale":
+    post:
+      summary: Scale a process
+      description: This endpoint scales the specified process.
+      operationId: post_v3_apps__app_guid__processes__type__actions_scaleScale
+      tags:
+      - Processes
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ProcessScaleMessageRequest"
+  "/v3/apps/{app_guid}/processes/{type}/instances/{index}":
+    delete:
+      summary: Terminate
+      description: This endpoint performs the terminate operation on the process.
+      operationId: delete_v3_apps__app_guid__processes__type__instances__index_Terminate
+      tags:
+      - Processes
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: index
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{app_guid}/processes/{type}/stats":
+    get:
+      summary: Get process stats
+      description: This endpoint retrieves stats for the specified process.
+      operationId: get_v3_apps__app_guid__processes__type__statsStats
+      tags:
+      - Processes
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Process"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/packages":
+    get:
+      summary: List packages
+      description: This endpoint retrieves the packages the user has access to.
+      operationId: get_v3_packagesIndex
+      tags:
+      - Packages
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: states
+        in: query
+        description: States
+        schema:
+          type: array
+          items:
+            type: string
+      - name: types
+        in: query
+        description: Types
+        schema:
+          type: array
+          items:
+            type: string
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: app_guid
+        in: query
+        description: App guid
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedPackageResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create a package
+      description: This endpoint creates a new package.
+      operationId: post_v3_packagesCreate
+      tags:
+      - Packages
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Package"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/PackageCreateMessageRequest"
+  "/v3/packages/{guid}":
+    get:
+      summary: Get a package
+      description: This endpoint retrieves the specified package object.
+      operationId: get_v3_packages__guid_Show
+      tags:
+      - Packages
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Package"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a package
+      description: This endpoint updates the specified package.
+      operationId: patch_v3_packages__guid_Update
+      tags:
+      - Packages
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Package"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/PackageUpdateMessageRequest"
+    delete:
+      summary: Delete a package
+      description: This endpoint deletes the specified package.
+      operationId: delete_v3_packages__guid_Destroy
+      tags:
+      - Packages
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Package"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/packages/{guid}/upload":
+    post:
+      summary: Upload package bits
+      description: This endpoint uploads bits for the specified package.
+      operationId: post_v3_packages__guid__uploadUpload
+      tags:
+      - Packages
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Package"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/PackageUploadMessageRequest"
+  "/v3/packages/{guid}/download":
+    get:
+      summary: Download package bits
+      description: This endpoint downloads bits for the specified package.
+      operationId: get_v3_packages__guid__downloadDownload
+      tags:
+      - Packages
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Package"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{app_guid}/packages":
+    get:
+      summary: List packages
+      description: This endpoint retrieves the packages the user has access to.
+      operationId: get_v3_apps__app_guid__packagesIndex
+      tags:
+      - Packages
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: states
+        in: query
+        description: States
+        schema:
+          type: array
+          items:
+            type: string
+      - name: types
+        in: query
+        description: Types
+        schema:
+          type: array
+          items:
+            type: string
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: app_guid
+        in: query
+        description: App guid
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedPackageResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/builds":
+    post:
+      summary: Create a build
+      description: This endpoint creates a new build.
+      operationId: post_v3_buildsCreate
+      tags:
+      - Builds
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Build"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BuildCreateMessageRequest"
+    get:
+      summary: List builds
+      description: This endpoint retrieves the builds the user has access to.
+      operationId: get_v3_buildsIndex
+      tags:
+      - Builds
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: package_guids
+        in: query
+        description: Package guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: states
+        in: query
+        description: States
+        schema:
+          type: array
+          items:
+            type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedBuildResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/builds/{guid}":
+    patch:
+      summary: Update a build
+      description: This endpoint updates the specified build.
+      operationId: patch_v3_builds__guid_Update
+      tags:
+      - Builds
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Build"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BuildUpdateMessageRequest"
+    get:
+      summary: Get a build
+      description: This endpoint retrieves the specified build object.
+      operationId: get_v3_builds__guid_Show
+      tags:
+      - Builds
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Build"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/deployments":
+    post:
+      summary: Create a deployment
+      description: This endpoint creates a new deployment.
+      operationId: post_v3_deploymentsCreate
+      tags:
+      - Deployments
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Deployment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DeploymentCreateMessageRequest"
+    get:
+      summary: List deployments
+      description: This endpoint retrieves the deployments the user has access to.
+      operationId: get_v3_deploymentsIndex
+      tags:
+      - Deployments
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: states
+        in: query
+        description: States
+        schema:
+          type: array
+          items:
+            type: string
+      - name: status_reasons
+        in: query
+        description: Status reasons
+        schema:
+          type: array
+          items:
+            type: string
+      - name: status_values
+        in: query
+        description: Status values
+        schema:
+          type: array
+          items:
+            type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedDeploymentResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/deployments/{guid}":
+    patch:
+      summary: Update a deployment
+      description: This endpoint updates the specified deployment.
+      operationId: patch_v3_deployments__guid_Update
+      tags:
+      - Deployments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Deployment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DeploymentUpdateMessageRequest"
+    get:
+      summary: Get a deployment
+      description: This endpoint retrieves the specified deployment object.
+      operationId: get_v3_deployments__guid_Show
+      tags:
+      - Deployments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Deployment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/deployments/{guid}/actions/cancel":
+    post:
+      summary: Cancel a deployment
+      description: This endpoint performs the cancel operation on the deployment.
+      operationId: post_v3_deployments__guid__actions_cancelCancel
+      tags:
+      - Deployments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Deployment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/deployments/{guid}/actions/continue":
+    post:
+      summary: Continue deployment
+      description: This endpoint performs the continue operation on the deployment.
+      operationId: post_v3_deployments__guid__actions_continueContinue
+      tags:
+      - Deployments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Deployment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/domains":
+    post:
+      summary: Create a domain
+      description: This endpoint creates a new domain.
+      operationId: post_v3_domainsCreate
+      tags:
+      - Domains
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Domain"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DomainCreateMessageRequest"
+    get:
+      summary: List domains
+      description: This endpoint retrieves the domains the user has access to.
+      operationId: get_v3_domainsIndex
+      tags:
+      - Domains
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/Names"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedDomainResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/domains/{guid}":
+    get:
+      summary: Get a domain
+      description: This endpoint retrieves the specified domain object.
+      operationId: get_v3_domains__guid_Show
+      tags:
+      - Domains
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Domain"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DomainShowMessageRequest"
+    delete:
+      summary: Delete a domain
+      description: This endpoint deletes the specified domain.
+      operationId: delete_v3_domains__guid_Destroy
+      tags:
+      - Domains
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Domain"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a domain
+      description: This endpoint updates the specified domain.
+      operationId: patch_v3_domains__guid_Update
+      tags:
+      - Domains
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Domain"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DomainUpdateMessageRequest"
+  "/v3/domains/{guid}/relationships/shared_organizations":
+    post:
+      summary: Update shared orgs
+      description: This endpoint performs the update_shared_orgs operation on the
+        domain.
+      operationId: post_v3_domains__guid__relationships_shared_organizationsUpdateSharedOrgs
+      tags:
+      - Domains
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Domain"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DomainUpdateSharedOrgsMessageRequest"
+  "/v3/domains/{guid}/relationships/shared_organizations/{org_guid}":
+    delete:
+      summary: Delete shared org
+      description: This endpoint performs the delete_shared_org operation on the domain.
+      operationId: delete_v3_domains__guid__relationships_shared_organizations__org_guid_DeleteSharedOrg
+      tags:
+      - Domains
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: org_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Domain"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DomainDeleteSharedOrgMessageRequest"
+  "/v3/domains/{guid}/route_reservations":
+    get:
+      summary: Check routes
+      description: This endpoint performs the check_routes operation on the domain.
+      operationId: get_v3_domains__guid__route_reservationsCheckRoutes
+      tags:
+      - Domains
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Domain"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/droplets":
+    post:
+      summary: Create a droplet
+      description: This endpoint creates a new droplet.
+      operationId: post_v3_dropletsCreate
+      tags:
+      - Droplets
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Droplet"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DropletCreateMessageRequest"
+    get:
+      summary: List droplets
+      description: This endpoint retrieves the droplets the user has access to.
+      operationId: get_v3_dropletsIndex
+      tags:
+      - Droplets
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: app_guid
+        in: query
+        description: App guid
+        schema:
+          type: string
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: current
+        in: query
+        description: Current
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: package_guid
+        in: query
+        description: Package guid
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - name: states
+        in: query
+        description: States
+        schema:
+          type: array
+          items:
+            type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedDropletResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/droplets/{guid}":
+    get:
+      summary: Get a droplet
+      description: This endpoint retrieves the specified droplet object.
+      operationId: get_v3_droplets__guid_Show
+      tags:
+      - Droplets
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Droplet"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete a droplet
+      description: This endpoint deletes the specified droplet.
+      operationId: delete_v3_droplets__guid_Destroy
+      tags:
+      - Droplets
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Droplet"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a droplet
+      description: This endpoint updates the specified droplet.
+      operationId: patch_v3_droplets__guid_Update
+      tags:
+      - Droplets
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Droplet"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DropletUpdateMessageRequest"
+  "/v3/apps/{app_guid}/droplets":
+    get:
+      summary: List droplets
+      description: This endpoint retrieves the droplets the user has access to.
+      operationId: get_v3_apps__app_guid__dropletsIndex
+      tags:
+      - Droplets
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: app_guid
+        in: query
+        description: App guid
+        schema:
+          type: string
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: current
+        in: query
+        description: Current
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: package_guid
+        in: query
+        description: Package guid
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - name: states
+        in: query
+        description: States
+        schema:
+          type: array
+          items:
+            type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedDropletResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/packages/{package_guid}/droplets":
+    get:
+      summary: List droplets
+      description: This endpoint retrieves the droplets the user has access to.
+      operationId: get_v3_packages__package_guid__dropletsIndex
+      tags:
+      - Droplets
+      parameters:
+      - name: package_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: app_guid
+        in: query
+        description: App guid
+        schema:
+          type: string
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: current
+        in: query
+        description: Current
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: package_guid
+        in: query
+        description: Package guid
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - name: states
+        in: query
+        description: States
+        schema:
+          type: array
+          items:
+            type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedDropletResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/droplets/{guid}/upload":
+    post:
+      summary: Upload droplet bits
+      description: This endpoint uploads bits for the specified droplet.
+      operationId: post_v3_droplets__guid__uploadUpload
+      tags:
+      - Droplets
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Droplet"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/DropletUploadMessageRequest"
+  "/v3/droplets/{guid}/download":
+    get:
+      summary: Download droplet bits
+      description: This endpoint downloads bits for the specified droplet.
+      operationId: get_v3_droplets__guid__downloadDownload
+      tags:
+      - Droplets
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Droplet"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/isolation_segments":
+    post:
+      summary: Create an isolation segment
+      description: This endpoint creates a new isolation segment.
+      operationId: post_v3_isolation_segmentsCreate
+      tags:
+      - IsolationSegments
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/IsolationSegment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/IsolationSegmentCreateMessageRequest"
+    get:
+      summary: List isolation segments
+      description: This endpoint retrieves the isolation segments the user has access
+        to.
+      operationId: get_v3_isolation_segmentsIndex
+      tags:
+      - IsolationSegments
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/Names"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedIsolationSegmentResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/isolation_segments/{guid}":
+    get:
+      summary: Get an isolation segment
+      description: This endpoint retrieves the specified isolation segment object.
+      operationId: get_v3_isolation_segments__guid_Show
+      tags:
+      - IsolationSegments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/IsolationSegment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete an isolation segment
+      description: This endpoint deletes the specified isolation segment.
+      operationId: delete_v3_isolation_segments__guid_Destroy
+      tags:
+      - IsolationSegments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/IsolationSegment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update an isolation segment
+      description: This endpoint updates the specified isolation segment.
+      operationId: patch_v3_isolation_segments__guid_Update
+      tags:
+      - IsolationSegments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/IsolationSegment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/IsolationSegmentUpdateMessageRequest"
+  "/v3/isolation_segments/{guid}/relationships/organizations":
+    post:
+      summary: Assign allowed organizations
+      description: This endpoint performs the assign_allowed_organizations operation
+        on the isolation segment.
+      operationId: post_v3_isolation_segments__guid__relationships_organizationsAssignAllowedOrganizations
+      tags:
+      - IsolationSegments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/IsolationSegment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    get:
+      summary: Relationships orgs
+      description: This endpoint performs the relationships_orgs operation on the
+        isolation segment.
+      operationId: get_v3_isolation_segments__guid__relationships_organizationsRelationshipsOrgs
+      tags:
+      - IsolationSegments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/IsolationSegment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/isolation_segments/{guid}/relationships/organizations/{org_guid}":
+    delete:
+      summary: Unassign allowed organization
+      description: This endpoint performs the unassign_allowed_organization operation
+        on the isolation segment.
+      operationId: delete_v3_isolation_segments__guid__relationships_organizations__org_guid_UnassignAllowedOrganization
+      tags:
+      - IsolationSegments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: org_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/IsolationSegment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/isolation_segments/{guid}/relationships/spaces":
+    get:
+      summary: Relationships spaces
+      description: This endpoint performs the relationships_spaces operation on the
+        isolation segment.
+      operationId: get_v3_isolation_segments__guid__relationships_spacesRelationshipsSpaces
+      tags:
+      - IsolationSegments
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/IsolationSegment"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/jobs/{guid}":
+    get:
+      summary: Get a jobs
+      description: This endpoint retrieves the specified jobs object.
+      operationId: get_v3_jobs__guid_Show
+      tags:
+      - Jobs
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Job"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organizations":
+    post:
+      summary: Create an organization
+      description: This endpoint creates a new organization.
+      operationId: post_v3_organizationsCreate
+      tags:
+      - Organizations
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/OrganizationCreateMessageRequest"
+    get:
+      summary: List organizations
+      description: This endpoint retrieves the organizations the user has access to.
+      operationId: get_v3_organizationsIndex
+      tags:
+      - Organizations
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedOrganizationResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organizations/{guid}":
+    get:
+      summary: Get an organization
+      description: This endpoint retrieves the specified organization object.
+      operationId: get_v3_organizations__guid_Show
+      tags:
+      - Organizations
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update an organization
+      description: This endpoint updates the specified organization.
+      operationId: patch_v3_organizations__guid_Update
+      tags:
+      - Organizations
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/OrganizationUpdateMessageRequest"
+    delete:
+      summary: Delete an organization
+      description: This endpoint deletes the specified organization.
+      operationId: delete_v3_organizations__guid_Destroy
+      tags:
+      - Organizations
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organizations/{guid}/domains":
+    get:
+      summary: Index org domains
+      description: This endpoint performs the index_org_domains operation on the organization.
+      operationId: get_v3_organizations__guid__domainsIndexOrgDomains
+      tags:
+      - Organizations
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organizations/{guid}/domains/default":
+    get:
+      summary: Show default domain
+      description: This endpoint performs the show_default_domain operation on the
+        organization.
+      operationId: get_v3_organizations__guid__domains_defaultShowDefaultDomain
+      tags:
+      - Organizations
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organizations/{guid}/usage_summary":
+    get:
+      summary: Show usage summary
+      description: This endpoint performs the show_usage_summary operation on the
+        organization.
+      operationId: get_v3_organizations__guid__usage_summaryShowUsageSummary
+      tags:
+      - Organizations
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/isolation_segments/{isolation_segment_guid}/organizations":
+    get:
+      summary: List organizations
+      description: This endpoint retrieves the organizations the user has access to.
+      operationId: get_v3_isolation_segments__isolation_segment_guid__organizationsIndex
+      tags:
+      - Organizations
+      parameters:
+      - name: isolation_segment_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedOrganizationResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organizations/{guid}/relationships/default_isolation_segment":
+    get:
+      summary: Show default isolation segment
+      description: This endpoint performs the show_default_isolation_segment operation
+        on the organization.
+      operationId: get_v3_organizations__guid__relationships_default_isolation_segmentShowDefaultIsolationSegment
+      tags:
+      - Organizations
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update default isolation segment
+      description: This endpoint performs the update_default_isolation_segment operation
+        on the organization.
+      operationId: patch_v3_organizations__guid__relationships_default_isolation_segmentUpdateDefaultIsolationSegment
+      tags:
+      - Organizations
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organizations/{guid}/users":
+    get:
+      summary: List members
+      description: This endpoint performs the list_members operation on the organization.
+      operationId: get_v3_organizations__guid__usersListMembers
+      tags:
+      - Organizations
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Organization"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organization_quotas":
+    post:
+      summary: Create an organization quota
+      description: This endpoint creates a new organization quota.
+      operationId: post_v3_organization_quotasCreate
+      tags:
+      - OrganizationQuotas
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OrganizationQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    get:
+      summary: List organization quotas
+      description: This endpoint retrieves the organization quotas the user has access
+        to.
+      operationId: get_v3_organization_quotasIndex
+      tags:
+      - OrganizationQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/Names"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedOrganizationQuotaResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organization_quotas/{guid}":
+    get:
+      summary: Get an organization quota
+      description: This endpoint retrieves the specified organization quota object.
+      operationId: get_v3_organization_quotas__guid_Show
+      tags:
+      - OrganizationQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OrganizationQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update an organization quota
+      description: This endpoint updates the specified organization quota.
+      operationId: patch_v3_organization_quotas__guid_Update
+      tags:
+      - OrganizationQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OrganizationQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete an organization quota
+      description: This endpoint deletes the specified organization quota.
+      operationId: delete_v3_organization_quotas__guid_Destroy
+      tags:
+      - OrganizationQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OrganizationQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/organization_quotas/{guid}/relationships/organizations":
+    post:
+      summary: Apply to organizations
+      description: This endpoint performs the apply_to_organizations operation on
+        the organization quota.
+      operationId: post_v3_organization_quotas__guid__relationships_organizationsApplyToOrganizations
+      tags:
+      - OrganizationQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OrganizationQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/resource_matches":
+    post:
+      summary: Create a resourcematches
+      description: This endpoint creates a new resourcematches.
+      operationId: post_v3_resource_matchesCreate
+      tags:
+      - ResourceMatches
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ResourceMatch"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ResourceMatchCreateMessageRequest"
+  "/v3/routes":
+    get:
+      summary: List routes
+      description: This endpoint retrieves the routes the user has access to.
+      operationId: get_v3_routesIndex
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: hosts
+        in: query
+        description: Hosts
+        schema:
+          type: array
+          items:
+            type: string
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: domain_guids
+        in: query
+        description: Domain guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: paths
+        in: query
+        description: Paths
+        schema:
+          type: array
+          items:
+            type: string
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: include
+        in: query
+        description: Include
+        schema:
+          type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      - name: ports
+        in: query
+        description: Ports
+        schema:
+          type: array
+          items:
+            type: string
+      - name: service_instance_guids
+        in: query
+        description: Service instance guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedRouteResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create a route
+      description: This endpoint creates a new route.
+      operationId: post_v3_routesCreate
+      tags:
+      - Routes
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RouteCreateMessageRequest"
+  "/v3/routes/{guid}":
+    get:
+      summary: Get a route
+      description: This endpoint retrieves the specified route object.
+      operationId: get_v3_routes__guid_Show
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RouteShowMessageRequest"
+    patch:
+      summary: Update a route
+      description: This endpoint updates the specified route.
+      operationId: patch_v3_routes__guid_Update
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RouteUpdateMessageRequest"
+    delete:
+      summary: Delete a route
+      description: This endpoint deletes the specified route.
+      operationId: delete_v3_routes__guid_Destroy
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/routes/{guid}/relationships/shared_spaces":
+    post:
+      summary: Share routes
+      description: This endpoint performs the share_routes operation on the route.
+      operationId: post_v3_routes__guid__relationships_shared_spacesShareRoutes
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    get:
+      summary: Relationships shared routes
+      description: This endpoint performs the relationships_shared_routes operation
+        on the route.
+      operationId: get_v3_routes__guid__relationships_shared_spacesRelationshipsSharedRoutes
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/routes/{guid}/relationships/shared_spaces/{space_guid}":
+    delete:
+      summary: Unshare route
+      description: This endpoint performs the unshare_route operation on the route.
+      operationId: delete_v3_routes__guid__relationships_shared_spaces__space_guid_UnshareRoute
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: space_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/routes/{guid}/relationships/space":
+    patch:
+      summary: Transfer owner
+      description: This endpoint performs the transfer_owner operation on the route.
+      operationId: patch_v3_routes__guid__relationships_spaceTransferOwner
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RouteTransferOwnerMessageRequest"
+  "/v3/apps/{guid}/routes":
+    get:
+      summary: Index by app
+      description: This endpoint performs the index_by_app operation on the route.
+      operationId: get_v3_apps__guid__routesIndexByApp
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/routes/{guid}/destinations":
+    get:
+      summary: Index destinations
+      description: This endpoint performs the index_destinations operation on the
+        route.
+      operationId: get_v3_routes__guid__destinationsIndexDestinations
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Insert destinations
+      description: This endpoint performs the insert_destinations operation on the
+        route.
+      operationId: post_v3_routes__guid__destinationsInsertDestinations
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Replace destinations
+      description: This endpoint performs the replace_destinations operation on the
+        route.
+      operationId: patch_v3_routes__guid__destinationsReplaceDestinations
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/routes/{guid}/destinations/{destination_guid}":
+    delete:
+      summary: Destroy destination
+      description: This endpoint performs the destroy_destination operation on the
+        route.
+      operationId: delete_v3_routes__guid__destinations__destination_guid_DestroyDestination
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: destination_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update destination
+      description: This endpoint performs the update_destination operation on the
+        route.
+      operationId: patch_v3_routes__guid__destinations__destination_guid_UpdateDestination
+      tags:
+      - Routes
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: destination_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Route"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/security_groups":
+    post:
+      summary: Create a security group
+      description: This endpoint creates a new security group.
+      operationId: post_v3_security_groupsCreate
+      tags:
+      - SecurityGroups
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SecurityGroupCreateMessageRequest"
+    get:
+      summary: List security groups
+      description: This endpoint retrieves the security groups the user has access
+        to.
+      operationId: get_v3_security_groupsIndex
+      tags:
+      - SecurityGroups
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedSecurityGroupResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/security_groups/{guid}/relationships/running_spaces":
+    post:
+      summary: Create running spaces
+      description: This endpoint performs the create_running_spaces operation on the
+        security group.
+      operationId: post_v3_security_groups__guid__relationships_running_spacesCreateRunningSpaces
+      tags:
+      - SecurityGroups
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/security_groups/{guid}/relationships/staging_spaces":
+    post:
+      summary: Create staging spaces
+      description: This endpoint performs the create_staging_spaces operation on the
+        security group.
+      operationId: post_v3_security_groups__guid__relationships_staging_spacesCreateStagingSpaces
+      tags:
+      - SecurityGroups
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/security_groups/{guid}":
+    get:
+      summary: Get a security group
+      description: This endpoint retrieves the specified security group object.
+      operationId: get_v3_security_groups__guid_Show
+      tags:
+      - SecurityGroups
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a security group
+      description: This endpoint updates the specified security group.
+      operationId: patch_v3_security_groups__guid_Update
+      tags:
+      - SecurityGroups
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SecurityGroupUpdateMessageRequest"
+    delete:
+      summary: Delete a security group
+      description: This endpoint deletes the specified security group.
+      operationId: delete_v3_security_groups__guid_Destroy
+      tags:
+      - SecurityGroups
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/security_groups/{guid}/relationships/running_spaces/{space_guid}":
+    delete:
+      summary: Delete running spaces
+      description: This endpoint performs the delete_running_spaces operation on the
+        security group.
+      operationId: delete_v3_security_groups__guid__relationships_running_spaces__space_guid_DeleteRunningSpaces
+      tags:
+      - SecurityGroups
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: space_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/security_groups/{guid}/relationships/staging_spaces/{space_guid}":
+    delete:
+      summary: Delete staging spaces
+      description: This endpoint performs the delete_staging_spaces operation on the
+        security group.
+      operationId: delete_v3_security_groups__guid__relationships_staging_spaces__space_guid_DeleteStagingSpaces
+      tags:
+      - SecurityGroups
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: space_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SecurityGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_bindings":
+    post:
+      summary: Create a servicebindings
+      description: This endpoint creates a new servicebindings.
+      operationId: post_v3_service_bindingsCreate
+      tags:
+      - ServiceBindings
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServiceBindingCreateMessageRequest"
+    get:
+      summary: List servicebindings
+      description: This endpoint retrieves the servicebindings the user has access
+        to.
+      operationId: get_v3_service_bindingsIndex
+      tags:
+      - ServiceBindings
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_bindings/{guid}":
+    get:
+      summary: Get a servicebindings
+      description: This endpoint retrieves the specified servicebindings object.
+      operationId: get_v3_service_bindings__guid_Show
+      tags:
+      - ServiceBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete a servicebindings
+      description: This endpoint deletes the specified servicebindings.
+      operationId: delete_v3_service_bindings__guid_Destroy
+      tags:
+      - ServiceBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_credential_bindings/{guid}/details":
+    get:
+      summary: Details
+      description: This endpoint performs the details operation on the service credential
+        binding.
+      operationId: get_v3_service_credential_bindings__guid__detailsDetails
+      tags:
+      - ServiceCredentialBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceCredentialBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_credential_bindings/{guid}/parameters":
+    get:
+      summary: Parameters
+      description: This endpoint performs the parameters operation on the service
+        credential binding.
+      operationId: get_v3_service_credential_bindings__guid__parametersParameters
+      tags:
+      - ServiceCredentialBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceCredentialBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_credential_bindings":
+    get:
+      summary: List service credential bindings
+      description: This endpoint retrieves the service credential bindings the user
+        has access to.
+      operationId: get_v3_service_credential_bindingsIndex
+      tags:
+      - ServiceCredentialBindings
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedServiceCredentialBindingResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create a service credential binding
+      description: This endpoint creates a new service credential binding.
+      operationId: post_v3_service_credential_bindingsCreate
+      tags:
+      - ServiceCredentialBindings
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceCredentialBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServiceCredentialBindingCreateMessageRequest"
+  "/v3/service_credential_bindings/{guid}":
+    get:
+      summary: Get a service credential binding
+      description: This endpoint retrieves the specified service credential binding
+        object.
+      operationId: get_v3_service_credential_bindings__guid_Show
+      tags:
+      - ServiceCredentialBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceCredentialBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServiceCredentialBindingShowMessageRequest"
+    patch:
+      summary: Update a service credential binding
+      description: This endpoint updates the specified service credential binding.
+      operationId: patch_v3_service_credential_bindings__guid_Update
+      tags:
+      - ServiceCredentialBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceCredentialBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    put:
+      summary: Update a service credential binding
+      description: This endpoint updates the specified service credential binding.
+      operationId: put_v3_service_credential_bindings__guid_Update
+      tags:
+      - ServiceCredentialBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceCredentialBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete a service credential binding
+      description: This endpoint deletes the specified service credential binding.
+      operationId: delete_v3_service_credential_bindings__guid_Destroy
+      tags:
+      - ServiceCredentialBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceCredentialBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_route_bindings/{guid}/parameters":
+    get:
+      summary: Parameters
+      description: This endpoint performs the parameters operation on the service
+        route binding.
+      operationId: get_v3_service_route_bindings__guid__parametersParameters
+      tags:
+      - ServiceRouteBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceRouteBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_route_bindings":
+    get:
+      summary: List service route bindings
+      description: This endpoint retrieves the service route bindings the user has
+        access to.
+      operationId: get_v3_service_route_bindingsIndex
+      tags:
+      - ServiceRouteBindings
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: service_instance_guids
+        in: query
+        description: Service instance guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: service_instance_names
+        in: query
+        description: Service instance names
+        schema:
+          type: array
+          items:
+            type: string
+      - name: route_guids
+        in: query
+        description: Route guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: include
+        in: query
+        description: Include
+        schema:
+          type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedServiceRouteBindingResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create a service route binding
+      description: This endpoint creates a new service route binding.
+      operationId: post_v3_service_route_bindingsCreate
+      tags:
+      - ServiceRouteBindings
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceRouteBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServiceRouteBindingCreateMessageRequest"
+  "/v3/service_route_bindings/{guid}":
+    get:
+      summary: Get a service route binding
+      description: This endpoint retrieves the specified service route binding object.
+      operationId: get_v3_service_route_bindings__guid_Show
+      tags:
+      - ServiceRouteBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceRouteBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServiceRouteBindingShowMessageRequest"
+    patch:
+      summary: Update a service route binding
+      description: This endpoint updates the specified service route binding.
+      operationId: patch_v3_service_route_bindings__guid_Update
+      tags:
+      - ServiceRouteBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceRouteBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    put:
+      summary: Update a service route binding
+      description: This endpoint updates the specified service route binding.
+      operationId: put_v3_service_route_bindings__guid_Update
+      tags:
+      - ServiceRouteBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceRouteBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete a service route binding
+      description: This endpoint deletes the specified service route binding.
+      operationId: delete_v3_service_route_bindings__guid_Destroy
+      tags:
+      - ServiceRouteBindings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceRouteBinding"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_brokers":
+    get:
+      summary: List service brokers
+      description: This endpoint retrieves the service brokers the user has access
+        to.
+      operationId: get_v3_service_brokersIndex
+      tags:
+      - ServiceBrokers
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - "$ref": "#/components/parameters/Names"
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedServiceBrokerResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create a service broker
+      description: This endpoint creates a new service broker.
+      operationId: post_v3_service_brokersCreate
+      tags:
+      - ServiceBrokers
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceBroker"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServiceBrokerCreateMessageRequest"
+  "/v3/service_brokers/{guid}":
+    get:
+      summary: Get a service broker
+      description: This endpoint retrieves the specified service broker object.
+      operationId: get_v3_service_brokers__guid_Show
+      tags:
+      - ServiceBrokers
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceBroker"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a service broker
+      description: This endpoint updates the specified service broker.
+      operationId: patch_v3_service_brokers__guid_Update
+      tags:
+      - ServiceBrokers
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceBroker"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServiceBrokerUpdateMessageRequest"
+    delete:
+      summary: Delete a service broker
+      description: This endpoint deletes the specified service broker.
+      operationId: delete_v3_service_brokers__guid_Destroy
+      tags:
+      - ServiceBrokers
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceBroker"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_offerings":
+    get:
+      summary: List service offerings
+      description: This endpoint retrieves the service offerings the user has access
+        to.
+      operationId: get_v3_service_offeringsIndex
+      tags:
+      - ServiceOfferings
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: available
+        in: query
+        description: Available
+        schema:
+          type: string
+      - name: fields
+        in: query
+        description: Fields
+        schema:
+          type: array
+          items:
+            type: string
+      - name: service_broker_guids
+        in: query
+        description: Service broker guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: service_broker_names
+        in: query
+        description: Service broker names
+        schema:
+          type: array
+          items:
+            type: string
+      - "$ref": "#/components/parameters/Names"
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedServiceOfferingResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_offerings/{guid}":
+    get:
+      summary: Get a service offering
+      description: This endpoint retrieves the specified service offering object.
+      operationId: get_v3_service_offerings__guid_Show
+      tags:
+      - ServiceOfferings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceOffering"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a service offering
+      description: This endpoint updates the specified service offering.
+      operationId: patch_v3_service_offerings__guid_Update
+      tags:
+      - ServiceOfferings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceOffering"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete a service offering
+      description: This endpoint deletes the specified service offering.
+      operationId: delete_v3_service_offerings__guid_Destroy
+      tags:
+      - ServiceOfferings
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceOffering"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_plans":
+    get:
+      summary: List service plans
+      description: This endpoint retrieves the service plans the user has access to.
+      operationId: get_v3_service_plansIndex
+      tags:
+      - ServicePlans
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: available
+        in: query
+        description: Available
+        schema:
+          type: string
+      - name: fields
+        in: query
+        description: Fields
+        schema:
+          type: array
+          items:
+            type: string
+      - name: broker_catalog_ids
+        in: query
+        description: Broker catalog ids
+        schema:
+          type: array
+          items:
+            type: string
+      - "$ref": "#/components/parameters/Names"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: service_broker_guids
+        in: query
+        description: Service broker guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: service_broker_names
+        in: query
+        description: Service broker names
+        schema:
+          type: array
+          items:
+            type: string
+      - name: service_instance_guids
+        in: query
+        description: Service instance guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: service_offering_guids
+        in: query
+        description: Service offering guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: service_offering_names
+        in: query
+        description: Service offering names
+        schema:
+          type: array
+          items:
+            type: string
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - name: include
+        in: query
+        description: Include
+        schema:
+          type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedServicePlanResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_plans/{guid}":
+    get:
+      summary: Get a service plan
+      description: This endpoint retrieves the specified service plan object.
+      operationId: get_v3_service_plans__guid_Show
+      tags:
+      - ServicePlans
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServicePlan"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a service plan
+      description: This endpoint updates the specified service plan.
+      operationId: patch_v3_service_plans__guid_Update
+      tags:
+      - ServicePlans
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServicePlan"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete a service plan
+      description: This endpoint deletes the specified service plan.
+      operationId: delete_v3_service_plans__guid_Destroy
+      tags:
+      - ServicePlans
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServicePlan"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_plans/{guid}/visibility":
+    get:
+      summary: Get a serviceplanvisibility
+      description: This endpoint retrieves the specified serviceplanvisibility object.
+      operationId: get_v3_service_plans__guid__visibilityShow
+      tags:
+      - ServicePlanVisibility
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServicePlanVisibility"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a serviceplanvisibility
+      description: This endpoint updates the specified serviceplanvisibility.
+      operationId: patch_v3_service_plans__guid__visibilityUpdate
+      tags:
+      - ServicePlanVisibility
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServicePlanVisibility"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServicePlanVisibilityUpdateMessageRequest"
+    post:
+      summary: Apply
+      description: This endpoint performs the apply operation on the serviceplanvisibility.
+      operationId: post_v3_service_plans__guid__visibilityApply
+      tags:
+      - ServicePlanVisibility
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServicePlanVisibility"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_plans/{guid}/visibility/{org_guid}":
+    delete:
+      summary: Delete a serviceplanvisibility
+      description: This endpoint deletes the specified serviceplanvisibility.
+      operationId: delete_v3_service_plans__guid__visibility__org_guid_Destroy
+      tags:
+      - ServicePlanVisibility
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: org_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServicePlanVisibility"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_instances":
+    get:
+      summary: List service instances
+      description: This endpoint retrieves the service instances the user has access
+        to.
+      operationId: get_v3_service_instancesIndex
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: type
+        in: query
+        description: Type
+        schema:
+          type: string
+      - name: fields
+        in: query
+        description: Fields
+        schema:
+          type: array
+          items:
+            type: string
+      - "$ref": "#/components/parameters/Names"
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: service_plan_guids
+        in: query
+        description: Service plan guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: service_plan_names
+        in: query
+        description: Service plan names
+        schema:
+          type: array
+          items:
+            type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedServiceInstanceResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create a service instance
+      description: This endpoint creates a new service instance.
+      operationId: post_v3_service_instancesCreate
+      tags:
+      - ServiceInstances
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServiceInstanceCreateMessageRequest"
+  "/v3/service_instances/{guid}":
+    get:
+      summary: Get a service instance
+      description: This endpoint retrieves the specified service instance object.
+      operationId: get_v3_service_instances__guid_Show
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ServiceInstanceShowMessageRequest"
+    patch:
+      summary: Update a service instance
+      description: This endpoint updates the specified service instance.
+      operationId: patch_v3_service_instances__guid_Update
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete a service instance
+      description: This endpoint deletes the specified service instance.
+      operationId: delete_v3_service_instances__guid_Destroy
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_instances/{guid}/relationships/shared_spaces":
+    get:
+      summary: Relationships shared spaces
+      description: This endpoint performs the relationships_shared_spaces operation
+        on the service instance.
+      operationId: get_v3_service_instances__guid__relationships_shared_spacesRelationshipsSharedSpaces
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Share service instance
+      description: This endpoint performs the share_service_instance operation on
+        the service instance.
+      operationId: post_v3_service_instances__guid__relationships_shared_spacesShareServiceInstance
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_instances/{guid}/relationships/shared_spaces/usage_summary":
+    get:
+      summary: Shared spaces usage summary
+      description: This endpoint performs the shared_spaces_usage_summary operation
+        on the service instance.
+      operationId: get_v3_service_instances__guid__relationships_shared_spaces_usage_summarySharedSpacesUsageSummary
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_instances/{guid}/credentials":
+    get:
+      summary: Credentials
+      description: This endpoint performs the credentials operation on the service
+        instance.
+      operationId: get_v3_service_instances__guid__credentialsCredentials
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_instances/{guid}/parameters":
+    get:
+      summary: Parameters
+      description: This endpoint performs the parameters operation on the service
+        instance.
+      operationId: get_v3_service_instances__guid__parametersParameters
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_instances/{guid}/permissions":
+    get:
+      summary: Show permissions
+      description: This endpoint performs the show_permissions operation on the service
+        instance.
+      operationId: get_v3_service_instances__guid__permissionsShowPermissions
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_instances/{guid}/relationships/shared_spaces/{space_guid}":
+    delete:
+      summary: Unshare service instance
+      description: This endpoint performs the unshare_service_instance operation on
+        the service instance.
+      operationId: delete_v3_service_instances__guid__relationships_shared_spaces__space_guid_UnshareServiceInstance
+      tags:
+      - ServiceInstances
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: space_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceInstance"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/spaces/{guid}/features/{name}":
+    get:
+      summary: Get a spacefeatures
+      description: This endpoint retrieves the specified spacefeatures object.
+      operationId: get_v3_spaces__guid__features__name_Show
+      tags:
+      - SpaceFeatures
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a spacefeatures
+      description: This endpoint updates the specified spacefeatures.
+      operationId: patch_v3_spaces__guid__features__name_Update
+      tags:
+      - SpaceFeatures
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SpaceFeatureUpdateMessageRequest"
+  "/v3/spaces/{guid}/features":
+    get:
+      summary: List spacefeatures
+      description: This endpoint retrieves the spacefeatures the user has access to.
+      operationId: get_v3_spaces__guid__featuresIndex
+      tags:
+      - SpaceFeatures
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/spaces/{guid}/actions/apply_manifest":
+    post:
+      summary: Apply manifest
+      description: This endpoint performs the apply_manifest operation on the spacemanifests.
+      operationId: post_v3_spaces__guid__actions_apply_manifestApplyManifest
+      tags:
+      - SpaceManifests
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/spaces/{guid}/manifest_diff":
+    post:
+      summary: Diff manifest
+      description: This endpoint performs the diff_manifest operation on the spacemanifests.
+      operationId: post_v3_spaces__guid__manifest_diffDiffManifest
+      tags:
+      - SpaceManifests
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/space_quotas":
+    post:
+      summary: Create a space quota
+      description: This endpoint creates a new space quota.
+      operationId: post_v3_space_quotasCreate
+      tags:
+      - SpaceQuotas
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SpaceQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    get:
+      summary: List space quotas
+      description: This endpoint retrieves the space quotas the user has access to.
+      operationId: get_v3_space_quotasIndex
+      tags:
+      - SpaceQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/Names"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - "$ref": "#/components/parameters/SpaceGuids"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedSpaceQuotaResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/space_quotas/{guid}":
+    get:
+      summary: Get a space quota
+      description: This endpoint retrieves the specified space quota object.
+      operationId: get_v3_space_quotas__guid_Show
+      tags:
+      - SpaceQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SpaceQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a space quota
+      description: This endpoint updates the specified space quota.
+      operationId: patch_v3_space_quotas__guid_Update
+      tags:
+      - SpaceQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SpaceQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SpaceQuotaUpdateMessageRequest"
+    delete:
+      summary: Delete a space quota
+      description: This endpoint deletes the specified space quota.
+      operationId: delete_v3_space_quotas__guid_Destroy
+      tags:
+      - SpaceQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SpaceQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/space_quotas/{guid}/relationships/spaces":
+    post:
+      summary: Apply to spaces
+      description: This endpoint performs the apply_to_spaces operation on the space
+        quota.
+      operationId: post_v3_space_quotas__guid__relationships_spacesApplyToSpaces
+      tags:
+      - SpaceQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SpaceQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/space_quotas/{guid}/relationships/spaces/{space_guid}":
+    delete:
+      summary: Remove from space
+      description: This endpoint performs the remove_from_space operation on the space
+        quota.
+      operationId: delete_v3_space_quotas__guid__relationships_spaces__space_guid_RemoveFromSpace
+      tags:
+      - SpaceQuotas
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      - name: space_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SpaceQuota"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/spaces":
+    post:
+      summary: Create a space
+      description: This endpoint creates a new space.
+      operationId: post_v3_spacesCreate
+      tags:
+      - Spaces
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SpaceCreateMessageRequest"
+    get:
+      summary: List spaces
+      description: This endpoint retrieves the spaces the user has access to.
+      operationId: get_v3_spacesIndex
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/Names"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - name: include
+        in: query
+        description: Include
+        schema:
+          type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedSpaceResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/spaces/{guid}":
+    get:
+      summary: Get a space
+      description: This endpoint retrieves the specified space object.
+      operationId: get_v3_spaces__guid_Show
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SpaceShowMessageRequest"
+    patch:
+      summary: Update a space
+      description: This endpoint updates the specified space.
+      operationId: patch_v3_spaces__guid_Update
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SpaceUpdateMessageRequest"
+    delete:
+      summary: Delete a space
+      description: This endpoint deletes the specified space.
+      operationId: delete_v3_spaces__guid_Destroy
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/spaces/{guid}/running_security_groups":
+    get:
+      summary: Running security groups
+      description: This endpoint performs the running_security_groups operation on
+        the space.
+      operationId: get_v3_spaces__guid__running_security_groupsRunningSecurityGroups
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/spaces/{guid}/staging_security_groups":
+    get:
+      summary: Staging security groups
+      description: This endpoint performs the staging_security_groups operation on
+        the space.
+      operationId: get_v3_spaces__guid__staging_security_groupsStagingSecurityGroups
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/spaces/{guid}/routes":
+    delete:
+      summary: Delete unmapped routes
+      description: This endpoint performs the delete_unmapped_routes operation on
+        the space.
+      operationId: delete_v3_spaces__guid__routesDeleteUnmappedRoutes
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SpaceDeleteUnmappedRoutesMessageRequest"
+  "/v3/spaces/{guid}/usage_summary":
+    get:
+      summary: Show usage summary
+      description: This endpoint performs the show_usage_summary operation on the
+        space.
+      operationId: get_v3_spaces__guid__usage_summaryShowUsageSummary
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/spaces/{guid}/relationships/isolation_segment":
+    get:
+      summary: Show isolation segment
+      description: This endpoint performs the show_isolation_segment operation on
+        the space.
+      operationId: get_v3_spaces__guid__relationships_isolation_segmentShowIsolationSegment
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update isolation segment
+      description: This endpoint performs the update_isolation_segment operation on
+        the space.
+      operationId: patch_v3_spaces__guid__relationships_isolation_segmentUpdateIsolationSegment
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/SpaceUpdateIsolationSegmentMessageRequest"
+  "/v3/spaces/{guid}/users":
+    get:
+      summary: List members
+      description: This endpoint performs the list_members operation on the space.
+      operationId: get_v3_spaces__guid__usersListMembers
+      tags:
+      - Spaces
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Space"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/tasks":
+    get:
+      summary: List tasks
+      description: This endpoint retrieves the tasks the user has access to.
+      operationId: get_v3_tasksIndex
+      tags:
+      - Tasks
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/Names"
+      - name: states
+        in: query
+        description: States
+        schema:
+          type: array
+          items:
+            type: string
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - name: app_guid
+        in: query
+        description: App guid
+        schema:
+          type: string
+      - name: sequence_ids
+        in: query
+        description: Sequence ids
+        schema:
+          type: array
+          items:
+            type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedTaskResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/tasks/{task_guid}":
+    get:
+      summary: Get a task
+      description: This endpoint retrieves the specified task object.
+      operationId: get_v3_tasks__task_guid_Show
+      tags:
+      - Tasks
+      parameters:
+      - name: task_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Task"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a task
+      description: This endpoint updates the specified task.
+      operationId: patch_v3_tasks__task_guid_Update
+      tags:
+      - Tasks
+      parameters:
+      - name: task_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Task"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/TaskUpdateMessageRequest"
+  "/v3/tasks/{task_guid}/cancel":
+    put:
+      summary: Cancel a task
+      description: This endpoint performs the cancel operation on the task.
+      operationId: put_v3_tasks__task_guid__cancelCancel
+      tags:
+      - Tasks
+      parameters:
+      - name: task_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Task"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/tasks/{task_guid}/actions/cancel":
+    post:
+      summary: Cancel a task
+      description: This endpoint performs the cancel operation on the task.
+      operationId: post_v3_tasks__task_guid__actions_cancelCancel
+      tags:
+      - Tasks
+      parameters:
+      - name: task_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Task"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/apps/{app_guid}/tasks":
+    post:
+      summary: Create a task
+      description: This endpoint creates a new task.
+      operationId: post_v3_apps__app_guid__tasksCreate
+      tags:
+      - Tasks
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Task"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/TaskCreateMessageRequest"
+    get:
+      summary: List tasks
+      description: This endpoint retrieves the tasks the user has access to.
+      operationId: get_v3_apps__app_guid__tasksIndex
+      tags:
+      - Tasks
+      parameters:
+      - name: app_guid
+        in: path
+        required: true
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/Names"
+      - name: states
+        in: query
+        description: States
+        schema:
+          type: array
+          items:
+            type: string
+      - name: app_guids
+        in: query
+        description: App guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - name: app_guid
+        in: query
+        description: App guid
+        schema:
+          type: string
+      - name: sequence_ids
+        in: query
+        description: Sequence ids
+        schema:
+          type: array
+          items:
+            type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedTaskResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/stacks":
+    get:
+      summary: List stacks
+      description: This endpoint retrieves the stacks the user has access to.
+      operationId: get_v3_stacksIndex
+      tags:
+      - Stacks
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/Names"
+      - name: default
+        in: query
+        description: Default
+        schema:
+          type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedStackResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create a stack
+      description: This endpoint creates a new stack.
+      operationId: post_v3_stacksCreate
+      tags:
+      - Stacks
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Stack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/StackCreateMessageRequest"
+  "/v3/stacks/{guid}":
+    get:
+      summary: Get a stack
+      description: This endpoint retrieves the specified stack object.
+      operationId: get_v3_stacks__guid_Show
+      tags:
+      - Stacks
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Stack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a stack
+      description: This endpoint updates the specified stack.
+      operationId: patch_v3_stacks__guid_Update
+      tags:
+      - Stacks
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Stack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/StackUpdateMessageRequest"
+    delete:
+      summary: Delete a stack
+      description: This endpoint deletes the specified stack.
+      operationId: delete_v3_stacks__guid_Destroy
+      tags:
+      - Stacks
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Stack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/stacks/{guid}/apps":
+    get:
+      summary: Show apps
+      description: This endpoint performs the show_apps operation on the stack.
+      operationId: get_v3_stacks__guid__appsShowApps
+      tags:
+      - Stacks
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Stack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/users":
+    get:
+      summary: List users
+      description: This endpoint retrieves the users the user has access to.
+      operationId: get_v3_usersIndex
+      tags:
+      - Users
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: usernames
+        in: query
+        description: Usernames
+        schema:
+          type: array
+          items:
+            type: string
+      - name: partial_usernames
+        in: query
+        description: Partial usernames
+        schema:
+          type: array
+          items:
+            type: string
+      - name: origins
+        in: query
+        description: Origins
+        schema:
+          type: array
+          items:
+            type: string
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedUserResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create an user
+      description: This endpoint creates a new user.
+      operationId: post_v3_usersCreate
+      tags:
+      - Users
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UserCreateMessageRequest"
+  "/v3/users/{guid}":
+    get:
+      summary: Get an user
+      description: This endpoint retrieves the specified user object.
+      operationId: get_v3_users__guid_Show
+      tags:
+      - Users
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update an user
+      description: This endpoint updates the specified user.
+      operationId: patch_v3_users__guid_Update
+      tags:
+      - Users
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UserUpdateMessageRequest"
+    delete:
+      summary: Delete an user
+      description: This endpoint deletes the specified user.
+      operationId: delete_v3_users__guid_Destroy
+      tags:
+      - Users
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/buildpacks":
+    get:
+      summary: List buildpacks
+      description: This endpoint retrieves the buildpacks the user has access to.
+      operationId: get_v3_buildpacksIndex
+      tags:
+      - Buildpacks
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: stacks
+        in: query
+        description: Stacks
+        schema:
+          type: array
+          items:
+            type: string
+      - "$ref": "#/components/parameters/Names"
+      - name: lifecycle
+        in: query
+        description: Lifecycle
+        schema:
+          type: string
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - name: label_selector
+        in: query
+        description: Label selector
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedBuildpackResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create a buildpack
+      description: This endpoint creates a new buildpack.
+      operationId: post_v3_buildpacksCreate
+      tags:
+      - Buildpacks
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Buildpack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BuildpackCreateMessageRequest"
+  "/v3/buildpacks/{guid}":
+    get:
+      summary: Get a buildpack
+      description: This endpoint retrieves the specified buildpack object.
+      operationId: get_v3_buildpacks__guid_Show
+      tags:
+      - Buildpacks
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Buildpack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a buildpack
+      description: This endpoint updates the specified buildpack.
+      operationId: patch_v3_buildpacks__guid_Update
+      tags:
+      - Buildpacks
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Buildpack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BuildpackUpdateMessageRequest"
+    delete:
+      summary: Delete a buildpack
+      description: This endpoint deletes the specified buildpack.
+      operationId: delete_v3_buildpacks__guid_Destroy
+      tags:
+      - Buildpacks
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Buildpack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/buildpacks/{guid}/upload":
+    post:
+      summary: Upload buildpack bits
+      description: This endpoint uploads bits for the specified buildpack.
+      operationId: post_v3_buildpacks__guid__uploadUpload
+      tags:
+      - Buildpacks
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Buildpack"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BuildpackUploadMessageRequest"
+  "/v3/feature_flags":
+    get:
+      summary: List feature flags
+      description: This endpoint retrieves the feature flags the user has access to.
+      operationId: get_v3_feature_flagsIndex
+      tags:
+      - FeatureFlags
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedFeatureFlagResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/feature_flags/{name}":
+    get:
+      summary: Get a feature flag
+      description: This endpoint retrieves the specified feature flag object.
+      operationId: get_v3_feature_flags__name_Show
+      tags:
+      - FeatureFlags
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FeatureFlag"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update a feature flag
+      description: This endpoint updates the specified feature flag.
+      operationId: patch_v3_feature_flags__name_Update
+      tags:
+      - FeatureFlags
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FeatureFlag"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/audit_events":
+    get:
+      summary: List events
+      description: This endpoint retrieves the events the user has access to.
+      operationId: get_v3_audit_eventsIndex
+      tags:
+      - Events
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: types
+        in: query
+        description: Types
+        schema:
+          type: array
+          items:
+            type: string
+      - name: target_guids
+        in: query
+        description: Target guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedEventResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/audit_events/{guid}":
+    get:
+      summary: Get an event
+      description: This endpoint retrieves the specified event object.
+      operationId: get_v3_audit_events__guid_Show
+      tags:
+      - Events
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Event"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/app_usage_events/{guid}":
+    get:
+      summary: Get an app usage event
+      description: This endpoint retrieves the specified app usage event object.
+      operationId: get_v3_app_usage_events__guid_Show
+      tags:
+      - AppUsageEvents
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AppUsageEvent"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/app_usage_events":
+    get:
+      summary: List app usage events
+      description: This endpoint retrieves the app usage events the user has access
+        to.
+      operationId: get_v3_app_usage_eventsIndex
+      tags:
+      - AppUsageEvents
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: after_guid
+        in: query
+        description: After guid
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedAppUsageEventResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/app_usage_events/actions/destructively_purge_all_and_reseed":
+    post:
+      summary: Destructively purge all and reseed app usage event
+      description: This endpoint performs the destructively_purge_all_and_reseed operation
+        on the app usage event.
+      operationId: post_v3_app_usage_events_actions_destructively_purge_all_and_reseedDestructivelyPurgeAllAndReseed
+      tags:
+      - AppUsageEvents
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AppUsageEvent"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_usage_events/{guid}":
+    get:
+      summary: Get a service usage event
+      description: This endpoint retrieves the specified service usage event object.
+      operationId: get_v3_service_usage_events__guid_Show
+      tags:
+      - ServiceUsageEvents
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceUsageEvent"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_usage_events":
+    get:
+      summary: List service usage events
+      description: This endpoint retrieves the service usage events the user has access
+        to.
+      operationId: get_v3_service_usage_eventsIndex
+      tags:
+      - ServiceUsageEvents
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - name: after_guid
+        in: query
+        description: After guid
+        schema:
+          type: string
+      - name: service_instance_types
+        in: query
+        description: Service instance types
+        schema:
+          type: array
+          items:
+            type: string
+      - name: service_offering_guids
+        in: query
+        description: Service offering guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedServiceUsageEventResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/service_usage_events/actions/destructively_purge_all_and_reseed":
+    post:
+      summary: Destructively purge all and reseed service usage event
+      description: This endpoint performs the destructively_purge_all_and_reseed operation
+        on the service usage event.
+      operationId: post_v3_service_usage_events_actions_destructively_purge_all_and_reseedDestructivelyPurgeAllAndReseed
+      tags:
+      - ServiceUsageEvents
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ServiceUsageEvent"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/environment_variable_groups/{name}":
+    get:
+      summary: Get an environment variable group
+      description: This endpoint retrieves the specified environment variable group
+        object.
+      operationId: get_v3_environment_variable_groups__name_Show
+      tags:
+      - EnvironmentVariableGroups
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/EnvironmentVariableGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    patch:
+      summary: Update an environment variable group
+      description: This endpoint updates the specified environment variable group.
+      operationId: patch_v3_environment_variable_groups__name_Update
+      tags:
+      - EnvironmentVariableGroups
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/EnvironmentVariableGroup"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/roles":
+    get:
+      summary: List roles
+      description: This endpoint retrieves the roles the user has access to.
+      operationId: get_v3_rolesIndex
+      tags:
+      - Roles
+      parameters:
+      - "$ref": "#/components/parameters/Page"
+      - "$ref": "#/components/parameters/PerPage"
+      - "$ref": "#/components/parameters/OrderBy"
+      - "$ref": "#/components/parameters/CreatedAts"
+      - "$ref": "#/components/parameters/UpdatedAts"
+      - "$ref": "#/components/parameters/Guids"
+      - "$ref": "#/components/parameters/OrganizationGuids"
+      - "$ref": "#/components/parameters/SpaceGuids"
+      - name: user_guids
+        in: query
+        description: User guids
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+      - name: types
+        in: query
+        description: Types
+        schema:
+          type: array
+          items:
+            type: string
+      - name: include
+        in: query
+        description: Include
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PaginatedRoleResponse"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+    post:
+      summary: Create a role
+      description: This endpoint creates a new role.
+      operationId: post_v3_rolesCreate
+      tags:
+      - Roles
+      parameters: []
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Role"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RoleCreateMessageRequest"
+  "/v3/roles/{guid}":
+    get:
+      summary: Get a role
+      description: This endpoint retrieves the specified role object.
+      operationId: get_v3_roles__guid_Show
+      tags:
+      - Roles
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Role"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/RoleShowMessageRequest"
+    delete:
+      summary: Delete a role
+      description: This endpoint deletes the specified role.
+      operationId: delete_v3_roles__guid_Destroy
+      tags:
+      - Roles
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '202':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Role"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/info":
+    get:
+      summary: V3 info
+      description: This endpoint performs the v3_info operation on the info.
+      operationId: get_v3_infoV3Info
+      tags:
+      - Info
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Info"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/info/usage_summary":
+    get:
+      summary: Show usage summary
+      description: This endpoint performs the show_usage_summary operation on the
+        info.
+      operationId: get_v3_info_usage_summaryShowUsageSummary
+      tags:
+      - Info
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Info"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+  "/v3/internal/builds/{guid}":
+    patch:
+      summary: Update a build
+      description: This endpoint updates the specified build.
+      operationId: patch_v3_internal_builds__guid_Update
+      tags:
+      - Builds
+      parameters:
+      - "$ref": "#/components/parameters/Guid"
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Build"
+        '400':
+          "$ref": "#/components/responses/BadRequest"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '403':
+          "$ref": "#/components/responses/Forbidden"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+        '500':
+          "$ref": "#/components/responses/InternalServerError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BuildUpdateMessageRequest"
+tags:
+- name: Root
+  description: ''
+- name: AdminActions
+  description: ''
+- name: Apps
+  description: ''
+- name: AppFeatures
+  description: ''
+- name: AppManifests
+  description: ''
+- name: AppRevisions
+  description: ''
+- name: Sidecars
+  description: ''
+- name: Revisions
+  description: ''
+- name: Processes
+  description: ''
+- name: Packages
+  description: ''
+- name: Builds
+  description: ''
+- name: Deployments
+  description: ''
+- name: Domains
+  description: ''
+- name: Droplets
+  description: ''
+- name: IsolationSegments
+  description: ''
+- name: Jobs
+  description: ''
+- name: Organizations
+  description: ''
+- name: OrganizationQuotas
+  description: ''
+- name: ResourceMatches
+  description: ''
+- name: Routes
+  description: ''
+- name: SecurityGroups
+  description: ''
+- name: ServiceBindings
+  description: ''
+- name: ServiceCredentialBindings
+  description: ''
+- name: ServiceRouteBindings
+  description: ''
+- name: ServiceBrokers
+  description: ''
+- name: ServiceOfferings
+  description: ''
+- name: ServicePlans
+  description: ''
+- name: ServicePlanVisibility
+  description: ''
+- name: ServiceInstances
+  description: ''
+- name: SpaceFeatures
+  description: ''
+- name: SpaceManifests
+  description: ''
+- name: SpaceQuotas
+  description: ''
+- name: Spaces
+  description: ''
+- name: Tasks
+  description: ''
+- name: Stacks
+  description: ''
+- name: Users
+  description: ''
+- name: Buildpacks
+  description: ''
+- name: FeatureFlags
+  description: ''
+- name: Events
+  description: ''
+- name: AppUsageEvents
+  description: ''
+- name: ServiceUsageEvents
+  description: ''
+- name: EnvironmentVariableGroups
+  description: ''
+- name: Roles
+  description: ''
+- name: Info
+  description: ''
+- name: Welcome
+  description: ''
+components:
+  schemas:
+    Pagination:
+      type: object
+      properties:
+        total_results:
+          type: integer
+        total_pages:
+          type: integer
+        first:
+          type: object
+          properties:
+            href:
+              type: string
+              format: uri
+        last:
+          type: object
+          properties:
+            href:
+              type: string
+              format: uri
+        next:
+          type: object
+          nullable: true
+          properties:
+            href:
+              type: string
+              format: uri
+        previous:
+          type: object
+          nullable: true
+          properties:
+            href:
+              type: string
+              format: uri
+    Error:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              code:
+                type: integer
+              detail:
+                type: string
+              title:
+                type: string
+    Metadata:
+      type: object
+      properties:
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+          description: Key-value pairs of labels
+        annotations:
+          type: object
+          additionalProperties:
+            type: string
+          description: Key-value pairs of annotations
+      description: Metadata containing labels and annotations
+    Links:
+      type: object
+      additionalProperties:
+        type: object
+        properties:
+          href:
+            type: string
+            format: uri
+          method:
+            type: string
+    AppDropletRelationship:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    AppEnv:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    AppEnvironmentVariables:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    AppFileBasedVcapServicesFeature:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    AppManifest:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Buildpack:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Docker:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Features:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Lifecycle:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    NameEnv:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ProcessProperties:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    RouteProperties:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServicesProperties:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    SidecarProperties:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    App:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        state:
+          type: string
+          enum:
+          - STARTED
+          - STOPPED
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        lifecycle:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - buildpack
+              - docker
+            data:
+              type: object
+        relationships:
+          type: object
+          properties:
+            space:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    guid:
+                      type: string
+                      format: uuid
+            current_droplet:
+              type: object
+              properties:
+                data:
+                  type: object
+                  nullable: true
+                  properties:
+                    guid:
+                      type: string
+                      format: uuid
+        links:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              href:
+                type: string
+                format: uri
+              method:
+                type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+      required:
+      - guid
+      - name
+      - state
+      - created_at
+      - updated_at
+      - lifecycle
+      - relationships
+      - links
+      - metadata
+    AppRevisionsFeature:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    AppServiceBindingK8sFeature:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    AppSshFeature:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    AppSshStatus:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    AppUsageEvent:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Build:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Deployment:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Domain:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    DomainSharedOrgs:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Droplet:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    EnvironmentVariableGroup:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Event:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    FeatureFlag:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Info:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    InfoUsageSummary:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    IsolationSegment:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Job:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Organization:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        suspended:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        relationships:
+          type: object
+          properties:
+            quota:
+              type: object
+              properties:
+                data:
+                  type: object
+                  nullable: true
+                  properties:
+                    guid:
+                      type: string
+                      format: uuid
+        links:
+          "$ref": "#/components/schemas/Links"
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+      required:
+      - guid
+      - name
+      - suspended
+      - created_at
+      - updated_at
+      - relationships
+      - links
+      - metadata
+    OrganizationQuota:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    OrganizationUsageSummary:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Package:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    PaginatedList:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Process:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ProcessStats:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Relationship:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ResourceMatch:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    RevisionEnvironmentVariables:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Revision:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Role:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    RouteDestination:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    RouteDestinations:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Route:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    SecurityGroup:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServiceBroker:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServiceCredentialBindingDetails:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServiceCredentialBinding:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServiceInstance:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServiceOffering:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServicePlan:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServicePlanVisibility:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServiceRouteBinding:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ServiceUsageEvent:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    SharedSpacesUsageSummary:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Sidecar:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Space:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        relationships:
+          type: object
+          properties:
+            organization:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    guid:
+                      type: string
+                      format: uuid
+            quota:
+              type: object
+              properties:
+                data:
+                  type: object
+                  nullable: true
+                  properties:
+                    guid:
+                      type: string
+                      format: uuid
+        links:
+          "$ref": "#/components/schemas/Links"
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+      required:
+      - guid
+      - name
+      - created_at
+      - updated_at
+      - relationships
+      - links
+      - metadata
+    SpaceQuota:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    SpaceSshFeature:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    SpaceUsageSummary:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Stack:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    Task:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ToManyRelationship:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    ToOneRelationship:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    User:
+      type: object
+      properties:
+        guid:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        name:
+          type: string
+        metadata:
+          "$ref": "#/components/schemas/Metadata"
+        links:
+          "$ref": "#/components/schemas/Links"
+    PaginatedAppResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/App"
+    AppCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        environment_variables:
+          type: string
+        lifecycle_type:
+          type: string
+        lifecycle_data:
+          type: string
+        relationships:
+          type: object
+        lifecycle:
+          "$ref": "#/components/schemas/BuildpackLifecycle"
+        metadata:
+          type: object
+      required: []
+    AppShowMessageRequest:
+      type: object
+      properties:
+        include:
+          type: string
+      required: []
+    AppUpdateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        lifecycle_type:
+          type: string
+        lifecycle_data:
+          type: string
+        lifecycle:
+          type: string
+        metadata:
+          type: object
+      required: []
+    AppFeatureUpdateMessageRequest:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+      required: []
+    SidecarCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        command:
+          type: string
+        process_types:
+          type: string
+        memory_in_mb:
+          type: integer
+      required:
+      - name
+      - command
+    SidecarUpdateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        command:
+          type: string
+        process_types:
+          type: string
+        memory_in_mb:
+          type: integer
+      required:
+      - name
+      - command
+    PaginatedProcessResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Process"
+    ProcessUpdateMessageRequest:
+      type: object
+      properties:
+        command:
+          type: string
+        user:
+          type: string
+        health_check_type:
+          type: string
+          enum:
+          - port
+          - process
+          - http
+        health_check_timeout:
+          type: integer
+        health_check_invocation_timeout:
+          type: integer
+        health_check_interval:
+          type: integer
+        health_check_endpoint:
+          type: string
+        readiness_health_check_type:
+          type: string
+          enum:
+          - port
+          - process
+          - http
+        readiness_health_check_invocation_timeout:
+          type: integer
+        readiness_health_check_interval:
+          type: integer
+        readiness_health_check_endpoint:
+          type: string
+        health_check:
+          type: string
+        readiness_health_check:
+          type: string
+        metadata:
+          type: object
+      required: []
+    ProcessScaleMessageRequest:
+      type: object
+      properties:
+        instances:
+          type: integer
+        memory_in_mb:
+          type: integer
+        disk_in_mb:
+          type: integer
+        log_rate_limit_in_bytes_per_second:
+          type: integer
+      required: []
+    PaginatedPackageResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Package"
+    PackageUpdateMessageRequest:
+      type: object
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+        metadata:
+          type: object
+      required: []
+    PackageUploadMessageRequest:
+      type: object
+      properties:
+        bits_path:
+          type: string
+        bits_name:
+          type: string
+        upload_start_time:
+          type: string
+        resources:
+          type: string
+      required: []
+    PackageCreateMessageRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - bits
+          - docker
+        relationships:
+          type: object
+        data:
+          type: string
+        metadata:
+          type: object
+      required: []
+    BuildCreateMessageRequest:
+      type: object
+      properties:
+        staging_disk_in_mb:
+          type: integer
+        staging_memory_in_mb:
+          type: integer
+        staging_log_rate_limit_bytes_per_second:
+          type: integer
+        package_guid:
+          type: string
+        lifecycle_type:
+          type: string
+        lifecycle_data:
+          type: string
+        environment_variables:
+          type: string
+        lifecycle:
+          type: string
+        package:
+          type: string
+        metadata:
+          type: object
+      required:
+      - package_guid
+    PaginatedBuildResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Build"
+    BuildUpdateMessageRequest:
+      type: object
+      properties:
+        error:
+          type: string
+        state:
+          type: string
+        lifecycle:
+          type: string
+        metadata:
+          type: object
+      required: []
+    DeploymentCreateMessageRequest:
+      type: object
+      properties:
+        strategy:
+          type: string
+          enum:
+          - rolling
+          - canary
+        relationships:
+          type: object
+        droplet:
+          type: string
+        revision:
+          type: string
+        options:
+          type: string
+        metadata:
+          type: object
+      required: []
+    DeploymentUpdateMessageRequest:
+      type: object
+      properties:
+        metadata:
+          type: object
+      required: []
+    PaginatedDeploymentResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Deployment"
+    DomainCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          pattern: "\\A^([^\\.]{0,63}\\.)*[^\\.]{0,63}$\\Z"
+        internal:
+          type: boolean
+        relationships:
+          type: object
+        router_group:
+          type: string
+        metadata:
+          type: object
+      required:
+      - name
+    PaginatedDomainResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Domain"
+    DomainShowMessageRequest:
+      type: object
+      properties:
+        guid:
+          type: string
+      required:
+      - guid
+    DomainUpdateSharedOrgsMessageRequest:
+      type: object
+      properties:
+        data:
+          type: string
+        guid:
+          type: string
+          format: uuid
+        metadata:
+          type: object
+      required: []
+    DomainDeleteSharedOrgMessageRequest:
+      type: object
+      properties:
+        guid:
+          type: string
+        org_guid:
+          type: string
+      required:
+      - guid
+      - org_guid
+    DomainUpdateMessageRequest:
+      type: object
+      properties:
+        guid:
+          type: string
+        metadata:
+          type: object
+      required:
+      - guid
+    DropletCreateMessageRequest:
+      type: object
+      properties:
+        relationships:
+          type: object
+        process_types:
+          type: string
+      required: []
+    PaginatedDropletResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Droplet"
+    DropletUpdateMessageRequest:
+      type: object
+      properties:
+        image:
+          type: string
+        metadata:
+          type: object
+      required: []
+    DropletUploadMessageRequest:
+      type: object
+      properties:
+        bits_path:
+          type: string
+        bits_name:
+          type: string
+        upload_start_time:
+          type: string
+      required: []
+    IsolationSegmentCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        metadata:
+          type: object
+      required:
+      - name
+    PaginatedIsolationSegmentResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/IsolationSegment"
+    IsolationSegmentUpdateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        metadata:
+          type: object
+      required: []
+    OrganizationCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        suspended:
+          type: boolean
+        metadata:
+          type: object
+      required:
+      - name
+    OrganizationUpdateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          pattern: "#<Proc:0x0000000115a586b8 /Users/i507599/SAPDevelop/git/cloud_controller_ng/app/messages/organization_update_message.rb:12
+            (lambda)>"
+        suspended:
+          type: boolean
+        metadata:
+          type: object
+      required: []
+    PaginatedOrganizationResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Organization"
+    PaginatedOrganizationQuotaResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/OrganizationQuota"
+    ResourceMatchCreateMessageRequest:
+      type: object
+      properties:
+        resources:
+          type: string
+      required: []
+    PaginatedRouteResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Route"
+    RouteShowMessageRequest:
+      type: object
+      properties:
+        guid:
+          type: string
+        include:
+          type: string
+      required:
+      - guid
+    RouteCreateMessageRequest:
+      type: object
+      properties:
+        host:
+          type: string
+          pattern: "\\A([\\w\\-]+|\\*)?\\z"
+        path:
+          type: string
+        port:
+          type: integer
+        relationships:
+          type: string
+        options:
+          type: string
+        metadata:
+          type: object
+      required:
+      - relationships
+    RouteTransferOwnerMessageRequest:
+      type: object
+      properties:
+        data:
+          type: string
+      required:
+      - data
+    RouteUpdateMessageRequest:
+      type: object
+      properties:
+        options:
+          type: string
+        metadata:
+          type: object
+      required: []
+    SecurityGroupCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        globally_enabled:
+          type: string
+        relationships:
+          type: object
+        rules:
+          type: string
+      required:
+      - name
+    PaginatedSecurityGroupResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/SecurityGroup"
+    SecurityGroupUpdateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        globally_enabled:
+          type: string
+        rules:
+          type: string
+      required: []
+    ServiceBindingCreateMessageRequest:
+      type: object
+      properties:
+        data:
+          type: string
+        type:
+          type: string
+          enum:
+          - app
+        name:
+          type: string
+        relationships:
+          type: object
+      required:
+      - type
+    PaginatedServiceCredentialBindingResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ServiceCredentialBinding"
+    ServiceCredentialBindingCreateMessageRequest:
+      type: object
+      properties:
+        parameters:
+          type: string
+        type:
+          type: string
+          enum:
+          - app
+          - key
+        name:
+          type: string
+        relationships:
+          type: object
+        metadata:
+          type: object
+      required: []
+    ServiceCredentialBindingShowMessageRequest:
+      type: object
+      properties:
+        include:
+          type: string
+      required: []
+    PaginatedServiceRouteBindingResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ServiceRouteBinding"
+    ServiceRouteBindingCreateMessageRequest:
+      type: object
+      properties:
+        parameters:
+          type: string
+        relationships:
+          type: object
+        metadata:
+          type: object
+      required: []
+    ServiceRouteBindingShowMessageRequest:
+      type: object
+      properties:
+        include:
+          type: string
+      required: []
+    PaginatedServiceBrokerResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ServiceBroker"
+    ServiceBrokerCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        url:
+          type: string
+        authentication:
+          type: string
+        relationships:
+          type: object
+        metadata:
+          type: object
+      required: []
+    ServiceBrokerUpdateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        url:
+          type: string
+        authentication:
+          type: string
+        metadata:
+          type: object
+      required: []
+    PaginatedServiceOfferingResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ServiceOffering"
+    PaginatedServicePlanResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ServicePlan"
+    ServicePlanVisibilityUpdateMessageRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - public
+          - admin
+          - organization
+        organizations:
+          type: string
+      required:
+      - organizations
+    PaginatedServiceInstanceResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ServiceInstance"
+    ServiceInstanceShowMessageRequest:
+      type: object
+      properties:
+        fields:
+          type: string
+      required: []
+    ServiceInstanceCreateMessageRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - managed
+          - user-provided
+        name:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        relationships:
+          type: object
+        metadata:
+          type: object
+      required:
+      - name
+    SpaceFeatureUpdateMessageRequest:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+      required: []
+    PaginatedSpaceQuotaResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/SpaceQuota"
+    SpaceQuotaUpdateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        apps:
+          type: string
+        services:
+          type: string
+        routes:
+          type: string
+      required:
+      - name
+    SpaceCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          pattern: "#<Proc:0x000000011527e3e8 /Users/i507599/SAPDevelop/git/cloud_controller_ng/app/messages/space_create_message.rb:14
+            (lambda)>"
+        relationships:
+          type: object
+        metadata:
+          type: object
+      required:
+      - name
+    PaginatedSpaceResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Space"
+    SpaceShowMessageRequest:
+      type: object
+      properties:
+        include:
+          type: string
+      required: []
+    SpaceUpdateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          pattern: "#<Proc:0x0000000115275fe0 /Users/i507599/SAPDevelop/git/cloud_controller_ng/app/messages/space_update_message.rb:12
+            (lambda)>"
+        metadata:
+          type: object
+      required: []
+    SpaceDeleteUnmappedRoutesMessageRequest:
+      type: object
+      properties:
+        unmapped:
+          type: string
+      required:
+      - unmapped
+    SpaceUpdateIsolationSegmentMessageRequest:
+      type: object
+      properties:
+        data:
+          type: string
+      required:
+      - data
+    PaginatedTaskResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Task"
+    TaskUpdateMessageRequest:
+      type: object
+      properties:
+        metadata:
+          type: object
+      required: []
+    TaskCreateMessageRequest:
+      type: object
+      properties:
+        disk_in_mb:
+          type: integer
+        memory_in_mb:
+          type: integer
+        log_rate_limit_in_bytes_per_second:
+          type: integer
+        droplet_guid:
+          type: string
+        template_process_guid:
+          type: string
+        user:
+          type: string
+        name:
+          type: string
+        command:
+          type: string
+        template:
+          type: string
+        metadata:
+          type: object
+      required: []
+    PaginatedStackResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Stack"
+    StackCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        metadata:
+          type: object
+      required:
+      - name
+    StackUpdateMessageRequest:
+      type: object
+      properties:
+        metadata:
+          type: object
+      required: []
+    PaginatedUserResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/User"
+    UserCreateMessageRequest:
+      type: object
+      properties:
+        guid:
+          type: string
+        origin:
+          type: string
+        username:
+          type: string
+        metadata:
+          type: object
+      required: []
+    UserUpdateMessageRequest:
+      type: object
+      properties:
+        metadata:
+          type: object
+      required: []
+    PaginatedBuildpackResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Buildpack"
+    BuildpackCreateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          pattern: "\\A[-\\w]+\\z"
+        stack:
+          type: string
+        position:
+          type: integer
+        enabled:
+          type: boolean
+        locked:
+          type: boolean
+        lifecycle:
+          type: string
+          enum:
+          - buildpack
+          - cnb
+        metadata:
+          type: object
+      required:
+      - name
+    BuildpackUpdateMessageRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          pattern: "\\A[-\\w]+\\z"
+        stack:
+          type: string
+        position:
+          type: integer
+        enabled:
+          type: boolean
+        locked:
+          type: boolean
+        metadata:
+          type: object
+      required: []
+    BuildpackUploadMessageRequest:
+      type: object
+      properties:
+        bits_path:
+          type: string
+        bits_name:
+          type: string
+        upload_start_time:
+          type: string
+      required: []
+    PaginatedFeatureFlagResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/FeatureFlag"
+    PaginatedEventResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Event"
+    PaginatedAppUsageEventResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/AppUsageEvent"
+    PaginatedServiceUsageEventResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ServiceUsageEvent"
+    PaginatedRoleResponse:
+      type: object
+      properties:
+        pagination:
+          "$ref": "#/components/schemas/Pagination"
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Role"
+    RoleShowMessageRequest:
+      type: object
+      properties:
+        include:
+          type: string
+      required: []
+    RoleCreateMessageRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - organization_auditor
+          - organization_manager
+          - organization_billing_manager
+          - organization_user
+          - space_auditor
+          - space_manager
+          - space_developer
+          - space_supporter
+        relationships:
+          type: object
+      required: []
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    Page:
+      name: page
+      in: query
+      description: Page to display; valid values are integers >= 1
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    PerPage:
+      name: per_page
+      in: query
+      description: Number of results per page, valid values are 1 through 5000
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 5000
+        default: 50
+    OrderBy:
+      name: order_by
+      in: query
+      description: Order results by a specific field. Prepend with - to sort descending.
+      schema:
+        type: string
+    Guid:
+      name: guid
+      in: path
+      required: true
+      description: The resource identifier
+      schema:
+        type: string
+        format: uuid
+    CreatedAts:
+      name: created_ats
+      in: query
+      description: Timestamp to filter by. When filtering on equality, several comma-delimited
+        timestamps may be passed.
+      schema:
+        type: string
+    UpdatedAts:
+      name: updated_ats
+      in: query
+      description: Timestamp to filter by. When filtering on equality, several comma-delimited
+        timestamps may be passed.
+      schema:
+        type: string
+    Guids:
+      name: guids
+      in: query
+      description: Comma-delimited list of guids to filter by
+      style: form
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
+          format: uuid
+    Names:
+      name: names
+      in: query
+      description: Comma-delimited list of names to filter by
+      style: form
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
+    OrganizationGuids:
+      name: organization_guids
+      in: query
+      description: Comma-delimited list of organization guids to filter by
+      style: form
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
+          format: uuid
+    SpaceGuids:
+      name: space_guids
+      in: query
+      description: Comma-delimited list of space guids to filter by
+      style: form
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
+          format: uuid
+  responses:
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Error"
+    Forbidden:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Error"
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Error"
+    UnprocessableEntity:
+      description: Unprocessable Entity
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Error"
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Error"
+    InternalServerError:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Error"
+security:
+- bearerAuth: []
+externalDocs:
+  description: Cloud Foundry API V3 Docs
+  url: https://v3-apidocs.cloudfoundry.org/


### PR DESCRIPTION
This is a PoC Showcasing methods to generate an openapi spec from ruby code - although not quite sucessfull just pushing this to reference it in discussions.

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
