### PR TITLE
Fix timezone mismatch in instances_stats_reporter_spec

### DIFF
--- a/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/reporters/instances_stats_reporter_spec.rb
@@ -46,7 +46,7 @@ module VCAP::CloudController
             'process_id' => ::Diego::Bbs::Models::MetricTagValue.new(static: process.guid)
           }
         end
-        let(:formatted_current_time) { Time.now.to_datetime.rfc3339 }
+        let(:formatted_current_time) { Time.now.utc.to_datetime.rfc3339 }
 
         let(:lrp_1_net_info) do
           ::Diego::Bbs::Models::ActualLRPNetInfo.new(


### PR DESCRIPTION
The test used local time (`Time.now`) but the production code uses UTC (`Time.now.utc`). This caused failures when run in non-UTC timezones.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
