### PR TITLE
Enforce lifecycle_type on apps, droplets, and builds

### DIFF
--- a/app/actions/build_create.rb
+++ b/app/actions/build_create.rb
@@ -54,6 +54,7 @@ module VCAP::CloudController
         state: BuildModel::STAGING_STATE,
         package_guid: package.guid,
         app: package.app,
+        lifecycle_type: lifecycle.type,
         staging_memory_in_mb: staging_details.staging_memory_in_mb,
         staging_disk_in_mb: staging_details.staging_disk_in_mb,
         staging_log_rate_limit: staging_details.staging_log_rate_limit_bytes_per_second,

--- a/app/actions/droplet_copy.rb
+++ b/app/actions/droplet_copy.rb
@@ -20,7 +20,7 @@ module VCAP::CloudController
       raise InvalidCopyError.new('source droplet is not staged') unless @source_droplet.staged?
       raise InvalidCopyError.new('source and destination lifecycle types do not match') unless @source_droplet.lifecycle_type == destination_app.lifecycle_type
 
-      new_droplet = DropletModel.new(state: DropletModel::COPYING_STATE, app: destination_app)
+      new_droplet = DropletModel.new(state: DropletModel::COPYING_STATE, app: destination_app, lifecycle_type: destination_app.lifecycle_type)
 
       # Needed to execute serializers and deserializers correctly on source and destination models
       CLONED_ATTRIBUTES.each do |attr|

--- a/app/actions/droplet_create.rb
+++ b/app/actions/droplet_create.rb
@@ -14,6 +14,7 @@ module VCAP::CloudController
       droplet = DropletModel.new(
         app: app,
         state: DropletModel::AWAITING_UPLOAD_STATE,
+        lifecycle_type: BuildpackLifecycleDataModel::LIFECYCLE_TYPE,
         process_types: message.process_types || DEFAULT_PROCESS_TYPES,
         execution_metadata: ''
       )
@@ -87,6 +88,7 @@ module VCAP::CloudController
         app: build.app,
         package_guid: build.package_guid,
         state: DropletModel::STAGING_STATE,
+        lifecycle_type: build.lifecycle_type,
         build: build
       )
     end

--- a/app/controllers/internal/staging_completion_controller.rb
+++ b/app/controllers/internal/staging_completion_controller.rb
@@ -22,7 +22,7 @@ module VCAP::CloudController
       droplet          = DropletModel.find(guid: staging_guid)
       raise CloudController::Errors::ApiError.new_from_details('ResourceNotFound', 'Droplet not found') if droplet.nil?
 
-      build = BuildModel.create(package: droplet.package, app: droplet.app, state: DropletModel::STAGING_STATE)
+      build = BuildModel.create(package: droplet.package, app: droplet.app, state: DropletModel::STAGING_STATE, lifecycle_type: droplet.lifecycle_type)
 
       BuildModel.db.transaction do
         build.lock!

--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -194,7 +194,7 @@ module VCAP::CloudController
 
       enqueued_job = nil
       DropletModel.db.transaction do
-        droplet = DropletModel.create(app: process.app, state: DropletModel::PROCESSING_UPLOAD_STATE)
+        droplet = DropletModel.create(app: process.app, state: DropletModel::PROCESSING_UPLOAD_STATE, lifecycle_type: BuildpackLifecycleDataModel::LIFECYCLE_TYPE)
         BuildpackLifecycleDataModel.create(droplet:)
 
         droplet_upload_job = Jobs::V2::UploadDropletFromUser.new(droplet_path, droplet.guid)

--- a/app/fetchers/app_list_fetcher.rb
+++ b/app/fetchers/app_list_fetcher.rb
@@ -33,32 +33,7 @@ module VCAP::CloudController
           dataset = dataset.where(guid: buildpack_lifecycle_data_dataset.select(:app_guid))
         end
 
