### PR TITLE
Add admin_limit to cc.rate_limiter configuration

### DIFF
--- a/config/cloud_controller.yml
+++ b/config/cloud_controller.yml
@@ -267,6 +267,8 @@ rate_limiter:
   global_general_limit: 20000
   per_process_unauthenticated_limit: 100
   global_unauthenticated_limit: 1000
+  per_process_admin_limit: -1
+  global_admin_limit: -1
   reset_interval_in_minutes: 60
 
 rate_limiter_v2_api:

--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -386,6 +386,8 @@ module VCAP::CloudController
             global_general_limit: Integer,
             per_process_unauthenticated_limit: Integer,
             global_unauthenticated_limit: Integer,
+            optional(:per_process_admin_limit) => Integer,
+            optional(:global_admin_limit) => Integer,
             reset_interval_in_minutes: Integer
           },
           max_concurrent_service_broker_requests: Integer,

--- a/lib/cloud_controller/rack_app_builder.rb
+++ b/lib/cloud_controller/rack_app_builder.rb
@@ -36,6 +36,8 @@ module VCAP::CloudController
             global_general_limit: config.get(:rate_limiter, :global_general_limit),
             per_process_unauthenticated_limit: config.get(:rate_limiter, :per_process_unauthenticated_limit),
             global_unauthenticated_limit: config.get(:rate_limiter, :global_unauthenticated_limit),
+            per_process_admin_limit: config.get(:rate_limiter, :per_process_admin_limit),
+            global_admin_limit: config.get(:rate_limiter, :global_admin_limit),
             interval: config.get(:rate_limiter, :reset_interval_in_minutes)
           }
         end

--- a/middleware/base_rate_limiter.rb
+++ b/middleware/base_rate_limiter.rb
@@ -141,10 +141,7 @@ module CloudFoundry
       end
 
       def exceeded_rate_limit(count, env)
-        limit = per_process_request_limit(env)
-        return false if limit == -1
-
-        count > limit
+        count > per_process_request_limit(env)
       end
 
       def estimate_remaining(env, new_count)

--- a/middleware/base_rate_limiter.rb
+++ b/middleware/base_rate_limiter.rb
@@ -141,7 +141,10 @@ module CloudFoundry
       end
 
       def exceeded_rate_limit(count, env)
-        count > per_process_request_limit(env)
+        limit = per_process_request_limit(env)
+        return false if limit == -1
+
+        count > limit
       end
 
       def estimate_remaining(env, new_count)

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -19,7 +19,11 @@ module CloudFoundry
 
       def apply_rate_limiting?(env)
         request = ActionDispatch::Request.new(env)
-        !basic_auth?(env) && !internal_api?(request) && !root_api?(request) && per_process_request_limit(env) != -1
+        return false if basic_auth?(env)
+        return false if internal_api?(request) || root_api?(request)
+        return false if per_process_request_limit(env) < 0
+
+        true
       end
 
       def root_api?(request)

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -10,6 +10,8 @@ module CloudFoundry
         @global_general_limit              = opts[:global_general_limit]
         @per_process_unauthenticated_limit = opts[:per_process_unauthenticated_limit]
         @global_unauthenticated_limit      = opts[:global_unauthenticated_limit]
+        @per_process_admin_limit           = opts[:per_process_admin_limit] || -1
+        @global_admin_limit                = opts[:global_admin_limit] || -1
         super(app, opts[:logger], EXPIRING_REQUEST_COUNTER, opts[:interval])
       end
 
@@ -17,7 +19,11 @@ module CloudFoundry
 
       def apply_rate_limiting?(env)
         request = ActionDispatch::Request.new(env)
-        !basic_auth?(env) && !internal_api?(request) && !root_api?(request) && !admin?
+        !basic_auth?(env) && !internal_api?(request) && !root_api?(request) && !admin_unlimited?
+      end
+
+      def admin_unlimited?
+        admin? && @per_process_admin_limit == -1
       end
 
       def root_api?(request)
@@ -29,10 +35,14 @@ module CloudFoundry
       end
 
       def global_request_limit(env)
+        return @global_admin_limit if admin?
+
         user_token?(env) ? @global_general_limit : @global_unauthenticated_limit
       end
 
       def per_process_request_limit(env)
+        return @per_process_admin_limit if admin?
+
         user_token?(env) ? @per_process_general_limit : @per_process_unauthenticated_limit
       end
 

