### PR TITLE
Fix cleanup job: Remove all droplets in state "failed"

### DIFF
--- a/app/jobs/runtime/expired_blob_cleanup.rb
+++ b/app/jobs/runtime/expired_blob_cleanup.rb
@@ -5,7 +5,7 @@ module VCAP::CloudController
         def perform
           logger.info('Deleting package and droplet blobs that are expired or failed')
 
-          DropletModel.where(state: [DropletModel::EXPIRED_STATE, DropletModel::FAILED_STATE]).exclude(droplet_hash: nil).each do |droplet|
+          DropletModel.where(state: [DropletModel::EXPIRED_STATE, DropletModel::FAILED_STATE]).each do |droplet|
             enqueue_droplet_delete_job(droplet.guid)
           end
 

--- a/spec/unit/jobs/runtime/expired_blob_cleanup_spec.rb
+++ b/spec/unit/jobs/runtime/expired_blob_cleanup_spec.rb
@@ -23,7 +23,7 @@ module VCAP::CloudController
           end
 
           it 'enqueues a deletion job only for buildpack droplets' do
-            expect { job.perform }.to change(Delayed::Job, :count).by(1)
+            expect { job.perform }.to change(Delayed::Job, :count).by(2)
             expect(Delayed::Job.last.handler).to include('DeleteExpiredDropletBlob')
           end
         end
@@ -35,7 +35,7 @@ module VCAP::CloudController
           end
 
           it 'enqueues a deletion job only for buildpack droplets' do
-            expect { job.perform }.to change(Delayed::Job, :count).by(1)
+            expect { job.perform }.to change(Delayed::Job, :count).by(2)
             expect(Delayed::Job.last.handler).to include('DeleteExpiredDropletBlob')
           end
         end


### PR DESCRIPTION
* A short explanation of the proposed change:

If DropletUpload fails in blobstore.cp_to_blobstore, the droplet has no hash assigned and will never be cleaned up.

* An explanation of the use cases your change solves

If a droplet is in state "failed", several CF operations fail (e.g. "cf create-deployment"). 

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
