### PR TITLE
Remove id guid id roundtrips

### DIFF
--- a/app/controllers/v3/domains_controller.rb
+++ b/app/controllers/v3/domains_controller.rb
@@ -18,7 +18,7 @@ class DomainsController < ApplicationController
     message = DomainsListMessage.from_params(query_params)
     invalid_param!(message.errors.full_messages) unless message.valid?
 
-    dataset = DomainFetcher.fetch(message, permission_queryer.readable_org_guids_for_domains_query)
+    dataset = DomainFetcher.fetch(message, permission_queryer.readable_org_ids_for_domains_query)
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::DomainPresenter,
@@ -164,7 +164,7 @@ class DomainsController < ApplicationController
   def find_domain(message)
     DomainFetcher.fetch(
       message,
-      permission_queryer.readable_org_guids_for_domains_query
+      permission_queryer.readable_org_ids_for_domains_query
     ).first
   end
 
@@ -249,7 +249,7 @@ class DomainsController < ApplicationController
     if permission_queryer.can_read_globally?
       { all_orgs_visible: true }
     else
-      { visible_org_guids_query: permission_queryer.readable_org_guids_query }
+      { visible_org_ids_query: permission_queryer.readable_org_ids_query }
     end
   end
 end

--- a/app/controllers/v3/isolation_segments_controller.rb
+++ b/app/controllers/v3/isolation_segments_controller.rb
@@ -90,7 +90,7 @@ class IsolationSegmentsController < ApplicationController
     organizations = if permission_queryer.can_read_globally?
                       fetcher.fetch_all
                     else
