### PR TITLE
Loosen file name validation for kubernetes service bindings

### DIFF
--- a/spec/unit/lib/cloud_controller/diego/service_binding_files_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/service_binding_files_builder_spec.rb
@@ -274,6 +274,14 @@ module VCAP::CloudController::Diego
               expect { service_binding_files }.to raise_error(ServiceBindingFilesBuilder::IncompatibleBindings, 'Invalid file name: ../secret')
             end
           end
+
+          context 'when credential keys contain underscores' do
+            let(:credentials) { { some_secret: 'hidden' } }
+
+            it 'does not return an error' do
+              expect { service_binding_files }.not_to raise_error
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

The ServiceBinding spec has been updated to explicitly mention that underscores are valid in credential keys (https://github.com/servicebinding/spec/blob/main/README.md#workload-projection). Updating the implementation to match the change in teh spec

* An explanation of the use cases your change solves

Many service bindings contain underscores in the credential keys. Previously these would return an error even though the spec only stated that credential keys should match the previous regex. The spec was updated to better clarify what should be allowed in credential keys


* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
