### PR TITLE
Removed unused flags

### DIFF
--- a/lib/cloud_controller/config_schemas/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/worker_schema.rb
@@ -23,11 +23,6 @@ module VCAP::CloudController
 
           optional(:temporary_enable_v2) => bool,
 
-          optional(:temporary_enable_async_recursive_delete) => {
-            optional(:apps) => bool,
-            optional(:service_instances) => bool
-          },
-
           uaa: {
             internal_url: String,
             optional(:ca_file) => String,


### PR DESCRIPTION
PR #5299 introduced some worker config flags which are not used and can be safely removed.

* Links to any other associated PRs
  #5299

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