-        if message.requested?(:lifecycle_type)
-          case message.lifecycle_type
-          when BuildpackLifecycleDataModel::LIFECYCLE_TYPE
-            dataset = dataset.where(
-              guid: BuildpackLifecycleDataModel.
-                    where(Sequel.~(app_guid: nil)).
-                    select(:app_guid)
-            )
-          when DockerLifecycleDataModel::LIFECYCLE_TYPE
-            dataset = dataset.exclude(
-              guid: BuildpackLifecycleDataModel.
-                    where(Sequel.~(app_guid: nil)).
-                    select(:app_guid)
-            ).exclude(
-              guid: CNBLifecycleDataModel.
-                    where(Sequel.~(app_guid: nil)).
-                    select(:app_guid)
-            )
-          when CNBLifecycleDataModel::LIFECYCLE_TYPE
-            dataset = dataset.where(
-              guid: CNBLifecycleDataModel.
-                    where(Sequel.~(app_guid: nil)).
-                    select(:app_guid)
-            )
-          end
-        end
+        dataset = dataset.where(lifecycle_type: message.lifecycle_type) if message.requested?(:lifecycle_type)
 
         if message.requested?(:organization_guids)
           dataset = dataset.

--- a/app/models/runtime/app_model.rb
+++ b/app/models/runtime/app_model.rb
@@ -98,14 +98,7 @@ module VCAP::CloudController
     end
 
     def lifecycle_type
-      return self[:lifecycle_type] if self[:lifecycle_type].present?
-
-      # Fallback for records written before the lifecycle_type column
-      # existed. Remove once existing rows are backfilled (see #5067).
-      return BuildpackLifecycleDataModel::LIFECYCLE_TYPE if buildpack_lifecycle_data
-      return CNBLifecycleDataModel::LIFECYCLE_TYPE if cnb_lifecycle_data
-
-      DockerLifecycleDataModel::LIFECYCLE_TYPE
+      self[:lifecycle_type]
     end
 
     def lifecycle_data

--- a/app/models/runtime/build_model.rb
+++ b/app/models/runtime/build_model.rb
@@ -63,14 +63,7 @@ module VCAP::CloudController
     end
 
     def lifecycle_type
-      return self[:lifecycle_type] if self[:lifecycle_type].present?
-
-      # Fallback for records written before the lifecycle_type column
-      # existed. Remove once existing rows are backfilled (see #5067).
-      return BuildpackLifecycleDataModel::LIFECYCLE_TYPE if buildpack_lifecycle_data
-      return CNBLifecycleDataModel::LIFECYCLE_TYPE if cnb_lifecycle_data
-
-      DockerLifecycleDataModel::LIFECYCLE_TYPE
+      self[:lifecycle_type]
     end
 
     def buildpack_lifecycle?

--- a/app/models/runtime/droplet_model.rb
+++ b/app/models/runtime/droplet_model.rb
@@ -176,14 +176,7 @@ module VCAP::CloudController
     end
 
     def lifecycle_type
-      return self[:lifecycle_type] if self[:lifecycle_type].present?
-
-      # Fallback for records written before the lifecycle_type column
-      # existed. Remove once existing rows are backfilled (see #5067).
-      return BuildpackLifecycleDataModel::LIFECYCLE_TYPE if buildpack_lifecycle_data
-      return CNBLifecycleDataModel::LIFECYCLE_TYPE if cnb_lifecycle_data
-
-      DockerLifecycleDataModel::LIFECYCLE_TYPE
+      self[:lifecycle_type]
     end
 
     def lifecycle_data

--- a/app/presenters/v3/process_presenter.rb
+++ b/app/presenters/v3/process_presenter.rb
@@ -11,7 +11,7 @@ module VCAP::CloudController
         class << self
           # :labels and :annotations come from MetadataPresentationHelpers
           def associated_resources
-            super + [{ app: %i[buildpack_lifecycle_data cnb_lifecycle_data] }]
+            super + [:app]
           end
         end
 

