### PR TITLE
Add configurable CCDB connection parameters

### DIFF
--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -121,7 +121,15 @@ module VCAP::CloudController
             optional(:connection_expiration_random_delay) => Integer,
             optional(:ssl_verify_hostname) => bool,
             optional(:ca_cert_path) => String,
-            optional(:enable_paginate_window) => bool
+            optional(:enable_paginate_window) => bool,
+            optional(:psql) => {
+              optional(:statement_timeout) => Integer,
+              optional(:idle_in_transaction_session_timeout) => Integer,
+              optional(:keepalives) => Integer,
+              optional(:keepalives_idle) => Integer,
+              optional(:keepalives_interval) => Integer,
+              optional(:keepalives_count) => Integer
+            }
           },
 
           optional(:redis) => {

--- a/lib/cloud_controller/config_schemas/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/worker_schema.rb
@@ -59,7 +59,15 @@ module VCAP::CloudController
             log_db_queries: bool,
             ssl_verify_hostname: bool,
             connection_validation_timeout: Integer,
-            optional(:ca_cert_path) => String
+            optional(:ca_cert_path) => String,
+            optional(:psql) => {
+              optional(:statement_timeout) => Integer,
+              optional(:idle_in_transaction_session_timeout) => Integer,
+              optional(:keepalives) => Integer,
+              optional(:keepalives_idle) => Integer,
+              optional(:keepalives_interval) => Integer,
+              optional(:keepalives_count) => Integer
+            }
           },
 
           staging: {

--- a/lib/cloud_controller/db_connection/postgres_options_factory.rb
+++ b/lib/cloud_controller/db_connection/postgres_options_factory.rb
@@ -1,6 +1,9 @@
 module VCAP::CloudController
   module DbConnection
     class PostgresOptionsFactory
+      SQL_CONNECTION_PARAMETERS = %i[statement_timeout idle_in_transaction_session_timeout].freeze
+      LIBPQ_CONNECTION_PARAMETERS = %i[keepalives keepalives_idle keepalives_interval keepalives_count].freeze
+
       def self.build(opts)
         options = {}
 
@@ -9,9 +12,16 @@ module VCAP::CloudController
           options[:sslmode] = opts[:ssl_verify_hostname] ? 'verify-full' : 'verify-ca'
         end
 
-        options[:after_connect] = proc do |connection|
-          connection.exec("SET time zone 'UTC'")
+        psql_opts = opts[:psql] || {}
+        sql_params = psql_opts.slice(*SQL_CONNECTION_PARAMETERS).compact
+        connect_sqls = ["SET time zone 'UTC'"]
+        sql_params.each do |key, value|
+          connect_sqls << "SET #{key} TO '#{value}'"
         end
+        options[:connect_sqls] = connect_sqls
+
+        libpq_params = psql_opts.slice(*LIBPQ_CONNECTION_PARAMETERS).compact
+        options.merge!(libpq_params)
 
         options
       end

--- a/spec/unit/lib/cloud_controller/db_connection/options_factory_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_connection/options_factory_spec.rb
@@ -46,10 +46,8 @@ RSpec.describe VCAP::CloudController::DbConnection::OptionsFactory do
         let(:adapter) { 'postgres' }
 
         it 'returns postgres-specific options' do
-          connection = double('connection', exec: '')
           postgres_options = VCAP::CloudController::DbConnection::OptionsFactory.build(required_options)
-          postgres_options[:after_connect].call(connection)
-          expect(connection).to have_received(:exec).with("SET time zone 'UTC'")
+          expect(postgres_options[:connect_sqls]).to include("SET time zone 'UTC'")
         end
       end
     end

--- a/spec/unit/lib/cloud_controller/db_connection/postgres_options_factory_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_connection/postgres_options_factory_spec.rb
@@ -17,10 +17,8 @@ RSpec.describe VCAP::CloudController::DbConnection::PostgresOptionsFactory do
       )
     end
 
-    it 'sets the timezone via a Proc' do
-      connection = double('connection', exec: '')
-      postgres_options[:after_connect].call(connection)
-      expect(connection).to have_received(:exec).with("SET time zone 'UTC'")
+    it 'sets the timezone via connect_sqls' do
+      expect(postgres_options[:connect_sqls]).to include("SET time zone 'UTC'")
     end
 
     describe 'when the CA cert path is not set' do
@@ -54,6 +52,103 @@ RSpec.describe VCAP::CloudController::DbConnection::PostgresOptionsFactory do
           it 'sets the sslmode to "verify-ca"' do
             expect(postgres_options[:sslmode]).to eq('verify-ca')
           end
