### PR TITLE
Add fog deprecation warning

### DIFF
--- a/lib/cloud_controller/blobstore/fog/fog_client.rb
+++ b/lib/cloud_controller/blobstore/fog/fog_client.rb
@@ -13,6 +13,9 @@ module CloudController
       attr_reader :root_dir
 
       DEFAULT_BATCH_SIZE = 1000
+      DEPRECATION_MESSAGE = '[DEPRECATION WARNING] The fog blobstore client is DEPRECATED and will be REMOVED. ' \
+                            "Please migrate to blobstore_type 'storage-cli' as soon as possible. " \
+                            'See https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0043-cc-blobstore-storage-cli.md for details.'.freeze
 
       def initialize(connection_config:,
                      directory_key:,
@@ -30,6 +33,7 @@ module CloudController
         @max_size = max_size
         @aws_storage_options = aws_storage_options
         @gcp_storage_options = gcp_storage_options
+        logger.warn('blobstore.fog-deprecated', message: DEPRECATION_MESSAGE)
       end
 
       def local?

--- a/spec/unit/jobs/runtime/service_operations_initial_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/service_operations_initial_cleanup_spec.rb
@@ -6,7 +6,7 @@ module VCAP::CloudController
       subject(:job) { ServiceOperationsInitialCleanup.new }
 
       let(:fake_orphan_mitigator) { double(VCAP::Services::ServiceBrokers::V2::OrphanMitigator) }
-      let(:fake_logger) { instance_double(Steno::Logger, info: nil) }
+      let(:fake_logger) { instance_double(Steno::Logger, info: nil, warn: nil) }
 
       it { is_expected.to be_a_valid_job }
 

--- a/spec/unit/lib/cloud_controller/blobstore/fog/fog_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/blobstore/fog/fog_client_spec.rb
@@ -29,6 +29,11 @@ module CloudController
         Fog::Mock.reset
       end
 
+      it 'logs a deprecation warning on initialization' do
+        expect_any_instance_of(Steno::Logger).to receive(:warn).with('blobstore.fog-deprecated', hash_including(:message))
+        FogClient.new(connection_config:, directory_key:)
+      end
+
       describe 'conforms to blobstore client interface' do
         let(:deletable_blob) { instance_double(FogBlob, file: nil) }
 


### PR DESCRIPTION
Fog is deprecated and replaced by storage-cli, thus we should inform operators about the planned removal.
Further details in RFC: 
- https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0043-cc-blobstore-storage-cli.md
- https://github.com/cloudfoundry/community/issues/1274

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
