### PR TITLE
Make many-to-many additions idempotent on unique constraint violation

### DIFF
--- a/app/models/runtime/security_group.rb
+++ b/app/models/runtime/security_group.rb
@@ -17,7 +17,8 @@ module VCAP::CloudController
                  class: 'VCAP::CloudController::Space',
                  join_table: 'staging_security_groups_spaces',
                  right_key: :staging_space_id,
-                 left_key: :staging_security_group_id
+                 left_key: :staging_security_group_id,
+                 ignored_unique_constraint_violation_errors: %w[staging_security_groups_spaces_ids]
 
     add_association_dependencies spaces: :nullify, staging_spaces: :nullify
 


### PR DESCRIPTION
Adds an `ignored_unique_constraint_violation_errors` option to the many_to_many association in the `VcapRelations` Sequel plugin. When this option is provided with a list of index name patterns, any `Sequel::UniqueConstraintViolation` error that occurs during an `add_` operation on an association and matches one of the patterns will be caught. The operation is wrapped in a transaction with a savepoint, which is rolled back upon catching the specific error, effectively making the addition idempotent. This prevents race conditions where concurrent requests attempt to add the same association. This issue can be observed when a user makes two POST requests at the same time to create a new resource instance.

This new option is applied to the `staging_spaces relationship` in the `SecurityGroup` model to handle potential concurrent updates. Further models will updated in separate commits.


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
