### PR TITLE
Show warning message if setting deployment configured feature flag via API

### DIFF
--- a/app/models/runtime/feature_flag.rb
+++ b/app/models/runtime/feature_flag.rb
@@ -90,7 +90,7 @@ module VCAP::CloudController
       invalid_keys = feature_flag_overrides.keys.to_set - FeatureFlag::DEFAULT_FLAGS.keys.to_set
       raise "Invalid feature flag name(s): #{invalid_keys.to_a}" if invalid_keys.any?
 
-      invalid_values = feature_flag_overrides.select { |k,v| !v.in? [true,false] }
+      invalid_values = feature_flag_overrides.reject { |_, v| v.is_a?(TrueClass) || v.is_a?(FalseClass) }
       raise "Invalid feature flag value(s): #{invalid_values}" if invalid_values.any?
 
       feature_flag_overrides.each do |flag_name, flag_value|

--- a/app/models/runtime/feature_flag.rb
+++ b/app/models/runtime/feature_flag.rb
@@ -87,8 +87,11 @@ module VCAP::CloudController
     end
 
     def self.override_default_flags(feature_flag_overrides)
-      raise "Invalid feature flag name(s): #{feature_flag_overrides}" unless feature_flag_overrides.keys.to_set <= DEFAULT_FLAGS.keys.to_set
-      raise "Invalid feature flag value(s): #{feature_flag_overrides}" unless feature_flag_overrides.values.all? { |item| item.is_a?(TrueClass) || item.is_a?(FalseClass) }
+      invalid_keys = feature_flag_overrides.keys.to_set - FeatureFlag::DEFAULT_FLAGS.keys.to_set
+      raise "Invalid feature flag name(s): #{invalid_keys.to_a}" if invalid_keys.any?
+
+      invalid_values = feature_flag_overrides.select { |k,v| !v.in? [true,false] }
+      raise "Invalid feature flag value(s): #{invalid_values}" if invalid_values.any?
 
       feature_flag_overrides.each do |flag_name, flag_value|
         feature_flag = FeatureFlag.find(name: flag_name.to_s)

--- a/app/models/runtime/feature_flag.rb
+++ b/app/models/runtime/feature_flag.rb
@@ -37,6 +37,8 @@ module VCAP::CloudController
 
     ADMIN_READ_ONLY_SKIPPABLE = [:space_developer_env_var_visibility].freeze
 
+    @feature_flag_overrides = nil
+
     export_attributes :name, :enabled, :error_message
     import_attributes :name, :enabled, :error_message
 
@@ -104,6 +106,12 @@ module VCAP::CloudController
         feature_flag.enabled = flag_value
         feature_flag.save
       end
+
+      @feature_flag_overrides = feature_flag_overrides
+    end
+
+    def self.config_overridden?(feature_flag_name)
+      @feature_flag_overrides && @feature_flag_overrides.keys.include?(feature_flag_name.to_sym)
     end
 
     private_class_method :admin?

--- a/app/models/runtime/feature_flag.rb
+++ b/app/models/runtime/feature_flag.rb
@@ -86,6 +86,23 @@ module VCAP::CloudController
       VCAP::CloudController::SecurityContext.admin_read_only?
     end
 
+    def self.override_default_flags(feature_flag_overrides)
+      raise "Invalid feature flag name(s): #{feature_flag_overrides}" unless feature_flag_overrides.keys.to_set <= DEFAULT_FLAGS.keys.to_set
+      raise "Invalid feature flag value(s): #{feature_flag_overrides}" unless feature_flag_overrides.values.all? { |item| item.is_a?(TrueClass) || item.is_a?(FalseClass) }
+
+      feature_flag_overrides.each do |flag_name, flag_value|
+        feature_flag = FeatureFlag.find(name: flag_name.to_s)
+        if feature_flag
+          next if feature_flag.enabled == flag_value
+        else
+          feature_flag = FeatureFlag.new(name: flag_name.to_s)
+        end
+
+        feature_flag.enabled = flag_value
+        feature_flag.save
+      end
+    end
+
     private_class_method :admin?
   end
 end

