### PR TITLE
Replace vcap.me with 127.0.0.1.nip.io

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -10,7 +10,7 @@ readiness_port:
   deployment_updater: -1
 
 external_protocol: http
-external_domain: api2.vcap.me
+external_domain: api2.127.0.0.1.nip.io
 temporary_disable_deployments: false
 deployment_updater:
   update_frequency_in_seconds: 30
@@ -19,7 +19,7 @@ deployment_updater:
 internal_service_hostname: api.internal.cf
 
 system_domain_organization: the-system_domain-org-name
-system_domain: vcap.me
+system_domain: 127.0.0.1.nip.io
 app_domains:
   - customer-app-domain1.com
   - name: customer-app-domain2.com

--- a/docs/v2/domains_(deprecated)/list_all_domains_(deprecated).html
+++ b/docs/v2/domains_(deprecated)/list_all_domains_(deprecated).html
@@ -373,7 +373,7 @@ Cookie: </pre>
         "updated_at": "2016-06-08T16:41:26Z"
       },
       "entity": {
-        "name": "vcap.me",
+        "name": "127.0.0.1.nip.io",
         "owning_organization_guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
         "owning_organization_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20",
         "spaces_url": "/v2/domains/ef91529f-7659-424c-96ac-68c55decb7bf/spaces"

--- a/docs/v2/info/get_info.html
+++ b/docs/v2/info/get_info.html
@@ -108,7 +108,7 @@ Cookie: </pre>
   "app_ssh_host_key_fingerprint": "47:0d:d1:c8:c3:3d:0a:36:d1:49:2f:f2:90:27:31:d0",
   "app_ssh_oauth_client": null,
   "routing_endpoint": "http://localhost:3000",
-  "logging_endpoint": "ws://loggregator.vcap.me:80"
+  "logging_endpoint": "ws://loggregator.127.0.0.1.nip.io:80"
 }</pre>
 
         <h4>Headers</h4>

