### PR TITLE
Add default ORDER BY id to Sequel model queries

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -173,6 +173,7 @@ RSpec/BeforeAfterAll:
     - 'spec/integration/app_log_emitter_spec.rb'
     - 'spec/integration/cors_spec.rb'
     - 'spec/isolated_specs/inline_runner_spec.rb'
+    - 'spec/unit/lib/sequel/extensions/default_order_by_id_spec.rb'
     - 'spec/unit/lib/vcap/rest_api/event_query_spec.rb'
     - 'spec/unit/lib/vcap/rest_api/query_spec.rb'
 

--- a/app/models/runtime/buildpack_lifecycle_data_model.rb
+++ b/app/models/runtime/buildpack_lifecycle_data_model.rb
@@ -28,8 +28,7 @@ module VCAP::CloudController
     one_to_many :buildpack_lifecycle_buildpacks,
                 class: '::VCAP::CloudController::BuildpackLifecycleBuildpackModel',
                 key: :buildpack_lifecycle_data_guid,
-                primary_key: :guid,
-                order: :id
+                primary_key: :guid
     plugin :nested_attributes
     nested_attributes :buildpack_lifecycle_buildpacks, destroy: true
     add_association_dependencies buildpack_lifecycle_buildpacks: :destroy

--- a/app/models/runtime/cnb_lifecycle_data_model.rb
+++ b/app/models/runtime/cnb_lifecycle_data_model.rb
@@ -27,8 +27,7 @@ module VCAP::CloudController
     one_to_many :buildpack_lifecycle_buildpacks,
                 class: '::VCAP::CloudController::BuildpackLifecycleBuildpackModel',
                 key: :cnb_lifecycle_data_guid,
-                primary_key: :guid,
-                order: :id
+                primary_key: :guid
     plugin :nested_attributes
     nested_attributes :buildpack_lifecycle_buildpacks, destroy: true
     add_association_dependencies buildpack_lifecycle_buildpacks: :destroy

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -5,6 +5,7 @@ require 'cloud_controller/db_connection/finalizer'
 require 'cloud_controller/execution_context'
 require 'sequel/extensions/query_length_logging'
 require 'sequel/extensions/request_query_metrics'
+require 'sequel/extensions/default_order_by_id'
 
 module VCAP::CloudController
   class DB
@@ -45,6 +46,7 @@ module VCAP::CloudController
       add_connection_expiration_extension(db, opts)
       add_connection_validator_extension(db, opts)
       db.extension(:requires_unique_column_names_in_subquery)
+      db.extension(:default_order_by_id)
       add_connection_metrics_extension(db)
       db
     end

--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -5,6 +5,7 @@ require 'cloud_controller/db_connection/finalizer'
 require 'cloud_controller/execution_context'
 require 'sequel/extensions/query_length_logging'
 require 'sequel/extensions/request_query_metrics'
+require 'sequel/extensions/default_order_by_id'
 
 module VCAP::CloudController
   class DB
@@ -32,7 +33,7 @@ module VCAP::CloudController
         db.logger = logger
         db.sql_log_level = opts[:log_level]
         db.extension :caller_logging
-        db.caller_logging_ignore = /sequel_paginator|query_length_logging|sequel_pg|paginated_collection_renderer|request_query_metrics/
+        db.caller_logging_ignore = /sequel_paginator|query_length_logging|sequel_pg|paginated_collection_renderer|request_query_metrics|default_order_by_id/
         db.caller_logging_formatter = lambda do |caller|
           "(#{caller.sub(%r{^.*/cloud_controller_ng/}, '')})"
         end
@@ -45,6 +46,8 @@ module VCAP::CloudController
       add_connection_expiration_extension(db, opts)
       add_connection_validator_extension(db, opts)
       db.extension(:requires_unique_column_names_in_subquery)
+      db.extension(:sql_comments)
+      db.extension(:default_order_by_id)
       add_connection_metrics_extension(db)
       db
     end