--- a/db/migrations/20260825120000_backfill_lifecycle_type.rb
+++ b/db/migrations/20260825120000_backfill_lifecycle_type.rb
@@ -1,0 +1,38 @@
+Sequel.migration do
+  no_transaction
+
+  up do
+    tables = [
+      { table: :apps,     guid_column: :app_guid     },
+      { table: :droplets, guid_column: :droplet_guid },
+      { table: :builds,   guid_column: :build_guid   }
+    ]
+    batch_size = 1000
+
+    tables.each do |t|
+      table       = t[:table]
+      guid_column = t[:guid_column]
+
+      loop do
+        guids = self[table].where(lifecycle_type: nil).limit(batch_size).select_map(:guid)
+        break if guids.empty?
+
+        guids_with_buildpack = self[:buildpack_lifecycle_data].where(guid_column => guids).select_map(guid_column)
+        guids_with_cnb       = self[:cnb_lifecycle_data].where(guid_column => guids).select_map(guid_column) - guids_with_buildpack
+        guids_docker         = guids - guids_with_buildpack - guids_with_cnb
+
+        transaction do
+          self[table].where(guid: guids_with_buildpack, lifecycle_type: nil).update(lifecycle_type: 'buildpack') unless guids_with_buildpack.empty?
+          self[table].where(guid: guids_with_cnb,       lifecycle_type: nil).update(lifecycle_type: 'cnb')       unless guids_with_cnb.empty?
+          self[table].where(guid: guids_docker,         lifecycle_type: nil).update(lifecycle_type: 'docker')    unless guids_docker.empty?
+        end
+
+        break if guids.size < batch_size
+      end
+    end
+  end
+
+  down do
+    # Intentionally left empty: backfilled values are correct and should not be reverted
+  end
+end

--- a/db/migrations/20260825120100_make_lifecycle_type_non_nullable.rb
+++ b/db/migrations/20260825120100_make_lifecycle_type_non_nullable.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table(:apps)     { set_column_not_null :lifecycle_type }
+    alter_table(:droplets) { set_column_not_null :lifecycle_type }
+    alter_table(:builds)   { set_column_not_null :lifecycle_type }
+  end
+
+  down do
+    alter_table(:apps)     { set_column_allow_null :lifecycle_type }
+    alter_table(:droplets) { set_column_allow_null :lifecycle_type }
+    alter_table(:builds)   { set_column_allow_null :lifecycle_type }
+  end
+end

--- a/db/migrations/20260825120100_make_lifecycle_type_non_nullable.rb
+++ b/db/migrations/20260825120100_make_lifecycle_type_non_nullable.rb
@@ -1,13 +1,33 @@
 Sequel.migration do
+  no_transaction
+
   up do
-    alter_table(:apps)     { set_column_not_null :lifecycle_type }
-    alter_table(:droplets) { set_column_not_null :lifecycle_type }
-    alter_table(:builds)   { set_column_not_null :lifecycle_type }
+    %i[apps droplets builds].each do |table|
+      if database_type == :postgres
+        transaction do
+          alter_table(table) do
+            add_constraint({ name: :"#{table}_lifecycle_type_not_null", not_valid: true }) do
+              Sequel.lit('lifecycle_type IS NOT NULL')
+            end
+          end
+        end
+
+        VCAP::Migration.with_concurrent_timeout(self) do
+          run("ALTER TABLE #{table} VALIDATE CONSTRAINT #{table}_lifecycle_type_not_null")
+        end
+      else
+        alter_table(table) { set_column_not_null :lifecycle_type }
+      end
+    end
   end
 
   down do
-    alter_table(:apps)     { set_column_allow_null :lifecycle_type }
-    alter_table(:droplets) { set_column_allow_null :lifecycle_type }
-    alter_table(:builds)   { set_column_allow_null :lifecycle_type }
+    %i[apps droplets builds].each do |table|
+      if database_type == :postgres
+        alter_table(table) { drop_constraint(:"#{table}_lifecycle_type_not_null") }
+      else
+        alter_table(table) { set_column_allow_null :lifecycle_type }
+      end
+    end
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -192,27 +192,6 @@ namespace :db do
     VCAP::BigintMigration.backfill(logger, db, args.table.to_sym, batch_size: args.batch_size.to_i, iterations: args.iterations.to_i)
   end
 
-  # One-off backfill - to be removed in a future version.
-  desc 'Backfill lifecycle_type column on apps, droplets, and builds (pass -1 for batches_per_run to drain)'
-  task :lifecycle_type_backfill, %i[batch_size batches_per_run] => :environment do |_t, args|
-    args.with_defaults(batch_size: 1_000, batches_per_run: 10)
-
-    RakeConfig.context = :api
-
-    batch_size      = args.batch_size.to_i
-    batches_per_run = args.batches_per_run.to_i
-    BackgroundJobEnvironment.new(RakeConfig.config).setup_environment do
-      # Ensure we always log to stdout (regardless of `stdout_sink_enabled`).
-      VCAP::CloudController::StenoConfigurer.new(RakeConfig.config.get(:logging)).configure do |steno_config_hash|
-        steno_config_hash[:sinks] << Steno::Sink::IO.new($stdout)
-      end
-      logger = Steno.logger('cc.db.lifecycle_type_backfill')
-      logger.info("starting lifecycle_type backfill (batch_size: #{batch_size}, batches_per_run: #{batches_per_run})")
-      VCAP::CloudController::Jobs::Runtime::LifecycleTypeBackfill.new(batch_size:, batches_per_run:).perform
-      logger.info('finished lifecycle_type backfill')
-    end
-  end
-
   namespace :dev do
     desc 'Migrate the database set in spec/support/bootstrap/db_config'
     task migrate: :environment do

