### PR TITLE
Tighten the semantics of POST /v3/service_plans/:guid/visibility

### DIFF
--- a/app/actions/v3/service_plan_visibility_update.rb
+++ b/app/actions/v3/service_plan_visibility_update.rb
@@ -8,16 +8,21 @@ module VCAP::CloudController
       end
 
       def update(service_plan, message, append_organizations: false)
-        type = message.type
+        requested_type = message.type
         requested_org_guids = message.organizations&.pluck(:guid) || []
 
-        unprocessable!("cannot update plans with visibility type 'space'") if space?(service_plan)
+        unprocessable!("cannot update plans with visibility type 'space'") if space?(service_plan.visibility_type)
+
+        if append_organizations # i.e. POST request
+          unprocessable!("type must be 'organization'") unless org?(requested_type)
+          unprocessable!("can only append organizations to plans with visibility type 'organization'") unless org?(service_plan.visibility_type)
+        end
 
         service_plan.db.transaction do
           service_plan.lock!
-          service_plan.public = public?(type)
+          service_plan.public = public?(requested_type)
           service_plan.save
-          if org?(type)
+          if org?(requested_type)
             update_service_plan_visibilities(service_plan, requested_org_guids, append_organizations)
           else
             service_plan.remove_all_service_plan_visibilities
@@ -69,8 +74,8 @@ module VCAP::CloudController
         raise UnprocessableRequest.new(message)
       end
 
-      def space?(service_plan)
-        service_plan.visibility_type == VCAP::CloudController::ServicePlanVisibilityTypes::SPACE
+      def space?(type)
+        type == VCAP::CloudController::ServicePlanVisibilityTypes::SPACE
       end
 
       def org?(type)

--- a/app/controllers/v3/service_plan_visibility_controller.rb
+++ b/app/controllers/v3/service_plan_visibility_controller.rb
@@ -59,7 +59,7 @@ class ServicePlanVisibilityController < ApplicationController
     VCAP::CloudController::Repositories::ServiceEventRepository::WithUserActor.new(user_audit_info)
   end
 
-  def update_visibility(opts={})
+  def update_visibility(append_organizations: false)
     service_plan = ServicePlanFetcher.fetch(hashed_params[:guid])
     service_plan_not_found! unless service_plan.present? && visible_to_current_user?(plan: service_plan)
     unauthorized! unless current_user_can_write?(service_plan)
@@ -67,7 +67,7 @@ class ServicePlanVisibilityController < ApplicationController
     message = ServicePlanVisibilityUpdateMessage.new(hashed_params[:body])
     bad_request!(message.errors.full_messages) unless message.valid?
 
-    updated_service_plan = V3::ServicePlanVisibilityUpdate.new.update(service_plan, message, **opts)
+    updated_service_plan = V3::ServicePlanVisibilityUpdate.new.update(service_plan, message, append_organizations:)
     event_repository.record_service_plan_update_visibility_event(service_plan, message.audit_hash)
     updated_service_plan
   rescue V3::ServicePlanVisibilityUpdate::UnprocessableRequest => e

--- a/docs/v3/source/includes/resources/service_plan_visibility/_apply.md.erb
+++ b/docs/v3/source/includes/resources/service_plan_visibility/_apply.md.erb
@@ -28,7 +28,7 @@ Content-Type: application/json
 <%= yield_content :service_plan_visibility_response %>
 ```
 
-This endpoint applies a service plan visibility. It behaves similar to the [PATCH service plan visibility endpoint](#update-a-service-plan-visibility) but this endpoint will append to the existing list of organizations when the service plan is `organization` visible.
+This endpoint appends to the existing list of organizations. See [PATCH service plan visibility endpoint](#update-a-service-plan-visibility) to replace the existing list or change the visibility `type`.
 
 #### Definition
 `POST /v3/service_plans/:guid/visibility`
@@ -37,8 +37,8 @@ This endpoint applies a service plan visibility. It behaves similar to the [PATC
 
 Name | Type | Description
 ---- | ---- | -----------
-**type** | _string_ | Denotes the visibility of the plan; can be `public`, `admin`, `organization`, see [_list of visibility types_](#list-of-visibility-types)
-**organizations** | _array of objects_ | Desired list of organizations GUIDs where the plan will be accessible; required if `type` is `organization`
+**type** | _string_ | Denotes the visibility of the plan; must be `organization`, see [_list of visibility types_](#list-of-visibility-types)
+**organizations** | _array of objects_ | Desired list of organizations GUIDs where the plan will be accessible; required.
 
 #### Permitted roles
  |

--- a/docs/v3/source/includes/resources/service_plan_visibility/_update.md.erb
+++ b/docs/v3/source/includes/resources/service_plan_visibility/_update.md.erb
@@ -28,7 +28,7 @@ Content-Type: application/json
 <%= yield_content :new_org_service_plan_visibility %>
 ```
 