--- a/lib/cloud_controller/diego/constants.rb
+++ b/lib/cloud_controller/diego/constants.rb
@@ -1,3 +1,5 @@
+require 'diego/lrp_constants'
+
 module VCAP::CloudController
   module Diego
     STAGING_DOMAIN                   = 'cf-app-staging'.freeze

--- a/lib/cloud_controller/diego/reporters/instances_reporter.rb
+++ b/lib/cloud_controller/diego/reporters/instances_reporter.rb
@@ -1,6 +1,6 @@
 require 'utils/workpool'
+require 'cloud_controller/diego/constants'
 require 'cloud_controller/diego/reporters/reporter_mixins'
-require 'diego/lrp_constants'
 
 module VCAP::CloudController
   module Diego

--- a/lib/sequel/extensions/default_order_by_id.rb
+++ b/lib/sequel/extensions/default_order_by_id.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+# Sequel extension that adds default ORDER BY id to model queries.
+#
+# Hooks into fetch methods (all, each, first) to add ORDER BY id just before
+# execution. This ensures ordering is only added to the final query, not to
+# subqueries or compound query parts.
+#
+# Skips default ordering when:
+# - Query already has explicit ORDER BY
+# - Query is incompatible (GROUP BY, compounds, DISTINCT ON, from_self)
+# - Query is schema introspection (LIMIT 0)
+# - Model doesn't have id as primary key
+# - id is not in the select list
+#
+# For JOIN queries with SELECT *, uses qualified column (table.id) to avoid
+# ambiguity.
+#
+# Ensures deterministic query results for consistent API responses and
+# reliable test behavior.
+#
+# Usage:
+#   DB.extension(:default_order_by_id)
+#
+module Sequel
+  module DefaultOrderById
+    module DatasetMethods
+      def all(*, &)
+        id_col = id_column_for_order
+        return super unless id_col
+
+        order(id_col).all(*, &)
+      end
+
+      def each(*, &)
+        id_col = id_column_for_order
+        return super unless id_col
+
+        order(id_col).each(*, &)
+      end
+
+      def first(*, &)
+        id_col = id_column_for_order
+        return super unless id_col
+
+        order(id_col).first(*, &)
+      end
+
+      private
+
+      def id_column_for_order
+        return if already_ordered? || incompatible_with_order? || not_a_data_query? || !model_has_id_primary_key?
+
+        find_id_column
+      end
+
+      def already_ordered?
+        opts[:order]
+      end
+
+      def incompatible_with_order?
+        opts[:group] ||       # Aggregated results don't have individual ids
+          opts[:compounds] || # Compound queries (e.g. UNION) have own ordering
+          distinct_on? ||     # DISTINCT ON requires matching ORDER BY
+          from_self?          # Outer query handles ordering
+      end
+
+      def distinct_on?
+        opts[:distinct].is_a?(Array) && opts[:distinct].any?
+      end
+
+      def from_self?
+        opts[:from].is_a?(Array) && opts[:from].any? { |f| f.is_a?(Sequel::SQL::AliasedExpression) }
+      end
+
+      def not_a_data_query?
+        opts[:limit] == 0 # Schema introspection query
+      end
+
+      def model_has_id_primary_key?
+        return false unless respond_to?(:model) && model
+
+        model.primary_key == :id
+      end
+
+      def find_id_column
+        select_cols = opts[:select]
+
+        if select_cols.nil? || select_cols.empty?
+          # SELECT * includes id
+          if opts[:join]
+            # Qualify to avoid ambiguity with joined tables
+            return Sequel.qualify(model.table_name, :id)
+          end
+
+          return :id
+        end
+
+        select_cols.each do |col|
+          # SELECT table.* includes id
+          return :id if col.is_a?(Sequel::SQL::ColumnAll) && col.table == model.table_name
+
+          id_col = extract_id_column(col)
+          return id_col if id_col
+        end
+
+        nil
+      end
+
+      def extract_id_column(col)
+        case col
+        when Symbol
+          col if col == :id || col.to_s.end_with?('__id')
+        when Sequel::SQL::Identifier
+          col if col.value == :id
+        when Sequel::SQL::QualifiedIdentifier
+          col if col.column == :id
+        when Sequel::SQL::AliasedExpression
+          # ORDER BY uses the alias, not the original expression
+          col.alias if col.alias == :id
+        end
+      end
+    end
+  end
+
+  Dataset.register_extension(:default_order_by_id, DefaultOrderById::DatasetMethods)
+end

