### PR TITLE
Remove unnecessary explicit adapter requires from monkeypatch

### DIFF
--- a/lib/vcap/sequel_case_insensitive_string_monkeypatch.rb
+++ b/lib/vcap/sequel_case_insensitive_string_monkeypatch.rb
@@ -1,6 +1,4 @@
 require 'sequel'
-require 'sequel/adapters/postgres'
-require 'sequel/adapters/mysql2'
 
 # Add :case_insensitive as an option to the string type during migrations.
 # This results in case insensitive comparisions for indexing and querying, but
@@ -26,24 +24,28 @@ require 'sequel/adapters/mysql2'
 # In the above migration, name will will have case insensitive comparisions,
 # but case preserving data, whereas base64_data will be case sensitive.
 
-Sequel::Postgres::Database.class_eval do
-  def case_insensitive_string_column_type
-    'CIText'
-  end
+if defined?(Sequel::Postgres::Database)
+  Sequel::Postgres::Database.class_eval do
+    def case_insensitive_string_column_type
+      'CIText'
+    end
 
-  def case_insensitive_string_column_opts
-    {}
+    def case_insensitive_string_column_opts
+      {}
+    end
   end
 end
 
-Sequel::Mysql2::Database.class_eval do
-  # Mysql is case insensitive by default
-  def case_insensitive_string_column_type
-    'VARCHAR(255)'
-  end
+if defined?(Sequel::Mysql2::Database)
+  Sequel::Mysql2::Database.class_eval do
+    # Mysql is case insensitive by default
+    def case_insensitive_string_column_type
+      'VARCHAR(255)'
+    end
 
-  def case_insensitive_string_column_opts
-    { collate: 'utf8_general_ci' }
+    def case_insensitive_string_column_opts
+      { collate: 'utf8_general_ci' }
+    end
   end
 end
 


### PR DESCRIPTION
The `sequel_case_insensitive_string_monkeypatch` unconditionally required `sequel/adapters/postgres` and `sequel/adapters/mysql2`, even though the file is only ever loaded via `DBMigrator.apply_migrations` after a DB connection is already established (which auto-loads the adapter).

Replace the explicit `requires` with `defined?` guards so each adapter is only patched when actually in use. This avoids loading cross-adapter code unnecessarily and makes tests that reference adapter-specific constants (like `Sequel::Postgres::Dataset`) fail visibly when the adapter is not loaded, rather than being silently masked.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
