### PR TITLE
Enforce from_params receives HashWithIndifferentAccess

### DIFF
--- a/app/messages/base_message.rb
+++ b/app/messages/base_message.rb
@@ -62,7 +62,7 @@ module VCAP::CloudController
     end
 
     def self.from_params(params, to_array_keys, fields: [])
-      opts = params.dup
+      opts = params.with_indifferent_access
       to_array_keys.each do |attribute|
         to_array! opts, attribute
       end


### PR DESCRIPTION
I hit https://github.com/cloudfoundry/cloud_controller_ng/issues/1521 yet again and was wondering what it might be like to finally go through and update these.  We seem to rely on unrepresentative behavior quite a bit in our tests.