### PR TITLE
Fix route options serialization to preserve explicitly removed values

### DIFF
--- a/app/models/runtime/route.rb
+++ b/app/models/runtime/route.rb
@@ -74,8 +74,9 @@ module VCAP::CloudController
       cleaned_opts = remove_hash_options_for_non_hash_loadbalancing(opts)
       rounded_opts = round_hash_balance_to_one_decimal(cleaned_opts)
       normalized_opts = normalize_hash_balance_to_string(rounded_opts)
-      # Remove nil values after all processing
-      normalized_opts = normalized_opts.compact if normalized_opts.is_a?(Hash)
+      # Convert nil values to empty strings to signal explicit removal to downstream consumers (e.g. gorouter),
+      # so they can distinguish "option was explicitly removed" from "option was never set".
+      normalized_opts = normalized_opts.transform_values { |v| v.nil? ? '' : v } if normalized_opts.is_a?(Hash)
       self.options_without_serialization = Oj.dump(normalized_opts)
     end
 

--- a/spec/unit/actions/manifest_route_update_spec.rb
+++ b/spec/unit/actions/manifest_route_update_spec.rb
@@ -650,8 +650,7 @@ module VCAP::CloudController
             ManifestRouteUpdate.update(app.guid, message, user_audit_info)
 
             route.reload
-            expect(route.options).to eq({})
-            expect(route.options).not_to have_key('loadbalancing')
+            expect(route.options).to eq({ 'loadbalancing' => '' })
             expect(route.options).not_to have_key('hash_header')
             expect(route.options).not_to have_key('hash_balance')
           end

--- a/spec/unit/actions/route_update_spec.rb
+++ b/spec/unit/actions/route_update_spec.rb
@@ -209,7 +209,7 @@ module VCAP::CloudController
             expect(message).to be_valid
             subject.update(route:, message:)
             route.reload
-            expect(route.options).to eq({})
+            expect(route.options).to eq({ 'loadbalancing' => '' })
           end
 
           it 'notifies the backend' do
@@ -299,7 +299,7 @@ module VCAP::CloudController
             subject.update(route:, message:)
             route.reload
             expect(route.options).to include({ 'loadbalancing' => 'hash', 'hash_header' => 'foobar' })
-            expect(route.options).not_to have_key('hash_balance')
+            expect(route.options['hash_balance']).to eq('')
           end
 
           it 'notifies the backend' do
@@ -502,7 +502,7 @@ module VCAP::CloudController
             expect(message).to be_valid
             subject.update(route:, message:)
             route.reload
-            expect(route.options).to eq({})
+            expect(route.options).to eq({ 'loadbalancing' => '' })
           end
 
           it 'notifies the backend' do

--- a/spec/unit/models/runtime/route_spec.rb
+++ b/spec/unit/models/runtime/route_spec.rb
@@ -1346,6 +1346,23 @@ module VCAP::CloudController
         end
       end
 
+      context 'when setting an option value to nil' do
+        it 'serializes nil values as empty strings to signal explicit removal' do
+          route = Route.make(
+            host: 'test-route',
+            domain: domain,
+            space: space,
+            options: { loadbalancing: 'round-robin' }
+          )
+
+          route.update(options: { loadbalancing: nil })
+          route.reload
+
+          parsed_options = Oj.load(route.options_without_serialization)
+          expect(parsed_options['loadbalancing']).to eq('')
+        end
+      end
+
       context 'when using string keys instead of symbols' do
         it 'still removes hash options for non-hash loadbalancing' do
           route = Route.make(


### PR DESCRIPTION
## Summary

When a route option (e.g., `loadbalancing`) is explicitly removed via the API, the value is set to `nil` internally. The `options=` setter previously called `.compact` on the options hash, which removed nil keys entirely from the serialized JSON. This made the resulting `"options":{}` indistinguishable from a route that never had options set, preventing downstream consumers (e.g., gorouter) from detecting the explicit removal and reverting to the platform default.

Fixes https://github.com/cloudfoundry/routing-release/issues/551
   
## Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                            
- Replace `.compact` with `.transform_values { |v| v.nil? ? '' : v }` in `Route#options_with_serialization=`, so that explicitly removed options are serialized as empty strings (e.g., `"options":{"loadbalancing":""}`) instead of being dropped                                                                                                                                                                                                                                     
- Update assertions in `route_update_spec.rb` and `manifest_route_update_spec.rb` to expect `{ 'loadbalancing' => '' }` instead of `{}`
- Add a new model-level test in `route_spec.rb` that explicitly verifies nil option values are serialized as empty strings                                                                                                                                                                                                                                                                                                                                                             
   
## Context                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                            
This is the Cloud Controller counterpart to a gorouter issue (https://github.com/cloudfoundry/routing-release/issues/551) that adds support for reverting a per-route load balancing algorithm to the platform default. Without this CC change, the removal signal is lost before it reaches gorouter via NATS. 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
