### PR TITLE
Fix broken Slack links in docs and skip slack.com in link checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Maintainability](https://qlty.sh/gh/cloudfoundry/projects/cloud_controller_ng/maintainability.svg)](https://qlty.sh/gh/cloudfoundry/projects/cloud_controller_ng)
-[![slack.cloudfoundry.org](https://slack.cloudfoundry.org/badge.svg)](https://cloudfoundry.slack.com/messages/capi/)
+[![slack.cloudfoundry.org](https://slack.cloudfoundry.org/badge.svg)](https://cloudfoundry.slack.com/archives/C07C04W4Q)
 
 # Welcome to the Cloud Controller
 

--- a/docs/v3/gulpfile.js
+++ b/docs/v3/gulpfile.js
@@ -182,7 +182,7 @@ gulp.task('checkV3docs', gulp.series('build', done => {
 
   try {
     checkPathAndExit('build', {
-      linksToSkip: ['http://localhost:8001/version/release-candidate'],
+      linksToSkip: ['http://localhost:8001/version/release-candidate', 'slack.com'],
       recurse: true,
       silent: true,
       markdown: true,

--- a/docs/v3/source/includes/introduction/_introduction.md
+++ b/docs/v3/source/includes/introduction/_introduction.md
@@ -11,7 +11,7 @@ key features:
 * Changing application source code without stopping the app via deployments
 
 ## Getting help
-The CAPI team can most easily be reached on our [Slack channel](https://cloudfoundry.slack.com/messages/capi/) for
+The CAPI team can most easily be reached on our [Slack channel](https://cloudfoundry.slack.com/archives/C07C04W4Q) for
 questions and issues regarding the API. To report an issue with the docs or API, please feel free to file a GitHub
 issue on our API repo, [cloud_controller_ng](https://github.com/cloudfoundry/cloud_controller_ng).
 

--- a/docs/v3/source/includes/upgrade_guide/_header.md
+++ b/docs/v3/source/includes/upgrade_guide/_header.md
@@ -5,6 +5,6 @@ This document is intended to help client authors upgrade from Cloud Foundry's V2
 When moving to the V3 API, it is important to understand that the V3 API is backed by the same database as the V2 API. Though resources may be presented differently and have different interaction patterns, the internal state of CF is the same across both APIs. If you create an organization using the V3 API,
 it will be visible to the V2 API, and vice-versa.
 
-If you have questions, need help, or want to chat about the upgrade process, please reach out to us in [Cloud Foundry Slack](https://cloudfoundry.slack.com/messages/C07C04W4Q).
+If you have questions, need help, or want to chat about the upgrade process, please reach out to us in [Cloud Foundry Slack](https://cloudfoundry.slack.com/archives/C07C04W4Q).
 
 


### PR DESCRIPTION
* A short explanation of the proposed change:

1.  Update Slack URLs in docs from deprecated /messages/ format to /archives/ format

2.  Add slack.com to linksToSkip in gulpfile.js to skip Slack links in the link checker

* An explanation of the use cases your change solves
Slack returns 403 to automated link checkers due to bot detection, causing the docs CI job (checkdocs) to fail. The existing Slack URL in _introduction.md also used the deprecated /messages/capi/ format which no longer resolves correctly. This fix ensures the docs CI passes reliably without depending on Slack's availability for bots.

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)