### PR TITLE
Bump UAA devcontainer to SapMachine JDK 25

### DIFF
--- a/.devcontainer/images/uaa/Dockerfile
+++ b/.devcontainer/images/uaa/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM sapmachine:21-jdk-headless-ubuntu-jammy AS builder
+FROM sapmachine:25-jdk-headless-ubuntu-jammy AS builder
 
 WORKDIR /uaa
 
@@ -22,7 +22,7 @@ RUN yq e '.oauth.clients.admin.authorities += ",password.write"' -i /uaa.yml \
   && yq e '.uaa.url = .issuer.uri' -i /uaa.yml
 
 # Runtime image - lightweight JRE instead of Tomcat
-FROM sapmachine:21-jre-headless-ubuntu-jammy
+FROM sapmachine:25-jre-headless-ubuntu-jammy
 
 # Copy config file from yq image
 COPY --from=yq /uaa.yml /uaa.yml


### PR DESCRIPTION
The UAA image clones the latest UAA release, which now requires Java 25 to compile. The pinned SapMachine 21 builder failed with `invalid source release: 25`. Bump both the builder and runtime stages to SapMachine 25.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
