### PR TITLE
Print rerun command for failed parallel_rspec shards

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -47,6 +47,7 @@ namespace :spec do
       #{env_vars} bundle exec parallel_rspec \
       --test-options '--order rand #{rspec_profile_option} --format progress --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec_main.log' \
       --runtime-log tmp/parallel_runtime_rspec_main.log \
+      --verbose-rerun-command \
       --single spec/integration/ \
       --single spec/acceptance/ \
       --isolate \
@@ -61,6 +62,7 @@ namespace :spec do
       #{env_vars} bundle exec parallel_rspec \
       --test-options '--order rand #{rspec_profile_option} --format progress --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec_migrations.log' \
       --runtime-log tmp/parallel_runtime_rspec_migrations.log \
+      --verbose-rerun-command \
       -- spec/migrations
     CMD
     sh command


### PR DESCRIPTION
Add `--verbose-rerun-command` to the parallel_rspec invocations so a failing shard prints a copy-pasteable command with its exact file list and seed. This makes order-dependent flakes reproducible locally, since RSpec order depends on both the seed and the shard's file set and the latter was not previously recoverable from CI output.

The flag only emits output on failure, so green runs are unaffected.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
