### PR TITLE
Adapt deployment updater schema for storage cli

### DIFF
--- a/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
@@ -14,6 +14,12 @@ module VCAP::CloudController
           },
 
           pid_filename: String, # Pid filename to use
+
+          optional(:storage_cli_config_file_buildpacks) => String,
+          optional(:storage_cli_config_file_packages) => String,
+          optional(:storage_cli_config_file_resource_pool) => String,
+          optional(:storage_cli_config_file_droplets) => String,
+
           readiness_port: {
             deployment_updater: Integer
           },


### PR DESCRIPTION
Adapt also deployment updater schema for storage cli usage like for api, worker and clock in #4581

* An explanation of the use cases your change solves
See #4581
* Links to any other associated PRs
#4581
* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