--- a/lib/sequel/extensions/default_order_by_id.rb
+++ b/lib/sequel/extensions/default_order_by_id.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# Sequel extension that adds default ORDER BY id to model queries.
+#
+# Hooks into fetch methods (all, each, first) to add ORDER BY id just before
+# execution. This ensures ordering is only added to the final query, not to
+# subqueries or compound query parts.
+#
+# Skips default ordering when:
+# - Query already has explicit ORDER BY
+# - Query is incompatible (GROUP BY, compounds, DISTINCT ON, from_self)
+# - Query is schema introspection (LIMIT 0)
+# - Model doesn't have id as primary key
+# - id is not in the select list
+#
+# For JOIN queries with SELECT *, uses qualified column (table.id) to avoid
+# ambiguity.
+#
+# Ensures deterministic query results for consistent API responses and
+# reliable test behavior.
+#
+# Usage:
+#   DB.extension(:sql_comments)
+#   DB.extension(:default_order_by_id)
+#
+module Sequel
+  module DefaultOrderById
+    module DatasetMethods
+      def all(*, &)
+        ds = default_order_by_id
+        return super unless ds
+
+        ds.all(*, &)
+      end
+
+      def each(*, &)
+        ds = default_order_by_id
+        return super unless ds
+
+        ds.each(*, &)
+      end
+
+      def first(*, &)
+        ds = default_order_by_id
+        return super unless ds
+
+        ds.first(*, &)
+      end
+
+      private
+
+      def default_order_by_id
+        id_col = id_column_for_order
+        return unless id_col
+
+        order(id_col).comment('default_order_by_id')
+      end
+
+      def id_column_for_order
+        return if already_ordered? || incompatible_with_order? || not_a_data_query? || !model_has_id_primary_key?
+
+        find_id_column
+      end
+
+      def already_ordered?
+        opts[:order]
+      end
+
+      def incompatible_with_order?
+        opts[:group] ||       # Aggregated results don't have individual ids
+          opts[:compounds] || # Compound queries (e.g. UNION) have own ordering
+          distinct_on? ||     # DISTINCT ON requires matching ORDER BY
+          from_self?          # Outer query handles ordering
+      end
+
+      def distinct_on?
+        opts[:distinct].is_a?(Array) && opts[:distinct].any?
+      end
+
+      def from_self?
+        opts[:from].is_a?(Array) && opts[:from].any? { |f| f.is_a?(Sequel::SQL::AliasedExpression) && f.expression.is_a?(Sequel::Dataset) }
+      end
+
+      def not_a_data_query?
+        opts[:limit] == 0 # Schema introspection query
+      end
+
+      def model_has_id_primary_key?
+        return false unless respond_to?(:model) && model
+
+        model.primary_key == :id
+      end
+
+      def find_id_column
+        select_cols = opts[:select]
+
+        if select_cols.nil? || select_cols.empty?
+          # SELECT * includes id
+          if opts[:join]
+            # Qualify to avoid ambiguity with joined tables
+            return Sequel.qualify(model.table_name, :id)
+          end
+
+          return :id
+        end
+
+        select_cols.each do |col|
+          # SELECT table.* includes id
+          return :id if col.is_a?(Sequel::SQL::ColumnAll) && col.table == model.table_name
+
+          id_col = extract_id_column(col)
+          return id_col if id_col
+        end
+
+        nil
+      end
+
+      def extract_id_column(col)
+        return col if id_expression?(col)
+
+        return col.alias if col.is_a?(Sequel::SQL::AliasedExpression) && id_expression?(col.expression)
+
+        nil
+      end
+
+      def id_expression?(expr)
+        case expr
+        when Symbol
+          expr == :id || expr.to_s.end_with?('__id')
+        when Sequel::SQL::Identifier
+          expr.value == :id
+        when Sequel::SQL::QualifiedIdentifier
+          expr.column == :id
+        else
+          false
+        end
+      end
+    end
+  end
+
+  Dataset.register_extension(:default_order_by_id, DefaultOrderById::DatasetMethods)
+end

