### PR TITLE
Avoid real StatsD UDP sends in tests

### DIFF
--- a/spec/support/bootstrap/test_config.rb
+++ b/spec/support/bootstrap/test_config.rb
@@ -69,7 +69,9 @@ module TestConfig
           fog_connection: fog_connection,
           max_staged_droplets_stored: 42
         },
-        db: DbConfig.new.config
+        db: DbConfig.new.config,
+        # Avoid real StatsD UDP sends in tests; specs needing the real client override this.
+        enable_statsd_metrics: false
       )
 
       config_hash.deep_merge!(uaa: { internal_url: 'https://uaa.service.cf.internal' })

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -476,7 +476,8 @@ RSpec.describe CloudController::DependencyLocator do
 
       TestConfig.override(
         statsd_host: host,
-        statsd_port: port
+        statsd_port: port,
+        enable_statsd_metrics: true
       )
 
       sink = instance_double(StatsD::Instrument::Sink)


### PR DESCRIPTION
PR #5278 replaced `statsd-client` with `statsd-intrument` and tests started to send real StatsD UDP metrics which triggered the following warning log: 
```
DEBUG -- : [StatsD::Instrument::Sink] [StatsD::Instrument::UdpConnection] Resetting connection because of Errno::ECONNREFUSED: Connection refused - send(2)
```
This change disables StatsD in the default test config.



* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
