### PR TITLE
Document case sensitivity of name fields in API docs

### DIFF
--- a/db/migrations/20130131184954_new_initial_schema.rb
+++ b/db/migrations/20130131184954_new_initial_schema.rb
@@ -106,7 +106,7 @@ Sequel.migration do
     create_table :frameworks do
       VCAP::Migration.common(self)
 
-      String :name,        null: false, case_insenstive: true
+      String :name,        null: false
       String :description, null: false
       String :internal_info, null: false, size: 2048
 

--- a/db/migrations/20130219194917_create_stacks_table.rb
+++ b/db/migrations/20130219194917_create_stacks_table.rb
@@ -6,7 +6,7 @@ Sequel.migration do
     create_table :stacks do
       VCAP::Migration.common(self)
 
-      String :name, null: false, case_insenstive: true
+      String :name, null: false
       String :description, null: false
 
       index :name, unique: true

--- a/db/migrations/20141008205150_create_lockings.rb
+++ b/db/migrations/20141008205150_create_lockings.rb
@@ -2,7 +2,7 @@ Sequel.migration do
   change do
     create_table :lockings do
       primary_key :id
-      String :name, null: false, case_insenstive: true
+      String :name, null: false
       index :name, unique: true
     end
   end

--- a/docs/v3/source/includes/resources/apps/_create.md.erb
+++ b/docs/v3/source/includes/resources/apps/_create.md.erb
@@ -39,7 +39,7 @@ Content-Type: application/json
 
 Name | Type | Description
 ---- | ---- | -----------