--- a/spec/lightweight_db_spec_helper.rb
+++ b/spec/lightweight_db_spec_helper.rb
@@ -1,0 +1,5 @@
+require 'lightweight_spec_helper'
+require 'sequel'
+require 'support/bootstrap/db_connection_string'
+
+DB = Sequel.connect(DbConnectionString.new.to_s)

--- a/spec/support/bootstrap/db_config.rb
+++ b/spec/support/bootstrap/db_config.rb
@@ -1,9 +1,10 @@
 require 'cloud_controller/db'
 require 'cloud_controller/database_parts_parser'
+require_relative 'db_connection_string'
 
 class DbConfig
   def initialize(connection_string: ENV.fetch('DB_CONNECTION_STRING', nil), db_type: ENV.fetch('DB', nil))
-    @connection_string = connection_string || default_connection_string(db_type || 'postgres')
+    @connection_string = DbConnectionString.new(connection_string: connection_string, db_type: db_type).to_s
     initialize_environment_for_cc_spawning
   end
 
@@ -48,26 +49,5 @@ class DbConfig
 
   def initialize_environment_for_cc_spawning
     ENV['DB_CONNECTION_STRING'] = connection_string
-  end
-
-  def default_connection_string(db_type)
-    "#{default_connection_prefix(db_type)}/#{default_name}"
-  end
-
-  def default_connection_prefix(db_type)
-    default_connection_prefixes = {
-      'mysql' => ENV['MYSQL_CONNECTION_PREFIX'] || 'mysql2://root:password@localhost:3306',
-      'postgres' => ENV['POSTGRES_CONNECTION_PREFIX'] || 'postgres://postgres@localhost:5432'
-    }
-
-    default_connection_prefixes[db_type]
-  end
-
-  def default_name
-    if ENV['TEST_ENV_NUMBER'].presence
-      "cc_test_#{ENV.fetch('TEST_ENV_NUMBER')}"
-    else
-      'cc_test_1'
-    end
   end
 end

--- a/spec/support/bootstrap/db_connection_string.rb
+++ b/spec/support/bootstrap/db_connection_string.rb
@@ -1,0 +1,28 @@
+class DbConnectionString
+  def initialize(connection_string: ENV.fetch('DB_CONNECTION_STRING', nil), db_type: ENV.fetch('DB', nil))
+    @connection_string = connection_string || default_connection_string(db_type)
+  end
+
+  def to_s
+    @connection_string
+  end
+
+  private
+
+  def default_connection_string(db_type)
+    "#{default_connection_prefix(db_type)}/#{default_name}"
+  end
+
+  def default_connection_prefix(db_type)
+    postgres = ENV.fetch('POSTGRES_CONNECTION_PREFIX', 'postgres://postgres@localhost:5432')
+    {
+      'mysql' => ENV.fetch('MYSQL_CONNECTION_PREFIX', 'mysql2://root:password@localhost:3306'),
+      'postgres' => postgres
+    }.fetch(db_type, postgres)
+  end
+
+  def default_name
+    test_env_number = ENV.fetch('TEST_ENV_NUMBER', '')
+    test_env_number.empty? ? 'cc_test_1' : "cc_test_#{test_env_number}"
+  end
+end