+        end
+      end
+    end
+
+    describe 'connection parameters' do
+      context 'when no connection parameters are set' do
+        let(:postgres_options) do
+          VCAP::CloudController::DbConnection::PostgresOptionsFactory.build(
+            database: { adapter: 'postgres' }
+          )
+        end
+
+        it 'only sets the timezone in connect_sqls' do
+          expect(postgres_options[:connect_sqls]).to eq(["SET time zone 'UTC'"])
+        end
+
+        it 'does not include any keepalive options in the returned hash' do
+          expect(postgres_options[:keepalives]).to be_nil
+          expect(postgres_options[:keepalives_idle]).to be_nil
+          expect(postgres_options[:keepalives_interval]).to be_nil
+          expect(postgres_options[:keepalives_count]).to be_nil
+        end
+      end
+
+      context 'when SQL params are set' do
+        let(:postgres_options) do
+          VCAP::CloudController::DbConnection::PostgresOptionsFactory.build(
+            database: { adapter: 'postgres' },
+            psql: {
+              statement_timeout: 3_600_000,
+              idle_in_transaction_session_timeout: 600_000
+            }
+          )
+        end
+
+        it 'sets the SQL params via connect_sqls' do
+          expect(postgres_options[:connect_sqls]).to include("SET time zone 'UTC'")
+          expect(postgres_options[:connect_sqls]).to include("SET statement_timeout TO '3600000'")
+          expect(postgres_options[:connect_sqls]).to include("SET idle_in_transaction_session_timeout TO '600000'")
+        end
+
+        it 'does not put SQL params into the returned options hash' do
+          expect(postgres_options[:statement_timeout]).to be_nil
+          expect(postgres_options[:idle_in_transaction_session_timeout]).to be_nil
+        end
+      end
+
+      context 'when libpq keepalive params are set' do
+        let(:postgres_options) do
+          VCAP::CloudController::DbConnection::PostgresOptionsFactory.build(
+            database: { adapter: 'postgres' },
+            psql: {
+              keepalives: 1,
+              keepalives_idle: 30,
+              keepalives_interval: 10,
+              keepalives_count: 3
+            }
+          )
+        end
+
+        it 'merges keepalive params into the returned options hash' do
+          expect(postgres_options[:keepalives]).to eq(1)
+          expect(postgres_options[:keepalives_idle]).to eq(30)
+          expect(postgres_options[:keepalives_interval]).to eq(10)
+          expect(postgres_options[:keepalives_count]).to eq(3)
+        end
+
+        it 'does not SET keepalive params via connect_sqls' do
+          expect(postgres_options[:connect_sqls]).not_to include(match(/SET keepalives/))
+        end
+      end
+
+      context 'when both SQL and libpq params are set' do
+        let(:postgres_options) do
+          VCAP::CloudController::DbConnection::PostgresOptionsFactory.build(
+            database: { adapter: 'postgres' },
+            psql: {
+              statement_timeout: 3_600_000,
+              keepalives: 1,
+              keepalives_idle: 30,
+              keepalives_interval: 10,
+              keepalives_count: 3
+            }
+          )
+        end
+
+        it 'sets SQL params via connect_sqls and merges libpq params into options hash' do
+          expect(postgres_options[:connect_sqls]).to include("SET statement_timeout TO '3600000'")
+          expect(postgres_options[:keepalives]).to eq(1)
+          expect(postgres_options[:keepalives_idle]).to eq(30)
+          expect(postgres_options[:keepalives_interval]).to eq(10)
+          expect(postgres_options[:keepalives_count]).to eq(3)
+        end
+
+        it 'does not mix up the two kinds: SQL params not in options hash, libpq params not SET via SQL' do
+          expect(postgres_options[:statement_timeout]).to be_nil
+          expect(postgres_options[:connect_sqls]).not_to include(match(/SET keepalives/))
         end
       end
     end


### PR DESCRIPTION
* A short explanation of the proposed change:

  Adds support for a `connection_parameters` hash in the CC config that allows operators to configure PostgreSQL connection settings per-connection
  SQL session parameters (`statement_timeout`, `idle_in_transaction_session_timeout`) are applied via Sequel's `connect_sqls` on every new DB connection
  libpq TCP keepalive parameters (`keepalives`, `keepalives_idle`, `keepalives_interval`, `keepalives_count`) are merged directly into the Sequel connection options

* An explanation of the use cases your change solves
  Currently CC relies on connection timeouts configured globally at the CCDB level (e.g. `statement_timeout = 1h`, `idle_in_transaction_session_timeout = 10min`). This works but requires DB-level access to change. This feature allows these same settings to be configured from the BOSH manifest, so they can be managed alongside other CC configuration without requiring direct DB access.

  Typical use case: set `statement_timeout` and `idle_in_transaction_session_timeout` to match or reinforce the DB-level defaults, and configure TCP keepalives (`keepalives`, `keepalives_idle`, `keepalives_interval`, `keepalives_count`) to detect dead connections.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
