### PR TITLE
Pass VCAP_PLATFORM_OPTIONS to cnb stage action

### DIFF
--- a/lib/cloud_controller/diego/cnb/staging_action_builder.rb
+++ b/lib/cloud_controller/diego/cnb/staging_action_builder.rb
@@ -45,7 +45,7 @@ module VCAP::CloudController
             path: '/tmp/lifecycle/builder',
             user: 'vcap',
             args: args,
-            env: env_vars
+            env: env_vars + platform_options_env
           )
         end
       end

--- a/spec/unit/lib/cloud_controller/diego/cnb/staging_action_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/cnb/staging_action_builder_spec.rb
@@ -173,6 +173,34 @@ module VCAP::CloudController
             let(:expected_credhub_arg) do
               { 'VCAP_PLATFORM_OPTIONS' => { 'credhub-uri' => credhub_url } }
             end
+
+            context 'when credhub url is present' do
+              context 'when the interpolation of service bindings is enabled' do
+                before do
+                  TestConfig.override(credential_references: { interpolate_service_bindings: true })
+                end
+
+                it 'sends the credhub_url in the environment variables' do
+                  result = builder.action
+                  actions = result.serial_action.actions
+
+                  expect(actions[1].run_action.env).to eq(bbs_env + expected_platform_options)
+                end
+              end
+
+              context 'when the interpolation of service bindings is disabled' do
+                before do
+                  TestConfig.override(credential_references: { interpolate_service_bindings: false })
+                end
+
+                it 'does not send the credhub_url in the environment variables' do
+                  result = builder.action
+                  actions = result.serial_action.actions
+
+                  expect(actions[1].run_action.env).to eq(bbs_env)
+                end
+              end
+            end
           end
 
           context 'when there is no buildpack cache' do


### PR DESCRIPTION
* A short explanation of the proposed change:

This passes VCAP_PLATFORM_OPTIONS if set to the staging action for cnb builds. This is the same as the buildpack staging action handler does (https://github.com/cloudfoundry/cloud_controller_ng/blob/b487f35fda27b6ddf632b19c38307d3379b8c3c8/lib/cloud_controller/diego/buildpack/staging_action_builder.rb#L38)

* An explanation of the use cases your change solves

This allows the cnbapplifecycle to resolve credhub references during staging for buildpacks to use

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
