### PR TITLE
When ordering by 'created_at', add another order by 'id'

### DIFF
--- a/spec/request_spec_shared_examples.rb
+++ b/spec/request_spec_shared_examples.rb
@@ -363,8 +363,8 @@ RSpec.shared_examples 'list endpoint order_by timestamps' do |endpoint|
 
   context 'order_by created_at' do
     let!(:resource_1) { resource_klass.make(guid: '1', created_at: '2020-05-26T18:47:03Z', **additional_resource_params) }
-    let!(:resource_2) { resource_klass.make(guid: '2', created_at: '2020-05-26T18:47:02Z', **additional_resource_params) }
-    let!(:resource_3) { resource_klass.make(guid: '3', created_at: '2020-05-26T18:47:01Z', **additional_resource_params) }
+    let!(:resource_2) { resource_klass.make(guid: '3', created_at: '2020-05-26T18:47:02Z', **additional_resource_params) }
+    let!(:resource_3) { resource_klass.make(guid: '2', created_at: '2020-05-26T18:47:02Z', **additional_resource_params) }
     let!(:resource_4) { resource_klass.make(guid: '4', created_at: '2020-05-26T18:47:04Z', **additional_resource_params) }
 
     it 'sorts ascending' do

--- a/spec/support/bootstrap/fake_model_tables.rb
+++ b/spec/support/bootstrap/fake_model_tables.rb
@@ -278,7 +278,7 @@ class FakeModelTables
   def tables_for_sequel_paginator_spec
     db.create_table :table_without_guid do
       primary_key :id
-      DateTime :created_at
+      String :name
     end
   end
 


### PR DESCRIPTION
This ensures a chronological order of records with the same `created_at` timestamp.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
