### PR TITLE
Introduce set_env method in db options factory

### DIFF
--- a/lib/cloud_controller/db.rb
+++ b/lib/cloud_controller/db.rb
@@ -25,6 +25,7 @@ module VCAP::CloudController
     #
     # @return [Sequel::Database]
     def self.connect(opts, logger)
+      VCAP::CloudController::DbConnection::OptionsFactory.set_env(opts)
       connection_options = VCAP::CloudController::DbConnection::OptionsFactory.build(opts)
 
       db = get_connection(opts, connection_options)

--- a/lib/cloud_controller/db_connection/mysql_options_factory.rb
+++ b/lib/cloud_controller/db_connection/mysql_options_factory.rb
@@ -24,6 +24,14 @@ module VCAP::CloudController
 
         options
       end
+
+      def self.reset_env(env)
+        env.delete('MARIADB_TLS_DISABLE_PEER_VERIFICATION')
+      end
+
+      def self.set_env(opts, env)
+        env['MARIADB_TLS_DISABLE_PEER_VERIFICATION'] = '1' unless opts[:ca_cert_path]
+      end
     end
   end
 end

--- a/lib/cloud_controller/db_connection/options_factory.rb
+++ b/lib/cloud_controller/db_connection/options_factory.rb
@@ -22,6 +22,13 @@ module VCAP::CloudController
             compact
         end
 
+        def set_env(opts) # rubocop:disable Naming/AccessorMethodName
+          FACTORIES.values.uniq.each do |factory|
+            factory.reset_env(ENV)
+          end
+          adapter_set_env(opts, ENV)
+        end
+
         private
 
         FACTORIES = {
@@ -44,8 +51,15 @@ module VCAP::CloudController
         end
 
         def adapter_options(opts)
-          adapter = opts[:database][:adapter]
-          factory_for(adapter).build(opts)
+          factory_for(adapter(opts)).build(opts)
+        end
+
+        def adapter_set_env(opts, env)
+          factory_for(adapter(opts)).set_env(opts, env)
+        end
+
+        def adapter(opts)
+          opts[:database][:adapter]
         end
 
         def factory_for(adapter)

--- a/lib/cloud_controller/db_connection/postgres_options_factory.rb
+++ b/lib/cloud_controller/db_connection/postgres_options_factory.rb
@@ -25,6 +25,10 @@ module VCAP::CloudController
 
         options
       end
+
+      def self.reset_env(_); end
+
+      def self.set_env(_, _); end
     end
   end
 end

--- a/spec/unit/lib/cloud_controller/db_connection/mysql_options_factory_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_connection/mysql_options_factory_spec.rb
@@ -63,4 +63,36 @@ RSpec.describe VCAP::CloudController::DbConnection::MysqlOptionsFactory do
       end
     end
   end
+
+  describe 'env vars' do
+    let(:env) { {} }
+
+    describe '.reset_env' do
+      it 'deletes MARIADB_TLS_DISABLE_PEER_VERIFICATION from env' do
+        env.merge!('MARIADB_TLS_DISABLE_PEER_VERIFICATION' => '1')
+        VCAP::CloudController::DbConnection::MysqlOptionsFactory.reset_env(env)
+        expect(env).not_to have_key('MARIADB_TLS_DISABLE_PEER_VERIFICATION')
+      end
+    end
+
+    describe '.set_env' do
+      it 'does not set MARIADB_TLS_DISABLE_PEER_VERIFICATION when there is a ca_cert_path' do
+        opts = { ca_cert_path: '/path/to/ca_cert' }
+        VCAP::CloudController::DbConnection::MysqlOptionsFactory.set_env(opts, env)
+        expect(env).not_to have_key('MARIADB_TLS_DISABLE_PEER_VERIFICATION')
+      end
+
+      it 'sets MARIADB_TLS_DISABLE_PEER_VERIFICATION when ca_cert_path is nil' do
+        opts = { ca_cert_path: nil }
+        VCAP::CloudController::DbConnection::MysqlOptionsFactory.set_env(opts, env)
+        expect(env['MARIADB_TLS_DISABLE_PEER_VERIFICATION']).to eq('1')
+      end
+
+      it 'sets MARIADB_TLS_DISABLE_PEER_VERIFICATION when there is no ca_cert_path' do
+        opts = {}
+        VCAP::CloudController::DbConnection::MysqlOptionsFactory.set_env(opts, env)
+        expect(env['MARIADB_TLS_DISABLE_PEER_VERIFICATION']).to eq('1')
+      end
+    end
+  end
 end

--- a/spec/unit/lib/cloud_controller/db_connection/options_factory_spec.rb
+++ b/spec/unit/lib/cloud_controller/db_connection/options_factory_spec.rb
@@ -126,4 +126,27 @@ RSpec.describe VCAP::CloudController::DbConnection::OptionsFactory do
       end
     end
   end
+
+  describe '.set_env' do
+    let(:adapter) { 'mysql' }
+
+    before do
+      allow(VCAP::CloudController::DbConnection::MysqlOptionsFactory).to receive(:reset_env).with(anything)
+      allow(VCAP::CloudController::DbConnection::MysqlOptionsFactory).to receive(:set_env).with(anything, anything)
+      allow(VCAP::CloudController::DbConnection::PostgresOptionsFactory).to receive(:reset_env).with(anything)
+      allow(VCAP::CloudController::DbConnection::PostgresOptionsFactory).to receive(:set_env).with(anything, anything)
+    end
+
+    it 'calls reset_env on all adapters exactly once' do
+      expect(VCAP::CloudController::DbConnection::MysqlOptionsFactory).to receive(:reset_env).with(ENV).once
+      expect(VCAP::CloudController::DbConnection::PostgresOptionsFactory).to receive(:reset_env).with(ENV).once
+      VCAP::CloudController::DbConnection::OptionsFactory.set_env(required_options)
+    end
+
+    it 'calls set_env on the adapter factory' do
+      expect(VCAP::CloudController::DbConnection::MysqlOptionsFactory).to receive(:set_env).with(required_options, ENV).once
+      expect(VCAP::CloudController::DbConnection::PostgresOptionsFactory).not_to receive(:set_env).with(anything, anything)
+      VCAP::CloudController::DbConnection::OptionsFactory.set_env(required_options)
+    end
+  end
 end


### PR DESCRIPTION
`VCAP::CloudController::DB` invokes dedicated factories for MySQL and Postgres connection options. Add `set_env` methods to the factories that set required environment variables depending on the adapter type and call it just before building the connection options. This mechanism provides a single place where e.g. `MARIADB_TLS_DISABLE_PEER_VERIFICATION` can be set instead of exporting it in various code places.

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
