### PR TITLE
Include route in error messages for manifest route updates

### DIFF
--- a/app/actions/manifest_route_update.rb
+++ b/app/actions/manifest_route_update.rb
@@ -18,14 +18,16 @@ module VCAP::CloudController
           app_guid => app
         }
         routes_to_map = []
+        current_route = nil
 
         message.manifest_route_mappings.each do |manifest_route_mapping|
+          current_route = manifest_route_mapping[:route].to_s
           route = {
             model: find_or_create_valid_route(app, manifest_route_mapping[:route].to_hash, user_audit_info),
             protocol: manifest_route_mapping[:protocol]
           }
 
-          raise InvalidRoute.new("No domains exist for route #{manifest_route_mapping[:route]}") if route[:model].blank?
+          raise InvalidRoute.new("No domains exist for route #{current_route}") if route[:model].blank?
 
           routes_to_map << route
         end
@@ -53,7 +55,8 @@ module VCAP::CloudController
             end
           end
       rescue Sequel::ValidationFailed, RouteCreate::Error, RouteUpdate::Error => e
-        raise InvalidRoute.new(e.message)
+        route_info = current_route ? "For route '#{current_route}': " : ''
+        raise InvalidRoute.new("#{route_info}#{e.message}")
       end
 
       private

--- a/app/actions/manifest_route_update.rb
+++ b/app/actions/manifest_route_update.rb
@@ -24,7 +24,8 @@ module VCAP::CloudController
           current_route = manifest_route_mapping[:route].to_s
           route = {
             model: find_or_create_valid_route(app, manifest_route_mapping[:route].to_hash, user_audit_info),
-            protocol: manifest_route_mapping[:protocol]
+            protocol: manifest_route_mapping[:protocol],
+            route_string: current_route
           }
 
           raise InvalidRoute.new("No domains exist for route #{current_route}") if route[:model].blank?
@@ -35,6 +36,7 @@ module VCAP::CloudController
         # map route to app, but do this only if the full message contains valid routes
         routes_to_map.
           each do |route|
+            current_route = route[:route_string]
             route_mapping = RouteMappingModel.find(app: app, route: route[:model])
             if route_mapping.nil?
               UpdateRouteDestinations.add(
@@ -57,6 +59,9 @@ module VCAP::CloudController
       rescue Sequel::ValidationFailed, RouteCreate::Error, RouteUpdate::Error => e
         route_info = current_route ? "For route '#{current_route}': " : ''
         raise InvalidRoute.new("#{route_info}#{e.message}")
+      rescue UpdateRouteDestinations::Error => e
+        route_info = current_route ? "For route '#{current_route}': " : ''
+        raise UpdateRouteDestinations::Error.new("#{route_info}#{e.message}")
       end
 
       private

--- a/spec/unit/actions/manifest_route_update_spec.rb
+++ b/spec/unit/actions/manifest_route_update_spec.rb
@@ -312,7 +312,10 @@ module VCAP::CloudController
               it 'throws an error' do
                 expect do
                   ManifestRouteUpdate.update(app.guid, message, user_audit_info)
-                end.to raise_error(VCAP::CloudController::UpdateRouteDestinations::Error, 'Cannot use \'http2\' protocol for tcp routes; valid options are: [tcp].')
+                end.to raise_error(
+                  VCAP::CloudController::UpdateRouteDestinations::Error,
+                  %r{For route 'http://tcp.tomato.avocado-toast.com:1234': Cannot use 'http2' protocol for tcp routes; valid options are: \[tcp\]}
+                )
               end
             end
           end
@@ -492,7 +495,10 @@ module VCAP::CloudController
           it 'raises an error indicating hash_header is required' do
             expect do
               ManifestRouteUpdate.update(app.guid, message, user_audit_info)
-            end.to raise_error(ManifestRouteUpdate::InvalidRoute, /Hash header must be present when loadbalancing is set to hash./)
+            end.to raise_error(
+              ManifestRouteUpdate::InvalidRoute,
+              %r{For route 'http://potato.tomato.avocado-toast.com/some-path': Hash header must be present when loadbalancing is set to hash.}
+            )
           end
         end
 


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: fix the issue https://github.com/cloudfoundry/cloud_controller_ng/issues/4971

Output during cf push with my change:
```

    buildpacks:
      nodejs_buildpack
+   routes:
+   - options:
+       loadbalancing: hash
+     route: hash-invalid.cfapps.aws-cfn07.aws.cfn.sapcloud.io
+   - options:
+       hash_balance: 1.25
+       loadbalancing: hash
+     route: hash-no-header.cfapps.aws-cfn07.aws.cfn.sapcloud.io
+   - options:
+       hash_header: hash-header
+       loadbalancing: hash
+     route: hash-no-balance.cfapps.aws-cfn07.aws.cfn.sapcloud.io
  version: 1
For application 'retry-test': For route 'hash-invalid.cfapps.aws-cfn07.aws.cfn.sapcloud.io': Hash header must be present when loadbalancing is set to hash.
```

* Links to any other associated PRs: related to hash-based routing implementation in [PR#4746](https://github.com/cloudfoundry/cloud_controller_ng/pull/4746) 

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