--- a/middleware/rate_limiter.rb
+++ b/middleware/rate_limiter.rb
@@ -19,11 +19,7 @@ module CloudFoundry
 
       def apply_rate_limiting?(env)
         request = ActionDispatch::Request.new(env)
-        !basic_auth?(env) && !internal_api?(request) && !root_api?(request) && !admin_unlimited?
-      end
-
-      def admin_unlimited?
-        admin? && @per_process_admin_limit == -1
+        !basic_auth?(env) && !internal_api?(request) && !root_api?(request) && per_process_request_limit(env) != -1
       end
 
       def root_api?(request)

--- a/spec/request/rate_limit_spec.rb
+++ b/spec/request/rate_limit_spec.rb
@@ -79,11 +79,9 @@ RSpec.describe 'Rate Limiting' do
 
     context 'when admin_limit is -1 (default, unlimited)' do
       it 'is not rate limited' do
-        20.times do |n|
-          get '/v3/spaces', nil, admin_headers
-          expect(last_response.status).to eq(200), "rate limited after #{n} requests"
-          expect(last_response.headers).not_to include('X-RateLimit-Limit')
-        end
+        get '/v3/spaces', nil, admin_headers
+        expect(last_response.status).to eq(200)
+        expect(last_response.headers).not_to include('X-RateLimit-Limit')
       end
     end
 

--- a/spec/request/rate_limit_spec.rb
+++ b/spec/request/rate_limit_spec.rb
@@ -73,4 +73,57 @@ RSpec.describe 'Rate Limiting' do
       expect(parsed_response['errors'].first['detail']).to include('Rate Limit Exceeded: Unauthenticated requests from this IP address have exceeded the limit')
     end
   end
+
+  context 'as an admin' do
+    let(:admin_headers) { admin_headers_for(VCAP::CloudController::User.make) }
+
+    context 'when admin_limit is -1 (default, unlimited)' do
+      it 'is not rate limited' do
+        20.times do |n|
+          get '/v3/spaces', nil, admin_headers
+          expect(last_response.status).to eq(200), "rate limited after #{n} requests"
+          expect(last_response.headers).not_to include('X-RateLimit-Limit')
+        end
+      end
+    end
+
+    context 'when admin_limit is set to a positive value' do
+      before do
+        TestConfig.override(
+          rate_limiter: {
+            enabled: true,
+            per_process_general_limit: 10,
+            global_general_limit: 100,
+            per_process_unauthenticated_limit: 2,
+            global_unauthenticated_limit: 20,
+            per_process_admin_limit: 3,
+            global_admin_limit: 30,
+            reset_interval_in_minutes: 60
+          }
+        )
+      end
+
+      it 'uses the admin limit' do
+        3.times do |n|
+          get '/v3/spaces', nil, admin_headers
+          expect(last_response.status).to eq(200), "rate limited after #{n} requests"
+          expect(last_response.headers['X-RateLimit-Limit']).to eq('30')
+        end
+
+        get '/v3/spaces', nil, admin_headers
+        expect(last_response.status).to eq(429)
+      end
+
+      it 'does not affect regular users' do
+        4.times { get '/v3/spaces', nil, admin_headers }
+
+        space = VCAP::CloudController::Space.make
+        user = make_developer_for_space(space)
+        user_headers = headers_for(user)
+
+        get '/v3/spaces', nil, user_headers
+        expect(last_response.status).to eq(200)
+      end
+    end
+  end
 end

--- a/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
@@ -68,6 +68,8 @@ module VCAP::CloudController
               global_general_limit: 1230,
               per_process_unauthenticated_limit: 1,
               global_unauthenticated_limit: 10,
+              per_process_admin_limit: nil,
+              global_admin_limit: nil,
               interval: 60
             )
           end

--- a/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
+++ b/spec/unit/lib/cloud_controller/rack_app_builder_spec.rb
@@ -56,7 +56,9 @@ module VCAP::CloudController
                                                 per_process_general_limit: 123,
                                                 global_general_limit: 1230,
                                                 per_process_unauthenticated_limit: 1,
-                                                global_unauthenticated_limit: 10
+                                                global_unauthenticated_limit: 10,
+                                                per_process_admin_limit: -1,
+                                                global_admin_limit: -1
                                               }), request_metrics, request_logs).to_app
           end
 
@@ -68,8 +70,8 @@ module VCAP::CloudController
               global_general_limit: 1230,
               per_process_unauthenticated_limit: 1,
               global_unauthenticated_limit: 10,
-              per_process_admin_limit: nil,
-              global_admin_limit: nil,
+              per_process_admin_limit: -1,
+              global_admin_limit: -1,
               interval: 60
             )
           end