-**name** | _string_ | Name of the app
+**name** | _string_ | Name of the app; must be unique within the space (case-insensitive)
 **relationships.space** | [_to-one relationship_](#to-one-relationships) | A relationship to a space
 
 #### Optional parameters

--- a/docs/v3/source/includes/resources/apps/_list.md.erb
+++ b/docs/v3/source/includes/resources/apps/_list.md.erb
@@ -31,10 +31,10 @@ Retrieve all apps the user has access to.
 Name | Type | Description
 ---- | ---- | ------------
 **guids** | _list of strings_ | Comma-delimited list of app guids to filter by
-**names** | _list of strings_ | Comma-delimited list of app names to filter by
+**names** | _list of strings_ | Comma-delimited list of app names to filter by (case-insensitive)
 **space_guids** | _list of strings_ | Comma-delimited list of space guids to filter by
 **organization_guids** | _list of strings_ | Comma-delimited list of organization guids to filter by
-**stacks** | _list of strings_ | Comma-delimited list of stack names to filter by
+**stacks** | _list of strings_ | Comma-delimited list of stack names to filter by (case-sensitive)
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. Valid values are `created_at`, `updated_at`, `name`, `state`

--- a/docs/v3/source/includes/resources/buildpacks/_create.md.erb
+++ b/docs/v3/source/includes/resources/buildpacks/_create.md.erb
@@ -36,7 +36,7 @@ Content-Type: application/json
 
 Name     | Type     | Description
 -------  | -------  | -----------
-**name** | _string_ | Name of the buildpack
+**name** | _string_ | Name of the buildpack; must be unique per stack (case-sensitive)
 
 #### Optional parameters
 

--- a/docs/v3/source/includes/resources/buildpacks/_list.md.erb
+++ b/docs/v3/source/includes/resources/buildpacks/_list.md.erb
@@ -32,8 +32,8 @@ Name | Type | Description
 ---- | ---- | ------------
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
-**names** | _list of strings_ | Comma-delimited list of buildpack names to filter by
-**stacks**| _list of strings_ | Comma-delimited list of stack names to filter by
+**names** | _list of strings_ | Comma-delimited list of buildpack names to filter by (case-sensitive)
+**stacks**| _list of strings_ | Comma-delimited list of stack names to filter by (case-sensitive)
 **lifecycle**| _string_ | Type of buildpack. Valid values are `buildpack` and `cnb`
 **order_by** | _string_ | Value to sort by; defaults to ascending. Prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`, `lifecycle`, and `position`
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements

--- a/docs/v3/source/includes/resources/domains/_create.md.erb
+++ b/docs/v3/source/includes/resources/domains/_create.md.erb
@@ -33,7 +33,7 @@ Content-Type: application/json
 
 Name     | Type     | Description
 -------  | -------  | -----------
-**name** | _string_ | Name of the domain
+**name** | _string_ | Name of the domain; must be unique (case-insensitive)
 
 #### Optional parameters
 

--- a/docs/v3/source/includes/resources/domains/_list.md.erb
+++ b/docs/v3/source/includes/resources/domains/_list.md.erb
@@ -31,7 +31,7 @@ Retrieve all domains the user has access to.
 | Name                   | Type              | Description
 | ------------           | ---------         | -----------
 | **guids**              | _list of strings_ | Comma-delimited list of guids to filter by
-| **names**              | _list of strings_ | Comma-delimited list of domain names to filter by
+| **names**              | _list of strings_ | Comma-delimited list of domain names to filter by (case-insensitive)
 | **organization_guids** | _list of strings_ | Comma-delimited list of owning organization guids to filter by
 | **page**               | _integer_         | Page to display; valid values are integers >= 1
 | **per_page**           | _integer_         | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/domains/_list_domains_for_an_org.md.erb
+++ b/docs/v3/source/includes/resources/domains/_list_domains_for_an_org.md.erb
@@ -32,15 +32,15 @@ To retrieve the default domain for an organization, use the [get default domain]
 
 #### Query parameters
 
-| Name                   | Type              | Description                                                                                                  |
-| ------------           | ---------         | -----------                                                                                                  |
-| **guids**              | _list of strings_ | Comma-delimited list of guids to filter by                                                           |
-| **names**              | _list of strings_ | Comma-delimited list of domain names to filter by                                                           |
-| **organization_guids** | _list of strings_ | Comma-delimited list of owning organization guids to filter by                                              |
-| **page**               | _integer_         | Page to display; valid values are integers >= 1                                                             |
-| **per_page**           | _integer_         | Number of results per page; <br>valid values are 1 through 5000                                             |
+| Name                   | Type              | Description
+| ------------           | ---------         | -----------
+| **guids**              | _list of strings_ | Comma-delimited list of guids to filter by
+| **names**              | _list of strings_ | Comma-delimited list of domain names to filter by (case-insensitive)
+| **organization_guids** | _list of strings_ | Comma-delimited list of owning organization guids to filter by
+| **page**               | _integer_         | Page to display; valid values are integers >= 1
+| **per_page**           | _integer_         | Number of results per page; <br>valid values are 1 through 5000
 | **order_by**           | _string_          | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`
-| **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements |
+| **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 
 #### Permitted roles
 

--- a/docs/v3/source/includes/resources/isolation_segments/_create.md.erb
+++ b/docs/v3/source/includes/resources/isolation_segments/_create.md.erb
@@ -32,7 +32,7 @@ Content-Type: application/json
 
 Name | Type | Description
 ---- | ---- | -----------
-**name** | _string_ | Name of the isolation segment; isolation segment names must be unique across the entire system, and case is ignored when checking for uniqueness
+**name** | _string_ | Name of the isolation segment; must be unique (case-insensitive)
 **metadata.labels** | [_label object_](#labels) | Labels applied to the isolation segment
 **metadata.annotations**  | [_annotation object_](#annotations) | Annotations applied to the isolation segment
 

--- a/docs/v3/source/includes/resources/isolation_segments/_list.md.erb
+++ b/docs/v3/source/includes/resources/isolation_segments/_list.md.erb
@@ -31,7 +31,7 @@ Retrieves all isolation segments to which the user has access.  For admin, this 
 Name | Type | Description
 ---- | ---- | ------------
 **guids** | _list of strings_ | Comma-delimited list of isolation segment guids to filter by
-**names** | _list of strings_ | Comma-delimited list of isolation segment names to filter by
+**names** | _list of strings_ | Comma-delimited list of isolation segment names to filter by (case-insensitive)
 **organization_guids** | _list of strings_ | Comma-delimited list of organization guids to filter by
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/organization_quotas/_create.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_create.md.erb
@@ -37,7 +37,7 @@ To create an organization quota you must be an admin.
 
 Name | Type | Description
 ---- | ---- | -----------
-**name** | _string_ | Name of the quota
+**name** | _string_ | Name of the quota (case-insensitive)
 
 #### Optional parameters
 Name | Type | Description | Default |

--- a/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_list.md.erb
@@ -30,7 +30,7 @@ This endpoint lists all organization quota resources.
 Name | Type | Description
 ---- | ---- | -----------
 **guids** | _list of strings_ | Comma-delimited list of organization quota guids to filter by
-**names** | _list of strings_ | Comma-delimited list of organization quota names to filter by
+**names** | _list of strings_ | Comma-delimited list of organization quota names to filter by (case-insensitive)
 **organization_guids** | _list of strings_ | Comma-delimited list of organization guids to filter by
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/organizations/_create.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_create.md.erb
@@ -31,7 +31,7 @@ Content-Type: application/json
 
 Name | Type | Description
 ---- | ---- | -----------
-**name** | _string_ | Organization name |
+**name** | _string_ | Organization name; must be unique (case-insensitive) |
 
 #### Optional parameters
 

--- a/docs/v3/source/includes/resources/organizations/_list.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_list.md.erb
@@ -30,7 +30,7 @@ Retrieve all organizations the user has access to.
 
 Name | Type | Description
 ---- | ---- | ------------
-**names** | _list of strings_ | Comma-delimited list of organization names to filter by
+**names** | _list of strings_ | Comma-delimited list of organization names to filter by (case-insensitive)
 **guids** | _list of strings_ | Comma-delimited list of organization guids to filter by
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/organizations/_list_for_isolation_segment.md.erb
+++ b/docs/v3/source/includes/resources/organizations/_list_for_isolation_segment.md.erb
@@ -30,7 +30,7 @@ Retrieve the organizations entitled to the isolation segment. Return only the or
 
 Name | Type | Description
 ---- | ---- | ------------
-**names** | _list of strings_ | Comma-delimited list of organization names to filter by
+**names** | _list of strings_ | Comma-delimited list of organization names to filter by (case-insensitive)
 **guids** | _list of strings_ | Comma-delimited list of organization guids to filter by
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/security_groups/_create.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_create.md.erb
@@ -46,7 +46,7 @@ Content-Type: application/json
 
 Name | Type | Description
 ---- | ---- | -----------
-**name** | _string_ | Name of the security group
+**name** | _string_ | Name of the security group; must be unique (case-sensitive)
 
 #### Optional parameters
 

--- a/docs/v3/source/includes/resources/security_groups/_list.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list.md.erb
@@ -29,7 +29,7 @@ Content-Type: application/json
 Name | Type | Description
 ---- | ---- | -----------
 **guids** | _list of strings_ | Comma-delimited list of security group guids to filter by
-**names** | _list of strings_ | Comma-delimited list of security group names to filter by
+**names** | _list of strings_ | Comma-delimited list of security group names to filter by (case-sensitive)
 **globally_enabled_running** | _boolean_ | If true, only include the security groups that are enabled for running
 **globally_enabled_staging** | _boolean_ | If true, only include the security groups that are enabled for staging
 **running_space_guids** | _list of strings_ | Comma-delimited list of space guids to filter by

--- a/docs/v3/source/includes/resources/security_groups/_list_running_security_groups.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list_running_security_groups.md.erb
@@ -31,7 +31,7 @@ This endpoint returns security groups that are enabled for running globally or a
 Name | Type | Description
 ---- | ---- | -----------
 **guids** | _list of strings_ | Comma-delimited list of security group guids to filter by
-**names** | _list of strings_ | Comma-delimited list of security group names to filter by
+**names** | _list of strings_ | Comma-delimited list of security group names to filter by (case-sensitive)
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`

--- a/docs/v3/source/includes/resources/security_groups/_list_staging_security_groups.md.erb
+++ b/docs/v3/source/includes/resources/security_groups/_list_staging_security_groups.md.erb
@@ -31,7 +31,7 @@ This endpoint returns security groups that are enabled for staging globally or a
 Name | Type | Description
 ---- | ---- | -----------
 **guids** | _list of strings_ | Comma-delimited list of security group guids to filter by
-**names** | _list of strings_ | Comma-delimited list of security group names to filter by
+**names** | _list of strings_ | Comma-delimited list of security group names to filter by (case-sensitive)
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending. <br>Valid values are `created_at`, `updated_at`

--- a/docs/v3/source/includes/resources/service_brokers/_create.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_create.md.erb
@@ -50,7 +50,7 @@ The `Location` header refers to the created job which syncs the broker with the 
 
 Name | Type | Description
 ---- | ---- | -----------
-**name** | _string_ | Name of the service broker
+**name** | _string_ | Name of the service broker; must be unique (case-sensitive)
 **url** | _string_ | URL of the service broker
 **authentication** | [_authentication_](#the-authentication-object) | Credentials used to authenticate against the service broker
 

--- a/docs/v3/source/includes/resources/service_brokers/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_brokers/_list.md.erb
@@ -30,7 +30,7 @@ This endpoint retrieves the service brokers the user has access to.
 
 Name | Type | Description
 ---- | ---- | ------------
-**names** | _list of strings_ | Comma-delimited list of service broker names to filter by
+**names** | _list of strings_ | Comma-delimited list of service broker names to filter by (case-sensitive)
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **space_guids** | _list of strings_ | Comma-delimited list of space GUIDs to filter by

--- a/docs/v3/source/includes/resources/service_credential_bindings/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_credential_bindings/_list.md.erb
@@ -31,15 +31,15 @@ This endpoint retrieves the service credential bindings the user has access to.
 
 Name | Type | Description
 ---- | ---- | ------------
-**names** | _list of strings_ | Comma-delimited list of service credential binding names to filter by
+**names** | _list of strings_ | Comma-delimited list of service credential binding names to filter by (case-sensitive)
 **service_instance_guids** | _list of strings_ | Comma-delimited list of service instance guids to filter by
-**service_instance_names** | _list of strings_ | Comma-delimited list of service instance names to filter by
+**service_instance_names** | _list of strings_ | Comma-delimited list of service instance names to filter by (case-sensitive)
 **app_guids** | _list of strings_ | Comma-delimited list of app guids to filter by
-**app_names** | _strings_ | Comma-delimited list of app names to filter by
+**app_names** | _strings_ | Comma-delimited list of app names to filter by (case-insensitive)
 **service_plan_guids** | _list of strings_ | Comma-delimited list of service plan guids to filter by
-**service_plan_names** | _list of strings_ | Comma-delimited list of service plan names to filter by
+**service_plan_names** | _list of strings_ | Comma-delimited list of service plan names to filter by (case-insensitive)
 **service_offering_guids** | _list of strings_ | Comma-delimited list of service offering guids to filter by
-**service_offering_names** | _list of strings_ | Comma-delimited list of service offering names to filter by
+**service_offering_names** | _list of strings_ | Comma-delimited list of service offering names to filter by (case-insensitive)
 **type** | _list of strings_ | Type of credential binding to filter by. Valid values are: `app` or `key`
 **guids** | _list of strings_ | Comma-delimited list of service route binding guids to filter by
 **created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)

--- a/docs/v3/source/includes/resources/service_instances/_create.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_create.md.erb
@@ -113,7 +113,7 @@ accordingly to cases outlined in the [OSBAPI specification](https://github.com/o
 Name | Type | Description
 ---- | ---- | -----------
 **type** | _string_ | Must be `managed`
-**name** | _string_ | Name of the service instance
+**name** | _string_ | Name of the service instance; must be unique within the space (case-sensitive)
 **relationships.space** | [_to-one relationship_](#to-one-relationships) | The space in which to create the service instance
 **relationships.service_plan** | [_to-one relationship_](#to-one-relationships) | The service plan from which to create the service instance
 
@@ -131,7 +131,7 @@ Name | Type | Description |
 Name | Type | Description
 ---- | ---- | -----------
 **type** | _string_ | Must be `user-provided`
-**name** | _string_ | Name of the service instance
+**name** | _string_ | Name of the service instance; must be unique within the space (case-sensitive)
 **relationships.space** | [_to-one relationship_](#to-one-relationships) | The space in which to create the service instance
 
 #### Optional parameters for user-provided service instance

--- a/docs/v3/source/includes/resources/service_instances/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_instances/_list.md.erb
@@ -29,13 +29,13 @@ This endpoint retrieves the service instances the user has access to, including 
 
 Name | Type | Description
 ---- | ---- | ------------
-**names** | _list of strings_ | Comma-delimited list of service instance names to filter by
+**names** | _list of strings_ | Comma-delimited list of service instance names to filter by (case-sensitive)
 **guids** | _list of strings_ | Comma-delimited list of service instance guids to filter by
 **type** | _string_ | Filter by type; valid values are `managed` and `user-provided`
 **space_guids** | _list of strings_ | Comma-delimited list of space guids to filter by
 **organization_guids** | _list of strings_ | Comma-delimited list of organization guids to filter by
 **service_plan_guids** | _list of strings_ | Comma-delimited list of service plan guids to filter by
-**service_plan_names** | _list of strings_ | Comma-delimited list of service plan names to filter by
+**service_plan_names** | _list of strings_ | Comma-delimited list of service plan names to filter by (case-insensitive)
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000
 **order_by** | _string_ | Value to sort by. Defaults to ascending; prepend with `-` to sort descending<br>Valid values are `created_at`, `updated_at`, and `name`

--- a/docs/v3/source/includes/resources/service_offerings/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_offerings/_list.md.erb
@@ -30,11 +30,11 @@ This endpoint retrieves the service offerings the user has access to.
 
 Name | Type | Description
 ---- | ---- | ------------
-**names** | _list of strings_ | Comma-delimited list of names to filter by
+**names** | _list of strings_ | Comma-delimited list of names to filter by (case-insensitive)
 **available** | _boolean_ | Filter by the `available` property; valid values are `true` or `false`
 **broker_catalog_ids** | _list of strings_ | Comma-delimited list of IDs provided by the service broker for the service offering to filter by
 **service_broker_guids** | _list of strings_ | Comma-delimited list of service broker GUIDs to filter by
-**service_broker_names** | _list of strings_ | Comma-delimited list of service broker names to filter by
+**service_broker_names** | _list of strings_ | Comma-delimited list of service broker names to filter by (case-sensitive)
 **space_guids** | _list of strings_ | Comma-delimited list of space GUIDs to filter by
 **organization_guids** | _list of strings_ | Comma-delimited list of organization GUIDs to filter by
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements

--- a/docs/v3/source/includes/resources/service_plans/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_plans/_list.md.erb
@@ -30,15 +30,15 @@ This endpoint retrieves the service plans the user has access to.
 
 Name | Type | Description
 ---- | ---- | ------------
-**names** | _list of strings_ | Comma-delimited list of names to filter by
+**names** | _list of strings_ | Comma-delimited list of names to filter by (case-insensitive)
 **available** | _boolean_ | Filter by the `available` property; valid values are `true` or `false`
 **broker_catalog_ids** | _list of strings_ | Comma-delimited list of IDs provided by the service broker for the service plan to filter by
 **space_guids** | _list of strings_ | Comma-delimited list of space GUIDs to filter by
 **organization_guids** | _list of strings_ | Comma-delimited list of organization GUIDs to filter by
 **service_broker_guids** | _list of strings_ | Comma-delimited list of service broker GUIDs to filter by
-**service_broker_names** | _list of strings_ | Comma-delimited list of service broker names to filter by
+**service_broker_names** | _list of strings_ | Comma-delimited list of service broker names to filter by (case-sensitive)
 **service_offering_guids** | _list of strings_ | Comma-delimited list of service Offering GUIDs to filter by
-**service_offering_names** | _list of strings_ | Comma-delimited list of service Offering names to filter by
+**service_offering_names** | _list of strings_ | Comma-delimited list of service Offering names to filter by (case-insensitive)
 **service_instance_guids** | _list of strings_ | Comma-delimited list of service Instance GUIDs to filter by
 **include** | _list of strings_ | Optionally include a list of unique related resources in the response; <br>valid values are `space.organization` and `service_offering`
 **page** | _integer_ | Page to display; valid values are integers >= 1

--- a/docs/v3/source/includes/resources/service_route_bindings/_list.md.erb
+++ b/docs/v3/source/includes/resources/service_route_bindings/_list.md.erb
@@ -33,7 +33,7 @@ Name | Type | Description
 ---- | ---- | ------------
 **route_guids** | _list of strings_ | Comma-delimited list of route guids to filter by
 **service_instance_guids** | _list of strings_ | Comma-delimited list of service instance guids to filter by
-**service_instance_names** | _list of strings_ | Comma-delimited list of service instance names to filter by
+**service_instance_names** | _list of strings_ | Comma-delimited list of service instance names to filter by (case-sensitive)
 **label_selector** | _string_ | A query string containing a list of [label selector](#labels-and-selectors) requirements
 **guids** | _list of strings_ | Comma-delimited list of service route binding guids to filter by
 **created_ats** | _[timestamp](#timestamps)_ | Timestamp to filter by. When filtering on equality, several comma-delimited timestamps may be passed. Also supports filtering with [relational operators](#relational-operators)

--- a/docs/v3/source/includes/resources/space_quotas/_create.md.erb
+++ b/docs/v3/source/includes/resources/space_quotas/_create.md.erb
@@ -41,7 +41,7 @@ This endpoint creates a new space quota scoped to a specific organization.
 
 Name | Type | Description
 ---- | ---- | -----------
-**name** | _string_ | Name of the quota
+**name** | _string_ | Name of the quota; must be unique within the organization (case-sensitive)
 **relationships.organization** | [_to-one relationship_](#to-one-relationships) | A relationship to the organization where the quota belongs | |
 
 #### Optional parameters

--- a/docs/v3/source/includes/resources/space_quotas/_list.md.erb
+++ b/docs/v3/source/includes/resources/space_quotas/_list.md.erb
@@ -30,7 +30,7 @@ This endpoint lists all space quota resources that the user has permission to vi
 Name | Type | Description
 ---- | ---- | -----------
 **guids** | _list of strings_ | Comma-delimited list of space quota guids to filter by
-**names** | _list of strings_ | Comma-delimited list of space quota names to filter by
+**names** | _list of strings_ | Comma-delimited list of space quota names to filter by (case-sensitive)
 **organization_guids** | _list of strings_ | Comma-delimited list of organization guids to filter by
 **space_guids** | _list of strings_ | Comma-delimited list of space guids to filter by
 **page** | _integer_ | Page to display; valid values are integers >= 1

--- a/docs/v3/source/includes/resources/spaces/_create.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_create.md.erb
@@ -40,7 +40,7 @@ Content-Type: application/json
 
 Name | Type | Description
 ---- | ---- | -----------
-**name** | _string_ | Space name |
+**name** | _string_ | Space name; must be unique within the organization (case-insensitive) |
 **relationships.organization** | [_to-one relationship_](#to-one-relationships) | A relationship to an organization
 
 #### Optional parameters

--- a/docs/v3/source/includes/resources/spaces/_list.md.erb
+++ b/docs/v3/source/includes/resources/spaces/_list.md.erb
@@ -30,7 +30,7 @@ Retrieve all spaces the user has access to.
 
 Name | Type | Description
 ---- | ---- | ------------
-**names** | _list of strings_ | Comma-delimited list of space names to filter by
+**names** | _list of strings_ | Comma-delimited list of space names to filter by (case-insensitive)
 **guids** | _list of strings_ | Comma-delimited list of space guids to filter by
 **organization_guids** | _list of strings_ | Comma-delimited list of organization guids to filter by
 **page** | _integer_ | Page to display; valid values are integers >= 1

--- a/docs/v3/source/includes/resources/stacks/_create.md.erb
+++ b/docs/v3/source/includes/resources/stacks/_create.md.erb
@@ -35,7 +35,7 @@ Content-Type: application/json
 
 Name | Type | Description
 ---- | ---- | -----------
-**name** | _string_ | Name of the stack; must be unique and no longer than 250 characters
+**name** | _string_ | Name of the stack; must be unique (case-sensitive) and no longer than 250 characters
 
 #### Optional parameters
 

--- a/docs/v3/source/includes/resources/stacks/_list.md.erb
+++ b/docs/v3/source/includes/resources/stacks/_list.md.erb
@@ -30,7 +30,7 @@ Retrieve all stacks.
 
 Name | Type | Description
 ---- | ---- | ------------
-**names** | _list of strings_ | Comma-delimited list of stack names to filter by
+**names** | _list of strings_ | Comma-delimited list of stack names to filter by (case-sensitive)
 **default** | _boolean_ | If true, only return the default stack
 **page** | _integer_ | Page to display; valid values are integers >= 1
 **per_page** | _integer_ | Number of results per page; <br>valid values are 1 through 5000

--- a/docs/v3/source/includes/resources/tasks/_list.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_list.md.erb
@@ -31,7 +31,7 @@ Retrieve all tasks the user has access to. The `command` field is excluded in th
 Name | Type | Description
 ---- | ---- | ------------
 **guids** | _list of strings_ | Comma-delimited list of task guids to filter by
-**names** | _list of strings_ | Comma-delimited list of task names to filter by
+**names** | _list of strings_ | Comma-delimited list of task names to filter by (case-insensitive)
 **states** | _list of strings_ | Comma-delimited list of task states to filter by
 **app_guids** | _list of strings_ | Comma-delimited list of app guids to filter by
 **space_guids** | _list of strings_ | Comma-delimited list of space guids to filter by

--- a/docs/v3/source/includes/resources/tasks/_list_for_app.md.erb
+++ b/docs/v3/source/includes/resources/tasks/_list_for_app.md.erb
@@ -32,7 +32,7 @@ excluded in the response based on the user's role.
 Name | Type | Description
 ---- | ---- | ------------
 **guids** | _list of strings_ | Comma-delimited list of task guids to filter by
-**names** | _list of strings_ | Comma-delimited list of task names to filter by
+**names** | _list of strings_ | Comma-delimited list of task names to filter by (case-insensitive)
 **states** | _list of strings_ | Comma-delimited list of task states to filter by
 **sequence_ids** | _list of strings_ | Comma delimited list of sequence ids to filter by Valid values are integers >= 1
 **page** | _integer_ | Page to display; valid values are integers >= 1


### PR DESCRIPTION
The API has inconsistent case sensitivity behavior across resources due to historical schema choices: some name columns use `citext` (case-insensitive) while others use plain `varchar` (case-sensitive). This was completely undocumented, causing confusion for API consumers.

Add (case-insensitive) or (case-sensitive) annotations to:
- Create endpoint name parameters, including uniqueness scope
- List endpoint name filter parameters
- Cross-resource name filters (e.g. `service_broker_names`)

Case-insensitive: apps, organizations, spaces, domains, isolation segments, organization quotas, service plans, service offerings, tasks

Case-sensitive: service instances, buildpacks, stacks, security groups, service brokers, space quotas, service credential bindings

Also remove the misspelled 'case_insenstive' option from three migrations (stacks, lockings, frameworks). The typo meant the option was silently ignored, so these columns were always case-sensitive. Removing the dead option makes the code reflect actual behavior.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
