### PR TITLE
fix doc: metadata.annotations keys should not allow spaces

### DIFF
--- a/docs/v3/source/includes/concepts/_metadata.md.erb
+++ b/docs/v3/source/includes/concepts/_metadata.md.erb
@@ -37,8 +37,8 @@ Only annotations with a prefix (e.g. `company.com/contacts`) are sent to service
 
 Examples may include (but are not limited to):
 
-- `"contact info": "bob@example.com jane@example.com"`
-- `"library versions": "Spring: 5.1, Redis Client: a184098. yaml parser: 38"`
+- `"contact-info": "bob@example.com jane@example.com"`
+- `"library-versions": "Spring: 5.1, Redis Client: a184098. yaml parser: 38"`
 - `"git-sha": "d56fe0367554ae5e878e37ed6c5b9a82f5995512"`
 
 #### Annotation keys

--- a/spec/unit/messages/validators/metadata_validator_spec.rb
+++ b/spec/unit/messages/validators/metadata_validator_spec.rb
@@ -81,6 +81,15 @@ module VCAP::CloudController::Validators
       end
 
       describe 'invalid keys' do
+        context 'when the key contains a space' do
+          let(:labels) { { 'potato mashed' => 'value' } }
+
+          it 'is invalid' do
+            expect(subject).not_to be_valid
+            expect(subject.errors_on(:metadata)).to include("label key error: 'potato mashed' contains invalid characters")
+          end
+        end
+
         context 'when the key contains one invalid character' do
           # for the 32nd-126th characters, excluding the ones inside of the %r()
           (32.chr..126.chr).to_a.reject { |c| %r{[\w\-._/\s]}.match(c) }.each do |c|
@@ -363,6 +372,15 @@ module VCAP::CloudController::Validators
           it 'does not run validations' do
             expect(subject).to be_valid
           end
+        end
+      end
+
+      context 'when the annotations key contains a space' do
+        let(:annotations) { { 'potato mashed' => 'value' } }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors_on(:metadata)).to include("annotation key error: 'potato mashed' contains invalid characters")
         end
       end
 


### PR DESCRIPTION
- the validation logic in app/messages/metadata_validator_helper.rb does not allow spaces in keys
- added a relevant test case
- fixed the examples provided in doc

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
