### PR TITLE
Prevent ThreadedWorker from leaking enqueue lifecycle callbacks

### DIFF
--- a/lib/delayed_job/threaded_worker.rb
+++ b/lib/delayed_job/threaded_worker.rb
@@ -1,5 +1,18 @@
 module Delayed
   class ThreadedWorker < Delayed::Worker
+    # Delayed::Plugin callbacks register against the base Delayed::Worker.lifecycle,
+    # but setup_lifecycle rebuilds the lifecycle on the class it is called on. On this
+    # subclass it would reset a different lifecycle than the one plugins append to,
+    # so every ThreadedWorker.new would leak another callback into the base lifecycle.
+    # Delegate to the base class so each instantiation rebuilds the same lifecycle.
+    def self.setup_lifecycle
+      Delayed::Worker.setup_lifecycle
+    end
+
+    def self.lifecycle
+      Delayed::Worker.lifecycle
+    end
+
     def initialize(options={})
       super
       @num_threads = options[:num_threads]

--- a/spec/unit/lib/delayed_job/threaded_worker_spec.rb
+++ b/spec/unit/lib/delayed_job/threaded_worker_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe Delayed::ThreadedWorker do
       worker = Delayed::ThreadedWorker.new({ num_threads: 2 })
       expect(worker.instance_variable_get(:@grace_period_seconds)).to eq(30)
     end
+
+    it 'does not accumulate enqueue lifecycle callbacks across instantiations' do
+      before_enqueue_callbacks = lambda do
+        Delayed::Worker.lifecycle.instance_variable_get(:@callbacks)[:enqueue].instance_variable_get(:@before).size
+      end
+
+      baseline = before_enqueue_callbacks.call
+      5.times { Delayed::ThreadedWorker.new(options) }
+      expect(before_enqueue_callbacks.call).to eq(baseline)
+    end
   end
 
   describe '#start' do


### PR DESCRIPTION
Plugin callbacks register against the base `Delayed::Worker.lifecycle`, but `setup_lifecycle` rebuilt the `lifecycle` on the class it was called on. On the `ThreadedWorker` subclass that reset a separate `lifecycle`, so the base one was never reset and each `ThreadedWorker.new` leaked another `before(:enqueue)` callback, creating many `PollableJobModel` rows per enqueue. Production is unaffected (one worker per process).

Delegate `setup_lifecycle` and `lifecycle` to the base class via `superclass`, not the `Delayed::Worker` constant, which tests may reassign to this subclass and cause infinite recursion.

_This change was developed with AI assistance; all code was reviewed and tested by me._

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
