### PR TITLE
Fix "require" import

### DIFF
--- a/lib/database/bigint_migration_step3ab.rb
+++ b/lib/database/bigint_migration_step3ab.rb
@@ -1,4 +1,4 @@
-require 'database/bigint_migration'
+require_relative 'bigint_migration'
 
 module VCAP::BigintMigration
   class << self


### PR DESCRIPTION
* A short explanation of the proposed change:
Fix "require" import in shared database migration code.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4591

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`
I've run the migration specs: `rake spec:serial ./spec/migrations`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
