### PR TITLE
Fix race condition in route destination updates

### DIFF
--- a/app/actions/update_route_destinations.rb
+++ b/app/actions/update_route_destinations.rb
@@ -92,9 +92,9 @@ module VCAP::CloudController
           end
 
           update_processes(processes_to_ports_map)
-        end
 
-        route.reload
+          route.reload
+        end
 
         route
       end


### PR DESCRIPTION
Move `route.reload` inside the transaction block to ensure the returned route reflects a consistent state. Previously, a concurrent request could modify or delete the route between transaction commit and reload.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
