### PR TITLE
Remove transformation of VCAP_SERVICES attributes in k8s bindings

### DIFF
--- a/lib/cloud_controller/diego/service_binding_files_builder.rb
+++ b/lib/cloud_controller/diego/service_binding_files_builder.rb
@@ -44,8 +44,7 @@ module VCAP::CloudController
           sb_hash.delete(:credentials)&.each { |k, v| total_bytesize += add_file(service_binding_files, name, k.to_s, v) }
 
           # add the rest of the hash; already existing credential keys are overwritten
-          # VCAP_SERVICES attribute names are transformed (e.g. binding_guid -> binding-guid)
-          sb_hash.each { |k, v| total_bytesize += add_file(service_binding_files, name, transform_vcap_services_attribute(k.to_s), v) }
+          sb_hash.each { |k, v| total_bytesize += add_file(service_binding_files, name, k.to_s, v) }
 
           # add the type and provider
           label = sb_hash[:label]
@@ -105,14 +104,6 @@ module VCAP::CloudController
 
       def valid_file_name?(name)
         name.match?(file_naming_convention)
-      end
-
-      def transform_vcap_services_attribute(name)
-        if %w[binding_guid binding_name instance_guid instance_name syslog_drain_url volume_mounts].include?(name)
-          name.tr('_', '-')
-        else
-          name
-        end
       end
     end
   end

--- a/spec/unit/lib/cloud_controller/diego/service_binding_files_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/service_binding_files_builder_spec.rb
@@ -12,16 +12,16 @@ module VCAP::CloudController::Diego
 
   RSpec.shared_examples 'mapping of binding metadata' do |name|
     it 'maps service binding metadata attributes to files' do
-      expect(service_binding_files.find { |f| f.path == "#{directory}/binding-guid" }).to have_attributes(content: binding.guid)
+      expect(service_binding_files.find { |f| f.path == "#{directory}/binding_guid" }).to have_attributes(content: binding.guid)
       expect(service_binding_files.find { |f| f.path == "#{directory}/name" }).to have_attributes(content: name || 'binding-name')
-      expect(service_binding_files.find { |f| f.path == "#{directory}/binding-name" }).to have_attributes(content: 'binding-name') if name.nil?
+      expect(service_binding_files.find { |f| f.path == "#{directory}/binding_name" }).to have_attributes(content: 'binding-name') if name.nil?
     end
   end
 
   RSpec.shared_examples 'mapping of instance metadata' do |instance_name|
     it 'maps service instance metadata attributes to files' do
-      expect(service_binding_files.find { |f| f.path == "#{directory}/instance-guid" }).to have_attributes(content: instance.guid)
-      expect(service_binding_files.find { |f| f.path == "#{directory}/instance-name" }).to have_attributes(content: instance_name || 'instance-name')
+      expect(service_binding_files.find { |f| f.path == "#{directory}/instance_guid" }).to have_attributes(content: instance.guid)
+      expect(service_binding_files.find { |f| f.path == "#{directory}/instance_name" }).to have_attributes(content: instance_name || 'instance-name')
     end
   end
 
@@ -130,7 +130,7 @@ module VCAP::CloudController::Diego
             expect(service_binding_files).not_to include(have_attributes(path: 'binding-name/volume_mounts'))
           end
 
-          include_examples 'expected files', %w[type provider label binding-guid name binding-name instance-guid instance-name plan tags string number boolean array hash]
+          include_examples 'expected files', %w[type provider label binding_guid name binding_name instance_guid instance_name plan tags string number boolean array hash]
 
           context 'when binding_name is nil' do
             let(:binding_name) { nil }
@@ -143,14 +143,14 @@ module VCAP::CloudController::Diego
             include_examples 'mapping of tags'
             include_examples 'mapping of credentials'
 
-            include_examples 'expected files', %w[type provider label binding-guid name instance-guid instance-name plan tags string number boolean array hash]
+            include_examples 'expected files', %w[type provider label binding_guid name instance_guid instance_name plan tags string number boolean array hash]
           end
 
           context 'when syslog_drain_url is set' do
             let(:syslog_drain_url) { 'https://syslog.drain' }
 
             it 'maps the attribute to a file' do
-              expect(service_binding_files.find { |f| f.path == 'binding-name/syslog-drain-url' }).to have_attributes(content: 'https://syslog.drain')
+              expect(service_binding_files.find { |f| f.path == 'binding-name/syslog_drain_url' }).to have_attributes(content: 'https://syslog.drain')
             end
 
             include_examples 'mapping of type and provider'
@@ -161,7 +161,7 @@ module VCAP::CloudController::Diego
             include_examples 'mapping of credentials'
 
             include_examples 'expected files',
-                             %w[type provider label binding-guid name binding-name instance-guid instance-name plan tags string number boolean array hash syslog-drain-url]
+                             %w[type provider label binding_guid name binding_name instance_guid instance_name plan tags string number boolean array hash syslog_drain_url]
           end
 
           context 'when volume_mounts is set' do
@@ -181,7 +181,7 @@ module VCAP::CloudController::Diego
 
             it 'maps the attribute to a file' do
               expect(service_binding_files.find do |f|
-                f.path == 'binding-name/volume-mounts'
+                f.path == 'binding-name/volume_mounts'
               end).to have_attributes(content: '[{"container_dir":"dir1","device_type":"type1","mode":"mode1"},{"container_dir":"dir2","device_type":"type2","mode":"mode2"}]')
             end
 
@@ -193,7 +193,7 @@ module VCAP::CloudController::Diego
             include_examples 'mapping of credentials'
 
             include_examples 'expected files',
-                             %w[type provider label binding-guid name binding-name instance-guid instance-name plan tags string number boolean array hash volume-mounts]
+                             %w[type provider label binding_guid name binding_name instance_guid instance_name plan tags string number boolean array hash volume_mounts]
           end
 
           context 'when the instance is user-provided' do
@@ -205,7 +205,7 @@ module VCAP::CloudController::Diego
             include_examples 'mapping of tags', '["an-upsi-tag","another-upsi-tag"]'
             include_examples 'mapping of credentials'
 
-            include_examples 'expected files', %w[type provider label binding-guid name binding-name instance-guid instance-name tags string number boolean array hash]
+            include_examples 'expected files', %w[type provider label binding_guid name binding_name instance_guid instance_name tags string number boolean array hash]
           end
 
           context 'when there are duplicate keys at different levels' do
@@ -218,7 +218,7 @@ module VCAP::CloudController::Diego
             include_examples 'mapping of tags'
             include_examples 'mapping of credentials', { credentials: '{"password":"secret"}' }
 
-            include_examples 'expected files', %w[type provider label binding-guid name binding-name instance-guid instance-name plan tags credentials]
+            include_examples 'expected files', %w[type provider label binding_guid name binding_name instance_guid instance_name plan tags credentials]
           end
 
           context 'when there are duplicate binding names' do


### PR DESCRIPTION
* A short explanation of the proposed change:
Remove transformation of VCAP_SERVICES attributes in k8s bindings

* An explanation of the use cases your change solves
This is not needed as per https://github.com/cloudfoundry/cloud_controller_ng/pull/4525#issuecomment-3224968354

* Links to any other associated PRs
- #4525 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
