### PR TITLE
Print failed specs

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -45,7 +45,7 @@ namespace :spec do
   def run_specs_parallel(path, env_vars='')
     command = <<~CMD
       #{env_vars} bundle exec parallel_rspec \
-      --test-options '--order rand #{rspec_profile_option} --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec_main.log' \
+      --test-options '--order rand #{rspec_profile_option} --format progress --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec_main.log' \
       --runtime-log tmp/parallel_runtime_rspec_main.log \
       --single spec/integration/ \
       --single spec/acceptance/ \
@@ -60,7 +60,7 @@ namespace :spec do
   def run_migration_specs_parallel(env_vars='')
     command = <<~CMD
       #{env_vars} bundle exec parallel_rspec \
-      --test-options '--order rand #{rspec_profile_option} --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec_migrations.log' \
+      --test-options '--order rand #{rspec_profile_option} --format progress --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec_migrations.log' \
       --runtime-log tmp/parallel_runtime_rspec_migrations.log \
       -- spec/migrations
     CMD


### PR DESCRIPTION
At the moment failed specs are not shown in the CI output. This change fixes that.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