--- a/spec/migrations/20260825120000_backfill_lifecycle_type_spec.rb
+++ b/spec/migrations/20260825120000_backfill_lifecycle_type_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to backfill lifecycle_type on apps, droplets, and builds', isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20260825120000_backfill_lifecycle_type.rb' }
+  end
+
+  before do
+    db[:apps].insert(guid: 'buildpack-app-guid')
+    db[:apps].insert(guid: 'cnb-app-guid')
+    db[:apps].insert(guid: 'docker-app-guid')
+    db[:apps].insert(guid: 'already-set-guid')
+    db[:apps].insert(guid: 'both-app-guid')
+
+    db[:buildpack_lifecycle_data].insert(guid: 'bld-app-guid', app_guid: 'buildpack-app-guid')
+    db[:cnb_lifecycle_data].insert(guid: 'cnb-app-guid-data', app_guid: 'cnb-app-guid')
+    db[:buildpack_lifecycle_data].insert(guid: 'bld-both-guid', app_guid: 'both-app-guid')
+    db[:cnb_lifecycle_data].insert(guid: 'cnb-both-guid', app_guid: 'both-app-guid')
+
+    db[:apps].where(guid: 'already-set-guid').update(lifecycle_type: 'docker')
+
+    db[:droplets].insert(guid: 'buildpack-droplet-guid', state: 'STAGED')
+    db[:droplets].insert(guid: 'cnb-droplet-guid', state: 'STAGED')
+    db[:droplets].insert(guid: 'docker-droplet-guid', state: 'STAGED')
+
+    db[:buildpack_lifecycle_data].insert(guid: 'bld-droplet-guid', droplet_guid: 'buildpack-droplet-guid')
+    db[:cnb_lifecycle_data].insert(guid: 'cnb-droplet-guid-data', droplet_guid: 'cnb-droplet-guid')
+
+    db[:builds].insert(guid: 'buildpack-build-guid')
+    db[:builds].insert(guid: 'cnb-build-guid')
+    db[:builds].insert(guid: 'docker-build-guid')
+
+    db[:buildpack_lifecycle_data].insert(guid: 'bld-build-guid', build_guid: 'buildpack-build-guid')
+    db[:cnb_lifecycle_data].insert(guid: 'cnb-build-guid-data', build_guid: 'cnb-build-guid')
+  end
+
+  it 'backfills lifecycle_type for apps, droplets, and builds, does not overwrite existing values, and prefers buildpack over cnb' do
+    Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+
+    expect(db[:apps].first(guid: 'buildpack-app-guid')[:lifecycle_type]).to eq('buildpack')
+    expect(db[:apps].first(guid: 'cnb-app-guid')[:lifecycle_type]).to eq('cnb')
+    expect(db[:apps].first(guid: 'docker-app-guid')[:lifecycle_type]).to eq('docker')
+    expect(db[:apps].first(guid: 'already-set-guid')[:lifecycle_type]).to eq('docker')
+    expect(db[:apps].first(guid: 'both-app-guid')[:lifecycle_type]).to eq('buildpack')
+
+    expect(db[:droplets].first(guid: 'buildpack-droplet-guid')[:lifecycle_type]).to eq('buildpack')
+    expect(db[:droplets].first(guid: 'cnb-droplet-guid')[:lifecycle_type]).to eq('cnb')
+    expect(db[:droplets].first(guid: 'docker-droplet-guid')[:lifecycle_type]).to eq('docker')
+
+    expect(db[:builds].first(guid: 'buildpack-build-guid')[:lifecycle_type]).to eq('buildpack')
+    expect(db[:builds].first(guid: 'cnb-build-guid')[:lifecycle_type]).to eq('cnb')
+    expect(db[:builds].first(guid: 'docker-build-guid')[:lifecycle_type]).to eq('docker')
+
+    expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+  end
+end

