### PR TITLE
Fix test leak of global Steno state

### DIFF
--- a/spec/unit/lib/delayed_job/delayed_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/delayed_worker_spec.rb
@@ -89,7 +89,14 @@ RSpec.describe CloudController::DelayedWorker do
   describe '#start_working' do
     let(:cc_delayed_worker) { CloudController::DelayedWorker.new(options) }
 
-    before { allow(delayed_worker).to receive(:name).and_return(options[:name]) }
+    before do
+      @steno_config_backup = Steno.config
+      allow(delayed_worker).to receive(:name).and_return(options[:name])
+    end
+
+    after do
+      Steno.init(@steno_config_backup)
+    end
 
     it 'sets up the environment and starts the worker' do
       expect(environment).to receive(:setup_environment).with(nil)


### PR DESCRIPTION
I noticed some tests flaking when using the [`tail_logs` test helper](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/support/log_helpers.rb). The cause appeared to be an extra `"worker_name"=>"test_worker"` included in the log data, which was breaking the `hash_including` matcher.

For example: https://github.com/cloudfoundry/cloud_controller_ng/actions/runs/17741913782/job/50428313694