-                      fetcher.fetch_for_organizations(org_guids_query: permission_queryer.readable_org_guids_query)
+                      fetcher.fetch_for_organizations(org_ids_query: permission_queryer.readable_org_ids_query)
                     end
 
     render status: :ok, json: Presenters::V3::ToManyRelationshipPresenter.new(

--- a/app/controllers/v3/organization_quotas_controller.rb
+++ b/app/controllers/v3/organization_quotas_controller.rb
@@ -17,7 +17,7 @@ class OrganizationQuotasController < ApplicationController
     dataset = if permission_queryer.can_read_globally?
                 OrganizationQuotaListFetcher.fetch_all(message:)
               else
-                OrganizationQuotaListFetcher.fetch(message: message, readable_org_guids_query: permission_queryer.readable_org_guids_query)
+                OrganizationQuotaListFetcher.fetch(message: message, readable_org_ids_query: permission_queryer.readable_org_ids_query)
               end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
@@ -110,7 +110,7 @@ class OrganizationQuotasController < ApplicationController
     if permission_queryer.can_read_globally?
       { all_orgs_visible: true }
     else
-      { visible_org_guids_query: permission_queryer.readable_org_guids_query }
+      { visible_org_ids_query: permission_queryer.readable_org_ids_query }
     end
   end
 end

--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -245,7 +245,7 @@ class OrganizationsV3Controller < ApplicationController
     else
       OrgListFetcher.fetch(
         message: message,
-        guids: permission_queryer.readable_org_guids_query,
+        ids: permission_queryer.readable_org_ids_query,
         eager_loaded_associations: Presenters::V3::OrganizationPresenter.associated_resources
       )
     end
@@ -260,7 +260,7 @@ class OrganizationsV3Controller < ApplicationController
     else
       isolation_segment, dataset = OrgListFetcher.fetch_for_isolation_segment(
         message: message,
-        guids: permission_queryer.readable_org_guids_query,
+        ids: permission_queryer.readable_org_ids_query,
         eager_loaded_associations: Presenters::V3::OrganizationPresenter.associated_resources
       )
     end
@@ -272,7 +272,7 @@ class OrganizationsV3Controller < ApplicationController
     if permission_queryer.can_read_globally?
       { all_orgs_visible: true }
     else
-      { visible_org_guids_query: permission_queryer.readable_org_guids_query }
+      { visible_org_ids_query: permission_queryer.readable_org_ids_query }
     end
   end
 end

--- a/app/controllers/v3/organizations_controller.rb
+++ b/app/controllers/v3/organizations_controller.rb
@@ -149,7 +149,8 @@ class OrganizationsV3Controller < ApplicationController
     message = DomainsListMessage.from_params(query_params.except(:guid))
     invalid_param!(message.errors.full_messages) unless message.valid?
 
-    domains = DomainFetcher.fetch(message, permission_queryer.readable_org_guids_for_domains_query.where(guid: org.guid))
+    readable_org_ids = Organization.where(id: org.id).where(id: permission_queryer.readable_org_ids_for_domains_query).select(:id)
+    domains = DomainFetcher.fetch(message, readable_org_ids)
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::DomainPresenter,
@@ -166,7 +167,7 @@ class OrganizationsV3Controller < ApplicationController
     domain = org.default_domain
 
     domain_not_found! unless domain
-    domain_not_found! if domain.private? && permission_queryer.readable_org_guids_for_domains_query.where(guid: org.guid).empty?
+    domain_not_found! if domain.private? && Organization.where(id: org.id).where(id: permission_queryer.readable_org_ids_for_domains_query).empty?
 
     render status: :ok, json: Presenters::V3::DomainPresenter.new(domain, **presenter_args)
   end

--- a/app/controllers/v3/security_groups_controller.rb
+++ b/app/controllers/v3/security_groups_controller.rb
@@ -18,7 +18,7 @@ class SecurityGroupsController < ApplicationController
     dataset = if permission_queryer.can_read_globally?
                 SecurityGroupListFetcher.fetch_all(message)
               else
-                SecurityGroupListFetcher.fetch(message, permission_queryer.readable_security_group_guids_query)
+                SecurityGroupListFetcher.fetch(message, permission_queryer.readable_security_group_ids_query)
               end
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
@@ -31,7 +31,7 @@ class SecurityGroupsController < ApplicationController
   end
 
   def show
-    security_group = SecurityGroupFetcher.fetch(hashed_params[:guid], permission_queryer.readable_security_group_guids_query)
+    security_group = SecurityGroupFetcher.fetch(hashed_params[:guid], permission_queryer.readable_security_group_ids_query)
     resource_not_found!(:security_group) unless security_group
 
     render status: :ok, json: Presenters::V3::SecurityGroupPresenter.new(

--- a/app/controllers/v3/spaces_controller.rb
+++ b/app/controllers/v3/spaces_controller.rb
@@ -106,8 +106,8 @@ class SpacesV3Controller < ApplicationController
     space = SpaceFetcher.new.fetch(hashed_params[:guid])
     space_not_found! unless space && permission_queryer.can_read_from_space?(space.id, space.organization_id)
 
-    unfiltered_group_guids = fetch_running_security_group_guids(space)
-    dataset = SecurityGroupListFetcher.fetch(message, unfiltered_group_guids)
+    unfiltered_group_ids = fetch_running_security_group_ids(space)
+    dataset = SecurityGroupListFetcher.fetch(message, unfiltered_group_ids)
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::SecurityGroupPresenter,
@@ -125,8 +125,8 @@ class SpacesV3Controller < ApplicationController
     space = SpaceFetcher.new.fetch(hashed_params[:guid])
     space_not_found! unless space && permission_queryer.can_read_from_space?(space.id, space.organization_id)
 
-    unfiltered_group_guids = fetch_staging_security_group_guids(space)
-    dataset = SecurityGroupListFetcher.fetch(message, unfiltered_group_guids)
+    unfiltered_group_ids = fetch_staging_security_group_ids(space)
+    dataset = SecurityGroupListFetcher.fetch(message, unfiltered_group_ids)
 
     render status: :ok, json: Presenters::V3::PaginatedListPresenter.new(
       presenter: Presenters::V3::SecurityGroupPresenter,
@@ -243,16 +243,16 @@ class SpacesV3Controller < ApplicationController
     IsolationSegmentModel.where(guid:).first
   end
 
-  def fetch_running_security_group_guids(space)
+  def fetch_running_security_group_ids(space)
     space_level_groups = SecurityGroup.where(spaces: space)
     global_groups = SecurityGroup.where(running_default: true)
-    space_level_groups.union(global_groups).select_map(:guid)
+    space_level_groups.union(global_groups).select_map(:id)
   end
 
-  def fetch_staging_security_group_guids(space)
+  def fetch_staging_security_group_ids(space)
     space_level_groups = SecurityGroup.where(staging_spaces: space)
     global_groups = SecurityGroup.where(staging_default: true)
-    space_level_groups.union(global_groups).distinct.select_map(:guid)
+    space_level_groups.union(global_groups).distinct.select_map(:id)
   end
 
   def space_not_found!

--- a/app/fetchers/domain_fetcher.rb
+++ b/app/fetchers/domain_fetcher.rb
@@ -3,11 +3,11 @@ require 'fetchers/base_list_fetcher'
 module VCAP::CloudController
   class DomainFetcher < BaseListFetcher
     class << self
-      def fetch_all_for_orgs(readable_org_guids)
+      def fetch_all_for_orgs(readable_org_ids)
         # Q: The "Domain" in Domain.dataset is arbitrary -- just a way to get access to any database table.
         # If there's a way to use a more generic way to access the database, maybe this can be revised.
         #
-        readable_orgs_filter = Domain.dataset.db[:organizations].where(guid: readable_org_guids).select(:id)
+        readable_orgs_filter = Domain.dataset.db[:organizations].where(id: readable_org_ids).select(:id)
 
         readable_shared_private_domains_filter = Domain.dataset.db[:organizations_private_domains].where(
           organization_id: readable_orgs_filter
@@ -22,8 +22,8 @@ module VCAP::CloudController
         Domain.where(user_visible_domains).qualify
       end
 
-      def fetch(message, readable_org_guids)
-        dataset = fetch_all_for_orgs(readable_org_guids)
+      def fetch(message, readable_org_ids)
+        dataset = fetch_all_for_orgs(readable_org_ids)
         filter(message, dataset)
       end
 

--- a/app/fetchers/isolation_segment_organizations_fetcher.rb
+++ b/app/fetchers/isolation_segment_organizations_fetcher.rb
@@ -8,8 +8,8 @@ module VCAP::CloudController
       @isolation_segment.organizations
     end
 
-    def fetch_for_organizations(org_guids_query:)
-      Organization.where(guid: org_guids_query, isolation_segment_models: @isolation_segment).all
+    def fetch_for_organizations(org_ids_query:)
+      Organization.where(id: org_ids_query, isolation_segment_models: @isolation_segment).all
     end
   end
 end

--- a/app/fetchers/org_list_fetcher.rb
+++ b/app/fetchers/org_list_fetcher.rb
@@ -5,8 +5,8 @@ require 'fetchers/base_list_fetcher'
 module VCAP::CloudController
   class OrgListFetcher < BaseListFetcher
     class << self
-      def fetch(message:, guids:, eager_loaded_associations: [])
-        dataset = Organization.where(guid: guids)
+      def fetch(message:, ids:, eager_loaded_associations: [])
+        dataset = Organization.where(id: ids)
         dataset = eager_load(dataset, eager_loaded_associations)
         filter(message, dataset)
       end
@@ -17,11 +17,11 @@ module VCAP::CloudController
         filter(message, dataset)
       end
 
-      def fetch_for_isolation_segment(message:, guids:, eager_loaded_associations: [])
+      def fetch_for_isolation_segment(message:, ids:, eager_loaded_associations: [])
         isolation_segment = IsolationSegmentModel.where(guid: message.isolation_segment_guid).first
         return nil unless isolation_segment
 
-        dataset = isolation_segment.organizations_dataset.where(guid: guids)
+        dataset = isolation_segment.organizations_dataset.where(id: ids)
         dataset = eager_load(dataset, eager_loaded_associations)
         [isolation_segment, filter(message, dataset)]
       end

--- a/app/fetchers/organization_quota_list_fetcher.rb
+++ b/app/fetchers/organization_quota_list_fetcher.rb
@@ -5,9 +5,9 @@ require 'fetchers/base_list_fetcher'
 module VCAP::CloudController
   class OrganizationQuotaListFetcher < BaseListFetcher
     class << self
-      def fetch(message:, readable_org_guids_query:)
+      def fetch(message:, readable_org_ids_query:)
         dataset = QuotaDefinition.dataset
-        filter(message, dataset, readable_org_guids_query)
+        filter(message, dataset, readable_org_ids_query)
       end
 
       def fetch_all(message:)
@@ -17,7 +17,7 @@ module VCAP::CloudController
 
       private
 
-      def filter(message, dataset, readable_org_guids_query=nil)
+      def filter(message, dataset, readable_org_ids_query=nil)
         dataset = dataset.where(name: message.names) if message.requested? :names
 
         if message.requested? :organization_guids
@@ -26,7 +26,7 @@ module VCAP::CloudController
                     where(organizations__guid: message.organization_guids).distinct(:id).
                     qualify(:quota_definitions)
 
-          dataset = dataset.where(organizations__guid: readable_org_guids_query) if readable_org_guids_query
+          dataset = dataset.where(organizations__id: readable_org_ids_query) if readable_org_ids_query
         end
 
         super(message, dataset, QuotaDefinition)

--- a/app/fetchers/security_group_fetcher.rb
+++ b/app/fetchers/security_group_fetcher.rb
@@ -1,9 +1,9 @@
 module VCAP::CloudController
   class SecurityGroupFetcher
     class << self
-      def fetch(guid, visible_security_group_guids=nil)
+      def fetch(guid, visible_security_group_ids=nil)
         dataset = SecurityGroup.where(guid:)
-        dataset = dataset.where(guid: visible_security_group_guids) if visible_security_group_guids
+        dataset = dataset.where(id: visible_security_group_ids) if visible_security_group_ids
         dataset = eager_load_running_and_staging_space_guids(dataset)
         dataset.all.first
       end

--- a/app/fetchers/security_group_list_fetcher.rb
+++ b/app/fetchers/security_group_list_fetcher.rb
@@ -13,8 +13,8 @@ module VCAP::CloudController
         filter(message, dataset)
       end
 
-      def fetch(message, visible_security_group_guids)
-        dataset = SecurityGroup.where(guid: visible_security_group_guids)
+      def fetch(message, visible_security_group_ids)
+        dataset = SecurityGroup.where(id: visible_security_group_ids)
         dataset = SecurityGroupFetcher.eager_load_running_and_staging_space_guids(dataset)
         filter(message, dataset)
       end

--- a/app/fetchers/service_plan_visibility_fetcher.rb
+++ b/app/fetchers/service_plan_visibility_fetcher.rb
@@ -24,7 +24,7 @@ module VCAP::CloudController
                 join(:service_plans, id: :service_plan_visibilities__service_plan_id).
                 where(service_plans__guid: service_plan_guids)
 
-      dataset = dataset.where(organizations__guid: @permission_queryer.readable_org_guids_query) unless @permission_queryer.can_read_globally?
+      dataset = dataset.where(organizations__id: @permission_queryer.readable_org_ids_query) unless @permission_queryer.can_read_globally?
 
       dataset
     end

--- a/app/presenters/v3/domain_presenter.rb
+++ b/app/presenters/v3/domain_presenter.rb
@@ -10,10 +10,10 @@ module VCAP::CloudController::Presenters::V3
       resource,
       show_secrets: false,
       censored_message: VCAP::CloudController::Presenters::Censorship::REDACTED_CREDENTIAL,
-      visible_org_guids_query: nil,
+      visible_org_ids_query: nil,
       all_orgs_visible: false
     )
-      @visible_org_guids_query = visible_org_guids_query
+      @visible_org_ids_query = visible_org_ids_query
       @all_orgs_visible = all_orgs_visible
 
       super(resource, show_secrets:, censored_message:)
@@ -53,11 +53,11 @@ module VCAP::CloudController::Presenters::V3
 
     private
 
-    attr_reader :visible_org_guids_query, :all_orgs_visible
+    attr_reader :visible_org_ids_query, :all_orgs_visible
 
     def shared_org_guids
       ds = domain.shared_organizations_dataset
-      ds = ds.where(guid: @visible_org_guids_query) unless @all_orgs_visible
+      ds = ds.where(id: @visible_org_ids_query) unless @all_orgs_visible
       ds.select_map(:guid).map { |g| { guid: g } }
     end
 

--- a/app/presenters/v3/domain_shared_orgs_presenter.rb
+++ b/app/presenters/v3/domain_shared_orgs_presenter.rb
@@ -6,10 +6,10 @@ module VCAP::CloudController::Presenters::V3
   class DomainSharedOrgsPresenter < BasePresenter
     def initialize(
       resource,
-      visible_org_guids_query: nil,
+      visible_org_ids_query: nil,
       all_orgs_visible: false
     )
-      @visible_org_guids_query = visible_org_guids_query
+      @visible_org_ids_query = visible_org_ids_query
       @all_orgs_visible = all_orgs_visible
 
       super(resource)
@@ -23,11 +23,11 @@ module VCAP::CloudController::Presenters::V3
 
     private
 
-    attr_reader :visible_org_guids_query, :all_orgs_visible
+    attr_reader :visible_org_ids_query, :all_orgs_visible
 
     def shared_org_guids
       ds = domain.shared_organizations_dataset
-      ds = ds.where(guid: @visible_org_guids_query) unless @all_orgs_visible
+      ds = ds.where(id: @visible_org_ids_query) unless @all_orgs_visible
       ds.select_map(:guid).map { |g| { guid: g } }
     end
 

--- a/app/presenters/v3/organization_quota_presenter.rb
+++ b/app/presenters/v3/organization_quota_presenter.rb
@@ -8,11 +8,11 @@ module VCAP::CloudController::Presenters::V3
       show_secrets: false,
       censored_message: VCAP::CloudController::Presenters::Censorship::REDACTED_CREDENTIAL,
       all_orgs_visible: false,
-      visible_org_guids_query: nil
+      visible_org_ids_query: nil
     )
       super(resource, show_secrets:, censored_message:)
       @all_orgs_visible = all_orgs_visible
-      @visible_org_guids_query = visible_org_guids_query
+      @visible_org_ids_query = visible_org_ids_query
     end
 
     def to_hash
@@ -53,7 +53,7 @@ module VCAP::CloudController::Presenters::V3
 
     def filtered_visible_orgs
       ds = organization_quota.organizations_dataset
-      ds = ds.where(guid: @visible_org_guids_query) unless @all_orgs_visible
+      ds = ds.where(id: @visible_org_ids_query) unless @all_orgs_visible
       ds.select_map(:guid).map { |g| { guid: g } }
     end
 

--- a/lib/cloud_controller/permissions.rb
+++ b/lib/cloud_controller/permissions.rb
@@ -143,6 +143,14 @@ class VCAP::CloudController::Permissions
     end
   end
 
+  def readable_org_ids_for_domains_query
+    if can_read_globally?
+      VCAP::CloudController::Organization.select(:id)
+    else
+      membership.authorized_org_ids_subquery(ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + SPACE_ROLES)
+    end
+  end
+
   def can_read_from_org?(org_id)
     can_read_globally? || membership.role_applies?(ROLES_FOR_ORG_READING, nil, org_id)
   end
@@ -355,8 +363,16 @@ class VCAP::CloudController::Permissions
   end
 
   def readable_security_group_guids_query
+    readable_security_groups_dataset.select(:guid)
+  end
+
+  def readable_security_group_ids_query
+    readable_security_groups_dataset.select(:id)
+  end
+
+  def readable_security_groups_dataset
     if can_read_globally?
-      VCAP::CloudController::SecurityGroup.dataset.select(:guid)
+      VCAP::CloudController::SecurityGroup.dataset
     elsif @user
       visible_space_ids = membership.authorized_space_ids_subquery(ROLES_FOR_SPACE_READING)
 
@@ -370,9 +386,9 @@ class VCAP::CloudController::Permissions
                   from_self: false
                 )]
         ])
