### PR TITLE
Fix MySQL backwards compatibility test failure

### DIFF
--- a/spec/unit/jobs/v3/services/update_broker_job_spec.rb
+++ b/spec/unit/jobs/v3/services/update_broker_job_spec.rb
@@ -448,7 +448,7 @@ module VCAP
 
           context 'when database disconnects during state rollback' do
             let(:catalog_error) { StandardError.new('Catalog fetch failed') }
-            let(:mock_dataset) { instance_double(Sequel::Postgres::Dataset) }
+            let(:mock_dataset) { instance_double(Sequel::Dataset) }
 
             before do
               allow_any_instance_of(VCAP::CloudController::V3::ServiceBrokerCatalogUpdater).to receive(:refresh).and_raise(catalog_error)


### PR DESCRIPTION
`Sequel::Postgres::Dataset` is only defined when the postgres adapter is loaded. In regular CI, the `case_insensitive_string_monkeypatch` requires `sequel/adapters/postgres` unconditionally, making the constant available even in MySQL runs. The backwards compatibility tests skip migrations (`NO_DB_MIGRATION=true`), so the monkeypatch is never loaded and the constant is undefined.

Use `Sequel::Dataset` instead, which is always available and sufficient for the mock (it only needs `.update`).

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