--- a/config/initializers/feature_flag_overrides.rb
+++ b/config/initializers/feature_flag_overrides.rb
@@ -1,0 +1,9 @@
+module CCInitializers
+  def self.feature_flag_overrides(cc_config)
+    @logger ||= Steno.logger('cc.feature_flag_overrides')
+    @logger.info("Initializing feature_flag_overrides: #{cc_config[:feature_flag_overrides]}")
+    return unless cc_config[:feature_flag_overrides]
+
+    VCAP::CloudController::FeatureFlag.override_default_flags(cc_config[:feature_flag_overrides])
+  end
+end

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -426,7 +426,8 @@ module VCAP::CloudController
           update_metric_tags_on_rename: bool,
           app_instance_stopping_state: bool,
 
-          optional(:enable_ipv6) => bool
+          optional(:enable_ipv6) => bool,
+          optional(:feature_flag_overrides) => Hash
         }
       end
       # rubocop:enable Metrics/BlockLength

--- a/lib/cloud_controller/config_schemas/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/clock_schema.rb
@@ -218,7 +218,9 @@ module VCAP::CloudController
 
           max_labels_per_resource: Integer,
           max_annotations_per_resource: Integer,
-          custom_metric_tag_prefix_list: Array
+          custom_metric_tag_prefix_list: Array,
+
+          optional(:feature_flag_overrides) => Hash
         }
       end
       # rubocop:enable Metrics/BlockLength

--- a/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
@@ -164,7 +164,9 @@ module VCAP::CloudController
 
           max_labels_per_resource: Integer,
           max_annotations_per_resource: Integer,
-          custom_metric_tag_prefix_list: Array
+          custom_metric_tag_prefix_list: Array,
+
+          optional(:feature_flag_overrides) => Hash
         }
       end
       # rubocop:enable Metrics/BlockLength

--- a/lib/cloud_controller/config_schemas/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/worker_schema.rb
@@ -223,7 +223,9 @@ module VCAP::CloudController
           max_labels_per_resource: Integer,
           max_annotations_per_resource: Integer,
           custom_metric_tag_prefix_list: Array,
-          default_app_lifecycle: enum('buildpack', 'cnb')
+          default_app_lifecycle: enum('buildpack', 'cnb'),
+
+          optional(:feature_flag_overrides) => Hash
         }
       end
       # rubocop:enable Metrics/BlockLength

--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -288,7 +288,7 @@ module VCAP::CloudController
       end
     end
 
-    describe '.update_default_flags' do
+    describe '.override_default_flags' do
       context 'with invalid flags' do
         it 'raises an error for the one and only invalid name' do
           expect do

--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -291,27 +291,31 @@ module VCAP::CloudController
     describe '.override_default_flags' do
       context 'with invalid flags' do
         it 'raises an error for the one and only invalid name' do
+          feature_flag_overrides = { an_invalid_name: true }
           expect do
-            FeatureFlag.override_default_flags({ an_invalid_name: true })
-          end.to raise_error(/Invalid feature flag name\(s\)/)
+            FeatureFlag.override_default_flags(feature_flag_overrides)
+          end.to raise_error("Invalid feature flag name(s): [:an_invalid_name]")
         end
 
         it 'raises an error for a mix of valid and invalid names' do
+          feature_flag_overrides = { diego_docker: true, an_invalid_name: true }
           expect do
-            FeatureFlag.override_default_flags({ diego_docker: true, an_invalid_name: true })
-          end.to raise_error(/Invalid feature flag name\(s\)/)
+            FeatureFlag.override_default_flags(feature_flag_overrides)
+          end.to raise_error("Invalid feature flag name(s): [:an_invalid_name]")
         end
 
         it 'raises an error for all invalid names' do
+          feature_flag_overrides = { invalid_name1: true, invalid_name2: false }
           expect do
-            FeatureFlag.override_default_flags({ invalid_name1: true, invalid_name2: false })
-          end.to raise_error(/Invalid feature flag name\(s\)/)
+            FeatureFlag.override_default_flags(feature_flag_overrides)
+          end.to raise_error("Invalid feature flag name(s): [:invalid_name1, :invalid_name2]")
         end
 
         it 'raises an error for invalid values' do
