### PR TITLE
Fix sporadic test failure in service broker deletion during creation

### DIFF
--- a/spec/request/lifecycle/service_brokers_spec.rb
+++ b/spec/request/lifecycle/service_brokers_spec.rb
@@ -151,6 +151,10 @@ RSpec.describe 'V3 service brokers' do
           stub_request(:get, 'http://example.org/my-service-broker-url/v2/catalog').
             with(basic_auth: %w[admin password]).
             to_return(status: 200, body: catalog, headers: {})
+
+          # Both jobs may be enqueued with the same timestamp, making pickup order non-deterministic.
+          # Give the delete job a higher priority number so the create job always runs first.
+          TestConfig.config[:jobs][:priorities] = { 'service_broker.delete': 10 }
         end
 
         it 'allows deletion during creation' do


### PR DESCRIPTION
The test was flaky because both create and delete jobs could be enqueued with the same timestamp, making pickup order non-deterministic. When the delete job ran first, the create job failed with `ServiceBrokerGone`.

Fix by setting a higher priority number for the delete job so the create job always runs first.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
