### PR TITLE
Fix transient attribute 

### DIFF
--- a/app/actions/role_delete.rb
+++ b/app/actions/role_delete.rb
@@ -5,12 +5,14 @@ module VCAP::CloudController
     class RoleDeleteError < StandardError
     end
 
-    def initialize(user_audit_info, role_owner)
+    def initialize(user_audit_info, role_owner, username)
       @user_audit_info = user_audit_info
       @role_owner = role_owner
+      @username = username
     end
 
     def delete(roles)
+      @role_owner.username = @username if @username.present?
       roles.each do |role|
         Role.db.transaction do
           record_event(role)

--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -84,7 +84,7 @@ class RolesController < ApplicationController
     end
 
     role_owner = fetch_role_owner_with_name(role)
-    delete_action = RoleDeleteAction.new(user_audit_info, role_owner)
+    delete_action = RoleDeleteAction.new(user_audit_info, role_owner, role_owner.username)
     deletion_job = VCAP::CloudController::Jobs::DeleteActionJob.new(Role, role.guid, delete_action)
     pollable_job = Jobs::Enqueuer.new(queue: Jobs::Queues.generic).enqueue_pollable(deletion_job)
 

--- a/spec/unit/actions/role_delete_spec.rb
+++ b/spec/unit/actions/role_delete_spec.rb
@@ -12,7 +12,7 @@ module VCAP::CloudController
       allow(user_with_role).to receive(:username).and_return('kiwi')
     end
 
-    subject { RoleDeleteAction.new(user_audit_info, user_with_role) }
+    subject { RoleDeleteAction.new(user_audit_info, user_with_role, user_with_role.username) }
 
     describe '#delete' do
       shared_examples 'deletion' do |opts|


### PR DESCRIPTION
During queuing of **RoleDeleteAction** class, the **role_owner** object is serialized. In such cases transient attributes such as **username** will be lost and that leads to **actee_name** field in **events** table be empty string during  role delete request for space developer.

**username**  sent as argument and added as attribute to **RoleDeleteAction** class


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`
