### PR TITLE
Prevent PackageUpload from downgrading a ready package to failed

### DIFF
--- a/app/models/runtime/package_model.rb
+++ b/app/models/runtime/package_model.rb
@@ -97,6 +97,9 @@ module VCAP::CloudController
     def fail_upload!(err_msg)
       db.transaction do
         lock!
+
+        return if ready?
+
         self.state = VCAP::CloudController::PackageModel::FAILED_STATE
         self.error = err_msg
         save

--- a/spec/unit/models/runtime/package_model_spec.rb
+++ b/spec/unit/models/runtime/package_model_spec.rb
@@ -79,6 +79,36 @@ module VCAP::CloudController
       end
     end
 
+    describe '#fail_upload!' do
+      context 'when the package is READY' do
+        let!(:package) { create(:package_model, state: PackageModel::READY_STATE) }
+
+        it 'does not downgrade the state' do
+          package.fail_upload!('something went wrong')
+          expect(package.reload.state).to eq(PackageModel::READY_STATE)
+        end
+
+        it 'does not set an error' do
+          package.fail_upload!('something went wrong')
+          expect(package.reload.error).to be_nil
+        end
+      end
+
+      context 'when the package is PENDING' do
+        let!(:package) { create(:package_model, state: PackageModel::PENDING_STATE) }
+
+        it 'marks the package as FAILED' do
+          package.fail_upload!('something went wrong')
+          expect(package.reload.state).to eq(PackageModel::FAILED_STATE)
+        end
+
+        it 'sets the error' do
+          package.fail_upload!('something went wrong')
+          expect(package.reload.error).to eq('something went wrong')
+        end
+      end
+    end
+
     describe 'metadata' do
       let(:package) { create(:package_model) }
       let(:annotation) { create(:package_annotation_model, package: package, key_name: 'test1', value: 'bommel') }


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

## A short explanation of the proposed change:
 Add guard against package downgrade by checking the current state inside the DB transaction after acquiring the row lock.
## An explanation of the use cases your change solves
If a PackageBits job is retried after the worker was restarted mid-job, the retry may fail (e.g. upload file already cleaned up) and call fail_upload!, which would downgrade a READY package back to FAILED.
## Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
