### PR TITLE
Make encryptor error-wrapping test deterministic

### DIFF
--- a/spec/unit/lib/cloud_controller/encryptor_spec.rb
+++ b/spec/unit/lib/cloud_controller/encryptor_spec.rb
@@ -161,6 +161,15 @@ module VCAP::CloudController
 
               expect(result).not_to eq(unencrypted_string)
             end
+
+            it 'wraps OpenSSL::Cipher::CipherError as an EncryptorError' do
+              encrypted_string = Encryptor.encrypt(unencrypted_string, salt)
+              allow_any_instance_of(OpenSSL::Cipher).to receive(:final).and_raise(OpenSSL::Cipher::CipherError, 'bad decrypt')
+
+              expect do
+                Encryptor.decrypt(encrypted_string, salt, iterations: encryption_iterations)
+              end.to raise_error(VCAP::CloudController::Encryptor::EncryptorError, %r{Encryption/Decryption failed: bad decrypt})
+            end
           end
 
           context 'when the wrong label is passed for decryption' do
@@ -176,13 +185,13 @@ module VCAP::CloudController
               expect(result).not_to eq(unencrypted_string)
             end
 
-            it 'raises an EncryptorError' do
-              allow(Encryptor).to receive(:current_encryption_key_label).and_return('foo')
+            it 'wraps OpenSSL::Cipher::CipherError as an EncryptorError' do
               encrypted_string = Encryptor.encrypt(unencrypted_string, salt)
+              allow_any_instance_of(OpenSSL::Cipher).to receive(:final).and_raise(OpenSSL::Cipher::CipherError, 'bad decrypt')
 
               expect do
                 Encryptor.decrypt(encrypted_string, salt, label: 'bar', iterations: encryption_iterations)
-              end.to raise_error(VCAP::CloudController::Encryptor::EncryptorError, %r{Encryption/Decryption failed: })
+              end.to raise_error(VCAP::CloudController::Encryptor::EncryptorError, %r{Encryption/Decryption failed: bad decrypt})
             end
           end
         end


### PR DESCRIPTION
The "raises an EncryptorError" test relied on AES-CBC + PKCS#7 producing invalid padding when decrypting with the wrong key. With a random plaintext, padding is coincidentally valid ~1/256 of the time (dominated by the last byte being 0x01), so `cipher.final` returns garbage instead of raising and the test flakes.

Stub `OpenSSL::Cipher#final` to raise `CipherError` so the test exercises the rescue/wrap logic in `run_cipher` deterministically. Add a parallel test in the "no key label" context, since the same wrapping applies there.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
