### PR TITLE
Fix two flaky test failures caused by test isolation issues

### DIFF
--- a/app/actions/manifest_route_update.rb
+++ b/app/actions/manifest_route_update.rb
@@ -102,7 +102,7 @@ module VCAP::CloudController
             )
           elsif !route.available_in_space?(app.space)
             raise InvalidRoute.new('Routes cannot be mapped to destinations in different spaces')
-          elsif manifest_route[:options]
+          elsif manifest_route[:options].present?
             message = RouteUpdateMessage.new({
                                                'options' => manifest_route[:options]
                                              })

--- a/lib/delayed_job_plugins/before_enqueue_hook.rb
+++ b/lib/delayed_job_plugins/before_enqueue_hook.rb
@@ -5,4 +5,4 @@ class BeforeEnqueueHook < Delayed::Plugin
     end
   end
 end
-Delayed::Worker.plugins << BeforeEnqueueHook
+Delayed::Worker.plugins << BeforeEnqueueHook unless Delayed::Worker.plugins.include?(BeforeEnqueueHook)

--- a/spec/unit/actions/manifest_route_update_spec.rb
+++ b/spec/unit/actions/manifest_route_update_spec.rb
@@ -49,6 +49,13 @@ module VCAP::CloudController
             end
           end
 
+          context 'when no options are provided' do
+            it 'does not call RouteUpdate' do
+              expect(RouteUpdate).not_to receive(:new)
+              ManifestRouteUpdate.update(app.guid, message, user_audit_info)
+            end
+          end
+
           context 'when the new route has a protocol' do
             let(:message) do
               ManifestRoutesUpdateMessage.new(

--- a/spec/unit/lib/delayed_job_plugins/before_enqueue_hook_spec.rb
+++ b/spec/unit/lib/delayed_job_plugins/before_enqueue_hook_spec.rb
@@ -1,0 +1,16 @@
+require 'delayed_job'
+require_relative '../../../../lib/delayed_job_plugins/before_enqueue_hook'
+
+RSpec.describe BeforeEnqueueHook do
+  it 'is registered in Delayed::Worker.plugins' do
+    expect(Delayed::Worker.plugins).to include(BeforeEnqueueHook)
+  end
+
+  it 'does not register duplicate entries when loaded multiple times' do
+    count_before = Delayed::Worker.plugins.count(BeforeEnqueueHook)
+    load File.expand_path('../../../../lib/delayed_job_plugins/before_enqueue_hook.rb', __dir__)
+    count_after = Delayed::Worker.plugins.count(BeforeEnqueueHook)
+
+    expect(count_after).to eq(count_before)
+  end
+end


### PR DESCRIPTION
`BeforeEnqueueHook`: Guard against duplicate plugin registration when the file is loaded multiple times. Duplicate callbacks caused multiple `PollableJobModel` records per enqueue instead of one.

`ManifestRouteUpdate`: Use `.present?` instead of truthiness check for `manifest_route[:options]`. `ManifestRoute.parse` always sets options to `{}`, which is truthy but semantically empty. This caused spurious `RouteUpdate` calls that mutated route columns, breaking Sequel object equality in subsequent lookups.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
