### PR TITLE
Fix race condition in ProcessesSync causing SSH key mismatch

### DIFF
--- a/lib/cloud_controller/diego/processes_sync.rb
+++ b/lib/cloud_controller/diego/processes_sync.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController
         @bump_freshness = true
         diego_lrps = bbs_apps_client.fetch_scheduling_infos.index_by { |d| d.desired_lrp_key.process_guid }
         logger.info('fetched-scheduling-infos')
-        to_desire = []
+        to_desire = {}
         to_update = {}
         batched_processes_for_sync do |processes|
           processes.each do |process|
@@ -29,7 +29,7 @@ module VCAP::CloudController
             diego_lrp = diego_lrps.delete(process_guid)
 
             if diego_lrp.nil?
-              to_desire.append(process.id)
+              to_desire[process.id] = process_guid
             elsif process.updated_at.to_f.to_s != diego_lrp.annotation
               to_update[process.id] = diego_lrp
             end
@@ -87,7 +87,10 @@ module VCAP::CloudController
       def update_lrps(to_update)
         batched_processes(to_update.keys) do |processes|
           processes.each do |process|
-            workpool.submit(process, to_update[process.id]) do |p, l|
+            existing_lrp = to_update[process.id]
+            next if ProcessGuid.from_process(process) != existing_lrp.desired_lrp_key.process_guid
+
+            workpool.submit(process, existing_lrp) do |p, l|
               logger.info('updating-lrp', process_guid: p.guid, app_guid: p.app_guid)
               bbs_apps_client.update_app(p, l)
               logger.info('update-lrp', process_guid: p.guid)
@@ -97,8 +100,11 @@ module VCAP::CloudController
       end
 
       def desire_lrps(to_desire)
-        batched_processes(to_desire) do |processes|
+        batched_processes(to_desire.keys) do |processes|
           processes.each do |process|
+            desired_process_guid = to_desire[process.id]
+            next if ProcessGuid.from_process(process) != desired_process_guid
+
             workpool.submit(process) do |p|
               logger.info('desiring-lrp', process_guid: p.guid, app_guid: p.app_guid)
               bbs_apps_client.desire_app(p)

--- a/spec/isolated_specs/processes_sync_spec.rb
+++ b/spec/isolated_specs/processes_sync_spec.rb
@@ -121,6 +121,22 @@ module VCAP::CloudController
             expect(bbs_apps_client).to have_received(:bump_freshness).once
           end
 
+          context 'when the stale process gets a new version between fetching for sync (only guid + version + created_at) and fetching for actual update (full model)' do
+            before do
+              allow(subject).to receive(:update_lrps).and_wrap_original do |method, *args|
+                stale_process.set_new_version
+                stale_process.save
+                method.call(*args)
+              end
+            end
+
+            it 'skips the (obsolete) update' do
+              allow(bbs_apps_client).to receive(:update_app)
+              subject.sync
+              expect(bbs_apps_client).not_to have_received(:update_app)
+            end
+          end
+
           context 'when the process is a cnb app' do
             let(:app) { AppModel.make(:cnb, droplet: DropletModel.make(:cnb)) }
             let!(:stale_process) { ProcessModel.make(:cnb, state: 'STARTED', app: app) }
@@ -251,6 +267,22 @@ module VCAP::CloudController
             subject.sync
             expect(bbs_apps_client).to have_received(:desire_app).with(missing_process)
             expect(bbs_apps_client).to have_received(:bump_freshness).once
+          end
+
+          context 'when the missing process gets a new version between fetching for sync (only guid + version + created_at) and fetching for actual creation (full model)' do
+            before do
+              allow(subject).to receive(:desire_lrps).and_wrap_original do |method, *args|
+                missing_process.set_new_version
+                missing_process.save
+                method.call(*args)
+              end
+            end
+
+            it 'skips the (obsolete) creation' do
+              allow(bbs_apps_client).to receive(:desire_app)
+              subject.sync
+              expect(bbs_apps_client).not_to have_received(:desire_app)
+            end
           end
 
           context 'when desiring app fails' do


### PR DESCRIPTION
### A short explanation of the proposed change:
The ProcessSync job could update an LRP with stale SSH route data from a previous version when the process version changed between the initial scan and the batch execution. As a result, the LRP has a different RSA key pair for the diego-sshd daemon and the diego-ssh route. "cf ssh" is broken until the app is manually restarted.

Fix: Before executing desire/update, verify the process version still matches what was recorded during the initial scan. Skip if mismatched - the next sync cycle will handle it correctly.

### An explanation of the use cases your change solves
Detailed diagram of the race condition:

```mermaid
sequenceDiagram
participant CC as Cloud Controller<br/>(ccdb)
participant PS as ProcessesSync<br/>cloud_controller_clock
participant BBS as Diego BBS

Note over CC,BBS: Initial state: process p1-v1, keypair k1, timestamp t1

PS->>BBS: fetch_desired_lrps → [p1-v1, annotation=t1]
PS->>CC: fetch_processes → [p1-v1, updated_at=t1]
Note over PS: annotations match → nothing to do

Note over CC,BBS: User restarts app (1st restart)
CC->>CC: process: guid=p1, version=v1→v2, updated_at=t2a
CC->>BBS: delete desired LRP p1-v1
CC->>BBS: desire_lrp p1-v2 (keypair k2, annotation=t2b)

Note over PS: ProcessesSync starts again
PS->>BBS: fetch_desired_lrps → [p1-v2, annotation=t2b]
PS->>CC: fetch_processes → [p1-v2, updated_at=t2a]
Note over PS: t2a ≠ t2b → add p1 to update list
Note over PS: The timestamp mismatch is already fixed with ccng PR 4935
Note over PS: 💤 sleep 15s (simulated delay)

Note over CC,BBS: User restarts app (2nd restart) during sleep
CC->>CC: process: guid=p1, version=v2→v3, updated_at=t3a
CC->>BBS: delete desired LRP p1-v2
CC->>BBS: desire_lrp p1-v3 (keypair k3, annotation=t3b)
Note over BBS: BBS now has p1-v3 with k3 in route AND action ✓

Note over PS: sleep ends → resume update_lrps
PS->>CC: reload process by id p1 → gets version v3 (updated_at=t3a)
PS->>BBS: update_desired_lrp p1-v3<br/>routes: k2 (copied from stale p1-v2 snapshot!)<br/>action: not updatable → stays k3

Note over BBS: ❌ BBS now has p1-v3:<br/>diego-ssh route → k2<br/>diego-sshd action → k3<br/>MISMATCH!

Note over CC,BBS: cf ssh fails until app is restarted again
```

The key mechanics that make this work:

- Line 88: update_lrps reloads the process from ccdb by id (gets v3) — so it uses the current process version as the target LRP guid
- Line 92: but it calls build_app_lrp_update(existing_lrp) where existing_lrp is the stale snapshot fetched at the start of the sync cycle (p1-v2 with k2)
- build_app_lrp_update copies the SSH route from that stale existing_lrp → k2 goes into the update
- BBS UpdateDesiredLRP cannot touch run_info (action) → k3 stays
- Result: route has k2, sshd has k3

### Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/4935

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats) -> ran CATs against cf-deployment v54.13.0