--- a/spec/migrations/20260825120100_make_lifecycle_type_non_nullable_spec.rb
+++ b/spec/migrations/20260825120100_make_lifecycle_type_non_nullable_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'migrations/helpers/migration_shared_context'
+
+RSpec.describe 'migration to make lifecycle_type non-nullable on apps, droplets, and builds', isolation: :truncation, type: :migration do
+  include_context 'migration' do
+    let(:migration_filename) { '20260825120100_make_lifecycle_type_non_nullable.rb' }
+  end
+
+  before do
+    db[:apps].insert(guid: 'app-guid', lifecycle_type: 'buildpack')
+    db[:droplets].insert(guid: 'droplet-guid', state: 'STAGED', lifecycle_type: 'buildpack')
+    db[:builds].insert(guid: 'build-guid', lifecycle_type: 'buildpack')
+  end
+
+  it 'makes lifecycle_type non-nullable, is reversible, and is idempotent' do
+    Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true)
+
+    expect(db.schema(:apps).find { |col| col[0] == :lifecycle_type }[1][:allow_null]).to be false
+    expect(db.schema(:droplets).find { |col| col[0] == :lifecycle_type }[1][:allow_null]).to be false
+    expect(db.schema(:builds).find { |col| col[0] == :lifecycle_type }[1][:allow_null]).to be false
+
+    expect { Sequel::Migrator.run(db, migrations_path, target: current_migration_index, allow_missing_migration_files: true) }.not_to raise_error
+
+    Sequel::Migrator.run(db, migrations_path, target: current_migration_index - 1, allow_missing_migration_files: true)
+
+    expect(db.schema(:apps).find { |col| col[0] == :lifecycle_type }[1][:allow_null]).to be true
+    expect(db.schema(:droplets).find { |col| col[0] == :lifecycle_type }[1][:allow_null]).to be true
+    expect(db.schema(:builds).find { |col| col[0] == :lifecycle_type }[1][:allow_null]).to be true
+  end
+end

--- a/spec/request/apps_spec.rb
+++ b/spec/request/apps_spec.rb
@@ -997,11 +997,8 @@ RSpec.describe 'Apps' do
 
       it 'filters by lifecycle_type' do
         create(:app_model, name: 'name1')
-        docker_app_model = create(:app_model, name: 'name2')
+        create(:app_model, :docker, name: 'name2')
         create(:app_model, name: 'name3')
-
-        docker_app_model.buildpack_lifecycle_data = nil
-        docker_app_model.save
 
         get '/v3/apps?lifecycle_type=buildpack', nil, admin_header
 

--- a/spec/request/processes_spec.rb
+++ b/spec/request/processes_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe 'Processes' do
         expect(parsed_response['resources'].count).to eq(4)
 
         expect { get_processes.call }.to have_queried_db_times(/SELECT .* FROM .apps. /i, 1) # instead of 4 w/o eager loading
-        expect { get_processes.call }.to have_queried_db_times(/SELECT .* FROM .buildpack_lifecycle_data. /i, 1) # instead of 4 w/o eager loading
-        expect { get_processes.call }.to have_queried_db_times(/SELECT .* FROM .cnb_lifecycle_data. /i, 1) # instead of 2 w/o eager loading
+        expect { get_processes.call }.to have_queried_db_times(/SELECT .* FROM .buildpack_lifecycle_data. /i, 0) # lifecycle_type is now a column, no join needed
+        expect { get_processes.call }.to have_queried_db_times(/SELECT .* FROM .cnb_lifecycle_data. /i, 0) # lifecycle_type is now a column, no join needed
       end
     end
 

--- a/spec/unit/controllers/v3/processes_controller_spec.rb
+++ b/spec/unit/controllers/v3/processes_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ProcessesController, type: :controller do
       it 'eager loads associated resources that the presenter specifies' do
         expect(VCAP::CloudController::ProcessListFetcher).to receive(:fetch_for_app).with(
           an_instance_of(VCAP::CloudController::ProcessesListMessage),
-          hash_including(eager_loaded_associations: [:labels, :annotations, { app: %i[buildpack_lifecycle_data cnb_lifecycle_data] }])
+          hash_including(eager_loaded_associations: %i[labels annotations app])
         ).and_call_original
 
         get :index, params: { app_guid: app.guid }