-      ).select(:guid)
+      )
     else
-      VCAP::CloudController::SecurityGroup.where(id: nil).select(:guid)
+      VCAP::CloudController::SecurityGroup.where(id: nil)
     end
   end
 

--- a/spec/unit/fetchers/domain_fetcher_spec.rb
+++ b/spec/unit/fetchers/domain_fetcher_spec.rb
@@ -21,7 +21,7 @@ module VCAP::CloudController
       let!(:private_domain2) { create(:private_domain, guid: 'private_domain2', owning_organization: org1) }
       let!(:private_domain3) { create(:private_domain, guid: 'private_domain3', owning_organization: org3) }
 
-      context 'when there are no readable org guids' do
+      context 'when there are no readable org ids' do
         it 'lists shared domains only' do
           domains = DomainFetcher.fetch_all_for_orgs([])
           expect(domains.map(&:guid)).to contain_exactly('shared_domain1', 'shared_domain2')
@@ -30,23 +30,23 @@ module VCAP::CloudController
 
       context 'when the user can see all shared private domains' do
         it 'gets org1' do
-          domains = DomainFetcher.fetch_all_for_orgs([org1.guid])
+          domains = DomainFetcher.fetch_all_for_orgs([org1.id])
           expect(domains.map(&:guid)).to contain_exactly('shared_domain1', 'shared_domain2', 'private_domain1', 'private_domain2')
         end
 
         it 'gets org2' do
