### PR TITLE
Prevent DropletUpload from downgrading a staged droplet to failed

### DIFF
--- a/app/jobs/v3/droplet_upload.rb
+++ b/app/jobs/v3/droplet_upload.rb
@@ -35,9 +35,13 @@ module VCAP::CloudController
           if droplet
             droplet.db.transaction do
               droplet.lock!
-              droplet.error_description = e.message
-              droplet.state = DropletModel::FAILED_STATE
-              droplet.save
+              if droplet.staged?
+                logger.info('droplet-upload.skipping-failed-state', droplet_guid: @droplet_guid, error: e.message)
+              else
+                droplet.error_description = e.message
+                droplet.state = DropletModel::FAILED_STATE
+                droplet.save
+              end
             end
           end
           raise
@@ -65,6 +69,10 @@ module VCAP::CloudController
 
         def blobstore
           @blobstore ||= CloudController::DependencyLocator.instance.droplet_blobstore
+        end
+
+        def logger
+          @logger ||= Steno.logger('cc.jobs.v3.droplet_upload')
         end
       end
     end

--- a/spec/unit/jobs/v3/droplet_upload_spec.rb
+++ b/spec/unit/jobs/v3/droplet_upload_spec.rb
@@ -146,6 +146,24 @@ module VCAP::CloudController
                 }.from(true).to(false)
               end
             end
+
+            context 'when the droplet is already STAGED' do
+              let(:staged_droplet) { create(:droplet_model, state: DropletModel::STAGED_STATE, droplet_hash: nil, sha256_checksum: nil, set_as_current_droplet: false) }
+
+              before do
+                staged_job = DropletUpload.new(local_file.path, staged_droplet.guid, skip_state_transition:)
+                Delayed::Job.enqueue(staged_job, queue: worker.name)
+                worker.work_off 1
+              end
+
+              it 'does not overwrite the droplet state' do
+                expect(staged_droplet.refresh.state).to eq(DropletModel::STAGED_STATE)
+              end
+
+              it 'does not set an error description' do
+                expect(staged_droplet.refresh.error_description).to be_nil
+              end
+            end
           end
 
           context 'if the file is missing' do


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

## A short explanation of the proposed change:
Prevent a droplet in state STAGED to be downgraded to FAILED

## An explanation of the use cases your change solves
If a worker is killed mid-job and restarts, it re-locks and re-runs its own job. When another worker already completed the job in the meantime, the droplet is already STAGED. The rescue block would unconditionally overwrite STAGED with FAILED in that case.

## Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
