### PR TITLE
Increase diego-ssh RSA host key from 2048 to 4096 bits

### DIFF
--- a/lib/cloud_controller/diego/ssh_key.rb
+++ b/lib/cloud_controller/diego/ssh_key.rb
@@ -8,7 +8,7 @@ module VCAP
   module CloudController
     module Diego
       class SSHKey
-        def initialize(bits=2048)
+        def initialize(bits=4096)
           @bits = bits
         end
 


### PR DESCRIPTION
Strengthen the SSH host key used by diego-sshd in LRPs by changing the default RSA key size from 2048 to 4096 bits.

Issue: https://github.com/cloudfoundry/capi-release/issues/643

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)

