### PR TITLE
Fix readiness endpoint reporting OK when request backlog exceeds threads

### DIFF
--- a/lib/cloud_controller/api_metrics_webserver.rb
+++ b/lib/cloud_controller/api_metrics_webserver.rb
@@ -57,9 +57,23 @@ module VCAP
 
         unhealthy = determine_unhealthy_state(all_busy)
 
-        build_status_response(all_busy, unhealthy)
+        response = build_status_response(all_busy, unhealthy)
+
+        seconds_since_increase = @last_requests_count_increase_time ? (Time.now - @last_requests_count_increase_time).round(2) : nil
+        worker_stats = worker_statuses&.map do |w|
+          ls = w[:last_status] || {}
+          "pool_capacity=#{ls[:pool_capacity]} requests_count=#{ls[:requests_count]}"
+        end&.join(', ')
+        log("[readiness] workers=[#{worker_stats}] all_busy=#{all_busy} secs_since_last_increase=#{seconds_since_increase.inspect} unhealthy=#{unhealthy} -> #{response[2].first}")
+
+        response
       rescue StandardError => e
+        log("[readiness] error: #{e.class}: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}")
         [500, { 'Content-Type' => 'text/plain' }, ["Readiness check error: #{e}"]]
+      end
+
+      def log(msg)
+        Steno.logger('cc.readiness').info(msg)
       end
 
       def track_request_count_increase(current_requests_count_sum)
@@ -88,7 +102,7 @@ module VCAP
 
       def all_workers_busy?(worker_statuses)
         worker_statuses.all? do |worker|
-          worker[:last_status][:busy_threads] == worker[:last_status][:running]
+          worker[:last_status][:pool_capacity].zero?
         end
       end
 

--- a/spec/request/status_spec.rb
+++ b/spec/request/status_spec.rb
@@ -13,8 +13,8 @@ module VCAP::CloudController
         before do
           allow(Puma).to receive(:stats_hash).and_return(
             worker_status: [
-              { last_status: { busy_threads: 2, running: 2, requests_count: 5 } },
-              { last_status: { busy_threads: 1, running: 1, requests_count: 3 } }
+              { last_status: { busy_threads: 2, running: 2, pool_capacity: 0, requests_count: 5 } },
+              { last_status: { busy_threads: 1, running: 1, pool_capacity: 0, requests_count: 3 } }
             ]
           )
           allow(metrics_webserver).to receive(:determine_unhealthy_state).and_return(true)
@@ -32,8 +32,8 @@ module VCAP::CloudController
         before do
           allow(Puma).to receive(:stats_hash).and_return(
             worker_status: [
-              { last_status: { busy_threads: 2, running: 2, requests_count: 5 } },
-              { last_status: { busy_threads: 1, running: 1, requests_count: 3 } }
+              { last_status: { busy_threads: 2, running: 2, pool_capacity: 0, requests_count: 5 } },
+              { last_status: { busy_threads: 1, running: 1, pool_capacity: 0, requests_count: 3 } }
             ]
           )
           allow(metrics_webserver).to receive(:determine_unhealthy_state).and_return(false)
@@ -47,12 +47,48 @@ module VCAP::CloudController
         end
       end
 
+      context 'when all workers are busy with a request backlog (busy_threads > running) but not yet unhealthy' do
+        before do
+          allow(Puma).to receive(:stats_hash).and_return(
+            worker_status: [
+              { last_status: { busy_threads: 12, running: 2, pool_capacity: 0, requests_count: 5 } }
+            ]
+          )
+          allow(metrics_webserver).to receive(:determine_unhealthy_state).and_return(false)
+        end
+
+        it 'returns 429 BUSY' do
+          get '/internal/v4/status'
+
+          expect(last_response.status).to eq(429)
+          expect(last_response.body).to eq('BUSY')
+        end
+      end
+
+      context 'when all workers are busy with a request backlog (busy_threads > running) and unhealthy' do
+        before do
+          allow(Puma).to receive(:stats_hash).and_return(
+            worker_status: [
+              { last_status: { busy_threads: 12, running: 2, pool_capacity: 0, requests_count: 5 } }
+            ]
+          )
+          allow(metrics_webserver).to receive(:determine_unhealthy_state).and_return(true)
+        end
+
+        it 'returns 503 UNHEALTHY' do
+          get '/internal/v4/status'
+
+          expect(last_response.status).to eq(503)
+          expect(last_response.body).to eq('UNHEALTHY')
+        end
+      end
+
       context 'when not all workers are busy' do
         before do
           allow(Puma).to receive(:stats_hash).and_return(
             worker_status: [
-              { last_status: { busy_threads: 1, running: 2, requests_count: 5 } },
-              { last_status: { busy_threads: 0, running: 1, requests_count: 3 } }
+              { last_status: { busy_threads: 1, running: 2, pool_capacity: 1, requests_count: 5 } },
+              { last_status: { busy_threads: 0, running: 1, pool_capacity: 1, requests_count: 3 } }
             ]
           )
         end


### PR DESCRIPTION
The all_workers_busy? check compared busy_threads == running, which is false when there is a request backlog: Puma inflates busy_threads to include queued requests (busy_threads = spawned - waiting + todo.size), so a fully saturated pool with queued work would have busy_threads > running and be incorrectly reported as not busy.

Fix by using pool_capacity == 0 instead, which is the correct signal that all threads are occupied regardless of queue depth.

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