+          feature_flag_overrides = { diego_docker: 'an invalid value', user_org_creation: false }
           expect do
-            FeatureFlag.override_default_flags({ diego_docker: 'an invalid value', user_org_creation: false })
-          end.to raise_error(/Invalid feature flag value\(s\)/)
+            FeatureFlag.override_default_flags(feature_flag_overrides)
+          end.to raise_error("Invalid feature flag value(s): {:diego_docker=>\"an invalid value\"}")
         end
       end
 

--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -294,28 +294,28 @@ module VCAP::CloudController
           feature_flag_overrides = { an_invalid_name: true }
           expect do
             FeatureFlag.override_default_flags(feature_flag_overrides)
-          end.to raise_error("Invalid feature flag name(s): [:an_invalid_name]")
+          end.to raise_error('Invalid feature flag name(s): [:an_invalid_name]')
         end
 
         it 'raises an error for a mix of valid and invalid names' do
           feature_flag_overrides = { diego_docker: true, an_invalid_name: true }
           expect do
             FeatureFlag.override_default_flags(feature_flag_overrides)
-          end.to raise_error("Invalid feature flag name(s): [:an_invalid_name]")
+          end.to raise_error('Invalid feature flag name(s): [:an_invalid_name]')
         end
 
         it 'raises an error for all invalid names' do
           feature_flag_overrides = { invalid_name1: true, invalid_name2: false }
           expect do
             FeatureFlag.override_default_flags(feature_flag_overrides)
-          end.to raise_error("Invalid feature flag name(s): [:invalid_name1, :invalid_name2]")
+          end.to raise_error('Invalid feature flag name(s): [:invalid_name1, :invalid_name2]')
         end
 
         it 'raises an error for invalid values' do
           feature_flag_overrides = { diego_docker: 'an invalid value', user_org_creation: false }
           expect do
             FeatureFlag.override_default_flags(feature_flag_overrides)
-          end.to raise_error("Invalid feature flag value(s): {:diego_docker=>\"an invalid value\"}")
+          end.to raise_error('Invalid feature flag value(s): {:diego_docker=>"an invalid value"}')
         end
       end
 

--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -237,10 +237,6 @@ module VCAP::CloudController
           FeatureFlag.override_default_flags({ key => config_value })
         end
 
-        after do
-          FeatureFlag.find(name: key.to_s)&.destroy
-        end
-
         context 'and the value is not changed by admin' do
           it 'returns the config-set value' do
             expect(FeatureFlag.enabled?(key)).to be config_value
@@ -259,10 +255,6 @@ module VCAP::CloudController
             admin_override
           end
 
-          after do
-            admin_override.destroy
-          end
-
           it 'returns the admin-set value' do
             expect(FeatureFlag.enabled?(key)).to be admin_value
           end
@@ -274,10 +266,6 @@ module VCAP::CloudController
 
         before do
           FeatureFlag.make(name: key.to_s, enabled: admin_value)
-        end
-
-        after do
-          FeatureFlag.find(name: key.to_s)&.destroy
         end
 
         it 'overwrites the existing admin-set value' do
@@ -327,12 +315,6 @@ module VCAP::CloudController
           expect do
             FeatureFlag.override_default_flags({ diego_docker: !default_diego_docker_value, user_org_creation: !default_user_org_creation_value })
           end.not_to raise_error
-        end
-
-        after do
-          %i[diego_docker user_org_creation].each do |flag_key|
-            FeatureFlag.find(name: flag_key.to_s)&.destroy
-          end
         end
 
         it 'updates values' do

