### PR TITLE
Fix v3/roles perf regression for regular users

### DIFF
--- a/app/controllers/v3/roles_controller.rb
+++ b/app/controllers/v3/roles_controller.rb
@@ -173,8 +173,8 @@ class RolesController < ApplicationController
     if permission_queryer.can_read_globally?
       Role
     else
-      readable_by_space = { space_id: permission_queryer.readable_spaces_query.select(:id) }
-      readable_by_org = { organization_id: permission_queryer.readable_orgs_query.select(:id) }
+      readable_by_space = { space_id: permission_queryer.readable_space_ids_query }
+      readable_by_org = { organization_id: permission_queryer.readable_org_ids_query }
       Role.where { Sequel.|(readable_by_space, readable_by_org) }
     end
   end

--- a/lib/cloud_controller/membership.rb
+++ b/lib/cloud_controller/membership.rb
@@ -29,14 +29,7 @@ module VCAP::CloudController
     end
 
     def authorized_orgs_subquery(roles)
-      space_ids_query = member_space_ids(roles)
-      org_ids_from_space_roles = Space.where(id: space_ids_query).select(:organization_id) if space_ids_query
-
-      if org_ids_from_space_roles
-        Organization.where(id: member_org_ids(roles)).or(id: org_ids_from_space_roles)
-      else
-        Organization.where(id: member_org_ids(roles))
-      end
+      Organization.where(id: authorized_org_ids_subquery(roles))
     end
 
     def authorized_space_guids(roles)
@@ -48,11 +41,36 @@ module VCAP::CloudController
     end
 
     def authorized_spaces_subquery(roles)
-      org_ids = member_org_ids(roles)
-      if org_ids
-        Space.where(id: member_space_ids(roles)).or(organization_id: org_ids).select(:id, :guid)
+      Space.where(id: authorized_space_ids_subquery(roles)).select(:id, :guid)
+    end
+
+    # Like authorized_spaces_subquery but returns a flat id-only UNION (no Space.where wrapper).
+    # Use when the caller filters by a raw space_id FK column to avoid an extra subplan over `spaces`.
+    def authorized_space_ids_subquery(roles)
+      space_ids_query = member_space_ids(roles)
+      org_ids_query   = member_org_ids(roles)
+
+      space_ids_via_orgs = Space.where(organization_id: org_ids_query).select(:id) if org_ids_query
+
+      if space_ids_query && space_ids_via_orgs
+        space_ids_query.union(space_ids_via_orgs, from_self: false)
       else
-        Space.where(id: member_space_ids(roles)).select(:id, :guid)
+        space_ids_query || space_ids_via_orgs
+      end
+    end
+
+    # Like authorized_orgs_subquery but returns a flat id-only UNION (no Organization.where wrapper).
+    # Use when the caller filters by a raw organization_id FK column.
+    def authorized_org_ids_subquery(roles)
+      space_ids_query = member_space_ids(roles)
+      org_ids_query   = member_org_ids(roles)
+
+      org_ids_via_space_roles = Space.where(id: space_ids_query).select(:organization_id) if space_ids_query
+
+      if org_ids_query && org_ids_via_space_roles
+        org_ids_query.union(org_ids_via_space_roles, from_self: false)
+      else
+        org_ids_query || org_ids_via_space_roles
       end
     end
 

--- a/lib/cloud_controller/membership.rb
+++ b/lib/cloud_controller/membership.rb
@@ -32,6 +32,19 @@ module VCAP::CloudController
       Organization.where(id: authorized_org_ids_subquery(roles))
     end
 
+    def authorized_org_ids_subquery(roles)
+      space_ids_query = member_space_ids(roles)
+      org_ids_query   = member_org_ids(roles)
+
+      org_ids_via_space_roles = Space.where(id: space_ids_query).select(:organization_id) if space_ids_query
+
+      if org_ids_query && org_ids_via_space_roles
+        org_ids_query.union(org_ids_via_space_roles, from_self: false)
+      else
+        org_ids_query || org_ids_via_space_roles
+      end
+    end
+
     def authorized_space_guids(roles)
       authorized_space_guids_subquery(roles).select_map(:guid)
     end
@@ -44,33 +57,16 @@ module VCAP::CloudController
       Space.where(id: authorized_space_ids_subquery(roles)).select(:id, :guid)
     end
 
-    # Like authorized_spaces_subquery but returns a flat id-only UNION (no Space.where wrapper).
-    # Use when the caller filters by a raw space_id FK column to avoid an extra subplan over `spaces`.
     def authorized_space_ids_subquery(roles)
       space_ids_query = member_space_ids(roles)
       org_ids_query   = member_org_ids(roles)
 
-      space_ids_via_orgs = Space.where(organization_id: org_ids_query).select(:id) if org_ids_query
+      space_ids_via_org_roles = Space.where(organization_id: org_ids_query).select(:id) if org_ids_query
 
-      if space_ids_query && space_ids_via_orgs
-        space_ids_query.union(space_ids_via_orgs, from_self: false)
+      if space_ids_query && space_ids_via_org_roles
+        space_ids_query.union(space_ids_via_org_roles, from_self: false)
       else
-        space_ids_query || space_ids_via_orgs
-      end
-    end
-
-    # Like authorized_orgs_subquery but returns a flat id-only UNION (no Organization.where wrapper).
-    # Use when the caller filters by a raw organization_id FK column.
-    def authorized_org_ids_subquery(roles)
-      space_ids_query = member_space_ids(roles)
-      org_ids_query   = member_org_ids(roles)
-
-      org_ids_via_space_roles = Space.where(id: space_ids_query).select(:organization_id) if space_ids_query
-
-      if org_ids_query && org_ids_via_space_roles
-        org_ids_query.union(org_ids_via_space_roles, from_self: false)
-      else
-        org_ids_query || org_ids_via_space_roles
+        space_ids_query || space_ids_via_org_roles
       end
     end
 

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -123,6 +123,15 @@ class VCAP::CloudController::Permissions
     end
   end
 
