### PR TITLE
Hide unavailable loggregator endpoints from / response

### DIFF
--- a/app/controllers/runtime/root_controller.rb
+++ b/app/controllers/runtime/root_controller.rb
@@ -41,17 +41,11 @@ module VCAP::CloudController
           credhub: credhub_link,
           routing: routing_link,
 
-          logging: {
-            href: config.get(:doppler, :url)
-          },
+          logging: logging_link,
 
-          log_cache: {
-            href: config.get(:log_cache, :url)
-          },
+          log_cache: log_cache_link,
 
-          log_stream: {
-            href: config.get(:log_stream, :url)
-          },
+          log_stream: log_stream_link,
 
           app_ssh: {
             href: config.get(:info, :app_ssh_endpoint),
@@ -86,6 +80,24 @@ module VCAP::CloudController
       return if config.get(:routing_api).blank?
 
       { href: config.get(:routing_api, :url) }
+    end
+
+    def logging_link
+      return if config.get(:doppler, :url).blank?
+
+      { href: config.get(:doppler, :url) }
+    end
+
+    def log_cache_link
+      return if config.get(:log_cache, :url).blank?
+
+      { href: config.get(:log_cache, :url) }
+    end
+
+    def log_stream_link
+      return if config.get(:log_stream, :url).blank?
+
+      { href: config.get(:log_stream, :url) }
     end
 
     def cloud_controller_v2(api_url_builder)

--- a/spec/unit/controllers/runtime/root_controller_spec.rb
+++ b/spec/unit/controllers/runtime/root_controller_spec.rb
@@ -127,29 +127,91 @@ module VCAP::CloudController
         expect(hash['links']['network_policy_v1']['href']).to eq(expected_uri)
       end
 
-      it 'returns a link to the logging API' do
-        expected_uri = 'wss://doppler.my-super-cool-cf.com:1234'
-        TestConfig.override(doppler: { url: expected_uri })
+      describe 'logging link' do
+        context 'doppler url is configured' do
+          it 'returns a link to the logging API' do
+            expected_uri = 'wss://doppler.my-super-cool-cf.com:1234'
+            TestConfig.override(doppler: { url: expected_uri })
 
-        get '/'
-        hash = Oj.load(last_response.body)
-        expect(hash['links']['logging']['href']).to eq(expected_uri)
+            get '/'
+            hash = Oj.load(last_response.body)
+            expect(hash['links']['logging']['href']).to eq(expected_uri)
+          end
+        end
+
+        context 'doppler url is blank' do
+          before do
+            TestConfig.override(doppler: { url: '' })
+          end
+
+          it 'does not return a link' do
+            get '/'
+            hash = Oj.load(last_response.body)
+            expect(hash['links']['logging']).to be_nil
+          end
+        end
       end
 
-      it 'returns a link to the log cache API' do
-        expected_uri = 'https://log-cache.example.com'
+      describe 'log_cache link' do
+        context 'log_cache url is configured' do
+          it 'returns a link to the log cache API' do
+            expected_uri = 'https://log-cache.example.com'
 
-        get '/'
-        hash = Oj.load(last_response.body)
-        expect(hash['links']['log_cache']['href']).to eq(expected_uri)
+            get '/'
+            hash = Oj.load(last_response.body)
+            expect(hash['links']['log_cache']['href']).to eq(expected_uri)
+          end
+        end
+
+        context 'log_cache url is blank' do
+          before do
+            TestConfig.override(log_cache: { url: '' })
+          end
+
+          it 'does not return a link' do
+            get '/'
+            hash = Oj.load(last_response.body)
+            expect(hash['links']['log_cache']).to be_nil
+          end
+        end
       end
 
-      it 'returns a link to the v2 logging API' do
-        expected_uri = 'https://log-stream.example.com'
+      describe 'log_stream link' do
+        context 'log_stream url is configured' do
+          it 'returns a link to the v2 logging API' do
+            expected_uri = 'https://log-stream.example.com'
 
-        get '/'
-        hash = Oj.load(last_response.body)
-        expect(hash['links']['log_stream']['href']).to eq(expected_uri)
+            get '/'
+            hash = Oj.load(last_response.body)
+            expect(hash['links']['log_stream']['href']).to eq(expected_uri)
+          end
+        end
+
+        context 'log_stream url is blank' do
+          before do
+            TestConfig.override(log_stream: { url: '' })
+          end
+
+          it 'does not return a link' do
+            get '/'
+            hash = Oj.load(last_response.body)
+            expect(hash['links']['log_stream']).to be_nil
+          end
+        end
+      end
+
+      context 'all loggregator urls are blank' do
+        before do
+          TestConfig.override(doppler: { url: '' }, log_cache: { url: '' }, log_stream: { url: '' })
+        end
+
+        it 'returns nil for all three loggregator links' do
+          get '/'
+          hash = Oj.load(last_response.body)
+          expect(hash['links']['logging']).to be_nil
+          expect(hash['links']['log_cache']).to be_nil
+          expect(hash['links']['log_stream']).to be_nil
+        end
       end
 
       it 'returns a link for app_ssh with metadata' do


### PR DESCRIPTION
Use a nil-when-blank helper for the `logging`, `log_cache`, and `log_stream` links in the root controller, matching the existing pattern used by `credhub_link` and `routing_link`. The link entry becomes `nil` when the underlying URL is not configured, instead of advertising an empty href.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
