### PR TITLE
Add ccdb.ssl_mode to control DB TLS without a CA

### DIFF
--- a/lib/cloud_controller/config_schemas/api_schema.rb
+++ b/lib/cloud_controller/config_schemas/api_schema.rb
@@ -121,6 +121,7 @@ module VCAP::CloudController
             optional(:connection_expiration_random_delay) => Integer,
             optional(:ssl_verify_hostname) => bool,
             optional(:ca_cert_path) => String,
+            optional(:ssl_mode) => String,
             optional(:enable_paginate_window) => bool,
             optional(:psql) => {
               optional(:statement_timeout) => Integer,

--- a/lib/cloud_controller/config_schemas/blobstore_benchmarks_schema.rb
+++ b/lib/cloud_controller/config_schemas/blobstore_benchmarks_schema.rb
@@ -40,7 +40,8 @@ module VCAP::CloudController
             log_db_queries: bool,
             ssl_verify_hostname: bool,
             connection_validation_timeout: Integer,
-            optional(:ca_cert_path) => String
+            optional(:ca_cert_path) => String,
+            optional(:ssl_mode) => String
           },
           optional(:storage_cli_config_file_resource_pool) => String,
           optional(:storage_cli_config_file_buildpacks) => String,

--- a/lib/cloud_controller/config_schemas/clock_schema.rb
+++ b/lib/cloud_controller/config_schemas/clock_schema.rb
@@ -73,7 +73,8 @@ module VCAP::CloudController
             log_db_queries: bool,
             ssl_verify_hostname: bool,
             connection_validation_timeout: Integer,
-            optional(:ca_cert_path) => String
+            optional(:ca_cert_path) => String,
+            optional(:ssl_mode) => String
           },
 
           staging: {

--- a/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
+++ b/lib/cloud_controller/config_schemas/deployment_updater_schema.rb
@@ -33,6 +33,7 @@ module VCAP::CloudController
             ssl_verify_hostname: bool,
             connection_validation_timeout: Integer,
             optional(:ca_cert_path) => String,
+            optional(:ssl_mode) => String,
             optional(:connection_expiration_timeout) => Integer,
             optional(:connection_expiration_random_delay) => Integer
           },

--- a/lib/cloud_controller/config_schemas/migrate_schema.rb
+++ b/lib/cloud_controller/config_schemas/migrate_schema.rb
@@ -20,6 +20,7 @@ module VCAP::CloudController
             optional(:log_db_queries) => bool,
             optional(:ssl_verify_hostname) => bool,
             optional(:ca_cert_path) => String,
+            optional(:ssl_mode) => String,
             optional(:enable_paginate_window) => bool
           },
 

--- a/lib/cloud_controller/config_schemas/rotate_database_key_schema.rb
+++ b/lib/cloud_controller/config_schemas/rotate_database_key_schema.rb
@@ -22,7 +22,8 @@ module VCAP::CloudController
             log_db_queries: bool,
             ssl_verify_hostname: bool,
             connection_validation_timeout: Integer,
-            optional(:ca_cert_path) => String
+            optional(:ca_cert_path) => String,
+            optional(:ssl_mode) => String
           },
 
           index: Integer, # Component index (cc-0, cc-1, etc)

--- a/lib/cloud_controller/config_schemas/route_syncer_schema.rb
+++ b/lib/cloud_controller/config_schemas/route_syncer_schema.rb
@@ -21,7 +21,8 @@ module VCAP::CloudController
             log_db_queries: bool,
             ssl_verify_hostname: bool,
             connection_validation_timeout: Integer,
-            optional(:ca_cert_path) => String
+            optional(:ca_cert_path) => String,
+            optional(:ssl_mode) => String
           },
 
           index: Integer, # Component index (cc-0, cc-1, etc)

--- a/lib/cloud_controller/config_schemas/worker_schema.rb
+++ b/lib/cloud_controller/config_schemas/worker_schema.rb
@@ -60,6 +60,7 @@ module VCAP::CloudController
             ssl_verify_hostname: bool,
             connection_validation_timeout: Integer,
             optional(:ca_cert_path) => String,