--- a/spec/unit/middleware/rate_limiter_spec.rb
+++ b/spec/unit/middleware/rate_limiter_spec.rb
@@ -12,6 +12,8 @@ module CloudFoundry
             global_general_limit:,
             per_process_unauthenticated_limit:,
             global_unauthenticated_limit:,
+            per_process_admin_limit:,
+            global_admin_limit:,
             interval:
           }
         )
@@ -23,6 +25,8 @@ module CloudFoundry
       let(:global_general_limit) { 1000 }
       let(:per_process_unauthenticated_limit) { 10 }
       let(:global_unauthenticated_limit) { 100 }
+      let(:per_process_admin_limit) { -1 }
+      let(:global_admin_limit) { -1 }
       let(:interval) { 60 }
       let(:logger) { double('logger', info: nil) }
       let(:expires_in) { 10.minutes.to_i }
@@ -230,19 +234,42 @@ module CloudFoundry
       end
 
       context 'when user has admin or admin_read_only scopes' do
-        let(:per_process_general_limit) { 1 }
-
         before do
           allow(VCAP::CloudController::SecurityContext).to receive(:admin_read_only?).and_return(true)
         end
 
-        it 'does not rate limit' do
-          2.times { middleware.call(user_1_env) }
-          status, response_headers, = middleware.call(user_1_env)
-          expect(response_headers).not_to include('X-RateLimit-Remaining')
-          expect(status).to eq(200)
-          expect(app).to have_received(:call).at_least(:once)
-          expect(expiring_request_counter).not_to have_received(:increment)
+        context 'when admin_limit is -1 (default, unlimited)' do
+          it 'does not rate limit' do
+            2.times { middleware.call(user_1_env) }
+            status, response_headers, = middleware.call(user_1_env)
+            expect(response_headers).not_to include('X-RateLimit-Remaining')
+            expect(status).to eq(200)
+            expect(app).to have_received(:call).at_least(:once)
+            expect(expiring_request_counter).not_to have_received(:increment)
+          end
+        end
+
+        context 'when admin_limit is set to a positive value' do
+          let(:per_process_admin_limit) { 2 }
+          let(:global_admin_limit) { 20 }
+
+          it 'rate limits admin users using the admin limits' do
+            _, response_headers, = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Limit']).to eq(global_admin_limit.to_s)
+          end
+
+          it 'returns 429 when admin limit is exceeded' do
+            allow(expiring_request_counter).to receive(:increment).and_return([per_process_admin_limit + 1, expires_in])
+            status, = middleware.call(user_1_env.merge('PATH_INFO' => '/v3/foo'))
+            expect(status).to eq(429)
+          end
+
+          it 'does not rate limit regular users with admin limits' do
+            allow(VCAP::CloudController::SecurityContext).to receive(:admin_read_only?).and_return(false)
+            allow(VCAP::CloudController::SecurityContext).to receive(:admin?).and_return(false)
+            _, response_headers, = middleware.call(user_1_env)
+            expect(response_headers['X-RateLimit-Limit']).to eq(global_general_limit.to_s)
+          end
         end
       end
 

--- a/spec/unit/middleware/rate_limiter_spec.rb
+++ b/spec/unit/middleware/rate_limiter_spec.rb
@@ -265,8 +265,7 @@ module CloudFoundry
           end
 
           it 'does not rate limit regular users with admin limits' do
-            allow(VCAP::CloudController::SecurityContext).to receive(:admin_read_only?).and_return(false)
-            allow(VCAP::CloudController::SecurityContext).to receive(:admin?).and_return(false)
+            allow(VCAP::CloudController::SecurityContext).to receive_messages(admin_read_only?: false, admin?: false)
             _, response_headers, = middleware.call(user_1_env)
             expect(response_headers['X-RateLimit-Limit']).to eq(global_general_limit.to_s)
           end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
CF API rate limits currently exclude admin users entirely. This PR extends cc.rate_limiter with an admin_limit parameter (default -1 = no limit, preserving existing behavior) that when set to a positive value applies rate limiting to admin users using their own counter, independent of the general user limit.
* An explanation of the use cases your change solves
  - Operators want to protect the CF API from abusive or runaway automation scripts running with admin credentials
  - Without this change, admin users can send unlimited requests and potentially overwhelm the API, while regular users are protected
  - With admin_limit: -1 (default), existing deployments are unaffected
* Links to any other associated PRs
Capi-release <https://github.com/cloudfoundry/capi-release/pull/655>
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