@@ -103,7 +103,7 @@ RSpec.describe ProcessesController, type: :controller do
         it 'eager loads associated resources that the presenter specifies' do
           expect(VCAP::CloudController::ProcessListFetcher).to receive(:fetch_all).with(
             an_instance_of(VCAP::CloudController::ProcessesListMessage),
-            hash_including(eager_loaded_associations: [:labels, :annotations, { app: %i[buildpack_lifecycle_data cnb_lifecycle_data] }])
+            hash_including(eager_loaded_associations: %i[labels annotations app])
           ).and_call_original
 
           get :index

--- a/spec/unit/lib/cloud_controller/diego/lifecycles/buildpack_lifecycle_spec.rb
+++ b/spec/unit/lib/cloud_controller/diego/lifecycles/buildpack_lifecycle_spec.rb
@@ -3,7 +3,7 @@ require_relative 'lifecycle_shared'
 
 module VCAP::CloudController
   RSpec.describe BuildpackLifecycle do
-    let(:app) { AppModel.create(name: 'some-app', space: create(:space)) }
+    let(:app) { AppModel.create(name: 'some-app', space: create(:space), lifecycle_type: 'buildpack') }
     let!(:package) { create(:package_model, type: PackageModel::BITS_TYPE, app: app) }
     let(:staging_message) { BuildCreateMessage.new(lifecycle: { data: request_data, type: 'buildpack' }) }
     let(:request_data) { {} }

--- a/spec/unit/models/runtime/app_model_spec.rb
+++ b/spec/unit/models/runtime/app_model_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module VCAP::CloudController
   RSpec.describe AppModel do
-    let(:app_model) { AppModel.create(space: space, name: 'some-name') }
+    let(:app_model) { AppModel.create(space: space, name: 'some-name', lifecycle_type: 'buildpack') }
     let(:space) { create(:space) }
 
     describe '#oldest_web_process' do
@@ -286,37 +286,6 @@ module VCAP::CloudController
           expect do
             create(:app_model, lifecycle_type: type)
           end.not_to raise_error
-        end
-      end
-    end
-
-    describe '#lifecycle_type' do
-      before do
-        # Remove lifecycle type to test fallback mechanism based on associated lifecycle data
-        app_model.update(lifecycle_type: '')
-      end
-
-      context 'when there is buildpack_lifecycle_data associated to the app' do
-        before { create(:buildpack_lifecycle_data_model, app: app_model) }
-
-        it 'returns the string "buildpack"' do
-          app_model.reload
-          expect(app_model.lifecycle_type).to eq('buildpack')
-        end
-      end
-
-      context 'when there is cnb_lifecycle_data associated to the app' do
-        before { create(:cnb_lifecycle_data_model, app: app_model) }
-
-        it 'returns the string "cnb"' do
-          app_model.reload
-          expect(app_model.lifecycle_type).to eq('cnb')
-        end
-      end
-
-      context 'when there is no lifecycle data associated to the app' do
-        it 'returns the string "docker"' do
-          expect(app_model.lifecycle_type).to eq('docker')
         end
       end
     end
@@ -646,7 +615,7 @@ module VCAP::CloudController
       context 'when not saving any encrypted fields, with db keys' do
         it 'still updates the encryption-key value' do
           TestConfig.override(database_encryption: { current_key_label: nil, keys: {} })
-          app = AppModel.create(name: 'jimmy')
+          app = AppModel.create(name: 'jimmy', lifecycle_type: 'buildpack')
           expect(app.encryption_key_label).to be_nil
 
           app.environment_variables = { building: 'house' }
@@ -660,10 +629,10 @@ module VCAP::CloudController
           app.reload
           expect(app.encryption_key_label).to eq('k2')
 
-          app2 = AppModel.create(name: 'bob', environment_variables: { building: 'mansion' })
+          app2 = AppModel.create(name: 'bob', lifecycle_type: 'buildpack', environment_variables: { building: 'mansion' })
           expect(app2.encryption_key_label).to eq('k2')
 
-          app3 = AppModel.create(name: 'randombuilder')
+          app3 = AppModel.create(name: 'randombuilder', lifecycle_type: 'buildpack')
           expect(app3.encryption_key_label).to eq('k2')
         end
       end

