### PR TITLE
Add unique index for route bindings

### DIFF
--- a/app/actions/service_route_binding_create.rb
+++ b/app/actions/service_route_binding_create.rb
@@ -37,6 +37,10 @@ module VCAP::CloudController
             MetadataUpdate.update(b, message)
           end
         end
+      rescue Sequel::ValidationFailed => e
+        raise e unless e.errors.on(%i[route_id service_instance_id])&.include?(:unique)
+
+        already_exists!
       end
 
       class RouteBindingAlreadyExists < StandardError; end

--- a/app/models/services/route_binding.rb
+++ b/app/models/services/route_binding.rb
@@ -67,6 +67,15 @@ module VCAP::CloudController
       self
     end
 
+    def around_save
+      yield
+    rescue Sequel::UniqueConstraintViolation => e
+      raise e unless e.message.include?('route_bindings_route_id_service_instance_id_index')
+
+      errors.add(%i[route_id service_instance_id], :unique)
+      raise validation_failed_error
+    end
+
     private
 
     def validate_routing_service

--- a/db/migrations/20251028135214_route_bindings_unique_index.rb
+++ b/db/migrations/20251028135214_route_bindings_unique_index.rb
@@ -1,0 +1,47 @@
+Sequel.migration do
+  up do
+    transaction do
+      # Remove duplicate entries if they exist
+      duplicates = self[:route_bindings].
+                   select(:route_id, :service_instance_id).
+                   group(:route_id, :service_instance_id).
+                   having { count(:id) > 1 }
+
+      duplicates.each do |dup|
+        ids_to_remove = self[:route_bindings].
+                        where(route_id: dup[:route_id], service_instance_id: dup[:service_instance_id]).
+                        select(:id).
+                        order(:id).
+                        offset(1).
+                        map(:id)
+
+        self[:route_bindings].where(id: ids_to_remove).delete
+      end
+
+      alter_table(:route_bindings) do
+        # Cannot add unique constraint concurrently as it requires a transaction
+        # rubocop:disable Sequel/ConcurrentIndex
+        unless @db.indexes(:route_bindings).key?(:route_bindings_route_id_service_instance_id_index)
+          add_index %i[route_id service_instance_id], unique: true,
+                                                      name: :route_bindings_route_id_service_instance_id_index
+        end
+        # rubocop:enable Sequel/ConcurrentIndex
+      end
+    end
+  end
+
+  down do
+    # rubocop:disable Sequel/ConcurrentIndex
+    if database_type == :mysql
+      # MySQL replaces the auto generate 'route_id' index with 'route_bindings_route_id_service_instance_id_index' but does not re-create it during down migration
+      alter_table(:route_bindings) { add_index :route_id, name: :route_id unless @db.indexes(:route_bindings).key?(:route_id) }
+    end
+    alter_table(:route_bindings) do
+      if @db.indexes(:route_bindings).key?(:route_bindings_route_id_service_instance_id_index)
+        drop_index %i[route_id service_instance_id], unique: true,
+                                                     name: :route_bindings_route_id_service_instance_id_index
+      end
+    end
+    # rubocop:enable Sequel/ConcurrentIndex
+  end
+end

--- a/spec/migrations/20251028135214_route_bindings_unique_index_spec.rb
+++ b/spec/migrations/20251028135214_route_bindings_unique_index_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'route bindings unique index', isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20251028135214_route_bindings_unique_index.rb' }
+  end
+
+  let(:space) { VCAP::CloudController::Space.make }
+  let(:service_instance_1) { VCAP::CloudController::ServiceInstance.make(space:) }
+  let(:service_instance_2) { VCAP::CloudController::ServiceInstance.make(space:) }
+  let(:route_1) { VCAP::CloudController::Route.make(space:) }
+  let(:route_2) { VCAP::CloudController::Route.make(space:) }
+
+  describe 'route_bindings table' do
+    context 'up migration' do
+      it 'is in the correct state before migration' do
+        expect(db.indexes(:route_bindings)).not_to include(:route_bindings_route_id_service_instance_id_index)
+      end
+
+      it 'removes duplicates and migrates successfully by adding unique index' do
+        db[:route_bindings].insert(route_id: route_1.id, service_instance_id: service_instance_1.id, guid: SecureRandom.uuid)
+        db[:route_bindings].insert(route_id: route_1.id, service_instance_id: service_instance_1.id, guid: SecureRandom.uuid)
+        db[:route_bindings].insert(route_id: route_2.id, service_instance_id: service_instance_1.id, guid: SecureRandom.uuid)
+        db[:route_bindings].insert(route_id: route_1.id, service_instance_id: service_instance_2.id, guid: SecureRandom.uuid)
+        db[:route_bindings].insert(route_id: route_2.id, service_instance_id: service_instance_2.id, guid: SecureRandom.uuid)
+        db[:route_bindings].insert(route_id: route_2.id, service_instance_id: service_instance_2.id, guid: SecureRandom.uuid)
+        db[:route_bindings].insert(route_id: route_2.id, service_instance_id: service_instance_2.id, guid: SecureRandom.uuid)
+
+        # Count duplicates before migration
+        expect(db[:route_bindings].where(service_instance_id: service_instance_1.id, route_id: route_1.id).count).to eq(2)
+        expect(db[:route_bindings].where(service_instance_id: service_instance_1.id, route_id: route_2.id).count).to eq(1)
+        expect(db[:route_bindings].where(service_instance_id: service_instance_2.id, route_id: route_1.id).count).to eq(1)
+        expect(db[:route_bindings].where(service_instance_id: service_instance_2.id, route_id: route_2.id).count).to eq(3)
+
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+
+        # Verify duplicates are removed after migration
+        expect(db[:route_bindings].where(service_instance_id: service_instance_1.id, route_id: route_1.id).count).to eq(1)
+        expect(db[:route_bindings].where(service_instance_id: service_instance_1.id, route_id: route_2.id).count).to eq(1)
+        expect(db[:route_bindings].where(service_instance_id: service_instance_2.id, route_id: route_1.id).count).to eq(1)
+        expect(db[:route_bindings].where(service_instance_id: service_instance_2.id, route_id: route_2.id).count).to eq(1)
+
+        # Verify index is added
+        expect(db.indexes(:route_bindings)).to include(:route_bindings_route_id_service_instance_id_index)
+      end
+
+      it 'does not fail if indexes/constraints are already in desired state' do
+        db.alter_table(:route_bindings) { add_index %i[route_id service_instance_id], unique: true, name: :route_bindings_route_id_service_instance_id_index }
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+      end
+    end
+
+    context 'down migration' do
+      it 'rolls back successfully' do
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
+        expect(db.indexes(:route_bindings)).not_to include(:route_bindings_route_id_service_instance_id_index)
+        expect(db.indexes(:route_bindings)).to include(:route_id) if db.database_type == :mysql
+      end
+
+      it 'does not fail if indexes/constraints are already in desired state' do
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+        db.alter_table(:route_bindings) { drop_index %i[route_id service_instance_id], unique: true, name: :route_bindings_route_id_service_instance_id_index }
+        expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
In case of concurrent requests/inserts duplicated entries in the `route_bindings` table might be created. This change adds a new migration which removes duplicates and adds a unique constraint. Additionally the error handling is adjusted so that `UniqueConstraintViolation` errors are rescued correctly.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
