### PR TITLE
Add rate limits to info end point

### DIFF
--- a/app/controllers/v3/info_controller.rb
+++ b/app/controllers/v3/info_controller.rb
@@ -5,17 +5,7 @@ require 'presenters/v3/info_usage_summary_presenter'
 class InfoController < ApplicationController
   def v3_info
     info = Info.new
-    config = VCAP::CloudController::Config.config
-
-    info.build = config.get(:info, :build) || ''
-    info.min_cli_version = config.get(:info, :min_cli_version) || ''
-    info.min_recommended_cli_version = config.get(:info, :min_recommended_cli_version) || ''
-    info.custom = config.get(:info, :custom) || {}
-    info.description = config.get(:info, :description) || ''
-    info.name = config.get(:info, :name) || ''
-    info.version = config.get(:info, :version) || 0
-    info.support_address = config.get(:info, :support_address) || ''
-
+    populate_info_fields(info)
     osbapi_version_file = Rails.root.join('config/osbapi_version').to_s
     if File.exist?(osbapi_version_file)
       info.osbapi_version = File.read(osbapi_version_file).strip
@@ -34,8 +24,27 @@ class InfoController < ApplicationController
 
     render status: :ok, json: VCAP::CloudController::Presenters::V3::InfoUsageSummaryPresenter.new(summary)
   end
+
+  private
+
+  def populate_info_fields(info)
+    config = VCAP::CloudController::Config.config
+
+    info.build = config.get(:info, :build) || ''
+    info.min_cli_version = config.get(:info, :min_cli_version) || ''
+    info.min_recommended_cli_version = config.get(:info, :min_recommended_cli_version) || ''
+    info.custom = config.get(:info, :custom) || {}
+    info.description = config.get(:info, :description) || ''
+    info.name = config.get(:info, :name) || ''
+    info.version = config.get(:info, :version) || 0
+    info.support_address = config.get(:info, :support_address) || ''
+    info.request_rate_limiter_enabled = config.get(:rate_limiter, :enabled) || false
+    info.request_rate_limiter_general_limit = config.get(:rate_limiter, :per_process_general_limit) || ''
+    info.request_rate_limiter_reset_interval_in_mins = config.get(:rate_limiter, :reset_interval_in_minutes) || ''
+  end
 end
 
 class Info
-  attr_accessor :build, :min_cli_version, :min_recommended_cli_version, :custom, :description, :name, :version, :support_address, :osbapi_version
+  attr_accessor :build, :min_cli_version, :min_recommended_cli_version, :custom, :description, :name, :version, :support_address, :osbapi_version, :request_rate_limiter_enabled,
+                :request_rate_limiter_general_limit, :request_rate_limiter_reset_interval_in_mins
 end

--- a/app/presenters/v3/info_presenter.rb
+++ b/app/presenters/v3/info_presenter.rb
@@ -16,6 +16,11 @@ module VCAP::CloudController::Presenters::V3
         name: info.name,
         version: info.version,
         osbapi_version: info.osbapi_version,
+        rate_limits: {
+          enabled: info.request_rate_limiter_enabled,
+          general_limit: info.request_rate_limiter_general_limit,
+          reset_interval_in_minutes: info.request_rate_limiter_reset_interval_in_mins
+        },
         links: {
           self: { href: build_self },
           support: { href: info.support_address }

--- a/docs/v3/source/includes/api_resources/_info.erb
+++ b/docs/v3/source/includes/api_resources/_info.erb
@@ -12,6 +12,11 @@
   "name": "Cloud Foundry",
   "version": 123,
   "osbapi_version": "2.15",
+  "rate_limits": {
+    "enabled": true,
+    "general_limit": 2000,
+    "reset_interval_in_minutes": 30
+  },
   "links": {
     "self": { "href": "http://api.example.com/v3/info" } ,
     "support": { "href": "http://support.example.com" }
@@ -31,6 +36,11 @@
   "name": "",
   "version": 0,
   "osbapi_version": "",
+  "rate_limits": {
+    "enabled": false,
+    "general_limit": 2000,
+    "reset_interval_in_minutes": 30
+  },
   "links": {
     "self": { "href": "http://api.example.com/v3/info" } ,
     "support": { "href": "" }


### PR DESCRIPTION
Add rate limits to /v3/info

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Add rate limits configuration to /v3/info end point.
cf curl "/v3/info"
{"build":"10.2.0-build.7","cli_version":{"minimum":"6.23.0","recommended":"6.23.0"},"custom":{},"description":"[https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-2/tpcf/runtime-rn.html","name":"Small](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-2/tpcf/runtime-rn.html%22,%22name%22:%22Small) Footprint Tanzu Platform for Cloud Foundry","version":0,"osbapi_version":"2.15","rate_limits":{"enabled":true,"general_limit":4000,"reset_interval_in_minutes":60},"links":{"self":{"href":"[https://api.sys.tas.7b5e3720.shepherd.tanzu.broadcom.net/v3/info"},"support":{"href":"https://tanzu.vmware.com/support"}}}](https://api.sys.tas.7b5e3720.shepherd.tanzu.broadcom.net/v3/info%22%7D,%22support%22:%7B%22href%22:%22https://tanzu.vmware.com/support%22%7D%7D%7D)

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