-          domains = DomainFetcher.fetch_all_for_orgs([org2.guid])
+          domains = DomainFetcher.fetch_all_for_orgs([org2.id])
           expect(domains.map(&:guid)).to contain_exactly('shared_domain1', 'shared_domain2')
         end
 
         it 'gets org3' do
-          domains = DomainFetcher.fetch_all_for_orgs([org3.guid])
+          domains = DomainFetcher.fetch_all_for_orgs([org3.id])
           expect(domains.map(&:guid)).to contain_exactly('shared_domain1',
                                                          'shared_domain2', 'private_domain1', 'private_domain3')
         end
 
         it 'returns readable domains for multiple orgs' do
-          domains = DomainFetcher.fetch_all_for_orgs([org1.guid, org3.guid])
+          domains = DomainFetcher.fetch_all_for_orgs([org1.id, org3.id])
           expect(domains.map(&:guid)).to contain_exactly(
             'shared_domain1', 'shared_domain2',
             'private_domain1', 'private_domain2', 'private_domain3'
@@ -54,8 +54,8 @@ module VCAP::CloudController
         end
 
         it 'returns readable domains for multiple orgs filtered using sequel subquery' do
-          org_guids = Organization.where(guid: [org2.guid, org3.guid]).select(:guid)
-          domains = DomainFetcher.fetch_all_for_orgs(org_guids)
+          org_ids = Organization.where(guid: [org2.guid, org3.guid]).select(:id)
+          domains = DomainFetcher.fetch_all_for_orgs(org_ids)
           expect(domains.map(&:guid)).to contain_exactly(
             'shared_domain1', 'shared_domain2',
             'private_domain1', 'private_domain3'
@@ -80,7 +80,7 @@ module VCAP::CloudController
           let!(:domain_guid_filter) { shared_domain1.guid }
 
           it 'returns only the shared domain for the given guid' do
-            results = DomainFetcher.fetch(message, [org1.guid]).all
+            results = DomainFetcher.fetch(message, [org1.id]).all
             expect(results.length).to eq(1)
             expect(results[0].guid).to eq('shared_domain1')
           end
@@ -93,7 +93,7 @@ module VCAP::CloudController
             let!(:domain_guid_filter) { private_domain.guid }
 
             it 'returns only the private domain' do
-              results = DomainFetcher.fetch(message, [org1.guid]).all
+              results = DomainFetcher.fetch(message, [org1.id]).all
               expect(results.length).to eq(1)
               expect(results[0].guid).to eq('private_domain')
             end
@@ -109,7 +109,7 @@ module VCAP::CloudController
             end
 
             it 'returns the private domain' do
-              results = DomainFetcher.fetch(message, [org1.guid]).all
+              results = DomainFetcher.fetch(message, [org1.id]).all
               expect(results.length).to eq(1)
               expect(results[0].guid).to eq('private_domain')
             end
@@ -126,7 +126,7 @@ module VCAP::CloudController
             end
 
             it 'returns no domains' do
-              results = DomainFetcher.fetch(message, [org1.guid]).all
+              results = DomainFetcher.fetch(message, [org1.id]).all
               expect(results.length).to eq(0)
             end
           end
@@ -145,7 +145,7 @@ module VCAP::CloudController
           let!(:domain_name_filter) { shared_domain2.name }
 
           it 'only returns the matching domain' do
-            results = DomainFetcher.fetch(message, [org1.guid]).all
+            results = DomainFetcher.fetch(message, [org1.id]).all
             expect(results.length).to eq(1)
             expect(results[0].guid).to eq('named-domain-2')
           end
@@ -173,7 +173,7 @@ module VCAP::CloudController
           let!(:domain_guid_filter) { shared_domain2.guid }
 
           it 'only returns the matching domain' do
-            results = DomainFetcher.fetch(message, [org1.guid]).all
+            results = DomainFetcher.fetch(message, [org1.id]).all
             expect(results.length).to eq(1)
             expect(results[0].guid).to eq('guid-2')
           end
@@ -202,7 +202,7 @@ module VCAP::CloudController
           let!(:organization_guid_filter) { org1.guid }
 
           it 'returns only privates_domain1' do
-            results = DomainFetcher.fetch(message, [org1.guid, org2.guid]).all
+            results = DomainFetcher.fetch(message, [org1.id, org2.id]).all
             expect(results.length).to eq(1)
             expect(results[0].name).to eq('named-domain-1.com')
           end
@@ -230,7 +230,7 @@ module VCAP::CloudController
           create(:domain_label_model, resource_guid: shared_domain2.guid, key_name: 'dog', value: 'poodle')
         end
 
-        let(:results) { DomainFetcher.fetch(message, [org1.guid]).all }
+        let(:results) { DomainFetcher.fetch(message, [org1.id]).all }
 
         context 'only the label_selector is present' do
           let(:message) do

--- a/spec/unit/fetchers/isolation_segment_organizations_fetcher_spec.rb
+++ b/spec/unit/fetchers/isolation_segment_organizations_fetcher_spec.rb
@@ -28,13 +28,13 @@ module VCAP::CloudController
 
     describe '#fetch_for_organizations' do
       it 'fetches only organizations specified as readable' do
-        organizations = fetcher.fetch_for_organizations(org_guids_query: Organization.where(id: [org1.id, org2.id, org4.id]).select(:guid))
+        organizations = fetcher.fetch_for_organizations(org_ids_query: Organization.where(id: [org1.id, org2.id, org4.id]).select(:id))
 
         expect(organizations).to contain_exactly(org1, org2)
       end
 
-      it 'returns no isolation segments when the list of org guids is empty' do
-        organizations = fetcher.fetch_for_organizations(org_guids_query: Organization.where(id: -1).select(:guid))
+      it 'returns no isolation segments when the list of org ids is empty' do
+        organizations = fetcher.fetch_for_organizations(org_ids_query: Organization.where(id: -1).select(:id))
 
         expect(organizations).to be_empty
       end

--- a/spec/unit/fetchers/org_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/org_list_fetcher_spec.rb
@@ -9,23 +9,23 @@ module VCAP::CloudController
     let!(:org3) { create(:organization, name: 'Beaver') }
     let!(:org4) { create(:organization, name: 'Capybara') }
     let!(:org5) { create(:organization, name: 'Groundhog') }
-    let(:some_org_guids) { [org1.guid, org3.guid, org4.guid] }
+    let(:some_org_ids) { [org1.id, org3.id, org4.id] }
 
     let(:fetcher) { OrgListFetcher }
 
     let(:message) { OrgsListMessage.from_params({}) }
 
     describe '#fetch' do
-      it 'includes all the orgs with the provided guids' do
-        results = fetcher.fetch(message: message, guids: some_org_guids).all
+      it 'includes all the orgs with the provided ids' do
+        results = fetcher.fetch(message: message, ids: some_org_ids).all
         expect(results).to contain_exactly(org1, org3, org4)
       end
 
       describe 'eager loading associated resources' do
-        let(:some_org_guids) { [org1.guid, org3.guid] }
+        let(:some_org_ids) { [org1.id, org3.id] }
 
         it 'eager loads the specified resources for all orgs' do
-          results = fetcher.fetch(message: message, guids: some_org_guids, eager_loaded_associations: %i[quota_definition labels]).all
+          results = fetcher.fetch(message: message, ids: some_org_ids, eager_loaded_associations: %i[quota_definition labels]).all
 
           expect(results.first.associations.key?(:quota_definition)).to be true
           expect(results.first.associations.key?(:labels)).to be true
@@ -38,34 +38,35 @@ module VCAP::CloudController
           let(:message) { OrgsListMessage.from_params names: %w[Marmot Capybara] }
 
           it 'returns the correct set of orgs' do
-            results = fetcher.fetch(message: message, guids: some_org_guids).all
+            results = fetcher.fetch(message: message, ids: some_org_ids).all
             expect(results).to contain_exactly(org1, org4)
           end
 
-          context 'respects any provided guids' do
+          context 'respects any provided ids' do
             let(:message) { OrgsListMessage.from_params names: %w[Marmot Rat] }
 
             it 'does not return orgs asked for if they are not part of the array passed into #fetch' do
-              results = fetcher.fetch(message: message, guids: some_org_guids).all
+              results = fetcher.fetch(message: message, ids: some_org_ids).all
               expect(results).to contain_exactly(org1)
             end
           end
         end
 
         context 'when org guids are provided' do
-          let(:all_org_guids) { [org1.guid, org2.guid, org3.guid, org4.guid, org5.guid] }
+          let(:all_org_ids) { [org1.id, org2.id, org3.id, org4.id, org5.id] }
           let(:message) { OrgsListMessage.from_params guids: some_org_guids }
+          let(:some_org_guids) { [org1.guid, org3.guid, org4.guid] }
 
           it 'returns the correct set of orgs' do
-            results = fetcher.fetch(message: message, guids: all_org_guids).all
+            results = fetcher.fetch(message: message, ids: all_org_ids).all
             expect(results).to contain_exactly(org1, org3, org4)
           end
 
-          context 'respects any provided guids' do
+          context 'respects any provided ids' do
             let(:message) { OrgsListMessage.from_params guids: [org1.guid, org2.guid] }
 
             it 'does not return orgs asked for if they are not part of the array passed into #fetch' do
-              results = fetcher.fetch(message: message, guids: some_org_guids).all
+              results = fetcher.fetch(message: message, ids: some_org_ids).all
               expect(results).to contain_exactly(org1)
             end
           end
@@ -109,6 +110,7 @@ module VCAP::CloudController
         end
 
         context 'when org guids are provided' do
+          let(:some_org_guids) { [org1.guid, org3.guid, org4.guid] }
           let(:message) { OrgsListMessage.from_params guids: some_org_guids }
 
           it 'returns the correct set of orgs' do
@@ -136,25 +138,25 @@ module VCAP::CloudController
       let(:isolation_segment) { create(:isolation_segment_model) }
       let(:assigner) { IsolationSegmentAssign.new }
       let(:message) { OrgsListMessage.from_params isolation_segment_guid: isolation_segment.guid }
-      let(:readable_org_guids) { [org1.guid, org2.guid] }
+      let(:readable_org_ids) { [org1.id, org2.id] }
 
       before do
         assigner.assign(isolation_segment, [org1, org2, org5])
       end
 
       it 'returns the correct isolation segment' do
-        returned_isolation_segment, = fetcher.fetch_for_isolation_segment(message: message, guids: readable_org_guids)
+        returned_isolation_segment, = fetcher.fetch_for_isolation_segment(message: message, ids: readable_org_ids)
         expect(returned_isolation_segment.guid).to eq(isolation_segment.guid)
       end
 
       it 'fetches the orgs that the user can see associated with the iso seg' do
-        _, results = fetcher.fetch_for_isolation_segment(message: message, guids: readable_org_guids)
+        _, results = fetcher.fetch_for_isolation_segment(message: message, ids: readable_org_ids)
         expect(results.all).to contain_exactly(org1, org2)
       end
 
       describe 'eager loading associated resources' do
         it 'eager loads the specified resources for all orgs' do
-          _, org_ds = fetcher.fetch_for_isolation_segment(message: message, guids: readable_org_guids, eager_loaded_associations: %i[quota_definition labels])
+          _, org_ds = fetcher.fetch_for_isolation_segment(message: message, ids: readable_org_ids, eager_loaded_associations: %i[quota_definition labels])
           results = org_ds.all
 
           expect(results).to contain_exactly(org1, org2)

--- a/spec/unit/fetchers/organization_quota_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/organization_quota_list_fetcher_spec.rb
@@ -11,12 +11,12 @@ module VCAP::CloudController
 
     let(:org1) { create(:organization, name: 'org1', quota_definition: quota1) }
     let(:org2) { create(:organization, name: 'org2', quota_definition: quota3) }
-    let(:visible_org_guids_query) { Organization.where(id: visible_org_ids).select(:guid) }
+    let(:visible_org_ids_query) { Organization.where(id: visible_org_ids).select(:id) }
     let(:visible_org_ids) { [org1.id, org2.id] }
 
     let(:message) { OrganizationQuotasListMessage.from_params(filters) }
 
-    subject { OrganizationQuotaListFetcher.fetch(message: message, readable_org_guids_query: visible_org_guids_query).all }
+    subject { OrganizationQuotaListFetcher.fetch(message: message, readable_org_ids_query: visible_org_ids_query).all }
 
     describe '#fetch' do
       context 'when filters are not provided' do

--- a/spec/unit/fetchers/security_group_fetcher_spec.rb
+++ b/spec/unit/fetchers/security_group_fetcher_spec.rb
@@ -28,16 +28,16 @@ module VCAP::CloudController
         expect(security_group).to eq(security_group_1)
       end
 
-      context 'security group guid in visible_security_group_guids' do
-        let(:visible_security_groups) { [security_group_1.guid] }
+      context 'security group id in visible_security_group_ids' do
+        let(:visible_security_groups) { [security_group_1.id] }
 
         it 'returns the security group' do
           expect(security_group).to eq(security_group_1)
         end
       end
 
-      context 'security group guid not in visible_security_group_guids' do
-        let(:visible_security_groups) { [security_group_2.guid] }
+      context 'security group id not in visible_security_group_ids' do
+        let(:visible_security_groups) { [security_group_2.id] }
 
         it 'returns nil' do
           expect(security_group).to be_nil

--- a/spec/unit/fetchers/security_group_list_fetcher_spec.rb
+++ b/spec/unit/fetchers/security_group_list_fetcher_spec.rb
@@ -41,7 +41,7 @@ module VCAP::CloudController
     end
 
     describe '#fetch' do
-      let(:visible_security_groups) { [security_group_1.guid, security_group_2.guid] }
+      let(:visible_security_groups) { [security_group_1.id, security_group_2.id] }
       let(:security_groups) { fetcher.fetch(message, visible_security_groups) }
 
       include_examples 'eager loading'

--- a/spec/unit/fetchers/service_plan_visibility_fetcher_spec.rb
+++ b/spec/unit/fetchers/service_plan_visibility_fetcher_spec.rb
@@ -9,7 +9,7 @@ module VCAP::CloudController
     let(:permission_querier) do
       double('Permission Querier',
              can_read_globally?: can_read_globally,
-             readable_org_guids_query: Organization.where(guid: readable_org_guids).select(:guid))
+             readable_org_ids_query: Organization.where(guid: readable_org_guids).select(:id))
     end
 
     let(:fetcher) { ServicePlanVisibilityFetcher.new(permission_querier) }

--- a/spec/unit/lib/cloud_controller/permissions_spec.rb
+++ b/spec/unit/lib/cloud_controller/permissions_spec.rb
@@ -199,6 +199,28 @@ module VCAP::CloudController
       end
     end
 
+    describe '#readable_org_ids_for_domains_query' do
+      context 'when user is not an admin' do
+        it 'returns the id subquery from membership for org- and space-scoped domain-reading roles' do
+          membership = instance_double(Membership)
+          subquery = instance_double(Sequel::Dataset)
+          expect(Membership).to receive(:new).with(user).and_return(membership)
+          expect(membership).to receive(:authorized_org_ids_subquery).
+            with(Permissions::ORG_ROLES_FOR_READING_DOMAINS_FROM_ORGS + Permissions::SPACE_ROLES).
+            and_return(subquery)
+          expect(permissions.readable_org_ids_for_domains_query).to be(subquery)
+        end
+      end
+
+      context 'when user can read globally' do
+        it 'returns all org ids' do
+          allow(permissions).to receive(:can_read_globally?).and_return(true)
+          expect(permissions.readable_org_ids_for_domains_query.sql).
+            to eq(VCAP::CloudController::Organization.select(:id).sql)
+        end
+      end
+    end
+
     describe '#can_read_from_org?' do
       context 'user has no membership' do
         context 'and user is an admin' do

--- a/spec/unit/presenters/v3/domain_presenter_spec.rb
+++ b/spec/unit/presenters/v3/domain_presenter_spec.rb
@@ -4,12 +4,12 @@ require 'presenters/v3/domain_presenter'
 module VCAP::CloudController::Presenters::V3
   RSpec.describe DomainPresenter do
     let(:visible_org_guids) { [] }
-    let(:visible_org_guids_query) { VCAP::CloudController::Organization.where(guid: visible_org_guids).select(:guid) }
+    let(:visible_org_ids_query) { VCAP::CloudController::Organization.where(guid: visible_org_guids).select(:id) }
     let(:all_orgs_visible) { false }
 
     describe '#to_hash' do
       subject do
-        DomainPresenter.new(domain, visible_org_guids_query:, all_orgs_visible:).to_hash
+        DomainPresenter.new(domain, visible_org_ids_query:, all_orgs_visible:).to_hash
       end
 
       context 'when the domain is public (shared)' do

--- a/spec/unit/presenters/v3/domain_shared_orgs_presenter_spec.rb
+++ b/spec/unit/presenters/v3/domain_shared_orgs_presenter_spec.rb
@@ -4,7 +4,7 @@ require 'presenters/v3/domain_shared_orgs_presenter'
 module VCAP::CloudController::Presenters::V3
   RSpec.describe DomainSharedOrgsPresenter do
     let(:visible_org_guids) { [] }
-    let(:visible_org_guids_query) { VCAP::CloudController::Organization.where(guid: visible_org_guids).select(:guid) }
+    let(:visible_org_ids_query) { VCAP::CloudController::Organization.where(guid: visible_org_guids).select(:id) }
     let(:all_orgs_visible) { false }
 
     describe '#to_hash' do
@@ -17,7 +17,7 @@ module VCAP::CloudController::Presenters::V3
       subject do
         DomainSharedOrgsPresenter.new(
           domain,
-          visible_org_guids_query:,
+          visible_org_ids_query:,
           all_orgs_visible:
         ).to_hash
       end

--- a/spec/unit/presenters/v3/organization_quota_presenter_spec.rb
+++ b/spec/unit/presenters/v3/organization_quota_presenter_spec.rb
@@ -8,7 +8,7 @@ module VCAP::CloudController::Presenters::V3
     let(:organization_quota) { create(:quota_definition, guid: 'quota-guid') }
     let(:all_orgs_visible) { false }
     let(:visible_org_guids) { [org.guid] }
-    let(:visible_org_guids_query) { VCAP::CloudController::Organization.where(guid: visible_org_guids).select(:guid) }
+    let(:visible_org_ids_query) { VCAP::CloudController::Organization.where(guid: visible_org_guids).select(:id) }
 
     before do
       organization_quota.add_organization(org)
@@ -16,7 +16,7 @@ module VCAP::CloudController::Presenters::V3
     end
 
     describe '#to_hash' do
-      let(:result) { OrganizationQuotaPresenter.new(organization_quota, visible_org_guids_query:, all_orgs_visible:).to_hash }
+      let(:result) { OrganizationQuotaPresenter.new(organization_quota, visible_org_ids_query:, all_orgs_visible:).to_hash }
 
       it 'presents the org as json' do
         expect(result[:guid]).to eq(organization_quota.guid)


### PR DESCRIPTION
### A short explanation of the proposed change:
Follow-up to https://github.com/cloudfoundry/cloud_controller_ng/pull/5157 and https://github.com/cloudfoundry/cloud_controller_ng/pull/5172.
Remove all guid -> id -> guid roundtrips mechanically.

### An explanation of the use cases your change solves
Improves performance in the following API paths:
app/fetchers/org_list_fetcher.rb - GET /v3/organizations
app/fetchers/organization_quota_list_fetcher.rb - GET /v3/organization_quotas
app/fetchers/service_plan_visibility_fetcher.rb - marketplace visibility checks
app/fetchers/security_group_list_fetcher.rb / security_group_fetcher.rb - GET /v3/security_groups*
app/fetchers/isolation_segment_organizations_fetcher.rb - GET /v3/isolation_segments/:guid/organizations
app/fetchers/domain_fetcher.rb - GET /v3/domains*
app/presenters/v3/organization_quota_presenter.rb, domain_presenter.rb, domain_shared_orgs_presenter.rb

**Before / After perf test results — id → guid → id round-trip removal (medians, N=3)**

  | Endpoint / case | Before | After | Δ |
  |---|---|---|---|
  | organizations — admin | 178.7ms | 178.3ms | ~0 |
  | organizations — regular | 189.1ms | 168.1ms | −11% |
  | organizations — regular, page 500 | 254.6ms | 250.7ms | −2% |
  | org_quotas — admin | 1201.6ms | 1348.5ms | +12% (noise, σ=183ms) |
  | org_quotas — regular | 952.1ms | 539.9ms | −43% |
  | org_quotas — regular, page 500 | 962.3ms | 570.2ms | −41% |
  | iso_segments — list admin | 222.2ms | 230.4ms | +4% (noise) |
  | iso_segments — list regular | 229.9ms | 254.0ms | +10% (noise) |
  | iso_segments — list admin, page 500 | 777.8ms | 838.3ms | +8% (noise) |
  | iso_segments — rel/orgs admin | 147.6ms | 147.3ms | ~0 |
  | iso_segments — rel/orgs regular | 157.5ms | 157.7ms | ~0 |

  **Analysis**

  **Wins — non-admin permission filtering:**
  - org_quotas regular −43%, page 500 −41%. Presenter filters orgs once per quota (50 quotas × ~2000 orgs). Round-trip removal compounds.
  - organizations regular −11%. σ=0.6ms, real.

  **Neutral (expected):**
  - Admin cases flat. Hit `can_read_globally?` short-circuit — not touched.
  - iso_segments rel/orgs flat. ~20 orgs per segment; segment join runs first, permission filter sees tiny set. Round-trip cost negligible at this scale.

  **Noise, not regressions:**
  - org_quotas admin +12%: σ jumped to 183ms, unchanged code path.
  - iso_segments list +4–10%: endpoint doesn't call the changed fetcher.

  **Bottom line:** Large win on non-admin org_quotas (~40%), solid on organizations regular (−11%). Admin + unrelated paths unchanged.

### Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
