### PR TITLE
Deployment Updater: Print error class name in case of unexpected error

### DIFF
--- a/lib/cloud_controller/deployment_updater/updater.rb
+++ b/lib/cloud_controller/deployment_updater/updater.rb
@@ -59,7 +59,7 @@ module VCAP::CloudController
           if APPROVED_ERRORS.include?(e.class)
             deployment.update(error: e.message)
           else
-            deployment.update(error: 'An unexpected error has occurred.')
+            deployment.update(error: "An unexpected error has occurred: #{error_name}")
           end
         rescue StandardError => new_error
           logger.error(

--- a/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
+++ b/spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb
@@ -184,7 +184,7 @@ module VCAP::CloudController
             subject.scale
           end.not_to raise_error
 
-          expect(deployment.error).to eq 'An unexpected error has occurred.'
+          expect(deployment.error).to eq 'An unexpected error has occurred: StandardError'
         end
       end
     end
@@ -396,7 +396,7 @@ module VCAP::CloudController
             subject.canary
           end.not_to raise_error
 
-          expect(deployment.error).to eq 'An unexpected error has occurred.'
+          expect(deployment.error).to eq 'An unexpected error has occurred: StandardError'
         end
       end
     end
@@ -429,7 +429,7 @@ module VCAP::CloudController
             subject.cancel
           end.not_to raise_error
 
-          expect(deployment.error).to eq 'An unexpected error has occurred.'
+          expect(deployment.error).to eq 'An unexpected error has occurred: StandardError'
         end
       end
     end
@@ -460,7 +460,7 @@ module VCAP::CloudController
 
           it 'provides a helpful error on the deployment model' do
             subject.scale
-            expect(deployment.error).to eq 'An unexpected error has occurred.'
+            expect(deployment.error).to eq 'An unexpected error has occurred: StandardError'
           end
         end
 


### PR DESCRIPTION
* A short explanation of the proposed change:

Log a bit more information if there is an unexpected exception in the deployment updater.

* An explanation of the use cases your change solves

Helps to trace down the root cause.

* Links to any other associated PRs

New storage cli configuration was missing for deployment_updater job and at first we didn't find a helpful error message:
https://github.com/cloudfoundry/capi-release/pull/583

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`
Only `./spec/unit/lib/cloud_controller/deployment_updater/updater_spec.rb`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
