### PR TITLE
Fix bool casting on mysql

### DIFF
--- a/app/models/services/service_plan.rb
+++ b/app/models/services/service_plan.rb
@@ -161,13 +161,13 @@ module VCAP::CloudController
     end
 
     def bindable?
-      return bindable unless bindable.nil?
+      return ActiveModel::Type::Boolean.new.cast(bindable) unless bindable.nil?
 
       service.bindable?
     end
 
     def plan_updateable?
-      return plan_updateable unless plan_updateable.nil?
+      return ActiveModel::Type::Boolean.new.cast(plan_updateable) unless plan_updateable.nil?
 
       !!service.plan_updateable
     end

--- a/spec/unit/models/services/service_plan_spec.rb
+++ b/spec/unit/models/services/service_plan_spec.rb
@@ -378,6 +378,22 @@ module VCAP::CloudController
           specify { expect(service_plan).to be_bindable }
         end
       end
+
+      context 'when the bindable value is returned as an integer (e.g. from a UNION query on MySQL)' do
+        let(:service) { Service.make(bindable: true) }
+
+        it 'returns true when the integer value is 1' do
+          service_plan = ServicePlan.make(service: service, bindable: true)
+          allow(service_plan).to receive(:bindable).and_return(1)
+          expect(service_plan.bindable?).to be(true)
+        end
+
+        it 'returns false when the integer value is 0' do
+          service_plan = ServicePlan.make(service: service, bindable: true)
+          allow(service_plan).to receive(:bindable).and_return(0)
+          expect(service_plan.bindable?).to be(false)
+        end
+      end
     end
 
     describe '#plan_updateable?' do
@@ -438,6 +454,22 @@ module VCAP::CloudController
           let(:service) { Service.make(plan_updateable: nil) }
 
           specify { expect(service_plan.plan_updateable?).to be(false) }
+        end
+      end
+
+      context 'when the plan_updateable value is returned as an integer (e.g. from a UNION query on MySQL)' do
+        let(:service) { Service.make(plan_updateable: true) }
+
+        it 'returns true when the integer value is 1' do
+          service_plan = ServicePlan.make(service: service, plan_updateable: true)
+          allow(service_plan).to receive(:plan_updateable).and_return(1)
+          expect(service_plan.plan_updateable?).to be(true)
+        end
+
+        it 'returns false when the integer value is 0' do
+          service_plan = ServicePlan.make(service: service, plan_updateable: true)
+          allow(service_plan).to receive(:plan_updateable).and_return(0)
+          expect(service_plan.plan_updateable?).to be(false)
         end
       end
     end


### PR DESCRIPTION
When:
1. Using MySQL 
2. The Broker specifies per plan level features (bindable/plan_updateable)
3. Using a non-admin user
4. Uses certain filters like space queries

The API will return an int instead of a bool for certain fields

```
{
  "pagination": {
....
  },
  "resources": [
    {
      "guid": "0d43da8c-1c0a-4f70-b9e6-2309addf6a5a",
      "created_at": "2026-06-23T16:13:41Z",
      "updated_at": "2026-06-23T17:08:26Z",
      "name": "simple",
      "visibility_type": "public",
      "available": true,
      "free": true,
      "costs": [],
      "description": "A very simple plan.",
      "maintenance_info": {},
      "broker_catalog": {
        "id": "6f357aaf95ab1e8bd7e03dacbc18f967",
        "metadata": {},
        "maximum_polling_duration": null,
        "features": {
          "bindable": 1, <<<<< THIS IS WRONG
          "plan_updateable": true
        }
      },
    ....

```

Seems like this is already handled for other certain bools with this comment (like free)
```
    # When selecting a UNION of multiple sub-queries, MySQL does not maintain the original type - i.e. tinyint(1) - and
    # thus Sequel does not convert the value to a boolean.
    # See https://bugs.mysql.com/bug.php?id=30886
```

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
