### PR TITLE
Fix v3 docs

### DIFF
--- a/docs/v3/source/includes/resources/route_policies/_list.md.erb
+++ b/docs/v3/source/includes/resources/route_policies/_list.md.erb
@@ -72,9 +72,8 @@ curl "https://api.example.org/v3/route_policies?include=route,source" \
 
 #### Use cases
 
-**Allow a frontend app to call a backend API:**
+**Create a policy to allow a frontend app to call a backend API:**
 ```shell
-# Create route policy
 curl "https://api.example.org/v3/route_policies" \
   -X POST \
   -H "Authorization: bearer [token]" \
@@ -130,7 +129,6 @@ curl "https://api.example.org/v3/route_policies?space_guids=my-space-guid" \
 
 **Find stale policies referencing a deleted app:**
 ```shell
-# After deleting an app, find policies that referenced it
 curl "https://api.example.org/v3/route_policies?source_guids=deleted-app-guid&include=source" \
   -X GET \
   -H "Authorization: bearer [token]"


### PR DESCRIPTION
* A short explanation of the proposed change:

Remove shell comments starting with '#' as those are interpreted as headlines.

* An explanation of the use cases your change solves

Fixes v3 doc structures. Current structure is messed up: https://v3-apidocs.cloudfoundry.org/version/3.224.0/index.html

* Links to any other associated PRs

https://github.com/cloudfoundry/cloud_controller_ng/pull/4910

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