--- a/spec/unit/lib/sequel/extensions/default_order_by_id_spec.rb
+++ b/spec/unit/lib/sequel/extensions/default_order_by_id_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sequel/extensions/default_order_by_id'
+
+RSpec.describe 'Sequel::DefaultOrderById' do
+  let(:model_class) { VCAP::CloudController::Organization }
+  let(:db) { model_class.db }
+
+  def capture_sql(&)
+    sqls = []
+    db.loggers << (logger = Class.new do
+      define_method(:info) { |msg| sqls << msg if msg.include?('SELECT') }
+      define_method(:debug) { |_| }
+      define_method(:error) { |_| }
+    end.new)
+    yield
+    db.loggers.delete(logger)
+    sqls.last
+  end
+
+  describe 'default ordering' do
+    it 'adds ORDER BY id to model queries' do
+      sql = capture_sql { model_class.dataset.first }
+      expect(sql).to match(/ORDER BY .id./)
+    end
+  end
+
+  describe 'already_ordered?' do
+    it 'preserves explicit ORDER BY' do
+      sql = capture_sql { model_class.dataset.order(:name).first }
+      expect(sql).to match(/ORDER BY .name./)
+      expect(sql).not_to match(/ORDER BY .id./)
+    end
+  end
+
+  describe 'incompatible_with_order?' do
+    it 'skips for GROUP BY' do
+      ds = model_class.dataset.group(:status)
+      expect(ds.sql).not_to match(/ORDER BY/)
+    end
+
+    it 'skips for compound queries (UNION)' do
+      ds1 = model_class.dataset.where(name: 'a')
+      ds2 = model_class.dataset.where(name: 'b')
+      sql = capture_sql { ds1.union(ds2, all: true, from_self: false).all }
+      expect(sql).not_to match(/\) ORDER BY/)
+    end
+
+    it 'skips for DISTINCT ON' do
+      sql = capture_sql { model_class.dataset.distinct(:guid).all }
+      expect(sql).not_to match(/ORDER BY/)
+    end
+
+    it 'skips for from_self (subquery)' do
+      sql = capture_sql { model_class.dataset.where(name: 'a').from_self.all }
+      expect(sql).to match(/AS .t1.$/)
+    end
+  end
+
+  describe 'not_a_data_query?' do
+    it 'skips for schema introspection (columns!)' do
+      sql = capture_sql { model_class.dataset.columns! }
+      expect(sql).not_to match(/ORDER BY/)
+    end
+  end
+
+  describe 'model_has_id_primary_key?' do
+    it 'skips for models with non-id primary key' do
+      guid_pk_model = Class.new(Sequel::Model(db[:organizations])) do
+        set_primary_key :guid
+      end
+      sql = capture_sql { guid_pk_model.dataset.first }
+      expect(sql).not_to match(/ORDER BY/)
+    end
+  end
+
+  describe 'find_id_column' do
+    context 'with SELECT *' do
+      it 'uses unqualified :id' do
+        sql = capture_sql { model_class.dataset.first }
+        expect(sql).to match(/ORDER BY .id./)
+        expect(sql).not_to match(/ORDER BY .organizations.\..id./)
+      end
+
+      it 'uses qualified column for JOIN to avoid ambiguity' do
+        sql = capture_sql { model_class.dataset.join(:spaces, organization_id: :id).first }
+        expect(sql).to match(/ORDER BY .organizations.\..id./)
+      end
+    end
+
+    context 'with SELECT table.*' do
+      it 'uses unqualified :id' do
+        sql = capture_sql { model_class.dataset.select(Sequel::SQL::ColumnAll.new(:organizations)).join(:spaces, organization_id: :id).first }
+        expect(sql).to match(/ORDER BY .id./)
+        expect(sql).not_to match(/ORDER BY .organizations.\..id./)
+      end
+    end
+
+    context 'with qualified id in select list' do
+      it 'uses the qualified column' do
+        sql = capture_sql { model_class.dataset.select(:organizations__id, :organizations__name).first }
+        expect(sql).to match(/ORDER BY .organizations.\..id./)
+      end
+    end
+
+    context 'with aliased id in select list' do
+      it 'uses the alias' do
+        sql = capture_sql { model_class.dataset.select(Sequel.as(:organizations__id, :id), :name).first }
+        expect(sql).to match(/ORDER BY .id./)
+      end
+    end
+
+    context 'without id in select list' do
+      it 'skips ordering' do
+        sql = capture_sql { model_class.dataset.select(:guid, :name).all }
+        expect(sql).not_to match(/ORDER BY/)
+      end
+    end
+  end
+end

