### PR TITLE
Remove tiny fog leftovers

### DIFF
--- a/.devcontainer/scripts/cc-generate-config
+++ b/.devcontainer/scripts/cc-generate-config
@@ -66,7 +66,6 @@ def generate_config(mode, hosts)
     %w[resource_pool packages droplets buildpacks].each do |store|
       config[store]['blobstore_type'] = 'local'
       config[store]['local_blobstore_path'] = blobstore_path
-      config[store]['fog_connection'] = {}
     end
   when 'storage-cli'
     config_dir = "#{Dir.pwd}/tmp/.dev-generated/storage_cli_configs"
@@ -78,7 +77,6 @@ def generate_config(mode, hosts)
                      'secret_access_key' => 'any', 'region' => 'us-east-1' }, mode: :compat, indent: 2
                  ))
       config[store]['blobstore_type'] = 'storage-cli'
-      config[store]['fog_connection'] = {}
       config[store].delete('local_blobstore_path')
       config["storage_cli_config_file_#{store}"] = "#{config_dir}/#{store}.json"
     end

--- a/LICENSE
+++ b/LICENSE
@@ -227,7 +227,6 @@ SECTION 1: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
    >>> em-http-request-1.1.0
    >>> em-socksify-0.3.0
    >>> excon-0.23.0
-   >>> fog-1.12.1
    >>> formatador-0.2.4
    >>> grape-0.5.0
    >>> guard-1.8.1
@@ -729,34 +728,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
->>> fog-1.12.1
-
-Copyright
-
-(The MIT License)
-
-Copyright (c) 2013 [geemus (Wesley Beary)](http://github.com/geemus)
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 >>> formatador-0.2.4

--- a/spec/unit/lib/cloud_controller/blobstore/url_generator/internal_url_generator_spec.rb
+++ b/spec/unit/lib/cloud_controller/blobstore/url_generator/internal_url_generator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'cloud_controller/blobstore/null_blob'
 require 'cloud_controller/blobstore/url_generator/internal_url_generator'
 
 module CloudController


### PR DESCRIPTION
* A short explanation of the proposed change:
Removes the last remaining fog references from Cloud Controller now that the fog gem family has been fully replaced by storage-cli.
* An explanation of the use cases your change solves
Completes the fog-gem removal so that no fog remnants remain anywhere in Cloud Controller — not just the gems and runtime code, but also developer tooling and license metadata.

* Links to any other associated PRs
https://github.com/cloudfoundry/cloud_controller_ng/pull/5288
* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