+  # Id-only variant of readable_orgs_query for callers filtering by a raw organization_id FK column.
+  def readable_org_ids_query
+    if can_read_globally?
+      VCAP::CloudController::Organization.dataset.select(:id)
+    else
+      membership.authorized_org_ids_subquery(ROLES_FOR_ORG_READING)
+    end
+  end
+
   def readable_org_guids_for_domains_query
     if can_read_globally?
       VCAP::CloudController::Organization.select(:guid)
@@ -166,6 +175,13 @@ class VCAP::CloudController::Permissions
     raise 'must not be called for users that can read globally' if can_read_globally?
 
     membership.authorized_spaces_subquery(ROLES_FOR_SPACE_READING)
+  end
+
+  # Id-only variant of readable_spaces_query for callers filtering by a raw space_id FK column.
+  def readable_space_ids_query
+    raise 'must not be called for users that can read globally' if can_read_globally?
+
+    membership.authorized_space_ids_subquery(ROLES_FOR_SPACE_READING)
   end
 
   def readable_space_guids_query

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -123,10 +123,9 @@ class VCAP::CloudController::Permissions
     end
   end
 
-  # Id-only variant of readable_orgs_query for callers filtering by a raw organization_id FK column.
   def readable_org_ids_query
     if can_read_globally?
-      VCAP::CloudController::Organization.dataset.select(:id)
+      VCAP::CloudController::Organization.select(:id)
     else
       membership.authorized_org_ids_subquery(ROLES_FOR_ORG_READING)
     end
@@ -177,7 +176,6 @@ class VCAP::CloudController::Permissions
     membership.authorized_spaces_subquery(ROLES_FOR_SPACE_READING)
   end
 
-  # Id-only variant of readable_spaces_query for callers filtering by a raw space_id FK column.
   def readable_space_ids_query
     raise 'must not be called for users that can read globally' if can_read_globally?
 

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -163,6 +163,16 @@ module VCAP::CloudController
       end
     end
 
+    describe '#readable_org_ids_query' do
+      it 'returns subquery from membership' do
+        membership = instance_double(Membership)
+        subquery = instance_double(Sequel::Dataset)
+        expect(Membership).to receive(:new).with(user).and_return(membership)
+        expect(membership).to receive(:authorized_org_ids_subquery).with(Permissions::ROLES_FOR_ORG_READING).and_return(subquery)
+        expect(permissions.readable_org_ids_query).to be(subquery)
+      end
+    end
+
     describe '#readable_org_guids_for_domains_query' do
       context 'when user has valid membership' do
         let(:membership) { instance_double(Membership) }
@@ -385,6 +395,16 @@ module VCAP::CloudController
         expect(Membership).to receive(:new).with(user).and_return(membership)
         expect(membership).to receive(:authorized_spaces_subquery).with(Permissions::ROLES_FOR_SPACE_READING).and_return(subquery)
         expect(permissions.readable_spaces_query).to be(subquery)
+      end
+    end
+
+    describe '#readable_space_ids_query' do
+      it 'returns subquery from membership' do
+        membership = instance_double(Membership)
+        subquery = instance_double(Sequel::Dataset)
+        expect(Membership).to receive(:new).with(user).and_return(membership)
+        expect(membership).to receive(:authorized_space_ids_subquery).with(Permissions::ROLES_FOR_SPACE_READING).and_return(subquery)
+        expect(permissions.readable_space_ids_query).to be(subquery)
       end
     end
 


### PR DESCRIPTION
## Summary

Fixes a ~2x perf regression on `GET /v3/roles` (as regular user) introduced by #5094.
Related performance tests results of capi release v1.236.0:
https://github.com/cloudfoundry/cf-performance-tests-pipeline/blob/main/results/rails/postgres/charts/roles-test-results/v1/roles-detailed-chart-with-most-recent-runs.png

Root cause: `Membership#authorized_spaces_subquery` returns `Space.where(id: ...).or(organization_id: ...)`, which Postgres compiles as a SubPlan re-evaluated once per branch of the `Role` UNION ALL — 8x `Seq Scan onspaces`.

## Perf measurements

Local repro: 5k orgs / 20k spaces / 50k users / ~880k role rows. Target user has mixed org + space role memberships. Benchmark calls `RolesController#readable_roles` directly via `bin/console` and runs `EXPLAIN ANALYZE`.

| State | Cost | Exec | Buffers |
|---|---|---|---|
| 1.236.0 (regression) | 133401 | 18.0 ms | 2369 |
| #5094 reverted (1.235.0) | 131804 | 4.6 ms | 532 |
| **This PR** | **131804** | **4.6 ms** | **532** |

Plan and buffer counts match the reverted state exactly.

## Fix

- `membership.rb`: rewrite `authorized_spaces_subquery` / `authorized_orgs_subquery`
    to push the OR inside a single `id IN (UNION)`. Same return contract; planner
    can now flatten. Benefits every caller of `readable_*_query`.
- `membership.rb`: add `authorized_space_ids_subquery` / `authorized_org_ids_subquery` + flat id-only UNIONs without the entity wrapper. Used by callers that filter
    by a raw `space_id` / `organization_id` FK column (avoids a redundant subplan over `spaces` / `organizations`).
- `permissions.rb`: expose `readable_space_ids_query` / `readable_org_ids_query`.
- `roles_controller.rb`: `readable_roles` uses the id-only queries.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