+            optional(:ssl_mode) => String,
             optional(:psql) => {
               optional(:statement_timeout) => Integer,
               optional(:idle_in_transaction_session_timeout) => Integer,

--- a/lib/cloud_controller/db_connection/mysql_options_factory.rb
+++ b/lib/cloud_controller/db_connection/mysql_options_factory.rb
@@ -1,6 +1,8 @@
 module VCAP::CloudController
   module DbConnection
     class MysqlOptionsFactory
+      SUPPORTED_SSL_MODES = %i[disabled required].freeze
+
       def self.build(opts)
         options = {
           charset: 'utf8'
@@ -13,13 +15,18 @@ module VCAP::CloudController
         if opts[:ca_cert_path]
           options[:sslca] = opts[:ca_cert_path]
           if opts[:ssl_verify_hostname]
-            options[:sslmode] = :verify_identity
-            # Unclear why this second line is necessary:
             # https://github.com/brianmario/mysql2/issues/879
             options[:sslverify] = true
-          else
-            options[:sslmode] = :verify_ca
           end
+        elsif opts[:ssl_mode]
+          # No CA configured: allow operators to pin an explicit ssl_mode instead
+          # of relying on the client library default.
+          ssl_mode = opts[:ssl_mode].to_sym
+          unless SUPPORTED_SSL_MODES.include?(ssl_mode)
+            raise ArgumentError.new("Unsupported ccdb.ssl_mode '#{opts[:ssl_mode]}' for mysql; supported values: #{SUPPORTED_SSL_MODES.join(', ')}")
+          end
+
+          options[:ssl_mode] = ssl_mode
         end
 
         options

--- a/lib/cloud_controller/db_connection/postgres_options_factory.rb
+++ b/lib/cloud_controller/db_connection/postgres_options_factory.rb
@@ -3,6 +3,7 @@ module VCAP::CloudController
     class PostgresOptionsFactory
       SQL_CONNECTION_PARAMETERS = %i[statement_timeout idle_in_transaction_session_timeout].freeze
       LIBPQ_CONNECTION_PARAMETERS = %i[keepalives keepalives_idle keepalives_interval keepalives_count].freeze
+      SUPPORTED_SSL_MODES = %w[disable allow prefer require].freeze
 
       def self.build(opts)
         options = {}
@@ -10,6 +11,14 @@ module VCAP::CloudController
         if opts[:ca_cert_path]
           options[:sslrootcert] = opts[:ca_cert_path]
           options[:sslmode] = opts[:ssl_verify_hostname] ? 'verify-full' : 'verify-ca'
+        elsif opts[:ssl_mode]
+          # No CA configured: allow operators to pin an explicit ssl_mode instead
+          # of relying on the client library default.
+          unless SUPPORTED_SSL_MODES.include?(opts[:ssl_mode])
+            raise ArgumentError.new("Unsupported ccdb.ssl_mode '#{opts[:ssl_mode]}' for postgres; supported values: #{SUPPORTED_SSL_MODES.join(', ')}")
+          end
+
+          options[:sslmode] = opts[:ssl_mode]
         end
 
         psql_opts = opts[:psql] || {}

--- a/spec/unit/lib/cloud_controller/db_connection/mysql_options_factory_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_connection/mysql_options_factory_spec.rb
@@ -7,13 +7,15 @@ RSpec.describe VCAP::CloudController::DbConnection::MysqlOptionsFactory do
   describe 'when the Cloud Controller Config specifies MySQL' do
     let(:ssl_verify_hostname) { true }
     let(:ca_cert_path) { nil }
+    let(:ssl_mode) { nil }
     let(:mysql_options) do
       VCAP::CloudController::DbConnection::MysqlOptionsFactory.build(
         database: {
           adapter: 'mysql2'
         },
         ca_cert_path: ca_cert_path,
-        ssl_verify_hostname: ssl_verify_hostname
+        ssl_verify_hostname: ssl_verify_hostname,
+        ssl_mode: ssl_mode
       )
     end
 
@@ -31,8 +33,35 @@ RSpec.describe VCAP::CloudController::DbConnection::MysqlOptionsFactory do
       it 'the options do not specify SSL' do
         expect(mysql_options[:ca_cert_path]).to be_nil
         expect(mysql_options[:sslca]).to be_nil
-        expect(mysql_options[:sslmode]).to be_nil
+        expect(mysql_options[:ssl_mode]).to be_nil
         expect(mysql_options[:sslverify]).to be_nil
+      end
+
+      describe 'when ssl_mode is set' do
+        context 'when ssl_mode is required' do
+          let(:ssl_mode) { 'required' }
+
+          it 'sets ssl_mode to :required without a CA' do
+            expect(mysql_options[:ssl_mode]).to eq(:required)
+            expect(mysql_options[:sslca]).to be_nil
+          end
+        end
+
+        context 'when ssl_mode is disabled' do
+          let(:ssl_mode) { 'disabled' }
+
+          it 'sets ssl_mode to :disabled' do
+            expect(mysql_options[:ssl_mode]).to eq(:disabled)
+          end
+        end
+
+        context 'when ssl_mode is an unsupported value' do
+          let(:ssl_mode) { 'prefer' }
+
+          it 'raises an ArgumentError' do
+            expect { mysql_options }.to raise_error(ArgumentError, /Unsupported ccdb.ssl_mode 'prefer' for mysql/)
+          end
+        end
       end
     end
 
@@ -43,12 +72,11 @@ RSpec.describe VCAP::CloudController::DbConnection::MysqlOptionsFactory do
         expect(mysql_options[:sslca]).to eq('/path/to/db_ca.crt')
       end
 
-      describe 'sslmode' do
+      describe 'ssl verification' do
         context 'when ssl_verify_hostname is truthy' do
           let(:ssl_verify_hostname) { true }
 
-          it 'sets the ssl verify options' do
-            expect(mysql_options[:sslmode]).to eq(:verify_identity)
+          it 'enables full server certificate verification' do
             expect(mysql_options[:sslverify]).to be(true)
           end
         end
@@ -56,9 +84,20 @@ RSpec.describe VCAP::CloudController::DbConnection::MysqlOptionsFactory do
         context 'when ssl_verify_hostname is falsey' do
           let(:ssl_verify_hostname) { false }
 
-          it 'sets the sslmode to :verify-ca' do
-            expect(mysql_options[:sslmode]).to eq(:verify_ca)
+          it 'sets the CA without enabling sslverify' do
+            expect(mysql_options[:sslca]).to eq('/path/to/db_ca.crt')
+            expect(mysql_options[:sslverify]).to be_nil
           end
+        end
+      end
+
+      context 'when ssl_mode is also set' do
+        let(:ssl_mode) { 'required' }
+
+        it 'ignores ssl_mode and uses the CA verification path' do
+          expect(mysql_options[:sslca]).to eq('/path/to/db_ca.crt')
+          expect(mysql_options[:sslverify]).to be(true)
+          expect(mysql_options[:ssl_mode]).to be_nil
         end
       end
     end

--- a/spec/unit/lib/cloud_controller/db_connection/postgres_options_factory_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_connection/postgres_options_factory_spec.rb
@@ -7,13 +7,15 @@ RSpec.describe VCAP::CloudController::DbConnection::PostgresOptionsFactory do
   describe 'when the Cloud Controller Config specifies Postgres' do
     let(:ssl_verify_hostname) { true }
     let(:ca_cert_path) { nil }
+    let(:ssl_mode) { nil }
     let(:postgres_options) do
       VCAP::CloudController::DbConnection::PostgresOptionsFactory.build(
         database: {
           adapter: 'postgres'
         },
         ca_cert_path: ca_cert_path,
-        ssl_verify_hostname: ssl_verify_hostname
+        ssl_verify_hostname: ssl_verify_hostname,
+        ssl_mode: ssl_mode
       )
     end
 
@@ -27,6 +29,33 @@ RSpec.describe VCAP::CloudController::DbConnection::PostgresOptionsFactory do
         expect(postgres_options[:sslrootcert]).to be_nil
         expect(postgres_options[:sslmode]).to be_nil
         expect(postgres_options[:ssl_verify_hostname]).to be_nil
+      end
+
+      describe 'when ssl_mode is set' do
+        context 'when ssl_mode is require' do
+          let(:ssl_mode) { 'require' }
+
+          it 'sets the sslmode to "require" without a root cert' do
+            expect(postgres_options[:sslmode]).to eq('require')
+            expect(postgres_options[:sslrootcert]).to be_nil
+          end
+        end
+
+        context 'when ssl_mode is disable' do
+          let(:ssl_mode) { 'disable' }
+
+          it 'sets the sslmode to "disable"' do
+            expect(postgres_options[:sslmode]).to eq('disable')
+          end
+        end
+
+        context 'when ssl_mode is an unsupported value' do
+          let(:ssl_mode) { 'required' }
+
+          it 'raises an ArgumentError' do
+            expect { postgres_options }.to raise_error(ArgumentError, /Unsupported ccdb.ssl_mode 'required' for postgres/)
+          end
+        end
       end
     end
 
@@ -52,6 +81,15 @@ RSpec.describe VCAP::CloudController::DbConnection::PostgresOptionsFactory do
           it 'sets the sslmode to "verify-ca"' do
             expect(postgres_options[:sslmode]).to eq('verify-ca')
           end
+        end
+      end
+
+      context 'when ssl_mode is also set' do
+        let(:ssl_mode) { 'require' }
+
+        it 'ignores ssl_mode and uses the verifying CA path' do
+          expect(postgres_options[:sslrootcert]).to eq('/path/to/db_ca.crt')
+          expect(postgres_options[:sslmode]).to eq('verify-full')
         end
       end
     end


### PR DESCRIPTION
When no `ccdb.ca_cert` is configured, the DB connection options factories previously emitted no SSL options, leaving the behavior to the client library default.

Add an optional `ccdb.ssl_mode` property, honored only when no CA is configured, so operators can pin an explicit mode:
- MySQL: disabled, required
- Postgres: disable, allow, prefer, require

Unknown values raise a clear error. A configured CA still takes the verifying path unchanged.

The property is added to all db-connection config schemas (api, worker, clock, deployment_updater, migrate, rotate_database_key, route_syncer, blobstore_benchmarks), because the rendered config is validated under
several contexts.

Also remove dead code from the MySQL factory: the `options[:sslmode]` assignments on the CA path were never read by mysql2, which only honors `options[:ssl_mode]`. Server-certificate verification on the CA path is
driven by `sslca` and `sslverify`, so removing the ignored `sslmode` keys does not change behavior. The new `ssl_mode` branch correctly emits `options[:ssl_mode]`. Postgres continues to use `sslmode`, which its
Sequel adapter does read.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
