### PR TITLE
Filter active service bindings per instance on dataset level

### DIFF
--- a/app/presenters/system_environment/system_env_presenter.rb
+++ b/app/presenters/system_environment/system_env_presenter.rb
@@ -3,9 +3,9 @@ require 'presenters/system_environment/service_binding_presenter'
 
 class SystemEnvPresenter
   def initialize(app_or_process)
+    @app_or_process = app_or_process
     @service_binding_k8s_enabled = app_or_process.service_binding_k8s_enabled
     @file_based_vcap_services_enabled = app_or_process.file_based_vcap_services_enabled
-    @service_bindings = app_or_process.service_bindings
   end
 
   def system_env
@@ -22,14 +22,8 @@ class SystemEnvPresenter
   private
 
   def service_binding_env_variables
-    latest_bindings = @service_bindings.
-                      select(&:create_succeeded?).
-                      group_by(&:service_instance_guid).
-                      values.
-                      map { |list| list.max_by(&:created_at) }
-
     services_hash = {}
-    latest_bindings.each do |service_binding|
+    @app_or_process.service_bindings_dataset.active_per_instance.each do |service_binding|
       service_name = service_binding_label(service_binding)
       services_hash[service_name.to_sym] ||= []
       services_hash[service_name.to_sym] << service_binding_env_values(service_binding)

--- a/spec/unit/lib/cloud_controller/diego/service_binding_files_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/service_binding_files_builder_spec.rb
@@ -39,9 +39,19 @@ module VCAP::CloudController::Diego
       end
 
       it 'uses the most recent binding' do
-        expect(service_binding_files.find { |f| f.path == "#{directory}/binding-guid" }).to have_attributes(content: newer_binding.guid)
+        expect(service_binding_files.find { |f| f.path == "#{directory}/binding_guid" }).to have_attributes(content: newer_binding.guid)
         expect(service_binding_files.find { |f| f.path == "#{directory}/name" }).to have_attributes(content: name || 'binding-name')
-        expect(service_binding_files.find { |f| f.path == "#{directory}/binding-name" }).to have_attributes(content: 'binding-name') if name.nil?
+        expect(service_binding_files.find { |f| f.path == "#{directory}/binding_name" }).to have_attributes(content: 'binding-name') if name.nil?
+      end
+
+      context 'when the bindings have the same created_at timestamp' do
+        let(:newer_binding_created_at) { binding_created_at }
+
+        it 'uses the most recent binding determined by highest id' do
+          expect(service_binding_files.find { |f| f.path == "#{directory}/binding_guid" }).to have_attributes(content: newer_binding.guid)
+          expect(service_binding_files.find { |f| f.path == "#{directory}/name" }).to have_attributes(content: name || 'binding-name')
+          expect(service_binding_files.find { |f| f.path == "#{directory}/binding_name" }).to have_attributes(content: 'binding-name') if name.nil?
+        end
       end
     end
   end


### PR DESCRIPTION
- 'active' means latest in state 'create succeeded' (or without any operation)
- filtering is done in SQL, not Ruby
- no duplicate code where filtering is needed

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