--- a/spec/unit/models/runtime/build_model_spec.rb
+++ b/spec/unit/models/runtime/build_model_spec.rb
@@ -44,44 +44,7 @@ module VCAP::CloudController
       end
     end
 
-    describe '#lifecycle_type' do
-      before do
-        # Remove lifecycle type to test fallback mechanism based on associated lifecycle data
-        build_model.update(lifecycle_type: '')
-      end
-
-      context 'when there is buildpack_lifecycle_data associated to the build' do
-        let(:build_model) { create(:build_model, app: nil) }
-
-        it 'returns the string "buildpack"' do
-          expect(build_model.lifecycle_type).to eq('buildpack')
-        end
-      end
-
-      context 'when there is cnb_lifecycle_data associated to the build' do
-        let(:build_model) { create(:build_model, :cnb, app: nil) }
-
-        it 'returns the string "cnb"' do
-          expect(build_model.lifecycle_type).to eq('cnb')
-        end
-      end
-
-      context 'when there is no lifecycle data associated to the build' do
-        let(:build_model) { create(:build_model, :docker, app: nil) }
-
-        it 'returns the string "docker"' do
-          expect(build_model.lifecycle_type).to eq('docker')
-        end
-      end
-    end
-
     describe '#before_create' do
-      it 'inherits lifecycle_type from app if not set' do
-        app = create(:app_model, :cnb)
-        build = BuildModel.create(app: app, state: BuildModel::STAGING_STATE)
-        expect(build[:lifecycle_type]).to eq('cnb')
-      end
-
       it 'uses explicit lifecycle_type if set' do
         app = create(:app_model)
         build = BuildModel.create(app: app, state: BuildModel::STAGING_STATE, lifecycle_type: 'docker')

--- a/spec/unit/models/runtime/droplet_model_spec.rb
+++ b/spec/unit/models/runtime/droplet_model_spec.rb
@@ -63,44 +63,7 @@ module VCAP::CloudController
       end
     end
 
-    describe '#lifecycle_type' do
-      before do
-        # Remove lifecycle type to test fallback mechanism based on associated lifecycle data
-        droplet_model.update(lifecycle_type: '')
-      end
-
-      context 'when there is buildpack_lifecycle_data associated to the droplet' do
-        let(:droplet_model) { create(:droplet_model, app: nil) }
-
-        it 'returns the string "buildpack"' do
-          expect(droplet_model.lifecycle_type).to eq('buildpack')
-        end
-      end
-
-      context 'when there is cnb_lifecycle_data associated to the droplet' do
-        let(:droplet_model) { create(:droplet_model, :cnb, app: nil) }
-
-        it 'returns the string "cnb"' do
-          expect(droplet_model.lifecycle_type).to eq('cnb')
-        end
-      end
-
-      context 'when there is no lifecycle data associated to the droplet' do
-        let(:droplet_model) { create(:droplet_model, :docker, app: nil) }
-
-        it 'returns the string "docker"' do
-          expect(droplet_model.lifecycle_type).to eq('docker')
-        end
-      end
-    end
-
     describe '#before_create' do
-      it 'inherits lifecycle_type from app if not set' do
-        app = create(:app_model, :cnb)
-        droplet = DropletModel.create(app: app, state: DropletModel::STAGING_STATE)
-        expect(droplet[:lifecycle_type]).to eq('cnb')
-      end
-
       it 'uses explicit lifecycle_type if set' do
         app = create(:app_model)
         droplet = DropletModel.create(app: app, state: DropletModel::STAGING_STATE, lifecycle_type: 'docker')


### PR DESCRIPTION
Related to #5067

> **Note**: This PR depends on #5401 being merged first. CI failures are expected until that happens.

* A short explanation of the proposed change:
    Backfills NULL lifecycle_type values via a migration, enforces NOT NULL
    constraint, removes fallback logic from models, optimizes AppListFetcher
    (subqueries → simple WHERE clause), and optimizes ProcessPresenter eager
    loading.

* An explanation of the use cases your change solves
    Allows lifecycle_type to be determined directly from the column without
    joining lifecycle data tables, reducing N+1 queries and simplifying code.
    Enables efficient filtering via GET /v3/apps?lifecycle_type=...

* [X] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [X] I have viewed, signed, and submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)