### PR TITLE
Fix missing resource_type for clearing app buildpack cache

### DIFF
--- a/app/jobs/v3/buildpack_cache_delete.rb
+++ b/app/jobs/v3/buildpack_cache_delete.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   module Jobs
     module V3
       class BuildpackCacheDelete < VCAP::CloudController::Jobs::CCJob
-        attr_accessor :resource_type, :resource_guid
+        attr_accessor :resource_guid
 
         def initialize(app_guid)
           @resource_guid = app_guid
@@ -22,6 +22,10 @@ module VCAP::CloudController
 
         def max_attempts
           3
+        end
+
+        def resource_type
+          'app'
         end
 
         def display_name

--- a/spec/unit/jobs/v3/buildpack_cache_delete_spec.rb
+++ b/spec/unit/jobs/v3/buildpack_cache_delete_spec.rb
@@ -50,6 +50,12 @@ module VCAP::CloudController
           expect(job.job_name_in_configuration).to equal(:buildpack_cache_delete)
         end
       end
+
+      describe '#display_name' do
+        it 'returns the correct display name' do
+          expect(job.display_name).to eq('app.clear_buildpack_cache')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
