### PR TITLE
Include pending tasks in quota calculations 

### DIFF
--- a/app/models/runtime/constraints/max_log_rate_limit_policy.rb
+++ b/app/models/runtime/constraints/max_log_rate_limit_policy.rb
@@ -69,7 +69,9 @@ class TaskMaxLogRateLimitPolicy < BaseMaxLogRateLimitPolicy
   private
 
   def additional_checks
-    IGNORED_STATES.exclude?(resource.state)
+    IGNORED_STATES.exclude?(resource.state) &&
+      # Skipping the TaskMaxLogRateLimitPolicy if the task is transitioning from PENDING to RUNNING state as it might be already running on Diego
+      resource.column_change(:state) != [VCAP::CloudController::TaskModel::PENDING_STATE, VCAP::CloudController::TaskModel::RUNNING_STATE]
   end
 
   def field

--- a/app/models/runtime/constraints/max_memory_policy.rb
+++ b/app/models/runtime/constraints/max_memory_policy.rb
@@ -56,7 +56,9 @@ class TaskMaxMemoryPolicy < BaseMaxMemoryPolicy
   private
 
   def additional_checks
-    IGNORED_STATES.exclude?(resource.state)
+    IGNORED_STATES.exclude?(resource.state) &&
+      # Skipping the TaskMaxMemoryPolicy if the task is transitioning from PENDING to RUNNING state as it might be already running on Diego
+      resource.column_change(:state) != [VCAP::CloudController::TaskModel::PENDING_STATE, VCAP::CloudController::TaskModel::RUNNING_STATE]
   end
 
   def field

--- a/app/models/runtime/organization.rb
+++ b/app/models/runtime/organization.rb
@@ -228,7 +228,7 @@ module VCAP::CloudController
     end
 
     def memory_used
-      started_app_memory + running_task_memory
+      started_app_memory + running_task_memory + pending_task_memory
     end
 
     def has_remaining_memory(mem)
@@ -333,11 +333,15 @@ module VCAP::CloudController
     end
 
     def log_rate_limit_remaining
-      quota_definition.log_rate_limit - (started_app_log_rate_limit + running_task_log_rate_limit)
+      quota_definition.log_rate_limit - (started_app_log_rate_limit + running_task_log_rate_limit + pending_task_log_rate_limit)
     end
 
     def running_task_memory
       tasks_dataset.where(state: TaskModel::RUNNING_STATE).sum(:memory_in_mb) || 0
+    end
+
+    def pending_task_memory
+      tasks_dataset.where(state: TaskModel::PENDING_STATE).sum(:memory_in_mb) || 0
     end
 
     def started_app_memory
@@ -346,6 +350,10 @@ module VCAP::CloudController
 
     def running_task_log_rate_limit
       tasks_dataset.where(state: TaskModel::RUNNING_STATE).sum(:log_rate_limit) || 0
+    end
+
+    def pending_task_log_rate_limit
+      tasks_dataset.where(state: TaskModel::PENDING_STATE).sum(:log_rate_limit) || 0
     end
 
     def started_app_log_rate_limit

--- a/app/models/runtime/space.rb
+++ b/app/models/runtime/space.rb
@@ -334,7 +334,7 @@ module VCAP::CloudController
     end
 
     def memory_used
-      started_app_memory + running_task_memory
+      started_app_memory + running_task_memory + pending_task_memory
     end
 
     def running_and_pending_tasks_count
@@ -356,11 +356,15 @@ module VCAP::CloudController
     end
 
     def log_rate_limit_remaining
-      space_quota_definition.log_rate_limit - (started_app_log_rate_limit + running_task_log_rate_limit)
+      space_quota_definition.log_rate_limit - (started_app_log_rate_limit + running_task_log_rate_limit + pending_task_log_rate_limit)
     end
 
     def running_task_memory
       tasks_dataset.where(state: TaskModel::RUNNING_STATE).sum(:memory_in_mb) || 0
+    end
+
+    def pending_task_memory
+      tasks_dataset.where(state: TaskModel::PENDING_STATE).sum(:memory_in_mb) || 0
     end
 
     def started_app_memory
@@ -369,6 +373,10 @@ module VCAP::CloudController
 
     def running_task_log_rate_limit
       tasks_dataset.where(state: TaskModel::RUNNING_STATE).sum(:log_rate_limit) || 0
+    end
+
+    def pending_task_log_rate_limit
+      tasks_dataset.where(state: TaskModel::PENDING_STATE).sum(:log_rate_limit) || 0
     end
 
     def started_app_log_rate_limit

--- a/spec/unit/models/runtime/constraints/max_log_rate_limit_policy_spec.rb
+++ b/spec/unit/models/runtime/constraints/max_log_rate_limit_policy_spec.rb
@@ -169,5 +169,12 @@ RSpec.describe 'max log_rate_limit policies' do
         expect(validator).to validate_without_error(task)
       end
     end
+
+    context 'when the task state changes from PENDING to RUNNING' do
+      it 'does not register error' do
+        allow(task).to receive(:column_change).with(:state).and_return([VCAP::CloudController::TaskModel::PENDING_STATE, VCAP::CloudController::TaskModel::RUNNING_STATE])
+        expect(validator).to validate_without_error(task)
+      end
+    end
   end
 end

--- a/spec/unit/models/runtime/constraints/max_memory_policy_spec.rb
+++ b/spec/unit/models/runtime/constraints/max_memory_policy_spec.rb
@@ -82,5 +82,12 @@ RSpec.describe 'max memory policies' do
         expect(validator).to validate_without_error(task)
       end
     end
+
+    context 'when the task state changes from PENDING to RUNNING' do
+      it 'does not register error' do
+        allow(task).to receive(:column_change).with(:state).and_return([VCAP::CloudController::TaskModel::PENDING_STATE, VCAP::CloudController::TaskModel::RUNNING_STATE])
+        expect(validator).to validate_without_error(task)
+      end
+    end
   end
 end


### PR DESCRIPTION
When creating tasks in parallel, a race condition could lead to quota over-commitment. Tasks are first created in a `PENDING` state, which was not included in quota calculations. This allowed multiple tasks to be created and submitted to Diego for execution, even if their combined resource usage exceeded the defined quota.
When the task's state was subsequently updated, the model validation would fail due to the exceeded quota, incorrectly marking the task as `FAILED`. This created a state mismatch, as the task had already been successfully submitted to Diego.

This change resolves the issue by including `PENDING` tasks in the memory and log rate limit calculations, treating the state as a desired state similar to apps. This prevents the initial over-submission of tasks.

Additionally, the quota validation is now skipped when a task transitions from `PENDING` to `RUNNING`. This ensures that a task successfully submitted to Diego is correctly reflected as `RUNNING` in the Cloud Controller database, aligning the desired state with the action taken.

Fixes #4619 


* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
