### PR TITLE
Fix LocalClient#delete_all_in_path not using partitioned key

### DIFF
--- a/lib/cloud_controller/blobstore/local/local_client.rb
+++ b/lib/cloud_controller/blobstore/local/local_client.rb
@@ -97,7 +97,7 @@ module CloudController
       end
 
       def delete_all_in_path(path)
-        dir = File.join(@base_path, path)
+        dir = File.join(@base_path, File.dirname(partitioned_key(path)))
         FileUtils.rm_rf(dir) if File.directory?(dir)
       end
 

--- a/spec/unit/lib/cloud_controller/blobstore/local/local_client_spec.rb
+++ b/spec/unit/lib/cloud_controller/blobstore/local/local_client_spec.rb
@@ -251,19 +251,22 @@ module CloudController
       end
 
       describe '#delete_all_in_path' do
-        it 'deletes all files in a specific path' do
-          path1 = File.join(base_path, directory_key, 'path1', 'file1')
-          path2 = File.join(base_path, directory_key, 'path2', 'file2')
+        it 'deletes all files in the partitioned directory for the given key' do
+          key1 = 'abcdef1234'
+          key2 = 'abcdef5678'
+          other_key = 'ffff001234'
+          tmpfile = Tempfile.new.tap { |f| f.write('x') && f.flush }
 
-          FileUtils.mkdir_p(File.dirname(path1))
-          FileUtils.mkdir_p(File.dirname(path2))
-          File.write(path1, 'content1')
-          File.write(path2, 'content2')
+          client.cp_to_blobstore(tmpfile.path, key1)
+          client.cp_to_blobstore(tmpfile.path, key2)
+          client.cp_to_blobstore(tmpfile.path, other_key)
 
-          client.delete_all_in_path('path1')
+          # key1 and key2 share the same partitioned directory (ab/cd/)
+          client.delete_all_in_path(key1)
 
-          expect(File.exist?(path1)).to be(false)
-          expect(File.exist?(path2)).to be(true)
+          expect(client.exists?(key1)).to be(false)
+          expect(client.exists?(key2)).to be(false)
+          expect(client.exists?(other_key)).to be(true)
         end
       end
 


### PR DESCRIPTION
* A short explanation of the proposed change:

`LocalClient#delete_all_in_path` was building the target path with the raw key instead of `partitioned_key(key)`, so it looked in the wrong directory and silently deleted nothing.

All other `LocalClient` methods (`exists?`, `cp_to_blobstore`, `file_path`, etc.) use `partitioned_key` consistently, which maps a key like `abcdef1234` to `ab/cd/abcdef1234`. `delete_all_in_path` was the only method missing this, making it a no-op in practice.

* An explanation of the use cases your change solves

- `lib/cloud_controller/blobstore/local/local_client.rb`: use `partitioned_key(path)` in `delete_all_in_path`
- `spec/unit/lib/cloud_controller/blobstore/local/local_client_spec.rb`: rewrite the test using real blobstore keys so the partitioned path is actually exercised (the old test used raw directory names and did not catch the bug)

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)