### PR TITLE
docs: align documented status to 200 OK for List roles and Update user

### DIFF
--- a/docs/v3/source/includes/resources/roles/_list.md.erb
+++ b/docs/v3/source/includes/resources/roles/_list.md.erb
@@ -16,7 +16,7 @@ Example Response
 ```
 
 ```http
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/json
 
 <%= yield_content :paginated_list_of_roles, '/v3/roles' %>

--- a/docs/v3/source/includes/resources/users/_update.md.erb
+++ b/docs/v3/source/includes/resources/users/_update.md.erb
@@ -24,7 +24,7 @@ Example Response
 ```
 
 ```http
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/json
 
 <%= yield_content :single_user_with_metadata %>


### PR DESCRIPTION
A short explanation of the proposed change:

Two endpoints document an `HTTP/1.1 201 Created` response, but the controllers render `status: :ok` (`200 OK`). This PR aligns the **docs** with the currently shipped server behavior:

- `GET /v3/roles` (List roles): `docs/v3/source/includes/resources/roles/_list.md.erb` — `201 Created` → `200 OK`
- `PATCH /v3/users/:guid` (Update a user): `docs/v3/source/includes/resources/users/_update.md.erb` — `201 Created` → `200 OK`

Controller source (pinned to `661aa67`):

- List roles renders `:ok` → [roles_controller.rb#L24](https://github.com/cloudfoundry/cloud_controller_ng/blob/661aa67c40ee8f352af2b0bdc0ed85b126760e01/app/controllers/v3/roles_controller.rb#L24); only `create` renders `:created` → [#L58](https://github.com/cloudfoundry/cloud_controller_ng/blob/661aa67c40ee8f352af2b0bdc0ed85b126760e01/app/controllers/v3/roles_controller.rb#L58)
- Update a user renders `:ok` → [users_controller.rb#L77](https://github.com/cloudfoundry/cloud_controller_ng/blob/661aa67c40ee8f352af2b0bdc0ed85b126760e01/app/controllers/v3/users_controller.rb#L77); only `create` renders `:created` → [#L51-L55](https://github.com/cloudfoundry/cloud_controller_ng/blob/661aa67c40ee8f352af2b0bdc0ed85b126760e01/app/controllers/v3/users_controller.rb#L51-L55)

An explanation of the use cases your change solves:

The docs currently misreport the success status for a list and an update endpoint, which can mislead client/SDK authors and contract-testing tools. This change makes the published docs match the actual response code (`200 OK`).

Note on direction: I deliberately picked the non-breaking fix (docs → match shipped behavior). If `201` was in fact the intended contract for these two endpoints, then the controllers would be the place to change instead — in that case I'm happy to close this in favor of that approach. See the discussion in #5183.

Links to any other associated PRs: none. Tracking issue: #5183.

- [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)
- [x] I have viewed, signed, and submitted the Contributor License Agreement
- [x] I have made this pull request to the `main` branch
- [ ] I have run all the unit tests using `bundle exec rake` — N/A, docs-only change (no Ruby code modified)
- [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats) — N/A, docs-only change
