### PR TITLE
Use tmpfs for DBs in gh workflows

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: rootpassword
         options: >-
+          --tmpfs /var/lib/postgresql/data:rw,size=2g
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
@@ -83,7 +84,12 @@ jobs:
         env:
           MYSQL_DATABASE: cc_test
           MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --tmpfs /var/lib/mysql:rw,size=2g
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
         ports:
           - 3306:3306
     steps:

--- a/.github/workflows/unit_tests_backwards_compatibility.yml
+++ b/.github/workflows/unit_tests_backwards_compatibility.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: rootpassword
         options: >-
+          --tmpfs /var/lib/postgresql/data:rw,size=2g
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
@@ -92,7 +93,12 @@ jobs:
         env:
           MYSQL_DATABASE: cc_test
           MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --tmpfs /var/lib/mysql:rw,size=2g
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
         ports:
           - 3306:3306
     steps:


### PR DESCRIPTION
Use tmpfs for DBs in github workflows to speed up test execution.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