-This endpoint updates a service plan visibility. It behaves similar to the [POST service plan visibility endpoint](#apply-a-service-plan-visibility) but this endpoint will replace the existing list of organizations when the service plan is `organization` visible.
+This endpoint updates a service plan visibility. When `type` is `organization`, it will **replace** the existing list of organizations. See [POST service plan visibility endpoint](#apply-a-service-plan-visibility) to append to the existing list.
 
 #### Definition
 `PATCH /v3/service_plans/:guid/visibility`

--- a/spec/support/lifecycle_tests_helpers.rb
+++ b/spec/support/lifecycle_tests_helpers.rb
@@ -88,7 +88,7 @@ module LifecycleSpecHelper
   end
 
   def make_plan_visible(plan_guid)
-    post "v3/service_plans/#{plan_guid}/visibility", { type: 'public' }.to_json, admin_headers
+    patch "v3/service_plans/#{plan_guid}/visibility", { type: 'public' }.to_json, admin_headers
     expect(last_response).to have_status_code(200)
 
     get "v3/service_plans/#{plan_guid}/visibility", nil, admin_headers

--- a/spec/unit/actions/v3/service_plan_visibility_update_spec.rb
+++ b/spec/unit/actions/v3/service_plan_visibility_update_spec.rb
@@ -19,9 +19,17 @@ module VCAP
                 updated_plan = subject.update(service_plan, message)
                 expect(updated_plan.reload.visibility_type).to eq 'public'
               end
+
+              context "when 'append_orgs' is set to true" do
+                it 'raises an error' do
+                  expect do
+                    subject.update(service_plan, message, append_organizations: true)
+                  end.to raise_error(ServicePlanVisibilityUpdate::UnprocessableRequest, "type must be 'organization'")
+                end
+              end
             end
 
-            context 'and its being updated do "organization"' do
+            context 'and its being updated to "organization"' do
               let(:org_guid) { Organization.make.guid }
               let(:other_org_guid) { Organization.make.guid }
               let(:params) do
@@ -37,6 +45,14 @@ module VCAP
                 visible_org_guids = updated_plan.service_plan_visibilities.map(&:organization_guid)
 
                 expect(visible_org_guids).to contain_exactly(org_guid, other_org_guid)
+              end
+
+              context "when 'append_orgs' is set to true" do
+                it 'raises an error' do
+                  expect do
+                    subject.update(service_plan, message, append_organizations: true)
+                  end.to raise_error(ServicePlanVisibilityUpdate::UnprocessableRequest, "can only append organizations to plans with visibility type 'organization'")
+                end
               end
             end
           end
@@ -51,9 +67,17 @@ module VCAP
                 updated_plan = subject.update(service_plan, message)
                 expect(updated_plan.reload.visibility_type).to eq 'admin'
               end
+
+              context "when 'append_orgs' is set to true" do
+                it 'raises an error' do
+                  expect do
+                    subject.update(service_plan, message, append_organizations: true)
+                  end.to raise_error(ServicePlanVisibilityUpdate::UnprocessableRequest, "type must be 'organization'")
+                end
+              end
             end
 
-            context 'and its being updated do "organization"' do
+            context 'and its being updated to "organization"' do
               let(:org_guid) { Organization.make.guid }
               let(:other_org_guid) { Organization.make.guid }
               let(:params) do
@@ -69,6 +93,14 @@ module VCAP
                 visible_org_guids = updated_plan.service_plan_visibilities.map(&:organization_guid)
 
                 expect(visible_org_guids).to contain_exactly(org_guid, other_org_guid)
+              end
+
+              context "when 'append_orgs' is set to true" do
+                it 'raises an error' do
+                  expect do
+                    subject.update(service_plan, message, append_organizations: true)
+                  end.to raise_error(ServicePlanVisibilityUpdate::UnprocessableRequest, "can only append organizations to plans with visibility type 'organization'")
+                end
               end
             end
           end
@@ -136,6 +168,14 @@ module VCAP
                 expect(updated_plan.service_plan_visibilities).to be_empty
                 expect(ServicePlanVisibility.where(service_plan:).all).to be_empty
               end
+
+              context "when 'append_orgs' is set to true" do
+                it 'raises an error' do
+                  expect do
+                    subject.update(service_plan, message, append_organizations: true)
+                  end.to raise_error(ServicePlanVisibilityUpdate::UnprocessableRequest, "type must be 'organization'")
+                end
+              end
             end
 
             context 'and its being updated to "public"' do
@@ -146,6 +186,14 @@ module VCAP
                 expect(updated_plan.reload.visibility_type).to eq 'public'
                 expect(updated_plan.service_plan_visibilities).to be_empty
                 expect(ServicePlanVisibility.where(service_plan:).all).to be_empty
+              end
+
+              context "when 'append_orgs' is set to true" do
+                it 'raises an error' do
+                  expect do
+                    subject.update(service_plan, message, append_organizations: true)
+                  end.to raise_error(ServicePlanVisibilityUpdate::UnprocessableRequest, "type must be 'organization'")
+                end
               end
             end
           end


### PR DESCRIPTION
- Allow `POST` only when `type = organization`. Otherwise fail with `422 Unprocessable Entity`.
- Ensure the target plan already has **visibility type** `organization`. If the plan’s visibility type is not `organization`, the request fails with `422 Unprocessable Entity`.

Fixes #4606 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