--- a/docs/v2/private_domains/list_all_private_domains.html
+++ b/docs/v2/private_domains/list_all_private_domains.html
@@ -253,7 +253,7 @@ Cookie: </pre>
         "updated_at": "2016-06-08T16:41:26Z"
       },
       "entity": {
-        "name": "vcap.me",
+        "name": "127.0.0.1.nip.io",
         "owning_organization_guid": "4cf3bc47-eccd-4662-9322-7833c3bdcded",
         "owning_organization_url": "/v2/organizations/4cf3bc47-eccd-4662-9322-7833c3bdcded",
         "shared_organizations_url": "/v2/private_domains/b2a35f0c-d5ad-4a59-bea7-461711d96b0d/shared_organizations"

--- a/docs/v2/private_domains/retrieve_a_particular_private_domain.html
+++ b/docs/v2/private_domains/retrieve_a_particular_private_domain.html
@@ -103,7 +103,7 @@ Cookie: </pre>
     "updated_at": "2016-06-08T16:41:26Z"
   },
   "entity": {
-    "name": "vcap.me",
+    "name": "127.0.0.1.nip.io",
     "owning_organization_guid": "4cf3bc47-eccd-4662-9322-7833c3bdcded",
     "owning_organization_url": "/v2/organizations/4cf3bc47-eccd-4662-9322-7833c3bdcded",
     "shared_organizations_url": "/v2/private_domains/b2a35f0c-d5ad-4a59-bea7-461711d96b0d/shared_organizations"

--- a/spec/fixtures/config/port_8181_config.yml
+++ b/spec/fixtures/config/port_8181_config.yml
@@ -1,7 +1,7 @@
 ---
 local_route: 127.0.0.1
 external_port: 8181
-external_domain: api2.vcap.me
+external_domain: api2.127.0.0.1.nip.io
 tls_port: 8183
 pid_filename: /tmp/cloud_controller.8181.pid
 internal_service_hostname: cc.internal.cf

--- a/spec/request/domains_spec.rb
+++ b/spec/request/domains_spec.rb
@@ -717,7 +717,7 @@ RSpec.describe 'Domains Request' do
         before do
           TestConfig.override(
             kubernetes: { host_url: nil },
-            external_domain: 'api2.vcap.me',
+            external_domain: 'api2.127.0.0.1.nip.io',
             external_protocol: 'https'
           )
           allow_any_instance_of(CloudController::DependencyLocator).to receive(:routing_api_client).and_return(routing_api_client)

--- a/spec/request/organizations_spec.rb
+++ b/spec/request/organizations_spec.rb
@@ -59,9 +59,9 @@ module VCAP::CloudController
             'name' => 'org1',
             'links' => {
               'self' => { 'href' => "#{link_prefix}/v3/organizations/#{created_org.guid}" },
-              'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{created_org.guid}/domains" },
-              'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{created_org.guid}/domains/default" },
-              'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{created_org.quota_definition.guid}" }
+              'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{created_org.guid}/domains" },
+              'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{created_org.guid}/domains/default" },
+              'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{created_org.quota_definition.guid}" }
             },
             'relationships' => { 'quota' => { 'data' => { 'guid' => created_org.quota_definition.guid } } },
             'metadata' => {
@@ -92,9 +92,9 @@ module VCAP::CloudController
             'name' => 'suspended-org',
             'links' => {
               'self' => { 'href' => "#{link_prefix}/v3/organizations/#{created_org.guid}" },
-              'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{created_org.guid}/domains" },
-              'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{created_org.guid}/domains/default" },
-              'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{created_org.quota_definition.guid}" }
+              'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{created_org.guid}/domains" },
+              'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{created_org.guid}/domains/default" },
+              'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{created_org.quota_definition.guid}" }
             },
             'metadata' => { 'labels' => {}, 'annotations' => {} },
             'relationships' => { 'quota' => { 'data' => { 'guid' => created_org.quota_definition.guid } } },
@@ -124,9 +124,9 @@ module VCAP::CloudController
               'name' => 'org1',
               'links' => {
                 'self' => { 'href' => "#{link_prefix}/v3/organizations/#{created_org.guid}" },
-                'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{created_org.guid}/domains" },
-                'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{created_org.guid}/domains/default" },
-                'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{created_org.quota_definition.guid}" }
+                'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{created_org.guid}/domains" },
+                'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{created_org.guid}/domains/default" },
+                'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{created_org.quota_definition.guid}" }
               },
               'relationships' => { 'quota' => { 'data' => { 'guid' => created_org.quota_definition.guid } } },
               'metadata' => {
@@ -243,9 +243,9 @@ module VCAP::CloudController
                   'self' => {
                     'href' => "#{link_prefix}/v3/organizations/#{organization1.guid}"
                   },
-                  'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}/domains" },
-                  'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}/domains/default" },
-                  'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{organization1.quota_definition.guid}" }
+                  'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}/domains" },
+                  'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}/domains/default" },
+                  'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{organization1.quota_definition.guid}" }
                 },
                 'metadata' => {
                   'labels' => {},
@@ -263,9 +263,9 @@ module VCAP::CloudController
                   'self' => {
                     'href' => "#{link_prefix}/v3/organizations/#{organization2.guid}"
                   },
-                  'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization2.guid}/domains" },
-                  'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization2.guid}/domains/default" },
-                  'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{organization2.quota_definition.guid}" }
+                  'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization2.guid}/domains" },
+                  'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization2.guid}/domains/default" },
+                  'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{organization2.quota_definition.guid}" }
                 },
                 'metadata' => {
                   'labels' => {},
@@ -368,9 +368,9 @@ module VCAP::CloudController
                   'self' => {
                     'href' => "#{link_prefix}/v3/organizations/#{organization2.guid}"
                   },
-                  'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization2.guid}/domains" },
-                  'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization2.guid}/domains/default" },
-                  'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{organization2.quota_definition.guid}" }
+                  'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization2.guid}/domains" },
+                  'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization2.guid}/domains/default" },
+                  'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{organization2.quota_definition.guid}" }
                 },
                 'metadata' => {
                   'labels' => {},
@@ -388,9 +388,9 @@ module VCAP::CloudController
                   'self' => {
                     'href' => "#{link_prefix}/v3/organizations/#{organization3.guid}"
                   },
-                  'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization3.guid}/domains" },
-                  'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization3.guid}/domains/default" },
-                  'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{organization3.quota_definition.guid}" }
+                  'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization3.guid}/domains" },
+                  'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization3.guid}/domains/default" },
+                  'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{organization3.quota_definition.guid}" }
                 },
                 'metadata' => {
                   'labels' => {},
@@ -1172,10 +1172,10 @@ module VCAP::CloudController
             'guid' => organization1.guid,
             'relationships' => { 'quota' => { 'data' => { 'guid' => organization1.quota_definition.guid } } },
             'links' => {
-              'self' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}" },
-              'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}/domains" },
-              'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}/domains/default" },
-              'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{organization1.quota_definition.guid}" }
+              'self' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}" },
+              'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}/domains" },
+              'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}/domains/default" },
+              'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{organization1.quota_definition.guid}" }
             },
             'created_at' => iso8601,
             'updated_at' => iso8601,
@@ -1225,10 +1225,10 @@ module VCAP::CloudController
             'guid' => organization1.guid,
             'relationships' => { 'quota' => { 'data' => { 'guid' => organization1.quota_definition.guid } } },
             'links' => {
-              'self' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}" },
-              'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}/domains" },
-              'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}/domains/default" },
-              'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{organization1.quota_definition.guid}" }
+              'self' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}" },
+              'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}/domains" },
+              'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}/domains/default" },
+              'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{organization1.quota_definition.guid}" }
             },
             'created_at' => iso8601,
             'updated_at' => iso8601,