--- a/spec/unit/lib/sequel/extensions/default_order_by_id_spec.rb
+++ b/spec/unit/lib/sequel/extensions/default_order_by_id_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'lightweight_db_spec_helper'
+require 'sequel/extensions/default_order_by_id'
+
+DB.extension(:sql_comments)
+DB.extension(:default_order_by_id)
+
+RSpec.describe 'Sequel::DefaultOrderById' do
+  let(:db) { DB }
+
+  let(:model_class) { Class.new(Sequel::Model(db[:test_default_order_main])) }
+
+  before(:all) do
+    DB.create_table?(:test_default_order_main) do
+      primary_key :id
+      String :name
+      String :guid
+      String :status
+    end
+    DB.create_table?(:test_default_order_join) do
+      primary_key :id
+      foreign_key :main_id, :test_default_order_main
+    end
+  end
+
+  after(:all) do
+    DB.drop_table?(:test_default_order_join)
+    DB.drop_table?(:test_default_order_main)
+  end
+
+  def capture_sql(&)
+    sqls = []
+    db.loggers << (logger = Class.new do
+      define_method(:info) { |msg| sqls << msg if msg.include?('SELECT') }
+      define_method(:debug) { |_| }
+      define_method(:error) { |_| }
+    end.new)
+    yield
+    sqls.last
+  ensure
+    db.loggers.delete(logger)
+  end
+
+  describe 'default ordering' do
+    it 'adds ORDER BY id to model queries' do
+      sql = capture_sql { model_class.dataset.all }
+      expect(sql).to match(/ORDER BY .id./)
+    end
+
+    it 'annotates queries with an SQL comment' do
+      sql = capture_sql { model_class.dataset.all }
+      expect(sql).to include('-- default_order_by_id')
+    end
+  end
+
+  describe 'already_ordered?' do
+    it 'preserves explicit ORDER BY' do
+      sql = capture_sql { model_class.dataset.order(:name).all }
+      expect(sql).to match(/ORDER BY .name./)
+    end
+  end
+
+  describe 'incompatible_with_order?' do
+    it 'skips for GROUP BY' do
+      sql = capture_sql { model_class.dataset.select_group(:status).select_append(Sequel.function(:max, :id).as(:id)).all }
+      expect(sql).not_to match(/ORDER BY/)
+    end
+
+    it 'skips for compound queries (UNION)' do
+      ds1 = model_class.dataset.where(name: 'a')
+      ds2 = model_class.dataset.where(name: 'b')
+      sql = capture_sql { ds1.union(ds2, all: true, from_self: false).all }
+      expect(sql).not_to match(/ORDER BY/)
+    end
+
+    it 'skips for DISTINCT ON' do
+      skip if db.database_type != :postgres
+
+      sql = capture_sql { model_class.dataset.distinct(:guid).all }
+      expect(sql).not_to match(/ORDER BY/)
+    end
+
+    it 'skips for from_self (subquery)' do
+      sql = capture_sql { model_class.dataset.where(name: 'a').from_self.all }
+      expect(sql).not_to match(/ORDER BY/)
+    end
+
+    it 'does not skip for table alias' do
+      sql = capture_sql { model_class.dataset.from(Sequel[:test_default_order_main].as(:aliased_table)).all }
+      expect(sql).to match(/ORDER BY .id./)
+    end
+  end
+
+  describe 'not_a_data_query?' do
+    it 'skips for schema introspection (columns!)' do
+      sql = capture_sql { model_class.dataset.columns! }
+      expect(sql).not_to match(/ORDER BY/)
+    end
+  end
+
+  describe 'model_has_id_primary_key?' do
+    it 'skips for models with non-id primary key' do
+      guid_pk_model = Class.new(Sequel::Model(db[:test_default_order_main])) do
+        set_primary_key :guid
+      end
+      sql = capture_sql { guid_pk_model.dataset.all }
+      expect(sql).not_to match(/ORDER BY/)
+    end
+  end
+
+  describe 'find_id_column' do
+    context 'with SELECT *' do
+      it 'uses unqualified :id' do
+        sql = capture_sql { model_class.dataset.all }
+        expect(sql).to match(/ORDER BY .id./)
+      end
+
+      it 'uses qualified column for JOIN to avoid ambiguity' do
+        sql = capture_sql { model_class.dataset.join(:test_default_order_join, main_id: :id).all }
+        expect(sql).to match(/ORDER BY .test_default_order_main.\..id./)
+      end
+    end
+
+    context 'with SELECT table.*' do
+      it 'uses unqualified :id' do
+        sql = capture_sql { model_class.dataset.select(Sequel::SQL::ColumnAll.new(:test_default_order_main)).join(:test_default_order_join, main_id: :id).all }
+        expect(sql).to match(/ORDER BY .id./)
+      end
+    end
+
+    context 'with qualified id in select list' do
+      it 'uses the qualified column' do
+        qualified_id = Sequel.qualify(:test_default_order_main, :id)
+        qualified_name = Sequel.qualify(:test_default_order_main, :name)
+        sql = capture_sql { model_class.dataset.select(qualified_id, qualified_name).all }
+        expect(sql).to match(/ORDER BY .test_default_order_main.\..id./)
+      end
+    end
+
+    context 'with aliased id in select list' do
+      it 'uses the alias' do
+        qualified_id = Sequel.qualify(:test_default_order_main, :id)
+        sql = capture_sql { model_class.dataset.select(Sequel.as(qualified_id, :order_id), :name).all }
+        expect(sql).to match(/ORDER BY .order_id./)
+      end
+    end
+
+    context 'without id in select list' do
+      it 'skips ordering' do
+        sql = capture_sql { model_class.dataset.select(:guid, :name).all }
+        expect(sql).not_to match(/ORDER BY/)
+      end
+    end
+  end
+end

