### PR TITLE
Require azure_storage_cli_client

### DIFF
--- a/lib/cloud_controller/blobstore/client_provider.rb
+++ b/lib/cloud_controller/blobstore/client_provider.rb
@@ -5,6 +5,7 @@ require 'cloud_controller/blobstore/error_handling_client'
 require 'cloud_controller/blobstore/webdav/dav_client'
 require 'cloud_controller/blobstore/safe_delete_client'
 require 'cloud_controller/blobstore/storage_cli/storage_cli_client'
+require 'cloud_controller/blobstore/storage_cli/azure_storage_cli_client'
 require 'google/apis/errors'
 
 module CloudController


### PR DESCRIPTION
Including this require ensures the AzureRM client is registered and available.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4476
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
