### PR TITLE
Cloud Foundry do not parse SB response and do not include custom metadata

### DIFF
--- a/app/models/services/managed_service_instance.rb
+++ b/app/models/services/managed_service_instance.rb
@@ -12,16 +12,16 @@ module VCAP::CloudController
 
     export_attributes :name, :credentials, :service_plan_guid,
                       :space_guid, :gateway_data, :dashboard_url, :type, :last_operation,
-                      :tags, :maintenance_info
+                      :tags, :maintenance_info, :broker_metadata
 
     import_attributes :name, :service_plan_guid,
-                      :space_guid, :gateway_data, :maintenance_info
+                      :space_guid, :gateway_data, :maintenance_info, :broker_metadata
 
     strip_attributes :name
 
     plugin :after_initialize
 
-    serialize_attributes :json, :maintenance_info
+    serialize_attributes :json, :maintenance_info, :broker_metadata
 
     def validation_policies
       if space

--- a/db/migrations/20251023214733_add_broker_metadata_to_service_instances.rb
+++ b/db/migrations/20251023214733_add_broker_metadata_to_service_instances.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :service_instances do
+      add_column :broker_metadata, String, text: true
+    end
+  end
+end

--- a/lib/services/service_brokers/v2/client.rb
+++ b/lib/services/service_brokers/v2/client.rb
@@ -56,7 +56,8 @@ module VCAP::Services::ServiceBrokers::V2
       return_values = {
         instance: {
           credentials: {},
-          dashboard_url: parsed_response['dashboard_url']
+          dashboard_url: parsed_response['dashboard_url'],
+          broker_metadata: parsed_response['metadata']
         },
         last_operation: {
           type: 'create',
@@ -203,6 +204,7 @@ module VCAP::Services::ServiceBrokers::V2
       }
 
       attributes[:dashboard_url] = dashboard_url if dashboard_url
+      attributes[:broker_metadata] = parsed_response['metadata'] if parsed_response['metadata']
 
       if state == 'in progress'
         proposed_changes = { service_plan_guid: plan.guid }

--- a/lib/services/service_brokers/v2/response_parser.rb
+++ b/lib/services/service_brokers/v2/response_parser.rb
@@ -263,6 +263,17 @@ module VCAP::Services
               'operation' => {
                 'type' => 'string',
                 'maxLength' => 10_000
+              },
+              'metadata' => {
+                'type' => 'object',
+                'properties' => {
+                  'labels' => {
+                    'type' => 'object'
+                  },
+                  'attributes' => {
+                    'type' => 'object'
+                  }
+                }
               }
             }
           }]
@@ -292,6 +303,17 @@ module VCAP::Services
               'operation' => {
                 'type' => 'string',
                 'maxLength' => 10_000
+              },
+              'metadata' => {
+                'type' => 'object',
+                'properties' => {
+                  'labels' => {
+                    'type' => 'object'
+                  },
+                  'attributes' => {
+                    'type' => 'object'
+                  }
+                }
               }
             }
           }]


### PR DESCRIPTION
* **A short explanation of the proposed change**:

Tanzu Data service tiles (like Postgres) bundle a specific engine version (e.g., Postgres 16.6), but this version is not visible on the ServiceInstance object in Cloud Foundry. This makes it hard for users to know which version they are consuming.

The Open Service Broker API (OSBI) already has a ServiceInstanceMetadata field to store this type of information, Even if the on-demand-service-broker (ODB) propagate the metadata it is not consumed during parsing in CAPI.

* **An explanation of the use cases your change solves**

This change makes the service version visible in Cloud Foundry by using the existing OSBI metadata field. This is a three-part process:

Service Adapter: The service-adapter (e.g., the Postgres tile's adapter) will be updated to add the engine version as a key-value pair in the tags section of the BOSH manifest it generates (e.g., postgres_version: "16.6").

On-Demand Service Broker (ODB): The ODB will be modified to read this new version tag from the manifest. The ODB will then take this value and populate the Metadata field in its ProvisionedServiceSpec and UpdateServiceSpec responses to Cloud Foundry.

Cloud Controller  will parse that metadata and merge with labels that comes from the Service Broker. The labels which comes from Service Broker will be shown only if the SI is managed.


* **Links to any other associated PRs**

1. **postgres-tile**  https://github.gwd.broadcom.net/TNZ/postgres-tile/pull/394
2. **on-demand-service-broke**r https://github.com/pivotal-cf/on-demand-service-broker/pull/439


* [Yes ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [Yes] I have viewed, signed, and submitted the Contributor License Agreement

* [ Yes] I have made this pull request to the `main` branch

* [Yes ] I have run all the unit tests using `bundle exec rake`

* [ No] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
