### PR TITLE
Fix flaky credential binding presenter spec

### DIFF
--- a/spec/unit/presenters/v3/service_credential_binding_presenter_spec.rb
+++ b/spec/unit/presenters/v3/service_credential_binding_presenter_spec.rb
@@ -147,8 +147,8 @@ module VCAP
                 type: 'create',
                 state: 'succeeded',
                 description: 'some description',
-                updated_at: credential_binding.updated_at,
-                created_at: credential_binding.created_at
+                updated_at: credential_binding.last_operation.updated_at,
+                created_at: credential_binding.last_operation.created_at
               },
               metadata: {
                 annotations: {


### PR DESCRIPTION
Use `last_operation` timestamps in assertions to match presenter behavior and avoid second-boundary drift.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
