### PR TITLE
Fix OpenAPI docs publishing pipeline not triggering Pages deploy

### DIFF
--- a/.github/workflows/openapi_deploy.yml
+++ b/.github/workflows/openapi_deploy.yml
@@ -17,6 +17,7 @@ jobs:
       image: node:24-alpine
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout main
         uses: actions/checkout@v7
@@ -46,10 +47,29 @@ jobs:
           cp -r main/docs/openapi/dist/. gh-pages/openapi/
 
       - name: Commit and push
+        id: commit
         working-directory: gh-pages
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add openapi
-          git diff --cached --quiet && echo "No changes to publish" || \
-            (git commit -m "Update openapi docs from ${GITHUB_SHA}" && git push)
+          if git diff --cached --quiet; then
+            echo "No changes to publish"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -m "Update openapi docs from ${GITHUB_SHA}"
+            git push
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger Pages deployment
+        if: steps.commit.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy_v3_docs.yml',
+              ref: 'gh-pages',
+            });


### PR DESCRIPTION
Commits pushed to gh-pages using the default GITHUB_TOKEN don't trigger other workflows, so "Deploy V3 API Docs to Pages" never ran after "Deploy CF API V3 OpenAPI Documentation" pushed updated docs. workflow_dispatch is exempt from that restriction, so explicitly dispatch the Pages deploy workflow via the API after a successful push.

Fixes cloudfoundry/cloud_controller_ng#5373

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
