### PR TITLE
Ignore unique errors for domain, route & service instances

### DIFF
--- a/app/models/runtime/domain.rb
+++ b/app/models/runtime/domain.rb
@@ -67,7 +67,8 @@ module VCAP::CloudController
       join_table: 'organizations_private_domains',
       left_key: :private_domain_id,
       right_key: :organization_id,
-      before_add: :validate_add_shared_organization
+      before_add: :validate_add_shared_organization,
+      ignored_unique_constraint_violation_errors: %w[orgs_pd_ids]
     )
 
     add_association_dependencies(

--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -31,7 +31,8 @@ module VCAP::CloudController
                  right_key: :target_space_guid,
                  right_primary_key: :guid,
                  join_table: :route_shares,
-                 class: VCAP::CloudController::Space
+                 class: VCAP::CloudController::Space,
+                 ignored_unique_constraint_violation_errors: %w[route_shares.PRIMARY route_target_space_pk]
 
     one_to_one :route_binding
     one_through_one :service_instance, join_table: :route_bindings

--- a/app/models/services/service_instance.rb
+++ b/app/models/services/service_instance.rb
@@ -42,7 +42,8 @@ module VCAP::CloudController
                  right_key: :target_space_guid,
                  right_primary_key: :guid,
                  join_table: :service_instance_shares,
-                 class: VCAP::CloudController::Space
+                 class: VCAP::CloudController::Space,
+                 ignored_unique_constraint_violation_errors: %w[service_instance_shares.PRIMARY service_instance_target_space_pk]
 
     many_to_many :routes, join_table: :route_bindings
 


### PR DESCRIPTION
Commit `8b932f9f9498d2d222b981aa7dc5db7a6d16dcf7` (PR #4611) introduced the  option to ignore `UniqueConstraintViolation`` errors for specified indexes/ constraints/ keys. This change does the same for the domain, route and service instance model.

The ignore logic is already tested in the vcap_relations plugin (see #4611).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
