### PR TITLE
Use have_queried_db_times matcher in lifecycle ordering tests

### DIFF
--- a/spec/unit/models/runtime/buildpack_lifecycle_data_model_spec.rb
+++ b/spec/unit/models/runtime/buildpack_lifecycle_data_model_spec.rb
@@ -14,18 +14,10 @@ module VCAP::CloudController
     describe 'buildpack_lifecycle_buildpacks association' do
       it 'orders by id via the default_order_by_id extension' do
         lifecycle_data.save
-        lifecycle_data.reload
 
-        sqls = []
-        logger = Logger.new(StringIO.new)
-        logger.define_singleton_method(:info) { |msg| sqls << msg }
-        BuildpackLifecycleDataModel.db.loggers << logger
-
-        lifecycle_data.buildpack_lifecycle_buildpacks
-
-        BuildpackLifecycleDataModel.db.loggers.delete(logger)
-        sql = sqls.find { |s| s.include?('buildpack_lifecycle_buildpacks') }
-        expect(sql).to match(/ORDER BY .id./)
+        expect do
+          lifecycle_data.buildpack_lifecycle_buildpacks
+        end.to have_queried_db_times(/buildpack_lifecycle_buildpacks.*ORDER BY .id./i, 1)
       end
     end
 

--- a/spec/unit/models/runtime/cnb_lifecycle_data_model_spec.rb
+++ b/spec/unit/models/runtime/cnb_lifecycle_data_model_spec.rb
@@ -6,18 +6,9 @@ module VCAP::CloudController
 
     describe 'buildpack_lifecycle_buildpacks association' do
       it 'orders by id via the default_order_by_id extension' do
-        lifecycle_data.reload
-
-        sqls = []
-        logger = Logger.new(StringIO.new)
-        logger.define_singleton_method(:info) { |msg| sqls << msg }
-        CNBLifecycleDataModel.db.loggers << logger
-
-        lifecycle_data.buildpack_lifecycle_buildpacks
-
-        CNBLifecycleDataModel.db.loggers.delete(logger)
-        sql = sqls.find { |s| s.include?('buildpack_lifecycle_buildpacks') }
-        expect(sql).to match(/ORDER BY .id./)
+        expect do
+          lifecycle_data.buildpack_lifecycle_buildpacks
+        end.to have_queried_db_times(/buildpack_lifecycle_buildpacks.*ORDER BY .id./i, 1)
       end
     end
 


### PR DESCRIPTION
Replace manual SQL logger capture with the existing `have_queried_db_times` matcher for consistency with the rest of the test suite.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