--- a/spec/unit/models/runtime/feature_flag_spec.rb
+++ b/spec/unit/models/runtime/feature_flag_spec.rb
@@ -225,5 +225,126 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe 'default flag override in config' do
+      let(:key) { :diego_docker }
+      let(:default_value) { FeatureFlag::DEFAULT_FLAGS[key] }
+
+      context 'when there was no previously set conflicting value' do
+        let(:config_value) { !default_value }
+
+        before do
+          FeatureFlag.override_default_flags({ key => config_value })
+        end
+
+        after do
+          FeatureFlag.find(name: key.to_s)&.destroy
+        end
+
+        context 'and the value is not changed by admin' do
+          it 'returns the config-set value' do
+            expect(FeatureFlag.enabled?(key)).to be config_value
+          end
+        end
+
+        context 'and the value is changed by admin' do
+          let(:admin_value) { !config_value }
+          let(:admin_override) do
+            flag = FeatureFlag.find(name: key.to_s)
+            flag.enabled = admin_value
+            flag.save
+          end
+
+          before do
+            admin_override
+          end
+
+          after do
+            admin_override.destroy
+          end
+
+          it 'returns the admin-set value' do
+            expect(FeatureFlag.enabled?(key)).to be admin_value
+          end
+        end
+      end
+
+      context 'when there was previously set conflicting value' do
+        let(:admin_value) { !default_value }
+
+        before do
+          FeatureFlag.make(name: key.to_s, enabled: admin_value)
+        end
+
+        after do
+          FeatureFlag.find(name: key.to_s)&.destroy
+        end
+
+        it 'overwrites the existing admin-set value' do
+          expect(FeatureFlag.enabled?(key)).to be admin_value
+          FeatureFlag.override_default_flags({ key => !admin_value })
+          expect(FeatureFlag.enabled?(key)).to be !admin_value
+        end
+      end
+    end
+
+    describe '.update_default_flags' do
+      context 'with invalid flags' do
+        it 'raises an error for the one and only invalid name' do
+          expect do
+            FeatureFlag.override_default_flags({ an_invalid_name: true })
+          end.to raise_error(/Invalid feature flag name\(s\)/)
+        end
+
+        it 'raises an error for a mix of valid and invalid names' do
+          expect do
+            FeatureFlag.override_default_flags({ diego_docker: true, an_invalid_name: true })
+          end.to raise_error(/Invalid feature flag name\(s\)/)
+        end
+
+        it 'raises an error for all invalid names' do
+          expect do
+            FeatureFlag.override_default_flags({ invalid_name1: true, invalid_name2: false })
+          end.to raise_error(/Invalid feature flag name\(s\)/)
+        end
+
+        it 'raises an error for invalid values' do
+          expect do
+            FeatureFlag.override_default_flags({ diego_docker: 'an invalid value', user_org_creation: false })
+          end.to raise_error(/Invalid feature flag value\(s\)/)
+        end
+      end
+
+      context 'with valid flags' do
+        let(:default_diego_docker_value) { FeatureFlag::DEFAULT_FLAGS[:diego_docker] }
+        let(:default_user_org_creation_value) { FeatureFlag::DEFAULT_FLAGS[:user_org_creation] }
+
+        before do
+          expect do
+            FeatureFlag.override_default_flags({ diego_docker: !default_diego_docker_value, user_org_creation: !default_user_org_creation_value })
+          end.not_to raise_error
+        end
+
+        after do
+          %i[diego_docker user_org_creation].each do |flag_key|
+            FeatureFlag.find(name: flag_key.to_s)&.destroy
+          end
+        end
+
+        it 'updates values' do
+          expect(FeatureFlag.enabled?(:diego_docker)).to be !default_diego_docker_value
+          expect(FeatureFlag.enabled?(:user_org_creation)).to be !default_user_org_creation_value
+        end
+      end
+
+      context 'with empty flags' do
+        it 'no effect' do
+          FeatureFlag.override_default_flags({})
+          FeatureFlag::DEFAULT_FLAGS.each do |key, value|
+            expect(FeatureFlag.enabled?(key)).to eq value
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
  Implementing feature - Platform Engineer sees a warning when specifying deployment-configured feature flags

* An explanation of the use cases your change solves
  See the above.

* Links to any other associated PRs
  Depends on https://github.com/cloudfoundry/cloud_controller_ng/pull/4523.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