--- a/spec/unit/lib/sequel/extensions/query_length_logging_spec.rb
+++ b/spec/unit/lib/sequel/extensions/query_length_logging_spec.rb
@@ -1,8 +1,9 @@
-require 'spec_helper'
+require 'lightweight_db_spec_helper'
+require 'sequel/extensions/query_length_logging'
 
 RSpec.describe Sequel::QueryLengthLogging do
   describe 'log_connection_yield' do
-    let(:db) { DbConfig.new.connection }
+    let(:db) { DB }
     let(:logs) { StringIO.new }
     let(:logger) { Logger.new(logs) }
 


### PR DESCRIPTION
Adds a Sequel extension that hooks into fetch methods (`all`, `each`, `first`) to add `ORDER BY id` just before execution, ensuring deterministic query results for consistent API responses and reliable test behavior.

Skips ordering when incompatible (`GROUP BY`, compounds, `DISTINCT ON`, `from_self`) or unnecessary (explicit `ORDER BY`, no `id` column).

Annotate auto-ordered queries with an SQL comment via the `sql_comments` extension for traceability in query logs.

Remove now-redundant explicit `order: :id` from lifecycle data model associations. Consolidate `diego/lrp_constants` require into `cloud_controller/diego/constants`.

Introduce `lightweight_db_spec_helper` for Sequel extension specs that only need a bare DB connection without the full app bootstrap. Extract `DbConnectionString` to share connection logic between `DbConfig` and the new helper. Switch `default_order_by_id` and `query_length_logging specs` to use it.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