@@ -1267,10 +1267,10 @@ module VCAP::CloudController
               'guid' => organization1.guid,
               'relationships' => { 'quota' => { 'data' => { 'guid' => organization1.quota_definition.guid } } },
               'links' => {
-                'self' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}" },
-                'domains' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}/domains" },
-                'default_domain' => { 'href' => "http://api2.vcap.me/v3/organizations/#{organization1.guid}/domains/default" },
-                'quota' => { 'href' => "http://api2.vcap.me/v3/organization_quotas/#{organization1.quota_definition.guid}" }
+                'self' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}" },
+                'domains' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}/domains" },
+                'default_domain' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organizations/#{organization1.guid}/domains/default" },
+                'quota' => { 'href' => "http://api2.127.0.0.1.nip.io/v3/organization_quotas/#{organization1.quota_definition.guid}" }
               },
               'created_at' => iso8601,
               'updated_at' => iso8601,

--- a/spec/request/routes_spec.rb
+++ b/spec/request/routes_spec.rb
@@ -313,10 +313,10 @@ RSpec.describe 'Routes Request' do
             },
             options: {},
             links: {
-              self: { href: "http://api2.vcap.me/v3/routes/#{route1_domain1.guid}" },
-              space: { href: "http://api2.vcap.me/v3/spaces/#{space.guid}" },
+              self: { href: "http://api2.127.0.0.1.nip.io/v3/routes/#{route1_domain1.guid}" },
+              space: { href: "http://api2.127.0.0.1.nip.io/v3/spaces/#{space.guid}" },
               destinations: { href: %r{#{Regexp.escape(link_prefix)}/v3/routes/#{route1_domain1.guid}/destinations} },
-              domain: { href: "http://api2.vcap.me/v3/domains/#{domain1.guid}" }
+              domain: { href: "http://api2.127.0.0.1.nip.io/v3/domains/#{domain1.guid}" }
             }
           }
         end
@@ -425,10 +425,10 @@ RSpec.describe 'Routes Request' do
           },
           options: {},
           links: {
-            self: { href: 'http://api2.vcap.me/v3/routes/route-without-host' },
-            space: { href: "http://api2.vcap.me/v3/spaces/#{space.guid}" },
+            self: { href: 'http://api2.127.0.0.1.nip.io/v3/routes/route-without-host' },
+            space: { href: "http://api2.127.0.0.1.nip.io/v3/spaces/#{space.guid}" },
             destinations: { href: %r{#{Regexp.escape(link_prefix)}/v3/routes/route-without-host/destinations} },
-            domain: { href: "http://api2.vcap.me/v3/domains/#{domain.guid}" }
+            domain: { href: "http://api2.127.0.0.1.nip.io/v3/domains/#{domain.guid}" }
           }
         }
       end
@@ -461,10 +461,10 @@ RSpec.describe 'Routes Request' do
           },
           options: {},
           links: {
-            self: { href: 'http://api2.vcap.me/v3/routes/route-without-host2' },
-            space: { href: "http://api2.vcap.me/v3/spaces/#{space.guid}" },
+            self: { href: 'http://api2.127.0.0.1.nip.io/v3/routes/route-without-host2' },
+            space: { href: "http://api2.127.0.0.1.nip.io/v3/spaces/#{space.guid}" },
             destinations: { href: %r{#{Regexp.escape(link_prefix)}/v3/routes/route-without-host2/destinations} },
-            domain: { href: "http://api2.vcap.me/v3/domains/#{domain.guid}" }
+            domain: { href: "http://api2.127.0.0.1.nip.io/v3/domains/#{domain.guid}" }
           }
         }
       end
@@ -500,10 +500,10 @@ RSpec.describe 'Routes Request' do
           },
           options: {},
           links: {
-            self: { href: 'http://api2.vcap.me/v3/routes/route-without-path' },
-            space: { href: "http://api2.vcap.me/v3/spaces/#{space.guid}" },
+            self: { href: 'http://api2.127.0.0.1.nip.io/v3/routes/route-without-path' },
+            space: { href: "http://api2.127.0.0.1.nip.io/v3/spaces/#{space.guid}" },
             destinations: { href: %r{#{Regexp.escape(link_prefix)}/v3/routes/route-without-path/destinations} },
-            domain: { href: "http://api2.vcap.me/v3/domains/#{domain.guid}" }
+            domain: { href: "http://api2.127.0.0.1.nip.io/v3/domains/#{domain.guid}" }
           }
         }
       end
@@ -1601,7 +1601,7 @@ RSpec.describe 'Routes Request' do
         before do
           TestConfig.override(
             kubernetes: { host_url: nil },
-            external_domain: 'api2.vcap.me',
+            external_domain: 'api2.127.0.0.1.nip.io',
             external_protocol: 'https'
           )
           allow_any_instance_of(CloudController::DependencyLocator).to receive(:routing_api_client).and_return(routing_api_client)

--- a/spec/unit/controllers/v3/apps_controller_spec.rb
+++ b/spec/unit/controllers/v3/apps_controller_spec.rb
@@ -1575,7 +1575,7 @@ RSpec.describe AppsV3Controller, type: :controller do
       expect(job.delayed_job_guid).to eq(enqueued_job.guid)
 
       expect(response).to have_http_status :accepted
-      expect(response['Location']).to eq("http://api2.vcap.me/v3/jobs/#{job.guid}")
+      expect(response['Location']).to eq("http://api2.127.0.0.1.nip.io/v3/jobs/#{job.guid}")
 
       execute_all_jobs(expected_successes: 1, expected_failures: 0)
     end

--- a/spec/unit/fetchers/global_usage_summary_fetcher_spec.rb
+++ b/spec/unit/fetchers/global_usage_summary_fetcher_spec.rb
@@ -39,7 +39,7 @@ module VCAP::CloudController
         expect(summary.routes).to eq(2)
         expect(summary.service_instances).to eq(2)
         expect(summary.reserved_ports).to eq(1)
-        expect(summary.domains).to eq(2) # system domain "vcap.me" plus :private_domain_without_router_group
+        expect(summary.domains).to eq(2) # system domain "127.0.0.1.nip.io" plus :private_domain_without_router_group
         expect(summary.per_app_tasks).to eq(1)
         expect(summary.service_keys).to eq(2)
       end

--- a/spec/unit/lib/cloud_controller/route_validator_spec.rb
+++ b/spec/unit/lib/cloud_controller/route_validator_spec.rb
@@ -18,7 +18,7 @@ module VCAP::CloudController
     before do
       TestConfig.override(
         kubernetes: { host_url: nil },
-        external_domain: 'api2.vcap.me',
+        external_domain: 'api2.127.0.0.1.nip.io',
         external_protocol: 'https'
       )
       allow_any_instance_of(CloudController::DependencyLocator).to receive(:routing_api_client).

--- a/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
+++ b/spec/unit/lib/services/service_brokers/v2/http_client_spec.rb
@@ -87,7 +87,7 @@ module VCAP::Services::ServiceBrokers::V2
         expect(fake_logger).to have_received(:debug).with(match(/X-Broker-API-Request-Identity"=>"[[:alnum:]-]+/))
         expect(fake_logger).to have_received(:debug).with(match(/X-Broker-Api-Version"=>"2\.15/))
         api_info_path = TestConfig.config[:temporary_enable_v2] ? '/v2/info' : '/'
-        expect(fake_logger).to have_received(:debug).with(match(/X-Api-Info-Location"=>"api2\.vcap\.me#{api_info_path}/))
+        expect(fake_logger).to have_received(:debug).with(match(/X-Api-Info-Location"=>"api2\.127\.0\.0\.1\.nip\.io#{api_info_path}/))
       end
 
       context 'when an https URL is used' do
@@ -161,7 +161,7 @@ module VCAP::Services::ServiceBrokers::V2
             expect(a_request(http_method, full_url).
               with(basic_auth:).
               with(query: hash_including({})).
-              with(headers: { 'X-Api-Info-Location' => 'api2.vcap.me/v2/info' })).
+              with(headers: { 'X-Api-Info-Location' => 'api2.127.0.0.1.nip.io/v2/info' })).
               to have_been_made
           end
         end
@@ -177,7 +177,7 @@ module VCAP::Services::ServiceBrokers::V2
             expect(a_request(http_method, full_url).
               with(basic_auth:).
               with(query: hash_including({})).
-              with(headers: { 'X-Api-Info-Location' => 'api2.vcap.me/' })).
+              with(headers: { 'X-Api-Info-Location' => 'api2.127.0.0.1.nip.io/' })).
               to have_been_made
           end
         end

--- a/spec/unit/presenters/v3/domain_presenter_spec.rb
+++ b/spec/unit/presenters/v3/domain_presenter_spec.rb
@@ -171,7 +171,7 @@ module VCAP::CloudController::Presenters::V3
         before do
           TestConfig.override(
             kubernetes: { host_url: nil },
-            external_domain: 'api2.vcap.me',
+            external_domain: 'api2.127.0.0.1.nip.io',
             external_protocol: 'https'
           )
           allow_any_instance_of(CloudController::DependencyLocator).to receive(:routing_api_client).and_return(routing_api_client)
@@ -213,9 +213,9 @@ module VCAP::CloudController::Presenters::V3
           expect(subject[:supported_protocols]).to eq(['tcp'])
           expect(subject[:metadata][:labels]).to eq({ 'maine.gov/potato' => 'mashed' })
           expect(subject[:metadata][:annotations]).to eq({ 'contacts' => 'Bill tel(1111111) email(bill@fixme), Bob tel(222222) pager(3333333#555) email(bob@fixme)' })
-          expect(subject[:links][:self][:href]).to eq("https://api2.vcap.me/v3/domains/#{domain.guid}")
-          expect(subject[:links][:route_reservations][:href]).to eq("https://api2.vcap.me/v3/domains/#{domain.guid}/route_reservations")
-          expect(subject[:links][:router_group][:href]).to eq('https://api2.vcap.me/routing/v1/router_groups/some-router-guid')
+          expect(subject[:links][:self][:href]).to eq("https://api2.127.0.0.1.nip.io/v3/domains/#{domain.guid}")
+          expect(subject[:links][:route_reservations][:href]).to eq("https://api2.127.0.0.1.nip.io/v3/domains/#{domain.guid}/route_reservations")
+          expect(subject[:links][:router_group][:href]).to eq('https://api2.127.0.0.1.nip.io/routing/v1/router_groups/some-router-guid')
         end
 
         context 'when the kubernetes host url is blank' do

--- a/spec/unit/presenters/v3/route_destination_presenter_spec.rb
+++ b/spec/unit/presenters/v3/route_destination_presenter_spec.rb
@@ -33,10 +33,10 @@ module VCAP::CloudController::Presenters::V3
           protocol: route_mapping.protocol,
           links: {
             destinations: {
-              href: "http://api2.vcap.me/v3/routes/#{route.guid}/destinations"
+              href: "http://api2.127.0.0.1.nip.io/v3/routes/#{route.guid}/destinations"
             },
             route: {
-              href: "http://api2.vcap.me/v3/routes/#{route.guid}"
+              href: "http://api2.127.0.0.1.nip.io/v3/routes/#{route.guid}"
             }
           },
           created_at: Time.at(1),


### PR DESCRIPTION
The vcap.me domain no longer resolves (NXDOMAIN).
Replace it with 127.0.0.1.nip.io which provides the same wildcard DNS functionality.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
