### PR TITLE
docs: align Apply organization quota status to 200 OK

### DIFF
--- a/docs/v3/source/includes/resources/organization_quotas/_apply.md.erb
+++ b/docs/v3/source/includes/resources/organization_quotas/_apply.md.erb
@@ -19,7 +19,7 @@ Example Response
 ```
 
 ```http
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/json
 
 <%= yield_content :apply_organization_quota %>


### PR DESCRIPTION
The "Apply an organization quota to an organization" endpoint
(`POST /v3/organization_quotas/:quota_guid/relationships/organizations`)
documents `201 Created`, but the controller renders `status: :ok` (200) via
`ToManyRelationshipPresenter` (`organization_quotas_controller.rb`, apply action).

This is the same class of mismatch as the roles/users fixes in #5185, and the
cf-openapi spec already documents `200` here. Docs-only, one line.

I have read and signed the [Contributor License Agreement](https://www.cloudfoundry.org/governance/cff_individual_cla/) — [x]