### PR TITLE
Add missing route_policies fields to domains OpenAPI spec

### DIFF
--- a/docs/openapi/apis/cf/latest/components/requestBodies/DomainCreateRequestBody.yaml
+++ b/docs/openapi/apis/cf/latest/components/requestBodies/DomainCreateRequestBody.yaml
@@ -20,6 +20,16 @@ content:
               type: string
               format: uuid
           description: 'The desired router group guid.  _note: creates a `tcp` domain; cannot be used when `internal` is set to `true` or domain is scoped to an org_'
+        enforce_route_policies:
+          type: boolean
+          description: When `true`, GoRouter enforces route policies for routes on this domain using mutual TLS (mTLS). Set at creation only; cannot be changed on update. Cannot be used with internal domains or router groups.
+        route_policies_scope:
+          type: string
+          enum:
+            - any
+            - org
+            - space
+          description: 'Operator-defined boundary for allowed callers: `any`, `org`, or `space`. Required when `enforce_route_policies` is `true`. Set at creation only; cannot be changed on update.'
         relationships:
           type: object
           properties:

--- a/docs/openapi/apis/cf/latest/components/schemas/Domain.yaml
+++ b/docs/openapi/apis/cf/latest/components/schemas/Domain.yaml
@@ -25,6 +25,16 @@ allOf:
             - http
             - tcp
         description: Available protocols for routes using the domain, currently `http` and `tcp`
+      enforce_route_policies:
+        type: boolean
+        description: When `true`, GoRouter enforces route policies for routes on this domain. This field only appears in the response when set to `true`. Set at creation only; cannot be changed on update
+      route_policies_scope:
+        type: string
+        enum:
+          - any
+          - org
+          - space
+        description: 'Operator-defined boundary for allowed callers: `any`, `org`, or `space`. Required when `enforce_route_policies` is `true`. This field only appears when `enforce_route_policies` is `true`. Set at creation only; cannot be changed on update'
       relationships:
         $ref: './Relationships.yaml'
       metadata:


### PR DESCRIPTION
See https://v3-apidocs.cloudfoundry.org/version/3.230.0/index.html#domains 

Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [ ] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/CONTRIBUTING.md)

* [ ] I have viewed, signed, and submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `bundle exec rake`

* [ ] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/spec/README.md#cf-acceptance-tests-cats)
