### PR TITLE
Fix/speedup service brokers get endpoint

### DIFF
--- a/app/fetchers/service_broker_list_fetcher.rb
+++ b/app/fetchers/service_broker_list_fetcher.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
   class ServiceBrokerListFetcher < BaseListFetcher
     class << self
       def fetch(message:, permitted_space_guids: nil, eager_loaded_associations: [])
-        dataset = ServiceBroker.dataset.eager(eager_loaded_associations).eager(:space)
+        dataset = ServiceBroker.dataset.eager(eager_loaded_associations)
 
         dataset = dataset.join(:spaces, id: Sequel[:service_brokers][:space_id]) if permitted_space_guids || message.requested?(:space_guids)
 

--- a/app/fetchers/service_broker_list_fetcher.rb
+++ b/app/fetchers/service_broker_list_fetcher.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
   class ServiceBrokerListFetcher < BaseListFetcher
     class << self
       def fetch(message:, permitted_space_guids: nil, eager_loaded_associations: [])
-        dataset = ServiceBroker.dataset.eager(eager_loaded_associations)
+        dataset = ServiceBroker.dataset.eager(eager_loaded_associations).eager(:space)
 
         dataset = dataset.join(:spaces, id: Sequel[:service_brokers][:space_id]) if permitted_space_guids || message.requested?(:space_guids)
 

--- a/app/presenters/v3/service_broker_presenter.rb
+++ b/app/presenters/v3/service_broker_presenter.rb
@@ -10,6 +10,12 @@ module VCAP::CloudController
       class ServiceBrokerPresenter < BasePresenter
         include VCAP::CloudController::Presenters::Mixins::MetadataPresentationHelpers
 
+        class << self
+          def associated_resources
+            super + [:space]
+          end
+        end
+
         def to_hash
           {
             guid: broker.guid,

--- a/spec/request/service_brokers_spec.rb
+++ b/spec/request/service_brokers_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe 'V3 service brokers' do
       it 'eager loads associated resources that the presenter specifies' do
         expect(VCAP::CloudController::ServiceBrokerListFetcher).to receive(:fetch).with(
           hash_including(
-            eager_loaded_associations: %i[labels annotations]
+            eager_loaded_associations: %i[labels annotations space]
           )
         ).and_call_original
 

--- a/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
@@ -47,7 +47,7 @@ module VCAP::CloudController
         end
 
         it 'sets space to nil for global brokers and to the space object for space-scoped brokers' do
-          brokers = fetcher.fetch(message:).all.index_by(&:name)
+          brokers = fetcher.fetch(message: message, eager_loaded_associations: [:space]).all.index_by(&:name)
 
           expect(brokers[broker.name].associations[:space]).to be_nil
           expect(brokers[space_scoped_broker_1.name].associations[:space]).to eq(space_1)

--- a/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_broker_list_fetcher_spec.rb
@@ -45,6 +45,13 @@ module VCAP::CloudController
           expect(dataset.all.first.associations.key?(:labels)).to be true
           expect(dataset.all.first.associations.key?(:annotations)).to be false
         end
+
+        it 'sets space to nil for global brokers and to the space object for space-scoped brokers' do
+          brokers = fetcher.fetch(message:).all.index_by(&:name)
+
+          expect(brokers[broker.name].associations[:space]).to be_nil
+          expect(brokers[space_scoped_broker_1.name].associations[:space]).to eq(space_1)
+        end
       end
 
       context 'when filtering by space GUIDs' do


### PR DESCRIPTION
During get request to **service_brokers** endpoint, if service broker is associated with **space**, it fetch also space information, that leads to N+1 query problem. With this PR we add eager loading for :space association to load all the necessary space information with 1 query. 

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
